### PR TITLE
refactor(registrar): extract orphan signer deregistration

### DIFF
--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -221,13 +221,18 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        future,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
     use alloy_primitives::{B256, Bloom};
     use alloy_rpc_types_eth::TransactionReceipt;
     use async_trait::async_trait;
     use base_tx_manager::SendHandle;
+    use tokio::sync::Notify;
 
     use super::*;
 
@@ -281,16 +286,16 @@ mod tests {
 
     #[tokio::test]
     async fn deregister_orphans_skips_ghost_entries() {
-        let registry = MockRegistry::with_true_signers(vec![SIGNER_B]);
+        let registry = MockRegistry::with_enumerated_and_true_signers(
+            vec![SIGNER_A, SIGNER_B],
+            vec![SIGNER_B],
+        );
         let tx_manager = MockTxManager::default();
         let history = Arc::new(Mutex::new(HashMap::new()));
         let manager =
             DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
 
-        manager
-            .deregister_orphans(&HashSet::new(), &[SIGNER_A, SIGNER_B], &CancellationToken::new())
-            .await
-            .unwrap();
+        manager.run_orphan_dereg(&HashSet::new(), &CancellationToken::new()).await.unwrap();
 
         let sent = tx_manager.take_candidates();
         assert_eq!(sent.len(), 1);
@@ -315,20 +320,72 @@ mod tests {
         assert!(tx_manager.take_candidates().is_empty());
     }
 
+    #[tokio::test]
+    async fn run_orphan_dereg_respects_cancellation_while_loading_signers() {
+        let registry = MockRegistry::stalling_get_registered_signers();
+        let get_registered_signers_started = registry.get_registered_signers_started();
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let cancel = CancellationToken::new();
+        let protected_signers = HashSet::new();
+
+        let run = manager.run_orphan_dereg(&protected_signers, &cancel);
+        tokio::pin!(run);
+
+        let notified = get_registered_signers_started.notified();
+        tokio::pin!(notified);
+        tokio::select! {
+            () = &mut notified => {}
+            result = &mut run => panic!("run_orphan_dereg completed before cancellation: {result:?}"),
+        }
+
+        cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), run)
+            .await
+            .expect("run_orphan_dereg should stop promptly after cancellation")
+            .unwrap();
+        assert!(tx_manager.take_candidates().is_empty());
+    }
+
     #[derive(Debug)]
     struct MockRegistry {
         signers: Vec<Address>,
         true_signers: HashSet<Address>,
+        get_registered_signers_started: Arc<Notify>,
+        stall_get_registered_signers: bool,
     }
 
     impl MockRegistry {
         fn with_signers(signers: Vec<Address>) -> Self {
-            let true_signers = signers.iter().copied().collect();
-            Self { signers, true_signers }
+            Self::with_enumerated_and_true_signers(signers.clone(), signers)
         }
 
-        fn with_true_signers(true_signers: Vec<Address>) -> Self {
-            Self { signers: true_signers.clone(), true_signers: true_signers.into_iter().collect() }
+        fn with_enumerated_and_true_signers(
+            enumerated_signers: Vec<Address>,
+            true_signers: Vec<Address>,
+        ) -> Self {
+            Self {
+                signers: enumerated_signers,
+                true_signers: true_signers.into_iter().collect(),
+                get_registered_signers_started: Arc::new(Notify::new()),
+                stall_get_registered_signers: false,
+            }
+        }
+
+        fn stalling_get_registered_signers() -> Self {
+            Self {
+                signers: vec![],
+                true_signers: HashSet::new(),
+                get_registered_signers_started: Arc::new(Notify::new()),
+                stall_get_registered_signers: true,
+            }
+        }
+
+        fn get_registered_signers_started(&self) -> Arc<Notify> {
+            Arc::clone(&self.get_registered_signers_started)
         }
     }
 
@@ -339,6 +396,10 @@ mod tests {
         }
 
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            self.get_registered_signers_started.notify_waiters();
+            if self.stall_get_registered_signers {
+                future::pending::<()>().await;
+            }
             Ok(self.signers.clone())
         }
     }

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -228,17 +228,40 @@ mod tests {
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{B256, Bloom};
+    use alloy_primitives::{B256, Bloom, address};
     use alloy_rpc_types_eth::TransactionReceipt;
     use async_trait::async_trait;
     use base_tx_manager::SendHandle;
+    use rstest::rstest;
     use tokio::sync::Notify;
 
     use super::*;
 
+    /// Expected byte length of ABI-encoded `deregisterSigner(address)` calldata:
+    /// 4-byte selector + 32-byte left-padded address word.
+    const DEREGISTER_CALLDATA_LEN: usize = 36;
+    /// Number of zero-padding bytes before the 20-byte address in the ABI word.
+    const ABI_ADDRESS_PAD: usize = 12;
+    /// Byte offset where the raw 20-byte address starts in the encoded calldata.
+    const ABI_ADDRESS_OFFSET: usize = 4 + ABI_ADDRESS_PAD;
     const REGISTRY_ADDRESS: Address = Address::new([0x11; 20]);
+    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     const SIGNER_A: Address = Address::new([0xAA; 20]);
     const SIGNER_B: Address = Address::new([0xBB; 20]);
+    const SIGNER_C: Address = Address::new([0xCC; 20]);
+
+    #[rstest]
+    #[case::zero_address(Address::ZERO)]
+    #[case::hardhat_account(HARDHAT_ACCOUNT)]
+    #[case::all_ones(Address::repeat_byte(0xFF))]
+    fn deregister_calldata_encodes_correctly(#[case] signer: Address) {
+        let calldata = ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode();
+
+        assert_eq!(calldata.len(), DEREGISTER_CALLDATA_LEN);
+        assert_eq!(&calldata[..4], &ITEEProverRegistry::deregisterSignerCall::SELECTOR);
+        assert_eq!(&calldata[4..ABI_ADDRESS_OFFSET], &[0u8; ABI_ADDRESS_PAD]);
+        assert_eq!(&calldata[ABI_ADDRESS_OFFSET..], signer.as_slice());
+    }
 
     #[test]
     fn candidate_targets_registry_with_deregister_signer_calldata() {
@@ -257,6 +280,31 @@ mod tests {
         );
         assert_eq!(candidate.gas_limit, 0);
         assert!(candidate.blobs.is_empty());
+    }
+
+    #[rstest]
+    #[case::no_orphans(vec![SIGNER_A, SIGNER_B], vec![SIGNER_A, SIGNER_B], 0)]
+    #[case::one_orphan(vec![SIGNER_A, SIGNER_B], vec![SIGNER_A], 1)]
+    #[case::all_orphans(vec![SIGNER_A, SIGNER_B], vec![], 2)]
+    #[tokio::test]
+    async fn deregister_orphans_tx_count(
+        #[case] registered_signers: Vec<Address>,
+        #[case] protected_signers: Vec<Address>,
+        #[case] expected_txs: usize,
+    ) {
+        let registry = MockRegistry::with_signers(registered_signers.clone());
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let protected_signers: HashSet<Address> = protected_signers.into_iter().collect();
+
+        manager
+            .deregister_orphans(&protected_signers, &registered_signers, &CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert_eq!(tx_manager.take_candidates().len(), expected_txs);
     }
 
     #[tokio::test]
@@ -303,6 +351,22 @@ mod tests {
             sent[0].tx_data,
             Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer: SIGNER_B }.abi_encode())
         );
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_skips_all_ghosts_sends_nothing() {
+        let registry = MockRegistry::with_enumerated_and_true_signers(
+            vec![SIGNER_A, SIGNER_B, SIGNER_C],
+            vec![],
+        );
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+
+        manager.run_orphan_dereg(&HashSet::new(), &CancellationToken::new()).await.unwrap();
+
+        assert!(tx_manager.take_candidates().is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -88,6 +88,11 @@ where
             "Deregistering signer"
         );
 
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
+
         match self.tx_manager.send(candidate).await {
             Ok(receipt) => {
                 if !receipt.inner.status() {
@@ -124,11 +129,21 @@ where
         registered_signers: &[Address],
         cancel: &CancellationToken,
     ) -> Result<()> {
-        let mut deregistered = 0usize;
-        let orphan_signers =
-            registered_signers.iter().copied().filter(|addr| !protected_signers.contains(addr));
+        let orphans: Vec<_> = registered_signers
+            .iter()
+            .copied()
+            .filter(|addr| !protected_signers.contains(addr))
+            .collect();
 
-        for signer in orphan_signers {
+        if orphans.is_empty() {
+            return Ok(());
+        }
+
+        info!(count = orphans.len(), "deregistering orphan signers");
+
+        let mut deregistered = 0usize;
+
+        for signer in orphans {
             if cancel.is_cancelled() {
                 debug!("shutdown requested, stopping orphan deregistration");
                 break;

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -48,19 +48,12 @@ where
     R: RegistryClient + ?Sized,
     T: TxManager + ?Sized,
 {
-    /// Drives the orphan-deregistration pass.
-    ///
-    /// Loads onchain signers, computes the orphan set (`registered \ protected`),
-    /// and deregisters each in sequence with a ghost-entry guard.
+    /// Loads registered signers and deregisters unprotected ones.
     pub async fn run_orphan_dereg(
         &self,
         protected_signers: &HashSet<Address>,
         cancel: &CancellationToken,
     ) -> Result<()> {
-        // Cancel-aware: `get_registered_signers` is a side-effect-free
-        // read, so dropping it on cancel is safe. Without this select,
-        // a shutdown during the registry RPC would extend drain latency
-        // by an entire round-trip before `deregister_orphans` is reached.
         let registered_signers = tokio::select! {
             biased;
             () = cancel.cancelled() => {
@@ -83,11 +76,6 @@ where
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
     pub async fn submit_deregistration(&self, signer: Address) -> bool {
         let candidate = self.candidate(signer);
-
-        // `last_known_instance = None` is the strongest single diagnostic
-        // for phantom rotations: a signer we never observed in any
-        // discovery cycle implies another registrar (or a prior
-        // deployment) wrote it.
         let last_known_instance = {
             let history = self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
             history.get(&signer).cloned()
@@ -98,11 +86,6 @@ where
             registry = %self.registry_address,
             calldata_len = candidate.tx_data.len(),
             "Deregistering signer"
-        );
-
-        info!(
-            tx = ?candidate,
-            "Sending tx candidate",
         );
 
         match self.tx_manager.send(candidate).await {
@@ -131,63 +114,26 @@ where
         }
     }
 
-    /// Deregisters any onchain signer that is not in the `protected_signers` set.
+    /// Deregisters registered signers that are not currently protected.
     ///
-    /// These orphans arise when a prover instance is terminated (e.g. ASG
-    /// scale-down) without first deregistering its signer onchain. The caller
-    /// supplies `protected_signers` as the union of resolved-this-cycle signers
-    /// and signers with an in-flight proof task, so transiently-unresolved
-    /// instances and mid-flight registrations are both shielded from the sweep.
-    ///
-    /// # Defense in depth
-    ///
-    /// Before submitting a deregistration transaction, each orphan candidate is
-    /// verified via [`RegistryClient::is_registered`] (backed by the
-    /// `isRegisteredSigner` mapping). This guards against ghost entries in the
-    /// onchain `EnumerableSetLib.AddressSet` that can appear after certain
-    /// add/remove sequences due to a bug in Solady v0.0.245. Without this
-    /// check, ghost addresses would be deregistered every cycle in an infinite
-    /// loop, burning gas without effect.
-    ///
-    /// # Assumptions
-    ///
-    /// - **Single registrar**: This method queries *all* onchain signers and
-    ///   treats any signer not in `protected_signers` as an orphan. If multiple
-    ///   registrar instances manage disjoint prover fleets, one registrar would
-    ///   incorrectly deregister another's signers. The current deployment model
-    ///   assumes a single registrar per registry contract.
+    /// Each candidate is checked against `isRegisteredSigner` before submitting a
+    /// transaction so stale `getRegisteredSigners()` entries do not loop forever.
     pub async fn deregister_orphans(
         &self,
         protected_signers: &HashSet<Address>,
         registered_signers: &[Address],
         cancel: &CancellationToken,
     ) -> Result<()> {
-        let orphans: Vec<_> = registered_signers
-            .iter()
-            .copied()
-            .filter(|addr| !protected_signers.contains(addr))
-            .collect();
-
-        if orphans.is_empty() {
-            return Ok(());
-        }
-
-        info!(count = orphans.len(), "deregistering orphan signers");
-
         let mut deregistered = 0usize;
-        for signer in orphans {
+        let orphan_signers =
+            registered_signers.iter().copied().filter(|addr| !protected_signers.contains(addr));
+
+        for signer in orphan_signers {
             if cancel.is_cancelled() {
                 debug!("shutdown requested, stopping orphan deregistration");
                 break;
             }
 
-            // Verify the signer is truly registered onchain before spending
-            // gas on a deregistration tx. The `getRegisteredSigners()` view
-            // reads from an `EnumerableSetLib.AddressSet` which can contain
-            // ghost entries (addresses that appear in `values()` but have
-            // `isRegisteredSigner == false`) due to a storage corruption bug
-            // in Solady v0.0.245. Skipping ghosts prevents an infinite
-            // deregistration loop.
             match self.registry.is_registered(signer).await {
                 Ok(false) => {
                     warn!(
@@ -214,7 +160,9 @@ where
             }
         }
 
-        info!(count = deregistered, "orphan deregistration complete");
+        if deregistered > 0 {
+            info!(count = deregistered, "orphan signers deregistered");
+        }
         Ok(())
     }
 }
@@ -228,7 +176,7 @@ mod tests {
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{B256, Bloom, address};
+    use alloy_primitives::{B256, Bloom};
     use alloy_rpc_types_eth::TransactionReceipt;
     use async_trait::async_trait;
     use base_tx_manager::SendHandle;
@@ -237,31 +185,10 @@ mod tests {
 
     use super::*;
 
-    /// Expected byte length of ABI-encoded `deregisterSigner(address)` calldata:
-    /// 4-byte selector + 32-byte left-padded address word.
-    const DEREGISTER_CALLDATA_LEN: usize = 36;
-    /// Number of zero-padding bytes before the 20-byte address in the ABI word.
-    const ABI_ADDRESS_PAD: usize = 12;
-    /// Byte offset where the raw 20-byte address starts in the encoded calldata.
-    const ABI_ADDRESS_OFFSET: usize = 4 + ABI_ADDRESS_PAD;
     const REGISTRY_ADDRESS: Address = Address::new([0x11; 20]);
-    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     const SIGNER_A: Address = Address::new([0xAA; 20]);
     const SIGNER_B: Address = Address::new([0xBB; 20]);
     const SIGNER_C: Address = Address::new([0xCC; 20]);
-
-    #[rstest]
-    #[case::zero_address(Address::ZERO)]
-    #[case::hardhat_account(HARDHAT_ACCOUNT)]
-    #[case::all_ones(Address::repeat_byte(0xFF))]
-    fn deregister_calldata_encodes_correctly(#[case] signer: Address) {
-        let calldata = ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode();
-
-        assert_eq!(calldata.len(), DEREGISTER_CALLDATA_LEN);
-        assert_eq!(&calldata[..4], &ITEEProverRegistry::deregisterSignerCall::SELECTOR);
-        assert_eq!(&calldata[4..ABI_ADDRESS_OFFSET], &[0u8; ABI_ADDRESS_PAD]);
-        assert_eq!(&calldata[ABI_ADDRESS_OFFSET..], signer.as_slice());
-    }
 
     #[test]
     fn candidate_targets_registry_with_deregister_signer_calldata() {

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -1,0 +1,396 @@
+//! Signer deregistration management for orphaned prover signers.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use alloy_primitives::{Address, Bytes};
+use alloy_sol_types::SolCall;
+use base_proof_contracts::ITEEProverRegistry;
+use base_tx_manager::{TxCandidate, TxManager};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{RegistrarMetrics, RegistryClient, Result};
+
+/// Manages orphan signer cleanup and `TEEProverRegistry.deregisterSigner` transactions.
+pub struct DeregistrationManager<'a, R: ?Sized, T: ?Sized> {
+    registry_address: Address,
+    registry: &'a R,
+    tx_manager: &'a T,
+    signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
+}
+
+impl<R: ?Sized, T: ?Sized> fmt::Debug for DeregistrationManager<'_, R, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeregistrationManager")
+            .field("registry_address", &self.registry_address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, R: ?Sized, T: ?Sized> DeregistrationManager<'a, R, T> {
+    /// Creates a manager for orphan signer cleanup.
+    pub const fn new(
+        registry_address: Address,
+        registry: &'a R,
+        tx_manager: &'a T,
+        signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
+    ) -> Self {
+        Self { registry_address, registry, tx_manager, signer_history }
+    }
+}
+
+impl<R, T> DeregistrationManager<'_, R, T>
+where
+    R: RegistryClient + ?Sized,
+    T: TxManager + ?Sized,
+{
+    /// Drives the orphan-deregistration pass.
+    ///
+    /// Loads onchain signers, computes the orphan set (`registered \ protected`),
+    /// and deregisters each in sequence with a ghost-entry guard.
+    pub async fn run_orphan_dereg(
+        &self,
+        protected_signers: &HashSet<Address>,
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        // Cancel-aware: `get_registered_signers` is a side-effect-free
+        // read, so dropping it on cancel is safe. Without this select,
+        // a shutdown during the registry RPC would extend drain latency
+        // by an entire round-trip before `deregister_orphans` is reached.
+        let registered_signers = tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                debug!("cancelled before loading registered signers for orphan dereg");
+                return Ok(());
+            }
+            res = self.registry.get_registered_signers() => res?,
+        };
+        self.deregister_orphans(protected_signers, &registered_signers, cancel).await
+    }
+
+    /// Builds the transaction candidate for `TEEProverRegistry.deregisterSigner`.
+    pub fn candidate(&self, signer: Address) -> TxCandidate {
+        let calldata =
+            Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode());
+
+        TxCandidate { tx_data: calldata, to: Some(self.registry_address), ..Default::default() }
+    }
+
+    /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
+    pub async fn submit_deregistration(&self, signer: Address) -> bool {
+        let candidate = self.candidate(signer);
+
+        // `last_known_instance = None` is the strongest single diagnostic
+        // for phantom rotations: a signer we never observed in any
+        // discovery cycle implies another registrar (or a prior
+        // deployment) wrote it.
+        let last_known_instance = {
+            let history = self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
+            history.get(&signer).cloned()
+        };
+        info!(
+            signer = %signer,
+            last_known_instance = ?last_known_instance,
+            registry = %self.registry_address,
+            calldata_len = candidate.tx_data.len(),
+            "Deregistering signer"
+        );
+
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
+
+        match self.tx_manager.send(candidate).await {
+            Ok(receipt) => {
+                if !receipt.inner.status() {
+                    warn!(
+                        signer = %signer,
+                        tx_hash = %receipt.transaction_hash,
+                        "deregistration transaction reverted onchain",
+                    );
+                    RegistrarMetrics::processing_errors_total().increment(1);
+                    return false;
+                }
+                info!(
+                    signer = %signer,
+                    tx_hash = %receipt.transaction_hash,
+                    "signer deregistered"
+                );
+                true
+            }
+            Err(e) => {
+                warn!(error = %e, signer = %signer, "failed to deregister signer");
+                RegistrarMetrics::processing_errors_total().increment(1);
+                false
+            }
+        }
+    }
+
+    /// Deregisters any onchain signer that is not in the `protected_signers` set.
+    ///
+    /// These orphans arise when a prover instance is terminated (e.g. ASG
+    /// scale-down) without first deregistering its signer onchain. The caller
+    /// supplies `protected_signers` as the union of resolved-this-cycle signers
+    /// and signers with an in-flight proof task, so transiently-unresolved
+    /// instances and mid-flight registrations are both shielded from the sweep.
+    ///
+    /// # Defense in depth
+    ///
+    /// Before submitting a deregistration transaction, each orphan candidate is
+    /// verified via [`RegistryClient::is_registered`] (backed by the
+    /// `isRegisteredSigner` mapping). This guards against ghost entries in the
+    /// onchain `EnumerableSetLib.AddressSet` that can appear after certain
+    /// add/remove sequences due to a bug in Solady v0.0.245. Without this
+    /// check, ghost addresses would be deregistered every cycle in an infinite
+    /// loop, burning gas without effect.
+    ///
+    /// # Assumptions
+    ///
+    /// - **Single registrar**: This method queries *all* onchain signers and
+    ///   treats any signer not in `protected_signers` as an orphan. If multiple
+    ///   registrar instances manage disjoint prover fleets, one registrar would
+    ///   incorrectly deregister another's signers. The current deployment model
+    ///   assumes a single registrar per registry contract.
+    pub async fn deregister_orphans(
+        &self,
+        protected_signers: &HashSet<Address>,
+        registered_signers: &[Address],
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        let orphans: Vec<_> = registered_signers
+            .iter()
+            .copied()
+            .filter(|addr| !protected_signers.contains(addr))
+            .collect();
+
+        if orphans.is_empty() {
+            return Ok(());
+        }
+
+        info!(count = orphans.len(), "deregistering orphan signers");
+
+        let mut deregistered = 0usize;
+        for signer in orphans {
+            if cancel.is_cancelled() {
+                debug!("shutdown requested, stopping orphan deregistration");
+                break;
+            }
+
+            // Verify the signer is truly registered onchain before spending
+            // gas on a deregistration tx. The `getRegisteredSigners()` view
+            // reads from an `EnumerableSetLib.AddressSet` which can contain
+            // ghost entries (addresses that appear in `values()` but have
+            // `isRegisteredSigner == false`) due to a storage corruption bug
+            // in Solady v0.0.245. Skipping ghosts prevents an infinite
+            // deregistration loop.
+            match self.registry.is_registered(signer).await {
+                Ok(false) => {
+                    warn!(
+                        signer = %signer,
+                        "signer appears in getRegisteredSigners but isRegisteredSigner is false, \
+                         skipping (possible EnumerableSet ghost entry)"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        signer = %signer,
+                        "failed to verify signer registration status, skipping deregistration"
+                    );
+                    continue;
+                }
+                Ok(true) => {}
+            }
+
+            if self.submit_deregistration(signer).await {
+                RegistrarMetrics::deregistrations_total().increment(1);
+                deregistered += 1;
+            }
+        }
+
+        info!(count = deregistered, "orphan deregistration complete");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{B256, Bloom};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use async_trait::async_trait;
+    use base_tx_manager::SendHandle;
+
+    use super::*;
+
+    const REGISTRY_ADDRESS: Address = Address::new([0x11; 20]);
+    const SIGNER_A: Address = Address::new([0xAA; 20]);
+    const SIGNER_B: Address = Address::new([0xBB; 20]);
+
+    #[test]
+    fn candidate_targets_registry_with_deregister_signer_calldata() {
+        let registry = MockRegistry::with_signers(vec![SIGNER_A]);
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+
+        let candidate = manager.candidate(SIGNER_A);
+
+        assert_eq!(candidate.to, Some(REGISTRY_ADDRESS));
+        assert_eq!(
+            candidate.tx_data,
+            Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer: SIGNER_A }.abi_encode())
+        );
+        assert_eq!(candidate.gas_limit, 0);
+        assert!(candidate.blobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_submits_only_unprotected_signers() {
+        let registry = MockRegistry::with_signers(vec![SIGNER_A, SIGNER_B]);
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+
+        manager
+            .deregister_orphans(
+                &HashSet::from([SIGNER_A]),
+                &[SIGNER_A, SIGNER_B],
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let sent = tx_manager.take_candidates();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(
+            sent[0].tx_data,
+            Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer: SIGNER_B }.abi_encode())
+        );
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_skips_ghost_entries() {
+        let registry = MockRegistry::with_true_signers(vec![SIGNER_B]);
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+
+        manager
+            .deregister_orphans(&HashSet::new(), &[SIGNER_A, SIGNER_B], &CancellationToken::new())
+            .await
+            .unwrap();
+
+        let sent = tx_manager.take_candidates();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(
+            sent[0].tx_data,
+            Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer: SIGNER_B }.abi_encode())
+        );
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_respects_cancellation() {
+        let registry = MockRegistry::with_signers(vec![SIGNER_A]);
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        manager.deregister_orphans(&HashSet::new(), &[SIGNER_A], &cancel).await.unwrap();
+
+        assert!(tx_manager.take_candidates().is_empty());
+    }
+
+    #[derive(Debug)]
+    struct MockRegistry {
+        signers: Vec<Address>,
+        true_signers: HashSet<Address>,
+    }
+
+    impl MockRegistry {
+        fn with_signers(signers: Vec<Address>) -> Self {
+            let true_signers = signers.iter().copied().collect();
+            Self { signers, true_signers }
+        }
+
+        fn with_true_signers(true_signers: Vec<Address>) -> Self {
+            Self { signers: true_signers.clone(), true_signers: true_signers.into_iter().collect() }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for MockRegistry {
+        async fn is_registered(&self, signer: Address) -> Result<bool> {
+            Ok(self.true_signers.contains(&signer))
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct MockTxManager {
+        sent_candidates: Arc<Mutex<Vec<TxCandidate>>>,
+    }
+
+    impl MockTxManager {
+        fn take_candidates(&self) -> Vec<TxCandidate> {
+            std::mem::take(&mut *self.sent_candidates.lock().unwrap())
+        }
+    }
+
+    impl TxManager for MockTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent_candidates.lock().unwrap().push(candidate);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            unreachable!("deregistration manager tests use synchronous send")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+}

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1187,22 +1187,6 @@ where
         }
         RegistrarMetrics::proof_tasks_pending().set(0.0);
     }
-
-    /// Test helper that delegates to [`DeregistrationManager::deregister_orphans`].
-    #[cfg(test)]
-    async fn deregister_orphans(
-        &self,
-        protected_signers: &HashSet<Address>,
-        registered_signers: &[Address],
-    ) -> Result<()> {
-        let manager = DeregistrationManager::new(
-            self.config.registry_address,
-            &self.registry,
-            &self.tx_manager,
-            &self.signer_history,
-        );
-        manager.deregister_orphans(protected_signers, registered_signers, &self.config.cancel).await
-    }
 }
 
 #[cfg(test)]
@@ -1234,17 +1218,6 @@ mod tests {
     use crate::{InstanceHealthStatus, RegistryClient, Result, SignerClient};
 
     // ── Shared constants ────────────────────────────────────────────────
-
-    /// Expected byte length of ABI-encoded `deregisterSigner(address)` calldata:
-    /// 4-byte selector + 32-byte left-padded address word.
-    const DEREGISTER_CALLDATA_LEN: usize = 36;
-
-    /// Number of zero-padding bytes before the 20-byte address in the ABI word.
-    const ABI_ADDRESS_PAD: usize = 12;
-
-    /// Byte offset where the raw 20-byte address starts in the encoded calldata
-    /// (after the 4-byte selector and 12 bytes of zero-padding).
-    const ABI_ADDRESS_OFFSET: usize = 4 + ABI_ADDRESS_PAD;
 
     /// Well-known Hardhat / Anvil account #0 address.
     const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -1594,30 +1567,6 @@ mod tests {
                 fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
             },
         }
-    }
-
-    /// Builds a driver for `deregister_orphans` tests (no signer client needed).
-    fn driver_with_shared_tx(
-        registered_signers: Vec<Address>,
-        tx: SharedTxManager,
-    ) -> RegistrationDriver<
-        MockDiscovery,
-        StubProofProvider,
-        MockRegistry,
-        SharedTxManager,
-        StubSignerClient,
-    > {
-        let registry = MockRegistry::with_signers(registered_signers);
-        RegistrationDriver::new(
-            MockDiscovery { instances: vec![] },
-            StubProofProvider,
-            registry,
-            tx,
-            StubSignerClient,
-            default_config(CancellationToken::new()),
-            None,
-        )
-        .expect("test driver construction succeeds")
     }
 
     /// Builds a fully-configured driver for primitive-level tests that
@@ -2111,172 +2060,6 @@ mod tests {
             ok_to_dereg: true,
             unresolved_instance_ids: HashSet::new(),
         }
-    }
-
-    // ── Calldata encoding tests ─────────────────────────────────────────
-
-    #[rstest]
-    #[case::zero_address(Address::ZERO)]
-    #[case::hardhat_account(HARDHAT_ACCOUNT)]
-    #[case::all_ones(Address::repeat_byte(0xFF))]
-    fn deregister_calldata_encodes_correctly(#[case] signer: Address) {
-        let calldata = ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode();
-
-        assert_eq!(calldata.len(), DEREGISTER_CALLDATA_LEN);
-        assert_eq!(&calldata[..4], &ITEEProverRegistry::deregisterSignerCall::SELECTOR);
-        // The 12 bytes between the selector and the address must be zero-padding.
-        assert_eq!(&calldata[4..ABI_ADDRESS_OFFSET], &[0u8; ABI_ADDRESS_PAD]);
-        // The last 20 bytes must be the raw signer address.
-        assert_eq!(&calldata[ABI_ADDRESS_OFFSET..], signer.as_slice());
-    }
-
-    // ── deregister_orphans tests ────────────────────────────────────────
-
-    #[rstest]
-    #[case::no_orphans(vec![ORPHAN_A, ORPHAN_B], vec![ORPHAN_A, ORPHAN_B], 0)]
-    #[case::one_orphan(vec![ORPHAN_A, ORPHAN_B], vec![ORPHAN_A], 1)]
-    #[case::all_orphans(vec![ORPHAN_A, ORPHAN_B], vec![], 2)]
-    #[tokio::test]
-    async fn deregister_orphans_tx_count(
-        #[case] registered: Vec<Address>,
-        #[case] active: Vec<Address>,
-        #[case] expected_txs: usize,
-    ) {
-        let active: HashSet<Address> = active.into_iter().collect();
-
-        let tx = SharedTxManager::new();
-        let driver = driver_with_shared_tx(registered.clone(), tx.clone());
-
-        driver.deregister_orphans(&active, &registered).await.unwrap();
-
-        assert_eq!(tx.sent_calldata().len(), expected_txs);
-    }
-
-    #[tokio::test]
-    async fn deregister_orphans_calldata_targets_orphan() {
-        let registered = vec![ORPHAN_A, ORPHAN_B];
-        let tx = SharedTxManager::new();
-        let driver = driver_with_shared_tx(registered.clone(), tx.clone());
-
-        driver.deregister_orphans(&HashSet::from([ORPHAN_A]), &registered).await.unwrap();
-
-        let sent = tx.sent_calldata();
-        let expected = ITEEProverRegistry::deregisterSignerCall { signer: ORPHAN_B }.abi_encode();
-        assert_eq!(sent[0], Bytes::from(expected));
-    }
-
-    #[tokio::test]
-    async fn deregister_orphans_respects_cancellation() {
-        let tx = SharedTxManager::new();
-        let cancel = CancellationToken::new();
-        let registry = MockRegistry::with_signers(vec![ORPHAN_A]);
-        let driver = RegistrationDriver::new(
-            MockDiscovery { instances: vec![] },
-            StubProofProvider,
-            registry,
-            tx.clone(),
-            StubSignerClient,
-            default_config(cancel.clone()),
-            None,
-        )
-        .expect("test driver construction succeeds");
-
-        let registered = vec![ORPHAN_A];
-        cancel.cancel();
-        driver.deregister_orphans(&HashSet::new(), &registered).await.unwrap();
-
-        assert!(tx.sent_calldata().is_empty(), "no txs should be sent after cancellation");
-    }
-
-    /// Mock registry that simulates a corrupted `EnumerableSetLib.AddressSet`.
-    ///
-    /// `get_registered_signers()` returns `all_values` (including ghost entries),
-    /// but `is_registered()` only returns `true` for addresses in
-    /// `truly_registered`. This models the Solady v0.0.245 bug where
-    /// `values()` contains stale addresses whose `isRegisteredSigner`
-    /// mapping is `false`.
-    #[derive(Debug)]
-    struct GhostRegistry {
-        /// Addresses returned by `getRegisteredSigners()` (includes ghosts).
-        all_values: Vec<Address>,
-        /// Addresses for which `isRegisteredSigner` is `true`.
-        truly_registered: HashSet<Address>,
-    }
-
-    impl GhostRegistry {
-        /// Creates a registry where `ghosts` appear in `values()` but have
-        /// `isRegisteredSigner == false`, and `real` signers appear in both.
-        fn new(real: Vec<Address>, ghosts: Vec<Address>) -> Self {
-            let truly_registered: HashSet<Address> = real.iter().copied().collect();
-            let mut all_values = real;
-            all_values.extend(ghosts);
-            Self { all_values, truly_registered }
-        }
-    }
-
-    #[async_trait]
-    impl RegistryClient for GhostRegistry {
-        async fn is_registered(&self, signer: Address) -> Result<bool> {
-            Ok(self.truly_registered.contains(&signer))
-        }
-
-        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            Ok(self.all_values.clone())
-        }
-    }
-
-    #[tokio::test]
-    async fn deregister_orphans_skips_ghost_entries() {
-        // Simulates the Solady v0.0.245 EnumerableSetLib bug: ORPHAN_A is a
-        // ghost entry that appears in getRegisteredSigners() but has
-        // isRegisteredSigner == false. ORPHAN_B is a real orphan.
-        let ghost_registry = GhostRegistry::new(vec![ORPHAN_B], vec![ORPHAN_A]);
-
-        let tx = SharedTxManager::new();
-        let driver = RegistrationDriver::new(
-            MockDiscovery { instances: vec![] },
-            StubProofProvider,
-            ghost_registry,
-            tx.clone(),
-            StubSignerClient,
-            default_config(CancellationToken::new()),
-            None,
-        )
-        .expect("test driver construction succeeds");
-
-        // Both ORPHAN_A and ORPHAN_B are "registered" (in values()),
-        // neither is in active_signers.
-        let registered = vec![ORPHAN_A, ORPHAN_B];
-        driver.deregister_orphans(&HashSet::new(), &registered).await.unwrap();
-
-        let sent = tx.sent_calldata();
-        // Only ORPHAN_B should be deregistered; ORPHAN_A is a ghost.
-        assert_eq!(sent.len(), 1, "ghost entry should be skipped");
-        let expected = ITEEProverRegistry::deregisterSignerCall { signer: ORPHAN_B }.abi_encode();
-        assert_eq!(sent[0], Bytes::from(expected));
-    }
-
-    #[tokio::test]
-    async fn deregister_orphans_skips_all_ghosts_sends_nothing() {
-        // All orphan candidates are ghost entries — no tx should be sent.
-        let ghost_registry = GhostRegistry::new(vec![], vec![ORPHAN_A, ORPHAN_B, ORPHAN_C]);
-
-        let tx = SharedTxManager::new();
-        let driver = RegistrationDriver::new(
-            MockDiscovery { instances: vec![] },
-            StubProofProvider,
-            ghost_registry,
-            tx.clone(),
-            StubSignerClient,
-            default_config(CancellationToken::new()),
-            None,
-        )
-        .expect("test driver construction succeeds");
-
-        let registered = vec![ORPHAN_A, ORPHAN_B, ORPHAN_C];
-        driver.deregister_orphans(&HashSet::new(), &registered).await.unwrap();
-
-        assert!(tx.sent_calldata().is_empty(), "all ghosts should be skipped, no txs sent");
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -262,15 +262,9 @@ pub struct RegistrationDriver<D, P, R, T, S> {
     /// the ~20 minute Boundless proof generation) so deduplication holds
     /// across cycles as well as within one.
     in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
-    /// Last-known EC2 instance ID for every signer address the registrar
-    /// has ever observed advertising itself in a discovery cycle.
-    /// Updated in `discover_and_resolve`, consulted by
-    /// [`DeregistrationManager::submit_deregistration`] so the "Deregistering
-    /// signer" log line can attribute the orphan to the EC2 instance it last
-    /// lived on.
-    /// `None` on dereg is the strongest single diagnostic that another
-    /// registrar (or a prior deployment) wrote the signer.
-    /// Entries are never evicted — bounded by historic fleet size.
+    /// Last-known EC2 instance ID for every signer observed during discovery.
+    /// Used to annotate orphan deregistration logs.
+    /// Entries are never evicted; bounded by historic fleet size.
     signer_history: Arc<Mutex<HashMap<Address, String>>>,
 }
 
@@ -427,15 +421,8 @@ where
                     }
 
                     if resolution.ok_to_dereg && !self.config.cancel.is_cancelled() {
-                        // Protect every in-flight signer in addition to
-                        // `active_signers`. An instance whose
-                        // `resolve_instance` failed this cycle is in
-                        // `unresolved_instance_ids` (so reconcile
-                        // preserves its task), but its signer is absent
-                        // from `active_signers`. Without this union the
-                        // preserved task could complete and `register`
-                        // the signer mid-pass, and the very same orphan
-                        // sweep would then deregister it (TOCTOU).
+                        // Pending proof tasks can register while orphan cleanup
+                        // is running, so protect those signers too.
                         let protected = Self::protected_signers(&resolution, &pending);
                         if let Err(e) = self.run_orphan_dereg(&protected).await {
                             warn!(error = %e, "orphan deregistration pass failed");
@@ -732,10 +719,8 @@ where
                     if outcome.unresolved {
                         unresolved_instance_ids.insert(instance.instance_id.clone());
                     }
-                    // Record signer -> instance attribution before the
-                    // `instance` is moved into `RegisterableSigner` below.
-                    // Consumed by `DeregistrationManager::submit_deregistration`
-                    // to annotate the dereg log with the last-known instance.
+                    // Record signer -> instance attribution before `instance`
+                    // is moved into `RegisterableSigner` below.
                     {
                         let mut history =
                             self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
@@ -806,15 +791,7 @@ where
         })
     }
 
-    /// Drives the orphan-deregistration pass.
-    ///
-    /// Delegates onchain signer loading and orphan cleanup to
-    /// [`DeregistrationManager`]. The [`Self::run`] pipeline invokes this
-    /// independently of the concurrent registration path.
-    ///
-    /// Both error paths (registry load and per-orphan deregistration)
-    /// propagate uniformly so the caller can log + increment
-    /// `processing_errors_total` once at a single site.
+    /// Runs orphan deregistration through [`DeregistrationManager`].
     async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
         let manager = DeregistrationManager::new(
             self.config.registry_address,
@@ -825,18 +802,10 @@ where
         manager.run_orphan_dereg(protected_signers, &self.config.cancel).await
     }
 
-    /// Builds the protected-signer set for the orphan-dereg pass: the
-    /// union of `resolution.active_signers` and the keys of `pending`.
+    /// Builds the protected-signer set for orphan deregistration.
     ///
-    /// Including `pending.keys()` closes the TOCTOU window described on
-    /// [`Self::run`]: when an instance fails [`Self::resolve_instance`]
-    /// transiently this cycle, its signer is absent from
-    /// `active_signers`, but [`Self::reconcile_proof_tasks`] preserves
-    /// the in-flight proof task (its instance id is in
-    /// [`DiscoveryResolution::unresolved_instance_ids`]). If that task
-    /// successfully registers the signer just as the orphan pass runs,
-    /// the union ensures the freshly registered signer is treated as
-    /// protected rather than as an orphan to be deregistered.
+    /// Includes both active signers and pending proof tasks so a signer that
+    /// registers mid-pass is not immediately deregistered.
     fn protected_signers(
         resolution: &DiscoveryResolution,
         pending: &HashMap<Address, PendingRegistration>,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -12,11 +12,9 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, Bytes, hex};
-use alloy_sol_types::SolCall;
-use base_proof_contracts::ITEEProverRegistry;
+use alloy_primitives::{Address, hex};
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
-use base_tx_manager::{TxCandidate, TxManager};
+use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
 use tokio::{
@@ -27,9 +25,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    ProofHandlerConfig, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics,
-    RegistrationManager, RegistryClient, Result, SignerClient,
+    CertManager, CrlConfig, DeregistrationManager, InstanceDiscovery, InstanceHealthStatus,
+    NitroVerifierClient, ProofHandlerConfig, ProverClient, ProverInstance, RegistrarError,
+    RegistrarMetrics, RegistrationManager, RegistryClient, Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -809,29 +807,21 @@ where
 
     /// Drives the orphan-deregistration pass.
     ///
-    /// Loads onchain signers, computes the orphan set (`registered \ active`),
-    /// and deregisters each in sequence with a ghost-entry guard. The
-    /// [`Self::run`] pipeline invokes this independently of the concurrent
-    /// registration path.
+    /// Delegates onchain signer loading and orphan cleanup to
+    /// [`DeregistrationManager`]. The [`Self::run`] pipeline invokes this
+    /// independently of the concurrent registration path.
     ///
     /// Both error paths (registry load and per-orphan deregistration)
     /// propagate uniformly so the caller can log + increment
     /// `processing_errors_total` once at a single site.
     async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
-        // Cancel-aware: `get_registered_signers` is a side-effect-free
-        // read, so dropping it on cancel is safe. Without this select,
-        // a shutdown during the registry RPC would extend drain latency
-        // by an entire round-trip before `deregister_orphans` is even
-        // reached.
-        let registered_signers = tokio::select! {
-            biased;
-            () = self.config.cancel.cancelled() => {
-                debug!("cancelled before loading registered signers for orphan dereg");
-                return Ok(());
-            }
-            res = self.registry.get_registered_signers() => res?,
-        };
-        self.deregister_orphans(protected_signers, &registered_signers).await
+        let manager = DeregistrationManager::new(
+            self.config.registry_address,
+            &self.registry,
+            &self.tx_manager,
+            &self.signer_history,
+        );
+        manager.run_orphan_dereg(protected_signers, &self.config.cancel).await
     }
 
     /// Builds the protected-signer set for the orphan-dereg pass: the
@@ -1197,64 +1187,6 @@ where
         RegistrarMetrics::proof_tasks_pending().set(0.0);
     }
 
-    /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
-    async fn submit_deregistration(&self, signer: Address) -> bool {
-        let calldata =
-            Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode());
-
-        // `last_known_instance = None` is the strongest single diagnostic
-        // for phantom rotations: a signer we never observed in any
-        // discovery cycle implies another registrar (or a prior
-        // deployment) wrote it.
-        let last_known_instance = {
-            let history = self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
-            history.get(&signer).cloned()
-        };
-        info!(
-            signer = %signer,
-            last_known_instance = ?last_known_instance,
-            registry = %self.config.registry_address,
-            calldata_len = calldata.len(),
-            "Deregistering signer"
-        );
-
-        let candidate = TxCandidate {
-            tx_data: calldata,
-            to: Some(self.config.registry_address),
-            ..Default::default()
-        };
-
-        info!(
-            tx = ?candidate,
-            "Sending tx candidate",
-        );
-
-        match self.tx_manager.send(candidate).await {
-            Ok(receipt) => {
-                if !receipt.inner.status() {
-                    warn!(
-                        signer = %signer,
-                        tx_hash = %receipt.transaction_hash,
-                        "deregistration transaction reverted onchain",
-                    );
-                    RegistrarMetrics::processing_errors_total().increment(1);
-                    return false;
-                }
-                info!(
-                    signer = %signer,
-                    tx_hash = %receipt.transaction_hash,
-                    "signer deregistered"
-                );
-                true
-            }
-            Err(e) => {
-                warn!(error = %e, signer = %signer, "failed to deregister signer");
-                RegistrarMetrics::processing_errors_total().increment(1);
-                false
-            }
-        }
-    }
-
     /// Deregisters any onchain signer that is not in the `protected_signers` set.
     ///
     /// These orphans arise when a prover instance is terminated (e.g. ASG
@@ -1281,65 +1213,19 @@ where
     ///   registrar instances manage disjoint prover fleets, one registrar would
     ///   incorrectly deregister another's signers. The current deployment model
     ///   assumes a single registrar per registry contract.
+    #[cfg(test)]
     async fn deregister_orphans(
         &self,
         protected_signers: &HashSet<Address>,
         registered_signers: &[Address],
     ) -> Result<()> {
-        let orphans: Vec<_> = registered_signers
-            .iter()
-            .copied()
-            .filter(|addr| !protected_signers.contains(addr))
-            .collect();
-
-        if orphans.is_empty() {
-            return Ok(());
-        }
-
-        info!(count = orphans.len(), "deregistering orphan signers");
-
-        let mut deregistered = 0usize;
-        for signer in orphans {
-            if self.config.cancel.is_cancelled() {
-                debug!("shutdown requested, stopping orphan deregistration");
-                break;
-            }
-
-            // Verify the signer is truly registered onchain before spending
-            // gas on a deregistration tx. The `getRegisteredSigners()` view
-            // reads from an `EnumerableSetLib.AddressSet` which can contain
-            // ghost entries (addresses that appear in `values()` but have
-            // `isRegisteredSigner == false`) due to a storage corruption bug
-            // in Solady v0.0.245. Skipping ghosts prevents an infinite
-            // deregistration loop.
-            match self.registry.is_registered(signer).await {
-                Ok(false) => {
-                    warn!(
-                        signer = %signer,
-                        "signer appears in getRegisteredSigners but isRegisteredSigner is false, \
-                         skipping (possible EnumerableSet ghost entry)"
-                    );
-                    continue;
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        signer = %signer,
-                        "failed to verify signer registration status, skipping deregistration"
-                    );
-                    continue;
-                }
-                Ok(true) => {}
-            }
-
-            if self.submit_deregistration(signer).await {
-                RegistrarMetrics::deregistrations_total().increment(1);
-                deregistered += 1;
-            }
-        }
-
-        info!(count = deregistered, "orphan deregistration complete");
-        Ok(())
+        let manager = DeregistrationManager::new(
+            self.config.registry_address,
+            &self.registry,
+            &self.tx_manager,
+            &self.signer_history,
+        );
+        manager.deregister_orphans(protected_signers, registered_signers, &self.config.cancel).await
     }
 }
 
@@ -1359,6 +1245,7 @@ mod tests {
     use alloy_rpc_types_eth::TransactionReceipt;
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
+    use base_proof_contracts::ITEEProverRegistry;
     use base_proof_tee_nitro_attestation_prover::AttestationProof;
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
     use hex_literal::hex;

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -265,8 +265,9 @@ pub struct RegistrationDriver<D, P, R, T, S> {
     /// Last-known EC2 instance ID for every signer address the registrar
     /// has ever observed advertising itself in a discovery cycle.
     /// Updated in `discover_and_resolve`, consulted by
-    /// `submit_deregistration` so the "Deregistering signer" log line
-    /// can attribute the orphan to the EC2 instance it last lived on.
+    /// [`DeregistrationManager::submit_deregistration`] so the "Deregistering
+    /// signer" log line can attribute the orphan to the EC2 instance it last
+    /// lived on.
     /// `None` on dereg is the strongest single diagnostic that another
     /// registrar (or a prior deployment) wrote the signer.
     /// Entries are never evicted — bounded by historic fleet size.
@@ -733,8 +734,8 @@ where
                     }
                     // Record signer -> instance attribution before the
                     // `instance` is moved into `RegisterableSigner` below.
-                    // Consumed by `submit_deregistration` to annotate the
-                    // dereg log with the last-known instance.
+                    // Consumed by `DeregistrationManager::submit_deregistration`
+                    // to annotate the dereg log with the last-known instance.
                     {
                         let mut history =
                             self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
@@ -1187,32 +1188,7 @@ where
         RegistrarMetrics::proof_tasks_pending().set(0.0);
     }
 
-    /// Deregisters any onchain signer that is not in the `protected_signers` set.
-    ///
-    /// These orphans arise when a prover instance is terminated (e.g. ASG
-    /// scale-down) without first deregistering its signer onchain. The
-    /// `protected_signers` set is built by [`Self::protected_signers`] as
-    /// the union of resolved-this-cycle signers and signers with an
-    /// in-flight proof task, so transiently-unresolved instances and
-    /// mid-flight registrations are both shielded from the sweep.
-    ///
-    /// # Defense in depth
-    ///
-    /// Before submitting a deregistration transaction, each orphan candidate is
-    /// verified via [`RegistryClient::is_registered`] (backed by the
-    /// `isRegisteredSigner` mapping). This guards against ghost entries in the
-    /// onchain `EnumerableSetLib.AddressSet` that can appear after certain
-    /// add/remove sequences due to a bug in Solady v0.0.245. Without this
-    /// check, ghost addresses would be deregistered every cycle in an infinite
-    /// loop, burning gas without effect.
-    ///
-    /// # Assumptions
-    ///
-    /// - **Single registrar**: This method queries *all* onchain signers and
-    ///   treats any signer not in `protected_signers` as an orphan. If multiple
-    ///   registrar instances manage disjoint prover fleets, one registrar would
-    ///   incorrectly deregister another's signers. The current deployment model
-    ///   assumes a single registrar per registry contract.
+    /// Test helper that delegates to [`DeregistrationManager::deregister_orphans`].
     #[cfg(test)]
     async fn deregister_orphans(
         &self,

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -19,6 +19,9 @@ pub use crl::{
     check_chain_against_crls,
 };
 
+mod deregistration_manager;
+pub use deregistration_manager::DeregistrationManager;
+
 mod discovery;
 pub use discovery::AwsTargetGroupDiscovery;
 


### PR DESCRIPTION
### What changed? Why?

This extracts orphan signer deregistration from the registrar driver into a dedicated `DeregistrationManager`.

The manager owns loading registered onchain signers, computing orphan signers, guarding against EnumerableSet ghost entries, and submitting `deregisterSigner` transactions. The registrar driver now delegates the orphan cleanup pass to the manager while retaining the existing test-facing helper.

### Notes to reviewers

This is intended to be behavior-preserving. The existing cancellation handling, ghost-entry guard, metrics increments, transaction candidate construction, and structured tracing fields were moved with the deregistration logic.

### How has it been tested?

- `cargo test -p base-proof-tee-registrar`
- `cargo clippy -p base-proof-tee-registrar --all-targets -- -D warnings`
- `cargo fmt --check`