### PR TITLE
fix(common): Align Asset Decimals Default

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -372,7 +372,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
 
             fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
                 let stored = self.asset.decimals()?;
-                Ok(if stored == 0 { 6 } else { stored })
+                Ok(if stored == 0 { Self::MIN_DECIMALS } else { stored })
             }
         }
     })

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -75,7 +75,8 @@ impl B20AssetStorage<'_> {
     /// WAD precision for multiplier arithmetic: 1e18.
     pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
-    /// Returns the configured asset decimals, defaulting an unset storage slot to `6`.
+    /// Returns the configured asset decimals, defaulting an unset storage slot to
+    /// [`Self::MIN_DECIMALS`].
     pub fn decimals(&self) -> Result<u8> {
         let decimals = self.asset.decimals()?;
         Ok(if decimals == 0 { Self::MIN_DECIMALS } else { decimals })
@@ -234,12 +235,13 @@ mod tests {
     }
 
     #[test]
-    fn decimals_uninitialized_slot_falls_back_to_six() {
+    fn decimals_uninitialized_slot_falls_back_to_min_decimals() {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
             let token = B20AssetStorage::from_address(TOKEN, ctx);
             assert_eq!(token.asset.decimals.read().unwrap(), 0);
+            assert_eq!(token.decimals().unwrap(), B20AssetStorage::MIN_DECIMALS);
             assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
         });
     }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -360,7 +360,7 @@ mod tests {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            decimals: 6,
+            decimals: B20AssetStorage::MIN_DECIMALS,
         }
     }
 
@@ -496,7 +496,7 @@ mod tests {
 
             assert_eq!(token.b20.name.read().unwrap(), "My Token");
             assert_eq!(token.b20.symbol.read().unwrap(), "MYT");
-            assert_eq!(AssetAccounting::decimals(&token).unwrap(), 6);
+            assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
             assert_eq!(token.supply_cap().unwrap(), B20FactoryStorage::DEFAULT_SUPPLY_CAP);
         });
     }

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -10,7 +10,7 @@ use base_precompile_storage::Result;
 
 use crate::{
     IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
-    b20_asset::{AssetAccounting, B20AssetToken},
+    b20_asset::{AssetAccounting, B20AssetStorage, B20AssetToken},
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
     common::{Policy, TokenAccounting},
 };
@@ -376,8 +376,7 @@ impl PolicyRegistry for InMemoryPolicy {
 
 impl AssetAccounting for InMemoryTokenAccounting {
     fn multiplier(&self) -> Result<U256> {
-        const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
-        Ok(if self.multiplier.is_zero() { WAD } else { self.multiplier })
+        Ok(if self.multiplier.is_zero() { B20AssetStorage::WAD } else { self.multiplier })
     }
 
     fn set_multiplier(&mut self, ratio: U256) -> Result<()> {
@@ -408,6 +407,6 @@ impl AssetAccounting for InMemoryTokenAccounting {
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(if self.decimals == 0 { 6 } else { self.decimals })
+        Ok(if self.decimals == 0 { B20AssetStorage::MIN_DECIMALS } else { self.decimals })
     }
 }


### PR DESCRIPTION
## Summary

This aligns the generated asset decimals fallback with the named storage bound instead of a hardcoded literal. The derive now emits Self::MIN_DECIMALS, while the storage docs, tests, factory fixtures, and in-memory asset fake all reference the same named constants. This keeps the storage-backed path and test doubles in sync if the bound changes later.