### PR TITLE
fix(common): Improve Install Option Diagnostics

### DIFF
--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -188,6 +188,9 @@ impl Parse for InstallConfig {
         input.parse::<Token![=]>()?;
         let address = input.parse()?;
 
+        if !input.is_empty() && !input.peek(Token![,]) {
+            return Err(syn::Error::new(input.span(), "unexpected `install` option"));
+        }
         if !input.is_empty() {
             input.parse::<Token![,]>()?;
         }
@@ -252,5 +255,19 @@ mod tests {
 
         assert!(config.storage.is_some());
         assert!(config.macro_path.is_some());
+    }
+
+    #[test]
+    fn config_rejects_install_option_without_comma_as_unexpected_option() {
+        let err = parse_config(quote! { install(address = X extra) }).err().unwrap();
+
+        assert!(err.to_string().contains("unexpected `install` option"));
+    }
+
+    #[test]
+    fn config_rejects_extra_install_option_after_comma() {
+        let err = parse_config(quote! { install(address = X, extra) }).err().unwrap();
+
+        assert!(err.to_string().contains("unexpected `install` option"));
     }
 }

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -188,7 +188,8 @@ impl Parse for InstallConfig {
         input.parse::<Token![=]>()?;
         let address = input.parse()?;
 
-        if !input.is_empty() && !input.peek(Token![,]) {
+        let has_non_comma_remainder = !input.is_empty() && !input.peek(Token![,]);
+        if has_non_comma_remainder {
             return Err(syn::Error::new(input.span(), "unexpected `install` option"));
         }
         if !input.is_empty() {


### PR DESCRIPTION
## Summary

This updates the #[precompile] install parser so unsupported trailing tokens report the dedicated install-option diagnostic instead of a missing comma. The change preserves valid address and trailing-comma forms while making malformed install arguments clearer for macro authors. Regression tests cover both unsupported-option forms.