### PR TITLE
feat(common): Add Beryl Precompile Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,6 +3711,8 @@ dependencies = [
  "base-common-consensus",
  "base-common-flz",
  "base-common-precompiles",
+ "base-metrics",
+ "metrics",
  "reth-evm",
  "revm",
  "rstest",

--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -33,6 +33,10 @@ auto_impl.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 
+# metrics
+base-metrics = { workspace = true, optional = true }
+metrics = { workspace = true, optional = true }
+
 # reth
 reth-evm = { workspace = true, optional = true }
 
@@ -69,6 +73,7 @@ serde = [
 	"revm/serde",
 ]
 reth = [ "dep:reth-evm", "std" ]
+metrics = [ "base-metrics/metrics", "dep:base-metrics", "dep:metrics", "std" ]
 bn = [ "base-common-precompiles/bn", "revm/bn" ]
 blst = [ "base-common-precompiles/blst", "revm/blst" ]
 c-kzg = [ "base-common-precompiles/c-kzg", "revm/c-kzg" ]

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -8,7 +8,17 @@ use revm::{
     interpreter::interpreter::EthInterpreter,
 };
 
-use crate::{BaseContext, BaseEvm, BasePrecompiles, BaseSpecId};
+use crate::{BaseContext, BaseEvm, BasePrecompiles, BaseSpecId, BerylPrecompileMetricsObserver};
+
+/// Installs Base precompiles for node execution with the production Beryl metrics observer.
+pub fn install_base_precompiles_for_node(
+    spec: BaseSpecId,
+    activation_admin_address: Option<Address>,
+) -> PrecompilesMap {
+    BasePrecompiles::new_with_spec(spec)
+        .with_activation_admin_address(activation_admin_address)
+        .install_with_observer(BerylPrecompileMetricsObserver)
+}
 
 /// Trait that allows constructing a [`BaseEvm`] from a [`BaseContext`].
 ///
@@ -37,10 +47,7 @@ pub trait Builder: Sized {
         self,
         activation_admin_address: Option<Address>,
     ) -> BaseEvm<Self::Db, (), PrecompilesMap> {
-        let spec = self.spec();
-        let precompiles = BasePrecompiles::new_with_spec(spec)
-            .with_activation_admin_address(activation_admin_address)
-            .install();
+        let precompiles = install_base_precompiles_for_node(self.spec(), activation_admin_address);
         self.build_base_with_precompiles(precompiles)
     }
 
@@ -69,10 +76,7 @@ pub trait Builder: Sized {
         inspector: INSP,
         activation_admin_address: Option<Address>,
     ) -> BaseEvm<Self::Db, INSP, PrecompilesMap> {
-        let spec = self.spec();
-        let precompiles = BasePrecompiles::new_with_spec(spec)
-            .with_activation_admin_address(activation_admin_address)
-            .install();
+        let precompiles = install_base_precompiles_for_node(self.spec(), activation_admin_address);
         self.build_with_inspector_and_precompiles(inspector, precompiles)
     }
 
@@ -148,7 +152,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{BaseTransaction, BaseUpgrade, DefaultBase};
+    use crate::{BaseTransaction, BaseUpgrade, BerylPrecompileMetricsObserver, DefaultBase};
 
     fn b20_token_address() -> Address {
         B20Variant::Asset.compute_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22)).0
@@ -193,6 +197,8 @@ mod tests {
 
     #[test]
     fn build_base_with_activation_admin_address_configures_activation_registry() {
+        BerylPrecompileMetricsObserver::reset_recorded_calls_for_test();
+
         let admin = Address::repeat_byte(0xaa);
         let ctx =
             Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)));
@@ -212,6 +218,7 @@ mod tests {
         let actual = IActivationRegistry::adminCall::abi_decode_returns(output).unwrap();
 
         assert_eq!(actual, admin);
+        assert!(BerylPrecompileMetricsObserver::recorded_calls_for_test() > 0);
     }
 
     struct ReadOnlyDbAdapter;

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -10,16 +10,6 @@ use revm::{
 
 use crate::{BaseContext, BaseEvm, BasePrecompiles, BaseSpecId, BerylPrecompileMetricsObserver};
 
-/// Installs Base precompiles for node execution with the production Beryl metrics observer.
-pub fn install_base_precompiles_for_node(
-    spec: BaseSpecId,
-    activation_admin_address: Option<Address>,
-) -> PrecompilesMap {
-    BasePrecompiles::new_with_spec(spec)
-        .with_activation_admin_address(activation_admin_address)
-        .install_with_observer(BerylPrecompileMetricsObserver)
-}
-
 /// Trait that allows constructing a [`BaseEvm`] from a [`BaseContext`].
 ///
 /// Implemented for [`BaseContext<DB>`] of any database. The resulting [`BaseEvm`]
@@ -31,6 +21,13 @@ pub trait Builder: Sized {
 
     /// Returns the active [`BaseSpecId`] for this builder.
     fn spec(&self) -> BaseSpecId;
+
+    /// Installs Base precompiles for node execution with the production Beryl metrics observer.
+    fn precompiles_for_node(&self, activation_admin_address: Option<Address>) -> PrecompilesMap {
+        BasePrecompiles::new_with_spec(self.spec())
+            .with_activation_admin_address(activation_admin_address)
+            .install_with_observer(BerylPrecompileMetricsObserver)
+    }
 
     /// Builds a [`BaseEvm`] with a `()` inspector. The inspect flag is `false`,
     /// so [`Inspector`][revm::Inspector] callbacks are never invoked via
@@ -47,7 +44,7 @@ pub trait Builder: Sized {
         self,
         activation_admin_address: Option<Address>,
     ) -> BaseEvm<Self::Db, (), PrecompilesMap> {
-        let precompiles = install_base_precompiles_for_node(self.spec(), activation_admin_address);
+        let precompiles = self.precompiles_for_node(activation_admin_address);
         self.build_base_with_precompiles(precompiles)
     }
 
@@ -76,7 +73,7 @@ pub trait Builder: Sized {
         inspector: INSP,
         activation_admin_address: Option<Address>,
     ) -> BaseEvm<Self::Db, INSP, PrecompilesMap> {
-        let precompiles = install_base_precompiles_for_node(self.spec(), activation_admin_address);
+        let precompiles = self.precompiles_for_node(activation_admin_address);
         self.build_with_inspector_and_precompiles(inspector, precompiles)
     }
 

--- a/crates/common/evm/src/api/mod.rs
+++ b/crates/common/evm/src/api/mod.rs
@@ -1,7 +1,7 @@
 //! Base API types.
 
 mod builder;
-pub use builder::Builder;
+pub use builder::{Builder, install_base_precompiles_for_node};
 
 mod default_ctx;
 pub use default_ctx::{BaseContext, DefaultBase};

--- a/crates/common/evm/src/api/mod.rs
+++ b/crates/common/evm/src/api/mod.rs
@@ -1,7 +1,7 @@
 //! Base API types.
 
 mod builder;
-pub use builder::{Builder, install_base_precompiles_for_node};
+pub use builder::Builder;
 
 mod default_ctx;
 pub use default_ctx::{BaseContext, DefaultBase};

--- a/crates/common/evm/src/beryl_metrics.rs
+++ b/crates/common/evm/src/beryl_metrics.rs
@@ -1,0 +1,190 @@
+//! Metrics observer for Beryl-native precompile calls.
+
+#[cfg(test)]
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(feature = "metrics")]
+use base_common_precompiles::PrecompileCallStatus;
+use base_common_precompiles::{
+    PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome,
+};
+
+#[cfg(feature = "metrics")]
+base_metrics::define_metrics! {
+    base.beryl.precompile,
+    struct = BerylPrecompileMetrics,
+    #[describe("Total Beryl native precompile calls")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    calls_total: counter,
+    #[describe("Beryl native precompile call duration in seconds")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    duration_seconds: histogram,
+    #[describe("Beryl native precompile calldata byte size")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    input_bytes: histogram,
+    #[describe("Beryl native precompile gas used")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    gas_used: histogram,
+    #[describe("Beryl native precompile state gas used")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    state_gas_used: histogram,
+    #[describe("Beryl native precompile gas refunded")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    gas_refunded: histogram,
+    #[describe("Beryl native precompile errors by bounded class")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(error)]
+    errors_total: counter,
+    #[describe("Successful Beryl native precompile calls that reported zero gas used")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    zero_gas_success_total: counter,
+    #[describe("B-20 tokens created by variant")]
+    #[label(name = "variant", default = ["asset", "stablecoin"])]
+    b20_created_total: counter,
+    #[describe("Beryl native precompile batch item counts")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    batch_items: histogram,
+    #[describe("Beryl native precompile internal call counts")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    internal_calls: histogram,
+    #[describe("Beryl native precompile internal call byte totals")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    internal_call_bytes: histogram,
+}
+
+#[cfg(test)]
+static RECORDED_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+/// Concrete observer that emits Beryl precompile metrics through the node metrics recorder.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BerylPrecompileMetricsObserver;
+
+impl BerylPrecompileMetricsObserver {
+    /// Resets the test-only call counter.
+    #[cfg(test)]
+    pub fn reset_recorded_calls_for_test() {
+        RECORDED_CALLS.store(0, Ordering::SeqCst);
+    }
+
+    /// Returns the test-only call counter.
+    #[cfg(test)]
+    pub fn recorded_calls_for_test() -> usize {
+        RECORDED_CALLS.load(Ordering::SeqCst)
+    }
+}
+
+impl PrecompileCallObserver for BerylPrecompileMetricsObserver {
+    fn record_call(&self, call: &PrecompileCallMetric, outcome: &PrecompileCallOutcome) {
+        #[cfg(test)]
+        RECORDED_CALLS.fetch_add(1, Ordering::SeqCst);
+
+        #[cfg(feature = "metrics")]
+        {
+            let method = call.method.clone().into_owned();
+            let variant = call.variant_label();
+            let status = outcome.status.as_label();
+
+            BerylPrecompileMetrics::calls_total(call.precompile, method.clone(), variant, status)
+                .increment(1);
+            BerylPrecompileMetrics::input_bytes(call.precompile, method.clone(), variant, status)
+                .record(call.input_bytes as f64);
+            BerylPrecompileMetrics::gas_used(call.precompile, method.clone(), variant, status)
+                .record(outcome.gas_used as f64);
+            BerylPrecompileMetrics::state_gas_used(
+                call.precompile,
+                method.clone(),
+                variant,
+                status,
+            )
+            .record(outcome.state_gas_used as f64);
+            BerylPrecompileMetrics::gas_refunded(call.precompile, method.clone(), variant, status)
+                .record(outcome.gas_refunded as f64);
+
+            if let Some(duration_seconds) = outcome.duration_seconds {
+                BerylPrecompileMetrics::duration_seconds(
+                    call.precompile,
+                    method.clone(),
+                    variant,
+                    status,
+                )
+                .record(duration_seconds);
+            }
+            if let Some(error) = outcome.error {
+                BerylPrecompileMetrics::errors_total(
+                    call.precompile,
+                    method.clone(),
+                    variant,
+                    error.as_label(),
+                )
+                .increment(1);
+            }
+            if outcome.status == PrecompileCallStatus::Success && outcome.gas_used == 0 {
+                BerylPrecompileMetrics::zero_gas_success_total(call.precompile, method, variant)
+                    .increment(1);
+            }
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = (call, outcome);
+    }
+
+    fn record_b20_created(&self, variant: &'static str) {
+        #[cfg(feature = "metrics")]
+        BerylPrecompileMetrics::b20_created_total(variant).increment(1);
+        #[cfg(not(feature = "metrics"))]
+        let _ = variant;
+    }
+
+    fn record_batch_items(&self, call: &PrecompileCallMetric, count: usize) {
+        #[cfg(feature = "metrics")]
+        BerylPrecompileMetrics::batch_items(
+            call.precompile,
+            call.method.clone().into_owned(),
+            call.variant_label(),
+        )
+        .record(count as f64);
+        #[cfg(not(feature = "metrics"))]
+        let _ = (call, count);
+    }
+
+    fn record_internal_calls(&self, call: &PrecompileCallMetric, calls: usize, bytes: usize) {
+        #[cfg(feature = "metrics")]
+        {
+            let method = call.method.clone().into_owned();
+            let variant = call.variant_label();
+            BerylPrecompileMetrics::internal_calls(call.precompile, method.clone(), variant)
+                .record(calls as f64);
+            BerylPrecompileMetrics::internal_call_bytes(call.precompile, method, variant)
+                .record(bytes as f64);
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = (call, calls, bytes);
+    }
+}

--- a/crates/common/evm/src/beryl_metrics.rs
+++ b/crates/common/evm/src/beryl_metrics.rs
@@ -8,6 +8,8 @@ use base_common_precompiles::PrecompileCallStatus;
 use base_common_precompiles::{
     PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome,
 };
+#[cfg(feature = "metrics")]
+use metrics::SharedString;
 
 #[cfg(feature = "metrics")]
 base_metrics::define_metrics! {
@@ -108,9 +110,10 @@ impl PrecompileCallObserver for BerylPrecompileMetricsObserver {
 
         #[cfg(feature = "metrics")]
         {
-            let method = call.method.clone().into_owned();
+            let method: SharedString = call.method.clone().into_owned().into();
             let variant = call.variant_label();
             let status = outcome.status.as_label();
+            let gas_refunded = outcome.gas_refunded.max(0) as f64;
 
             BerylPrecompileMetrics::calls_total(call.precompile, method.clone(), variant, status)
                 .increment(1);
@@ -126,7 +129,7 @@ impl PrecompileCallObserver for BerylPrecompileMetricsObserver {
             )
             .record(outcome.state_gas_used as f64);
             BerylPrecompileMetrics::gas_refunded(call.precompile, method.clone(), variant, status)
-                .record(outcome.gas_refunded as f64);
+                .record(gas_refunded);
 
             if let Some(duration_seconds) = outcome.duration_seconds {
                 BerylPrecompileMetrics::duration_seconds(

--- a/crates/common/evm/src/lib.rs
+++ b/crates/common/evm/src/lib.rs
@@ -28,8 +28,13 @@ pub use handler::{BaseHandler, IsTxError};
 mod precompiles;
 pub use precompiles::BasePrecompiles;
 
+mod beryl_metrics;
+pub use beryl_metrics::BerylPrecompileMetricsObserver;
+
 mod api;
-pub use api::{BaseContext, BaseContextTr, BaseError, Builder, DefaultBase};
+pub use api::{
+    BaseContext, BaseContextTr, BaseError, Builder, DefaultBase, install_base_precompiles_for_node,
+};
 
 mod evm;
 pub use evm::BaseEvm;

--- a/crates/common/evm/src/lib.rs
+++ b/crates/common/evm/src/lib.rs
@@ -32,9 +32,7 @@ mod beryl_metrics;
 pub use beryl_metrics::BerylPrecompileMetricsObserver;
 
 mod api;
-pub use api::{
-    BaseContext, BaseContextTr, BaseError, Builder, DefaultBase, install_base_precompiles_for_node,
-};
+pub use api::{BaseContext, BaseContextTr, BaseError, Builder, DefaultBase};
 
 mod evm;
 pub use evm::BaseEvm;

--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -42,3 +42,30 @@ sol! {
         function deactivate(bytes32 feature) external;
     }
 }
+
+impl IActivationRegistry::IActivationRegistryCalls {
+    /// Returns the stable metric label for this decoded activation-registry call.
+    pub const fn as_label(&self) -> &'static str {
+        match self {
+            Self::isActivated(_) => "activation.isActivated",
+            Self::checkActivated(_) => "activation.checkActivated",
+            Self::admin(_) => "activation.admin",
+            Self::activate(_) => "activation.activate",
+            Self::deactivate(_) => "activation.deactivate",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::IActivationRegistry;
+
+    #[test]
+    fn activation_call_labels_are_stable() {
+        assert_eq!(
+            IActivationRegistry::IActivationRegistryCalls::admin(IActivationRegistry::adminCall {})
+                .as_label(),
+            "activation.admin"
+        );
+    }
+}

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -6,9 +6,10 @@ use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationRegistryStorage,
+    ActivationRegistryStorage, BerylCallRecorder, BerylMetricLabels,
     IActivationRegistry::{self, IActivationRegistryCalls as C},
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    NoopPrecompileCallObserver, PrecompileCallObserver,
+    macros::decode_precompile_call,
 };
 
 impl ActivationRegistryStorage<'_> {
@@ -19,8 +20,33 @@ impl ActivationRegistryStorage<'_> {
         calldata: &[u8],
         activation_admin_address: Option<Address>,
     ) -> PrecompileResult {
-        deduct_calldata_cost!(ctx, calldata);
-        ctx.result_output(self.inner(calldata, activation_admin_address), |output| output)
+        self.dispatch_with_observer(
+            ctx,
+            calldata,
+            activation_admin_address,
+            NoopPrecompileCallObserver,
+        )
+    }
+
+    /// ABI-dispatches activation registry calldata with an observer.
+    pub fn dispatch_with_observer<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        activation_admin_address: Option<Address>,
+        observer: O,
+    ) -> PrecompileResult
+    where
+        O: PrecompileCallObserver,
+    {
+        let mut recorder =
+            BerylCallRecorder::start(observer, BerylMetricLabels::activation_call(calldata));
+        if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
+            return recorder.record_base_error_result(ctx, error);
+        }
+        recorder.record_base_result(ctx, self.inner(calldata, activation_admin_address), |output| {
+            output
+        })
     }
 
     fn inner(

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,11 +1,47 @@
 //! Precompile entry point for the activation registry.
 
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::Address;
 use base_precompile_macros::precompile;
 
-use crate::ActivationRegistryStorage;
+use crate::{ActivationRegistryStorage, PrecompileCallObserver, macros::base_precompile};
 
 /// Entry point for the activation registry precompile.
 #[precompile(install, args(activation_admin_address: Option<Address>))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
+
+impl ActivationRegistry {
+    /// Installs the activation registry precompile with an observer.
+    pub fn install_with_observer<O>(
+        precompiles: &mut PrecompilesMap,
+        activation_admin_address: Option<Address>,
+        observer: O,
+    ) where
+        O: PrecompileCallObserver,
+    {
+        precompiles.extend_precompiles(core::iter::once((
+            ActivationRegistryStorage::ADDRESS,
+            Self::precompile_with_observer(activation_admin_address, observer),
+        )));
+    }
+
+    /// Creates the EVM precompile wrapper for the activation registry with an observer.
+    pub fn precompile_with_observer<O>(
+        activation_admin_address: Option<Address>,
+        observer: O,
+    ) -> DynPrecompile
+    where
+        O: PrecompileCallObserver,
+    {
+        base_precompile!("ActivationRegistry", |ctx, calldata| {
+            let observer = observer.clone();
+            ActivationRegistryStorage::new(ctx).dispatch_with_observer(
+                ctx,
+                &calldata,
+                activation_admin_address,
+                observer,
+            )
+        })
+    }
+}

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -124,7 +124,9 @@ impl IB20Asset::IB20AssetCalls {
 
 #[cfg(test)]
 mod tests {
-    use crate::IB20Asset;
+    use alloy_sol_types::SolInterface;
+
+    use crate::{IB20, IB20Asset};
 
     #[test]
     fn asset_call_labels_are_stable() {
@@ -136,5 +138,22 @@ mod tests {
             .as_label(),
             "precompile-b20-asset-updateExtraMetadata"
         );
+    }
+
+    #[test]
+    fn asset_and_inherited_call_selectors_are_disjoint() {
+        for selector in IB20Asset::IB20AssetCalls::selectors() {
+            assert!(
+                !IB20::IB20Calls::valid_selector(selector),
+                "asset selector {selector:?} overlaps with inherited IB20 selector"
+            );
+        }
+
+        for selector in IB20::IB20Calls::selectors() {
+            assert!(
+                !IB20Asset::IB20AssetCalls::valid_selector(selector),
+                "inherited IB20 selector {selector:?} overlaps with asset selector"
+            );
+        }
     }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -110,8 +110,10 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
                 BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
             })?;
             let label = call.as_label();
-            return observer
-                .observe(label, || self.handle_asset_call(ctx, call, privileged, &observer));
+            let asset_observer = observer.clone();
+            return observer.observe(label, move || {
+                self.handle_asset_call(ctx, call, privileged, asset_observer)
+            });
         }
 
         // Fall through to inherited IB20 selectors.
@@ -338,7 +340,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         ctx: StorageCtx<'_>,
         call: SC,
         privileged: bool,
-        observer: &O,
+        observer: O,
     ) -> base_precompile_storage::Result<Bytes>
     where
         O: PrecompileCallObserver,
@@ -373,7 +375,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
             // --- Announcement ---
             SC::announce(c) => {
-                self.announce(ctx, c, privileged, observer)?;
+                self.announce(ctx, c, privileged, &observer)?;
                 Bytes::new()
             }
 

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -3,7 +3,7 @@
 //! Asset-specific selectors are tried first via `IB20Asset::IB20AssetCalls`.
 //! The `IB20` match block handles inherited selectors.
 
-use alloc::{string::String, vec::Vec};
+use alloc::string::ToString;
 
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolEvent, SolInterface, SolValue};
@@ -11,12 +11,13 @@ use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    AssetAccounting, B20AssetStorage, B20AssetToken, B20TokenRole, Burnable, Configurable,
+    AssetAccounting, B20AssetStorage, B20AssetToken, B20TokenRole, BerylAuxiliaryMetrics,
+    BerylCallRecorder, BerylMetricLabels, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
     PrecompileCallObserver, RoleManaged, Token, Transferable,
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    macros::decode_precompile_call,
 };
 
 impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
@@ -35,17 +36,21 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        deduct_calldata_cost!(ctx, calldata);
+        let mut recorder =
+            BerylCallRecorder::start(observer.clone(), BerylMetricLabels::b20_asset_call(calldata));
+        if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
+            return recorder.record_base_error_result(ctx, error);
+        }
 
         match self.accounting().is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+                return recorder
+                    .record_base_error_result(ctx, BasePrecompileError::Revert(Bytes::new()));
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
+            Err(error) => return recorder.record_base_error_result(ctx, error),
         }
-        ctx.result_output(self.inner_with_observer(ctx, calldata, observer), |b| b)
+        recorder.record_base_result(ctx, self.inner_with_observer(ctx, calldata, observer), |b| b)
     }
 
     /// Decodes calldata and executes the matching `IB20Asset` or inherited `IB20` operation.
@@ -98,9 +103,15 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         O: PrecompileCallObserver,
     {
         // Asset-specific and overridden selectors are caught here first.
-        if let Ok(call) = IB20Asset::IB20AssetCalls::abi_decode(calldata) {
+        if let Some(selector) = BerylMetricLabels::selector(calldata)
+            && IB20Asset::IB20AssetCalls::valid_selector(selector)
+        {
+            let call = IB20Asset::IB20AssetCalls::abi_decode(calldata).map_err(|error| {
+                BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+            })?;
             let label = call.as_label();
-            return observer.observe(label, || self.handle_asset_call(ctx, call, privileged));
+            return observer
+                .observe(label, || self.handle_asset_call(ctx, call, privileged, &observer));
         }
 
         // Fall through to inherited IB20 selectors.
@@ -322,12 +333,16 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         Ok(encoded)
     }
 
-    fn handle_asset_call(
+    fn handle_asset_call<O>(
         &mut self,
         ctx: StorageCtx<'_>,
         call: SC,
         privileged: bool,
-    ) -> base_precompile_storage::Result<Bytes> {
+        observer: &O,
+    ) -> base_precompile_storage::Result<Bytes>
+    where
+        O: PrecompileCallObserver,
+    {
         let caller = ctx.caller();
         let encoded: Bytes = match call {
             // --- Role / precision constants ---
@@ -358,12 +373,16 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
             // --- Announcement ---
             SC::announce(c) => {
-                self.announce(ctx, c.internalCalls, c.id, c.description, c.uri, privileged)?;
+                self.announce(ctx, c, privileged, observer)?;
                 Bytes::new()
             }
 
             // --- Batched mint ---
             SC::batchMint(c) => {
+                observer.record_batch_items(
+                    &BerylAuxiliaryMetrics::b20("asset", "batchMint"),
+                    c.recipients.len(),
+                );
                 self.batch_mint(caller, c.recipients, c.amounts, privileged)?;
                 Bytes::new()
             }
@@ -380,25 +399,41 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     /// Posts an announcement and atomically executes `internal_calls` via self-dispatch.
     ///
     /// The selector check in the inner loop prevents recursive invocation.
-    fn announce(
+    fn announce<O>(
         &mut self,
         ctx: StorageCtx<'_>,
-        internal_calls: Vec<Bytes>,
-        id: String,
-        description: String,
-        uri: String,
+        call: IB20Asset::announceCall,
         privileged: bool,
-    ) -> base_precompile_storage::Result<()> {
+        observer: &O,
+    ) -> base_precompile_storage::Result<()>
+    where
+        O: PrecompileCallObserver,
+    {
         let caller = ctx.caller();
+        let internal_calls = call.internalCalls;
+        let internal_call_count = internal_calls.len();
+        let internal_call_bytes = internal_calls.iter().map(|call| call.len()).sum();
+        observer.record_internal_calls(
+            &BerylAuxiliaryMetrics::b20("asset", "announce"),
+            internal_call_count,
+            internal_call_bytes,
+        );
         self.ensure_operator_role(caller, privileged)?;
 
+        let id = call.id;
         if self.accounting().is_announcement_id_used(id.as_str())? {
             return Err(BasePrecompileError::revert(IB20Asset::AnnouncementIdAlreadyUsed { id }));
         }
         self.accounting_mut().mark_announcement_id_used(id.as_str())?;
 
         self.accounting_mut().emit_event(
-            IB20Asset::Announcement { caller, id: id.clone(), description, uri }.encode_log_data(),
+            IB20Asset::Announcement {
+                caller,
+                id: id.clone(),
+                description: call.description,
+                uri: call.uri,
+            }
+            .encode_log_data(),
         )?;
 
         for call in &internal_calls {
@@ -422,7 +457,8 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::{string::String, vec::Vec};
+    use std::sync::{Arc, Mutex};
 
     use alloy_primitives::{Address, Bytes, U256};
     use alloy_sol_types::{SolCall, SolEvent};
@@ -432,11 +468,29 @@ mod tests {
 
     use crate::{
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
-        B20AssetToken, B20TokenRole, IB20, IB20Asset, InMemoryPolicy, InMemoryTokenAccounting,
-        Token, TokenAccounting,
+        B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset, InMemoryPolicy,
+        InMemoryTokenAccounting, PrecompileCallMetric, PrecompileCallObserver,
+        PrecompileCallOutcome, PrecompileCallStatus, Token, TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
+
+    #[derive(Debug, Clone, Default)]
+    struct RecordingObserver {
+        calls: Arc<Mutex<Vec<(PrecompileCallMetric, PrecompileCallOutcome)>>>,
+    }
+
+    impl RecordingObserver {
+        fn calls(&self) -> Vec<(PrecompileCallMetric, PrecompileCallOutcome)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl PrecompileCallObserver for RecordingObserver {
+        fn record_call(&self, call: &PrecompileCallMetric, outcome: &PrecompileCallOutcome) {
+            self.calls.lock().unwrap().push((call.clone(), *outcome));
+        }
+    }
 
     const ALICE: Address = Address::repeat_byte(0xaa);
     const BOB: Address = Address::repeat_byte(0xbb);
@@ -471,6 +525,49 @@ mod tests {
 
     fn batch_mint_calldata(recipients: Vec<Address>, amounts: Vec<U256>) -> Vec<u8> {
         IB20Asset::batchMintCall { recipients, amounts }.abi_encode()
+    }
+
+    #[test]
+    fn dispatch_with_observer_records_asset_success() {
+        let observer = RecordingObserver::default();
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+        let mut storage = storage_with_caller(ALICE);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, observer.clone())
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(output.is_success());
+        let calls = observer.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0.precompile, "b20");
+        assert_eq!(calls[0].0.method, "balanceOf");
+        assert_eq!(calls[0].0.variant, Some("asset"));
+        assert_eq!(calls[0].1.status, PrecompileCallStatus::Success);
+    }
+
+    #[test]
+    fn dispatch_with_observer_records_asset_decode_failure() {
+        let observer = RecordingObserver::default();
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall::SELECTOR;
+        let mut storage = storage_with_caller(ALICE);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, observer.clone())
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(output.is_revert());
+        let calls = observer.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0.precompile, "b20");
+        assert_eq!(calls[0].0.method, "balanceOf");
+        assert_eq!(calls[0].0.variant, Some("asset"));
+        assert_eq!(calls[0].1.status, PrecompileCallStatus::Revert);
+        assert_eq!(calls[0].1.error, Some(BerylErrorKind::AbiDecode));
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -12,7 +12,7 @@ use revm::precompile::PrecompileResult;
 
 use crate::{
     AssetAccounting, B20AssetStorage, B20AssetToken, B20TokenRole, BerylAuxiliaryMetrics,
-    BerylCallRecorder, BerylMetricLabels, Burnable, Configurable,
+    BerylCallRecorder, BerylMetricLabels, BerylSelector, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -103,7 +103,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         O: PrecompileCallObserver,
     {
         // Asset-specific and overridden selectors are caught here first.
-        if let Some(selector) = BerylMetricLabels::selector(calldata)
+        if let Some(selector) = BerylSelector::selector(calldata)
             && IB20Asset::IB20AssetCalls::valid_selector(selector)
         {
             let call = IB20Asset::IB20AssetCalls::abi_decode(calldata).map_err(|error| {

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -97,3 +97,35 @@ sol! {
         function isB20Initialized(address token) external view returns (bool);
     }
 }
+
+impl IB20Factory::IB20FactoryCalls {
+    /// Returns the stable metric label for this decoded factory call.
+    pub const fn as_label(&self) -> &'static str {
+        match self {
+            Self::createB20(_) => "factory.createB20",
+            Self::getB20Address(_) => "factory.getB20Address",
+            Self::isB20(_) => "factory.isB20",
+            Self::isB20Initialized(_) => "factory.isB20Initialized",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256};
+
+    use crate::IB20Factory;
+
+    #[test]
+    fn factory_call_labels_are_stable() {
+        assert_eq!(
+            IB20Factory::IB20FactoryCalls::getB20Address(IB20Factory::getB20AddressCall {
+                variant: IB20Factory::B20Variant::ASSET,
+                sender: Address::ZERO,
+                salt: B256::ZERO,
+            })
+            .as_label(),
+            "factory.getB20Address"
+        );
+    }
+}

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -6,26 +6,51 @@ use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20FactoryStorage, B20Variant, IB20Factory,
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    B20FactoryStorage, B20Variant, BerylCallRecorder, BerylMetricLabels, IB20Factory,
+    NoopPrecompileCallObserver, PrecompileCallObserver, macros::decode_precompile_call,
 };
 
 impl<'a> B20FactoryStorage<'a> {
     /// ABI-dispatches `calldata` to the appropriate `IB20Factory` handler.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        deduct_calldata_cost!(ctx, calldata);
-        ctx.result_output(self.inner(ctx, calldata), |b| b)
+        self.dispatch_with_observer(ctx, calldata, NoopPrecompileCallObserver)
     }
 
-    fn inner(
+    /// ABI-dispatches `calldata` to the appropriate `IB20Factory` handler with an observer.
+    pub fn dispatch_with_observer<O>(
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
-    ) -> base_precompile_storage::Result<Bytes> {
+        observer: O,
+    ) -> PrecompileResult
+    where
+        O: PrecompileCallObserver,
+    {
+        let mut recorder =
+            BerylCallRecorder::start(observer.clone(), BerylMetricLabels::factory_call(calldata));
+        if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
+            return recorder.record_base_error_result(ctx, error);
+        }
+        recorder.record_base_result(ctx, self.inner(ctx, calldata, observer), |b| b)
+    }
+
+    fn inner<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+    ) -> base_precompile_storage::Result<Bytes>
+    where
+        O: PrecompileCallObserver,
+    {
         match decode_precompile_call!(calldata, IB20Factory::IB20FactoryCalls) {
             IB20Factory::IB20FactoryCalls::createB20(call) => {
                 let caller = ctx.caller();
-                let token = self.create_b20(caller, call)?;
+                let variant = B20Variant::from_abi(call.variant);
+                let token = self.create_b20_with_observer(caller, call, observer.clone())?;
+                if let Some(variant) = variant {
+                    observer.record_b20_created(variant.as_label());
+                }
                 Ok(IB20Factory::createB20Call::abi_encode_returns(&token).into())
             }
             IB20Factory::IB20FactoryCalls::getB20Address(call) => {

--- a/crates/common/precompiles/src/b20_factory/precompile.rs
+++ b/crates/common/precompiles/src/b20_factory/precompile.rs
@@ -1,10 +1,35 @@
 //! Precompile entry point for the `B20Factory`.
 
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use base_precompile_macros::precompile;
 
-use crate::B20FactoryStorage;
+use crate::{B20FactoryStorage, PrecompileCallObserver, macros::base_precompile};
 
 /// Entry point for the `B20Factory` precompile.
 #[precompile(install)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct B20Factory;
+
+impl B20Factory {
+    /// Installs the `B20Factory` precompile with an observer.
+    pub fn install_with_observer<O>(precompiles: &mut PrecompilesMap, observer: O)
+    where
+        O: PrecompileCallObserver,
+    {
+        precompiles.extend_precompiles(core::iter::once((
+            B20FactoryStorage::ADDRESS,
+            Self::precompile_with_observer(observer),
+        )));
+    }
+
+    /// Creates the EVM precompile wrapper for `B20Factory` with an observer.
+    pub fn precompile_with_observer<O>(observer: O) -> DynPrecompile
+    where
+        O: PrecompileCallObserver,
+    {
+        base_precompile!("B20Factory", |ctx, calldata| {
+            let observer = observer.clone();
+            B20FactoryStorage::new(ctx).dispatch_with_observer(ctx, &calldata, observer)
+        })
+    }
+}

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -8,8 +8,9 @@ use revm::state::Bytecode;
 
 use crate::{
     ActivationRegistryStorage, B20AssetInit, B20AssetStorage, B20AssetToken, B20StablecoinInit,
-    B20StablecoinStorage, B20StablecoinToken, B20TokenRole, B20Variant, IB20Factory, PolicyHandle,
-    RoleManaged, Token,
+    B20StablecoinStorage, B20StablecoinToken, B20TokenRole, B20Variant, BerylAuxiliaryMetrics,
+    IB20Factory, NoopPrecompileCallObserver, PolicyHandle, PrecompileCallObserver, RoleManaged,
+    Token,
 };
 
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
@@ -49,6 +50,19 @@ impl<'a> B20FactoryStorage<'a> {
         caller: Address,
         call: IB20Factory::createB20Call,
     ) -> Result<Address> {
+        self.create_b20_with_observer(caller, call, NoopPrecompileCallObserver)
+    }
+
+    /// Creates a token at a deterministic address and records observer-only metrics.
+    pub fn create_b20_with_observer<O>(
+        &mut self,
+        caller: Address,
+        call: IB20Factory::createB20Call,
+        observer: O,
+    ) -> Result<Address>
+    where
+        O: PrecompileCallObserver,
+    {
         let variant = B20Variant::from_abi(call.variant)
             .ok_or_else(|| BasePrecompileError::revert(IB20Factory::InvalidVariant {}))?;
         ActivationRegistryStorage::new(self.storage)
@@ -73,10 +87,10 @@ impl<'a> B20FactoryStorage<'a> {
         let init_calls = call.initCalls;
         match params {
             TokenCreateParams::Stablecoin { common, init } => {
-                self.init_stablecoin(token_address, common, init, init_calls)?;
+                self.init_stablecoin(token_address, common, init, init_calls, observer)?;
             }
             TokenCreateParams::Asset { common, init } => {
-                self.init_asset_token(token_address, common, init, init_calls)?;
+                self.init_asset_token(token_address, common, init, init_calls, observer)?;
             }
         }
 
@@ -101,13 +115,17 @@ impl<'a> B20FactoryStorage<'a> {
         self.storage.with_account_info(token, |info| Ok(!info.is_empty_code_hash()))
     }
 
-    fn init_stablecoin(
+    fn init_stablecoin<O>(
         &mut self,
         token_address: Address,
         common: CommonParams,
         init: B20StablecoinInit,
         init_calls: Vec<Bytes>,
-    ) -> Result<()> {
+        observer: O,
+    ) -> Result<()>
+    where
+        O: PrecompileCallObserver,
+    {
         let mut token = B20StablecoinToken::with_storage_and_policy(
             B20StablecoinStorage::from_address(token_address, self.storage),
             PolicyHandle::new(self.storage),
@@ -133,6 +151,14 @@ impl<'a> B20FactoryStorage<'a> {
             )?;
         }
 
+        let internal_call_count = init_calls.len();
+        let internal_call_bytes = init_calls.iter().map(|call| call.len()).sum();
+        observer.record_internal_calls(
+            &BerylAuxiliaryMetrics::singleton("factory", "createB20"),
+            internal_call_count,
+            internal_call_bytes,
+        );
+
         self.storage.with_caller(Self::ADDRESS, || {
             for (index, calldata) in init_calls.into_iter().enumerate() {
                 token
@@ -144,13 +170,17 @@ impl<'a> B20FactoryStorage<'a> {
         Ok(())
     }
 
-    fn init_asset_token(
+    fn init_asset_token<O>(
         &mut self,
         token_address: Address,
         common: CommonParams,
         init: B20AssetInit,
         init_calls: Vec<Bytes>,
-    ) -> Result<()> {
+        observer: O,
+    ) -> Result<()>
+    where
+        O: PrecompileCallObserver,
+    {
         let mut token = B20AssetToken::with_storage_and_policy(
             B20AssetStorage::from_address(token_address, self.storage),
             PolicyHandle::new(self.storage),
@@ -174,6 +204,14 @@ impl<'a> B20FactoryStorage<'a> {
                 Self::ADDRESS,
             )?;
         }
+
+        let internal_call_count = init_calls.len();
+        let internal_call_bytes = init_calls.iter().map(|call| call.len()).sum();
+        observer.record_internal_calls(
+            &BerylAuxiliaryMetrics::singleton("factory", "createB20"),
+            internal_call_count,
+            internal_call_bytes,
+        );
 
         self.storage.with_caller(Self::ADDRESS, || {
             for (index, calldata) in init_calls.into_iter().enumerate() {

--- a/crates/common/precompiles/src/b20_factory/variant.rs
+++ b/crates/common/precompiles/src/b20_factory/variant.rs
@@ -108,6 +108,14 @@ impl B20Variant {
         }
     }
 
+    /// Returns the stable metric label for this B-20 variant.
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Asset => "asset",
+            Self::Stablecoin => "stablecoin",
+        }
+    }
+
     /// Builds this variant's B-20 address prefix.
     pub const fn address_prefix(self) -> [u8; 11] {
         [Self::PREFIX_BYTE, 0, 0, 0, 0, 0, 0, 0, 0, 0, self.discriminant()]

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -5,18 +5,20 @@
 //! distinction is the `StablecoinAccounting` bound that provides `currency()`
 //! from the stablecoin extension namespace.
 
+use alloc::string::ToString;
+
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20StablecoinToken, B20TokenRole, Burnable, Configurable,
+    B20StablecoinToken, B20TokenRole, BerylCallRecorder, BerylMetricLabels, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
     PrecompileCallObserver, RoleManaged, StablecoinAccounting, Token, Transferable,
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    macros::decode_precompile_call,
 };
 
 impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
@@ -35,17 +37,23 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        deduct_calldata_cost!(ctx, calldata);
+        let mut recorder = BerylCallRecorder::start(
+            observer.clone(),
+            BerylMetricLabels::b20_stablecoin_call(calldata),
+        );
+        if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
+            return recorder.record_base_error_result(ctx, error);
+        }
         // Ensure the token has been deployed (has bytecode at its address).
         match self.accounting().is_initialized() {
             Ok(true) => {}
             Ok(false) => {
-                return BasePrecompileError::Revert(Bytes::new())
-                    .into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+                return recorder
+                    .record_base_error_result(ctx, BasePrecompileError::Revert(Bytes::new()));
             }
-            Err(e) => return e.into_precompile_result(ctx.gas_used(), ctx.state_gas_used()),
+            Err(error) => return recorder.record_base_error_result(ctx, error),
         }
-        ctx.result_output(self.inner_with_observer(ctx, calldata, observer), |b| b)
+        recorder.record_base_result(ctx, self.inner_with_observer(ctx, calldata, observer), |b| b)
     }
 
     /// Decodes calldata and executes the matching `IB20` operation.
@@ -97,7 +105,13 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        if let Ok(call) = IB20Stablecoin::IB20StablecoinCalls::abi_decode(calldata) {
+        if let Some(selector) = BerylMetricLabels::selector(calldata)
+            && IB20Stablecoin::IB20StablecoinCalls::valid_selector(selector)
+        {
+            let call =
+                IB20Stablecoin::IB20StablecoinCalls::abi_decode(calldata).map_err(|error| {
+                    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+                })?;
             let label = call.as_label();
             return observer.observe(label, || self.handle_stablecoin_call(call));
         }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -13,7 +13,8 @@ use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20StablecoinToken, B20TokenRole, BerylCallRecorder, BerylMetricLabels, Burnable, Configurable,
+    B20StablecoinToken, B20TokenRole, BerylCallRecorder, BerylMetricLabels, BerylSelector,
+    Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -105,7 +106,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        if let Some(selector) = BerylMetricLabels::selector(calldata)
+        if let Some(selector) = BerylSelector::selector(calldata)
             && IB20Stablecoin::IB20StablecoinCalls::valid_selector(selector)
         {
             let call =

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -51,7 +51,7 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 mod metrics;
 pub use metrics::{
     BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
-    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, PrecompileCallMetric,
+    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, PrecompileCallMetric,
     PrecompileCallOutcome, PrecompileCallStatus,
 };
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -48,6 +48,13 @@ pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, T
 mod observer;
 pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver};
 
+mod metrics;
+pub use metrics::{
+    BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
+    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, PrecompileCallMetric,
+    PrecompileCallOutcome, PrecompileCallStatus,
+};
+
 mod b20_asset;
 pub use b20_asset::{
     AssetAccounting, B20AssetExtensionStorage, B20AssetInit, B20AssetPrecompile, B20AssetStorage,

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -46,21 +46,6 @@ macro_rules! base_precompile {
 
 pub(crate) use base_precompile;
 
-/// Deducts the per-word calldata gas charged by Base native precompile dispatch.
-macro_rules! deduct_calldata_cost {
-    ($ctx:expr, $calldata:expr $(,)?) => {{
-        const G_SHA3WORD: u64 = 6;
-
-        let calldata_len = $calldata.len();
-        let calldata_cost = calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64;
-        if let Err(e) = $ctx.deduct_gas(calldata_cost) {
-            return e.into_precompile_result($ctx.gas_used(), $ctx.state_gas_used());
-        }
-    }};
-}
-
-pub(crate) use deduct_calldata_cost;
-
 /// Decodes calldata into the requested ABI interface call or returns an unknown selector error.
 macro_rules! decode_precompile_call {
     ($calldata:expr, $call_ty:ty $(,)?) => {{
@@ -80,9 +65,24 @@ macro_rules! decode_precompile_call {
             }
         };
 
-        <$call_ty as ::alloy_sol_types::SolInterface>::abi_decode(calldata).map_err(|_| {
-            ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector(selector)
-        })?
+        match <$call_ty as ::alloy_sol_types::SolInterface>::abi_decode(calldata) {
+            Ok(call) => call,
+            Err(error)
+                if <$call_ty as ::alloy_sol_types::SolInterface>::valid_selector(selector) =>
+            {
+                return Err(::base_precompile_storage::BasePrecompileError::AbiDecodeFailed {
+                    selector,
+                    error: ::alloc::string::ToString::to_string(&error),
+                });
+            }
+            Err(_) => {
+                return Err(
+                    ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector(
+                        selector,
+                    ),
+                );
+            }
+        }
     }};
 }
 
@@ -111,6 +111,19 @@ mod tests {
         let err = decode_policy_call(&[1, 2, 3, 4]).unwrap_err();
 
         assert_eq!(err, BasePrecompileError::UnknownFunctionSelector([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn decode_precompile_call_classifies_known_selector_decode_failure() {
+        let err = decode_policy_call(&IPolicyRegistry::createPolicyCall::SELECTOR).unwrap_err();
+
+        assert!(matches!(
+            err,
+            BasePrecompileError::AbiDecodeFailed {
+                selector: IPolicyRegistry::createPolicyCall::SELECTOR,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -245,7 +245,7 @@ impl BerylErrorKind {
 
     /// Classifies ABI-encoded revert bytes into a bounded metric label.
     pub fn from_revert_bytes(bytes: &Bytes) -> Self {
-        let Some(selector) = BerylErrorClassifier::selector(bytes) else {
+        let Some(selector) = BerylSelector::selector(bytes.as_ref()) else {
             return Self::OtherRevert;
         };
 
@@ -339,19 +339,25 @@ impl BerylErrorKind {
     }
 }
 
-/// Helpers for working with ABI error selectors.
+/// Helpers for extracting ABI selectors from encoded data.
 #[derive(Debug, Clone, Copy)]
-pub struct BerylErrorClassifier;
+pub struct BerylSelector;
 
-impl BerylErrorClassifier {
-    /// Returns the ABI error selector from encoded revert bytes.
-    pub fn selector(bytes: &Bytes) -> Option<[u8; 4]> {
+impl BerylSelector {
+    /// Returns the ABI selector from encoded data, if present.
+    pub fn selector(bytes: &[u8]) -> Option<[u8; 4]> {
         let bytes = bytes.get(..4)?;
         let mut selector = [0u8; 4];
         selector.copy_from_slice(bytes);
         Some(selector)
     }
+}
 
+/// Helpers for working with ABI error selectors.
+#[derive(Debug, Clone, Copy)]
+pub struct BerylErrorClassifier;
+
+impl BerylErrorClassifier {
     /// Returns whether `selector` belongs to the ABI error type `E`.
     pub fn is_error_selector<E>(selector: [u8; 4]) -> bool
     where
@@ -366,14 +372,6 @@ impl BerylErrorClassifier {
 pub struct BerylMetricLabels;
 
 impl BerylMetricLabels {
-    /// Returns the ABI selector in calldata, if present.
-    pub fn selector(calldata: &[u8]) -> Option<[u8; 4]> {
-        let bytes = calldata.get(..4)?;
-        let mut selector = [0u8; 4];
-        selector.copy_from_slice(bytes);
-        Some(selector)
-    }
-
     /// Returns a B-20 method label from an existing stable call label.
     pub fn b20_method(label: &'static str) -> Cow<'static, str> {
         Cow::Borrowed(
@@ -397,7 +395,7 @@ impl BerylMetricLabels {
 
     /// Returns the metric method label for factory calldata.
     pub fn factory_method(calldata: &[u8]) -> Cow<'static, str> {
-        match Self::selector(calldata) {
+        match BerylSelector::selector(calldata) {
             Some(IB20Factory::createB20Call::SELECTOR) => Cow::Borrowed("createB20"),
             Some(IB20Factory::getB20AddressCall::SELECTOR) => Cow::Borrowed("getB20Address"),
             Some(IB20Factory::isB20Call::SELECTOR) => Cow::Borrowed("isB20"),
@@ -417,7 +415,7 @@ impl BerylMetricLabels {
 
     /// Returns the metric method label for activation-registry calldata.
     pub fn activation_method(calldata: &[u8]) -> Cow<'static, str> {
-        match Self::selector(calldata) {
+        match BerylSelector::selector(calldata) {
             Some(IActivationRegistry::isActivatedCall::SELECTOR) => Cow::Borrowed("isActivated"),
             Some(IActivationRegistry::checkActivatedCall::SELECTOR) => {
                 Cow::Borrowed("checkActivated")
@@ -436,7 +434,7 @@ impl BerylMetricLabels {
 
     /// Returns the metric method label for policy-registry calldata.
     pub fn policy_method(calldata: &[u8]) -> Cow<'static, str> {
-        match Self::selector(calldata) {
+        match BerylSelector::selector(calldata) {
             Some(IPolicyRegistry::createPolicyCall::SELECTOR) => Cow::Borrowed("createPolicy"),
             Some(IPolicyRegistry::createPolicyWithAccountsCall::SELECTOR) => {
                 Cow::Borrowed("createPolicyWithAccounts")
@@ -471,7 +469,7 @@ impl BerylMetricLabels {
 
     /// Returns the metric method label for asset B-20 calldata.
     pub fn b20_asset_method(calldata: &[u8]) -> Cow<'static, str> {
-        let Some(selector) = Self::selector(calldata) else {
+        let Some(selector) = BerylSelector::selector(calldata) else {
             return Self::unknown();
         };
         if let Some(method) = IB20Asset::IB20AssetCalls::name_by_selector(selector) {
@@ -494,7 +492,7 @@ impl BerylMetricLabels {
 
     /// Returns the metric method label for stablecoin B-20 calldata.
     pub fn b20_stablecoin_method(calldata: &[u8]) -> Cow<'static, str> {
-        let Some(selector) = Self::selector(calldata) else {
+        let Some(selector) = BerylSelector::selector(calldata) else {
             return Self::unknown();
         };
         if let Some(method) = IB20Stablecoin::IB20StablecoinCalls::name_by_selector(selector) {
@@ -646,8 +644,8 @@ mod tests {
     use base_precompile_storage::BasePrecompileError;
 
     use crate::{
-        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, IB20, IB20Factory, IPolicyRegistry,
-        metrics::BerylErrorClassifier,
+        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, BerylSelector, IB20, IB20Factory,
+        IPolicyRegistry,
     };
 
     #[test]
@@ -696,9 +694,9 @@ mod tests {
 
     #[test]
     fn selector_extracts_revert_selector() {
-        let bytes = IB20::Unauthorized {}.abi_encode().into();
+        let bytes = IB20::Unauthorized {}.abi_encode();
         assert_eq!(
-            BerylErrorClassifier::selector(&bytes),
+            BerylSelector::selector(&bytes),
             Some(<IB20::Unauthorized as SolError>::SELECTOR)
         );
     }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -579,8 +579,7 @@ where
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
         const G_SHA3WORD: u64 = 6;
 
-        let calldata_len = calldata.len();
-        let calldata_cost = calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64;
+        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(G_SHA3WORD);
         ctx.deduct_gas(calldata_cost)
     }
 

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -1,0 +1,717 @@
+//! Low-cardinality metadata for observing Beryl-native precompile calls.
+
+use alloc::{borrow::Cow, string::ToString};
+#[cfg(feature = "std")]
+use std::time::Instant;
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::{SolCall, SolError};
+use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
+use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+
+use crate::{IActivationRegistry, IB20, IB20Asset, IB20Factory, IB20Stablecoin, IPolicyRegistry};
+
+/// Low-cardinality metadata for one Beryl-native precompile call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrecompileCallMetric {
+    /// Beryl precompile surface, such as `factory`, `activation`, `policy`, or `b20`.
+    pub precompile: &'static str,
+    /// ABI method name or `unknown`.
+    pub method: Cow<'static, str>,
+    /// Optional variant label. Dynamic B-20 calls use `asset` or `stablecoin`.
+    pub variant: Option<&'static str>,
+    /// Calldata byte length.
+    pub input_bytes: usize,
+}
+
+impl PrecompileCallMetric {
+    /// Creates a call metric descriptor.
+    pub fn new(
+        precompile: &'static str,
+        method: impl Into<Cow<'static, str>>,
+        variant: Option<&'static str>,
+        input_bytes: usize,
+    ) -> Self {
+        Self { precompile, method: method.into(), variant, input_bytes }
+    }
+
+    /// Creates a call metric descriptor without a variant.
+    pub fn singleton(
+        precompile: &'static str,
+        method: impl Into<Cow<'static, str>>,
+        input_bytes: usize,
+    ) -> Self {
+        Self::new(precompile, method, None, input_bytes)
+    }
+
+    /// Creates a call metric descriptor for a dynamic B-20 token call.
+    pub fn b20(
+        variant: &'static str,
+        method: impl Into<Cow<'static, str>>,
+        input_bytes: usize,
+    ) -> Self {
+        Self::new("b20", method, Some(variant), input_bytes)
+    }
+
+    /// Returns the variant label used by metrics backends for calls without a variant.
+    pub fn variant_label(&self) -> &'static str {
+        self.variant.unwrap_or("none")
+    }
+}
+
+/// Bounded terminal status for a native precompile call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrecompileCallStatus {
+    /// The call completed successfully.
+    Success,
+    /// The call returned an EVM revert.
+    Revert,
+    /// The call halted without returning an EVM revert.
+    Halt,
+    /// The call returned a fatal precompile error.
+    Fatal,
+}
+
+impl PrecompileCallStatus {
+    /// Returns the metric label for this status.
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Revert => "revert",
+            Self::Halt => "halt",
+            Self::Fatal => "fatal",
+        }
+    }
+
+    /// Classifies a [`PrecompileResult`] into a bounded status.
+    pub fn from_result(result: &PrecompileResult) -> Self {
+        match result {
+            Ok(output) if output.is_success() => Self::Success,
+            Ok(output) if output.is_revert() => Self::Revert,
+            Ok(_) => Self::Halt,
+            Err(_) => Self::Fatal,
+        }
+    }
+}
+
+/// Backwards-compatible alias for Beryl call status labels.
+pub type BerylCallOutcome = PrecompileCallStatus;
+
+/// Final outcome for one Beryl-native precompile call.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PrecompileCallOutcome {
+    /// Terminal call status.
+    pub status: PrecompileCallStatus,
+    /// Regular gas used by the precompile.
+    pub gas_used: u64,
+    /// State gas used by the precompile.
+    pub state_gas_used: u64,
+    /// Gas refunded by the precompile.
+    pub gas_refunded: i64,
+    /// Total time spent in the Beryl dispatch wrapper, in seconds.
+    pub duration_seconds: Option<f64>,
+    /// Optional bounded error class.
+    pub error: Option<BerylErrorKind>,
+}
+
+impl PrecompileCallOutcome {
+    /// Creates a call outcome from a [`PrecompileResult`].
+    pub fn from_result(
+        result: &PrecompileResult,
+        duration_seconds: Option<f64>,
+        error: Option<BerylErrorKind>,
+    ) -> Self {
+        match result {
+            Ok(output) => Self::from_output(output, duration_seconds, error),
+            Err(error) => Self {
+                status: PrecompileCallStatus::Fatal,
+                gas_used: 0,
+                state_gas_used: 0,
+                gas_refunded: 0,
+                duration_seconds,
+                error: Some(BerylErrorKind::from_precompile_error(error)),
+            },
+        }
+    }
+
+    /// Creates a call outcome from a successful, reverted, or halted precompile output.
+    pub fn from_output(
+        output: &PrecompileOutput,
+        duration_seconds: Option<f64>,
+        mut error: Option<BerylErrorKind>,
+    ) -> Self {
+        let status = if output.is_success() {
+            PrecompileCallStatus::Success
+        } else if output.is_revert() {
+            if error.is_none() {
+                error = Some(BerylErrorKind::from_revert_bytes(&output.bytes));
+            }
+            PrecompileCallStatus::Revert
+        } else {
+            PrecompileCallStatus::Halt
+        };
+
+        Self {
+            status,
+            gas_used: output.gas_used,
+            state_gas_used: output.state_gas_used,
+            gas_refunded: output.gas_refunded,
+            duration_seconds,
+            error,
+        }
+    }
+}
+
+/// Bounded error-class label for precompile failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BerylErrorKind {
+    /// State mutation was attempted during a static call.
+    StaticWrite,
+    /// Calldata did not contain a known selector.
+    UnknownSelector,
+    /// Calldata used a known selector but failed ABI decoding.
+    AbiDecode,
+    /// The feature was inactive in the activation registry.
+    FeatureInactive,
+    /// The caller did not have the required permission.
+    Unauthorized,
+    /// A policy denied the attempted operation.
+    PolicyDenied,
+    /// A referenced policy does not exist.
+    PolicyMissing,
+    /// The token feature was paused.
+    Paused,
+    /// Factory creation targeted an already-created token address.
+    DuplicateCreate,
+    /// Inputs were invalid.
+    InvalidInput,
+    /// An internal call failed.
+    InternalCallFailed,
+    /// The precompile ran out of gas.
+    OutOfGas,
+    /// The precompile returned a Solidity panic.
+    Panic,
+    /// The precompile hit an unrecoverable internal error.
+    Fatal,
+    /// The precompile hit a storage-slot overflow.
+    SlotOverflow,
+    /// The revert did not match a more specific bounded class.
+    OtherRevert,
+}
+
+impl BerylErrorKind {
+    /// Returns the metric label for this error kind.
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::StaticWrite => "static_write",
+            Self::UnknownSelector => "unknown_selector",
+            Self::AbiDecode => "abi_decode",
+            Self::FeatureInactive => "feature_inactive",
+            Self::Unauthorized => "unauthorized",
+            Self::PolicyDenied => "policy_denied",
+            Self::PolicyMissing => "policy_missing",
+            Self::Paused => "paused",
+            Self::DuplicateCreate => "duplicate_create",
+            Self::InvalidInput => "invalid_input",
+            Self::InternalCallFailed => "internal_call_failed",
+            Self::OutOfGas => "out_of_gas",
+            Self::Panic => "panic",
+            Self::Fatal => "fatal",
+            Self::SlotOverflow => "slot_overflow",
+            Self::OtherRevert => "other_revert",
+        }
+    }
+
+    /// Classifies a Base precompile error into a bounded metric label.
+    pub fn from_base_error(error: &BasePrecompileError) -> Self {
+        match error {
+            BasePrecompileError::StaticCallViolation => Self::StaticWrite,
+            BasePrecompileError::UnknownFunctionSelector(_) => Self::UnknownSelector,
+            BasePrecompileError::AbiDecodeFailed { .. } => Self::AbiDecode,
+            BasePrecompileError::OutOfGas => Self::OutOfGas,
+            BasePrecompileError::Panic(_) => Self::Panic,
+            BasePrecompileError::Fatal(_) => Self::Fatal,
+            BasePrecompileError::SlotOverflow => Self::SlotOverflow,
+            BasePrecompileError::Revert(bytes) => Self::from_revert_bytes(bytes),
+        }
+    }
+
+    /// Classifies a raw precompile error into a bounded metric label.
+    pub const fn from_precompile_error(error: &PrecompileError) -> Self {
+        match error {
+            PrecompileError::Fatal(_) | PrecompileError::FatalAny(_) => Self::Fatal,
+        }
+    }
+
+    /// Classifies ABI-encoded revert bytes into a bounded metric label.
+    pub fn from_revert_bytes(bytes: &Bytes) -> Self {
+        let Some(selector) = BerylErrorClassifier::selector(bytes) else {
+            return Self::OtherRevert;
+        };
+
+        if BerylErrorClassifier::is_error_selector::<IActivationRegistry::StaticCallNotAllowed>(
+            selector,
+        ) {
+            return Self::StaticWrite;
+        }
+        if BerylErrorClassifier::is_error_selector::<IActivationRegistry::FeatureNotActivated>(
+            selector,
+        ) {
+            return Self::FeatureInactive;
+        }
+        if BerylErrorClassifier::is_error_selector::<IActivationRegistry::Unauthorized>(selector)
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::Unauthorized>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::Unauthorized>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::AccessControlUnauthorizedAccount>(
+                selector,
+            )
+        {
+            return Self::Unauthorized;
+        }
+        if BerylErrorClassifier::is_error_selector::<IB20::PolicyForbids>(selector) {
+            return Self::PolicyDenied;
+        }
+        if BerylErrorClassifier::is_error_selector::<IPolicyRegistry::PolicyNotFound>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::PolicyNotFound>(selector)
+        {
+            return Self::PolicyMissing;
+        }
+        if BerylErrorClassifier::is_error_selector::<IB20::ContractPaused>(selector) {
+            return Self::Paused;
+        }
+        if BerylErrorClassifier::is_error_selector::<IB20Factory::TokenAlreadyExists>(selector) {
+            return Self::DuplicateCreate;
+        }
+        if BerylErrorClassifier::is_error_selector::<IB20Factory::InitCallFailed>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::InternalCallFailed>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::InternalCallMalformed>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::AnnouncementInProgress>(
+                selector,
+            )
+        {
+            return Self::InternalCallFailed;
+        }
+        if BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidVariant>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Factory::UnsupportedVersion>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Factory::MissingRequiredField>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidCurrency>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidDecimals>(selector)
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::IncompatiblePolicyType>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::ZeroAddress>(selector)
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::BatchSizeTooLarge>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::NoPendingAdmin>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::AnnouncementIdAlreadyUsed>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::InvalidMetadataKey>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::LengthMismatch>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::EmptyBatch>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSender>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidReceiver>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidApprover>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSpender>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidAmount>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::EmptyFeatureSet>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSupplyCap>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::SupplyCapExceeded>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InsufficientAllowance>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InsufficientBalance>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::AccountNotBlocked>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::ExpiredSignature>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSigner>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::LastAdminCannotRenounce>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::NotSoleAdmin>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::AccessControlBadConfirmation>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IB20::UnsupportedPolicyType>(selector)
+        {
+            return Self::InvalidInput;
+        }
+
+        Self::OtherRevert
+    }
+}
+
+/// Helpers for working with ABI error selectors.
+#[derive(Debug, Clone, Copy)]
+pub struct BerylErrorClassifier;
+
+impl BerylErrorClassifier {
+    /// Returns the ABI error selector from encoded revert bytes.
+    pub fn selector(bytes: &Bytes) -> Option<[u8; 4]> {
+        let bytes = bytes.get(..4)?;
+        let mut selector = [0u8; 4];
+        selector.copy_from_slice(bytes);
+        Some(selector)
+    }
+
+    /// Returns whether `selector` belongs to the ABI error type `E`.
+    pub fn is_error_selector<E>(selector: [u8; 4]) -> bool
+    where
+        E: SolError,
+    {
+        selector == E::SELECTOR
+    }
+}
+
+/// Method-label helpers for Beryl call observation.
+#[derive(Debug, Clone, Copy)]
+pub struct BerylMetricLabels;
+
+impl BerylMetricLabels {
+    /// Returns the ABI selector in calldata, if present.
+    pub fn selector(calldata: &[u8]) -> Option<[u8; 4]> {
+        let bytes = calldata.get(..4)?;
+        let mut selector = [0u8; 4];
+        selector.copy_from_slice(bytes);
+        Some(selector)
+    }
+
+    /// Returns a B-20 method label from an existing stable call label.
+    pub fn b20_method(label: &'static str) -> Cow<'static, str> {
+        Cow::Borrowed(
+            label
+                .strip_prefix("precompile-b20-asset-")
+                .or_else(|| label.strip_prefix("precompile-b20-stablecoin-"))
+                .or_else(|| label.strip_prefix("precompile-b20-"))
+                .unwrap_or(label),
+        )
+    }
+
+    /// Returns the metric method label for an unknown method.
+    pub const fn unknown() -> Cow<'static, str> {
+        Cow::Borrowed("unknown")
+    }
+
+    /// Returns call metadata for factory calldata.
+    pub fn factory_call(calldata: &[u8]) -> PrecompileCallMetric {
+        PrecompileCallMetric::singleton("factory", Self::factory_method(calldata), calldata.len())
+    }
+
+    /// Returns the metric method label for factory calldata.
+    pub fn factory_method(calldata: &[u8]) -> Cow<'static, str> {
+        match Self::selector(calldata) {
+            Some(IB20Factory::createB20Call::SELECTOR) => Cow::Borrowed("createB20"),
+            Some(IB20Factory::getB20AddressCall::SELECTOR) => Cow::Borrowed("getB20Address"),
+            Some(IB20Factory::isB20Call::SELECTOR) => Cow::Borrowed("isB20"),
+            Some(IB20Factory::isB20InitializedCall::SELECTOR) => Cow::Borrowed("isB20Initialized"),
+            _ => Self::unknown(),
+        }
+    }
+
+    /// Returns call metadata for activation-registry calldata.
+    pub fn activation_call(calldata: &[u8]) -> PrecompileCallMetric {
+        PrecompileCallMetric::singleton(
+            "activation",
+            Self::activation_method(calldata),
+            calldata.len(),
+        )
+    }
+
+    /// Returns the metric method label for activation-registry calldata.
+    pub fn activation_method(calldata: &[u8]) -> Cow<'static, str> {
+        match Self::selector(calldata) {
+            Some(IActivationRegistry::isActivatedCall::SELECTOR) => Cow::Borrowed("isActivated"),
+            Some(IActivationRegistry::checkActivatedCall::SELECTOR) => {
+                Cow::Borrowed("checkActivated")
+            }
+            Some(IActivationRegistry::adminCall::SELECTOR) => Cow::Borrowed("admin"),
+            Some(IActivationRegistry::activateCall::SELECTOR) => Cow::Borrowed("activate"),
+            Some(IActivationRegistry::deactivateCall::SELECTOR) => Cow::Borrowed("deactivate"),
+            _ => Self::unknown(),
+        }
+    }
+
+    /// Returns call metadata for policy-registry calldata.
+    pub fn policy_call(calldata: &[u8]) -> PrecompileCallMetric {
+        PrecompileCallMetric::singleton("policy", Self::policy_method(calldata), calldata.len())
+    }
+
+    /// Returns the metric method label for policy-registry calldata.
+    pub fn policy_method(calldata: &[u8]) -> Cow<'static, str> {
+        match Self::selector(calldata) {
+            Some(IPolicyRegistry::createPolicyCall::SELECTOR) => Cow::Borrowed("createPolicy"),
+            Some(IPolicyRegistry::createPolicyWithAccountsCall::SELECTOR) => {
+                Cow::Borrowed("createPolicyWithAccounts")
+            }
+            Some(IPolicyRegistry::stageUpdateAdminCall::SELECTOR) => {
+                Cow::Borrowed("stageUpdateAdmin")
+            }
+            Some(IPolicyRegistry::finalizeUpdateAdminCall::SELECTOR) => {
+                Cow::Borrowed("finalizeUpdateAdmin")
+            }
+            Some(IPolicyRegistry::renounceAdminCall::SELECTOR) => Cow::Borrowed("renounceAdmin"),
+            Some(IPolicyRegistry::updateAllowlistCall::SELECTOR) => {
+                Cow::Borrowed("updateAllowlist")
+            }
+            Some(IPolicyRegistry::updateBlocklistCall::SELECTOR) => {
+                Cow::Borrowed("updateBlocklist")
+            }
+            Some(IPolicyRegistry::isAuthorizedCall::SELECTOR) => Cow::Borrowed("isAuthorized"),
+            Some(IPolicyRegistry::policyExistsCall::SELECTOR) => Cow::Borrowed("policyExists"),
+            Some(IPolicyRegistry::policyAdminCall::SELECTOR) => Cow::Borrowed("policyAdmin"),
+            Some(IPolicyRegistry::pendingPolicyAdminCall::SELECTOR) => {
+                Cow::Borrowed("pendingPolicyAdmin")
+            }
+            _ => Self::unknown(),
+        }
+    }
+
+    /// Returns call metadata for asset B-20 calldata.
+    pub fn b20_asset_call(calldata: &[u8]) -> PrecompileCallMetric {
+        PrecompileCallMetric::b20("asset", Self::b20_asset_method(calldata), calldata.len())
+    }
+
+    /// Returns the metric method label for asset B-20 calldata.
+    pub fn b20_asset_method(calldata: &[u8]) -> Cow<'static, str> {
+        let Some(selector) = Self::selector(calldata) else {
+            return Self::unknown();
+        };
+        if let Some(method) = IB20Asset::IB20AssetCalls::name_by_selector(selector) {
+            return Cow::Owned(method.to_string());
+        }
+        if let Some(method) = IB20::IB20Calls::name_by_selector(selector) {
+            return Cow::Owned(method.to_string());
+        }
+        Self::unknown()
+    }
+
+    /// Returns call metadata for stablecoin B-20 calldata.
+    pub fn b20_stablecoin_call(calldata: &[u8]) -> PrecompileCallMetric {
+        PrecompileCallMetric::b20(
+            "stablecoin",
+            Self::b20_stablecoin_method(calldata),
+            calldata.len(),
+        )
+    }
+
+    /// Returns the metric method label for stablecoin B-20 calldata.
+    pub fn b20_stablecoin_method(calldata: &[u8]) -> Cow<'static, str> {
+        let Some(selector) = Self::selector(calldata) else {
+            return Self::unknown();
+        };
+        if let Some(method) = IB20Stablecoin::IB20StablecoinCalls::name_by_selector(selector) {
+            return Cow::Owned(method.to_string());
+        }
+        if let Some(method) = IB20::IB20Calls::name_by_selector(selector) {
+            return Cow::Owned(method.to_string());
+        }
+        Self::unknown()
+    }
+}
+
+/// Call timer used by Beryl call recorders.
+#[derive(Debug)]
+pub struct BerylCallTimer {
+    #[cfg(feature = "std")]
+    start: Instant,
+}
+
+impl BerylCallTimer {
+    /// Starts a new call timer.
+    #[cfg(feature = "std")]
+    pub fn start() -> Self {
+        Self { start: Instant::now() }
+    }
+
+    /// Starts a new no-op call timer.
+    #[cfg(not(feature = "std"))]
+    pub const fn start() -> Self {
+        Self {}
+    }
+
+    /// Returns elapsed wall-clock time in seconds when std timing is available.
+    #[cfg(feature = "std")]
+    pub fn elapsed_seconds(&self) -> Option<f64> {
+        Some(self.start.elapsed().as_secs_f64())
+    }
+
+    /// Returns no elapsed wall-clock time when std timing is unavailable.
+    #[cfg(not(feature = "std"))]
+    pub const fn elapsed_seconds(&self) -> Option<f64> {
+        None
+    }
+}
+
+/// Per-call recorder for Beryl precompile observations.
+#[derive(Debug)]
+pub struct BerylCallRecorder<O> {
+    observer: O,
+    timer: BerylCallTimer,
+    call: PrecompileCallMetric,
+    error: Option<BerylErrorKind>,
+}
+
+impl<O> BerylCallRecorder<O>
+where
+    O: crate::PrecompileCallObserver,
+{
+    /// Starts a recorder for a precompile call.
+    #[cfg(feature = "std")]
+    pub fn start(observer: O, call: PrecompileCallMetric) -> Self {
+        Self { observer, timer: BerylCallTimer::start(), call, error: None }
+    }
+
+    /// Starts a recorder for a precompile call.
+    #[cfg(not(feature = "std"))]
+    pub const fn start(observer: O, call: PrecompileCallMetric) -> Self {
+        Self { observer, timer: BerylCallTimer::start(), call, error: None }
+    }
+
+    /// Updates the current call metadata.
+    pub fn set_call(&mut self, call: PrecompileCallMetric) {
+        self.call = call;
+    }
+
+    /// Returns the current call metadata.
+    pub const fn call(&self) -> &PrecompileCallMetric {
+        &self.call
+    }
+
+    /// Deducts the common calldata gas charged by Beryl precompile dispatch.
+    pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
+        const G_SHA3WORD: u64 = 6;
+
+        let calldata_len = calldata.len();
+        let calldata_cost = calldata_len.div_ceil(32).saturating_mul(G_SHA3WORD as usize) as u64;
+        ctx.deduct_gas(calldata_cost)
+    }
+
+    /// Records a Base precompile error before it is converted to a [`PrecompileResult`].
+    pub fn record_base_error(&mut self, error: &BasePrecompileError) {
+        self.error = Some(BerylErrorKind::from_base_error(error));
+    }
+
+    /// Records the final result of the precompile call.
+    pub fn record_result(&mut self, result: &PrecompileResult) {
+        let outcome =
+            PrecompileCallOutcome::from_result(result, self.timer.elapsed_seconds(), self.error);
+        self.observer.record_call(&self.call, &outcome);
+    }
+
+    /// Converts and records a Base precompile result.
+    pub fn record_base_result<T>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        result: Result<T>,
+        encode_ok: impl FnOnce(T) -> Bytes,
+    ) -> PrecompileResult {
+        if let Err(error) = &result {
+            self.record_base_error(error);
+        }
+        let result = ctx.result_output(result, encode_ok);
+        self.record_result(&result);
+        result
+    }
+
+    /// Converts and records a Base precompile error.
+    pub fn record_base_error_result(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        error: BasePrecompileError,
+    ) -> PrecompileResult {
+        self.record_base_error(&error);
+        let result = error.into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+        self.record_result(&result);
+        result
+    }
+}
+
+/// Helper methods for observer-only Beryl metric families.
+#[derive(Debug, Clone, Copy)]
+pub struct BerylAuxiliaryMetrics;
+
+impl BerylAuxiliaryMetrics {
+    /// Creates a singleton call descriptor for auxiliary metric recording.
+    pub fn singleton(precompile: &'static str, method: &'static str) -> PrecompileCallMetric {
+        PrecompileCallMetric::singleton(precompile, method, 0)
+    }
+
+    /// Creates a B-20 call descriptor for auxiliary metric recording.
+    pub fn b20(variant: &'static str, method: &'static str) -> PrecompileCallMetric {
+        PrecompileCallMetric::b20(variant, method, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, U256};
+    use alloy_sol_types::{SolCall, SolError};
+    use base_precompile_storage::BasePrecompileError;
+
+    use crate::{
+        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, IB20, IB20Factory, IPolicyRegistry,
+        metrics::BerylErrorClassifier,
+    };
+
+    #[test]
+    fn b20_method_labels_strip_precompile_prefixes() {
+        assert_eq!(BerylMetricLabels::b20_method("precompile-b20-transfer"), "transfer");
+        assert_eq!(BerylMetricLabels::b20_method("precompile-b20-stablecoin-currency"), "currency");
+    }
+
+    #[test]
+    fn selector_method_labels_are_stable() {
+        let factory = IB20Factory::getB20AddressCall {
+            variant: IB20Factory::B20Variant::ASSET,
+            sender: Address::ZERO,
+            salt: B256::ZERO,
+        }
+        .abi_encode();
+        assert_eq!(BerylMetricLabels::factory_method(&factory), "getB20Address");
+
+        let b20 = IB20::transferCall { to: Address::ZERO, amount: U256::ZERO }.abi_encode();
+        assert_eq!(BerylMetricLabels::b20_asset_method(&b20), "transfer");
+    }
+
+    #[test]
+    fn base_errors_are_classified() {
+        assert_eq!(
+            BerylErrorKind::from_base_error(&BasePrecompileError::UnknownFunctionSelector([0; 4])),
+            BerylErrorKind::UnknownSelector
+        );
+        assert_eq!(
+            BerylErrorKind::from_base_error(&BasePrecompileError::StaticCallViolation),
+            BerylErrorKind::StaticWrite
+        );
+    }
+
+    #[test]
+    fn revert_bytes_are_classified() {
+        let unauthorized = IB20::Unauthorized {}.abi_encode().into();
+        assert_eq!(BerylErrorKind::from_revert_bytes(&unauthorized), BerylErrorKind::Unauthorized);
+
+        let policy_not_found = IPolicyRegistry::PolicyNotFound {}.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&policy_not_found),
+            BerylErrorKind::PolicyMissing
+        );
+    }
+
+    #[test]
+    fn selector_extracts_revert_selector() {
+        let bytes = IB20::Unauthorized {}.abi_encode().into();
+        assert_eq!(
+            BerylErrorClassifier::selector(&bytes),
+            Some(<IB20::Unauthorized as SolError>::SELECTOR)
+        );
+    }
+
+    #[test]
+    fn result_outcomes_are_classified() {
+        let success = Ok(revm::precompile::PrecompileOutput::new(1, Default::default(), 0));
+        let revert = Ok(revm::precompile::PrecompileOutput::revert(1, Default::default(), 0));
+        let fatal = Err(revm::precompile::PrecompileError::Fatal("boom".into()));
+
+        assert_eq!(BerylCallOutcome::from_result(&success), BerylCallOutcome::Success);
+        assert_eq!(BerylCallOutcome::from_result(&revert), BerylCallOutcome::Revert);
+        assert_eq!(BerylCallOutcome::from_result(&fatal), BerylCallOutcome::Fatal);
+    }
+}

--- a/crates/common/precompiles/src/observer.rs
+++ b/crates/common/precompiles/src/observer.rs
@@ -1,5 +1,7 @@
 //! Native precompile observation hooks.
 
+use crate::{PrecompileCallMetric, PrecompileCallOutcome};
+
 /// Observer that does not record native precompile calls.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NoopPrecompileCallObserver;
@@ -21,6 +23,18 @@ pub trait PrecompileCallObserver: Clone + Send + Sync + 'static {
         let _guard = EndGuard { observer: self, label };
         f()
     }
+
+    /// Records one completed native precompile call.
+    fn record_call(&self, _call: &PrecompileCallMetric, _outcome: &PrecompileCallOutcome) {}
+
+    /// Records a B-20 token creation.
+    fn record_b20_created(&self, _variant: &'static str) {}
+
+    /// Records the number of logical items in a Beryl batch call.
+    fn record_batch_items(&self, _call: &PrecompileCallMetric, _count: usize) {}
+
+    /// Records internal calls made by Beryl precompile logic.
+    fn record_internal_calls(&self, _call: &PrecompileCallMetric, _calls: usize, _bytes: usize) {}
 }
 
 impl PrecompileCallObserver for NoopPrecompileCallObserver {}

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -40,6 +40,25 @@ sol! {
     }
 }
 
+impl IPolicyRegistry::IPolicyRegistryCalls {
+    /// Returns the stable metric label for this decoded policy-registry call.
+    pub const fn as_label(&self) -> &'static str {
+        match self {
+            Self::createPolicy(_) => "policy.createPolicy",
+            Self::createPolicyWithAccounts(_) => "policy.createPolicyWithAccounts",
+            Self::stageUpdateAdmin(_) => "policy.stageUpdateAdmin",
+            Self::finalizeUpdateAdmin(_) => "policy.finalizeUpdateAdmin",
+            Self::renounceAdmin(_) => "policy.renounceAdmin",
+            Self::updateAllowlist(_) => "policy.updateAllowlist",
+            Self::updateBlocklist(_) => "policy.updateBlocklist",
+            Self::isAuthorized(_) => "policy.isAuthorized",
+            Self::policyExists(_) => "policy.policyExists",
+            Self::policyAdmin(_) => "policy.policyAdmin",
+            Self::pendingPolicyAdmin(_) => "policy.pendingPolicyAdmin",
+        }
+    }
+}
+
 impl IPolicyRegistry::PolicyType {
     /// Returns the raw `u8` discriminant for this policy type.
     pub const fn as_discriminant(self) -> u8 {
@@ -54,6 +73,7 @@ impl IPolicyRegistry::PolicyType {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::Address;
     use alloy_sol_types::SolEnum;
 
     use super::IPolicyRegistry;
@@ -66,5 +86,16 @@ mod tests {
 
             assert!(policy_type.is_valid());
         }
+    }
+
+    #[test]
+    fn policy_call_labels_are_stable() {
+        assert_eq!(
+            IPolicyRegistry::IPolicyRegistryCalls::isAuthorized(
+                IPolicyRegistry::isAuthorizedCall { policyId: 0, account: Address::ZERO },
+            )
+            .as_label(),
+            "policy.isAuthorized"
+        );
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -4,10 +4,11 @@ use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage,
+    ActivationFeature, ActivationRegistryStorage, BerylAuxiliaryMetrics, BerylCallRecorder,
+    BerylMetricLabels,
     IPolicyRegistry::{self, IPolicyRegistryCalls as C},
-    PolicyRegistryStorage,
-    macros::{decode_precompile_call, deduct_calldata_cost},
+    NoopPrecompileCallObserver, PolicyRegistryStorage, PrecompileCallObserver,
+    macros::decode_precompile_call,
 };
 
 impl PolicyRegistryStorage<'_> {
@@ -16,15 +17,32 @@ impl PolicyRegistryStorage<'_> {
     /// View (read-only) calls bypass the activation gate and remain accessible even when the
     /// feature is disabled. Write calls require the feature to be activated.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
-        deduct_calldata_cost!(ctx, calldata);
+        self.dispatch_with_observer(ctx, calldata, NoopPrecompileCallObserver)
+    }
+
+    /// ABI-dispatches policy registry calldata with an observer.
+    pub fn dispatch_with_observer<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+    ) -> PrecompileResult
+    where
+        O: PrecompileCallObserver,
+    {
+        let mut recorder =
+            BerylCallRecorder::start(observer.clone(), BerylMetricLabels::policy_call(calldata));
+        if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
+            return recorder.record_base_error_result(ctx, error);
+        }
         let result = if Self::is_view_selector(calldata) {
-            self.inner(calldata)
+            self.inner(calldata, &observer)
         } else {
             ActivationRegistryStorage::new(ctx)
                 .ensure_activated(ActivationFeature::PolicyRegistry.id())
-                .and_then(|()| self.inner(calldata))
+                .and_then(|()| self.inner(calldata, &observer))
         };
-        ctx.result_output(result, |b| b)
+        recorder.record_base_result(ctx, result, |b| b)
     }
 
     /// Returns `true` when the calldata selector belongs to a view (read-only) function.
@@ -42,13 +60,20 @@ impl PolicyRegistryStorage<'_> {
             || selector == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR
     }
 
-    fn inner(&mut self, calldata: &[u8]) -> base_precompile_storage::Result<Bytes> {
+    fn inner<O>(&mut self, calldata: &[u8], observer: &O) -> base_precompile_storage::Result<Bytes>
+    where
+        O: PrecompileCallObserver,
+    {
         match decode_precompile_call!(calldata, IPolicyRegistry::IPolicyRegistryCalls) {
             C::createPolicy(call) => {
                 let id = self.create_policy(call.admin, call.policyType)?;
                 Ok(IPolicyRegistry::createPolicyCall::abi_encode_returns(&id).into())
             }
             C::createPolicyWithAccounts(call) => {
+                observer.record_batch_items(
+                    &BerylAuxiliaryMetrics::singleton("policy", "createPolicyWithAccounts"),
+                    call.accounts.len(),
+                );
                 let id =
                     self.create_policy_with_accounts(call.admin, call.policyType, call.accounts)?;
                 Ok(IPolicyRegistry::createPolicyWithAccountsCall::abi_encode_returns(&id).into())
@@ -66,10 +91,18 @@ impl PolicyRegistryStorage<'_> {
                 Ok(Bytes::new())
             }
             C::updateAllowlist(call) => {
+                observer.record_batch_items(
+                    &BerylAuxiliaryMetrics::singleton("policy", "updateAllowlist"),
+                    call.accounts.len(),
+                );
                 self.update_allowlist(call.policyId, call.allowed, call.accounts)?;
                 Ok(Bytes::new())
             }
             C::updateBlocklist(call) => {
+                observer.record_batch_items(
+                    &BerylAuxiliaryMetrics::singleton("policy", "updateBlocklist"),
+                    call.accounts.len(),
+                );
                 self.update_blocklist(call.policyId, call.blocked, call.accounts)?;
                 Ok(Bytes::new())
             }
@@ -95,17 +128,38 @@ impl PolicyRegistryStorage<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use alloy_primitives::{Address, Bytes, U256, address};
     use alloy_sol_types::{Panic, PanicKind, SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, IPolicyRegistry, PolicyRegistryStorage,
+        ActivationFeature, ActivationRegistryStorage, BerylErrorKind, IPolicyRegistry,
+        PolicyRegistryStorage, PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome,
+        PrecompileCallStatus,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
     const ADMIN: Address = address!("0x1000000000000000000000000000000000000001");
     const ALICE: Address = address!("0xA000000000000000000000000000000000000001");
+
+    #[derive(Debug, Clone, Default)]
+    struct RecordingObserver {
+        calls: Arc<Mutex<Vec<(PrecompileCallMetric, PrecompileCallOutcome)>>>,
+    }
+
+    impl RecordingObserver {
+        fn calls(&self) -> Vec<(PrecompileCallMetric, PrecompileCallOutcome)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl PrecompileCallObserver for RecordingObserver {
+        fn record_call(&self, call: &PrecompileCallMetric, outcome: &PrecompileCallOutcome) {
+            self.calls.lock().unwrap().push((call.clone(), *outcome));
+        }
+    }
 
     fn activate_policy_registry(storage: &mut HashMapStorageProvider) {
         storage.set_caller(ACTIVATION_ADMIN);
@@ -135,6 +189,54 @@ mod tests {
                 .deactivate(ActivationFeature::PolicyRegistry.id(), Some(ACTIVATION_ADMIN))
                 .unwrap()
         });
+    }
+
+    #[test]
+    fn dispatch_with_observer_records_singleton_success() {
+        let observer = RecordingObserver::default();
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_and_init(&mut storage);
+        let calldata =
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID }
+                .abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch_with_observer(ctx, &calldata, observer.clone())
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(output.is_success());
+        let calls = observer.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0.precompile, "policy");
+        assert_eq!(calls[0].0.method, "policyExists");
+        assert_eq!(calls[0].0.variant, None);
+        assert_eq!(calls[0].1.status, PrecompileCallStatus::Success);
+    }
+
+    #[test]
+    fn dispatch_with_observer_records_singleton_revert() {
+        let observer = RecordingObserver::default();
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+        let calldata = IPolicyRegistry::createPolicyCall {
+            admin: ADMIN,
+            policyType: IPolicyRegistry::PolicyType::ALLOWLIST,
+        }
+        .abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch_with_observer(ctx, &calldata, observer.clone())
+        })
+        .expect("dispatch should not fatally error");
+
+        assert!(output.is_revert());
+        let calls = observer.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0.precompile, "policy");
+        assert_eq!(calls[0].0.method, "createPolicy");
+        assert_eq!(calls[0].1.status, PrecompileCallStatus::Revert);
+        assert_eq!(calls[0].1.error, Some(BerylErrorKind::FeatureInactive));
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/precompile.rs
+++ b/crates/common/precompiles/src/policy/precompile.rs
@@ -1,10 +1,35 @@
 //! Entry point for the `PolicyRegistry` precompile.
 
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use base_precompile_macros::precompile;
 
-use crate::PolicyRegistryStorage;
+use crate::{PolicyRegistryStorage, PrecompileCallObserver, macros::base_precompile};
 
 /// EVM entry point for the `PolicyRegistry` precompile.
 #[precompile(install)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PolicyRegistryPrecompile;
+
+impl PolicyRegistryPrecompile {
+    /// Installs the `PolicyRegistryPrecompile` precompile with an observer.
+    pub fn install_with_observer<O>(precompiles: &mut PrecompilesMap, observer: O)
+    where
+        O: PrecompileCallObserver,
+    {
+        precompiles.extend_precompiles(core::iter::once((
+            PolicyRegistryStorage::ADDRESS,
+            Self::precompile_with_observer(observer),
+        )));
+    }
+
+    /// Creates the EVM precompile wrapper for `PolicyRegistryPrecompile` with an observer.
+    pub fn precompile_with_observer<O>(observer: O) -> DynPrecompile
+    where
+        O: PrecompileCallObserver,
+    {
+        base_precompile!("PolicyRegistryPrecompile", |ctx, calldata| {
+            let observer = observer.clone();
+            PolicyRegistryStorage::new(ctx).dispatch_with_observer(ctx, &calldata, observer)
+        })
+    }
+}

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -183,10 +183,14 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     {
         let mut precompiles = PrecompilesMap::from_static(self.precompiles());
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
-            B20Factory::install(&mut precompiles);
-            BerylLookup::install_with_observer(&mut precompiles, observer);
-            PolicyRegistryPrecompile::install(&mut precompiles);
-            ActivationRegistry::install(&mut precompiles, self.activation_admin_address);
+            B20Factory::install_with_observer(&mut precompiles, observer.clone());
+            BerylLookup::install_with_observer(&mut precompiles, observer.clone());
+            PolicyRegistryPrecompile::install_with_observer(&mut precompiles, observer.clone());
+            ActivationRegistry::install_with_observer(
+                &mut precompiles,
+                self.activation_admin_address,
+                observer,
+            );
         }
         precompiles
     }

--- a/crates/execution/evm/Cargo.toml
+++ b/crates/execution/evm/Cargo.toml
@@ -47,7 +47,8 @@ reth-revm = { workspace = true, features = ["test-utils"] }
 base-common-consensus = { workspace = true, features = ["arbitrary"] }
 
 [features]
-default = [ "std" ]
+default = [ "metrics", "std" ]
+metrics = [ "base-common-evm/metrics" ]
 std = [
 	"alloy-consensus/std",
 	"alloy-eips/std",

--- a/crates/utilities/metrics/src/define_metrics.rs
+++ b/crates/utilities/metrics/src/define_metrics.rs
@@ -13,7 +13,7 @@
 /// # Attributes
 ///
 /// - `#[describe("...")]` — required per-field; human-readable description.
-/// - `#[label(name)]` — optional per-field (may be repeated up to 2x).
+/// - `#[label(name)]` — optional per-field (may be repeated up to 4x).
 /// - `#[label(name = "...")]` — optional per-field string label name.
 /// - `#[label(name = "...", default = ["..."])]` — optional per-field labeled zero values.
 /// - `#[no_zero]` — optional per-field; opts the metric out of the auto-generated
@@ -179,6 +179,48 @@ macro_rules! __define_metric_fn {
         #[allow(unused)]
         pub fn $field<S1, S2>(_: S1, _: S2) -> $crate::NoopMetric { $crate::NoopMetric }
     };
+    (@emit $macro_name:ident $ret:ident @fn3 {$($scope:ident).+}, $field:ident, $l1:expr, $l2:expr, $l3:expr) => {
+        #[doc = concat!("Returns the `", stringify!($field), "` ", stringify!($macro_name), ".")]
+        #[cfg(feature = "metrics")]
+        pub fn $field(
+            label0: impl Into<::metrics::SharedString>,
+            label1: impl Into<::metrics::SharedString>,
+            label2: impl Into<::metrics::SharedString>,
+        ) -> ::metrics::$ret {
+            ::metrics::$macro_name!(
+                concat!($(stringify!($scope), ".",)+ stringify!($field)),
+                $l1 => label0,
+                $l2 => label1,
+                $l3 => label2
+            )
+        }
+        #[doc = concat!("Returns the `", stringify!($field), "` ", stringify!($macro_name), ".")]
+        #[cfg(not(feature = "metrics"))]
+        #[inline(always)]
+        pub fn $field<S1, S2, S3>(_: S1, _: S2, _: S3) -> $crate::NoopMetric { $crate::NoopMetric }
+    };
+    (@emit $macro_name:ident $ret:ident @fn4 {$($scope:ident).+}, $field:ident, $l1:expr, $l2:expr, $l3:expr, $l4:expr) => {
+        #[doc = concat!("Returns the `", stringify!($field), "` ", stringify!($macro_name), ".")]
+        #[cfg(feature = "metrics")]
+        pub fn $field(
+            label0: impl Into<::metrics::SharedString>,
+            label1: impl Into<::metrics::SharedString>,
+            label2: impl Into<::metrics::SharedString>,
+            label3: impl Into<::metrics::SharedString>,
+        ) -> ::metrics::$ret {
+            ::metrics::$macro_name!(
+                concat!($(stringify!($scope), ".",)+ stringify!($field)),
+                $l1 => label0,
+                $l2 => label1,
+                $l3 => label2,
+                $l4 => label3
+            )
+        }
+        #[doc = concat!("Returns the `", stringify!($field), "` ", stringify!($macro_name), ".")]
+        #[cfg(not(feature = "metrics"))]
+        #[inline(always)]
+        pub fn $field<S1, S2, S3, S4>(_: S1, _: S2, _: S3, _: S4) -> $crate::NoopMetric { $crate::NoopMetric }
+    };
     (@emit $macro_name:ident $ret:ident @fn1 {$($scope:ident).+}, $field:ident, $l:expr) => {
         #[doc = concat!("Returns the `", stringify!($field), "` ", stringify!($macro_name), ".")]
         #[cfg(feature = "metrics")]
@@ -253,8 +295,26 @@ macro_rules! __metric_label_keys {
     (@collect ($scope:tt, $field:ident, histogram) [$l1:expr, $l2:expr,] ) => {
         $crate::__define_metric_fn!(@emit histogram Histogram @fn2 $scope, $field, $l1, $l2);
     };
-    (@collect ($scope:tt, $field:ident, $kind:ident) [$l1:expr, $l2:expr, $l3:expr $(, $rest:expr)*,] ) => {
-        ::core::compile_error!("define_metrics! supports at most 2 #[label(...)] attributes per metric");
+    (@collect ($scope:tt, $field:ident, counter) [$l1:expr, $l2:expr, $l3:expr,] ) => {
+        $crate::__define_metric_fn!(@emit counter Counter @fn3 $scope, $field, $l1, $l2, $l3);
+    };
+    (@collect ($scope:tt, $field:ident, gauge) [$l1:expr, $l2:expr, $l3:expr,] ) => {
+        $crate::__define_metric_fn!(@emit gauge Gauge @fn3 $scope, $field, $l1, $l2, $l3);
+    };
+    (@collect ($scope:tt, $field:ident, histogram) [$l1:expr, $l2:expr, $l3:expr,] ) => {
+        $crate::__define_metric_fn!(@emit histogram Histogram @fn3 $scope, $field, $l1, $l2, $l3);
+    };
+    (@collect ($scope:tt, $field:ident, counter) [$l1:expr, $l2:expr, $l3:expr, $l4:expr,] ) => {
+        $crate::__define_metric_fn!(@emit counter Counter @fn4 $scope, $field, $l1, $l2, $l3, $l4);
+    };
+    (@collect ($scope:tt, $field:ident, gauge) [$l1:expr, $l2:expr, $l3:expr, $l4:expr,] ) => {
+        $crate::__define_metric_fn!(@emit gauge Gauge @fn4 $scope, $field, $l1, $l2, $l3, $l4);
+    };
+    (@collect ($scope:tt, $field:ident, histogram) [$l1:expr, $l2:expr, $l3:expr, $l4:expr,] ) => {
+        $crate::__define_metric_fn!(@emit histogram Histogram @fn4 $scope, $field, $l1, $l2, $l3, $l4);
+    };
+    (@collect ($scope:tt, $field:ident, $kind:ident) [$l1:expr, $l2:expr, $l3:expr, $l4:expr, $l5:expr $(, $rest:expr)*,] ) => {
+        ::core::compile_error!("define_metrics! supports at most 4 #[label(...)] attributes per metric");
     };
 }
 
@@ -342,6 +402,37 @@ macro_rules! __metric_zero_defaults {
             }
         }
     };
+    (@collect ($field:ident, $kind:ident) [(@defaults [$($d1:expr),*]) (@defaults [$($d2:expr),*]) (@defaults [$($d3:expr),*])] ) => {
+        {
+            let label1_values = [$(::metrics::SharedString::from($d1)),*];
+            let label2_values = [$(::metrics::SharedString::from($d2)),*];
+            let label3_values = [$(::metrics::SharedString::from($d3)),*];
+            for label1 in &label1_values {
+                for label2 in &label2_values {
+                    for label3 in &label3_values {
+                        $crate::__zero_metric_call_3!($field, $kind, label1.clone(), label2.clone(), label3.clone());
+                    }
+                }
+            }
+        }
+    };
+    (@collect ($field:ident, $kind:ident) [(@defaults [$($d1:expr),*]) (@defaults [$($d2:expr),*]) (@defaults [$($d3:expr),*]) (@defaults [$($d4:expr),*])] ) => {
+        {
+            let label1_values = [$(::metrics::SharedString::from($d1)),*];
+            let label2_values = [$(::metrics::SharedString::from($d2)),*];
+            let label3_values = [$(::metrics::SharedString::from($d3)),*];
+            let label4_values = [$(::metrics::SharedString::from($d4)),*];
+            for label1 in &label1_values {
+                for label2 in &label2_values {
+                    for label3 in &label3_values {
+                        for label4 in &label4_values {
+                            $crate::__zero_metric_call_4!($field, $kind, label1.clone(), label2.clone(), label3.clone(), label4.clone());
+                        }
+                    }
+                }
+            }
+        }
+    };
     // Mixed default/non-default labeled metrics are intentionally left uninitialized.
     (@collect ($field:ident, $kind:ident) [$($labels:tt)+] ) => {};
 }
@@ -370,4 +461,30 @@ macro_rules! __zero_metric_call_2 {
         Self::$field($label1, $label2).set(0.0);
     };
     ($field:ident, histogram, $label1:expr, $label2:expr) => {};
+}
+
+/// Internal — zeroes a three-label metric.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __zero_metric_call_3 {
+    ($field:ident, counter, $label1:expr, $label2:expr, $label3:expr) => {
+        Self::$field($label1, $label2, $label3).absolute(0);
+    };
+    ($field:ident, gauge, $label1:expr, $label2:expr, $label3:expr) => {
+        Self::$field($label1, $label2, $label3).set(0.0);
+    };
+    ($field:ident, histogram, $label1:expr, $label2:expr, $label3:expr) => {};
+}
+
+/// Internal — zeroes a four-label metric.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __zero_metric_call_4 {
+    ($field:ident, counter, $label1:expr, $label2:expr, $label3:expr, $label4:expr) => {
+        Self::$field($label1, $label2, $label3, $label4).absolute(0);
+    };
+    ($field:ident, gauge, $label1:expr, $label2:expr, $label3:expr, $label4:expr) => {
+        Self::$field($label1, $label2, $label3, $label4).set(0.0);
+    };
+    ($field:ident, histogram, $label1:expr, $label2:expr, $label3:expr, $label4:expr) => {};
 }

--- a/crates/utilities/metrics/tests/metrics.rs
+++ b/crates/utilities/metrics/tests/metrics.rs
@@ -276,6 +276,79 @@ fn two_label_counter() {
 }
 
 base_metrics::define_metrics! {
+    beryl_label,
+    struct = BerylLabelMetrics,
+
+    #[describe("Calls by precompile, method, variant, and status")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    calls: counter,
+
+    #[describe("Batch items by precompile, method, and variant")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    batch_items: histogram,
+
+    #[describe("Zeroed calls by precompile, method, variant, and status")]
+    #[label(name = "precompile", default = ["factory"])]
+    #[label(name = "method", default = ["create"])]
+    #[label(name = "variant", default = ["b20"])]
+    #[label(name = "status", default = ["success"])]
+    zeroed_calls: counter,
+}
+
+#[test]
+fn three_and_four_label_metrics_record_and_zero() {
+    with_recorder(|snap| {
+        BerylLabelMetrics::calls("factory", "create", "b20", "success").increment(9);
+        BerylLabelMetrics::batch_items("policy", "createPolicies", "none").record(3.0);
+        BerylLabelMetrics::zero();
+
+        let snapshot = snap.snapshot().into_vec();
+        assert_eq!(
+            find_metric_labeled(
+                &snapshot,
+                MetricKind::Counter,
+                "beryl_label.calls",
+                &[
+                    ("precompile", "factory"),
+                    ("method", "create"),
+                    ("variant", "b20"),
+                    ("status", "success")
+                ]
+            ),
+            Some(&DebugValue::Counter(9)),
+        );
+        assert_eq!(
+            find_metric_labeled(
+                &snapshot,
+                MetricKind::Histogram,
+                "beryl_label.batch_items",
+                &[("precompile", "policy"), ("method", "createPolicies"), ("variant", "none")]
+            ),
+            Some(&DebugValue::Histogram(vec![OrderedFloat(3.0)])),
+        );
+        assert_eq!(
+            find_metric_labeled(
+                &snapshot,
+                MetricKind::Counter,
+                "beryl_label.zeroed_calls",
+                &[
+                    ("precompile", "factory"),
+                    ("method", "create"),
+                    ("variant", "b20"),
+                    ("status", "success")
+                ]
+            ),
+            Some(&DebugValue::Counter(0)),
+        );
+    });
+}
+
+base_metrics::define_metrics! {
     timer_test,
     struct = TimerMetrics,
     #[describe("Duration")]


### PR DESCRIPTION
## Summary

This adds production Beryl precompile metrics for native precompile calls. The observer records call labels, terminal status, gas fields, input size, duration, and bounded errors across factory, policy, activation, and B20 calls. Production Base EVM construction now installs Beryl precompiles with the metrics observer, and the metrics macro supports the required multi-label series.