### PR TITLE
refactor(registrar): extract proof handler

### DIFF
--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -161,7 +161,7 @@ pub struct RegistrarConfig {
     pub prover_timeout: Duration,
     /// Maximum number of instances to process concurrently within a single
     /// registration cycle. Each instance may trigger a ~20-minute proof
-    /// generation, so this limits concurrent proof work and nonce acquisition.
+    /// generation, so this limits concurrent proof work.
     pub max_concurrency: usize,
     /// Maximum number of transaction submission retries for transient errors.
     pub max_tx_retries: u32,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -16,7 +16,7 @@ use alloy_primitives::{Address, Bytes, hex};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::ITEEProverRegistry;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
-use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
+use base_tx_manager::{TxCandidate, TxManager};
 use futures::stream::StreamExt;
 use rand::random;
 use tokio::{
@@ -28,8 +28,8 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result,
-    SignerClient,
+    ProofHandler, ProofHandlerConfig, ProofHandlerContext, ProofHandlerRequest, ProverClient,
+    ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -278,29 +278,6 @@ pub struct RegistrationDriver<D, P, R, T, S> {
     /// registrar (or a prior deployment) wrote the signer.
     /// Entries are never evicted — bounded by historic fleet size.
     signer_history: Arc<Mutex<HashMap<Address, String>>>,
-}
-
-/// RAII guard that removes a signer address from [`RegistrationDriver::in_flight_registrations`]
-/// when dropped.
-///
-/// Ensures cleanup on every exit path from `try_register` — success,
-/// error, retry-exhaustion, cancellation drop, and panic — so a failed
-/// or cancelled registration does not permanently block future attempts
-/// for the same signer.
-struct InFlightGuard {
-    in_flight: Arc<Mutex<HashSet<Address>>>,
-    signer: Address,
-}
-
-impl Drop for InFlightGuard {
-    fn drop(&mut self) {
-        // The critical section is a single `HashSet::remove` and cannot
-        // panic under normal conditions, so poisoning is effectively
-        // impossible. If it ever occurs, the set contents are still
-        // valid and cleanup must proceed.
-        let mut set = self.in_flight.lock().unwrap_or_else(|e| e.into_inner());
-        set.remove(&self.signer);
-    }
 }
 
 impl<D, P, R, T, S> fmt::Debug for RegistrationDriver<D, P, R, T, S> {
@@ -699,360 +676,30 @@ where
         attestation_bytes: &[u8],
         signer_cancel: &CancellationToken,
     ) -> Result<()> {
-        // Check cancellation BEFORE any other work: a task that was
-        // already cancelled (e.g. its signer just vanished from
-        // discovery, or shutdown started) shouldn't acquire the
-        // in-flight mutex or do registry RPC work. This bounds
-        // shutdown latency by the longest in-flight operation rather
-        // than by an additional registry round-trip per pending task
-        // (audit finding #8).
-        if signer_cancel.is_cancelled() {
-            debug!(signer = %signer_address, "task cancelled before registry probe");
-            return Ok(());
-        }
-
-        // Reserve this signer in the in-flight set before the
-        // `is_registered` precheck. If another concurrent task already
-        // owns it — e.g. a sibling `process_instance` future for a
-        // different prover instance that happens to back the same
-        // enclave signing key during a rotation — short-circuit so we
-        // don't race past the TOCTOU `is_registered` check, regenerate
-        // the proof, and submit a duplicate registration transaction.
-        //
-        // This is a defence-in-depth backstop to the [`Self::run`]
-        // spawn loop's task-spawn-time dedupe (`in_flight: HashSet<Address>`),
-        // catching any caller path that bypasses the spawn loop.
-        //
-        // The guard is held across the entire registration (including
-        // the ~20 minute Boundless proof generation and the onchain
-        // confirmation wait) and is released via RAII on every exit
-        // path: success, error, retry-exhaustion, cancellation drop,
-        // and panic.
-        let _in_flight = {
-            let mut set = self.in_flight_registrations.lock().unwrap_or_else(|e| e.into_inner());
-            if !set.insert(signer_address) {
-                debug!(
-                    signer = %signer_address,
-                    enclave_index,
-                    instance = %instance.instance_id,
-                    "registration already in flight for this signer, skipping duplicate",
-                );
-                return Ok(());
-            }
-            InFlightGuard {
-                in_flight: Arc::clone(&self.in_flight_registrations),
-                signer: signer_address,
-            }
+        let handler_config = ProofHandlerConfig {
+            registry_address: self.config.registry_address,
+            max_tx_retries: self.config.max_tx_retries,
+            tx_retry_delay: self.config.tx_retry_delay,
         };
 
-        // Cancel-aware: `is_registered` is a side-effect-free read, so
-        // dropping it on cancel is safe (no nonce risk, no onchain
-        // state mutation). Without this select, a shutdown during the
-        // registry RPC would extend drain latency by an entire
-        // round-trip per pending task.
-        let already_registered = tokio::select! {
-            biased;
-            () = signer_cancel.cancelled() => {
-                debug!(
-                    signer = %signer_address,
-                    "cancelled while probing registry pre-proof-gen"
-                );
-                return Ok(());
-            }
-            res = self.registry.is_registered(signer_address) => res?,
-        };
-        if already_registered {
-            debug!(signer = %signer_address, "already registered, skipping");
-            return Ok(());
-        }
-
-        // Check cancellation before the most expensive operation (proof generation
-        // can take minutes via Boundless).
-        if signer_cancel.is_cancelled() {
-            debug!("shutdown requested, skipping proof generation");
-            return Ok(());
-        }
-
-        info!(
-            signer = %signer_address,
-            enclave_index,
-            instance = %instance.instance_id,
-            "generating proof for unregistered signer"
-        );
-
-        // Acquire a proof-concurrency permit. Bounds the number of
-        // simultaneous Boundless/Direct proof generations across all
-        // spawned tasks to [`DriverConfig::max_concurrency`], matching the
-        // discovery/resolve concurrency bound. Held until `_permit` drops
-        // at the end of this scope (after proof gen + the tx send loop).
-        // Cancellation while waiting on a permit is a clean exit.
-        let _permit = tokio::select! {
-            biased;
-            () = signer_cancel.cancelled() => {
-                debug!(
-                    signer = %signer_address,
-                    instance = %instance.instance_id,
-                    "task cancelled before acquiring proof permit"
-                );
-                return Ok(());
-            }
-            permit = Arc::clone(&self.proof_semaphore).acquire_owned() => {
-                // `acquire_owned` only errors when the semaphore is
-                // closed; we never call `close()`, so this branch should
-                // be unreachable. Treat it as a clean exit rather than a
-                // panic so a future refactor that introduces `close()`
-                // (or pulls in a third-party semaphore wrapper) cannot
-                // crash the registration driver loop.
-                match permit {
-                    Ok(p) => p,
-                    Err(_) => {
-                        warn!(
-                            signer = %signer_address,
-                            instance = %instance.instance_id,
-                            "proof semaphore closed unexpectedly, exiting task"
-                        );
-                        return Ok(());
-                    }
-                }
-            }
-        };
-
-        // Cooperative cancel-safety around the long-running proof.
-        //
-        // `signer_cancel` is a child of the driver's global cancel token,
-        // so a process-wide shutdown or a `reconcile_proof_tasks` decision
-        // (instance vanished / no longer registerable) both reach us here.
-        // Biased select! checks the token first to bound wake latency.
-        //
-        // Dropping the `generate_proof_for_signer` future on cancel may
-        // abandon work the impl had already started (see provider docs);
-        // for `DirectProver` this leaks a `spawn_blocking` until the
-        // backend completes, and for `BoundlessProver` any already-submitted
-        // offchain request is recoverable via the deterministic
-        // request-id derivation on the next call.
-        //
-        // Race window: the biased `select!` polls the cancel branch first,
-        // but if the token fires *between* that poll and the provider's own
-        // internal `cancel.is_cancelled()` check, the provider returns an
-        // `Err` that we must not propagate as a task failure (it would
-        // violate the `PendingRegistration` "cancelled task always
-        // returns `Ok(signer)`" contract and bump `processing_errors_total`
-        // for a clean cancel).
-        // The `Err(_) if signer_cancel.is_cancelled()` arm closes that gap.
-        //
-        // Invariant: the token forwarded to the provider MUST be the
-        // same `signer_cancel` the outer arm polls — the guard observes
-        // provider-side cancel-fires through that shared state. A future
-        // refactor that passed a child token to the provider (e.g. for
-        // per-provider tighter scoping) would silently break this guard
-        // because `signer_cancel.is_cancelled()` would stay `false` when
-        // only the child fired.
-        let proof = tokio::select! {
-            biased;
-            () = signer_cancel.cancelled() => {
-                debug!(
-                    signer = %signer_address,
-                    instance = %instance.instance_id,
-                    "task cancelled during proof generation"
-                );
-                return Ok(());
-            }
-            res = self.proof_provider.generate_proof_for_signer(attestation_bytes, signer_address, signer_cancel) => {
-                match res {
-                    Ok(p) => p,
-                    Err(_) if signer_cancel.is_cancelled() => {
-                        debug!(
-                            signer = %signer_address,
-                            instance = %instance.instance_id,
-                            "task cancelled during proof generation (provider returned Err after cancel)",
-                        );
-                        return Ok(());
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-        };
-
-        // Check cancellation before submitting the transaction — avoid starting
-        // new onchain work if shutdown is in progress.
-        if signer_cancel.is_cancelled() {
-            debug!("shutdown requested, skipping transaction submission");
-            return Ok(());
-        }
-
-        let calldata = Bytes::from(
-            ITEEProverRegistry::registerSignerCall {
-                output: proof.output,
-                proofBytes: proof.proof_bytes,
-            }
-            .abi_encode(),
-        );
-
-        info!(
-            signer = %signer_address,
-            instance = %instance.instance_id,
-            registry = %self.config.registry_address,
-            calldata_len = calldata.len(),
-            "Registering signer"
-        );
-
-        let candidate = TxCandidate {
-            tx_data: calldata,
-            to: Some(self.config.registry_address),
-            ..Default::default()
-        };
-
-        info!(
-            tx = ?candidate,
-            "Sending tx candidate",
-        );
-
-        // Retry tx submission on transient errors to avoid discarding an
-        // expensive proof (~20 min Boundless generation) on a nonce race
-        // or brief network blip.
-        //
-        // Only errors that `TxManagerError::is_retryable()` considers
-        // transient are retried.  Deterministic failures (execution
-        // reverted, insufficient funds, config errors, fee limits, etc.)
-        // abort immediately since retrying with the same calldata and
-        // state cannot succeed.
-        let max_tx_retries = self.config.max_tx_retries;
-        let tx_retry_delay = self.config.tx_retry_delay;
-        let mut tx_retries = 0;
-
-        let receipt = loop {
-            // Check cancellation at the top of each iteration to avoid
-            // starting new onchain work after shutdown is requested.
-            //
-            // IMPORTANT: we never wrap `tx_manager.send()` itself in a
-            // `select!` against `signer_cancel` — dropping `send()` after
-            // nonce acquisition but before broadcast leaves a nonce gap
-            // (see `NonceGuard::Drop` which does not roll back).
-            if signer_cancel.is_cancelled() {
-                debug!("shutdown requested, aborting tx submission");
-                return Ok(());
-            }
-
-            match self.tx_manager.send(candidate.clone()).await {
-                Ok(receipt) => break receipt,
-                Err(e) => {
-                    // The signer may already be registered despite the error
-                    // (e.g. the tx was mined but the tx manager reported a
-                    // nonce race during fee bumping). Check onchain state.
-                    //
-                    // Cancel-aware: side-effect-free read; safe to drop on
-                    // cancel. The surrounding retry loop's top-of-iter
-                    // `signer_cancel.is_cancelled()` check already bounds
-                    // latency to one in-flight tx send, but a stalled
-                    // registry RPC here would still extend drain by an
-                    // entire round-trip per failed-tx retry.
-                    let post_err_check = tokio::select! {
-                        biased;
-                        () = signer_cancel.cancelled() => {
-                            debug!(
-                                signer = %signer_address,
-                                "cancelled while verifying post-tx-error registration state"
-                            );
-                            return Ok(());
-                        }
-                        res = self.registry.is_registered(signer_address) => res,
-                    };
-                    match post_err_check {
-                        Ok(true) => {
-                            info!(
-                                signer = %signer_address,
-                                error = %e,
-                                "tx error but signer is registered onchain, treating as success"
-                            );
-                            RegistrarMetrics::registrations_total().increment(1);
-                            return Ok(());
-                        }
-                        Err(registry_err) => {
-                            warn!(
-                                error = %registry_err,
-                                signer = %signer_address,
-                                "failed to query is_registered after tx error"
-                            );
-                        }
-                        Ok(false) => {}
-                    }
-
-                    // Non-retryable errors (execution reverts, insufficient
-                    // funds, config errors, fee limits, etc.) cannot be
-                    // resolved by retrying with the same calldata.
-                    if !e.is_retryable() {
-                        // If the contract reverted execution, the proof
-                        // itself is likely invalid (wrong image ID, stale
-                        // attestation, etc.). Block recovery for this
-                        // signer so the next cycle generates a fresh
-                        // proof instead of re-recovering the same one.
-                        if matches!(e, TxManagerError::ExecutionReverted { .. }) {
-                            warn!(
-                                signer = %signer_address,
-                                "execution reverted, blocking proof recovery for signer"
-                            );
-                            self.proof_provider.block_recovery_for_signer(signer_address);
-                        }
-                        return Err(RegistrarError::from(e));
-                    }
-
-                    tx_retries += 1;
-                    if tx_retries > max_tx_retries {
-                        return Err(RegistrarError::from(e));
-                    }
-
-                    warn!(
-                        error = %e,
-                        signer = %signer_address,
-                        retry = tx_retries,
-                        max_retries = max_tx_retries,
-                        "tx submission failed, retrying with same proof"
-                    );
-
-                    // Cancellation-aware delay: abort immediately if
-                    // shutdown is requested during the retry wait.
-                    tokio::select! {
-                        biased;
-                        () = signer_cancel.cancelled() => {
-                            // Cooperative cancel during the retry wait is
-                            // a clean exit, not a task failure — match the
-                            // `PendingRegistration` doc contract ("returns
-                            // `Ok(signer)` when it observes the cancel").
-                            // The underlying
-                            // tx error is logged for context; the next
-                            // discovery cycle will respawn if still wanted.
-                            debug!(
-                                error = %e,
-                                signer = %signer_address,
-                                "shutdown requested during retry delay; abandoning task"
-                            );
-                            return Ok(());
-                        }
-                        () = tokio::time::sleep(tx_retry_delay) => {}
-                    }
-                }
-            }
-        };
-
-        if !receipt.inner.status() {
-            warn!(
-                signer = %signer_address,
-                tx_hash = %receipt.transaction_hash,
-                "registration transaction reverted onchain",
-            );
-            return Err(RegistrarError::Transaction(
-                format!("registration transaction {} reverted", receipt.transaction_hash,).into(),
-            ));
-        }
-
-        info!(
-            signer = %signer_address,
-            tx_hash = %receipt.transaction_hash,
-            "signer registered successfully"
-        );
-        RegistrarMetrics::registrations_total().increment(1);
-
-        Ok(())
+        ProofHandler::register_signer(
+            ProofHandlerContext {
+                proof_provider: &self.proof_provider,
+                registry: &self.registry,
+                tx_manager: &self.tx_manager,
+                proof_semaphore: self.proof_semaphore.as_ref(),
+                in_flight_registrations: &self.in_flight_registrations,
+                config: &handler_config,
+            },
+            ProofHandlerRequest {
+                instance,
+                signer_address,
+                enclave_index,
+                attestation_bytes,
+                signer_cancel,
+            },
+        )
+        .await
     }
 
     /// Resolves the signer addresses for a single instance and decides

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -28,8 +28,8 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    ProofHandler, ProofHandlerConfig, ProofHandlerContext, ProofHandlerRequest, ProverClient,
-    ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result, SignerClient,
+    ProofHandler, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient,
+    Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -676,29 +676,17 @@ where
         attestation_bytes: &[u8],
         signer_cancel: &CancellationToken,
     ) -> Result<()> {
-        let handler_config = ProofHandlerConfig {
+        ProofHandler {
+            proof_provider: &self.proof_provider,
+            registry: &self.registry,
+            tx_manager: &self.tx_manager,
+            proof_semaphore: self.proof_semaphore.as_ref(),
+            in_flight_registrations: &self.in_flight_registrations,
             registry_address: self.config.registry_address,
             max_tx_retries: self.config.max_tx_retries,
             tx_retry_delay: self.config.tx_retry_delay,
-        };
-
-        ProofHandler::register_signer(
-            ProofHandlerContext {
-                proof_provider: &self.proof_provider,
-                registry: &self.registry,
-                tx_manager: &self.tx_manager,
-                proof_semaphore: self.proof_semaphore.as_ref(),
-                in_flight_registrations: &self.in_flight_registrations,
-                config: &handler_config,
-            },
-            ProofHandlerRequest {
-                instance,
-                signer_address,
-                enclave_index,
-                attestation_bytes,
-                signer_cancel,
-            },
-        )
+        }
+        .register_signer(instance, signer_address, enclave_index, attestation_bytes, signer_cancel)
         .await
     }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -28,8 +28,8 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    ProofHandler, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient,
-    Result, SignerClient,
+    ProofHandler, ProofHandlerConfig, ProverClient, ProverInstance, RegistrarError,
+    RegistrarMetrics, RegistryClient, Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -676,16 +676,18 @@ where
         attestation_bytes: &[u8],
         signer_cancel: &CancellationToken,
     ) -> Result<()> {
-        ProofHandler {
-            proof_provider: &self.proof_provider,
-            registry: &self.registry,
-            tx_manager: &self.tx_manager,
-            proof_semaphore: self.proof_semaphore.as_ref(),
-            in_flight_registrations: &self.in_flight_registrations,
-            registry_address: self.config.registry_address,
-            max_tx_retries: self.config.max_tx_retries,
-            tx_retry_delay: self.config.tx_retry_delay,
-        }
+        ProofHandler::new(
+            &self.proof_provider,
+            &self.registry,
+            &self.tx_manager,
+            self.proof_semaphore.as_ref(),
+            &self.in_flight_registrations,
+            ProofHandlerConfig {
+                registry_address: self.config.registry_address,
+                max_tx_retries: self.config.max_tx_retries,
+                tx_retry_delay: self.config.tx_retry_delay,
+            },
+        )
         .register_signer(instance, signer_address, enclave_index, attestation_bytes, signer_cancel)
         .await
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -36,8 +36,8 @@ use crate::{
 ///
 /// Each instance may trigger a ~20-minute Boundless proof generation, so
 /// limiting concurrency prevents overwhelming the proof service and keeps
-/// nonce management tractable. The default allows moderate parallelism
-/// while keeping resource usage bounded.
+/// resource usage bounded. The transaction manager handles nonce
+/// serialization separately.
 pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
 /// Default maximum number of transaction submission retries for transient
@@ -70,8 +70,8 @@ pub struct DriverConfig {
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
     /// Maximum number of instances to process concurrently. Each instance
-    /// may trigger proof generation, so this bounds concurrent proof work
-    /// and nonce acquisition. Defaults to [`DEFAULT_MAX_CONCURRENCY`].
+    /// may trigger proof generation, so this bounds concurrent proof work.
+    /// Defaults to [`DEFAULT_MAX_CONCURRENCY`].
     pub max_concurrency: usize,
     /// Maximum number of transaction submission retries for transient errors.
     /// Defaults to [`DEFAULT_MAX_TX_RETRIES`].

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1524,7 +1524,7 @@ mod tests {
         collections::{HashMap, HashSet, VecDeque},
         sync::{
             Arc, Mutex,
-            atomic::{AtomicU32, AtomicUsize, Ordering},
+            atomic::{AtomicUsize, Ordering},
         },
         time::SystemTime,
     };
@@ -1705,33 +1705,6 @@ mod tests {
         ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
             Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
                 "simulated proof failure".into(),
-            ))
-        }
-    }
-
-    /// Mock proof provider that cancels its own token and then returns
-    /// `Err` synchronously on the same poll — simulating the race window
-    /// where `BoundlessProver`'s internal `cancel.is_cancelled()` check
-    /// fires *after* `try_register`'s biased `select!` has polled the
-    /// cancel branch (Pending) but *before* the select can re-poll it.
-    ///
-    /// Without the `Err(_) if signer_cancel.is_cancelled()` guard in
-    /// `try_register`, this `Err` would propagate as a task failure and
-    /// violate the `PendingRegistration` "cancelled task always
-    /// returns `Ok(signer)`" contract.
-    #[derive(Debug)]
-    struct CancelThenErrorProofProvider;
-
-    #[async_trait]
-    impl AttestationProofProvider for CancelThenErrorProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            cancel.cancel();
-            Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
-                "simulated cancel-race".into(),
             ))
         }
     }
@@ -1995,45 +1968,7 @@ mod tests {
         )
     }
 
-    // ── Configurable mock types for retry tests ────────────────────────
-
-    /// Maximum number of tx submission retries used by `default_config`.
-    const MAX_TX_RETRIES: u32 = DEFAULT_MAX_TX_RETRIES;
-
-    /// Proof provider that counts `generate_proof` invocations.
-    ///
-    /// Returns the same stub proof as [`StubProofProvider`] but tracks
-    /// how many times it was called, allowing tests to assert that the
-    /// expensive proof generation is not repeated across retries.
-    #[derive(Debug)]
-    struct CountingProofProvider {
-        call_count: AtomicU32,
-    }
-
-    impl CountingProofProvider {
-        fn new() -> Self {
-            Self { call_count: AtomicU32::new(0) }
-        }
-
-        fn call_count(&self) -> u32 {
-            self.call_count.load(Ordering::Relaxed)
-        }
-    }
-
-    #[async_trait]
-    impl AttestationProofProvider for CountingProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            self.call_count.fetch_add(1, Ordering::Relaxed);
-            Ok(AttestationProof {
-                output: Bytes::from_static(b"stub-output"),
-                proof_bytes: Bytes::from_static(b"stub-proof"),
-            })
-        }
-    }
+    // ── Proof-task mock types ─────────────────────────────────────────
 
     /// Proof provider that records the `(signer, attestation_bytes)` pair
     /// passed to every `generate_proof_for_signer` invocation, then
@@ -2103,12 +2038,7 @@ mod tests {
             Self { results: Arc::new(Mutex::new(results)), sent: Arc::new(Mutex::new(vec![])) }
         }
 
-        /// Returns the number of `send()` calls made.
-        fn send_count(&self) -> usize {
-            self.sent.lock().unwrap().len()
-        }
-
-        /// Returns all submitted calldata for equality assertions.
+        /// Returns all submitted calldata for assertion.
         fn sent_calldata(&self) -> Vec<Bytes> {
             self.sent.lock().unwrap().clone()
         }
@@ -2125,7 +2055,7 @@ mod tests {
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-            panic!("FailingTxManager::send_async is not implemented; retry tests only use send()")
+            panic!("FailingTxManager::send_async is not implemented; tests only use send()")
         }
 
         fn sender_address(&self) -> Address {
@@ -2152,16 +2082,6 @@ mod tests {
         fn never_registered(signers: Vec<Address>) -> Self {
             Self { signers, responses: Mutex::new(VecDeque::new()), default_registered: false }
         }
-
-        /// Registry where the first call returns `false` (initial check),
-        /// then subsequent calls return `true` (signer appeared onchain).
-        fn registered_after_first_check(signers: Vec<Address>) -> Self {
-            Self {
-                signers,
-                responses: Mutex::new(VecDeque::from([false])),
-                default_registered: true,
-            }
-        }
     }
 
     #[async_trait]
@@ -2174,28 +2094,6 @@ mod tests {
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
             Ok(self.signers.clone())
         }
-    }
-
-    /// Builds a driver for tx retry tests with configurable proof provider,
-    /// tx manager, and registry.
-    fn retry_driver<P: AttestationProofProvider + 'static>(
-        signer_client: MockSignerClient,
-        registry: DynamicRegistry,
-        tx: FailingTxManager,
-        proof_provider: P,
-        cancel: CancellationToken,
-    ) -> RegistrationDriver<MockDiscovery, P, DynamicRegistry, FailingTxManager, MockSignerClient>
-    {
-        RegistrationDriver::new(
-            MockDiscovery { instances: vec![] },
-            proof_provider,
-            registry,
-            tx,
-            signer_client,
-            default_config(cancel),
-            None,
-        )
-        .expect("test driver construction succeeds")
     }
 
     // ── Pipeline test infrastructure ────────────────────────────────────
@@ -3964,341 +3862,35 @@ mod tests {
         assert!(tx.sent_calldata().is_empty(), "discover_and_resolve must not send txs");
     }
 
-    // ── tx retry tests (Fix C) ──────────────────────────────────────────
-    //
-    // These tests verify the retry loop in `try_register`. Key
-    // invariants:
-    // - The expensive proof is generated exactly once and reused across
-    //   retries (identical calldata in every `send()` call).
-    // - Non-retryable errors abort immediately.
-    // - `is_registered` is checked after each failure to catch false
-    //   negatives.
-    // - Cancellation is respected both at the top of the loop and during
-    //   the retry delay.
-
-    /// Asserts that all calldata entries submitted to the tx manager are
-    /// identical, confirming the same proof is reused across retries.
-    fn assert_all_calldata_identical(sent: &[Bytes]) {
-        if sent.len() < 2 {
-            return;
-        }
-        for (i, entry) in sent.iter().enumerate().skip(1) {
-            assert_eq!(
-                &sent[0], entry,
-                "calldata mismatch: sent[0] != sent[{i}] — proof was regenerated"
-            );
-        }
-    }
-
-    /// Transient errors followed by success: the retry loop should retry
-    /// and eventually succeed. Proof is generated once, same calldata
-    /// across all attempts.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_retries_transient_error_then_succeeds() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![
-            TxManagerError::Rpc("transient 1".into()),
-            TxManagerError::Rpc("transient 2".into()),
-        ]);
-        let proof_provider = CountingProofProvider::new();
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            proof_provider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        assert!(result.is_ok(), "should succeed after retries: {result:?}");
-        // 2 failed attempts + 1 success = 3 total sends.
-        assert_eq!(tx.send_count(), 3);
-        assert_all_calldata_identical(&tx.sent_calldata());
-        assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
-    }
-
-    /// Transient error but onchain check shows signer is already
-    /// registered: should return Ok without retrying.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_already_registered_after_error_returns_ok() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![TxManagerError::Rpc("nonce race".into())]);
-        // First `is_registered` call (before proof gen) returns false.
-        // Second call (after tx error) returns true (tx was mined despite error).
-        let registry = DynamicRegistry::registered_after_first_check(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            StubProofProvider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        assert!(result.is_ok(), "should succeed: signer registered onchain: {result:?}");
-        // Only 1 send attempt — the is_registered check short-circuits retry.
-        assert_eq!(tx.send_count(), 1);
-    }
-
-    /// Non-retryable errors abort immediately without retry.
-    /// Each variant is a distinct `TxManagerError` that `is_retryable()` returns
-    /// `false` for — the retry loop must recognise them and bail after one send.
-    #[rstest]
-    #[case::execution_reverted(TxManagerError::ExecutionReverted {
-        reason: Some("bad proof".into()),
-        data: None,
-    })]
-    #[case::insufficient_funds(TxManagerError::InsufficientFunds)]
-    #[case::fee_limit_exceeded(TxManagerError::FeeLimitExceeded { fee: 500, ceiling: 100 })]
-    #[tokio::test(start_paused = true)]
-    async fn try_register_non_retryable_error_aborts_immediately(#[case] error: TxManagerError) {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![error]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            StubProofProvider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        // process_instance logs errors but doesn't propagate them, so it returns Ok.
-        // However, the tx manager should only have been called once (no retry).
-        assert!(result.is_ok());
-        assert_eq!(tx.send_count(), 1, "should not retry after non-retryable error");
-    }
-
-    /// Transient errors exhaust all retries: should fail after
-    /// `MAX_TX_RETRIES` + 1 attempts. Same calldata in every attempt.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_exhausts_retries_then_fails() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        // Return more errors than MAX_TX_RETRIES allows.
-        let errors: Vec<TxManagerError> = (0..=MAX_TX_RETRIES)
-            .map(|_| TxManagerError::Rpc("persistent failure".into()))
-            .collect();
-        let tx = FailingTxManager::with_errors(errors);
-        let proof_provider = CountingProofProvider::new();
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            proof_provider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        // process_instance catches the error — verify via send count.
-        assert!(result.is_ok());
-        // 1 initial + MAX_TX_RETRIES retries = MAX_TX_RETRIES + 1 total.
-        assert_eq!(
-            tx.send_count(),
-            (MAX_TX_RETRIES + 1) as usize,
-            "should attempt exactly MAX_TX_RETRIES + 1 sends",
-        );
-        assert_all_calldata_identical(&tx.sent_calldata());
-        assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
-    }
-
-    /// Cancellation during the retry sleep aborts the retry loop without
-    /// sending another transaction.
-    ///
-    /// Uses `start_paused = true` so time advances only when polled.
-    /// The cancel token fires 1 second into the 5-second retry delay,
-    /// then we advance time past the full delay to prove no second send
-    /// occurs.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_cancellation_during_retry_sleep_aborts() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        // Return enough transient errors for multiple retries — but
-        // cancellation should prevent all but the first.
-        let tx = FailingTxManager::with_errors(vec![
-            TxManagerError::Rpc("fail 1".into()),
-            TxManagerError::Rpc("fail 2".into()),
-            TxManagerError::Rpc("fail 3".into()),
-        ]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let cancel = CancellationToken::new();
-        let driver =
-            retry_driver(signer_client, registry, tx.clone(), StubProofProvider, cancel.clone());
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-
-        // Spawn a task that cancels after 1 second (during the 5s delay).
-        let cancel_handle = cancel.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            cancel_handle.cancel();
-        });
-
-        let result = driver.process_instance(&inst).await;
-
-        assert!(result.is_ok());
-        // Only 1 send: the tokio::select! in the retry delay catches
-        // the cancellation before the sleep completes.
-        assert_eq!(tx.send_count(), 1, "should abort during retry sleep");
-    }
-
-    /// Cancellation before the retry loop starts: no tx is sent at all.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_cancellation_before_loop_sends_nothing() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let cancel = CancellationToken::new();
-        cancel.cancel(); // Cancel before entering try_register.
-        let driver = retry_driver(signer_client, registry, tx.clone(), StubProofProvider, cancel);
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        assert!(result.is_ok());
-        assert_eq!(tx.send_count(), 0, "should not send any tx after pre-cancellation");
-    }
-
-    /// Cancel-race: provider returns `Err` synchronously *after* having
-    /// fired the cancel token in the same poll. The biased `select!` in
-    /// `try_register` polled the cancel branch (then Pending) before
-    /// polling the provider arm, so it commits to the provider's `Err`
-    /// rather than the (now-fired) cancel. The
-    /// `Err(_) if signer_cancel.is_cancelled()` guard catches this and
-    /// returns `Ok(())` so the outer `run_proof_task` can map it to
-    /// `Ok(signer)` per the `PendingRegistration` contract.
-    #[tokio::test]
-    async fn try_register_provider_err_after_cancel_returns_ok() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let cancel = CancellationToken::new();
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            CancelThenErrorProofProvider,
-            cancel.clone(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-
-        let res = driver.try_register(&inst, signer, 0, b"stub-attestation", &cancel).await;
-
-        assert!(
-            res.is_ok(),
-            "provider Err after cancel must be mapped to Ok(()) by try_register; got {res:?}",
-        );
-        assert_eq!(tx.send_count(), 0, "cancelled task must not submit a transaction");
-    }
-
-    /// Mixed errors: transient → `ExecutionReverted`. The retry loop should
-    /// process the first error (retryable), then abort on the second
-    /// (non-retryable) without further retries.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_transient_then_execution_reverted() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![
-            TxManagerError::Rpc("transient".into()),
-            TxManagerError::ExecutionReverted { reason: None, data: None },
-        ]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            StubProofProvider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        assert!(result.is_ok());
-        // 2 sends: first retryable, second fatal.
-        assert_eq!(tx.send_count(), 2);
-        assert_all_calldata_identical(&tx.sent_calldata());
-    }
-
-    /// Immediate success on first attempt: no retries needed.
-    #[tokio::test(start_paused = true)]
-    async fn try_register_immediate_success() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![]); // no errors — immediate success
-        let proof_provider = CountingProofProvider::new();
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            proof_provider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let result = driver.process_instance(&inst).await;
-
-        assert!(result.is_ok());
-        assert_eq!(tx.send_count(), 1, "should succeed on first attempt");
-        assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
-    }
-
     // ── cancel-aware registry await tests ──────────────────────────────
     //
-    // The three production registry RPCs in the spawned-task path —
-    // `is_registered` (pre-proof-gen and post-tx-error in `try_register`)
-    // and `get_registered_signers` (in `run_orphan_dereg`) — are each
-    // wrapped in `select!` against their owning cancel token so a
-    // shutdown during the RPC drops the call immediately. Without these
-    // wraps, a stalled registry RPC would extend drain latency by an
-    // entire round-trip per pending task (or per orphan-dereg cycle),
-    // far above the cooperative `tx_manager.send()` bound that drain
-    // already accepts.
+    // `get_registered_signers` in `run_orphan_dereg` is wrapped in
+    // `select!` against the driver cancel token so a shutdown during the
+    // RPC drops the call immediately. Proof-handler-owned registry awaits
+    // are covered in `proof_handler::tests`.
 
     /// Per-call stall registry: parks the configured method on a
     /// never-completing future. Used to assert that the `select!`
-    /// wrappers in `try_register` and `run_orphan_dereg` short-circuit
-    /// on cancel instead of blocking on the RPC.
+    /// wrapper in `run_orphan_dereg` short-circuits on cancel instead of
+    /// blocking on the RPC.
     struct StallingRegistry {
-        stall_is_registered: bool,
-        stall_get_registered_signers: bool,
         signers: Vec<Address>,
     }
 
     impl StallingRegistry {
-        fn stalling_is_registered() -> Self {
-            Self { stall_is_registered: true, stall_get_registered_signers: false, signers: vec![] }
-        }
-
         fn stalling_get_registered_signers(signers: Vec<Address>) -> Self {
-            Self { stall_is_registered: false, stall_get_registered_signers: true, signers }
+            Self { signers }
         }
     }
 
     #[async_trait]
     impl RegistryClient for StallingRegistry {
         async fn is_registered(&self, _signer: Address) -> Result<bool> {
-            if self.stall_is_registered {
-                std::future::pending::<()>().await;
-            }
             Ok(false)
         }
 
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            if self.stall_get_registered_signers {
-                std::future::pending::<()>().await;
-            }
+            std::future::pending::<()>().await;
             Ok(self.signers.clone())
         }
     }
@@ -4315,58 +3907,6 @@ mod tests {
     /// reaches its `is_registered` await point, short enough that the
     /// total test time stays well under [`CANCEL_ABORT_BUDGET`].
     const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
-
-    /// `try_register` MUST abort promptly when its `signer_cancel`
-    /// fires during the pre-proof-gen `is_registered` RPC. Without the
-    /// `select!` wrap this call would block until the RPC eventually
-    /// returns, extending drain latency by one round-trip per pending
-    /// task at shutdown.
-    #[tokio::test]
-    async fn try_register_aborts_promptly_when_cancel_fires_during_registry_stall() {
-        let cancel = CancellationToken::new();
-        let signer_cancel = cancel.child_token();
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let driver = Arc::new(
-            RegistrationDriver::new(
-                MockDiscovery { instances: vec![] },
-                StubProofProvider,
-                StallingRegistry::stalling_is_registered(),
-                SharedTxManager::new(),
-                StubSignerClient,
-                default_config(cancel.clone()),
-                None,
-            )
-            .expect("driver constructs"),
-        );
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let attestation = vec![0u8; 32];
-
-        let driver_clone = Arc::clone(&driver);
-        let signer_cancel_clone = signer_cancel.clone();
-        let handle = tokio::spawn(async move {
-            let start = tokio::time::Instant::now();
-            let res = driver_clone
-                .try_register(&inst, signer, 0, &attestation, &signer_cancel_clone)
-                .await;
-            (res, start.elapsed())
-        });
-
-        // Let the spawned task reach its `is_registered` await.
-        tokio::time::sleep(PRE_CANCEL_WARMUP).await;
-        signer_cancel.cancel();
-
-        let (result, elapsed) = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
-            .await
-            .expect("try_register must not hang past the timeout")
-            .expect("spawned task must not panic");
-
-        assert!(result.is_ok(), "cancel-induced exit must be Ok(()): {result:?}");
-        assert!(
-            elapsed < CANCEL_ABORT_BUDGET,
-            "cancel must abort the registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
-        );
-    }
 
     /// `run_orphan_dereg` MUST abort promptly when `config.cancel` fires
     /// during the `get_registered_signers` RPC. Without the `select!`
@@ -5708,158 +5248,4 @@ mod tests {
     // paths. Mixing real cert bytes into these orchestration tests would
     // not exercise any additional code and would add ~3 KB of attestation
     // byte literals to every test run.
-
-    // ── In-flight dedup tests (try_register layer) ──────────────────────
-    //
-    // Covers the in-flight registration guard at the `try_register`
-    // layer (process-local `Mutex<HashSet<Address>>`) which closes the
-    // TOCTOU race in which two concurrent `try_register` invocations
-    // for the same signer race past the `is_registered` precheck and
-    // both submit duplicate registration transactions. This is a
-    // defence-in-depth backstop to the spawn-loop dedupe in
-    // [`RegistrationDriver::run`].
-
-    /// Proof provider that yields cooperatively during proof generation.
-    ///
-    /// Without yielding, the single-threaded test executor would run the
-    /// first concurrent future to completion before polling the second,
-    /// hiding any race window in `try_register`. The repeated yields here
-    /// guarantee a second concurrent caller is polled — and reaches its
-    /// own in-flight check — while the first is still mid-proof.
-    #[derive(Debug)]
-    struct YieldingProofProvider {
-        call_count: Arc<AtomicU32>,
-    }
-
-    impl YieldingProofProvider {
-        fn new() -> Self {
-            Self { call_count: Arc::new(AtomicU32::new(0)) }
-        }
-
-        fn call_count(&self) -> u32 {
-            self.call_count.load(Ordering::Relaxed)
-        }
-    }
-
-    #[async_trait]
-    impl AttestationProofProvider for YieldingProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            self.call_count.fetch_add(1, Ordering::Relaxed);
-            // Yield repeatedly so any concurrent task gets polled and
-            // exercises the in-flight dedup path.
-            for _ in 0..16 {
-                tokio::task::yield_now().await;
-            }
-            Ok(AttestationProof {
-                output: Bytes::from_static(b"stub-output"),
-                proof_bytes: Bytes::from_static(b"stub-proof"),
-            })
-        }
-    }
-
-    /// Two concurrent `process_instance` calls that resolve to the same
-    /// signer address must collapse into a single registration: only one
-    /// proof generated, only one tx submitted, both calls return Ok.
-    ///
-    /// Models the cross-instance rotation case where two prover instances
-    /// briefly back the same enclave signing key, as well as the
-    /// intra-instance case where the per-enclave loop resolves the same
-    /// address more than once.
-    #[tokio::test]
-    async fn try_register_concurrent_same_signer_dedups() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![]); // both attempts succeed
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let proof_provider = YieldingProofProvider::new();
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            proof_provider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let (r1, r2) = tokio::join!(driver.process_instance(&inst), driver.process_instance(&inst));
-
-        assert!(r1.is_ok(), "first concurrent registration failed: {r1:?}");
-        assert!(r2.is_ok(), "second concurrent registration failed: {r2:?}");
-        assert_eq!(
-            tx.send_count(),
-            1,
-            "concurrent registration of the same signer must dedup to a single tx",
-        );
-        assert_eq!(
-            driver.proof_provider.call_count(),
-            1,
-            "concurrent registration of the same signer must not regenerate the proof",
-        );
-    }
-
-    /// After a successful registration completes, the in-flight slot must
-    /// be released so a later cycle can re-register the same signer if it
-    /// becomes orphaned and re-discovered. Sequential calls for the same
-    /// signer must both execute their `is_registered` precheck (which in
-    /// the test mock returns false twice via `never_registered`), and both
-    /// submit txs — proving the guard does not leak across calls.
-    #[tokio::test]
-    async fn try_register_in_flight_slot_released_after_completion() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = FailingTxManager::with_errors(vec![]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            StubProofProvider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        driver.process_instance(&inst).await.unwrap();
-        driver.process_instance(&inst).await.unwrap();
-
-        assert_eq!(
-            tx.send_count(),
-            2,
-            "sequential (non-overlapping) registrations must each submit their own tx — \
-             the in-flight slot must be released when try_register returns",
-        );
-    }
-
-    /// A failed registration (non-retryable error from the tx manager)
-    /// must still release the in-flight slot. Otherwise a transient
-    /// failure for one signer would permanently block subsequent
-    /// registration attempts for that signer.
-    #[tokio::test]
-    async fn try_register_in_flight_slot_released_after_failure() {
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        // First call fails non-retryably; second call succeeds.
-        let tx = FailingTxManager::with_errors(vec![TxManagerError::InsufficientFunds]);
-        let registry = DynamicRegistry::never_registered(vec![]);
-        let driver = retry_driver(
-            signer_client,
-            registry,
-            tx.clone(),
-            StubProofProvider,
-            CancellationToken::new(),
-        );
-
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        // First attempt: fails non-retryably (slot released on Err path).
-        driver.process_instance(&inst).await.unwrap();
-        // Second attempt: must reach the tx manager again — proving the
-        // in-flight slot was released after the first call's failure.
-        driver.process_instance(&inst).await.unwrap();
-
-        assert_eq!(
-            tx.send_count(),
-            2,
-            "a failed registration must release the in-flight slot so retries can proceed",
-        );
-    }
 }

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -39,7 +39,7 @@ mod prover;
 pub use prover::ProverClient;
 
 mod proof_handler;
-pub use proof_handler::{InFlightRegistrationGuard, ProofHandler};
+pub use proof_handler::{InFlightRegistrationGuard, ProofHandler, ProofHandlerConfig};
 
 mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -38,6 +38,12 @@ pub use metrics::RegistrarMetrics;
 mod prover;
 pub use prover::ProverClient;
 
+mod proof_handler;
+pub use proof_handler::{
+    InFlightRegistrationGuard, ProofHandler, ProofHandlerConfig, ProofHandlerContext,
+    ProofHandlerRequest,
+};
+
 mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};
 

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -39,10 +39,7 @@ mod prover;
 pub use prover::ProverClient;
 
 mod proof_handler;
-pub use proof_handler::{
-    InFlightRegistrationGuard, ProofHandler, ProofHandlerConfig, ProofHandlerContext,
-    ProofHandlerRequest,
-};
+pub use proof_handler::{InFlightRegistrationGuard, ProofHandler};
 
 mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -22,19 +22,9 @@ use tracing::{debug, info, warn};
 
 use crate::{ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result};
 
-/// Component responsible for turning attestation proof results into durable
-/// onchain signer registrations.
-pub struct ProofHandler<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
-    /// Proof provider used to poll or generate the attestation proof result.
-    pub proof_provider: &'a P,
-    /// Registry client used for side-effect-free registration state checks.
-    pub registry: &'a R,
-    /// Transaction manager used to deliver `registerSigner`.
-    pub tx_manager: &'a T,
-    /// Semaphore bounding concurrent proof work.
-    pub proof_semaphore: &'a Semaphore,
-    /// Process-local signer set used to deduplicate concurrent attempts.
-    pub in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
+/// Runtime parameters for proof-result handling.
+#[derive(Debug, Clone, Copy)]
+pub struct ProofHandlerConfig {
     /// `TEEProverRegistry` contract address on L1.
     pub registry_address: Address,
     /// Maximum number of transaction submission retries for transient errors.
@@ -43,13 +33,51 @@ pub struct ProofHandler<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
     pub tx_retry_delay: Duration,
 }
 
+/// Component responsible for turning attestation proof results into durable
+/// onchain signer registrations.
+pub struct ProofHandler<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
+    /// Proof provider used to poll or generate the attestation proof result.
+    proof_provider: &'a P,
+    /// Registry client used for side-effect-free registration state checks.
+    registry: &'a R,
+    /// Transaction manager used to deliver `registerSigner`.
+    tx_manager: &'a T,
+    /// Semaphore bounding concurrent proof work.
+    proof_semaphore: &'a Semaphore,
+    /// Process-local signer set used to deduplicate concurrent attempts.
+    in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
+    /// Runtime settings for registration transaction handling.
+    config: ProofHandlerConfig,
+}
+
 impl<P: ?Sized, R: ?Sized, T: ?Sized> fmt::Debug for ProofHandler<'_, P, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProofHandler")
-            .field("registry_address", &self.registry_address)
-            .field("max_tx_retries", &self.max_tx_retries)
-            .field("tx_retry_delay", &self.tx_retry_delay)
+            .field("registry_address", &self.config.registry_address)
+            .field("max_tx_retries", &self.config.max_tx_retries)
+            .field("tx_retry_delay", &self.config.tx_retry_delay)
             .finish_non_exhaustive()
+    }
+}
+
+impl<'a, P: ?Sized, R: ?Sized, T: ?Sized> ProofHandler<'a, P, R, T> {
+    /// Creates a proof handler from the registration pipeline dependencies.
+    pub const fn new(
+        proof_provider: &'a P,
+        registry: &'a R,
+        tx_manager: &'a T,
+        proof_semaphore: &'a Semaphore,
+        in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
+        config: ProofHandlerConfig,
+    ) -> Self {
+        Self {
+            proof_provider,
+            registry,
+            tx_manager,
+            proof_semaphore,
+            in_flight_registrations,
+            config,
+        }
     }
 }
 
@@ -290,14 +318,14 @@ where
         info!(
             signer = %signer_address,
             instance = %instance.instance_id,
-            registry = %self.registry_address,
+            registry = %self.config.registry_address,
             calldata_len = calldata.len(),
             "Registering signer"
         );
 
         let candidate = TxCandidate {
             tx_data: calldata,
-            to: Some(self.registry_address),
+            to: Some(self.config.registry_address),
             ..Default::default()
         };
 
@@ -385,7 +413,7 @@ where
                     }
 
                     tx_retries += 1;
-                    if tx_retries > self.max_tx_retries {
+                    if tx_retries > self.config.max_tx_retries {
                         return Err(RegistrarError::from(e));
                     }
 
@@ -393,7 +421,7 @@ where
                         error = %e,
                         signer = %signer_address,
                         retry = tx_retries,
-                        max_retries = self.max_tx_retries,
+                        max_retries = self.config.max_tx_retries,
                         "tx submission failed, retrying with same proof"
                     );
 
@@ -407,7 +435,7 @@ where
                             );
                             return Ok(());
                         }
-                        () = tokio::time::sleep(self.tx_retry_delay) => {}
+                        () = tokio::time::sleep(self.config.tx_retry_delay) => {}
                     }
                 }
             }
@@ -522,16 +550,18 @@ mod tests {
         }
 
         fn handler(&self) -> ProofHandler<'_, P, R, T> {
-            ProofHandler {
-                proof_provider: &self.proof_provider,
-                registry: &self.registry,
-                tx_manager: &self.tx_manager,
-                proof_semaphore: &self.proof_semaphore,
-                in_flight_registrations: &self.in_flight_registrations,
-                registry_address: TEST_REGISTRY_ADDRESS,
-                max_tx_retries: MAX_TX_RETRIES,
-                tx_retry_delay: TX_RETRY_DELAY,
-            }
+            ProofHandler::new(
+                &self.proof_provider,
+                &self.registry,
+                &self.tx_manager,
+                &self.proof_semaphore,
+                &self.in_flight_registrations,
+                ProofHandlerConfig {
+                    registry_address: TEST_REGISTRY_ADDRESS,
+                    max_tx_retries: MAX_TX_RETRIES,
+                    tx_retry_delay: TX_RETRY_DELAY,
+                },
+            )
         }
     }
 

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -380,3 +380,536 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashSet, VecDeque},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU32, Ordering},
+        },
+        time::Duration,
+    };
+
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{B256, Bloom};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use async_trait::async_trait;
+    use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
+    use base_tx_manager::{SendHandle, TxManagerError};
+    use rstest::rstest;
+    use tokio::sync::Semaphore;
+    use url::Url;
+
+    use super::*;
+    use crate::{InstanceHealthStatus, RegistryClient};
+
+    const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
+    const TEST_SIGNER: Address = Address::repeat_byte(0x02);
+    const MAX_TX_RETRIES: u32 = 3;
+    const TX_RETRY_DELAY: Duration = Duration::from_secs(5);
+    const CANCEL_ABORT_BUDGET: Duration = Duration::from_secs(1);
+    const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+    const ATTESTATION: &[u8] = b"stub-attestation";
+
+    fn instance() -> ProverInstance {
+        ProverInstance {
+            instance_id: "i-proof-handler".to_string(),
+            endpoint: Url::parse("http://10.0.0.1:8000").unwrap(),
+            health_status: InstanceHealthStatus::Healthy,
+            launch_time: None,
+        }
+    }
+
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    struct HandlerHarness<P, R, T> {
+        proof_provider: P,
+        registry: R,
+        tx_manager: T,
+        proof_semaphore: Semaphore,
+        in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
+    }
+
+    impl<P, R, T> HandlerHarness<P, R, T> {
+        fn new(proof_provider: P, registry: R, tx_manager: T) -> Self {
+            Self {
+                proof_provider,
+                registry,
+                tx_manager,
+                proof_semaphore: Semaphore::new(4),
+                in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
+            }
+        }
+
+        fn handler(&self) -> ProofHandler<'_, P, R, T> {
+            ProofHandler {
+                proof_provider: &self.proof_provider,
+                registry: &self.registry,
+                tx_manager: &self.tx_manager,
+                proof_semaphore: &self.proof_semaphore,
+                in_flight_registrations: &self.in_flight_registrations,
+                registry_address: TEST_REGISTRY_ADDRESS,
+                max_tx_retries: MAX_TX_RETRIES,
+                tx_retry_delay: TX_RETRY_DELAY,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct StubProofProvider;
+
+    #[async_trait]
+    impl AttestationProofProvider for StubProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            Ok(AttestationProof {
+                output: Bytes::from_static(b"stub-output"),
+                proof_bytes: Bytes::from_static(b"stub-proof"),
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingProofProvider {
+        call_count: AtomicU32,
+    }
+
+    impl CountingProofProvider {
+        fn new() -> Self {
+            Self { call_count: AtomicU32::new(0) }
+        }
+
+        fn call_count(&self) -> u32 {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl AttestationProofProvider for CountingProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            Ok(AttestationProof {
+                output: Bytes::from_static(b"stub-output"),
+                proof_bytes: Bytes::from_static(b"stub-proof"),
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct CancelThenErrorProofProvider;
+
+    #[async_trait]
+    impl AttestationProofProvider for CancelThenErrorProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            cancel.cancel();
+            Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
+                "simulated cancel race".into(),
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct YieldingProofProvider {
+        call_count: Arc<AtomicU32>,
+    }
+
+    impl YieldingProofProvider {
+        fn new() -> Self {
+            Self { call_count: Arc::new(AtomicU32::new(0)) }
+        }
+
+        fn call_count(&self) -> u32 {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl AttestationProofProvider for YieldingProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            for _ in 0..16 {
+                tokio::task::yield_now().await;
+            }
+            Ok(AttestationProof {
+                output: Bytes::from_static(b"stub-output"),
+                proof_bytes: Bytes::from_static(b"stub-proof"),
+            })
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailingTxManager {
+        results: Arc<Mutex<VecDeque<Option<TxManagerError>>>>,
+        sent: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl FailingTxManager {
+        fn with_errors(errors: Vec<TxManagerError>) -> Self {
+            let results = errors.into_iter().map(Some).collect();
+            Self { results: Arc::new(Mutex::new(results)), sent: Arc::new(Mutex::new(vec![])) }
+        }
+
+        fn send_count(&self) -> usize {
+            self.sent.lock().unwrap().len()
+        }
+
+        fn sent_calldata(&self) -> Vec<Bytes> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl TxManager for FailingTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent.lock().unwrap().push(candidate.tx_data);
+            let next = self.results.lock().unwrap().pop_front();
+            match next {
+                Some(Some(e)) => Err(e),
+                _ => Ok(stub_receipt()),
+            }
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            panic!("FailingTxManager::send_async is not implemented; tests only use send()")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    #[derive(Debug)]
+    struct DynamicRegistry {
+        signers: Vec<Address>,
+        responses: Mutex<VecDeque<bool>>,
+        default_registered: bool,
+    }
+
+    impl DynamicRegistry {
+        fn never_registered(signers: Vec<Address>) -> Self {
+            Self { signers, responses: Mutex::new(VecDeque::new()), default_registered: false }
+        }
+
+        fn registered_after_first_check(signers: Vec<Address>) -> Self {
+            Self {
+                signers,
+                responses: Mutex::new(VecDeque::from([false])),
+                default_registered: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for DynamicRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            let next = self.responses.lock().unwrap().pop_front();
+            Ok(next.unwrap_or(self.default_registered))
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct StallingRegistry;
+
+    #[async_trait]
+    impl RegistryClient for StallingRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            std::future::pending::<()>().await;
+            Ok(false)
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(vec![])
+        }
+    }
+
+    fn assert_all_calldata_identical(sent: &[Bytes]) {
+        if sent.len() < 2 {
+            return;
+        }
+        for (i, entry) in sent.iter().enumerate().skip(1) {
+            assert_eq!(&sent[0], entry, "calldata mismatch: sent[0] != sent[{i}]");
+        }
+    }
+
+    async fn register<P, R, T>(
+        harness: &HandlerHarness<P, R, T>,
+        cancel: &CancellationToken,
+    ) -> Result<()>
+    where
+        P: AttestationProofProvider,
+        R: RegistryClient,
+        T: TxManager,
+    {
+        harness.handler().register_signer(&instance(), TEST_SIGNER, 0, ATTESTATION, cancel).await
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_already_registered_after_error_returns_ok() {
+        let tx = FailingTxManager::with_errors(vec![TxManagerError::Rpc("nonce race".into())]);
+        let harness = HandlerHarness::new(
+            StubProofProvider,
+            DynamicRegistry::registered_after_first_check(vec![]),
+            tx.clone(),
+        );
+
+        let result = register(&harness, &CancellationToken::new()).await;
+
+        assert!(result.is_ok(), "should succeed when signer is registered onchain: {result:?}");
+        assert_eq!(tx.send_count(), 1);
+    }
+
+    #[rstest]
+    #[case::execution_reverted(TxManagerError::ExecutionReverted {
+        reason: Some("bad proof".into()),
+        data: None,
+    })]
+    #[case::insufficient_funds(TxManagerError::InsufficientFunds)]
+    #[case::fee_limit_exceeded(TxManagerError::FeeLimitExceeded { fee: 500, ceiling: 100 })]
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_non_retryable_error_aborts_immediately(#[case] error: TxManagerError) {
+        let tx = FailingTxManager::with_errors(vec![error]);
+        let harness = HandlerHarness::new(
+            StubProofProvider,
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+
+        let result = register(&harness, &CancellationToken::new()).await;
+
+        assert!(result.is_err(), "non-retryable tx errors should propagate");
+        assert_eq!(tx.send_count(), 1, "should not retry after non-retryable error");
+    }
+
+    #[rstest]
+    #[case::immediate_success(vec![], true, 1)]
+    #[case::transient_retry_success(
+        vec![
+            TxManagerError::Rpc("transient 1".into()),
+            TxManagerError::Rpc("transient 2".into()),
+        ],
+        true,
+        3,
+    )]
+    #[case::retry_exhaustion(
+        (0..=MAX_TX_RETRIES)
+            .map(|_| TxManagerError::Rpc("persistent failure".into()))
+            .collect(),
+        false,
+        (MAX_TX_RETRIES + 1) as usize,
+    )]
+    #[case::transient_then_execution_reverted(
+        vec![
+            TxManagerError::Rpc("transient".into()),
+            TxManagerError::ExecutionReverted { reason: None, data: None },
+        ],
+        false,
+        2,
+    )]
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_tx_outcome(
+        #[case] errors: Vec<TxManagerError>,
+        #[case] should_succeed: bool,
+        #[case] expected_sends: usize,
+    ) {
+        let tx = FailingTxManager::with_errors(errors);
+        let harness = HandlerHarness::new(
+            CountingProofProvider::new(),
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+
+        let result = register(&harness, &CancellationToken::new()).await;
+
+        assert_eq!(result.is_ok(), should_succeed, "unexpected registration result: {result:?}",);
+        assert_eq!(tx.send_count(), expected_sends);
+        assert_all_calldata_identical(&tx.sent_calldata());
+        assert_eq!(harness.proof_provider.call_count(), 1, "proof should be generated once");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_cancellation_during_retry_sleep_aborts() {
+        let tx = FailingTxManager::with_errors(vec![
+            TxManagerError::Rpc("fail 1".into()),
+            TxManagerError::Rpc("fail 2".into()),
+            TxManagerError::Rpc("fail 3".into()),
+        ]);
+        let harness = HandlerHarness::new(
+            StubProofProvider,
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+        let cancel = CancellationToken::new();
+        let cancel_handle = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            cancel_handle.cancel();
+        });
+
+        let result = register(&harness, &cancel).await;
+
+        assert!(result.is_ok(), "cancel-induced exit should be Ok(()): {result:?}");
+        assert_eq!(tx.send_count(), 1, "should abort during retry sleep");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_cancellation_before_loop_sends_nothing() {
+        let tx = FailingTxManager::with_errors(vec![]);
+        let harness = HandlerHarness::new(
+            StubProofProvider,
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let result = register(&harness, &cancel).await;
+
+        assert!(result.is_ok(), "pre-cancel should be a cooperative success: {result:?}");
+        assert_eq!(tx.send_count(), 0, "should not send any tx after pre-cancellation");
+    }
+
+    #[tokio::test]
+    async fn register_signer_provider_err_after_cancel_returns_ok() {
+        let tx = FailingTxManager::with_errors(vec![]);
+        let harness = HandlerHarness::new(
+            CancelThenErrorProofProvider,
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+        let cancel = CancellationToken::new();
+
+        let result = register(&harness, &cancel).await;
+
+        assert!(result.is_ok(), "provider Err after cancel must be mapped to Ok(()): {result:?}",);
+        assert_eq!(tx.send_count(), 0, "cancelled task must not submit a transaction");
+    }
+
+    #[tokio::test]
+    async fn register_signer_aborts_promptly_when_cancel_fires_during_registry_stall() {
+        let harness = Arc::new(HandlerHarness::new(
+            StubProofProvider,
+            StallingRegistry,
+            FailingTxManager::with_errors(vec![]),
+        ));
+        let signer_cancel = CancellationToken::new();
+        let task_harness = Arc::clone(&harness);
+        let task_cancel = signer_cancel.clone();
+        let inst = instance();
+        let handle = tokio::spawn(async move {
+            let start = tokio::time::Instant::now();
+            let res = task_harness
+                .handler()
+                .register_signer(&inst, TEST_SIGNER, 0, ATTESTATION, &task_cancel)
+                .await;
+            (res, start.elapsed())
+        });
+
+        tokio::time::sleep(PRE_CANCEL_WARMUP).await;
+        signer_cancel.cancel();
+
+        let (result, elapsed) = tokio::time::timeout(WAIT_TIMEOUT, handle)
+            .await
+            .expect("register_signer must not hang past the timeout")
+            .expect("spawned task must not panic");
+
+        assert!(result.is_ok(), "cancel-induced exit must be Ok(()): {result:?}");
+        assert!(
+            elapsed < CANCEL_ABORT_BUDGET,
+            "cancel must abort the registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
+        );
+    }
+
+    #[tokio::test]
+    async fn register_signer_concurrent_same_signer_dedups() {
+        let tx = FailingTxManager::with_errors(vec![]);
+        let harness = HandlerHarness::new(
+            YieldingProofProvider::new(),
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+        let cancel = CancellationToken::new();
+        let handler = harness.handler();
+        let inst = instance();
+
+        let (r1, r2) = tokio::join!(
+            handler.register_signer(&inst, TEST_SIGNER, 0, ATTESTATION, &cancel),
+            handler.register_signer(&inst, TEST_SIGNER, 0, ATTESTATION, &cancel),
+        );
+
+        assert!(r1.is_ok(), "first concurrent registration failed: {r1:?}");
+        assert!(r2.is_ok(), "second concurrent registration failed: {r2:?}");
+        assert_eq!(tx.send_count(), 1, "same signer must dedup to a single tx");
+        assert_eq!(harness.proof_provider.call_count(), 1, "proof should be generated once");
+    }
+
+    #[rstest]
+    #[case::completion(vec![], false)]
+    #[case::failure(vec![TxManagerError::InsufficientFunds], true)]
+    #[tokio::test]
+    async fn register_signer_in_flight_slot_released_after_attempt(
+        #[case] errors: Vec<TxManagerError>,
+        #[case] first_attempt_should_fail: bool,
+    ) {
+        let tx = FailingTxManager::with_errors(errors);
+        let harness = HandlerHarness::new(
+            StubProofProvider,
+            DynamicRegistry::never_registered(vec![]),
+            tx.clone(),
+        );
+        let cancel = CancellationToken::new();
+
+        let first_result = register(&harness, &cancel).await;
+        assert_eq!(
+            first_result.is_err(),
+            first_attempt_should_fail,
+            "unexpected first registration result: {first_result:?}",
+        );
+        register(&harness, &cancel).await.unwrap();
+
+        assert_eq!(tx.send_count(), 2, "registration must release in-flight slot");
+    }
+}

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -75,10 +75,7 @@ impl InFlightRegistrationGuard {
 
 impl Drop for InFlightRegistrationGuard {
     fn drop(&mut self) {
-        // The critical section is a single `HashSet::remove` and cannot
-        // panic under normal conditions, so poisoning is effectively
-        // impossible. If it ever occurs, the set contents are still
-        // valid and cleanup must proceed.
+        // Recover from poisoning so guard cleanup still runs.
         let mut set = self.in_flight.lock().unwrap_or_else(|e| e.into_inner());
         set.remove(&self.signer);
     }
@@ -122,11 +119,7 @@ where
             tx_retry_delay,
         } = *self;
 
-        // Check cancellation BEFORE any other work: a task that was
-        // already cancelled should not acquire the in-flight mutex or do
-        // registry RPC work. This bounds shutdown latency by the longest
-        // in-flight operation rather than by an additional registry round-trip
-        // per pending task.
+        // Avoid taking locks or making registry RPCs after cancellation.
         if signer_cancel.is_cancelled() {
             debug!(signer = %signer_address, "task cancelled before registry probe");
             return Ok(());
@@ -148,8 +141,7 @@ where
             return Ok(());
         };
 
-        // Cancel-aware: `is_registered` is a side-effect-free read, so
-        // dropping it on cancel is safe.
+        // Safe to cancel because this is a side-effect-free registry read.
         let already_registered = tokio::select! {
             biased;
             () = signer_cancel.cancelled() => {
@@ -241,8 +233,6 @@ where
             }
         };
 
-        // Check cancellation before submitting the transaction to avoid starting
-        // new onchain work if shutdown is in progress.
         if signer_cancel.is_cancelled() {
             debug!("shutdown requested, skipping transaction submission");
             return Ok(());
@@ -325,8 +315,6 @@ where
                         Ok(false) => {}
                     }
 
-                    // Non-retryable errors cannot be resolved by retrying with
-                    // the same calldata.
                     if !e.is_retryable() {
                         // If the contract reverted execution, the proof itself
                         // is likely invalid. Block recovery for this signer so
@@ -355,8 +343,6 @@ where
                         "tx submission failed, retrying with same proof"
                     );
 
-                    // Cancellation-aware delay: abort immediately if shutdown
-                    // is requested during the retry wait.
                     tokio::select! {
                         biased;
                         () = signer_cancel.cancelled() => {

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -108,29 +108,55 @@ where
         attestation_bytes: &[u8],
         signer_cancel: &CancellationToken,
     ) -> Result<()> {
-        let Self {
-            proof_provider,
-            registry,
-            tx_manager,
-            proof_semaphore,
-            in_flight_registrations,
-            registry_address,
-            max_tx_retries,
-            tx_retry_delay,
-        } = *self;
+        let Some(_in_flight) = self
+            .prepare_registration_attempt(instance, signer_address, enclave_index, signer_cancel)
+            .await?
+        else {
+            return Ok(());
+        };
 
+        let Some(proof) = self
+            .generate_registration_proof(
+                instance,
+                signer_address,
+                enclave_index,
+                attestation_bytes,
+                signer_cancel,
+            )
+            .await?
+        else {
+            return Ok(());
+        };
+
+        if signer_cancel.is_cancelled() {
+            debug!("shutdown requested, skipping transaction submission");
+            return Ok(());
+        }
+
+        let candidate = self.registration_tx_candidate(instance, signer_address, proof);
+        self.submit_registration_candidate(signer_address, candidate, signer_cancel).await
+    }
+
+    /// Reserves this signer and confirms it still needs registration.
+    pub async fn prepare_registration_attempt(
+        &self,
+        instance: &ProverInstance,
+        signer_address: Address,
+        enclave_index: usize,
+        signer_cancel: &CancellationToken,
+    ) -> Result<Option<InFlightRegistrationGuard>> {
         // Avoid taking locks or making registry RPCs after cancellation.
         if signer_cancel.is_cancelled() {
             debug!(signer = %signer_address, "task cancelled before registry probe");
-            return Ok(());
+            return Ok(None);
         }
 
         // Reserve this signer in the in-flight set before the `is_registered`
         // precheck. If another concurrent task already owns it, short-circuit
         // so we do not race past the precheck, regenerate the proof, and
         // submit a duplicate registration transaction.
-        let Some(_in_flight) =
-            InFlightRegistrationGuard::try_acquire(in_flight_registrations, signer_address)
+        let Some(in_flight) =
+            InFlightRegistrationGuard::try_acquire(self.in_flight_registrations, signer_address)
         else {
             debug!(
                 signer = %signer_address,
@@ -138,7 +164,7 @@ where
                 instance = %instance.instance_id,
                 "registration already in flight for this signer, skipping duplicate",
             );
-            return Ok(());
+            return Ok(None);
         };
 
         // Safe to cancel because this is a side-effect-free registry read.
@@ -149,20 +175,32 @@ where
                     signer = %signer_address,
                     "cancelled while probing registry pre-proof-gen"
                 );
-                return Ok(());
+                return Ok(None);
             }
-            res = registry.is_registered(signer_address) => res?,
+            res = self.registry.is_registered(signer_address) => res?,
         };
         if already_registered {
             debug!(signer = %signer_address, "already registered, skipping");
-            return Ok(());
+            return Ok(None);
         }
 
+        Ok(Some(in_flight))
+    }
+
+    /// Generates a registration proof for a signer, returning `None` on cooperative shutdown.
+    pub async fn generate_registration_proof(
+        &self,
+        instance: &ProverInstance,
+        signer_address: Address,
+        enclave_index: usize,
+        attestation_bytes: &[u8],
+        signer_cancel: &CancellationToken,
+    ) -> Result<Option<base_proof_tee_nitro_attestation_prover::AttestationProof>> {
         // Check cancellation before the most expensive operation. Proof
         // generation and proof-result polling can take minutes via Boundless.
         if signer_cancel.is_cancelled() {
             debug!("shutdown requested, skipping proof generation");
-            return Ok(());
+            return Ok(None);
         }
 
         info!(
@@ -182,9 +220,9 @@ where
                     instance = %instance.instance_id,
                     "task cancelled before acquiring proof permit"
                 );
-                return Ok(());
+                return Ok(None);
             }
-            permit = proof_semaphore.acquire() => {
+            permit = self.proof_semaphore.acquire() => {
                 match permit {
                     Ok(p) => p,
                     Err(_) => {
@@ -193,7 +231,7 @@ where
                             instance = %instance.instance_id,
                             "proof semaphore closed unexpectedly, exiting task"
                         );
-                        return Ok(());
+                        return Ok(None);
                     }
                 }
             }
@@ -203,7 +241,7 @@ where
         // provider future on cancel may abandon work the impl had already
         // started; for Boundless, any submitted offchain request is recoverable
         // via deterministic request-id derivation on the next call.
-        let proof = tokio::select! {
+        tokio::select! {
             biased;
             () = signer_cancel.cancelled() => {
                 debug!(
@@ -211,33 +249,36 @@ where
                     instance = %instance.instance_id,
                     "task cancelled during proof generation"
                 );
-                return Ok(());
+                Ok(None)
             }
-            res = proof_provider.generate_proof_for_signer(
+            res = self.proof_provider.generate_proof_for_signer(
                 attestation_bytes,
                 signer_address,
                 signer_cancel,
             ) => {
                 match res {
-                    Ok(p) => p,
+                    Ok(proof) => Ok(Some(proof)),
                     Err(_) if signer_cancel.is_cancelled() => {
                         debug!(
                             signer = %signer_address,
                             instance = %instance.instance_id,
                             "task cancelled during proof generation (provider returned Err after cancel)",
                         );
-                        return Ok(());
+                        Ok(None)
                     }
-                    Err(e) => return Err(e.into()),
+                    Err(e) => Err(e.into()),
                 }
             }
-        };
-
-        if signer_cancel.is_cancelled() {
-            debug!("shutdown requested, skipping transaction submission");
-            return Ok(());
         }
+    }
 
+    /// Builds the `registerSigner` transaction candidate for a generated proof.
+    pub fn registration_tx_candidate(
+        &self,
+        instance: &ProverInstance,
+        signer_address: Address,
+        proof: base_proof_tee_nitro_attestation_prover::AttestationProof,
+    ) -> TxCandidate {
         let calldata = Bytes::from(
             ITEEProverRegistry::registerSignerCall {
                 output: proof.output,
@@ -249,19 +290,32 @@ where
         info!(
             signer = %signer_address,
             instance = %instance.instance_id,
-            registry = %registry_address,
+            registry = %self.registry_address,
             calldata_len = calldata.len(),
             "Registering signer"
         );
 
-        let candidate =
-            TxCandidate { tx_data: calldata, to: Some(registry_address), ..Default::default() };
+        let candidate = TxCandidate {
+            tx_data: calldata,
+            to: Some(self.registry_address),
+            ..Default::default()
+        };
 
         info!(
             tx = ?candidate,
             "Sending tx candidate",
         );
 
+        candidate
+    }
+
+    /// Submits a registration transaction and retries transient delivery failures.
+    pub async fn submit_registration_candidate(
+        &self,
+        signer_address: Address,
+        candidate: TxCandidate,
+        signer_cancel: &CancellationToken,
+    ) -> Result<()> {
         // Retry tx submission on transient errors to avoid discarding an
         // expensive proof on a nonce race or brief network blip.
         let mut tx_retries = 0;
@@ -278,7 +332,7 @@ where
                 return Ok(());
             }
 
-            match tx_manager.send(candidate.clone()).await {
+            match self.tx_manager.send(candidate.clone()).await {
                 Ok(receipt) => break receipt,
                 Err(e) => {
                     // The signer may already be registered despite the error
@@ -293,7 +347,7 @@ where
                             );
                             return Ok(());
                         }
-                        res = registry.is_registered(signer_address) => res,
+                        res = self.registry.is_registered(signer_address) => res,
                     };
                     match post_err_check {
                         Ok(true) => {
@@ -325,13 +379,13 @@ where
                                 signer = %signer_address,
                                 "execution reverted, blocking proof recovery for signer"
                             );
-                            proof_provider.block_recovery_for_signer(signer_address);
+                            self.proof_provider.block_recovery_for_signer(signer_address);
                         }
                         return Err(RegistrarError::from(e));
                     }
 
                     tx_retries += 1;
-                    if tx_retries > max_tx_retries {
+                    if tx_retries > self.max_tx_retries {
                         return Err(RegistrarError::from(e));
                     }
 
@@ -339,7 +393,7 @@ where
                         error = %e,
                         signer = %signer_address,
                         retry = tx_retries,
-                        max_retries = max_tx_retries,
+                        max_retries = self.max_tx_retries,
                         "tx submission failed, retrying with same proof"
                     );
 
@@ -353,7 +407,7 @@ where
                             );
                             return Ok(());
                         }
-                        () = tokio::time::sleep(tx_retry_delay) => {}
+                        () = tokio::time::sleep(self.tx_retry_delay) => {}
                     }
                 }
             }

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::HashSet,
+    fmt,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -21,20 +22,9 @@ use tracing::{debug, info, warn};
 
 use crate::{ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result};
 
-/// Runtime settings used by [`ProofHandler`] when registering a signer.
-#[derive(Debug, Clone, Copy)]
-pub struct ProofHandlerConfig {
-    /// `TEEProverRegistry` contract address on L1.
-    pub registry_address: Address,
-    /// Maximum number of transaction submission retries for transient errors.
-    pub max_tx_retries: u32,
-    /// Delay between transaction submission retries.
-    pub tx_retry_delay: Duration,
-}
-
-/// Shared dependencies used by [`ProofHandler`] for one registration attempt.
-#[derive(Debug)]
-pub struct ProofHandlerContext<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
+/// Component responsible for turning attestation proof results into durable
+/// onchain signer registrations.
+pub struct ProofHandler<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
     /// Proof provider used to poll or generate the attestation proof result.
     pub proof_provider: &'a P,
     /// Registry client used for side-effect-free registration state checks.
@@ -45,29 +35,23 @@ pub struct ProofHandlerContext<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
     pub proof_semaphore: &'a Semaphore,
     /// Process-local signer set used to deduplicate concurrent attempts.
     pub in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
-    /// Runtime settings for this attempt.
-    pub config: &'a ProofHandlerConfig,
+    /// `TEEProverRegistry` contract address on L1.
+    pub registry_address: Address,
+    /// Maximum number of transaction submission retries for transient errors.
+    pub max_tx_retries: u32,
+    /// Delay between transaction submission retries.
+    pub tx_retry_delay: Duration,
 }
 
-/// Input data for one signer registration attempt.
-#[derive(Debug, Clone, Copy)]
-pub struct ProofHandlerRequest<'a> {
-    /// Prover instance that supplied the signer and attestation.
-    pub instance: &'a ProverInstance,
-    /// Signer address to register.
-    pub signer_address: Address,
-    /// Zero-based enclave index on the source instance.
-    pub enclave_index: usize,
-    /// Raw Nitro attestation bytes used as proof input.
-    pub attestation_bytes: &'a [u8],
-    /// Task-scoped cancellation token.
-    pub signer_cancel: &'a CancellationToken,
+impl<P: ?Sized, R: ?Sized, T: ?Sized> fmt::Debug for ProofHandler<'_, P, R, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProofHandler")
+            .field("registry_address", &self.registry_address)
+            .field("max_tx_retries", &self.max_tx_retries)
+            .field("tx_retry_delay", &self.tx_retry_delay)
+            .finish_non_exhaustive()
+    }
 }
-
-/// Component responsible for turning attestation proof results into durable
-/// onchain signer registrations.
-#[derive(Debug)]
-pub struct ProofHandler;
 
 /// RAII guard that removes a signer address from the in-flight set when
 /// dropped.
@@ -81,6 +65,14 @@ pub struct InFlightRegistrationGuard {
     signer: Address,
 }
 
+impl InFlightRegistrationGuard {
+    /// Reserves `signer` in `in_flight` until the returned guard is dropped.
+    pub fn try_acquire(in_flight: &Arc<Mutex<HashSet<Address>>>, signer: Address) -> Option<Self> {
+        let mut set = in_flight.lock().unwrap_or_else(|e| e.into_inner());
+        set.insert(signer).then(|| Self { in_flight: Arc::clone(in_flight), signer })
+    }
+}
+
 impl Drop for InFlightRegistrationGuard {
     fn drop(&mut self) {
         // The critical section is a single `HashSet::remove` and cannot
@@ -92,7 +84,12 @@ impl Drop for InFlightRegistrationGuard {
     }
 }
 
-impl ProofHandler {
+impl<'a, P, R, T> ProofHandler<'a, P, R, T>
+where
+    P: AttestationProofProvider + ?Sized,
+    R: RegistryClient + ?Sized,
+    T: TxManager + ?Sized,
+{
     /// Attempts to register a signer onchain if it is not already registered.
     ///
     /// This is the expensive path: checks onchain status, polls or generates a
@@ -106,30 +103,24 @@ impl ProofHandler {
     /// `TEEVerifier` gates proof acceptance on `TEE_IMAGE_HASH` at submission
     /// time, so pre-registered enclaves cannot produce accepted proposals
     /// until the hardfork activates.
-    pub async fn register_signer<P, R, T>(
-        context: ProofHandlerContext<'_, P, R, T>,
-        request: ProofHandlerRequest<'_>,
-    ) -> Result<()>
-    where
-        P: AttestationProofProvider + ?Sized,
-        R: RegistryClient + ?Sized,
-        T: TxManager + ?Sized,
-    {
-        let ProofHandlerContext {
+    pub async fn register_signer(
+        &self,
+        instance: &ProverInstance,
+        signer_address: Address,
+        enclave_index: usize,
+        attestation_bytes: &[u8],
+        signer_cancel: &CancellationToken,
+    ) -> Result<()> {
+        let Self {
             proof_provider,
             registry,
             tx_manager,
             proof_semaphore,
             in_flight_registrations,
-            config,
-        } = context;
-        let ProofHandlerRequest {
-            instance,
-            signer_address,
-            enclave_index,
-            attestation_bytes,
-            signer_cancel,
-        } = request;
+            registry_address,
+            max_tx_retries,
+            tx_retry_delay,
+        } = *self;
 
         // Check cancellation BEFORE any other work: a task that was
         // already cancelled should not acquire the in-flight mutex or do
@@ -145,21 +136,16 @@ impl ProofHandler {
         // precheck. If another concurrent task already owns it, short-circuit
         // so we do not race past the precheck, regenerate the proof, and
         // submit a duplicate registration transaction.
-        let _in_flight = {
-            let mut set = in_flight_registrations.lock().unwrap_or_else(|e| e.into_inner());
-            if !set.insert(signer_address) {
-                debug!(
-                    signer = %signer_address,
-                    enclave_index,
-                    instance = %instance.instance_id,
-                    "registration already in flight for this signer, skipping duplicate",
-                );
-                return Ok(());
-            }
-            InFlightRegistrationGuard {
-                in_flight: Arc::clone(in_flight_registrations),
-                signer: signer_address,
-            }
+        let Some(_in_flight) =
+            InFlightRegistrationGuard::try_acquire(in_flight_registrations, signer_address)
+        else {
+            debug!(
+                signer = %signer_address,
+                enclave_index,
+                instance = %instance.instance_id,
+                "registration already in flight for this signer, skipping duplicate",
+            );
+            return Ok(());
         };
 
         // Cancel-aware: `is_registered` is a side-effect-free read, so
@@ -273,16 +259,13 @@ impl ProofHandler {
         info!(
             signer = %signer_address,
             instance = %instance.instance_id,
-            registry = %config.registry_address,
+            registry = %registry_address,
             calldata_len = calldata.len(),
             "Registering signer"
         );
 
-        let candidate = TxCandidate {
-            tx_data: calldata,
-            to: Some(config.registry_address),
-            ..Default::default()
-        };
+        let candidate =
+            TxCandidate { tx_data: calldata, to: Some(registry_address), ..Default::default() };
 
         info!(
             tx = ?candidate,
@@ -291,8 +274,6 @@ impl ProofHandler {
 
         // Retry tx submission on transient errors to avoid discarding an
         // expensive proof on a nonce race or brief network blip.
-        let max_tx_retries = config.max_tx_retries;
-        let tx_retry_delay = config.tx_retry_delay;
         let mut tx_retries = 0;
 
         let receipt = loop {

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -1,0 +1,415 @@
+//! Proof result handling and onchain signer registration.
+//!
+//! Polls or waits for attestation proof results, checks whether the signer is
+//! already registered onchain, and submits `TEEProverRegistry.registerSigner`
+//! transactions through the transaction manager with delivery retries.
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use alloy_primitives::{Address, Bytes};
+use alloy_sol_types::SolCall;
+use base_proof_contracts::ITEEProverRegistry;
+use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
+use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result};
+
+/// Runtime settings used by [`ProofHandler`] when registering a signer.
+#[derive(Debug, Clone, Copy)]
+pub struct ProofHandlerConfig {
+    /// `TEEProverRegistry` contract address on L1.
+    pub registry_address: Address,
+    /// Maximum number of transaction submission retries for transient errors.
+    pub max_tx_retries: u32,
+    /// Delay between transaction submission retries.
+    pub tx_retry_delay: Duration,
+}
+
+/// Shared dependencies used by [`ProofHandler`] for one registration attempt.
+#[derive(Debug)]
+pub struct ProofHandlerContext<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
+    /// Proof provider used to poll or generate the attestation proof result.
+    pub proof_provider: &'a P,
+    /// Registry client used for side-effect-free registration state checks.
+    pub registry: &'a R,
+    /// Transaction manager used to deliver `registerSigner`.
+    pub tx_manager: &'a T,
+    /// Semaphore bounding concurrent proof work.
+    pub proof_semaphore: &'a Semaphore,
+    /// Process-local signer set used to deduplicate concurrent attempts.
+    pub in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
+    /// Runtime settings for this attempt.
+    pub config: &'a ProofHandlerConfig,
+}
+
+/// Input data for one signer registration attempt.
+#[derive(Debug, Clone, Copy)]
+pub struct ProofHandlerRequest<'a> {
+    /// Prover instance that supplied the signer and attestation.
+    pub instance: &'a ProverInstance,
+    /// Signer address to register.
+    pub signer_address: Address,
+    /// Zero-based enclave index on the source instance.
+    pub enclave_index: usize,
+    /// Raw Nitro attestation bytes used as proof input.
+    pub attestation_bytes: &'a [u8],
+    /// Task-scoped cancellation token.
+    pub signer_cancel: &'a CancellationToken,
+}
+
+/// Component responsible for turning attestation proof results into durable
+/// onchain signer registrations.
+#[derive(Debug)]
+pub struct ProofHandler;
+
+/// RAII guard that removes a signer address from the in-flight set when
+/// dropped.
+///
+/// Ensures cleanup on every exit path from [`ProofHandler::register_signer`]:
+/// success, error, retry exhaustion, cancellation drop, and panic.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct InFlightRegistrationGuard {
+    in_flight: Arc<Mutex<HashSet<Address>>>,
+    signer: Address,
+}
+
+impl Drop for InFlightRegistrationGuard {
+    fn drop(&mut self) {
+        // The critical section is a single `HashSet::remove` and cannot
+        // panic under normal conditions, so poisoning is effectively
+        // impossible. If it ever occurs, the set contents are still
+        // valid and cleanup must proceed.
+        let mut set = self.in_flight.lock().unwrap_or_else(|e| e.into_inner());
+        set.remove(&self.signer);
+    }
+}
+
+impl ProofHandler {
+    /// Attempts to register a signer onchain if it is not already registered.
+    ///
+    /// This is the expensive path: checks onchain status, polls or generates a
+    /// proof from the pre-fetched attestation, and submits a registration
+    /// transaction with delivery retries.
+    ///
+    /// Registration is PCR0-agnostic: all legitimate enclaves are registered
+    /// regardless of their PCR0 measurement. This enables pre-registration of
+    /// new-PCR0 enclaves before a hardfork, eliminating the proof-generation
+    /// delay when the onchain `TEE_IMAGE_HASH` rotates. The onchain
+    /// `TEEVerifier` gates proof acceptance on `TEE_IMAGE_HASH` at submission
+    /// time, so pre-registered enclaves cannot produce accepted proposals
+    /// until the hardfork activates.
+    pub async fn register_signer<P, R, T>(
+        context: ProofHandlerContext<'_, P, R, T>,
+        request: ProofHandlerRequest<'_>,
+    ) -> Result<()>
+    where
+        P: AttestationProofProvider + ?Sized,
+        R: RegistryClient + ?Sized,
+        T: TxManager + ?Sized,
+    {
+        let ProofHandlerContext {
+            proof_provider,
+            registry,
+            tx_manager,
+            proof_semaphore,
+            in_flight_registrations,
+            config,
+        } = context;
+        let ProofHandlerRequest {
+            instance,
+            signer_address,
+            enclave_index,
+            attestation_bytes,
+            signer_cancel,
+        } = request;
+
+        // Check cancellation BEFORE any other work: a task that was
+        // already cancelled should not acquire the in-flight mutex or do
+        // registry RPC work. This bounds shutdown latency by the longest
+        // in-flight operation rather than by an additional registry round-trip
+        // per pending task.
+        if signer_cancel.is_cancelled() {
+            debug!(signer = %signer_address, "task cancelled before registry probe");
+            return Ok(());
+        }
+
+        // Reserve this signer in the in-flight set before the `is_registered`
+        // precheck. If another concurrent task already owns it, short-circuit
+        // so we do not race past the precheck, regenerate the proof, and
+        // submit a duplicate registration transaction.
+        let _in_flight = {
+            let mut set = in_flight_registrations.lock().unwrap_or_else(|e| e.into_inner());
+            if !set.insert(signer_address) {
+                debug!(
+                    signer = %signer_address,
+                    enclave_index,
+                    instance = %instance.instance_id,
+                    "registration already in flight for this signer, skipping duplicate",
+                );
+                return Ok(());
+            }
+            InFlightRegistrationGuard {
+                in_flight: Arc::clone(in_flight_registrations),
+                signer: signer_address,
+            }
+        };
+
+        // Cancel-aware: `is_registered` is a side-effect-free read, so
+        // dropping it on cancel is safe.
+        let already_registered = tokio::select! {
+            biased;
+            () = signer_cancel.cancelled() => {
+                debug!(
+                    signer = %signer_address,
+                    "cancelled while probing registry pre-proof-gen"
+                );
+                return Ok(());
+            }
+            res = registry.is_registered(signer_address) => res?,
+        };
+        if already_registered {
+            debug!(signer = %signer_address, "already registered, skipping");
+            return Ok(());
+        }
+
+        // Check cancellation before the most expensive operation. Proof
+        // generation and proof-result polling can take minutes via Boundless.
+        if signer_cancel.is_cancelled() {
+            debug!("shutdown requested, skipping proof generation");
+            return Ok(());
+        }
+
+        info!(
+            signer = %signer_address,
+            enclave_index,
+            instance = %instance.instance_id,
+            "generating proof for unregistered signer"
+        );
+
+        // Acquire a proof-concurrency permit. Bounds simultaneous
+        // Boundless/Direct proof generations across all spawned tasks.
+        let _permit = tokio::select! {
+            biased;
+            () = signer_cancel.cancelled() => {
+                debug!(
+                    signer = %signer_address,
+                    instance = %instance.instance_id,
+                    "task cancelled before acquiring proof permit"
+                );
+                return Ok(());
+            }
+            permit = proof_semaphore.acquire() => {
+                match permit {
+                    Ok(p) => p,
+                    Err(_) => {
+                        warn!(
+                            signer = %signer_address,
+                            instance = %instance.instance_id,
+                            "proof semaphore closed unexpectedly, exiting task"
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+        };
+
+        // Cooperative cancel-safety around the long-running proof. Dropping the
+        // provider future on cancel may abandon work the impl had already
+        // started; for Boundless, any submitted offchain request is recoverable
+        // via deterministic request-id derivation on the next call.
+        let proof = tokio::select! {
+            biased;
+            () = signer_cancel.cancelled() => {
+                debug!(
+                    signer = %signer_address,
+                    instance = %instance.instance_id,
+                    "task cancelled during proof generation"
+                );
+                return Ok(());
+            }
+            res = proof_provider.generate_proof_for_signer(
+                attestation_bytes,
+                signer_address,
+                signer_cancel,
+            ) => {
+                match res {
+                    Ok(p) => p,
+                    Err(_) if signer_cancel.is_cancelled() => {
+                        debug!(
+                            signer = %signer_address,
+                            instance = %instance.instance_id,
+                            "task cancelled during proof generation (provider returned Err after cancel)",
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        };
+
+        // Check cancellation before submitting the transaction to avoid starting
+        // new onchain work if shutdown is in progress.
+        if signer_cancel.is_cancelled() {
+            debug!("shutdown requested, skipping transaction submission");
+            return Ok(());
+        }
+
+        let calldata = Bytes::from(
+            ITEEProverRegistry::registerSignerCall {
+                output: proof.output,
+                proofBytes: proof.proof_bytes,
+            }
+            .abi_encode(),
+        );
+
+        info!(
+            signer = %signer_address,
+            instance = %instance.instance_id,
+            registry = %config.registry_address,
+            calldata_len = calldata.len(),
+            "Registering signer"
+        );
+
+        let candidate = TxCandidate {
+            tx_data: calldata,
+            to: Some(config.registry_address),
+            ..Default::default()
+        };
+
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
+
+        // Retry tx submission on transient errors to avoid discarding an
+        // expensive proof on a nonce race or brief network blip.
+        let max_tx_retries = config.max_tx_retries;
+        let tx_retry_delay = config.tx_retry_delay;
+        let mut tx_retries = 0;
+
+        let receipt = loop {
+            // Check cancellation at the top of each iteration to avoid starting
+            // new onchain work after shutdown is requested.
+            //
+            // IMPORTANT: we never wrap `tx_manager.send()` itself in a
+            // `select!` against `signer_cancel`; dropping `send()` after nonce
+            // acquisition but before broadcast leaves a nonce gap.
+            if signer_cancel.is_cancelled() {
+                debug!("shutdown requested, aborting tx submission");
+                return Ok(());
+            }
+
+            match tx_manager.send(candidate.clone()).await {
+                Ok(receipt) => break receipt,
+                Err(e) => {
+                    // The signer may already be registered despite the error
+                    // (for example, the tx was mined but the tx manager reported
+                    // a nonce race during fee bumping). Check onchain state.
+                    let post_err_check = tokio::select! {
+                        biased;
+                        () = signer_cancel.cancelled() => {
+                            debug!(
+                                signer = %signer_address,
+                                "cancelled while verifying post-tx-error registration state"
+                            );
+                            return Ok(());
+                        }
+                        res = registry.is_registered(signer_address) => res,
+                    };
+                    match post_err_check {
+                        Ok(true) => {
+                            info!(
+                                signer = %signer_address,
+                                error = %e,
+                                "tx error but signer is registered onchain, treating as success"
+                            );
+                            RegistrarMetrics::registrations_total().increment(1);
+                            return Ok(());
+                        }
+                        Err(registry_err) => {
+                            warn!(
+                                error = %registry_err,
+                                signer = %signer_address,
+                                "failed to query is_registered after tx error"
+                            );
+                        }
+                        Ok(false) => {}
+                    }
+
+                    // Non-retryable errors cannot be resolved by retrying with
+                    // the same calldata.
+                    if !e.is_retryable() {
+                        // If the contract reverted execution, the proof itself
+                        // is likely invalid. Block recovery for this signer so
+                        // the next cycle generates a fresh proof instead of
+                        // re-recovering the same one.
+                        if matches!(e, TxManagerError::ExecutionReverted { .. }) {
+                            warn!(
+                                signer = %signer_address,
+                                "execution reverted, blocking proof recovery for signer"
+                            );
+                            proof_provider.block_recovery_for_signer(signer_address);
+                        }
+                        return Err(RegistrarError::from(e));
+                    }
+
+                    tx_retries += 1;
+                    if tx_retries > max_tx_retries {
+                        return Err(RegistrarError::from(e));
+                    }
+
+                    warn!(
+                        error = %e,
+                        signer = %signer_address,
+                        retry = tx_retries,
+                        max_retries = max_tx_retries,
+                        "tx submission failed, retrying with same proof"
+                    );
+
+                    // Cancellation-aware delay: abort immediately if shutdown
+                    // is requested during the retry wait.
+                    tokio::select! {
+                        biased;
+                        () = signer_cancel.cancelled() => {
+                            debug!(
+                                error = %e,
+                                signer = %signer_address,
+                                "shutdown requested during retry delay; abandoning task"
+                            );
+                            return Ok(());
+                        }
+                        () = tokio::time::sleep(tx_retry_delay) => {}
+                    }
+                }
+            }
+        };
+
+        if !receipt.inner.status() {
+            warn!(
+                signer = %signer_address,
+                tx_hash = %receipt.transaction_hash,
+                "registration transaction reverted onchain",
+            );
+            return Err(RegistrarError::Transaction(
+                format!("registration transaction {} reverted", receipt.transaction_hash).into(),
+            ));
+        }
+
+        info!(
+            signer = %signer_address,
+            tx_hash = %receipt.transaction_hash,
+            "signer registered successfully"
+        );
+        RegistrarMetrics::registrations_total().increment(1);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### What changed? Why?

Extracts the registrar proof-generation and registerSigner transaction flow from `RegistrationDriver` into a new `ProofHandler` module. This keeps the driver focused on discovery/task orchestration while preserving the registration outcomes, cancellation handling, in-flight dedupe, retry behavior, and registration metrics.

The refactor intentionally narrows the proof-concurrency semaphore lifetime to proof generation only. Previously the permit stayed held through transaction submission retries because the whole flow lived in one method scope. The semaphore is now scoped to the expensive Boundless/Direct proof work; transaction nonce serialization remains handled by the transaction manager.

### Notes to reviewers

The driver now builds a small handler config/context/request and delegates the previous `try_register` implementation to `ProofHandler::register_signer`. The public handler keeps only `register_signer` as the primary entry point; pipeline helpers remain available for focused unit coverage.

### How has it been tested?

- `cargo fmt --check`
- `cargo check -p base-proof-tee-registrar`