### PR TITLE
feat(docker): bundle extra binaries into node-reth-dev image

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -59,8 +59,16 @@ ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=client-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
-    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-reth-node /app/base-client
+    cargo build --profile $PROFILE \
+      --bin base-reth-node \
+      --bin base-consensus \
+      --bin basectl \
+      --bin snapshotter && \
+    target_dir="/app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")" && \
+    cp "$target_dir/base-reth-node" /app/base-reth-node && \
+    cp "$target_dir/base-consensus" /app/base-consensus && \
+    cp "$target_dir/basectl" /app/basectl && \
+    cp "$target_dir/snapshotter" /app/snapshotter
 
 FROM source AS base-builder
 ARG PROFILE=release
@@ -145,7 +153,11 @@ RUN apt-get update && \
 WORKDIR /app
 
 FROM runtime-base AS client
-COPY --from=client-builder /app/base-client ./base-client
+COPY --from=client-builder /app/base-reth-node ./base-reth-node
+COPY --from=client-builder /app/base-consensus ./base-consensus
+COPY --from=client-builder /app/basectl ./basectl
+COPY --from=client-builder /app/snapshotter ./snapshotter
+RUN ln -s ./base-reth-node ./base-client
 ENTRYPOINT ["./base-client"]
 
 FROM runtime-base AS base

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.93
+ARG RUST_VERSION=1.94.1
 FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-base
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       --bin basectl \
       --bin snapshotter && \
     target_dir="/app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")" && \
-    cp "$target_dir/base-reth-node" /app/base-reth-node && \
+    cp "$target_dir/base-reth-node" /app/base-client && \
     cp "$target_dir/base-consensus" /app/base-consensus && \
     cp "$target_dir/basectl" /app/basectl && \
     cp "$target_dir/snapshotter" /app/snapshotter
@@ -153,11 +153,10 @@ RUN apt-get update && \
 WORKDIR /app
 
 FROM runtime-base AS client
-COPY --from=client-builder /app/base-reth-node ./base-reth-node
+COPY --from=client-builder /app/base-client ./base-client
 COPY --from=client-builder /app/base-consensus ./base-consensus
 COPY --from=client-builder /app/basectl ./basectl
 COPY --from=client-builder /app/snapshotter ./snapshotter
-RUN ln -s ./base-reth-node ./base-client
 ENTRYPOINT ["./base-client"]
 
 FROM runtime-base AS base

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -4,7 +4,7 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 
 ## Dockerfiles
 
-`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It bundles `base-reth-node`, `base-consensus`, `basectl`, and `snapshotter`, while preserving the historical `base-client` entrypoint as a compatibility alias to `base-reth-node`.
+`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It bundles `base-consensus`, `basectl`, and `snapshotter`, while preserving the historical `base-client` entrypoint by copying the `base-reth-node` binary into the image under that compatible name.
 
 `Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) and setup scripts. This image bootstraps L1 and L2 chain configurations for local development.
 

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -4,7 +4,7 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 
 ## Dockerfiles
 
-`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It provides `client`, `builder`, `consensus`, `proposer`, `websocket-proxy`, `ingress-rpc`, `audit-archiver`, `batcher`, and `zk-prover` targets.
+`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It bundles `base-reth-node`, `base-consensus`, `basectl`, and `snapshotter`, while preserving the historical `base-client` entrypoint as a compatibility alias to `base-reth-node`.
 
 `Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) and setup scripts. This image bootstraps L1 and L2 chain configurations for local development.
 

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "ZK_PROVER_PROFILE" {
 }
 
 variable "RUST_VERSION" {
-  default = "1.93"
+  default = "1.94.1"
 }
 
 variable "BASE_SUCCINCT_ELF_REQUIRE" {


### PR DESCRIPTION
## Summary
- bundle `base-consensus`, `basectl`, and `snapshotter` into the published `node-reth-dev` client image
- preserve the historical `base-client` entrypoint by copying the `base-reth-node` binary into the image under that compatible name
- align the Docker Rust toolchain version with the workspace toolchain (`1.94.1`)
- update the Docker docs to describe the final bundled image behavior

## Validation
- `docker buildx bake -f etc/docker/docker-bake.hcl client --print`

## Notes
- the published image still starts with `/app/base-client`
- the extra binaries are available alongside it in the same runtime image