### PR TITLE
test(precompiles): Expand Beryl Precompile Coverage

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -336,6 +336,157 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
 }
 
 #[tokio::test]
+async fn b20_role_lifecycle_updates_state_and_emits_events() {
+    let mut scenario = B20TokenScenario::new().await;
+
+    scenario
+        .assert_staticcall_cases(vec![
+            StaticcallCase::output(
+                "DEFAULT_ADMIN_ROLE",
+                IB20::DEFAULT_ADMIN_ROLECall {}.abi_encode(),
+                B20TokenRole::DefaultAdmin.id().abi_encode(),
+            ),
+            StaticcallCase::output(
+                "MINT_ROLE",
+                IB20::MINT_ROLECall {}.abi_encode(),
+                B20TokenRole::Mint.id().abi_encode(),
+            ),
+            StaticcallCase::word(
+                "hasRole(default admin, alice)",
+                IB20::hasRoleCall {
+                    role: B20TokenRole::DefaultAdmin.id(),
+                    account: BerylTestEnv::alice(),
+                }
+                .abi_encode(),
+                U256::ONE,
+            ),
+            StaticcallCase::output(
+                "getRoleAdmin(MINT_ROLE)",
+                IB20::getRoleAdminCall { role: B20TokenRole::Mint.id() }.abi_encode(),
+                B20TokenRole::DefaultAdmin.id().abi_encode(),
+            ),
+        ])
+        .await;
+
+    let grant_bob = scenario.call_tx(IB20::grantRoleCall {
+        role: B20TokenRole::Mint.id(),
+        account: BerylTestEnv::bob(),
+    });
+    let block = scenario.build_block_with_transactions(vec![grant_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "grantRole must succeed");
+    scenario.assert_log(
+        &block,
+        0,
+        IB20::RoleGranted {
+            role: B20TokenRole::Mint.id(),
+            account: BerylTestEnv::bob(),
+            sender: BerylTestEnv::alice(),
+        }
+        .encode_log_data(),
+    );
+    scenario
+        .assert_staticcall_cases(vec![StaticcallCase::word(
+            "hasRole(MINT_ROLE, bob)",
+            IB20::hasRoleCall { role: B20TokenRole::Mint.id(), account: BerylTestEnv::bob() }
+                .abi_encode(),
+            U256::ONE,
+        )])
+        .await;
+
+    let revoke_bob = scenario.call_tx(IB20::revokeRoleCall {
+        role: B20TokenRole::Mint.id(),
+        account: BerylTestEnv::bob(),
+    });
+    let block = scenario.build_block_with_transactions(vec![revoke_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "revokeRole must succeed");
+    scenario.assert_log(
+        &block,
+        0,
+        IB20::RoleRevoked {
+            role: B20TokenRole::Mint.id(),
+            account: BerylTestEnv::bob(),
+            sender: BerylTestEnv::alice(),
+        }
+        .encode_log_data(),
+    );
+
+    let grant_alice_mint = scenario.call_tx(IB20::grantRoleCall {
+        role: B20TokenRole::Mint.id(),
+        account: BerylTestEnv::alice(),
+    });
+    let renounce_alice_mint = scenario.call_tx(IB20::renounceRoleCall {
+        role: B20TokenRole::Mint.id(),
+        callerConfirmation: BerylTestEnv::alice(),
+    });
+    let set_pause_admin = scenario.call_tx(IB20::setRoleAdminCall {
+        role: B20TokenRole::Pause.id(),
+        newAdminRole: B20TokenRole::Mint.id(),
+    });
+    let renounce_last_admin = scenario.call_tx(IB20::renounceLastAdminCall {});
+    let block = scenario
+        .build_block_with_transactions(vec![
+            grant_alice_mint,
+            renounce_alice_mint,
+            set_pause_admin,
+            renounce_last_admin,
+        ])
+        .await;
+    for index in 0..4 {
+        assert!(
+            scenario.env.user_tx_succeeded(&block, index),
+            "role lifecycle tx {index} must succeed"
+        );
+    }
+    scenario.assert_log(
+        &block,
+        2,
+        IB20::RoleAdminChanged {
+            role: B20TokenRole::Pause.id(),
+            previousAdminRole: B20TokenRole::DefaultAdmin.id(),
+            newAdminRole: B20TokenRole::Mint.id(),
+        }
+        .encode_log_data(),
+    );
+    scenario.assert_log(
+        &block,
+        3,
+        IB20::LastAdminRenounced { previousAdmin: BerylTestEnv::alice() }.encode_log_data(),
+    );
+    scenario
+        .assert_staticcall_cases(vec![
+            StaticcallCase::word(
+                "hasRole(MINT_ROLE, bob) after revoke",
+                IB20::hasRoleCall { role: B20TokenRole::Mint.id(), account: BerylTestEnv::bob() }
+                    .abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::word(
+                "hasRole(MINT_ROLE, alice) after renounce",
+                IB20::hasRoleCall { role: B20TokenRole::Mint.id(), account: BerylTestEnv::alice() }
+                    .abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::word(
+                "hasRole(DEFAULT_ADMIN_ROLE, alice) after renounceLastAdmin",
+                IB20::hasRoleCall {
+                    role: B20TokenRole::DefaultAdmin.id(),
+                    account: BerylTestEnv::alice(),
+                }
+                .abi_encode(),
+                U256::ZERO,
+            ),
+            StaticcallCase::output(
+                "getRoleAdmin(PAUSE_ROLE) after setRoleAdmin",
+                IB20::getRoleAdminCall { role: B20TokenRole::Pause.id() }.abi_encode(),
+                B20TokenRole::Mint.id().abi_encode(),
+            ),
+        ])
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
 async fn b20_extended_mutations_update_state_and_emit_events() {
     let mut scenario = B20TokenScenario::new().await;
     let initial = BerylTestEnv::B20_INITIAL_SUPPLY;
@@ -576,6 +727,100 @@ async fn b20_permit_updates_allowance_and_nonce() {
     scenario
         .assert_staticcall_cases(vec![StaticcallCase::word(
             "nonces after permit",
+            IB20::noncesCall { owner: BerylTestEnv::alice() }.abi_encode(),
+            U256::ONE,
+        )])
+        .await;
+
+    scenario.derive().await;
+}
+
+#[tokio::test]
+async fn b20_permit_rejects_replay_expired_and_wrong_signature() {
+    let mut scenario = B20TokenScenario::new().await;
+    let value = U256::from(123);
+    let deadline = U256::MAX;
+    let domain_sep =
+        domain_separator(scenario.env.chain_id(), scenario.token, BerylTestEnv::B20_NAME);
+    let (v, r, s) = sign_permit(
+        domain_sep,
+        BerylTestEnv::alice(),
+        BerylTestEnv::bob(),
+        value,
+        U256::ZERO,
+        deadline,
+    );
+
+    let valid = scenario.call_tx(IB20::permitCall {
+        owner: BerylTestEnv::alice(),
+        spender: BerylTestEnv::bob(),
+        value,
+        deadline,
+        v,
+        r,
+        s,
+    });
+    let block = scenario.build_block_with_transactions(vec![valid]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "initial permit must succeed");
+    scenario.assert_allowance(BerylTestEnv::alice(), BerylTestEnv::bob(), 123);
+
+    let replay = scenario.call_tx(IB20::permitCall {
+        owner: BerylTestEnv::alice(),
+        spender: BerylTestEnv::bob(),
+        value,
+        deadline,
+        v,
+        r,
+        s,
+    });
+    let expired_deadline = U256::ZERO;
+    let (expired_v, expired_r, expired_s) = sign_permit(
+        domain_sep,
+        BerylTestEnv::alice(),
+        BerylTestEnv::bob(),
+        U256::from(456),
+        U256::ONE,
+        expired_deadline,
+    );
+    let expired = scenario.call_tx(IB20::permitCall {
+        owner: BerylTestEnv::alice(),
+        spender: BerylTestEnv::bob(),
+        value: U256::from(456),
+        deadline: expired_deadline,
+        v: expired_v,
+        r: expired_r,
+        s: expired_s,
+    });
+    let (wrong_v, wrong_r, wrong_s) = sign_permit(
+        domain_sep,
+        BerylTestEnv::bob(),
+        BerylTestEnv::bob(),
+        U256::from(789),
+        U256::ONE,
+        deadline,
+    );
+    let wrong_signature = scenario.call_tx(IB20::permitCall {
+        owner: BerylTestEnv::alice(),
+        spender: BerylTestEnv::bob(),
+        value: U256::from(789),
+        deadline,
+        v: wrong_v,
+        r: wrong_r,
+        s: wrong_s,
+    });
+    let block =
+        scenario.build_block_with_transactions(vec![replay, expired, wrong_signature]).await;
+
+    for index in 0..3 {
+        assert!(
+            !scenario.env.user_tx_succeeded(&block, index),
+            "invalid permit {index} must revert"
+        );
+    }
+    scenario.assert_allowance(BerylTestEnv::alice(), BerylTestEnv::bob(), 123);
+    scenario
+        .assert_staticcall_cases(vec![StaticcallCase::word(
+            "nonces after invalid permits",
             IB20::noncesCall { owner: BerylTestEnv::alice() }.abi_encode(),
             U256::ONE,
         )])

--- a/actions/harness/tests/beryl/b20_policy.rs
+++ b/actions/harness/tests/beryl/b20_policy.rs
@@ -7,7 +7,9 @@
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_sol_types::SolCall;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
-use base_common_precompiles::{B20PolicyType, IB20, IPolicyRegistry, PolicyRegistryStorage};
+use base_common_precompiles::{
+    B20PolicyType, B20TokenRole, IB20, IPolicyRegistry, PolicyRegistryStorage,
+};
 
 use crate::env::BerylTestEnv;
 
@@ -219,6 +221,134 @@ async fn b20_allowlist_receiver_policy_blocks_non_members() {
     );
     scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - 1);
     scenario.assert_balance(BerylTestEnv::bob(), 1);
+
+    scenario.derive().await;
+}
+
+/// `TRANSFER_EXECUTOR_POLICY` gates delegated transfers independently from the sender/receiver.
+#[tokio::test]
+async fn b20_always_block_executor_policy_blocks_transfer_from_spender() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let approve_bob = scenario
+        .token_tx(IB20::approveCall { spender: BerylTestEnv::bob(), amount: U256::from(2) });
+    let block = scenario.build_block(vec![approve_bob]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "approve must succeed");
+
+    let first_transfer = scenario.bob_token_tx(IB20::transferFromCall {
+        from: BerylTestEnv::alice(),
+        to: BerylTestEnv::carol(),
+        amount: TRANSFER_AMOUNT,
+    });
+    let block = scenario.build_block(vec![first_transfer]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "transferFrom must succeed before executor policy is blocked"
+    );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - 1);
+    scenario.assert_balance(BerylTestEnv::carol(), 1);
+
+    let wire_executor = scenario.token_tx(IB20::updatePolicyCall {
+        policyScope: B20PolicyType::TransferExecutor.id(),
+        newPolicyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+    });
+    let block = scenario.build_block(vec![wire_executor]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "executor updatePolicy must succeed");
+
+    let blocked = scenario.bob_token_tx(IB20::transferFromCall {
+        from: BerylTestEnv::alice(),
+        to: BerylTestEnv::carol(),
+        amount: TRANSFER_AMOUNT,
+    });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "transferFrom must revert when spender is blocked by TRANSFER_EXECUTOR_POLICY"
+    );
+    scenario.assert_balance(BerylTestEnv::alice(), BerylTestEnv::B20_INITIAL_SUPPLY - 1);
+    scenario.assert_balance(BerylTestEnv::carol(), 1);
+
+    scenario.derive().await;
+}
+
+/// `MINT_RECEIVER_POLICY` gates the recipient for direct mint calls.
+#[tokio::test]
+async fn b20_always_block_mint_receiver_policy_blocks_mint_recipient() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let grant_mint_role = scenario.token_tx(IB20::grantRoleCall {
+        role: B20TokenRole::Mint.id(),
+        account: BerylTestEnv::alice(),
+    });
+    let block = scenario.build_block(vec![grant_mint_role]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "MINT_ROLE grant must succeed");
+
+    let mint_allowed =
+        scenario.token_tx(IB20::mintCall { to: BerylTestEnv::bob(), amount: TRANSFER_AMOUNT });
+    let block = scenario.build_block(vec![mint_allowed]).await;
+    assert!(
+        scenario.env.user_tx_succeeded(&block, 0),
+        "mint must succeed before policy is blocked"
+    );
+    scenario.assert_balance(BerylTestEnv::bob(), 1);
+
+    let wire_mint_receiver = scenario.token_tx(IB20::updatePolicyCall {
+        policyScope: B20PolicyType::MintReceiver.id(),
+        newPolicyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+    });
+    let block = scenario.build_block(vec![wire_mint_receiver]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "mint receiver updatePolicy must succeed");
+
+    let blocked =
+        scenario.token_tx(IB20::mintCall { to: BerylTestEnv::carol(), amount: TRANSFER_AMOUNT });
+    let block = scenario.build_block(vec![blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "mint must revert when recipient is blocked by MINT_RECEIVER_POLICY"
+    );
+    scenario.assert_balance(BerylTestEnv::bob(), 1);
+    scenario.assert_balance(BerylTestEnv::carol(), 0);
+
+    scenario.derive().await;
+}
+
+/// `burnBlocked` burns only accounts denied by the current transfer-sender policy.
+#[tokio::test]
+async fn b20_burn_blocked_requires_blocked_account() {
+    let mut scenario = B20PolicyScenario::new().await;
+
+    let seed_bob =
+        scenario.token_tx(IB20::transferCall { to: BerylTestEnv::bob(), amount: SEED_AMOUNT });
+    let grant_burn_blocked = scenario.token_tx(IB20::grantRoleCall {
+        role: B20TokenRole::BurnBlocked.id(),
+        account: BerylTestEnv::alice(),
+    });
+    let block = scenario.build_block(vec![seed_bob, grant_burn_blocked]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "seeding bob must succeed");
+    assert!(scenario.env.user_tx_succeeded(&block, 1), "BURN_BLOCKED_ROLE grant must succeed");
+    scenario.assert_balance(BerylTestEnv::bob(), 100_000);
+
+    let not_blocked = scenario
+        .token_tx(IB20::burnBlockedCall { from: BerylTestEnv::bob(), amount: TRANSFER_AMOUNT });
+    let block = scenario.build_block(vec![not_blocked]).await;
+    assert!(
+        !scenario.env.user_tx_succeeded(&block, 0),
+        "burnBlocked must revert while account is allowed by the sender policy"
+    );
+    scenario.assert_balance(BerylTestEnv::bob(), 100_000);
+
+    let wire_sender_block = scenario.token_tx(IB20::updatePolicyCall {
+        policyScope: B20PolicyType::TransferSender.id(),
+        newPolicyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+    });
+    let block = scenario.build_block(vec![wire_sender_block]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "sender updatePolicy must succeed");
+
+    let burned = scenario
+        .token_tx(IB20::burnBlockedCall { from: BerylTestEnv::bob(), amount: TRANSFER_AMOUNT });
+    let block = scenario.build_block(vec![burned]).await;
+    assert!(scenario.env.user_tx_succeeded(&block, 0), "burnBlocked must burn blocked account");
+    scenario.assert_balance(BerylTestEnv::bob(), 99_999);
 
     scenario.derive().await;
 }

--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -2,9 +2,9 @@
 
 use alloy_consensus::TxReceipt;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use alloy_sol_types::{SolCall, SolEvent};
+use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_consensus::BaseBlock;
-use base_common_precompiles::{B20FactoryStorage, IB20Factory};
+use base_common_precompiles::{B20FactoryStorage, B20Variant, IB20Factory};
 
 use crate::env::BerylTestEnv;
 
@@ -253,6 +253,147 @@ async fn b20_factory_views_and_events_are_available_after_beryl_activation() {
         10,
     )
     .await;
+}
+
+#[tokio::test]
+async fn b20_factory_rejects_invalid_creation_parameters() {
+    let mut env = BerylTestEnv::new();
+
+    let block1 = env.sequencer.build_empty_block().await;
+    let activate_asset = env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
+    let activate_stablecoin = env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
+    let block2 = env
+        .sequencer
+        .build_next_block_with_transactions(vec![activate_asset, activate_stablecoin])
+        .await;
+    assert!(env.user_tx_succeeded(&block2, 0), "B20_ASSET activation must succeed");
+    assert!(env.user_tx_succeeded(&block2, 1), "B20_STABLECOIN activation must succeed");
+
+    let invalid_variant = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::__Invalid,
+                salt: BerylTestEnv::ALT_SALT,
+                params: Bytes::new(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let unsupported_asset_version = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::ASSET,
+                salt: BerylTestEnv::ALT_SALT,
+                params: IB20Factory::B20AssetCreateParams {
+                    version: B20Variant::Asset.supported_version() + 1,
+                    name: "Bad Version".to_string(),
+                    symbol: "BADV".to_string(),
+                    initialAdmin: BerylTestEnv::alice(),
+                    decimals: BerylTestEnv::B20_DECIMALS,
+                }
+                .abi_encode()
+                .into(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let invalid_asset_decimals = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::ASSET,
+                salt: BerylTestEnv::ALT_SALT,
+                params: IB20Factory::B20AssetCreateParams {
+                    version: B20Variant::Asset.supported_version(),
+                    name: "Bad Decimals".to_string(),
+                    symbol: "BADD".to_string(),
+                    initialAdmin: BerylTestEnv::alice(),
+                    decimals: 5,
+                }
+                .abi_encode()
+                .into(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let missing_currency = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::STABLECOIN,
+                salt: BerylTestEnv::ALT_SALT,
+                params: IB20Factory::B20StablecoinCreateParams {
+                    version: B20Variant::Stablecoin.supported_version(),
+                    name: "Missing Currency".to_string(),
+                    symbol: "MISS".to_string(),
+                    initialAdmin: BerylTestEnv::alice(),
+                    currency: String::new(),
+                }
+                .abi_encode()
+                .into(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let block3 = env
+        .sequencer
+        .build_next_block_with_transactions(vec![
+            invalid_variant,
+            unsupported_asset_version,
+            invalid_asset_decimals,
+            missing_currency,
+        ])
+        .await;
+
+    for index in 0..4 {
+        assert!(!env.user_tx_succeeded(&block3, index), "invalid factory call {index} must revert");
+    }
+    let invalid_asset =
+        B20Variant::Asset.compute_address(BerylTestEnv::alice(), BerylTestEnv::ALT_SALT).0;
+    let invalid_stablecoin =
+        B20Variant::Stablecoin.compute_address(BerylTestEnv::alice(), BerylTestEnv::ALT_SALT).0;
+    assert!(!env.sequencer.has_code(invalid_asset), "invalid asset creations must not deploy code");
+    assert!(
+        !env.sequencer.has_code(invalid_stablecoin),
+        "invalid stablecoin creation must not deploy code"
+    );
+
+    let (probe, deploy_probe) = env.deploy_staticcall_probe_tx(B20FactoryStorage::ADDRESS);
+    let block4 = env.sequencer.build_next_block_with_transactions(vec![deploy_probe]).await;
+    assert!(env.user_tx_succeeded(&block4, 0), "factory staticcall probe must deploy");
+
+    let invalid_address = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(
+            IB20Factory::getB20AddressCall {
+                variant: IB20Factory::B20Variant::__Invalid,
+                sender: BerylTestEnv::alice(),
+                salt: BerylTestEnv::ALT_SALT,
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block5 = env.sequencer.build_next_block_with_transactions(vec![invalid_address]).await;
+    assert!(env.user_tx_succeeded(&block5, 0), "invalid getB20Address probe tx must succeed");
+    assert!(env.probe_call_succeeded(probe), "invalid getB20Address staticcall must succeed");
+    assert_eq!(
+        env.probe_return_word(probe),
+        U256::ZERO,
+        "getB20Address(__Invalid) must return address(0)"
+    );
+
+    env.derive_blocks([(block1, 1), (block2, 2), (block3, 3), (block4, 4), (block5, 5)], 5).await;
 }
 
 struct B20FactoryPrecompiles;

--- a/actions/harness/tests/beryl/policy_registry.rs
+++ b/actions/harness/tests/beryl/policy_registry.rs
@@ -90,15 +90,34 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
         "policy registry view staticcall must succeed when POLICY_REGISTRY is deactivated"
     );
 
-    // Block6: re-activate POLICY_REGISTRY (committed state before block7).
+    // Block6: write calls must still fail while POLICY_REGISTRY is deactivated.
+    let write_while_deactivated = env.create_tx(
+        TxKind::Call(PolicyRegistryStorage::ADDRESS),
+        Bytes::from(
+            IPolicyRegistry::createPolicyCall {
+                admin: BerylTestEnv::alice(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            }
+            .abi_encode(),
+        ),
+        GAS_LIMIT,
+    );
+    let block6 =
+        env.sequencer.build_next_block_with_transactions(vec![write_while_deactivated]).await;
+    assert!(
+        !env.user_tx_succeeded(&block6, 0),
+        "policy registry write call must revert when POLICY_REGISTRY is deactivated"
+    );
+
+    // Block7: re-activate POLICY_REGISTRY (committed state before block8).
     let reactivate_registry = env.activate_feature_tx(BerylTestEnv::policy_registry_feature());
-    let block6 = env.sequencer.build_next_block_with_transactions(vec![reactivate_registry]).await;
+    let block7 = env.sequencer.build_next_block_with_transactions(vec![reactivate_registry]).await;
 
-    assert!(env.user_tx_succeeded(&block6, 0), "POLICY_REGISTRY re-activation must succeed");
+    assert!(env.user_tx_succeeded(&block7, 0), "POLICY_REGISTRY re-activation must succeed");
 
-    // Block7: probe's staticcall must succeed again after re-activation.
+    // Block8: probe's staticcall must succeed again after re-activation.
     let probe_after_reactivate = env.create_tx(TxKind::Call(probe), policy_exists_call, GAS_LIMIT);
-    let block7 =
+    let block8 =
         env.sequencer.build_next_block_with_transactions(vec![probe_after_reactivate]).await;
 
     assert_eq!(
@@ -122,8 +141,9 @@ async fn beryl_enables_policy_registry_singleton_precompile() {
             (block5, 6),
             (block6, 7),
             (block7, 8),
+            (block8, 9),
         ],
-        8,
+        9,
     )
     .await;
 }

--- a/actions/harness/tests/beryl/security.rs
+++ b/actions/harness/tests/beryl/security.rs
@@ -100,6 +100,11 @@ async fn security_creation_initializes_identifiers_and_factory_views() {
                     U256::from(100),
                 ),
                 StaticcallCase::word(
+                    "toRawBalance",
+                    IB20Asset::toRawBalanceCall { scaledBalance: U256::from(100) }.abi_encode(),
+                    U256::from(100),
+                ),
+                StaticcallCase::word(
                     "scaledBalanceOf((alice)",
                     IB20Asset::scaledBalanceOfCall { account: BerylTestEnv::alice() }.abi_encode(),
                     U256::from(BerylTestEnv::B20_INITIAL_SUPPLY),
@@ -238,6 +243,11 @@ async fn security_mutations_update_state_and_emit_events() {
                     "toScaledBalance after update",
                     IB20Asset::toScaledBalanceCall { rawBalance: U256::from(50) }.abi_encode(),
                     U256::from(100),
+                ),
+                StaticcallCase::word(
+                    "toRawBalance after update",
+                    IB20Asset::toRawBalanceCall { scaledBalance: U256::from(100) }.abi_encode(),
+                    U256::from(50),
                 ),
                 StaticcallCase::word(
                     "scaledBalanceOf((alice) after update",

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -158,6 +158,45 @@ async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> 
     Ok(())
 }
 
+/// `checkActivated` reverts before activation and succeeds while the feature is active.
+#[tokio::test]
+async fn test_activation_registry_check_activated_gate() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse system test private key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let feature = ActivationFeature::B20Asset.id();
+
+    assert!(
+        client
+            .call(
+                ActivationRegistryStorage::ADDRESS,
+                IActivationRegistry::checkActivatedCall { feature },
+            )
+            .await
+            .is_err(),
+        "checkActivated should revert while feature is inactive"
+    );
+
+    client.activate_feature(feature).await?;
+    assert!(is_activated(&client, feature).await?, "feature should be active");
+    client
+        .call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::checkActivatedCall { feature },
+        )
+        .await
+        .wrap_err("checkActivated should succeed while feature is active")?;
+
+    client.deactivate_feature(feature).await?;
+    assert!(!is_activated(&client, feature).await?, "feature should be inactive");
+
+    Ok(())
+}
+
 async fn is_activated(client: &B20PrecompileClient<'_>, feature: B256) -> Result<bool> {
     let output = client
         .call(ActivationRegistryStorage::ADDRESS, IActivationRegistry::isActivatedCall { feature })

--- a/etc/systems/tests/b20_precompile.rs
+++ b/etc/systems/tests/b20_precompile.rs
@@ -2,13 +2,14 @@
 
 mod common;
 
-use alloy_primitives::{Address, B256, Bytes, LogData, U256};
+use alloy_primitives::{Address, B256, Bytes, LogData, U256, keccak256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolEvent, SolValue};
+use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_network::Base;
 use base_common_precompiles::{
-    ActivationFeature, B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory,
+    ActivationFeature, B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Asset, IB20Factory,
+    IB20Stablecoin,
 };
 use base_common_rpc_types::BaseTransactionReceipt;
 use base_system_tests::{
@@ -29,6 +30,8 @@ const INITIAL_SUPPLY_CAP: u64 = 2_000_000_000;
 const PAUSE_TRANSFER_AMOUNT: u64 = 10_000;
 const STABLECOIN_CURRENCY: &str = "USD";
 const PRE_BERYL_TEST_ACTIVATION_BLOCK: u64 = 8;
+const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+const UPDATED_MULTIPLIER: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
 
 async fn start_beryl_system_before_activation() -> Result<(SystemTestStack, RootProvider<Base>)> {
     let system = SystemTestStackBuilder::new()
@@ -239,19 +242,8 @@ async fn test_b20_mint_and_burn() -> Result<()> {
     )
     .await?;
 
-    let zero_mint_succeeded = b20
-        .try_send_call(
-            token,
-            IB20::mintCall { to: admin.address(), amount: U256::ZERO },
-            "zero amount B-20 mint",
-        )
-        .await?;
-    assert!(!zero_mint_succeeded, "zero amount B-20 mint should revert");
-
-    let zero_burn_succeeded = b20
-        .try_send_call(token, IB20::burnCall { amount: U256::ZERO }, "zero amount B-20 burn")
-        .await?;
-    assert!(!zero_burn_succeeded, "zero amount B-20 burn should revert");
+    b20.mint(token, admin.address(), U256::ZERO).await?;
+    b20.burn(token, U256::ZERO).await?;
     assert_eq!(b20.total_supply(token).await?, supply_before);
 
     b20.mint(token, admin.address(), U256::from(MINT_AMOUNT)).await?;
@@ -269,6 +261,195 @@ async fn test_b20_mint_and_burn() -> Result<()> {
     assert_eq!(
         b20.balance_of(token, admin.address()).await?,
         U256::from(INITIAL_SUPPLY) + U256::from(MINT_AMOUNT) - U256::from(BURN_AMOUNT),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_stablecoin_create_and_currency_via_rpc() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    b20.activate_feature(ActivationFeature::B20Stablecoin.id()).await?;
+
+    let salt = B256::repeat_byte(0x19);
+    let token = b20.predict_token_address(B20Variant::Stablecoin, salt);
+    let params = IB20Factory::B20StablecoinCreateParams {
+        version: B20Variant::Stablecoin.supported_version(),
+        name: "System USD".to_string(),
+        symbol: "SUSD".to_string(),
+        initialAdmin: admin.address(),
+        currency: "USD".to_string(),
+    };
+    b20.send_call(
+        B20FactoryStorage::ADDRESS,
+        IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::STABLECOIN,
+            salt,
+            params: params.abi_encode().into(),
+            initCalls: vec![
+                IB20::mintCall { to: admin.address(), amount: U256::from(INITIAL_SUPPLY) }
+                    .abi_encode()
+                    .into(),
+            ],
+        },
+        "create B-20 stablecoin",
+    )
+    .await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    let output = b20.call(token, IB20Stablecoin::currencyCall {}).await?;
+    let currency = IB20Stablecoin::currencyCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode currency")?;
+    assert_eq!(currency, "USD");
+    assert_eq!(b20.name(token).await?, "System USD");
+    assert_eq!(b20.total_supply(token).await?, U256::from(INITIAL_SUPPLY));
+    assert!(b20.is_b20(token).await?, "stablecoin should be recognised as B-20");
+    assert!(b20.is_b20_initialized(token).await?, "stablecoin should be initialized");
+
+    let invalid_salt = B256::repeat_byte(0x1a);
+    let invalid_token = b20.predict_token_address(B20Variant::Stablecoin, invalid_salt);
+    let invalid_params = IB20Factory::B20StablecoinCreateParams {
+        version: B20Variant::Stablecoin.supported_version(),
+        name: "Invalid USD".to_string(),
+        symbol: "IUSD".to_string(),
+        initialAdmin: admin.address(),
+        currency: "usd".to_string(),
+    };
+    let invalid_succeeded = b20
+        .try_send_call(
+            B20FactoryStorage::ADDRESS,
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::STABLECOIN,
+                salt: invalid_salt,
+                params: invalid_params.abi_encode().into(),
+                initCalls: Vec::new(),
+            },
+            "create B-20 stablecoin with invalid currency",
+        )
+        .await?;
+    assert!(!invalid_succeeded, "lowercase stablecoin currency should revert");
+    assert!(provider.get_code_at(invalid_token).await?.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_asset_extension_via_rpc() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    let bob = ANVIL_ACCOUNT_6.address;
+    let carol = ANVIL_ACCOUNT_7.address;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let b20 = activated_b20_client(&provider, &admin).await?;
+    let salt = B256::repeat_byte(0x1b);
+    let params = B20PrecompileClient::token_params(
+        "System Asset",
+        "ASST",
+        admin.address(),
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    assert_eq!(asset_word(&b20, token, IB20Asset::multiplierCall {}).await?, WAD);
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::toRawBalanceCall { scaledBalance: U256::from(100) })
+            .await?,
+        U256::from(100),
+    );
+
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: operator_role(), account: admin.address() },
+        "grant B-20 operator role",
+    )
+    .await?;
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Metadata.id(), account: admin.address() },
+        "grant B-20 metadata role",
+    )
+    .await?;
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: admin.address() },
+        "grant B-20 mint role",
+    )
+    .await?;
+
+    b20.send_call(
+        token,
+        IB20Asset::updateMultiplierCall { newMultiplier: UPDATED_MULTIPLIER },
+        "update B-20 asset multiplier",
+    )
+    .await?;
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::toScaledBalanceCall { rawBalance: U256::from(100) })
+            .await?,
+        U256::from(200),
+    );
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::toRawBalanceCall { scaledBalance: U256::from(200) })
+            .await?,
+        U256::from(100),
+    );
+
+    b20.send_call(
+        token,
+        IB20Asset::updateExtraMetadataCall {
+            key: "CUSIP".to_string(),
+            value: "123456789".to_string(),
+        },
+        "update B-20 asset metadata",
+    )
+    .await?;
+    assert_eq!(asset_string(&b20, token, "CUSIP").await?, "123456789");
+
+    b20.send_call(
+        token,
+        IB20Asset::batchMintCall {
+            recipients: vec![bob, carol],
+            amounts: vec![U256::from(100), U256::from(200)],
+        },
+        "batchMint B-20 asset",
+    )
+    .await?;
+    assert_eq!(b20.balance_of(token, bob).await?, U256::from(100));
+    assert_eq!(b20.balance_of(token, carol).await?, U256::from(200));
+
+    let update_figi = IB20Asset::updateExtraMetadataCall {
+        key: "FIGI".to_string(),
+        value: "BBG000000001".to_string(),
+    };
+    b20.send_call(
+        token,
+        IB20Asset::announceCall {
+            internalCalls: vec![update_figi.abi_encode().into()],
+            id: "asset-rpc-1".to_string(),
+            description: "update FIGI".to_string(),
+            uri: "ipfs://asset-rpc".to_string(),
+        },
+        "announce B-20 asset metadata update",
+    )
+    .await?;
+    assert_eq!(asset_string(&b20, token, "FIGI").await?, "BBG000000001");
+    assert!(
+        asset_bool(
+            &b20,
+            token,
+            IB20Asset::isAnnouncementIdUsedCall { id: "asset-rpc-1".to_string() },
+        )
+        .await?,
+        "announcement id should be marked as used",
     );
 
     Ok(())
@@ -677,4 +858,33 @@ fn assert_receipt_log(receipt: &BaseTransactionReceipt, address: Address, expect
         "receipt must contain expected log at {address}; expected={expected:?}, logs={:?}",
         receipt.inner.logs()
     );
+}
+
+async fn asset_word<C>(client: &B20PrecompileClient<'_>, token: Address, call: C) -> Result<U256>
+where
+    C: SolCall,
+{
+    let output = client.call(token, call).await?;
+    U256::abi_decode(output.as_ref()).wrap_err("Failed to decode asset word")
+}
+
+async fn asset_string(
+    client: &B20PrecompileClient<'_>,
+    token: Address,
+    key: &str,
+) -> Result<String> {
+    let output = client.call(token, IB20Asset::extraMetadataCall { key: key.to_string() }).await?;
+    String::abi_decode(output.as_ref()).wrap_err("Failed to decode asset string")
+}
+
+async fn asset_bool<C>(client: &B20PrecompileClient<'_>, token: Address, call: C) -> Result<bool>
+where
+    C: SolCall,
+{
+    let output = client.call(token, call).await?;
+    bool::abi_decode(output.as_ref()).wrap_err("Failed to decode asset bool")
+}
+
+fn operator_role() -> B256 {
+    keccak256("OPERATOR_ROLE")
 }

--- a/etc/systems/tests/policy_registry.rs
+++ b/etc/systems/tests/policy_registry.rs
@@ -7,7 +7,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent};
 use base_common_precompiles::{ActivationFeature, IPolicyRegistry, PolicyRegistryStorage};
 use base_common_rpc_types::BaseTransactionReceipt;
-use base_system_tests::{ANVIL_ACCOUNT_5, B20PrecompileClient};
+use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, ANVIL_ACCOUNT_7, B20PrecompileClient};
 use eyre::{Result, WrapErr};
 
 /// `createPolicy` emits the expected policy-registry events over RPC receipts.
@@ -81,6 +81,306 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
     assert!(result, "policyExists(0) should return true after Beryl activation");
 
     Ok(())
+}
+
+/// Custom policy creation, membership, admin transfer, renounce, and error paths round-trip over RPC.
+#[tokio::test]
+async fn test_policy_registry_lifecycle_and_error_paths() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse policy admin key")?;
+    let next_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
+        .wrap_err("Failed to parse next policy admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, next_admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let next_admin_client = B20PrecompileClient::new(&provider, &next_admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
+
+    let allowlist_id = create_policy(
+        &client,
+        admin.address(),
+        IPolicyRegistry::PolicyType::ALLOWLIST,
+        "create allowlist policy",
+    )
+    .await?;
+    assert!(policy_exists(&client, allowlist_id).await?, "new policy should exist");
+    assert_eq!(policy_admin(&client, allowlist_id).await?, admin.address());
+    assert_eq!(pending_policy_admin(&client, allowlist_id).await?, Address::ZERO);
+    assert!(
+        !is_authorized(&client, allowlist_id, ANVIL_ACCOUNT_7.address).await?,
+        "fresh allowlist should reject non-members"
+    );
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: allowlist_id,
+                allowed: true,
+                accounts: vec![ANVIL_ACCOUNT_7.address],
+            },
+            "update allowlist add account",
+        )
+        .await?;
+    assert!(
+        is_authorized(&client, allowlist_id, ANVIL_ACCOUNT_7.address).await?,
+        "allowlisted account should be authorized"
+    );
+
+    let blocklist_id = create_policy_with_accounts(
+        &client,
+        admin.address(),
+        IPolicyRegistry::PolicyType::BLOCKLIST,
+        vec![ANVIL_ACCOUNT_7.address],
+        "create blocklist policy with accounts",
+    )
+    .await?;
+    assert!(
+        !is_authorized(&client, blocklist_id, ANVIL_ACCOUNT_7.address).await?,
+        "blocklisted account should not be authorized"
+    );
+
+    let allowlist_on_blocklist = client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: blocklist_id,
+                allowed: true,
+                accounts: vec![ANVIL_ACCOUNT_7.address],
+            },
+            "update allowlist on blocklist policy",
+        )
+        .await?;
+    assert!(!allowlist_on_blocklist, "updateAllowlist on BLOCKLIST policy should revert");
+
+    let blocklist_on_allowlist = client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateBlocklistCall {
+                policyId: allowlist_id,
+                blocked: true,
+                accounts: vec![ANVIL_ACCOUNT_7.address],
+            },
+            "update blocklist on allowlist policy",
+        )
+        .await?;
+    assert!(!blocklist_on_allowlist, "updateBlocklist on ALLOWLIST policy should revert");
+
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::stageUpdateAdminCall {
+                policyId: allowlist_id,
+                newAdmin: next_admin.address(),
+            },
+            "stage policy admin",
+        )
+        .await?;
+    assert_eq!(pending_policy_admin(&client, allowlist_id).await?, next_admin.address());
+
+    next_admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::finalizeUpdateAdminCall { policyId: allowlist_id },
+            "finalize policy admin",
+        )
+        .await?;
+    assert_eq!(policy_admin(&client, allowlist_id).await?, next_admin.address());
+
+    let old_admin_update = client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: allowlist_id,
+                allowed: false,
+                accounts: vec![ANVIL_ACCOUNT_7.address],
+            },
+            "old admin update allowlist",
+        )
+        .await?;
+    assert!(!old_admin_update, "old admin update should revert after admin transfer");
+
+    next_admin_client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::renounceAdminCall { policyId: allowlist_id },
+            "renounce policy admin",
+        )
+        .await?;
+    assert_eq!(policy_admin(&client, allowlist_id).await?, Address::ZERO);
+
+    let renounced_update = next_admin_client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateAllowlistCall {
+                policyId: allowlist_id,
+                allowed: false,
+                accounts: vec![ANVIL_ACCOUNT_7.address],
+            },
+            "renounced policy update allowlist",
+        )
+        .await?;
+    assert!(!renounced_update, "renounced policy should be frozen");
+
+    let zero_admin_create = client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: Address::ZERO,
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "create policy with zero admin",
+        )
+        .await?;
+    assert!(!zero_admin_create, "createPolicy with zero admin should revert");
+
+    let no_pending = client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::finalizeUpdateAdminCall { policyId: allowlist_id },
+            "finalize without pending admin",
+        )
+        .await?;
+    assert!(!no_pending, "finalizeUpdateAdmin without pending admin should revert");
+
+    Ok(())
+}
+
+/// View calls remain available while write calls are gated when the policy registry is deactivated.
+#[tokio::test]
+async fn test_policy_registry_deactivated_views_and_write_gate() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse policy admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
+
+    let blocklist_id = create_policy(
+        &client,
+        admin.address(),
+        IPolicyRegistry::PolicyType::BLOCKLIST,
+        "create blocklist policy",
+    )
+    .await?;
+    client
+        .send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::updateBlocklistCall {
+                policyId: blocklist_id,
+                blocked: true,
+                accounts: vec![ANVIL_ACCOUNT_6.address],
+            },
+            "update blocklist add account",
+        )
+        .await?;
+
+    client.deactivate_feature(ActivationFeature::PolicyRegistry.id()).await?;
+    assert!(policy_exists(&client, blocklist_id).await?, "view policyExists should still succeed");
+    assert_eq!(policy_admin(&client, blocklist_id).await?, admin.address());
+    assert!(
+        !is_authorized(&client, blocklist_id, ANVIL_ACCOUNT_6.address).await?,
+        "view isAuthorized should preserve blocked account state while deactivated"
+    );
+
+    let create_while_deactivated = client
+        .try_send_call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::createPolicyCall {
+                admin: admin.address(),
+                policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+            },
+            "create policy while deactivated",
+        )
+        .await?;
+    assert!(!create_while_deactivated, "policy registry writes should revert while deactivated");
+
+    Ok(())
+}
+
+async fn create_policy(
+    client: &B20PrecompileClient<'_>,
+    admin: Address,
+    policy_type: IPolicyRegistry::PolicyType,
+    label: &'static str,
+) -> Result<u64> {
+    let call = IPolicyRegistry::createPolicyCall { admin, policyType: policy_type };
+    let output = client.call(PolicyRegistryStorage::ADDRESS, call.clone()).await?;
+    let policy_id = IPolicyRegistry::createPolicyCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode createPolicy")?;
+    client.send_call(PolicyRegistryStorage::ADDRESS, call, label).await?;
+    Ok(policy_id)
+}
+
+async fn create_policy_with_accounts(
+    client: &B20PrecompileClient<'_>,
+    admin: Address,
+    policy_type: IPolicyRegistry::PolicyType,
+    accounts: Vec<Address>,
+    label: &'static str,
+) -> Result<u64> {
+    let call =
+        IPolicyRegistry::createPolicyWithAccountsCall { admin, policyType: policy_type, accounts };
+    let output = client.call(PolicyRegistryStorage::ADDRESS, call.clone()).await?;
+    let policy_id =
+        IPolicyRegistry::createPolicyWithAccountsCall::abi_decode_returns(output.as_ref())
+            .wrap_err("Failed to decode createPolicyWithAccounts")?;
+    client.send_call(PolicyRegistryStorage::ADDRESS, call, label).await?;
+    Ok(policy_id)
+}
+
+async fn policy_exists(client: &B20PrecompileClient<'_>, policy_id: u64) -> Result<bool> {
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyExistsCall { policyId: policy_id },
+        )
+        .await?;
+    IPolicyRegistry::policyExistsCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode policyExists")
+}
+
+async fn policy_admin(client: &B20PrecompileClient<'_>, policy_id: u64) -> Result<Address> {
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::policyAdminCall { policyId: policy_id },
+        )
+        .await?;
+    IPolicyRegistry::policyAdminCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode policyAdmin")
+}
+
+async fn pending_policy_admin(client: &B20PrecompileClient<'_>, policy_id: u64) -> Result<Address> {
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::pendingPolicyAdminCall { policyId: policy_id },
+        )
+        .await?;
+    IPolicyRegistry::pendingPolicyAdminCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode pendingPolicyAdmin")
+}
+
+async fn is_authorized(
+    client: &B20PrecompileClient<'_>,
+    policy_id: u64,
+    account: Address,
+) -> Result<bool> {
+    let output = client
+        .call(
+            PolicyRegistryStorage::ADDRESS,
+            IPolicyRegistry::isAuthorizedCall { policyId: policy_id, account },
+        )
+        .await?;
+    IPolicyRegistry::isAuthorizedCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode isAuthorized")
 }
 
 fn assert_receipt_log(receipt: &BaseTransactionReceipt, address: Address, expected: LogData) {


### PR DESCRIPTION
## Summary

This expands Beryl precompile coverage across the action harness and system tests. It adds positive and negative coverage for activation, factory validation, policy registry lifecycle, policy-gated B20 operations, B20 role lifecycle, permit failures, stablecoin creation, and asset-specific selectors. It also aligns the zero-amount mint/burn system test with the implementation and action tests.