### PR TITLE
refactor(registrar): simplify CRL certificate metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5781,7 +5781,6 @@ dependencies = [
  "rand 0.9.4",
  "reqwest 0.13.3",
  "rstest",
- "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -66,7 +66,6 @@ url.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-sha2.workspace = true
 rstest.workspace = true
 metrics.workspace = true
 hex-literal.workspace = true

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -117,8 +117,9 @@ impl CertManager {
     ) -> Result<bool> {
         for info in crl::CertCrlInfo::intermediates(cert_infos) {
             if self.nitro_verifier.is_revoked(info.path_digest).await? {
+                let cert = info.intermediate_label();
                 warn!(
-                    cert = %format!("intermediate {}", info.index),
+                    cert = %cert,
                     path_digest = %info.path_digest,
                     instance = %instance_id,
                     "intermediate is revoked onchain (durable sentinel set), skipping registration"
@@ -145,7 +146,7 @@ impl CertManager {
         let cert_revoker = CertRevoker::new(verifier_address, tx_manager);
 
         for revoked in revoked_certs {
-            let cert = format!("intermediate {}", revoked.index);
+            let cert = revoked.intermediate_label();
             match self.nitro_verifier.is_revoked(revoked.path_digest).await {
                 Ok(true) => {
                     warn!(

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -118,7 +118,7 @@ impl CertManager {
         for info in crl::CertCrlInfo::intermediates(cert_infos) {
             if self.nitro_verifier.is_revoked(info.path_digest).await? {
                 warn!(
-                    cert = %info.label,
+                    cert = %format!("intermediate {}", info.index),
                     path_digest = %info.path_digest,
                     instance = %instance_id,
                     "intermediate is revoked onchain (durable sentinel set), skipping registration"
@@ -145,10 +145,11 @@ impl CertManager {
         let cert_revoker = CertRevoker::new(verifier_address, tx_manager);
 
         for revoked in revoked_certs {
+            let cert = format!("intermediate {}", revoked.index);
             match self.nitro_verifier.is_revoked(revoked.path_digest).await {
                 Ok(true) => {
                     warn!(
-                        cert = %revoked.label,
+                        cert = %cert,
                         path_digest = %revoked.path_digest,
                         instance = %instance.instance_id,
                         "certificate already revoked onchain, skipping revokeCert"
@@ -160,7 +161,7 @@ impl CertManager {
                 Err(e) => {
                     warn!(
                         error = %e,
-                        cert = %revoked.label,
+                        cert = %cert,
                         path_digest = %revoked.path_digest,
                         instance = %instance.instance_id,
                         "onchain revocation check failed for CRL hit; submitting revokeCert"
@@ -170,7 +171,7 @@ impl CertManager {
             }
 
             warn!(
-                cert = %revoked.label,
+                cert = %cert,
                 path_digest = %revoked.path_digest,
                 instance = %instance.instance_id,
                 "submitting revokeCert transaction"
@@ -325,7 +326,7 @@ mod tests {
     }
 
     fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {
-        crl::RevokedCertInfo { label: "intermediate 1".to_string(), path_digest }
+        crl::RevokedCertInfo { index: INTER1_INDEX, path_digest }
     }
 
     fn revoke_cert_calldata(path_digest: B256) -> Bytes {

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -286,6 +286,7 @@ mod tests {
         thread::{self, JoinHandle},
     };
 
+    use alloy_primitives::{B256, b256};
     use rstest::{fixture, rstest};
 
     use super::*;
@@ -302,6 +303,13 @@ mod tests {
     const INTER2_EXPECTED_SERIAL_HEX: &str = "cb286a4a4a09207f8b0c14950dcd6861";
     const INTER3_EXPECTED_SERIAL_HEX: &str = "c8925d382506d820d93d2c704a7523c4ba2ddfaa";
     const LEAF_EXPECTED_SERIAL_HEX: &str = "0193685e7fee7d8500000000674b3bd8";
+    const EXPECTED_PATH_DIGESTS: [B256; 5] = [
+        b256!("641a0321a3e244efe456463195d606317ed7cdcc3c1756e09893f3c68f79bb5b"),
+        b256!("aa413b647367f37da57079d2ae215fa2b14cb42ec0c4e4275f56dd3caff95b36"),
+        b256!("bc023b9f717f6a435ab56642c5b5784179fb4d39166d36641d47887d3011c125"),
+        b256!("f8cffb2fa4503ee3753a54d06d3dcbf96f4ea1db505cccc5c14f784f5234604a"),
+        b256!("140ad974a8d3c771bf24a12fdbfff85a7191ba9a9a703869948aebedc16dd3ad"),
+    ];
     const EMPTY_CRL_DER: [u8; 49] = [
         0x30, 0x2f, 0x30, 0x1d, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03,
         0x03, 0x30, 0x00, 0x17, 0x0d, 0x32, 0x34, 0x30, 0x31, 0x30, 0x31, 0x30, 0x30, 0x30, 0x30,
@@ -399,10 +407,9 @@ mod tests {
     fn path_digests_match_onchain_computation(full_chain: ChainFixture) {
         let refs = full_chain.refs();
         let infos = CertCrlInfo::from_chain(&refs).unwrap();
-        let expected = compute_path_digests(&refs);
 
-        assert_eq!(infos.len(), expected.len());
-        for (info, expected_digest) in infos.iter().zip(expected) {
+        assert_eq!(infos.len(), EXPECTED_PATH_DIGESTS.len());
+        for (info, expected_digest) in infos.iter().zip(EXPECTED_PATH_DIGESTS) {
             assert_eq!(info.path_digest, expected_digest);
         }
     }

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -80,6 +80,11 @@ impl CertCrlInfo {
     pub fn intermediates(infos: &[Self]) -> impl Iterator<Item = &Self> {
         infos.iter().skip(1).take(infos.len().saturating_sub(2))
     }
+
+    /// Returns the label used when logging this intermediate certificate.
+    pub fn intermediate_label(&self) -> String {
+        intermediate_cert_label(self.index)
+    }
 }
 
 /// Information about a revoked certificate.
@@ -91,13 +96,10 @@ pub struct RevokedCertInfo {
     pub path_digest: B256,
 }
 
-fn cert_label(index: usize, chain_len: usize) -> String {
-    if index == 0 {
-        "root".to_string()
-    } else if index == chain_len.saturating_sub(1) {
-        "leaf".to_string()
-    } else {
-        intermediate_cert_label(index)
+impl RevokedCertInfo {
+    /// Returns the label used when logging this revoked intermediate certificate.
+    pub fn intermediate_label(&self) -> String {
+        intermediate_cert_label(self.index)
     }
 }
 
@@ -150,7 +152,7 @@ pub async fn check_chain_against_crls(
     let mut revoked = Vec::new();
 
     for info in CertCrlInfo::intermediates(cert_infos) {
-        let cert = cert_label(info.index, cert_infos.len());
+        let cert = info.intermediate_label();
         let Some(ref crl_url) = info.crl_url else {
             debug!(cert = %cert, "no CRL distribution point, skipping");
             continue;

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -1,19 +1,8 @@
-//! On-demand CRL (Certificate Revocation List) checking for AWS Nitro
-//! intermediate certificates.
+//! CRL (Certificate Revocation List) checking for AWS Nitro intermediate
+//! certificates.
 //!
-//! Extracts CRL distribution point URLs and serial numbers from DER-encoded
-//! X.509 certificates, fetches the CRL from AWS S3, and checks whether any
-//! certificate has been revoked.
-//!
-//! The check is **fail-open**: if a CRL cannot be fetched or parsed, the
-//! registration proceeds with a warning. The onchain expiry tracking
-//! (Step 2) provides a backstop for expired certs.
-//!
-//! **TOCTOU note**: there is an inherent race between the CRL check and the
-//! onchain registration transaction. A certificate could be added to the
-//! CRL after the check passes but before the registration lands. This is
-//! acceptable because the onchain expiry backstop and periodic re-checks
-//! bound the exposure window.
+//! Fetch and parse failures are fail-open; onchain expiry tracking and
+//! periodic re-checks bound the remaining exposure window.
 
 use std::time::Duration;
 
@@ -27,37 +16,18 @@ use x509_parser::{
     revocation_list::CertificateRevocationList,
 };
 
-/// Default HTTP timeout for CRL fetches from AWS S3.
+/// Default timeout for CRL fetches.
 pub const DEFAULT_CRL_FETCH_TIMEOUT_SECS: u64 = 30;
 
-/// Maximum allowed CRL response body size (10 `MiB`).
-///
-/// Prevents unbounded memory allocation when fetching CRLs. AWS Nitro CRLs
-/// are typically a few KB; this cap is generous to accommodate growth while
-/// still protecting against resource exhaustion from malicious or corrupted
-/// responses.
 const MAX_CRL_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
-
-/// Allowed hostname suffix for CRL distribution point URLs.
-///
-/// All legitimate AWS Nitro CRL distribution points are hosted on S3
-/// endpoints matching this pattern. Rejecting other hosts prevents SSRF
-/// via attacker-controlled attestation documents.
 const ALLOWED_CRL_HOST_SUFFIX: &str = ".amazonaws.com";
-
-/// Required substring in the hostname of CRL distribution point URLs.
-///
-/// In addition to the `.amazonaws.com` suffix, all legitimate AWS Nitro CRL
-/// URLs contain `nitro-enclave` in the hostname (e.g.
-/// `aws-nitro-enclaves-crl.s3.amazonaws.com`). This provides a second layer
-/// of allowlisting.
 const ALLOWED_CRL_HOST_KEYWORD: &str = "nitro-enclave";
 
 /// Information extracted from a single certificate needed for CRL checking.
 #[derive(Debug, Clone)]
 pub struct CertCrlInfo {
-    /// Human-readable label for logging (e.g. "intermediate 1").
-    pub label: String,
+    /// Position of the certificate in the chain.
+    pub index: usize,
     /// Serial number of the certificate (big-endian, unsigned).
     pub serial_number: Vec<u8>,
     /// CRL distribution point URL, if present in the certificate.
@@ -68,8 +38,7 @@ pub struct CertCrlInfo {
 }
 
 impl CertCrlInfo {
-    /// Extracts CRL-relevant information from each certificate in a
-    /// DER-encoded chain.
+    /// Extracts CRL-relevant information from a DER-encoded chain.
     ///
     /// The certificates must be in chain order: root → intermediates → leaf.
     /// Path digests are computed identically to the onchain
@@ -80,13 +49,14 @@ impl CertCrlInfo {
     /// Returns an error if any certificate cannot be parsed from DER.
     pub fn from_chain(certs_der: &[&[u8]]) -> Result<Vec<Self>, CrlError> {
         let mut infos = Vec::with_capacity(certs_der.len());
+        let path_digests = compute_path_digests(certs_der);
 
-        for (i, der) in certs_der.iter().enumerate() {
+        for (index, (der, path_digest)) in certs_der.iter().zip(path_digests).enumerate() {
             let (remaining, cert) = X509Certificate::from_der(der)
-                .map_err(|e| CrlError::CertParse(format!("certificate {i}: {e}")))?;
+                .map_err(|e| CrlError::CertParse(format!("certificate {index}: {e}")))?;
             if !remaining.is_empty() {
                 return Err(CrlError::CertParse(format!(
-                    "certificate {i}: trailing DER data ({} bytes)",
+                    "certificate {index}: trailing DER data ({} bytes)",
                     remaining.len()
                 )));
             }
@@ -94,27 +64,13 @@ impl CertCrlInfo {
             let serial_number = cert.tbs_certificate.serial.to_bytes_be();
             let crl_url = extract_crl_distribution_point(&cert);
 
-            let label = if i == 0 {
-                "root".to_string()
-            } else if i == certs_der.len() - 1 {
-                "leaf".to_string()
-            } else {
-                format!("intermediate {i}")
-            };
-
-            infos.push(Self { label, serial_number, crl_url, path_digest: B256::ZERO });
-        }
-
-        let path_digests = compute_path_digests(certs_der);
-        for (info, path_digest) in infos.iter_mut().zip(path_digests) {
-            info.path_digest = path_digest;
+            infos.push(Self { index, serial_number, crl_url, path_digest });
         }
 
         Ok(infos)
     }
 
-    /// Returns an iterator over the intermediate certificates in a chain,
-    /// skipping the root (index 0) and the leaf (last index).
+    /// Returns intermediate certificates, skipping the root and leaf.
     ///
     /// Roots manage their own trust and leaves are short-lived
     /// (~3 hours), so neither participates in the onchain
@@ -129,17 +85,26 @@ impl CertCrlInfo {
 /// Information about a revoked certificate.
 #[derive(Debug, Clone)]
 pub struct RevokedCertInfo {
-    /// Label of the revoked certificate (e.g. "intermediate 1").
-    pub label: String,
+    /// Position of the revoked certificate in the chain.
+    pub index: usize,
     /// Path digest for onchain `revokeCert()`.
     pub path_digest: B256,
 }
 
-/// Extracts the first HTTP/HTTPS CRL distribution point URL from a
-/// certificate's extensions.
-///
-/// Returns `None` if the certificate has no CRL distribution points
-/// extension or if none of the distribution points contain a URI.
+fn cert_label(index: usize, chain_len: usize) -> String {
+    if index == 0 {
+        "root".to_string()
+    } else if index == chain_len.saturating_sub(1) {
+        "leaf".to_string()
+    } else {
+        intermediate_cert_label(index)
+    }
+}
+
+fn intermediate_cert_label(index: usize) -> String {
+    format!("intermediate {index}")
+}
+
 fn extract_crl_distribution_point(cert: &X509Certificate<'_>) -> Option<String> {
     for ext in cert.extensions() {
         let ParsedExtension::CRLDistributionPoints(cdp) = ext.parsed_extension() else {
@@ -161,26 +126,13 @@ fn extract_crl_distribution_point(cert: &X509Certificate<'_>) -> Option<String> 
     None
 }
 
-/// Returns `true` if the given URL's host is an allowed AWS CRL endpoint.
-///
-/// Validates that the hostname ends with [`.amazonaws.com`](ALLOWED_CRL_HOST_SUFFIX)
-/// and contains [`nitro-enclave`](ALLOWED_CRL_HOST_KEYWORD). This prevents
-/// SSRF attacks via attacker-controlled CRL distribution point URLs in
-/// unverified attestation documents.
 fn is_allowed_crl_host(url: &str) -> bool {
     url::Url::parse(url).ok().and_then(|u| u.host_str().map(|h| h.to_lowercase())).is_some_and(
         |host| host.ends_with(ALLOWED_CRL_HOST_SUFFIX) && host.contains(ALLOWED_CRL_HOST_KEYWORD),
     )
 }
 
-/// Checks a pre-parsed certificate chain against CRLs fetched from
-/// distribution points.
-///
-/// For each intermediate (root and leaf are skipped via
-/// [`CertCrlInfo::intermediates`]) the function:
-/// 1. Reads the CRL distribution point URL recorded during parsing
-/// 2. Fetches the CRL
-/// 3. Checks whether the certificate's serial number appears on the CRL
+/// Checks intermediate certificates against their CRL distribution points.
 ///
 /// **Fail-open policy**: CRL fetch or parse failures are logged as warnings
 /// but do not abort the check. Only confirmed revocations are reported.
@@ -190,7 +142,7 @@ fn is_allowed_crl_host(url: &str) -> bool {
 /// * `cert_infos` - Pre-parsed cert chain info, typically produced once per
 ///   cycle by [`CertCrlInfo::from_chain`] and shared with the onchain
 ///   revocation pre-check so the DER parse only happens once.
-/// * `http_client` - HTTP client for fetching CRLs
+/// * `http_client` - HTTP client for fetching CRLs.
 pub async fn check_chain_against_crls(
     cert_infos: &[CertCrlInfo],
     http_client: &reqwest::Client,
@@ -198,34 +150,31 @@ pub async fn check_chain_against_crls(
     let mut revoked = Vec::new();
 
     for info in CertCrlInfo::intermediates(cert_infos) {
+        let cert = cert_label(info.index, cert_infos.len());
         let Some(ref crl_url) = info.crl_url else {
-            debug!(cert = %info.label, "no CRL distribution point, skipping");
+            debug!(cert = %cert, "no CRL distribution point, skipping");
             continue;
         };
 
-        debug!(cert = %info.label, url = %crl_url, "fetching CRL");
+        debug!(cert = %cert, url = %crl_url, "fetching CRL");
 
         match fetch_and_check_crl(http_client, crl_url, &info.serial_number).await {
             Ok(true) => {
                 warn!(
-                    cert = %info.label,
+                    cert = %cert,
                     url = %crl_url,
                     serial = %hex::encode(&info.serial_number),
                     path_digest = %info.path_digest,
                     "certificate found on CRL — REVOKED"
                 );
-                revoked.push(RevokedCertInfo {
-                    label: info.label.clone(),
-                    path_digest: info.path_digest,
-                });
+                revoked.push(RevokedCertInfo { index: info.index, path_digest: info.path_digest });
             }
             Ok(false) => {
-                debug!(cert = %info.label, "certificate not on CRL");
+                debug!(cert = %cert, "certificate not on CRL");
             }
             Err(e) => {
-                // Fail-open: log warning but continue.
                 warn!(
-                    cert = %info.label,
+                    cert = %cert,
                     url = %crl_url,
                     error = %e,
                     "CRL check failed (fail-open, proceeding)"
@@ -237,20 +186,11 @@ pub async fn check_chain_against_crls(
     revoked
 }
 
-/// Fetches a CRL from the given URL and checks if the serial number is
-/// present.
-///
-/// Returns `Ok(true)` if the serial number is on the CRL (revoked),
-/// `Ok(false)` if not, and `Err` if the CRL could not be fetched or parsed.
-///
-/// The URL is validated against an allowlist before fetching to prevent SSRF.
-/// Responses larger than [`MAX_CRL_RESPONSE_BYTES`] are rejected.
 async fn fetch_and_check_crl(
     http_client: &reqwest::Client,
     crl_url: &str,
     serial_number: &[u8],
 ) -> Result<bool, CrlError> {
-    // Reject URLs that don't match the AWS Nitro CRL host allowlist.
     if !is_allowed_crl_host(crl_url) {
         return Err(CrlError::Fetch(format!(
             "{crl_url}: host not in CRL allowlist (must be *{ALLOWED_CRL_HOST_SUFFIX} \
@@ -268,8 +208,6 @@ async fn fetch_and_check_crl(
         return Err(CrlError::Fetch(format!("{crl_url}: HTTP {}", response.status())));
     }
 
-    // Check Content-Length header if present to reject obviously oversized
-    // responses before buffering the body.
     if let Some(content_length) = response.content_length()
         && content_length > MAX_CRL_RESPONSE_BYTES as u64
     {
@@ -299,9 +237,7 @@ async fn fetch_and_check_crl(
         )));
     }
 
-    // Check if the serial number appears in the revoked certificates list.
-    // Both sides use `BigUint::to_bytes_be()` which normalises away ASN.1
-    // leading-zero padding, so direct comparison is correct.
+    // `to_bytes_be()` normalizes away ASN.1 leading-zero padding.
     for revoked_cert in crl.iter_revoked_certificates() {
         if revoked_cert.user_certificate.to_bytes_be() == serial_number {
             return Ok(true);
@@ -311,10 +247,7 @@ async fn fetch_and_check_crl(
     Ok(false)
 }
 
-/// Creates an HTTP client configured for CRL fetching.
-///
-/// Uses a timeout to prevent hanging on unresponsive S3 endpoints.
-/// Redirects are disabled to prevent SSRF via open-redirect chains.
+/// Builds a CRL HTTP client with redirects disabled.
 pub fn build_crl_http_client(timeout: Duration) -> Result<reqwest::Client, CrlError> {
     reqwest::Client::builder()
         .timeout(timeout)
@@ -352,41 +285,21 @@ mod tests {
     };
 
     use rstest::{fixture, rstest};
-    use sha2::{Digest, Sha256};
 
     use super::*;
     use crate::test_utils::{
         CertFixtures, INTER1_HEX, INTER2_HEX, INTER3_HEX, INVALID_DER_BYTES, LEAF_HEX, ROOT_HEX,
     };
 
-    // ── Expected constants ──────────────────────────────────────────────
-
-    /// Expected CRL distribution point URL for intermediate 1.
     const INTER1_EXPECTED_CRL_URL: &str = "http://aws-nitro-enclaves-crl.s3.amazonaws.com/crl/ab4960cc-7d63-42bd-9e9f-59338cb67f84.crl";
 
-    /// Expected CRL distribution point URL for intermediate 2.
     const INTER2_EXPECTED_CRL_URL: &str = "http://crl-us-east-1-aws-nitro-enclaves.s3.us-east-1.amazonaws.com/crl/06d48f8e-2c08-4781-a645-b1de402aefb8.crl";
 
-    /// Expected serial number (hex) for root CA (`BigUint::to_bytes_be()`).
     const ROOT_EXPECTED_SERIAL_HEX: &str = "f93175681b90afe11d46ccb4e4e7f856";
-
-    /// Expected serial number (hex) for intermediate 1.
     const INTER1_EXPECTED_SERIAL_HEX: &str = "56bfc987fd05ac99c475061b1a65eedc";
-
-    /// Expected serial number (hex) for intermediate 2 (`BigUint::to_bytes_be()`).
     const INTER2_EXPECTED_SERIAL_HEX: &str = "cb286a4a4a09207f8b0c14950dcd6861";
-
-    /// Expected serial number (hex) for intermediate 3.
     const INTER3_EXPECTED_SERIAL_HEX: &str = "c8925d382506d820d93d2c704a7523c4ba2ddfaa";
-
-    /// Expected serial number (hex) for the leaf/enclave certificate.
     const LEAF_EXPECTED_SERIAL_HEX: &str = "0193685e7fee7d8500000000674b3bd8";
-
-    /// Number of certificates in the full Nitro attestation chain
-    /// (root + 3 intermediates + leaf).
-    const FULL_CHAIN_LEN: usize = 5;
-
-    /// Minimal valid DER-encoded CRL with no revoked certificates.
     const EMPTY_CRL_DER: [u8; 49] = [
         0x30, 0x2f, 0x30, 0x1d, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03,
         0x03, 0x30, 0x00, 0x17, 0x0d, 0x32, 0x34, 0x30, 0x31, 0x30, 0x31, 0x30, 0x30, 0x30, 0x30,
@@ -396,10 +309,6 @@ mod tests {
 
     const CRL_TEST_HOST: &str = "aws-nitro-enclave-test.amazonaws.com";
 
-    // ── Fixtures ────────────────────────────────────────────────────────
-
-    /// Decoded DER bytes and their slice references for the full 5-cert
-    /// chain, ready for use in `CertCrlInfo::from_chain`.
     struct ChainFixture {
         owned: Vec<Vec<u8>>,
     }
@@ -410,8 +319,6 @@ mod tests {
         }
     }
 
-    /// Full 5-cert chain (root → 3 intermediates → leaf) from real Nitro
-    /// attestation.
     #[fixture]
     fn full_chain() -> ChainFixture {
         ChainFixture {
@@ -421,22 +328,11 @@ mod tests {
         }
     }
 
-    /// Single-cert chain containing only the root.
-    #[fixture]
-    fn root_only_chain() -> ChainFixture {
-        ChainFixture { owned: CertFixtures::decode_chain(&[ROOT_HEX]) }
-    }
-
-    /// Two-cert chain containing root and leaf (no intermediates).
     #[fixture]
     fn root_and_leaf_chain() -> ChainFixture {
         ChainFixture { owned: CertFixtures::decode_chain(&[ROOT_HEX, LEAF_HEX]) }
     }
 
-    // ── Helpers ─────────────────────────────────────────────────────────
-
-    /// Parses a single hex-encoded cert and extracts its CRL distribution
-    /// point URL.
     fn crl_url_for_hex(cert_hex: &str) -> Option<String> {
         let der = CertFixtures::decode(cert_hex);
         let (remaining, cert) = X509Certificate::from_der(&der).unwrap();
@@ -470,8 +366,6 @@ mod tests {
         reqwest::Client::builder().no_proxy().resolve(CRL_TEST_HOST, addr).build().unwrap()
     }
 
-    // ── CRL distribution point extraction (parameterised) ───────────────
-
     #[rstest]
     #[case::intermediate_1(INTER1_HEX, Some(INTER1_EXPECTED_CRL_URL))]
     #[case::intermediate_2(INTER2_HEX, Some(INTER2_EXPECTED_CRL_URL))]
@@ -482,8 +376,6 @@ mod tests {
         let url = crl_url_for_hex(cert_hex);
         assert_eq!(url.as_deref(), expected);
     }
-
-    // ── Serial number extraction (parameterised) ────────────────────────
 
     #[rstest]
     #[case::root(0, ROOT_EXPECTED_SERIAL_HEX)]
@@ -501,70 +393,17 @@ mod tests {
         assert_eq!(hex::encode(&infos[index].serial_number), expected_hex);
     }
 
-    // ── Path digest consistency ─────────────────────────────────────────
-
     #[rstest]
     fn path_digests_match_onchain_computation(full_chain: ChainFixture) {
         let refs = full_chain.refs();
         let infos = CertCrlInfo::from_chain(&refs).unwrap();
+        let expected = compute_path_digests(&refs);
 
-        // First digest = sha256(root_der).
-        let root_hash = B256::from_slice(Sha256::digest(&full_chain.owned[0]).as_slice());
-        assert_eq!(infos[0].path_digest, root_hash);
-
-        // Second digest = sha256(root_hash || sha256(inter1_der)).
-        let inter1_hash = B256::from_slice(Sha256::digest(&full_chain.owned[1]).as_slice());
-        let mut hasher = Sha256::new();
-        hasher.update(root_hash.as_slice());
-        hasher.update(inter1_hash.as_slice());
-        let expected = B256::from_slice(hasher.finalize().as_slice());
-        assert_eq!(infos[1].path_digest, expected);
+        assert_eq!(infos.len(), expected.len());
+        for (info, expected_digest) in infos.iter().zip(expected) {
+            assert_eq!(info.path_digest, expected_digest);
+        }
     }
-
-    // ── CertCrlInfo::from_chain: full chain properties ────────────────────
-
-    #[rstest]
-    fn full_chain_has_correct_count(full_chain: ChainFixture) {
-        let refs = full_chain.refs();
-        let infos = CertCrlInfo::from_chain(&refs).unwrap();
-        assert_eq!(infos.len(), FULL_CHAIN_LEN);
-    }
-
-    #[rstest]
-    fn labels_are_correct(full_chain: ChainFixture) {
-        let refs = full_chain.refs();
-        let infos = CertCrlInfo::from_chain(&refs).unwrap();
-        assert_eq!(infos[0].label, "root");
-        assert_eq!(infos[1].label, "intermediate 1");
-        assert_eq!(infos[2].label, "intermediate 2");
-        assert_eq!(infos[3].label, "intermediate 3");
-        assert_eq!(infos[4].label, "leaf");
-    }
-
-    #[rstest]
-    fn intermediates_1_and_2_have_crl_urls(full_chain: ChainFixture) {
-        let refs = full_chain.refs();
-        let infos = CertCrlInfo::from_chain(&refs).unwrap();
-
-        assert!(infos[0].crl_url.is_none(), "root should not have a CRL URL");
-        assert_eq!(
-            infos[1].crl_url.as_deref(),
-            Some(INTER1_EXPECTED_CRL_URL),
-            "intermediate 1 should have a CRL URL"
-        );
-        assert_eq!(
-            infos[2].crl_url.as_deref(),
-            Some(INTER2_EXPECTED_CRL_URL),
-            "intermediate 2 should have a CRL URL"
-        );
-        assert!(
-            infos[3].crl_url.is_none(),
-            "intermediate 3 does not have a CRL distribution points extension"
-        );
-        assert!(infos[4].crl_url.is_none(), "leaf should not have a CRL URL");
-    }
-
-    // ── Edge cases: empty and invalid chains ────────────────────────────
 
     #[rstest]
     fn empty_chain_returns_empty_vec() {
@@ -592,48 +431,6 @@ mod tests {
         assert!(msg.contains("trailing DER data"), "expected trailing DER error, got: {msg}");
     }
 
-    // ── Edge cases: single-cert and two-cert chains ─────────────────────
-
-    #[rstest]
-    fn single_cert_chain_labels_as_root_and_leaf(root_only_chain: ChainFixture) {
-        let refs = root_only_chain.refs();
-        let infos = CertCrlInfo::from_chain(&refs).unwrap();
-        // A single cert is both first (root) and last (leaf). The labelling
-        // logic checks `i == 0` first, so it should be labelled "root".
-        assert_eq!(infos.len(), 1);
-        assert_eq!(infos[0].label, "root");
-    }
-
-    #[rstest]
-    fn two_cert_chain_labels_root_and_leaf(root_and_leaf_chain: ChainFixture) {
-        let refs = root_and_leaf_chain.refs();
-        let infos = CertCrlInfo::from_chain(&refs).unwrap();
-        assert_eq!(infos.len(), 2);
-        assert_eq!(infos[0].label, "root");
-        assert_eq!(infos[1].label, "leaf");
-        // No intermediates → no CRL URLs expected.
-        assert!(infos[0].crl_url.is_none());
-        assert!(infos[1].crl_url.is_none());
-    }
-
-    // ── build_crl_http_client ───────────────────────────────────────────
-
-    #[rstest]
-    fn build_crl_http_client_succeeds_with_valid_timeout() {
-        let client = build_crl_http_client(Duration::from_secs(DEFAULT_CRL_FETCH_TIMEOUT_SECS));
-        assert!(client.is_ok());
-    }
-
-    #[rstest]
-    fn build_crl_http_client_succeeds_with_zero_timeout() {
-        // Zero timeout is technically valid for reqwest — it means no
-        // timeout. The builder should still succeed.
-        let client = build_crl_http_client(Duration::ZERO);
-        assert!(client.is_ok());
-    }
-
-    // ── check_chain_against_crls: empty / no-intermediate chains ────────
-
     #[tokio::test]
     #[rstest]
     async fn check_chain_against_crls_clean_for_empty_chain() {
@@ -645,8 +442,6 @@ mod tests {
     #[tokio::test]
     #[rstest]
     async fn check_chain_against_crls_skips_root_and_leaf(root_and_leaf_chain: ChainFixture) {
-        // With only root + leaf and no intermediates, no CRL fetches should
-        // be attempted, so the result is Clean even without network access.
         let client = build_crl_http_client(Duration::from_secs(1)).unwrap();
         let refs = root_and_leaf_chain.refs();
         let cert_infos = CertCrlInfo::from_chain(&refs).unwrap();
@@ -675,30 +470,6 @@ mod tests {
         assert!(matches!(&err, CrlError::Parse(_)), "expected Parse, got: {msg}");
         assert!(msg.contains("trailing DER data"), "expected trailing DER error, got: {msg}");
     }
-
-    // ── fetch_and_check_crl: serial comparison logic ────────────────────
-
-    #[rstest]
-    fn serial_bytes_are_correctly_decoded() {
-        // Verify that the serial hex constants round-trip through the
-        // full chain extraction, confirming the `to_bytes_be()` stripping
-        // behaviour is consistent.
-        let expected_serials = [
-            ROOT_EXPECTED_SERIAL_HEX,
-            INTER1_EXPECTED_SERIAL_HEX,
-            INTER2_EXPECTED_SERIAL_HEX,
-            INTER3_EXPECTED_SERIAL_HEX,
-            LEAF_EXPECTED_SERIAL_HEX,
-        ];
-        for serial_hex in &expected_serials {
-            let bytes = hex::decode(serial_hex).unwrap();
-            assert!(!bytes.is_empty(), "serial {serial_hex} decoded to empty bytes");
-            // Round-trip: decode → re-encode should be identical.
-            assert_eq!(&hex::encode(&bytes), *serial_hex);
-        }
-    }
-
-    // ── is_allowed_crl_host tests ───────────────────────────────────────
 
     #[rstest]
     #[case::inter1_url(INTER1_EXPECTED_CRL_URL, true)]


### PR DESCRIPTION
### What changed? Why?

- Simplified CRL certificate metadata to store chain indices instead of persisted display labels.
- Derived labels at logging points and updated revoked-cert tracking to carry index and path digest only.
- Removed redundant CRL tests/docs and dropped the now-unused sha2 dev dependency.

### Notes to reviewers

This is intended to be behavior-preserving. CRL checks still skip root/leaf certificates and use the same path digest computation for revokeCert.

### How has it been tested?

- cargo test -p base-proof-tee-registrar