### PR TITLE
fix(proof/succinct): use i64::try_from for block_number cast in consistency check

### DIFF
--- a/crates/proof/succinct/validity/src/utils.rs
+++ b/crates/proof/succinct/validity/src/utils.rs
@@ -85,7 +85,10 @@ pub fn get_ranges_to_prove_by_gas(
             })?;
 
             // Validate block number consistency
-            if block_info.block_number as i64 != block_num {
+            let block_number_i64 = i64::try_from(block_info.block_number).map_err(|_| {
+                anyhow!("block_number {} exceeds i64::MAX", block_info.block_number)
+            })?;
+            if block_number_i64 != block_num {
                 return Err(anyhow!(
                     "BlockInfo has inconsistent block number: expected {}, got {}",
                     block_num,


### PR DESCRIPTION
Fixes #3293.

`get_ranges_to_prove_by_gas` in `utils.rs` compared `block_info.block_number` (u64) against `block_num` (i64) using an unchecked `as i64` cast. If `block_number` exceeds `i64::MAX`, the cast silently wraps to a negative value and the consistency check either passes with wrong data or fails with a misleading error.

Replaced with `i64::try_from` which returns an explicit error if the value is out of range, consistent with how the rest of the codebase handles u64→i64 conversions.