### PR TITLE
fix(proof/fetcher): replace unwrap() with descriptive errors on Option RPC results

### DIFF
--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -234,10 +234,16 @@ impl OPSuccinctDataFetcher {
 
         let block_data = stream::iter(start + 1..=end)
             .map(|block_number| async move {
-                let block =
-                    self.l2_provider.get_block_by_number(block_number.into()).await?.unwrap();
-                let receipts =
-                    self.l2_provider.get_block_receipts(block_number.into()).await?.unwrap();
+                let block = self
+                    .l2_provider
+                    .get_block_by_number(block_number.into())
+                    .await?
+                    .ok_or_else(|| anyhow!("L2 block {block_number} not found"))?;
+                let receipts = self
+                    .l2_provider
+                    .get_block_receipts(block_number.into())
+                    .await?
+                    .ok_or_else(|| anyhow!("receipts for L2 block {block_number} not found"))?;
                 let total_l1_fees: u128 =
                     receipts.iter().map(|tx| tx.l1_block_info.l1_fee.unwrap_or(0)).sum();
                 let total_tx_fees: u128 = receipts
@@ -762,7 +768,10 @@ impl OPSuccinctDataFetcher {
         let agreed_l2_output_root = keccak256(l2_output_encoded.abi_encode());
 
         // Get L2 claim data.
-        let l2_claim_block = l2_provider.get_block_by_number(l2_end_block.into()).await?.unwrap();
+        let l2_claim_block = l2_provider
+            .get_block_by_number(l2_end_block.into())
+            .await?
+            .ok_or_else(|| anyhow!("L2 block {l2_end_block} not found"))?;
         let l2_claim_state_root = l2_claim_block.header.state_root;
         let l2_claim_hash = l2_claim_block.header.hash;
         let l2_claim_storage_hash = l2_provider


### PR DESCRIPTION
## Summary
- `get_l2_block_data_range` and `get_proof_inputs` in `crates/proof/succinct/utils/host/src/fetcher.rs` called `.unwrap()` on `Option`-returning RPC results (`get_block_by_number`, `get_block_receipts`). If the RPC returns `None` (block not found — pruned node, incorrect range, race condition), the prover host panics instead of propagating a descriptive error.
- Replaced each `.unwrap()` with `.ok_or_else(|| anyhow!(...))`, the same pattern already used by the correct sibling `get_latest_l1_head_in_batch`.

Fixes #2791

Related: #2701 (same class of bug in `get_earliest_l1_head_in_batch`)

## Test plan
- [ ] `cargo nextest run -p base-proof-succinct-host`