### PR TITLE
fix(flashblocks): avoid unwrap() panic on empty flashblocks in build_pending_state

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -348,6 +348,10 @@ where
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         flashblocks: &[Flashblock],
     ) -> Result<Option<Arc<PendingBlocks>>> {
+        if flashblocks.is_empty() {
+            return Ok(None);
+        }
+
         // BTreeMap guarantees ascending order of keys while iterating
         let mut flashblocks_per_block = BTreeMap::<BlockNumber, Vec<Flashblock>>::new();
         for flashblock in flashblocks {
@@ -357,7 +361,8 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
+        let earliest_block_number =
+            flashblocks_per_block.keys().min().expect("flashblocks_per_block is non-empty");
         let canonical_block = earliest_block_number - 1;
         let mut last_block_header = self
             .client


### PR DESCRIPTION
## Summary
- `build_pending_state` unconditionally called `.unwrap()` on `flashblocks_per_block.keys().min()`. When the `flashblocks` slice passed in is empty, the map is empty, `min()` returns `None`, and the `.unwrap()` panics — taking down the execution node.
- Returns `Ok(None)` early when `flashblocks` is empty, before any work is done, matching the safe pattern already used by `get_latest_l1_head_in_batch` in `fetcher.rs`.

Fixes #2785

## Test plan
- [ ] `cargo nextest run -p base-reth-flashblocks`