### PR TITLE
chore: specify minimum just as 1.51.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ If you want to work on something that doesn't have an issue yet, open an issue f
 ### Developer Setup
 
 - Rust `1.94` or newer
-- [`just`](https://github.com/casey/just)
+- [`just`](https://github.com/casey/just) `1.51.0` or newer
 - Foundry (`forge`) for Solidity-based test fixtures
 - Bun and Node.js `22+` if you want to run the spec site locally
 - Docker if you want to use the local devnet or build container images


### PR DESCRIPTION
The CONTRIBUTING.md doesn't specify which just versions so I had to do upgrade JUST to realize why the Justfile was not parsing correctly. Just 1.42.0 is actually the minimum version but it's not available on brew. This makes it easier for developers to get started.