### PR TITLE
refactor(common): Remove Namespace Contract Reorder

### DIFF
--- a/crates/common/precompile-macros/README.md
+++ b/crates/common/precompile-macros/README.md
@@ -12,6 +12,16 @@ Procedural macros for type-safe EVM storage abstractions for Base native precomp
 - `storable_arrays!()`, `storable_nested_arrays!()` — fixed-size array impls
 - `gen_storable_tests!()` — proptest round-trip tests for all storage types
 
+For `#[contract]` layouts, place the namespace helper below `#[contract]`:
+
+```rust,ignore
+#[contract]
+#[namespace("b20")]
+pub struct B20Contract {
+    pub total_supply: U256,
+}
+```
+
 For `Storable` layouts, place the derive before the namespace helper:
 
 ```rust,ignore

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -27,7 +27,10 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     contract::generate(input, config.address.as_ref())
 }
 
-/// Namespaces a `#[contract]` storage struct or `Storable` layout using an ERC-7201 storage root.
+/// Adds an ERC-7201 namespace to a `Storable` layout.
+///
+/// Contract storage layouts support `#[namespace("id")]` when it is placed below `#[contract]`;
+/// in that order, `#[contract]` consumes the helper attribute directly.
 #[proc_macro_attribute]
 pub fn namespace(attr: TokenStream, item: TokenStream) -> TokenStream {
     namespace::expand(attr, item)

--- a/crates/common/precompile-macros/src/namespace.rs
+++ b/crates/common/precompile-macros/src/namespace.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, LitStr};
 
-use crate::utils::{attr_path_is, parse_namespace_id};
+use crate::utils::attr_path_is;
 
 pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
     match expand_impl(attr.into(), item.into()) {
@@ -20,19 +20,17 @@ fn expand_impl(
     let namespace_id: LitStr = syn::parse2(attr)?;
     let mut input: DeriveInput = syn::parse2(item)?;
 
-    parse_namespace_id(namespace_id.clone())?;
-
     if input.attrs.iter().any(|attr| {
         attr_path_is(attr.path(), "namespace") || attr_path_is(attr.path(), "storage_namespace")
     }) {
         return Err(syn::Error::new_spanned(&input.ident, "duplicate `namespace` attribute"));
     }
 
-    if let Some(contract_index) =
-        input.attrs.iter().position(|attr| attr_path_is(attr.path(), "contract"))
-    {
-        input.attrs.insert(contract_index + 1, syn::parse_quote!(#[namespace(#namespace_id)]));
-        return Ok(quote! { #input });
+    if input.attrs.iter().any(|attr| attr_path_is(attr.path(), "contract")) {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[namespace]` must be placed below `#[contract]` on contract storage layouts",
+        ));
     }
 
     if has_storable_derive(&input)? {
@@ -42,7 +40,7 @@ fn expand_impl(
 
     Err(syn::Error::new_spanned(
         &input.ident,
-        "`#[namespace]` must be paired with `#[contract]` or `#[derive(Storable)]`",
+        "`#[namespace]` must be paired with `#[derive(Storable)]` or placed below `#[contract]`",
     ))
 }
 

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -661,27 +661,3 @@ mod packed_slot_layout {
         });
     }
 }
-
-mod namespace_outer_order {
-    use alloy_primitives::{Address, U256, address, uint};
-    use base_precompile_macros::{contract, namespace};
-
-    const ORDER_ADDR: Address = address!("0000000000000000000000000000000000005678");
-
-    #[namespace("b20.outer-order")]
-    #[contract(addr = ORDER_ADDR)]
-    pub struct OuterOrderStorage {
-        pub value: U256,
-    }
-
-    #[test]
-    fn namespace_macro_reorders_above_contract() {
-        assert_eq!(ORDER_ADDR, address!("0000000000000000000000000000000000005678"));
-        assert_eq!(slots::NAMESPACE_ID, "b20.outer-order");
-        assert_eq!(
-            slots::NAMESPACE_ROOT,
-            uint!(0xf06e16fd945cfdfdb627e60cabea1fb8bb965382c21574655d1e8bb28bdfcf00_U256)
-        );
-        assert_eq!(slots::VALUE, slots::NAMESPACE_ROOT);
-    }
-}


### PR DESCRIPTION
## Summary

This removes the unused contract reordering branch from the namespace macro so contract-level namespace handling stays owned by #[contract]. The supported contract attribute ordering is now documented explicitly, and the inverted-order compatibility test has been removed. Namespace validation now flows through the existing extract_namespace and extract_storage_namespace paths instead of an extra side-effect parse.