### PR TITLE
refactor(common): Simplify Role Admin Read

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -219,12 +219,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                 &self,
                 role: ::alloy_primitives::B256,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::B256> {
-                let admin_role = self.b20.role_admin(role)?;
-                if admin_role.is_zero() && role != crate::B20TokenRole::DefaultAdmin.id() {
-                    Ok(crate::B20TokenRole::DefaultAdmin.id())
-                } else {
-                    Ok(admin_role)
-                }
+                self.b20.role_admin(role)
             }
 
             fn set_role_admin(

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -84,14 +84,14 @@ impl B20AssetStorage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256, address, uint};
+    use alloy_primitives::{Address, B256, U256, address, uint};
     use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
 
     use super::{
         __packing_b20_asset_extension_storage, B20AssetExtensionStorage, B20AssetInit,
         B20AssetStorage, slots,
     };
-    use crate::{AssetAccounting, B20CoreStorage};
+    use crate::{AssetAccounting, B20CoreStorage, B20TokenRole, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -157,6 +157,24 @@ mod tests {
 
             assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), configured_multiplier);
             assert_eq!(token.multiplier().unwrap(), configured_multiplier);
+        });
+    }
+
+    #[test]
+    fn role_admin_reads_raw_storage_default() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let token = B20AssetStorage::from_address(TOKEN, ctx);
+
+            assert_eq!(
+                TokenAccounting::role_admin(&token, B20TokenRole::Mint.id()).unwrap(),
+                B20TokenRole::DefaultAdmin.id()
+            );
+            assert_eq!(
+                TokenAccounting::role_admin(&token, B20TokenRole::DefaultAdmin.id()).unwrap(),
+                B256::ZERO
+            );
         });
     }
 

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -294,6 +294,11 @@ mod tests {
     }
 
     #[test]
+    fn default_admin_role_matches_access_control_zero() {
+        assert_eq!(B20TokenRole::DefaultAdmin.id(), B256::ZERO);
+    }
+
+    #[test]
     fn grant_role_authorizes_against_role_admin_and_emits_event() {
         let mut token = token_with_default_admin();
 


### PR DESCRIPTION
## Summary

This removes a redundant generated fallback in the B-20 role admin storage adapter so the Rust implementation matches the raw storage-read model used by base-std. The behavior remains unchanged because unset role-admin storage reads as zero, and DEFAULT_ADMIN_ROLE is intentionally zero. Focused tests now cover both the zero-role invariant and the generated asset storage adapter path.