### PR TITLE
refactor(registrar): extract cert manager

### DIFF
--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -2,7 +2,7 @@
 
 Library crate for the prover registrar service.
 
-Implements automated discovery and on-chain registration of TEE prover signer
+Implements automated discovery and onchain registration of TEE prover signer
 keys for the Base multi-proof system. The registrar polls AWS ALB target groups
 to detect new Nitro enclave instances, fetches their attestation documents via
 `enclave_signerAttestation`, generates ZK proofs via the Boundless Network

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -1,0 +1,409 @@
+//! Certificate revocation management for AWS Nitro certificate chains.
+//!
+//! Parses Nitro attestations, checks the onchain durable revocation sentinel,
+//! fetches AWS Nitro CRLs, and submits `revokeCert` transactions for
+//! certificates that are newly observed on a CRL.
+
+use std::{fmt, sync::Arc};
+
+use base_proof_tee_nitro_verifier::AttestationReport;
+use base_tx_manager::TxManager;
+use tracing::{debug, warn};
+
+use crate::{
+    CertRevoker, CrlConfig, NitroVerifierClient, ProverInstance, RegistrarError, RegistrarMetrics,
+    Result, crl,
+};
+
+/// Manages Nitro certificate revocation checks and revocation transaction submission.
+pub struct CertManager {
+    http_client: reqwest::Client,
+    nitro_verifier: Arc<dyn NitroVerifierClient>,
+}
+
+impl fmt::Debug for CertManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CertManager").finish_non_exhaustive()
+    }
+}
+
+impl CertManager {
+    /// Creates a certificate manager from CRL configuration and a verifier client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::Config`] if the CRL HTTP client cannot be built.
+    pub fn new(config: &CrlConfig, nitro_verifier: Arc<dyn NitroVerifierClient>) -> Result<Self> {
+        let http_client = crl::build_crl_http_client(config.fetch_timeout).map_err(|e| {
+            RegistrarError::Config(format!(
+                "failed to build CRL HTTP client (Layer 2 / AWS CRL fetch): {e}"
+            ))
+        })?;
+        Ok(Self::from_parts(http_client, nitro_verifier))
+    }
+
+    /// Creates a certificate manager from pre-built dependencies.
+    pub fn from_parts(
+        http_client: reqwest::Client,
+        nitro_verifier: Arc<dyn NitroVerifierClient>,
+    ) -> Self {
+        Self { http_client, nitro_verifier }
+    }
+
+    /// Checks an attestation's intermediate certificates and submits revocations.
+    ///
+    /// Returns `Ok(true)` if any intermediate is revoked by either the
+    /// onchain sentinel or the AWS CRL layer, `Ok(false)` if every checked
+    /// intermediate is clean.
+    ///
+    /// The durable onchain pre-check preserves previously-revoked
+    /// intermediates even if AWS later prunes its CRL. AWS CRL fetches are
+    /// then performed in parallel, and every CRL hit is checked onchain
+    /// before a `revokeCert` transaction is submitted.
+    pub async fn check_and_revoke_crls<T>(
+        &self,
+        attestation_bytes: &[u8],
+        instance: &ProverInstance,
+        tx_manager: &T,
+    ) -> Result<bool>
+    where
+        T: TxManager,
+    {
+        let cert_infos = {
+            let report = AttestationReport::parse(attestation_bytes).map_err(|e| {
+                RegistrarError::ProverClient {
+                    instance: instance.endpoint.to_string(),
+                    source: format!("failed to parse attestation for CRL check: {e}").into(),
+                }
+            })?;
+            let cert_chain_der = report.cert_chain_der();
+            crl::CertCrlInfo::from_chain(&cert_chain_der)?
+        };
+
+        RegistrarMetrics::onchain_revocation_checks_total().increment(1);
+        match OnchainRevocationCheck::run(
+            self.nitro_verifier.as_ref(),
+            &cert_infos,
+            &instance.instance_id,
+        )
+        .await
+        {
+            Ok(true) => return Ok(true),
+            Ok(false) => {}
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    instance = %instance.instance_id,
+                    "onchain revocation pre-check failed; falling through to AWS CRL layer"
+                );
+                RegistrarMetrics::onchain_revocation_check_errors().increment(1);
+            }
+        }
+
+        RegistrarMetrics::crl_checks_total().increment(1);
+        let revoked_certs = crl::check_chain_against_crls(&cert_infos, &self.http_client).await;
+
+        if revoked_certs.is_empty() {
+            debug!(instance = %instance.instance_id, "CRL check passed, all certs clean");
+            return Ok(false);
+        }
+
+        RegistrarMetrics::crl_revocations_detected().increment(revoked_certs.len() as u64);
+        self.submit_revocations_for_revoked_certs(&revoked_certs, instance, tx_manager).await;
+
+        Ok(true)
+    }
+
+    /// Checks each CRL-hit against the onchain sentinel and submits needed revocations.
+    pub async fn submit_revocations_for_revoked_certs<T>(
+        &self,
+        revoked_certs: &[crl::RevokedCertInfo],
+        instance: &ProverInstance,
+        tx_manager: &T,
+    ) where
+        T: TxManager,
+    {
+        let verifier_address = self.nitro_verifier.address();
+        let cert_revoker = CertRevoker::new(verifier_address, tx_manager);
+
+        for revoked in revoked_certs {
+            match self.nitro_verifier.is_revoked(revoked.path_digest).await {
+                Ok(true) => {
+                    warn!(
+                        cert = %revoked.label,
+                        path_digest = %revoked.path_digest,
+                        instance = %instance.instance_id,
+                        "certificate already revoked onchain, skipping revokeCert"
+                    );
+                    RegistrarMetrics::onchain_revocations_detected().increment(1);
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        cert = %revoked.label,
+                        path_digest = %revoked.path_digest,
+                        instance = %instance.instance_id,
+                        "onchain revocation check failed for CRL hit; submitting revokeCert"
+                    );
+                    RegistrarMetrics::onchain_revocation_check_errors().increment(1);
+                }
+            }
+
+            warn!(
+                cert = %revoked.label,
+                path_digest = %revoked.path_digest,
+                instance = %instance.instance_id,
+                "submitting revokeCert transaction"
+            );
+            cert_revoker.revoke_cert(revoked.path_digest).await;
+        }
+    }
+}
+
+/// Onchain durable revocation check.
+///
+/// Consults the `revokedCerts` mapping for every intermediate in a pre-parsed
+/// Nitro cert chain. Root and leaf certificates are skipped.
+#[derive(Debug)]
+pub struct OnchainRevocationCheck;
+
+impl OnchainRevocationCheck {
+    /// Returns `Ok(true)` as soon as any intermediate's accumulated path
+    /// digest is found revoked onchain, `Ok(false)` if every intermediate
+    /// is clean.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying RPC error verbatim; the caller decides whether
+    /// to fail-open or propagate.
+    pub async fn run(
+        verifier: &dyn NitroVerifierClient,
+        cert_infos: &[crl::CertCrlInfo],
+        instance_id: &str,
+    ) -> Result<bool> {
+        for info in crl::CertCrlInfo::intermediates(cert_infos) {
+            if verifier.is_revoked(info.path_digest).await? {
+                warn!(
+                    cert = %info.label,
+                    path_digest = %info.path_digest,
+                    instance = %instance_id,
+                    "intermediate is revoked onchain (durable sentinel set), skipping registration"
+                );
+                RegistrarMetrics::onchain_revocations_detected().increment(1);
+                return Ok(true);
+            }
+        }
+
+        debug!(instance = %instance_id, "onchain revocation pre-check passed");
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            Mutex,
+            atomic::{AtomicU32, Ordering},
+        },
+    };
+
+    use alloy_primitives::{Address, FixedBytes};
+    use async_trait::async_trait;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::test_utils::{CertFixtures, INTER1_HEX, INTER2_HEX, LEAF_HEX, ROOT_HEX};
+
+    const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
+    const TEST_VERIFIER_ADDRESS: Address = Address::repeat_byte(0xAB);
+    const ROOT_INDEX: usize = 0;
+    const INTER1_INDEX: usize = 1;
+    const INTER2_INDEX: usize = 2;
+    const LEAF_INDEX: usize = 3;
+
+    /// Mock [`NitroVerifierClient`] for unit-testing the onchain pre-check.
+    #[derive(Debug, Default)]
+    struct MockNitroVerifier {
+        revoked: HashSet<FixedBytes<32>>,
+        error: Mutex<Option<RegistrarError>>,
+        call_count: AtomicU32,
+    }
+
+    impl MockNitroVerifier {
+        fn revoking(hashes: impl IntoIterator<Item = FixedBytes<32>>) -> Self {
+            Self {
+                revoked: hashes.into_iter().collect(),
+                error: Mutex::new(None),
+                call_count: AtomicU32::new(0),
+            }
+        }
+
+        fn failing(error: RegistrarError) -> Self {
+            Self {
+                revoked: HashSet::new(),
+                error: Mutex::new(Some(error)),
+                call_count: AtomicU32::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl crate::NitroVerifierClient for MockNitroVerifier {
+        fn address(&self) -> Address {
+            TEST_VERIFIER_ADDRESS
+        }
+
+        async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            if let Some(err) = self.error.lock().unwrap().take() {
+                return Err(err);
+            }
+            Ok(self.revoked.contains(&cert_hash))
+        }
+    }
+
+    fn full_chain_der() -> Vec<Vec<u8>> {
+        CertFixtures::decode_chain(&[ROOT_HEX, INTER1_HEX, INTER2_HEX, LEAF_HEX])
+    }
+
+    fn chain_subset(indices: &[usize]) -> Vec<Vec<u8>> {
+        let full = full_chain_der();
+        indices.iter().map(|&i| full[i].clone()).collect()
+    }
+
+    fn path_digest_for(index: usize) -> FixedBytes<32> {
+        let der = full_chain_der();
+        let refs: Vec<&[u8]> = der.iter().map(Vec::as_slice).collect();
+        crl::CertCrlInfo::from_chain(&refs)
+            .expect("static fixtures parse")
+            .remove(index)
+            .path_digest
+    }
+
+    fn full_chain_cert_infos() -> Vec<crl::CertCrlInfo> {
+        let der = full_chain_der();
+        let refs: Vec<&[u8]> = der.iter().map(Vec::as_slice).collect();
+        crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse")
+    }
+
+    fn full_chain_intermediate_count() -> u32 {
+        u32::try_from(full_chain_der().len().saturating_sub(2)).unwrap()
+    }
+
+    async fn run_pre_check(verifier: &MockNitroVerifier) -> (Result<bool>, u32) {
+        let cert_infos = full_chain_cert_infos();
+        let result =
+            OnchainRevocationCheck::run(verifier, &cert_infos, ONCHAIN_TEST_INSTANCE_ID).await;
+        (result, verifier.call_count.load(Ordering::SeqCst))
+    }
+
+    #[tokio::test]
+    async fn onchain_revocation_check_returns_false_when_no_intermediates_revoked() {
+        let verifier = MockNitroVerifier::default();
+        let (result, calls) = run_pre_check(&verifier).await;
+
+        assert!(
+            !result.expect("clean chain must succeed"),
+            "no intermediates flagged as revoked; registration must proceed"
+        );
+        assert_eq!(
+            calls,
+            full_chain_intermediate_count(),
+            "every intermediate must be queried when none are revoked"
+        );
+    }
+
+    #[rstest]
+    #[case::inter1_revoked(INTER1_INDEX, 1)]
+    #[case::inter2_revoked(INTER2_INDEX, 2)]
+    #[tokio::test]
+    async fn onchain_revocation_check_blocks_when_any_intermediate_revoked(
+        #[case] revoked_index: usize,
+        #[case] expected_calls_at_short_circuit: u32,
+    ) {
+        let verifier = MockNitroVerifier::revoking([path_digest_for(revoked_index)]);
+        let (result, calls) = run_pre_check(&verifier).await;
+
+        assert!(
+            result.expect("revoked-intermediate query must succeed"),
+            "revoked intermediate must block registration",
+        );
+        assert_eq!(
+            calls, expected_calls_at_short_circuit,
+            "pre-check must short-circuit at the first revoked intermediate",
+        );
+    }
+
+    #[tokio::test]
+    async fn onchain_revocation_check_short_circuits_when_all_intermediates_revoked() {
+        let verifier = MockNitroVerifier::revoking([
+            path_digest_for(INTER1_INDEX),
+            path_digest_for(INTER2_INDEX),
+        ]);
+        let (result, calls) = run_pre_check(&verifier).await;
+
+        assert!(result.expect("query must succeed"), "any revoked intermediate must block");
+        assert_eq!(calls, 1, "first intermediate triggers short-circuit");
+    }
+
+    #[tokio::test]
+    async fn onchain_revocation_check_skips_root_and_leaf() {
+        let verifier =
+            MockNitroVerifier::revoking([path_digest_for(ROOT_INDEX), path_digest_for(LEAF_INDEX)]);
+        let (result, calls) = run_pre_check(&verifier).await;
+
+        assert!(
+            !result.expect("query must succeed"),
+            "root/leaf revocation flags must not block registration",
+        );
+        assert_eq!(
+            calls,
+            full_chain_intermediate_count(),
+            "only intermediates are queried; root and leaf are skipped",
+        );
+    }
+
+    #[tokio::test]
+    async fn onchain_revocation_check_propagates_rpc_errors() {
+        let verifier = MockNitroVerifier::failing(RegistrarError::NitroVerifierCall {
+            context: "revokedCerts(0xdeadbeef)".into(),
+            source: "boom".into(),
+        });
+        let (result, _calls) = run_pre_check(&verifier).await;
+
+        let err = result.expect_err("RPC errors must surface to the caller");
+        assert!(
+            matches!(err, RegistrarError::NitroVerifierCall { .. }),
+            "expected NitroVerifierCall, got: {err:?}"
+        );
+    }
+
+    #[rstest]
+    #[case::root_only(&[ROOT_INDEX], 0)]
+    #[case::root_and_leaf(&[ROOT_INDEX, LEAF_INDEX], 0)]
+    #[case::three_cert(&[ROOT_INDEX, INTER1_INDEX, LEAF_INDEX], 1)]
+    #[tokio::test]
+    async fn onchain_revocation_check_queries_intermediates_only(
+        #[case] indices: &[usize],
+        #[case] expected_calls: u32,
+    ) {
+        let owned = chain_subset(indices);
+        let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+        let cert_infos = crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse");
+        let verifier = MockNitroVerifier::default();
+
+        let result =
+            OnchainRevocationCheck::run(&verifier, &cert_infos, ONCHAIN_TEST_INSTANCE_ID).await;
+
+        assert!(!result.expect("query must succeed"), "clean chain not revoked");
+        assert_eq!(
+            verifier.call_count.load(Ordering::SeqCst),
+            expected_calls,
+            "only intermediates (root and leaf skipped) should produce RPC calls",
+        );
+    }
+}

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -279,7 +279,7 @@ mod tests {
 
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
         let verifier = Arc::new(verifier);
-        let cert_manager = test_cert_manager(verifier.clone());
+        let cert_manager = test_cert_manager(Arc::clone(&verifier));
         let cert_infos = full_chain_cert_infos();
         let result = cert_manager
             .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
@@ -381,7 +381,7 @@ mod tests {
         let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
         let cert_infos = crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse");
         let verifier = Arc::new(MockNitroVerifier::default());
-        let cert_manager = test_cert_manager(verifier.clone());
+        let cert_manager = test_cert_manager(Arc::clone(&verifier));
 
         let result = cert_manager
             .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -49,8 +49,8 @@ impl CertManager {
     /// intermediate is clean.
     ///
     /// The durable onchain pre-check preserves previously-revoked
-    /// intermediates even if AWS later prunes its CRL. AWS CRL fetches are
-    /// then performed in parallel, and every CRL hit is checked onchain
+    /// intermediates even if AWS later prunes its CRL. AWS CRLs are then
+    /// checked for each intermediate, and every CRL hit is checked onchain
     /// before a `revokeCert` transaction is submitted.
     pub async fn check_and_revoke_crls<T>(
         &self,

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -190,8 +190,13 @@ mod tests {
         },
     };
 
-    use alloy_primitives::{Address, FixedBytes};
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{Address, B256, Bloom, Bytes, FixedBytes};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolCall;
     use async_trait::async_trait;
+    use base_proof_contracts::INitroEnclaveVerifier;
+    use base_tx_manager::TxCandidate;
     use rstest::rstest;
 
     use super::*;
@@ -245,6 +250,39 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default, Clone)]
+    struct MockTxManager {
+        sent_candidates: Arc<Mutex<Vec<TxCandidate>>>,
+    }
+
+    impl MockTxManager {
+        fn take_candidates(&self) -> Vec<TxCandidate> {
+            std::mem::take(&mut *self.sent_candidates.lock().unwrap())
+        }
+    }
+
+    impl TxManager for MockTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent_candidates.lock().unwrap().push(candidate);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> base_tx_manager::SendHandle {
+            unreachable!("submit_revocations_for_revoked_certs only uses send")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum OnchainCheckOutcome {
+        AlreadyRevoked,
+        NotRevoked,
+        RpcError,
+    }
+
     fn full_chain_der() -> Vec<Vec<u8>> {
         CertFixtures::decode_chain(&[ROOT_HEX, INTER1_HEX, INTER2_HEX, LEAF_HEX])
     }
@@ -275,6 +313,48 @@ mod tests {
 
     fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager {
         CertManager { http_client: reqwest::Client::new(), nitro_verifier: verifier }
+    }
+
+    fn test_instance() -> ProverInstance {
+        ProverInstance {
+            instance_id: ONCHAIN_TEST_INSTANCE_ID.to_string(),
+            endpoint: "http://127.0.0.1:8000/".parse().unwrap(),
+            health_status: crate::InstanceHealthStatus::Healthy,
+            launch_time: None,
+        }
+    }
+
+    fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {
+        crl::RevokedCertInfo { label: "intermediate 1".to_string(), path_digest }
+    }
+
+    fn revoke_cert_calldata(path_digest: B256) -> Bytes {
+        Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: path_digest }.abi_encode())
+    }
+
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::success(),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
     }
 
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
@@ -393,5 +473,56 @@ mod tests {
             expected_calls,
             "only intermediates (root and leaf skipped) should produce RPC calls",
         );
+    }
+
+    #[rstest]
+    #[case::already_revoked(OnchainCheckOutcome::AlreadyRevoked, false)]
+    #[case::not_revoked(OnchainCheckOutcome::NotRevoked, true)]
+    #[case::rpc_error(OnchainCheckOutcome::RpcError, true)]
+    #[tokio::test]
+    async fn submit_revocations_checks_onchain_before_deciding_whether_to_submit(
+        #[case] onchain_check: OnchainCheckOutcome,
+        #[case] expect_revoke_cert: bool,
+    ) {
+        let path_digest = path_digest_for(INTER1_INDEX);
+        let verifier = match onchain_check {
+            OnchainCheckOutcome::AlreadyRevoked => {
+                Arc::new(MockNitroVerifier::revoking([path_digest]))
+            }
+            OnchainCheckOutcome::NotRevoked => Arc::new(MockNitroVerifier::default()),
+            OnchainCheckOutcome::RpcError => {
+                Arc::new(MockNitroVerifier::failing(RegistrarError::NitroVerifierCall {
+                    context: "revokedCerts(0xdeadbeef)".into(),
+                    source: "boom".into(),
+                }))
+            }
+        };
+        let cert_manager = test_cert_manager(Arc::clone(&verifier));
+        let tx_manager = MockTxManager::default();
+        let instance = test_instance();
+
+        cert_manager
+            .submit_revocations_for_revoked_certs(
+                &[revoked_cert(path_digest)],
+                &instance,
+                &tx_manager,
+            )
+            .await;
+
+        assert_eq!(
+            verifier.call_count.load(Ordering::SeqCst),
+            1,
+            "CRL-hit cert should be checked onchain before deciding whether to submit revokeCert",
+        );
+        let candidates = tx_manager.take_candidates();
+        assert_eq!(
+            candidates.len(),
+            usize::from(expect_revoke_cert),
+            "revokeCert submission expectation did not match onchain check outcome",
+        );
+        if expect_revoke_cert {
+            assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
+            assert_eq!(candidates[0].tx_data, revoke_cert_calldata(path_digest));
+        }
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -39,15 +39,7 @@ impl CertManager {
                 "failed to build CRL HTTP client (Layer 2 / AWS CRL fetch): {e}"
             ))
         })?;
-        Ok(Self::from_parts(http_client, nitro_verifier))
-    }
-
-    /// Creates a certificate manager from pre-built dependencies.
-    pub fn from_parts(
-        http_client: reqwest::Client,
-        nitro_verifier: Arc<dyn NitroVerifierClient>,
-    ) -> Self {
-        Self { http_client, nitro_verifier }
+        Ok(Self { http_client, nitro_verifier })
     }
 
     /// Checks an attestation's intermediate certificates and submits revocations.
@@ -81,13 +73,7 @@ impl CertManager {
         };
 
         RegistrarMetrics::onchain_revocation_checks_total().increment(1);
-        match OnchainRevocationCheck::run(
-            self.nitro_verifier.as_ref(),
-            &cert_infos,
-            &instance.instance_id,
-        )
-        .await
-        {
+        match self.has_onchain_revoked_intermediate(&cert_infos, &instance.instance_id).await {
             Ok(true) => return Ok(true),
             Ok(false) => {}
             Err(e) => {
@@ -112,6 +98,38 @@ impl CertManager {
         self.submit_revocations_for_revoked_certs(&revoked_certs, instance, tx_manager).await;
 
         Ok(true)
+    }
+
+    /// Checks whether any intermediate certificate has already been revoked onchain.
+    ///
+    /// Root and leaf certificates are skipped because only intermediate
+    /// accumulated path digests participate in the durable `revokedCerts`
+    /// sentinel used by registrar CRL handling.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying RPC error verbatim; the caller decides whether
+    /// to fail-open or propagate.
+    pub async fn has_onchain_revoked_intermediate(
+        &self,
+        cert_infos: &[crl::CertCrlInfo],
+        instance_id: &str,
+    ) -> Result<bool> {
+        for info in crl::CertCrlInfo::intermediates(cert_infos) {
+            if self.nitro_verifier.is_revoked(info.path_digest).await? {
+                warn!(
+                    cert = %info.label,
+                    path_digest = %info.path_digest,
+                    instance = %instance_id,
+                    "intermediate is revoked onchain (durable sentinel set), skipping registration"
+                );
+                RegistrarMetrics::onchain_revocations_detected().increment(1);
+                return Ok(true);
+            }
+        }
+
+        debug!(instance = %instance_id, "onchain revocation pre-check passed");
+        Ok(false)
     }
 
     /// Checks each CRL-hit against the onchain sentinel and submits needed revocations.
@@ -159,45 +177,6 @@ impl CertManager {
             );
             cert_revoker.revoke_cert(revoked.path_digest).await;
         }
-    }
-}
-
-/// Onchain durable revocation check.
-///
-/// Consults the `revokedCerts` mapping for every intermediate in a pre-parsed
-/// Nitro cert chain. Root and leaf certificates are skipped.
-#[derive(Debug)]
-pub struct OnchainRevocationCheck;
-
-impl OnchainRevocationCheck {
-    /// Returns `Ok(true)` as soon as any intermediate's accumulated path
-    /// digest is found revoked onchain, `Ok(false)` if every intermediate
-    /// is clean.
-    ///
-    /// # Errors
-    ///
-    /// Returns the underlying RPC error verbatim; the caller decides whether
-    /// to fail-open or propagate.
-    pub async fn run(
-        verifier: &dyn NitroVerifierClient,
-        cert_infos: &[crl::CertCrlInfo],
-        instance_id: &str,
-    ) -> Result<bool> {
-        for info in crl::CertCrlInfo::intermediates(cert_infos) {
-            if verifier.is_revoked(info.path_digest).await? {
-                warn!(
-                    cert = %info.label,
-                    path_digest = %info.path_digest,
-                    instance = %instance_id,
-                    "intermediate is revoked onchain (durable sentinel set), skipping registration"
-                );
-                RegistrarMetrics::onchain_revocations_detected().increment(1);
-                return Ok(true);
-            }
-        }
-
-        debug!(instance = %instance_id, "onchain revocation pre-check passed");
-        Ok(false)
     }
 }
 
@@ -294,17 +273,24 @@ mod tests {
         u32::try_from(full_chain_der().len().saturating_sub(2)).unwrap()
     }
 
-    async fn run_pre_check(verifier: &MockNitroVerifier) -> (Result<bool>, u32) {
+    fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager {
+        CertManager { http_client: reqwest::Client::new(), nitro_verifier: verifier }
+    }
+
+    async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
+        let verifier = Arc::new(verifier);
+        let cert_manager = test_cert_manager(verifier.clone());
         let cert_infos = full_chain_cert_infos();
-        let result =
-            OnchainRevocationCheck::run(verifier, &cert_infos, ONCHAIN_TEST_INSTANCE_ID).await;
+        let result = cert_manager
+            .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
+            .await;
         (result, verifier.call_count.load(Ordering::SeqCst))
     }
 
     #[tokio::test]
     async fn onchain_revocation_check_returns_false_when_no_intermediates_revoked() {
         let verifier = MockNitroVerifier::default();
-        let (result, calls) = run_pre_check(&verifier).await;
+        let (result, calls) = run_pre_check(verifier).await;
 
         assert!(
             !result.expect("clean chain must succeed"),
@@ -326,7 +312,7 @@ mod tests {
         #[case] expected_calls_at_short_circuit: u32,
     ) {
         let verifier = MockNitroVerifier::revoking([path_digest_for(revoked_index)]);
-        let (result, calls) = run_pre_check(&verifier).await;
+        let (result, calls) = run_pre_check(verifier).await;
 
         assert!(
             result.expect("revoked-intermediate query must succeed"),
@@ -344,7 +330,7 @@ mod tests {
             path_digest_for(INTER1_INDEX),
             path_digest_for(INTER2_INDEX),
         ]);
-        let (result, calls) = run_pre_check(&verifier).await;
+        let (result, calls) = run_pre_check(verifier).await;
 
         assert!(result.expect("query must succeed"), "any revoked intermediate must block");
         assert_eq!(calls, 1, "first intermediate triggers short-circuit");
@@ -354,7 +340,7 @@ mod tests {
     async fn onchain_revocation_check_skips_root_and_leaf() {
         let verifier =
             MockNitroVerifier::revoking([path_digest_for(ROOT_INDEX), path_digest_for(LEAF_INDEX)]);
-        let (result, calls) = run_pre_check(&verifier).await;
+        let (result, calls) = run_pre_check(verifier).await;
 
         assert!(
             !result.expect("query must succeed"),
@@ -373,7 +359,7 @@ mod tests {
             context: "revokedCerts(0xdeadbeef)".into(),
             source: "boom".into(),
         });
-        let (result, _calls) = run_pre_check(&verifier).await;
+        let (result, _calls) = run_pre_check(verifier).await;
 
         let err = result.expect_err("RPC errors must surface to the caller");
         assert!(
@@ -394,10 +380,12 @@ mod tests {
         let owned = chain_subset(indices);
         let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
         let cert_infos = crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse");
-        let verifier = MockNitroVerifier::default();
+        let verifier = Arc::new(MockNitroVerifier::default());
+        let cert_manager = test_cert_manager(verifier.clone());
 
-        let result =
-            OnchainRevocationCheck::run(&verifier, &cert_infos, ONCHAIN_TEST_INSTANCE_ID).await;
+        let result = cert_manager
+            .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
+            .await;
 
         assert!(!result.expect("query must succeed"), "clean chain not revoked");
         assert_eq!(

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_MAX_RECOVERY_ATTEMPTS: u32 = 5;
 /// Default maximum age (in seconds) of a recovered proof's attestation
 /// timestamp before it is considered stale and skipped.
 ///
-/// Set to 3300 s (55 minutes), slightly under the on-chain `MAX_AGE` of
+/// Set to 3300 s (55 minutes), slightly under the onchain `MAX_AGE` of
 /// 60 minutes, to account for clock skew and processing delays.
 pub const DEFAULT_MAX_ATTESTATION_AGE_SECS: u64 = 3300;
 
@@ -53,7 +53,7 @@ pub struct BoundlessConfig {
     pub max_recovery_attempts: u32,
     /// Maximum age of a recovered proof's attestation timestamp before it
     /// is considered stale and skipped. Should be set slightly below the
-    /// on-chain `MAX_AGE` to account for clock skew.
+    /// onchain `MAX_AGE` to account for clock skew.
     pub max_attestation_age: Duration,
     /// Optional minimum Boundless offer price for each submitted proof request.
     pub offer_min_price: Option<Amount>,
@@ -123,7 +123,7 @@ pub struct CrlConfig {
     /// `revokeCert` transactions are attempted. Defaults to `false`.
     pub enabled: bool,
     /// `NitroEnclaveVerifier` contract address on L1. Required when
-    /// `enabled` is `true`; consulted both for the durable on-chain
+    /// `enabled` is `true`; consulted both for the durable onchain
     /// `revokedCerts` pre-check and as the destination for outgoing
     /// `revokeCert` transactions.
     pub nitro_verifier_address: Option<Address>,

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -19,7 +19,6 @@ use std::time::Duration;
 
 use alloy_primitives::B256;
 use base_proof_tee_nitro_verifier::compute_path_digests;
-use futures::stream::{self, StreamExt};
 use tracing::{debug, warn};
 use x509_parser::{
     certificate::X509Certificate,
@@ -198,58 +197,40 @@ pub async fn check_chain_against_crls(
 ) -> Vec<RevokedCertInfo> {
     let mut revoked = Vec::new();
 
-    let intermediates: Vec<_> = CertCrlInfo::intermediates(cert_infos).cloned().collect();
-    if intermediates.is_empty() {
-        return revoked;
-    }
+    for info in CertCrlInfo::intermediates(cert_infos) {
+        let Some(ref crl_url) = info.crl_url else {
+            debug!(cert = %info.label, "no CRL distribution point, skipping");
+            continue;
+        };
 
-    // Nitro attestation chains have a small number of intermediates, so fan
-    // out one CRL fetch per intermediate instead of adding another limiter.
-    let concurrency = intermediates.len();
-    let mut checks = stream::iter(intermediates)
-        .map(|info| async move {
-            let Some(ref crl_url) = info.crl_url else {
-                debug!(cert = %info.label, "no CRL distribution point, skipping");
-                return None;
-            };
+        debug!(cert = %info.label, url = %crl_url, "fetching CRL");
 
-            debug!(cert = %info.label, url = %crl_url, "fetching CRL");
-
-            match fetch_and_check_crl(http_client, crl_url, &info.serial_number).await {
-                Ok(true) => {
-                    warn!(
-                        cert = %info.label,
-                        url = %crl_url,
-                        serial = %hex::encode(&info.serial_number),
-                        path_digest = %info.path_digest,
-                        "certificate found on CRL — REVOKED"
-                    );
-                    Some(RevokedCertInfo {
-                        label: info.label.clone(),
-                        path_digest: info.path_digest,
-                    })
-                }
-                Ok(false) => {
-                    debug!(cert = %info.label, "certificate not on CRL");
-                    None
-                }
-                Err(e) => {
-                    // Fail-open: log warning but continue.
-                    warn!(
-                        cert = %info.label,
-                        url = %crl_url,
-                        error = %e,
-                        "CRL check failed (fail-open, proceeding)"
-                    );
-                    None
-                }
+        match fetch_and_check_crl(http_client, crl_url, &info.serial_number).await {
+            Ok(true) => {
+                warn!(
+                    cert = %info.label,
+                    url = %crl_url,
+                    serial = %hex::encode(&info.serial_number),
+                    path_digest = %info.path_digest,
+                    "certificate found on CRL — REVOKED"
+                );
+                revoked.push(RevokedCertInfo {
+                    label: info.label.clone(),
+                    path_digest: info.path_digest,
+                });
             }
-        })
-        .buffer_unordered(concurrency);
-
-    while let Some(result) = checks.next().await {
-        if let Some(revoked_cert) = result {
-            revoked.push(revoked_cert);
+            Ok(false) => {
+                debug!(cert = %info.label, "certificate not on CRL");
+            }
+            Err(e) => {
+                // Fail-open: log warning but continue.
+                warn!(
+                    cert = %info.label,
+                    url = %crl_url,
+                    error = %e,
+                    "CRL check failed (fail-open, proceeding)"
+                );
+            }
         }
     }
 

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -6,19 +6,20 @@
 //! certificate has been revoked.
 //!
 //! The check is **fail-open**: if a CRL cannot be fetched or parsed, the
-//! registration proceeds with a warning. The on-chain expiry tracking
+//! registration proceeds with a warning. The onchain expiry tracking
 //! (Step 2) provides a backstop for expired certs.
 //!
 //! **TOCTOU note**: there is an inherent race between the CRL check and the
-//! on-chain registration transaction. A certificate could be added to the
+//! onchain registration transaction. A certificate could be added to the
 //! CRL after the check passes but before the registration lands. This is
-//! acceptable because the on-chain expiry backstop and periodic re-checks
+//! acceptable because the onchain expiry backstop and periodic re-checks
 //! bound the exposure window.
 
 use std::time::Duration;
 
 use alloy_primitives::B256;
 use base_proof_tee_nitro_verifier::compute_path_digests;
+use futures::stream::{self, StreamExt};
 use tracing::{debug, warn};
 use x509_parser::{
     certificate::X509Certificate,
@@ -62,7 +63,7 @@ pub struct CertCrlInfo {
     pub serial_number: Vec<u8>,
     /// CRL distribution point URL, if present in the certificate.
     pub crl_url: Option<String>,
-    /// Accumulated path digest for this certificate position (for on-chain
+    /// Accumulated path digest for this certificate position (for onchain
     /// `revokeCert` calls).
     pub path_digest: B256,
 }
@@ -72,7 +73,7 @@ impl CertCrlInfo {
     /// DER-encoded chain.
     ///
     /// The certificates must be in chain order: root → intermediates → leaf.
-    /// Path digests are computed identically to the on-chain
+    /// Path digests are computed identically to the onchain
     /// `NitroEnclaveVerifier` accumulation.
     ///
     /// # Errors
@@ -117,7 +118,7 @@ impl CertCrlInfo {
     /// skipping the root (index 0) and the leaf (last index).
     ///
     /// Roots manage their own trust and leaves are short-lived
-    /// (~3 hours), so neither participates in the on-chain
+    /// (~3 hours), so neither participates in the onchain
     /// `_cacheNewCert` rewrite that the durable revocation sentinel
     /// guards against; the AWS CRL layer applies the same scope.
     /// Chains shorter than three certificates yield an empty iterator.
@@ -131,7 +132,7 @@ impl CertCrlInfo {
 pub struct RevokedCertInfo {
     /// Label of the revoked certificate (e.g. "intermediate 1").
     pub label: String,
-    /// Path digest for on-chain `revokeCert()`.
+    /// Path digest for onchain `revokeCert()`.
     pub path_digest: B256,
 }
 
@@ -188,7 +189,7 @@ fn is_allowed_crl_host(url: &str) -> bool {
 /// # Arguments
 ///
 /// * `cert_infos` - Pre-parsed cert chain info, typically produced once per
-///   cycle by [`CertCrlInfo::from_chain`] and shared with the on-chain
+///   cycle by [`CertCrlInfo::from_chain`] and shared with the onchain
 ///   revocation pre-check so the DER parse only happens once.
 /// * `http_client` - HTTP client for fetching CRLs
 pub async fn check_chain_against_crls(
@@ -197,40 +198,52 @@ pub async fn check_chain_against_crls(
 ) -> Vec<RevokedCertInfo> {
     let mut revoked = Vec::new();
 
-    for info in CertCrlInfo::intermediates(cert_infos) {
-        let Some(ref crl_url) = info.crl_url else {
-            debug!(cert = %info.label, "no CRL distribution point, skipping");
-            continue;
-        };
+    let intermediates: Vec<_> = CertCrlInfo::intermediates(cert_infos).cloned().collect();
+    let concurrency = intermediates.len().max(1);
+    let mut checks = stream::iter(intermediates)
+        .map(|info| async move {
+            let Some(ref crl_url) = info.crl_url else {
+                debug!(cert = %info.label, "no CRL distribution point, skipping");
+                return None;
+            };
 
-        debug!(cert = %info.label, url = %crl_url, "fetching CRL");
+            debug!(cert = %info.label, url = %crl_url, "fetching CRL");
 
-        match fetch_and_check_crl(http_client, crl_url, &info.serial_number).await {
-            Ok(true) => {
-                warn!(
-                    cert = %info.label,
-                    url = %crl_url,
-                    serial = %hex::encode(&info.serial_number),
-                    path_digest = %info.path_digest,
-                    "certificate found on CRL — REVOKED"
-                );
-                revoked.push(RevokedCertInfo {
-                    label: info.label.clone(),
-                    path_digest: info.path_digest,
-                });
+            match fetch_and_check_crl(http_client, crl_url, &info.serial_number).await {
+                Ok(true) => {
+                    warn!(
+                        cert = %info.label,
+                        url = %crl_url,
+                        serial = %hex::encode(&info.serial_number),
+                        path_digest = %info.path_digest,
+                        "certificate found on CRL — REVOKED"
+                    );
+                    Some(RevokedCertInfo {
+                        label: info.label.clone(),
+                        path_digest: info.path_digest,
+                    })
+                }
+                Ok(false) => {
+                    debug!(cert = %info.label, "certificate not on CRL");
+                    None
+                }
+                Err(e) => {
+                    // Fail-open: log warning but continue.
+                    warn!(
+                        cert = %info.label,
+                        url = %crl_url,
+                        error = %e,
+                        "CRL check failed (fail-open, proceeding)"
+                    );
+                    None
+                }
             }
-            Ok(false) => {
-                debug!(cert = %info.label, "certificate not on CRL");
-            }
-            Err(e) => {
-                // Fail-open: log warning but continue.
-                warn!(
-                    cert = %info.label,
-                    url = %crl_url,
-                    error = %e,
-                    "CRL check failed (fail-open, proceeding)"
-                );
-            }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some(result) = checks.next().await {
+        if let Some(revoked_cert) = result {
+            revoked.push(revoked_cert);
         }
     }
 

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -199,7 +199,13 @@ pub async fn check_chain_against_crls(
     let mut revoked = Vec::new();
 
     let intermediates: Vec<_> = CertCrlInfo::intermediates(cert_infos).cloned().collect();
-    let concurrency = intermediates.len().max(1);
+    if intermediates.is_empty() {
+        return revoked;
+    }
+
+    // Nitro attestation chains have a small number of intermediates, so fan
+    // out one CRL fetch per intermediate instead of adding another limiter.
+    let concurrency = intermediates.len();
     let mut checks = stream::iter(intermediates)
         .map(|info| async move {
             let Some(ref crl_url) = info.crl_url else {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1,8 +1,8 @@
 //! Registration driver — core orchestration loop.
 //!
-//! Discovers prover instances, checks on-chain registration status, generates
+//! Discovers prover instances, checks onchain registration status, generates
 //! ZK proofs for unregistered signers, and submits registration transactions
-//! to L1 via the [`TxManager`]. Also detects orphaned on-chain signers (those
+//! to L1 via the [`TxManager`]. Also detects orphaned onchain signers (those
 //! no longer backed by a healthy instance) and deregisters them.
 
 use std::{
@@ -16,7 +16,6 @@ use alloy_primitives::{Address, Bytes, hex};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::ITEEProverRegistry;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
-use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 use futures::stream::StreamExt;
 use rand::random;
@@ -28,9 +27,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CertRevoker, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
+    CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
     ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result,
-    SignerClient, crl,
+    SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -225,7 +224,7 @@ pub struct ResolveOutcome {
 }
 
 /// Core registration loop tying together discovery, attestation polling,
-/// ZK proof generation, and on-chain submission.
+/// ZK proof generation, and onchain submission.
 ///
 /// Generic over the discovery, proof generation, registry, transaction
 /// manager, and signer client backends so each can be mocked independently
@@ -237,14 +236,9 @@ pub struct RegistrationDriver<D, P, R, T, S> {
     tx_manager: T,
     signer_client: S,
     config: DriverConfig,
-    /// Pre-built HTTP client for CRL fetches. Built once at construction
-    /// time when CRL checking is enabled. `None` when CRL is disabled.
-    crl_http_client: Option<reqwest::Client>,
-    /// Optional on-chain `NitroEnclaveVerifier` revocation client. Consulted
-    /// before submitting a registration so that intermediates already revoked
-    /// on-chain (`revokedCerts` sentinel set) cannot be re-trusted via the
-    /// `_cacheNewCert` rewrite path.
-    nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
+    /// Optional certificate revocation manager. Built once at construction
+    /// time when CRL checking is enabled. `None` when CRL checking is disabled.
+    cert_manager: Option<CertManager>,
     /// Bounds the number of proof-generation calls that may be in-flight
     /// across the spawned task pool at once. Sized from
     /// [`DriverConfig::max_concurrency`], matching the discovery/resolve
@@ -327,16 +321,16 @@ where
     ///
     /// When CRL checking is enabled, pre-builds the HTTP client used for
     /// CRL fetches so it can be reused across registration cycles. The
-    /// optional `nitro_verifier` client consults the on-chain durable
+    /// optional `nitro_verifier` client consults the onchain durable
     /// revocation sentinel before each registration; pass `None` to disable
-    /// the on-chain pre-check (useful for tests and unit deployments).
+    /// the onchain pre-check (useful for tests and unit deployments).
     ///
     /// # Errors
     ///
     /// Returns [`RegistrarError::Config`] when `config.crl.enabled` is `true`
-    /// and either the `nitro_verifier` client is missing or the CRL HTTP
-    /// client fails to build. Failing fast prevents a misconfigured driver
-    /// from silently bypassing CRL protection at runtime.
+    /// and either the `nitro_verifier` client is missing or the
+    /// [`CertManager`] fails to initialize. Failing fast prevents a
+    /// misconfigured driver from silently bypassing CRL protection at runtime.
     pub fn new(
         discovery: D,
         proof_provider: P,
@@ -346,20 +340,16 @@ where
         config: DriverConfig,
         nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
     ) -> Result<Self> {
-        if config.crl.enabled && nitro_verifier.is_none() {
-            return Err(RegistrarError::Config(
-                "CRL checking enabled but nitro_verifier client not configured; \
-                 a NitroEnclaveVerifier client is required as both the revokeCert \
-                 destination and the on-chain revokedCerts sentinel source"
-                    .into(),
-            ));
-        }
-        let crl_http_client = if config.crl.enabled {
-            Some(crl::build_crl_http_client(config.crl.fetch_timeout).map_err(|e| {
-                RegistrarError::Config(format!(
-                    "failed to build CRL HTTP client (Layer 2 / AWS CRL fetch): {e}"
-                ))
-            })?)
+        let cert_manager = if config.crl.enabled {
+            let Some(nitro_verifier) = nitro_verifier else {
+                return Err(RegistrarError::Config(
+                    "CRL checking enabled but nitro_verifier client not configured; \
+                     a NitroEnclaveVerifier client is required as both the revokeCert \
+                     destination and the onchain revokedCerts sentinel source"
+                        .into(),
+                ));
+            };
+            Some(CertManager::new(&config.crl, nitro_verifier)?)
         } else {
             None
         };
@@ -371,8 +361,7 @@ where
             tx_manager,
             signer_client,
             config,
-            crl_http_client,
-            nitro_verifier,
+            cert_manager,
             proof_semaphore,
             in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
             signer_history: Arc::new(Mutex::new(HashMap::new())),
@@ -628,11 +617,16 @@ where
         // runs once per instance (all enclaves share the same cert chain).
         //
         // NOTE: This check runs even when all signers are already registered
-        // on-chain. This is a known inefficiency — the CRL check could be
+        // onchain. This is a known inefficiency — the CRL check could be
         // skipped in that case, but would add complexity for minimal benefit
         // since CRL fetches are fast relative to proof generation.
         if self.config.crl.enabled {
-            match self.check_and_revoke_crls(&all_attestations[0], instance).await {
+            let cert_manager =
+                self.cert_manager.as_ref().expect("cert_manager required when CRL enabled");
+            match cert_manager
+                .check_and_revoke_crls(&all_attestations[0], instance, &self.tx_manager)
+                .await
+            {
                 Ok(true) => {
                     // Confirmed revocation — block registration for this instance.
                     warn!(
@@ -684,16 +678,16 @@ where
         Ok(addresses)
     }
 
-    /// Attempts to register a signer on-chain if not already registered.
+    /// Attempts to register a signer onchain if not already registered.
     ///
-    /// This is the expensive path: checks on-chain status, generates a ZK
+    /// This is the expensive path: checks onchain status, generates a ZK
     /// proof from the pre-fetched attestation, and submits a registration
     /// transaction.
     ///
     /// Registration is PCR0-agnostic: all legitimate enclaves are registered
     /// regardless of their PCR0 measurement. This enables pre-registration of
     /// new-PCR0 enclaves before a hardfork, eliminating the proof-generation
-    /// delay when the on-chain `TEE_IMAGE_HASH` rotates. The on-chain
+    /// delay when the onchain `TEE_IMAGE_HASH` rotates. The onchain
     /// `TEEVerifier` gates proof acceptance on `TEE_IMAGE_HASH` at submission
     /// time, so pre-registered enclaves cannot produce accepted proposals
     /// until the hardfork activates.
@@ -730,7 +724,7 @@ where
         // catching any caller path that bypasses the spawn loop.
         //
         // The guard is held across the entire registration (including
-        // the ~20 minute Boundless proof generation and the on-chain
+        // the ~20 minute Boundless proof generation and the onchain
         // confirmation wait) and is released via RAII on every exit
         // path: success, error, retry-exhaustion, cancellation drop,
         // and panic.
@@ -752,7 +746,7 @@ where
         };
 
         // Cancel-aware: `is_registered` is a side-effect-free read, so
-        // dropping it on cancel is safe (no nonce risk, no on-chain
+        // dropping it on cancel is safe (no nonce risk, no onchain
         // state mutation). Without this select, a shutdown during the
         // registry RPC would extend drain latency by an entire
         // round-trip per pending task.
@@ -834,7 +828,7 @@ where
         // abandon work the impl had already started (see provider docs);
         // for `DirectProver` this leaks a `spawn_blocking` until the
         // backend completes, and for `BoundlessProver` any already-submitted
-        // off-chain request is recoverable via the deterministic
+        // offchain request is recoverable via the deterministic
         // request-id derivation on the next call.
         //
         // Race window: the biased `select!` polls the cancel branch first,
@@ -880,7 +874,7 @@ where
         };
 
         // Check cancellation before submitting the transaction — avoid starting
-        // new on-chain work if shutdown is in progress.
+        // new onchain work if shutdown is in progress.
         if signer_cancel.is_cancelled() {
             debug!("shutdown requested, skipping transaction submission");
             return Ok(());
@@ -928,7 +922,7 @@ where
 
         let receipt = loop {
             // Check cancellation at the top of each iteration to avoid
-            // starting new on-chain work after shutdown is requested.
+            // starting new onchain work after shutdown is requested.
             //
             // IMPORTANT: we never wrap `tx_manager.send()` itself in a
             // `select!` against `signer_cancel` — dropping `send()` after
@@ -944,7 +938,7 @@ where
                 Err(e) => {
                     // The signer may already be registered despite the error
                     // (e.g. the tx was mined but the tx manager reported a
-                    // nonce race during fee bumping). Check on-chain state.
+                    // nonce race during fee bumping). Check onchain state.
                     //
                     // Cancel-aware: side-effect-free read; safe to drop on
                     // cancel. The surrounding retry loop's top-of-iter
@@ -968,7 +962,7 @@ where
                             info!(
                                 signer = %signer_address,
                                 error = %e,
-                                "tx error but signer is registered on-chain, treating as success"
+                                "tx error but signer is registered onchain, treating as success"
                             );
                             RegistrarMetrics::registrations_total().increment(1);
                             return Ok(());
@@ -1188,7 +1182,12 @@ where
                     instance: instance.endpoint.to_string(),
                     source: "no attestations available for CRL check".into(),
                 })?;
-            match self.check_and_revoke_crls(first_attestation, instance).await {
+            let cert_manager =
+                self.cert_manager.as_ref().expect("cert_manager required when CRL enabled");
+            match cert_manager
+                .check_and_revoke_crls(first_attestation, instance, &self.tx_manager)
+                .await
+            {
                 Ok(true) => {
                     warn!(
                         instance = %instance.instance_id,
@@ -1362,7 +1361,7 @@ where
 
     /// Drives the orphan-deregistration pass.
     ///
-    /// Loads on-chain signers, computes the orphan set
+    /// Loads onchain signers, computes the orphan set
     /// (`registered \ active`), and deregisters each in sequence with a
     /// ghost-entry guard. Mirrors the trailing half of the legacy
     /// synchronous `step` helper — extracted so the [`Self::run`] pipeline
@@ -1738,93 +1737,6 @@ where
         RegistrarMetrics::proof_tasks_pending().set(0.0);
     }
 
-    /// Checks the attestation's intermediate certificates against two
-    /// revocation sources and submits `revokeCert` transactions for any
-    /// newly-revoked certificates. Returns `Ok(true)` if any intermediate
-    /// is revoked at either layer, `Ok(false)` if all are clean.
-    ///
-    /// 1. **On-chain pre-check** (CHAIN-4194 / Immunefi #75608): each
-    ///    intermediate's path digest is queried via
-    ///    [`NitroVerifierClient::is_revoked`]. The contract's
-    ///    `revokedCerts` sentinel is persistent across `_cacheNewCert`
-    ///    overwrites, so an operator-revoked hash keeps failing
-    ///    registration even after the AWS CRL is pruned. A hit
-    ///    short-circuits the AWS fetch; no `revokeCert` tx is needed.
-    /// 2. **AWS CRL check**: any intermediate matched against its CRL
-    ///    distribution point triggers a `revokeCert` tx to the
-    ///    `NitroEnclaveVerifier`.
-    ///
-    /// Layer 1 fails open: RPC/decode errors (e.g. against a verifier
-    /// contract predating the `revokedCerts` selector) are logged and
-    /// the call falls through to Layer 2, never silently disabling AWS
-    /// CRL enforcement.
-    async fn check_and_revoke_crls(
-        &self,
-        attestation_bytes: &[u8],
-        instance: &ProverInstance,
-    ) -> Result<bool> {
-        // Invariants enforced by `RegistrationDriver::new` when `crl.enabled`.
-        let verifier =
-            self.nitro_verifier.as_deref().expect("nitro_verifier required when CRL enabled");
-        let verifier_address = verifier.address();
-
-        // Parse the attestation document to get the cert chain.
-        let report = AttestationReport::parse(attestation_bytes).map_err(|e| {
-            RegistrarError::ProverClient {
-                instance: instance.endpoint.to_string(),
-                source: format!("failed to parse attestation for CRL check: {e}").into(),
-            }
-        })?;
-
-        let cert_chain_der = report.cert_chain_der();
-        // Parse the chain once and share the result across both layers.
-        let cert_infos = crl::CertCrlInfo::from_chain(&cert_chain_der)?;
-
-        // ── Layer 1: on-chain durable revocation sentinel ───────────────
-        RegistrarMetrics::onchain_revocation_checks_total().increment(1);
-        match OnchainRevocationCheck::run(verifier, &cert_infos, &instance.instance_id).await {
-            Ok(true) => return Ok(true),
-            Ok(false) => {}
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    instance = %instance.instance_id,
-                    "on-chain revocation pre-check failed; falling through to AWS CRL layer"
-                );
-                RegistrarMetrics::onchain_revocation_check_errors().increment(1);
-            }
-        }
-
-        // ── Layer 2: AWS CRL distribution point check ───────────────────
-        let http_client =
-            self.crl_http_client.as_ref().expect("crl_http_client required when CRL enabled");
-
-        RegistrarMetrics::crl_checks_total().increment(1);
-
-        let revoked_certs = crl::check_chain_against_crls(&cert_infos, http_client).await;
-
-        if revoked_certs.is_empty() {
-            debug!(instance = %instance.instance_id, "CRL check passed, all certs clean");
-            return Ok(false);
-        }
-
-        RegistrarMetrics::crl_revocations_detected().increment(revoked_certs.len() as u64);
-
-        let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
-        for revoked in &revoked_certs {
-            warn!(
-                cert = %revoked.label,
-                path_digest = %revoked.path_digest,
-                instance = %instance.instance_id,
-                "submitting revokeCert transaction"
-            );
-
-            cert_revoker.revoke_cert(revoked.path_digest).await;
-        }
-
-        Ok(true)
-    }
-
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
     async fn submit_deregistration(&self, signer: Address) -> bool {
         let calldata =
@@ -1883,10 +1795,10 @@ where
         }
     }
 
-    /// Deregisters any on-chain signer that is not in the `protected_signers` set.
+    /// Deregisters any onchain signer that is not in the `protected_signers` set.
     ///
     /// These orphans arise when a prover instance is terminated (e.g. ASG
-    /// scale-down) without first deregistering its signer on-chain. The
+    /// scale-down) without first deregistering its signer onchain. The
     /// `protected_signers` set is built by [`Self::protected_signers`] as
     /// the union of resolved-this-cycle signers and signers with an
     /// in-flight proof task, so transiently-unresolved instances and
@@ -1897,14 +1809,14 @@ where
     /// Before submitting a deregistration transaction, each orphan candidate is
     /// verified via [`RegistryClient::is_registered`] (backed by the
     /// `isRegisteredSigner` mapping). This guards against ghost entries in the
-    /// on-chain `EnumerableSetLib.AddressSet` that can appear after certain
+    /// onchain `EnumerableSetLib.AddressSet` that can appear after certain
     /// add/remove sequences due to a bug in Solady v0.0.245. Without this
     /// check, ghost addresses would be deregistered every cycle in an infinite
     /// loop, burning gas without effect.
     ///
     /// # Assumptions
     ///
-    /// - **Single registrar**: This method queries *all* on-chain signers and
+    /// - **Single registrar**: This method queries *all* onchain signers and
     ///   treats any signer not in `protected_signers` as an orphan. If multiple
     ///   registrar instances manage disjoint prover fleets, one registrar would
     ///   incorrectly deregister another's signers. The current deployment model
@@ -1933,7 +1845,7 @@ where
                 break;
             }
 
-            // Verify the signer is truly registered on-chain before spending
+            // Verify the signer is truly registered onchain before spending
             // gas on a deregistration tx. The `getRegisteredSigners()` view
             // reads from an `EnumerableSetLib.AddressSet` which can contain
             // ghost entries (addresses that appear in `values()` but have
@@ -1971,47 +1883,6 @@ where
     }
 }
 
-/// On-chain durable revocation check.
-///
-/// Consults the `revokedCerts` mapping for every intermediate in a pre-parsed
-/// Nitro cert chain (root and leaf are skipped — see
-/// [`crl::CertCrlInfo::intermediates`]).
-#[derive(Debug)]
-pub struct OnchainRevocationCheck;
-
-impl OnchainRevocationCheck {
-    /// Returns `Ok(true)` as soon as any intermediate's accumulated path
-    /// digest is found revoked on-chain, `Ok(false)` if every intermediate
-    /// is clean.
-    ///
-    /// # Errors
-    ///
-    /// Returns the underlying RPC error verbatim; the caller decides whether
-    /// to fail-open or propagate.
-    pub async fn run(
-        verifier: &dyn NitroVerifierClient,
-        cert_infos: &[crl::CertCrlInfo],
-        instance_id: &str,
-    ) -> Result<bool> {
-        for info in crl::CertCrlInfo::intermediates(cert_infos) {
-            if verifier.is_revoked(info.path_digest).await? {
-                warn!(
-                    cert = %info.label,
-                    path_digest = %info.path_digest,
-                    instance = %instance_id,
-                    "intermediate is revoked on-chain (durable sentinel set), \
-                     skipping registration"
-                );
-                RegistrarMetrics::onchain_revocations_detected().increment(1);
-                return Ok(true);
-            }
-        }
-
-        debug!(instance = %instance_id, "on-chain revocation pre-check passed");
-        Ok(false)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -2024,7 +1895,7 @@ mod tests {
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom, Bytes, FixedBytes, address};
+    use alloy_primitives::{Address, B256, Bloom, Bytes, address};
     use alloy_rpc_types_eth::TransactionReceipt;
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
@@ -2037,10 +1908,7 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::{
-        InstanceHealthStatus, RegistryClient, Result, SignerClient,
-        test_utils::{CertFixtures, INTER1_HEX, INTER2_HEX, LEAF_HEX, ROOT_HEX},
-    };
+    use crate::{InstanceHealthStatus, RegistryClient, Result, SignerClient};
 
     // ── Shared constants ────────────────────────────────────────────────
 
@@ -2651,7 +2519,7 @@ mod tests {
         }
 
         /// Registry where the first call returns `false` (initial check),
-        /// then subsequent calls return `true` (signer appeared on-chain).
+        /// then subsequent calls return `true` (signer appeared onchain).
         fn registered_after_first_check(signers: Vec<Address>) -> Self {
             Self {
                 signers,
@@ -3025,7 +2893,7 @@ mod tests {
     }
 
     /// Builds a [`MockRegistry`] that reports zero registered signers.
-    /// Used by every pipeline test that wants the on-chain state to
+    /// Used by every pipeline test that wants the onchain state to
     /// start empty.
     fn empty_registry() -> MockRegistry {
         MockRegistry::with_signers(vec![])
@@ -3033,7 +2901,7 @@ mod tests {
 
     /// Builds the single-instance / single-key `(EP1, HARDHAT_KEY_0)`
     /// harness used by most pipeline tests, with no signers registered
-    /// on-chain. Centralising this pair removes ~5 lines of boilerplate
+    /// onchain. Centralising this pair removes ~5 lines of boilerplate
     /// per test and makes it impossible for them to drift out of sync.
     fn single_healthy_harness() -> GatedRunHarness {
         GatedRunHarness::new(
@@ -3044,7 +2912,7 @@ mod tests {
     }
 
     /// Builds an `n`-instance harness with all healthy instances and
-    /// no signers registered on-chain. The signer client is seeded with
+    /// no signers registered onchain. The signer client is seeded with
     /// **every** endpoint in [`ALL_ENDPOINTS`] (not just the initial
     /// `n`) so scale-up tests that swap the discovery list mid-run can
     /// resolve public keys for instances that weren't part of the
@@ -3430,7 +3298,7 @@ mod tests {
         // `is_recently_launched_unhealthy`), and (2) contribute its
         // signer to `active_signers` (preventing premature
         // deregistration). The orphan-dereg pass over the active set
-        // must NOT touch the signer even though it's already on-chain.
+        // must NOT touch the signer even though it's already onchain.
         let addr = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
         let launch_time = Some(SystemTime::now() - Duration::from_secs(300));
 
@@ -3442,7 +3310,7 @@ mod tests {
         let driver = cycle_driver(
             vec![instance_under_test.clone()],
             signer_client,
-            // addr is already on-chain; without active_signers protection it would be deregistered.
+            // addr is already onchain; without active_signers protection it would be deregistered.
             MockRegistry::with_signers(vec![addr]),
             tx.clone(),
             CancellationToken::new(),
@@ -3463,7 +3331,7 @@ mod tests {
 
         // Drive the registration path via the legacy synchronous helper —
         // try_register short-circuits because the signer is already
-        // on-chain, so no registration tx is sent.
+        // onchain, so no registration tx is sent.
         driver.process_instance(&instance_under_test).await.unwrap();
 
         // Orphan-dereg pass must not deregister the signer (it's in active_signers).
@@ -3478,10 +3346,10 @@ mod tests {
     // ── discover_and_resolve + run_orphan_dereg tests ──────────────────
 
     /// When discovery returns zero instances the active set is empty, so
-    /// every on-chain signer is an orphan and must be deregistered.
+    /// every onchain signer is an orphan and must be deregistered.
     /// Verifies both that `discover_and_resolve` flips `ok_to_dereg` to
     /// `true` for the legitimate zero-instance case and that
-    /// `run_orphan_dereg` emits a deregistration tx per on-chain signer.
+    /// `run_orphan_dereg` emits a deregistration tx per onchain signer.
     #[rstest]
     #[case::single_orphan(vec![ORPHAN_A])]
     #[case::multiple_orphans(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C])]
@@ -3509,7 +3377,7 @@ mod tests {
         driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         let sent = tx.sent_calldata();
-        assert_eq!(sent.len(), expected_count, "all on-chain signers should be deregistered");
+        assert_eq!(sent.len(), expected_count, "all onchain signers should be deregistered");
 
         // Verify each deregistration targets the correct signer.
         for orphan in orphans {
@@ -3552,7 +3420,7 @@ mod tests {
             !resolution.ok_to_dereg,
             "1/3 reachable: majority guard should block orphan-dereg pass",
         );
-        // Resolution itself sends no on-chain tx (no CRL revocation).
+        // Resolution itself sends no onchain tx (no CRL revocation).
         assert!(tx.sent_calldata().is_empty(), "discover_and_resolve must not send txs");
     }
 
@@ -3599,7 +3467,7 @@ mod tests {
         // A draining instance must contribute its signer to
         // `active_signers` (protecting it from orphan-dereg) but must
         // NOT appear in `registerable`. The orphan-dereg pass over the
-        // active set then must not deregister the on-chain signer.
+        // active set then must not deregister the onchain signer.
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
         let instances = vec![instance(EP1, InstanceHealthStatus::Draining)];
 
@@ -3607,7 +3475,7 @@ mod tests {
         let driver = cycle_driver(
             instances,
             signer_client,
-            // The derived address for HARDHAT_KEY_0 is already on-chain,
+            // The derived address for HARDHAT_KEY_0 is already onchain,
             // so it should NOT be deregistered.
             MockRegistry::with_signers(vec![HARDHAT_ACCOUNT]),
             tx.clone(),
@@ -3680,7 +3548,7 @@ mod tests {
             instances,
             signer_client,
             // All reachable signers already registered, so no registration txs.
-            // The orphan is on-chain — deregistered only if guard passes.
+            // The orphan is onchain — deregistered only if guard passes.
             MockRegistry::all_registered(vec![ORPHAN_D]),
             tx.clone(),
             CancellationToken::new(),
@@ -3779,7 +3647,7 @@ mod tests {
         // A signer whose registration tx fails must remain in
         // `active_signers`, preventing it from being deregistered as an
         // orphan. This protects against the case where a signer is
-        // already on-chain from a previous cycle but the current
+        // already onchain from a previous cycle but the current
         // registration attempt fails (e.g. insufficient funds).
         //
         // Exercised via the primitives: `discover_and_resolve` populates
@@ -3794,7 +3662,7 @@ mod tests {
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
 
         // is_registered returns false (first call in try_register), then
-        // false again (post-error check). The signer IS in the on-chain
+        // false again (post-error check). The signer IS in the onchain
         // set for get_registered_signers — so without active_signers
         // protection it would be deregistered as an orphan.
         let registry = DynamicRegistry::never_registered(vec![signer_addr]);
@@ -3933,7 +3801,7 @@ mod tests {
 
     #[tokio::test]
     async fn healthy_instances_register_via_primitives_and_orphan_dereg_removes_extras() {
-        // Two healthy instances plus one orphan on-chain → resolution
+        // Two healthy instances plus one orphan onchain → resolution
         // surfaces both signers as registerable AND in active_signers,
         // process_instance drives the two registrations, and
         // run_orphan_dereg emits a single deregistration for the orphan.
@@ -3954,7 +3822,7 @@ mod tests {
         let driver = cycle_driver(
             healthy_instances.to_vec(),
             signer_client,
-            // addr1 and addr2 are not yet registered; orphan is on-chain.
+            // addr1 and addr2 are not yet registered; orphan is onchain.
             MockRegistry::with_signers(vec![orphan]),
             tx.clone(),
             CancellationToken::new(),
@@ -4053,7 +3921,7 @@ mod tests {
         let driver = cycle_driver(
             instances,
             signer_client,
-            // Both signers are on-chain — without active_signers protection
+            // Both signers are onchain — without active_signers protection
             // they would be deregistered as orphans.
             MockRegistry::with_signers(vec![addr0, addr1]),
             tx.clone(),
@@ -4107,7 +3975,7 @@ mod tests {
         let driver = cycle_driver(
             instances,
             signer_client,
-            // The unhealthy signer is on-chain. Without active_signers protection it would be
+            // The unhealthy signer is onchain. Without active_signers protection it would be
             // deregistered.
             MockRegistry::with_signers(vec![addr_unhealthy]),
             tx.clone(),
@@ -4233,7 +4101,7 @@ mod tests {
         // ever invoked it, the resolution would error (or skip the
         // signer); instead the signer must land in `active_signers` and
         // `run_orphan_dereg` must emit no deregistration tx for the
-        // on-chain signer.
+        // onchain signer.
         let signer_addr =
             ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
 
@@ -4297,7 +4165,7 @@ mod tests {
         let driver = cycle_driver(
             instances,
             signer_client,
-            // The draining signer is on-chain. The healthy signer is not.
+            // The draining signer is onchain. The healthy signer is not.
             MockRegistry::with_signers(vec![addr_draining]),
             tx.clone(),
             CancellationToken::new(),
@@ -4457,7 +4325,7 @@ mod tests {
             ALL_ENDPOINTS.len(),
             "all 4 healthy instances should resolve into the registerable set",
         );
-        // Resolution itself emits no on-chain tx — the spawn pass owns registration.
+        // Resolution itself emits no onchain tx — the spawn pass owns registration.
         assert!(tx.sent_calldata().is_empty(), "discover_and_resolve must not send txs");
     }
 
@@ -4517,7 +4385,7 @@ mod tests {
         assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
     }
 
-    /// Transient error but on-chain check shows signer is already
+    /// Transient error but onchain check shows signer is already
     /// registered: should return Ok without retrying.
     #[tokio::test(start_paused = true)]
     async fn try_register_already_registered_after_error_returns_ok() {
@@ -4537,7 +4405,7 @@ mod tests {
         let inst = instance(EP1, InstanceHealthStatus::Healthy);
         let result = driver.process_instance(&inst).await;
 
-        assert!(result.is_ok(), "should succeed: signer registered on-chain: {result:?}");
+        assert!(result.is_ok(), "should succeed: signer registered onchain: {result:?}");
         // Only 1 send attempt — the is_registered check short-circuits retry.
         assert_eq!(tx.send_count(), 1);
     }
@@ -5169,7 +5037,7 @@ mod tests {
     /// `resolution.active_signers` (no fresh evidence this cycle) but
     /// is **present in** `pending` (reconcile preserves the task via
     /// `unresolved_instance_ids`). If the preserved task succeeds and
-    /// registers the signer on-chain right as the orphan-dereg pass
+    /// registers the signer onchain right as the orphan-dereg pass
     /// runs, the protected set assembled by
     /// [`RunDriver::protected_signers`] MUST union the two, otherwise
     /// the very next call to `deregister_orphans` would deregister the
@@ -5179,7 +5047,7 @@ mod tests {
         let signer =
             ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
 
-        // Registry reports the signer as already registered on-chain —
+        // Registry reports the signer as already registered onchain —
         // the state that exists immediately after the preserved task's
         // `registerSigner` tx confirms.
         let harness = GatedRunHarness::new(
@@ -5245,7 +5113,7 @@ mod tests {
 
     /// Sanity contrast for
     /// [`protected_signers_union_blocks_dereg_of_freshly_registered_signer`]:
-    /// with `pending` empty and the same on-chain state, the orphan
+    /// with `pending` empty and the same onchain state, the orphan
     /// pass MUST deregister the signer. Proves the previous test's
     /// success was due to the union, not unrelated logic.
     #[tokio::test]
@@ -5770,7 +5638,7 @@ mod tests {
         /// window doesn't apply.
         InstanceUnhealthy,
         /// Instance is `Healthy` but the derived signer is already on
-        /// the on-chain registry, so `try_register` short-circuits in
+        /// the onchain registry, so `try_register` short-circuits in
         /// `is_registered()`.
         SignerAlreadyRegistered,
     }
@@ -5834,7 +5702,7 @@ mod tests {
     #[tokio::test]
     async fn run_deregisters_orphan_signer_via_orphan_pass() {
         // No discovered instances → active_signers is empty →
-        // every on-chain signer is an orphan. ok_to_dereg is true
+        // every onchain signer is an orphan. ok_to_dereg is true
         // when total_count == 0, so the orphan pass fires and
         // deregisters ORPHAN_A.
         let harness = GatedRunHarness::new(vec![], &[], MockRegistry::with_signers(vec![ORPHAN_A]));
@@ -6094,7 +5962,7 @@ mod tests {
     #[tokio::test]
     async fn run_handles_orphan_dereg_and_active_registration_in_same_cycle() {
         // Mixed-mode cycle: EP1 is healthy + unregistered (so it must
-        // register), while ORPHAN_A is already on-chain but has no
+        // register), while ORPHAN_A is already onchain but has no
         // backing instance (so it must be deregistered). Both passes
         // must run in the same cycle and both transactions must land.
         let harness = GatedRunHarness::new(
@@ -6201,10 +6069,10 @@ mod tests {
     // disabled in [`default_config`], and `MockRegistry` does not verify
     // calldata. The canonical 4-certificate chain from
     // `crate::test_utils` is exercised separately and exhaustively by
-    // the OnchainRevocationCheck tests below, which target the actual
-    // cert-parsing code paths. Mixing real cert bytes into these
-    // orchestration tests would not exercise any additional code and
-    // would add ~3 KB of attestation byte literals to every test run.
+    // the cert manager tests, which target the actual cert-parsing code
+    // paths. Mixing real cert bytes into these orchestration tests would
+    // not exercise any additional code and would add ~3 KB of attestation
+    // byte literals to every test run.
 
     // ── In-flight dedup tests (try_register layer) ──────────────────────
     //
@@ -6357,205 +6225,6 @@ mod tests {
             tx.send_count(),
             2,
             "a failed registration must release the in-flight slot so retries can proceed",
-        );
-    }
-
-    // ── OnchainRevocationCheck tests ────────────────────────────────────
-    //
-    // Covers the durable on-chain revocation pre-check (CHAIN-4194 /
-    // Immunefi #75608). Uses the canonical 4-cert chain
-    // (root → inter1 → inter2 → leaf) from [`crate::test_utils`].
-
-    const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
-
-    /// Mock [`NitroVerifierClient`] for unit-testing the on-chain pre-check.
-    /// `error`, when set, is returned once and then cleared.
-    #[derive(Default)]
-    struct MockNitroVerifier {
-        revoked: HashSet<FixedBytes<32>>,
-        error: Mutex<Option<RegistrarError>>,
-        call_count: AtomicU32,
-    }
-
-    impl MockNitroVerifier {
-        fn revoking(hashes: impl IntoIterator<Item = FixedBytes<32>>) -> Self {
-            Self {
-                revoked: hashes.into_iter().collect(),
-                error: Mutex::new(None),
-                call_count: AtomicU32::new(0),
-            }
-        }
-
-        fn failing(error: RegistrarError) -> Self {
-            Self {
-                revoked: HashSet::new(),
-                error: Mutex::new(Some(error)),
-                call_count: AtomicU32::new(0),
-            }
-        }
-    }
-
-    const TEST_VERIFIER_ADDRESS: Address = Address::repeat_byte(0xAB);
-
-    #[async_trait::async_trait]
-    impl crate::NitroVerifierClient for MockNitroVerifier {
-        fn address(&self) -> Address {
-            TEST_VERIFIER_ADDRESS
-        }
-
-        async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool> {
-            self.call_count.fetch_add(1, Ordering::SeqCst);
-            if let Some(err) = self.error.lock().unwrap().take() {
-                return Err(err);
-            }
-            Ok(self.revoked.contains(&cert_hash))
-        }
-    }
-
-    // Cert indices in the canonical chain.
-    const ROOT_INDEX: usize = 0;
-    const INTER1_INDEX: usize = 1;
-    const INTER2_INDEX: usize = 2;
-    const LEAF_INDEX: usize = 3;
-
-    fn full_chain_der() -> Vec<Vec<u8>> {
-        CertFixtures::decode_chain(&[ROOT_HEX, INTER1_HEX, INTER2_HEX, LEAF_HEX])
-    }
-
-    fn chain_subset(indices: &[usize]) -> Vec<Vec<u8>> {
-        let full = full_chain_der();
-        indices.iter().map(|&i| full[i].clone()).collect()
-    }
-
-    fn path_digest_for(index: usize) -> FixedBytes<32> {
-        let der = full_chain_der();
-        let refs: Vec<&[u8]> = der.iter().map(Vec::as_slice).collect();
-        crl::CertCrlInfo::from_chain(&refs)
-            .expect("static fixtures parse")
-            .remove(index)
-            .path_digest
-    }
-
-    fn full_chain_cert_infos() -> Vec<crl::CertCrlInfo> {
-        let der = full_chain_der();
-        let refs: Vec<&[u8]> = der.iter().map(Vec::as_slice).collect();
-        crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse")
-    }
-
-    fn full_chain_intermediate_count() -> u32 {
-        u32::try_from(full_chain_der().len().saturating_sub(2)).unwrap()
-    }
-
-    async fn run_pre_check(verifier: &MockNitroVerifier) -> (Result<bool>, u32) {
-        let cert_infos = full_chain_cert_infos();
-        let result =
-            OnchainRevocationCheck::run(verifier, &cert_infos, ONCHAIN_TEST_INSTANCE_ID).await;
-        (result, verifier.call_count.load(Ordering::SeqCst))
-    }
-
-    #[tokio::test]
-    async fn onchain_revocation_check_returns_false_when_no_intermediates_revoked() {
-        let verifier = MockNitroVerifier::default();
-        let (result, calls) = run_pre_check(&verifier).await;
-
-        assert!(
-            !result.expect("clean chain must succeed"),
-            "no intermediates flagged as revoked → registration must proceed"
-        );
-        assert_eq!(
-            calls,
-            full_chain_intermediate_count(),
-            "every intermediate must be queried when none are revoked"
-        );
-    }
-
-    #[rstest]
-    #[case::inter1_revoked(INTER1_INDEX, 1)]
-    #[case::inter2_revoked(INTER2_INDEX, 2)]
-    #[tokio::test]
-    async fn onchain_revocation_check_blocks_when_any_intermediate_revoked(
-        #[case] revoked_index: usize,
-        #[case] expected_calls_at_short_circuit: u32,
-    ) {
-        let verifier = MockNitroVerifier::revoking([path_digest_for(revoked_index)]);
-        let (result, calls) = run_pre_check(&verifier).await;
-
-        assert!(
-            result.expect("revoked-intermediate query must succeed"),
-            "revoked intermediate must block registration",
-        );
-        assert_eq!(
-            calls, expected_calls_at_short_circuit,
-            "pre-check must short-circuit at the first revoked intermediate",
-        );
-    }
-
-    #[tokio::test]
-    async fn onchain_revocation_check_short_circuits_when_all_intermediates_revoked() {
-        let verifier = MockNitroVerifier::revoking([
-            path_digest_for(INTER1_INDEX),
-            path_digest_for(INTER2_INDEX),
-        ]);
-        let (result, calls) = run_pre_check(&verifier).await;
-
-        assert!(result.expect("query must succeed"), "any revoked intermediate must block");
-        assert_eq!(calls, 1, "first intermediate triggers short-circuit");
-    }
-
-    #[tokio::test]
-    async fn onchain_revocation_check_skips_root_and_leaf() {
-        let verifier =
-            MockNitroVerifier::revoking([path_digest_for(ROOT_INDEX), path_digest_for(LEAF_INDEX)]);
-        let (result, calls) = run_pre_check(&verifier).await;
-
-        assert!(
-            !result.expect("query must succeed"),
-            "root/leaf revocation flags must not block registration",
-        );
-        assert_eq!(
-            calls,
-            full_chain_intermediate_count(),
-            "only intermediates are queried; root and leaf are skipped",
-        );
-    }
-
-    #[tokio::test]
-    async fn onchain_revocation_check_propagates_rpc_errors() {
-        let verifier = MockNitroVerifier::failing(RegistrarError::NitroVerifierCall {
-            context: "revokedCerts(0xdeadbeef)".into(),
-            source: "boom".into(),
-        });
-        let (result, _calls) = run_pre_check(&verifier).await;
-
-        let err = result.expect_err("RPC errors must surface to the caller");
-        assert!(
-            matches!(err, RegistrarError::NitroVerifierCall { .. }),
-            "expected NitroVerifierCall, got: {err:?}"
-        );
-    }
-
-    #[rstest]
-    #[case::root_only(&[ROOT_INDEX], 0)]
-    #[case::root_and_leaf(&[ROOT_INDEX, LEAF_INDEX], 0)]
-    #[case::three_cert(&[ROOT_INDEX, INTER1_INDEX, LEAF_INDEX], 1)]
-    #[tokio::test]
-    async fn onchain_revocation_check_queries_intermediates_only(
-        #[case] indices: &[usize],
-        #[case] expected_calls: u32,
-    ) {
-        let owned = chain_subset(indices);
-        let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
-        let cert_infos = crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse");
-        let verifier = MockNitroVerifier::default();
-
-        let result =
-            OnchainRevocationCheck::run(&verifier, &cert_infos, ONCHAIN_TEST_INSTANCE_ID).await;
-
-        assert!(!result.expect("query must succeed"), "clean chain not revoked");
-        assert_eq!(
-            verifier.call_count.load(Ordering::SeqCst),
-            expected_calls,
-            "only intermediates (root and leaf skipped) should produce RPC calls",
         );
     }
 }

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -31,7 +31,7 @@ pub enum RegistrarError {
     #[error("registry error")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-    /// An on-chain registry contract call failed.
+    /// An onchain registry contract call failed.
     #[error("registry call failed: {context}")]
     RegistryCall {
         /// Description of the call that failed (e.g. `"isValidSigner(0x1234…)"`).
@@ -41,7 +41,7 @@ pub enum RegistrarError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    /// An on-chain `NitroEnclaveVerifier` contract call failed.
+    /// An onchain `NitroEnclaveVerifier` contract call failed.
     #[error("nitro verifier call failed: {context}")]
     NitroVerifierCall {
         /// Description of the call that failed (e.g. `"revokedCerts(0x…)"`).

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -10,6 +10,9 @@ pub use config::{
 mod cert_revoker;
 pub use cert_revoker::CertRevoker;
 
+mod cert_manager;
+pub use cert_manager::{CertManager, OnchainRevocationCheck};
+
 mod crl;
 pub use crl::{
     CertCrlInfo, CrlError, DEFAULT_CRL_FETCH_TIMEOUT_SECS, RevokedCertInfo, build_crl_http_client,
@@ -23,8 +26,7 @@ mod driver;
 pub use driver::{
     DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DiscoveryResolution, DriverConfig,
-    OnchainRevocationCheck, PendingRegistration, RegisterableSigner, RegistrationDriver,
-    ResolveOutcome,
+    PendingRegistration, RegisterableSigner, RegistrationDriver, ResolveOutcome,
 };
 
 mod error;

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -11,7 +11,7 @@ mod cert_revoker;
 pub use cert_revoker::CertRevoker;
 
 mod cert_manager;
-pub use cert_manager::{CertManager, OnchainRevocationCheck};
+pub use cert_manager::CertManager;
 
 mod crl;
 pub use crl::{

--- a/crates/proof/tee/registrar/src/metrics.rs
+++ b/crates/proof/tee/registrar/src/metrics.rs
@@ -25,13 +25,13 @@ base_metrics::define_metrics! {
     #[describe("Total number of certificate revocations detected via CRL")]
     crl_revocations_detected: counter,
 
-    #[describe("Total number of on-chain durable revocation pre-checks performed")]
+    #[describe("Total number of onchain durable revocation pre-checks performed")]
     onchain_revocation_checks_total: counter,
 
-    #[describe("Total number of intermediates rejected by the on-chain durable revocation sentinel")]
+    #[describe("Total number of intermediates rejected by the onchain durable revocation sentinel")]
     onchain_revocations_detected: counter,
 
-    #[describe("Total number of on-chain revocation pre-checks that failed and fell through to the AWS CRL layer (fail-open)")]
+    #[describe("Total number of onchain revocation pre-checks that failed and fell through to the AWS CRL layer (fail-open)")]
     onchain_revocation_check_errors: counter,
 
     #[describe("Total number of revokeCert transaction submission failures")]

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -14,10 +14,10 @@ use url::Url;
 
 use crate::{RegistrarError, Result};
 
-/// Reads registration state from the on-chain `TEEProverRegistry`.
+/// Reads registration state from the onchain `TEEProverRegistry`.
 #[async_trait]
 pub trait RegistryClient: Send + Sync {
-    /// Returns `true` if `signer` is currently registered on-chain.
+    /// Returns `true` if `signer` is currently registered onchain.
     async fn is_registered(&self, signer: Address) -> Result<bool>;
 
     /// Fetches the complete set of registered signer addresses in a single view call.

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -31,7 +31,7 @@ pub enum InstanceHealthStatus {
 }
 
 impl InstanceHealthStatus {
-    /// Returns `true` if the instance should be registered on-chain.
+    /// Returns `true` if the instance should be registered onchain.
     ///
     /// Both `Initial` (AWS warm-up) and `Healthy` instances are candidates for
     /// registration. `Unhealthy` and `Draining` instances are not.
@@ -52,7 +52,7 @@ impl InstanceHealthStatus {
     }
 }
 
-/// A signer currently registered on-chain via `TEEProverRegistry`.
+/// A signer currently registered onchain via `TEEProverRegistry`.
 #[derive(Debug, Clone)]
 pub struct RegisteredSigner {
     /// The signer's Ethereum address.

--- a/crates/proof/tee/registrar/src/verifier.rs
+++ b/crates/proof/tee/registrar/src/verifier.rs
@@ -1,6 +1,6 @@
 //! `NitroEnclaveVerifier` client adapter for the registrar.
 //!
-//! Provides the durable on-chain revocation check (CHAIN-4194 / Immunefi
+//! Provides the durable onchain revocation check (CHAIN-4194 / Immunefi
 //! #75608) that the driver consults before submitting a registration: even
 //! if the AWS CRL is silent, a previously-revoked intermediate must continue
 //! to fail registration until an operator explicitly re-trusts it via
@@ -13,16 +13,16 @@ use url::Url;
 
 use crate::{RegistrarError, Result};
 
-/// Reads the durable revocation sentinel from the on-chain
+/// Reads the durable revocation sentinel from the onchain
 /// `NitroEnclaveVerifier`.
 #[async_trait]
 pub trait NitroVerifierClient: Send + Sync {
-    /// Returns the on-chain address of the verifier this client is bound to.
+    /// Returns the onchain address of the verifier this client is bound to.
     /// Used by the driver as the destination for `revokeCert` transactions.
     fn address(&self) -> Address;
 
     /// Returns `true` if the given accumulated-path-digest hash is currently
-    /// marked as revoked on-chain.
+    /// marked as revoked onchain.
     async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool>;
 }
 


### PR DESCRIPTION
### What changed? Why?

Extracted Nitro certificate revocation handling from the registration driver into a dedicated CertManager, including onchain sentinel checks, AWS CRL checks, and revokeCert submission. CRL hits now skip revokeCert when the onchain sentinel already marks the certificate as revoked.

Also updated registrar docs and comments to use the repository-standard onchain spelling.

### Notes to reviewers

The driver now owns orchestration and delegates certificate revocation behavior to CertManager. OnchainRevocationCheck moved with the new manager and is still re-exported from lib.rs.

CRL fetches remain serial per certificate chain; this PR only extracts and preserves that behavior.

### How has it been tested?

- cargo fmt --package base-proof-tee-registrar
- cargo test -p base-proof-tee-registrar