### PR TITLE
fix(common): Support Mapping-Only Storable Structs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -76,6 +76,7 @@ runs:
           build-essential \
           clang \
           libclang-dev \
+          libprotobuf-dev \
           libsqlite3-dev \
           llvm \
           llvm-dev \

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -70,7 +70,7 @@ runs:
       uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
       with:
         packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config protobuf-compiler
-        version: 1.4
+        version: 1.5
 
     - name: Install Rust (stable via rust-toolchain.toml)
       if: inputs.toolchain == 'stable'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -67,10 +67,20 @@ runs:
 
     - name: Install native dependencies
       if: inputs.native-deps == 'true'
-      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
-      with:
-        packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config protobuf-compiler
-        version: 1.5
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential \
+          clang \
+          libclang-dev \
+          libsqlite3-dev \
+          llvm \
+          llvm-dev \
+          pkg-config \
+          protobuf-compiler
 
     - name: Install Rust (stable via rust-toolchain.toml)
       if: inputs.toolchain == 'stable'

--- a/crates/common/precompile-macros/src/storable.rs
+++ b/crates/common/precompile-macros/src/storable.rs
@@ -97,20 +97,30 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
     let packing_module = gen_packing_module_from_ir(&layout_fields, &mod_ident);
 
     let len = fields.len();
-    let (direct_fields, direct_names, mapping_names) = field_infos.iter().fold(
-        (Vec::with_capacity(len), Vec::with_capacity(len), Vec::new()),
+    let (direct_fields, field_inits) = field_infos.iter().fold(
+        (Vec::with_capacity(len), Vec::with_capacity(len)),
         |mut out, field_info| {
+            let name = &field_info.name;
             if extract_mapping_types(&field_info.ty).is_none() {
-                out.0.push((&field_info.name, &field_info.ty));
-                out.1.push(&field_info.name);
+                out.0.push((name, &field_info.ty));
+                out.1.push(quote! { #name });
             } else {
-                out.2.push(&field_info.name);
+                out.1.push(quote! { #name: Default::default() });
             }
             out
         },
     );
 
     let direct_tys: Vec<_> = direct_fields.iter().map(|(_, ty)| *ty).collect();
+    let is_dynamic = if direct_tys.is_empty() {
+        quote! { false }
+    } else {
+        quote! {
+            #(
+                <#direct_tys as ::base_precompile_storage::StorableType>::IS_DYNAMIC
+            )||*
+        }
+    };
 
     let load_impl = gen_load_impl(&direct_fields, &mod_ident);
     let store_impl = gen_store_impl(&direct_fields, &mod_ident);
@@ -128,9 +138,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
             const LAYOUT: ::base_precompile_storage::Layout = ::base_precompile_storage::Layout::Slots(#mod_ident::SLOT_COUNT);
             #namespace_consts
 
-            const IS_DYNAMIC: bool = #(
-                <#direct_tys as ::base_precompile_storage::StorableType>::IS_DYNAMIC
-            )||*;
+            const IS_DYNAMIC: bool = #is_dynamic;
 
             type Handler<'a> = #handler_name<'a>;
 
@@ -156,8 +164,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
                 #load_impl
 
                 Ok(Self {
-                    #(#direct_names),*,
-                    #(#mapping_names: Default::default()),*
+                    #(#field_inits),*
                 })
             }
 
@@ -715,6 +722,10 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
 }
 
 fn gen_delete_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
+    if fields.is_empty() {
+        return quote! {};
+    }
+
     let dynamic_deletes = fields.iter().map(|(name, ty)| {
         let loc_const = PackingConstants::new(name).location();
         quote! {

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -66,6 +66,28 @@ fn test_contract_macro_basic_roundtrip() {
     });
 }
 
+mod mapping_only_storable_layout {
+    use alloy_primitives::{Address, U256};
+    use base_precompile_macros::Storable;
+    use base_precompile_storage::{Mapping, StorableType};
+
+    #[derive(Debug, Clone, Storable)]
+    struct MappingOnlyStorage {
+        balances: Mapping<Address, U256>,
+        allowances: Mapping<Address, Mapping<Address, U256>>,
+    }
+
+    #[test]
+    fn mapping_only_storable_struct_uses_static_layout() {
+        assert!(!<MappingOnlyStorage as StorableType>::IS_DYNAMIC);
+        assert_eq!(<MappingOnlyStorage as StorableType>::SLOTS, 2);
+
+        let value =
+            MappingOnlyStorage { balances: Mapping::default(), allowances: Mapping::default() };
+        let _ = (value.balances, value.allowances);
+    }
+}
+
 #[test]
 fn test_contract_slots_are_deterministic() {
     // Verify that the generated slot constants are stable across runs.

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -79,7 +79,7 @@ mod mapping_only_storable_layout {
 
     #[test]
     fn mapping_only_storable_struct_uses_static_layout() {
-        assert!(!<MappingOnlyStorage as StorableType>::IS_DYNAMIC);
+        const { assert!(!<MappingOnlyStorage as StorableType>::IS_DYNAMIC) };
         assert_eq!(<MappingOnlyStorage as StorableType>::SLOTS, 2);
 
         let value =


### PR DESCRIPTION
## Summary

This fixes the Storable derive output for structs that contain only mapping fields. The macro now emits a valid static IS_DYNAMIC expression, initializes mapping-only loaded values without malformed commas, and skips direct-field delete code when there are no direct fields. A regression test covers a mapping-only storage layout so the generated code keeps compiling.