### PR TITLE
test(precompile-macros): add compile-fail test for namespace-above-contract ordering

### DIFF
--- a/crates/common/precompile-storage/wip/08_namespace_above_contract.stderr
+++ b/crates/common/precompile-storage/wip/08_namespace_above_contract.stderr
@@ -1,0 +1,5 @@
+error: `#[namespace]` must be placed below `#[contract]` on contract storage layouts
+  --> tests/ui/08_namespace_above_contract.rs:10:12
+   |
+10 | pub struct Foo {
+   |            ^^^


### PR DESCRIPTION

## Motivation

A previous PR introduced a compile error when `#[namespace]` is placed above `#[contract]` on a storage struct. Without a test pinning that error, a future change could silently remove the guard — or alter the error message — with no CI failure to catch it.

## What changed

Added a compile-fail test that confirms the macro produces the right error in the right place when the attribute order is wrong. The test records the exact expected compiler output, so CI fails if the error message, location, or behavior changes.