### PR TITLE
feat(proposer): add collector polling support

### DIFF
--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -24,7 +24,7 @@ mod proof_adapter;
 pub use proof_adapter::{DispatchedProof, ProofRequesterDispatcher, ProposerProofAdapter};
 
 mod proof_collector;
-pub use proof_collector::{CollectedProof, ProofCollector};
+pub use proof_collector::{CollectedProof, ProofCollector, TargetPoll};
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -46,6 +46,33 @@ impl ProofRequesterDispatcher {
         request: PrimitiveProofRequest,
     ) -> Result<DispatchedProof, ProposerError> {
         let request = ProposerProofAdapter::tee_prove_block_range_request(request, self.tee_kind);
+        self.dispatch_prepared(request).await
+    }
+
+    /// Submits a TEE proof request under an explicit session id.
+    ///
+    /// Used for discard retries. The normal proposer session id is keyed only
+    /// by claimed output root so restarts can rediscover in-flight work, but a
+    /// discarded `Succeeded` session cannot be requeued by replaying that same
+    /// id. A retry-specific id lets the proposer obtain a genuinely fresh TEE
+    /// proof for the same output root.
+    pub async fn dispatch_tee_with_session_id(
+        &self,
+        request: PrimitiveProofRequest,
+        session_id: String,
+    ) -> Result<DispatchedProof, ProposerError> {
+        let request = ProposerProofAdapter::tee_prove_block_range_request_with_session_id(
+            request,
+            self.tee_kind,
+            session_id,
+        );
+        self.dispatch_prepared(request).await
+    }
+
+    async fn dispatch_prepared(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> Result<DispatchedProof, ProposerError> {
         let response = self
             .requester
             .prove_block_range(request)
@@ -97,12 +124,37 @@ impl ProposerProofAdapter {
         ProofSessionId::derive(Self::SESSION_NAMESPACE, Self::tee_session_label(tee_kind), root)
     }
 
+    /// Derives a TEE proof retry session id for a discarded proof.
+    pub fn tee_discard_retry_session_id(
+        request: &PrimitiveProofRequest,
+        tee_kind: TeeKind,
+        attempt: u32,
+    ) -> String {
+        let label = Self::tee_session_label(tee_kind);
+        let l1_head_number = request.l1_head_number.to_be_bytes();
+        let attempt = attempt.to_be_bytes();
+        ProofSessionId::derive_from_components(
+            Self::SESSION_NAMESPACE,
+            label,
+            &[request.claimed_l2_output_root.as_slice(), &l1_head_number, &attempt],
+        )
+    }
+
     /// Builds a prover-service request for a TEE proposal proof.
     pub fn tee_prove_block_range_request(
         request: PrimitiveProofRequest,
         tee_kind: TeeKind,
     ) -> ProveBlockRangeRequest {
         let session_id = Self::tee_session_id(&request, tee_kind);
+        Self::tee_prove_block_range_request_with_session_id(request, tee_kind, session_id)
+    }
+
+    /// Builds a prover-service request for a TEE proposal proof with a caller-supplied session id.
+    pub const fn tee_prove_block_range_request_with_session_id(
+        request: PrimitiveProofRequest,
+        tee_kind: TeeKind,
+        session_id: String,
+    ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -307,6 +307,38 @@ mod tests {
     }
 
     #[test]
+    fn tee_discard_retry_session_id_differs_from_root_session() {
+        let request = test_request(B256::repeat_byte(0xaa));
+
+        assert_ne!(
+            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 1),
+            ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro),
+        );
+    }
+
+    #[test]
+    fn tee_discard_retry_session_id_changes_by_attempt() {
+        let request = test_request(B256::repeat_byte(0xaa));
+
+        assert_ne!(
+            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 1),
+            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 2),
+        );
+    }
+
+    #[test]
+    fn tee_discard_retry_session_id_changes_by_l1_head_number() {
+        let first = test_request(B256::repeat_byte(0xaa));
+        let mut second = first.clone();
+        second.l1_head_number += 1;
+
+        assert_ne!(
+            ProposerProofAdapter::tee_discard_retry_session_id(&first, TeeKind::AwsNitro, 1),
+            ProposerProofAdapter::tee_discard_retry_session_id(&second, TeeKind::AwsNitro, 1),
+        );
+    }
+
+    #[test]
     fn tee_prove_block_range_request_wraps_primitive_request() {
         let request = test_request(B256::repeat_byte(0xaa));
         let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -192,6 +192,10 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         safe_head: u64,
         is_excluded: impl Fn(u64) -> bool,
     ) -> Vec<u64> {
+        if self.block_interval == 0 {
+            return Vec::new();
+        }
+
         let mut cursor = match recovered.l2_block_number.checked_add(self.block_interval) {
             Some(cursor) => cursor,
             None => return Vec::new(),
@@ -349,11 +353,108 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
     /// Polls a specific prover-service session for `target_block`.
     ///
     /// Used after a discard retry is dispatched under a retry-specific session
-    /// id. The canonical root is still fetched so a terminal failed session can
-    /// be re-dispatched with a complete proof request.
+    /// id. The canonical root is fetched lazily only for outcomes that need it
+    /// (`NotFound` and `Failed`) so pending retry sessions do not depend on an
+    /// unrelated rollup RPC.
     pub async fn poll_session(&self, target_block: u64, session_id: String) -> TargetPoll {
-        let output = match self.rollup_client.output_at_block(target_block).await {
-            Ok(out) => out,
+        let response = match self.get_proof(session_id.clone()).await {
+            Ok(response) => response,
+            Err(e) if e.is_not_found() => {
+                let claimed_l2_output_root =
+                    match self.retry_session_output_root(target_block, &session_id).await {
+                        Ok(root) => root,
+                        Err(error) => {
+                            return TargetPoll::Unknown { session_id: Some(session_id), error };
+                        }
+                    };
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    "Retry session missing from prover service, dispatch needed",
+                );
+                return TargetPoll::NotFound { session_id, claimed_l2_output_root };
+            }
+            Err(e) => {
+                return TargetPoll::Unknown {
+                    session_id: Some(session_id),
+                    error: Self::error_from_client(e),
+                };
+            }
+        };
+
+        Metrics::proof_status_received_total(Self::status_label(response.status)).increment(1);
+        match response.status {
+            ProofStatus::Queued | ProofStatus::Running => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    status = ?response.status,
+                    "Proof request still pending",
+                );
+                TargetPoll::Pending { session_id, status: response.status }
+            }
+            ProofStatus::Failed => {
+                let claimed_l2_output_root =
+                    match self.retry_session_output_root(target_block, &session_id).await {
+                        Ok(root) => root,
+                        Err(error) => {
+                            return TargetPoll::Unknown { session_id: Some(session_id), error };
+                        }
+                    };
+                let message = response.error_message.unwrap_or_else(|| {
+                    format!("proof session {session_id} failed without an error message")
+                });
+                TargetPoll::Failed {
+                    session_id,
+                    claimed_l2_output_root,
+                    error: ProposerError::Prover(message),
+                }
+            }
+            ProofStatus::Succeeded => {
+                let result = match response.result {
+                    Some(result) => result,
+                    None => {
+                        let claimed_l2_output_root = match self
+                            .retry_session_output_root(target_block, &session_id)
+                            .await
+                        {
+                            Ok(root) => root,
+                            Err(error) => {
+                                return TargetPoll::Unknown { session_id: Some(session_id), error };
+                            }
+                        };
+                        let error = ProposerError::Prover(format!(
+                            "proof session {session_id} succeeded without a result"
+                        ));
+                        return TargetPoll::Failed { session_id, claimed_l2_output_root, error };
+                    }
+                };
+                match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
+                    Ok(proof) => TargetPoll::Ready { session_id, proof },
+                    Err(error) => {
+                        let claimed_l2_output_root = match self
+                            .retry_session_output_root(target_block, &session_id)
+                            .await
+                        {
+                            Ok(root) => root,
+                            Err(error) => {
+                                return TargetPoll::Unknown { session_id: Some(session_id), error };
+                            }
+                        };
+                        TargetPoll::Failed { session_id, claimed_l2_output_root, error }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn retry_session_output_root(
+        &self,
+        target_block: u64,
+        session_id: &str,
+    ) -> Result<B256, ProposerError> {
+        match self.rollup_client.output_at_block(target_block).await {
+            Ok(out) => Ok(out.output_root),
             Err(e) => {
                 debug!(
                     target_block,
@@ -361,29 +462,8 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                     error = %e,
                     "Failed to fetch canonical output root for retry session",
                 );
-                return TargetPoll::Unknown {
-                    session_id: Some(session_id),
-                    error: ProposerError::Rpc(e),
-                };
+                Err(ProposerError::Rpc(e))
             }
-        };
-
-        match self.get_proof(session_id.clone()).await {
-            Ok(response) => {
-                self.response_to_poll(target_block, session_id, output.output_root, response)
-            }
-            Err(e) if e.is_not_found() => {
-                debug!(
-                    target_block,
-                    session_id = %session_id,
-                    "Retry session missing from prover service, dispatch needed",
-                );
-                TargetPoll::NotFound { session_id, claimed_l2_output_root: output.output_root }
-            }
-            Err(e) => TargetPoll::Unknown {
-                session_id: Some(session_id),
-                error: Self::error_from_client(e),
-            },
         }
     }
 
@@ -489,6 +569,30 @@ mod tests {
         proof_adapter::ProofRequesterDispatcher,
         test_utils::{MockProofRequester, MockRollupClient, test_sync_status},
     };
+
+    fn recovered(block: u64) -> RecoveredState {
+        RecoveredState {
+            parent_address: Address::ZERO,
+            output_root: B256::ZERO,
+            l2_block_number: block,
+        }
+    }
+
+    #[test]
+    fn collectable_targets_returns_empty_for_zero_block_interval() {
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(100, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let collector = ProofCollector::target_poller_aws_nitro(proof_requester, rollup_client);
+
+        let targets = collector.collectable_targets(&recovered(0), 100, |_| false);
+
+        assert!(targets.is_empty());
+    }
 
     /// Restart/recovery: the collector derives the prover-service session id
     /// solely from the canonical L2 output root + tee kind, so a freshly

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -414,15 +414,16 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                 let result = match response.result {
                     Some(result) => result,
                     None => {
-                        let claimed_l2_output_root = match self
-                            .retry_session_output_root(target_block, &session_id)
-                            .await
-                        {
-                            Ok(root) => root,
-                            Err(error) => {
-                                return TargetPoll::Unknown { session_id: Some(session_id), error };
-                            }
-                        };
+                        let claimed_l2_output_root =
+                            match self.retry_session_output_root(target_block, &session_id).await {
+                                Ok(root) => root,
+                                Err(root_error) => {
+                                    return TargetPoll::Unknown {
+                                        session_id: Some(session_id),
+                                        error: root_error,
+                                    };
+                                }
+                            };
                         let error = ProposerError::Prover(format!(
                             "proof session {session_id} succeeded without a result"
                         ));
@@ -431,17 +432,22 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                 };
                 match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
                     Ok(proof) => TargetPoll::Ready { session_id, proof },
-                    Err(error) => {
-                        let claimed_l2_output_root = match self
-                            .retry_session_output_root(target_block, &session_id)
-                            .await
-                        {
-                            Ok(root) => root,
-                            Err(error) => {
-                                return TargetPoll::Unknown { session_id: Some(session_id), error };
-                            }
-                        };
-                        TargetPoll::Failed { session_id, claimed_l2_output_root, error }
+                    Err(decode_error) => {
+                        let claimed_l2_output_root =
+                            match self.retry_session_output_root(target_block, &session_id).await {
+                                Ok(root) => root,
+                                Err(root_error) => {
+                                    return TargetPoll::Unknown {
+                                        session_id: Some(session_id),
+                                        error: root_error,
+                                    };
+                                }
+                            };
+                        TargetPoll::Failed {
+                            session_id,
+                            claimed_l2_output_root,
+                            error: decode_error,
+                        }
                     }
                 }
             }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -560,7 +560,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeSet, HashMap};
 
     use alloy_primitives::{Address, B256};
 
@@ -576,6 +576,49 @@ mod tests {
             output_root: B256::ZERO,
             l2_block_number: block,
         }
+    }
+
+    fn make_collector(block_interval: u64) -> ProofCollector<MockRollupClient> {
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(0, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        ProofCollector::aws_nitro(proof_requester, rollup_client, block_interval, 4)
+    }
+
+    #[test]
+    fn collectable_targets_returns_next_expected_blocks_excluding_proved_and_submitting() {
+        let collector = make_collector(100);
+
+        let proved: BTreeSet<u64> = [200, 400].into_iter().collect();
+        let submitting: Option<u64> = Some(300);
+
+        let targets = collector.collectable_targets(&recovered(100), 700, |t| {
+            proved.contains(&t) || submitting == Some(t)
+        });
+
+        assert_eq!(targets, vec![500, 600, 700]);
+    }
+
+    #[test]
+    fn collectable_targets_returns_all_eligible_targets_up_to_safe_head() {
+        let collector = make_collector(100);
+
+        let targets = collector.collectable_targets(&recovered(100), 1000, |_| false);
+
+        assert_eq!(targets, vec![200, 300, 400, 500, 600, 700, 800, 900, 1000]);
+    }
+
+    #[test]
+    fn collectable_targets_returns_empty_when_safe_head_below_first_target() {
+        let collector = make_collector(100);
+
+        let targets = collector.collectable_targets(&recovered(500), 550, |_| false);
+
+        assert!(targets.is_empty());
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1,25 +1,26 @@
-//! Polls the prover service for completed proofs of derived target blocks.
+//! Polls the prover service for the proof of a single derived target block.
 //!
 //! The [`ProofCollector`] does not care about the proof dispatcher. It assumes that
-//! eligible block ranges have already had `prove_block_range` requests initiated
-//! (whether by this proposer instance or a previous one), derives the next-expected
-//! L2 block targets from the recovered on-chain state and the safe head, derives
-//! the deterministic prover-service session ID via
-//! [`ProposerProofAdapter::tee_session_id_for_root`], calls `get_proof`, and returns
-//! ready/failed outcomes to the caller.
+//! the eligible block range either has, or will have, a `prove_block_range` request
+//! initiated against the prover service (whether by this proposer instance or a
+//! previous one). Given a target block, the collector fetches its canonical L2
+//! output root, derives the deterministic prover-service session ID via
+//! [`ProposerProofAdapter::tee_session_id_for_root`], calls `get_proof`, and
+//! returns a [`TargetPoll`] outcome that tells the caller exactly what to do
+//! next: submit the proof, dispatch a new request, wait, or treat as a transient
+//! error.
 //!
-//! Because session derivation is deterministic and independent of in-memory dispatch
-//! state, the collector can rediscover and complete sessions across proposer restarts.
-//! The pipeline owns its [`PipelineState`](crate::pipeline) and is responsible for
-//! applying retry/recovery bookkeeping to the returned outcomes.
+//! Because session derivation is deterministic and independent of in-memory
+//! dispatch state, the collector can rediscover and complete sessions across
+//! proposer restarts.
 
 use std::{collections::HashMap, sync::Arc};
 
 use alloy_primitives::B256;
 use base_proof_primitives::ProofResult;
 use base_proof_rpc::RollupProvider;
-use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{GetProofRequest, ProofStatus, TeeKind};
+use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
+use base_prover_service_protocol::{GetProofRequest, GetProofResponse, ProofStatus, TeeKind};
 use futures::{StreamExt, stream};
 use tracing::debug;
 
@@ -27,6 +28,61 @@ use crate::{
     driver::RecoveredState, error::ProposerError, metrics::Metrics,
     proof_adapter::ProposerProofAdapter,
 };
+
+/// Outcome of polling the prover service for a single target block.
+///
+/// Returned by [`ProofCollector::poll`] and consumed by the proposer's
+/// proposer pipeline to choose the next action: submit, dispatch, wait, or
+/// retry.
+#[derive(Debug)]
+pub enum TargetPoll {
+    /// The prover service produced a successful, decoded proof for the target.
+    Ready {
+        /// Deterministic prover-service session identifier.
+        session_id: String,
+        /// Decoded proof result ready for inline on-chain submission.
+        proof: ProofResult,
+    },
+    /// The prover service reported a terminal failed session, or its result
+    /// could not be decoded.
+    Failed {
+        /// Deterministic prover-service session identifier.
+        session_id: String,
+        /// Canonical L2 output root at the target block.
+        claimed_l2_output_root: B256,
+        /// Underlying error returned by the prover service or the decoder.
+        error: ProposerError,
+    },
+    /// The prover service has the session but it has not finished proving.
+    Pending {
+        /// Deterministic prover-service session identifier.
+        session_id: String,
+        /// Either [`ProofStatus::Queued`] or [`ProofStatus::Running`].
+        status: ProofStatus,
+    },
+    /// The prover service has no record of a session for this target's
+    /// canonical output root. The caller should dispatch a new request.
+    NotFound {
+        /// Deterministic prover-service session identifier the caller should
+        /// expect when dispatching the matching `prove_block_range` request.
+        session_id: String,
+        /// Canonical L2 output root at the target block, already fetched
+        /// while deriving the session id. Threaded through so the dispatch
+        /// path does not need to call `output_at_block(target_block)` a
+        /// second time.
+        claimed_l2_output_root: B256,
+    },
+    /// A transient error prevented the poll from completing (RPC failure,
+    /// canonical root fetch error, etc.). The caller should sleep and retry
+    /// on the next iteration without counting against the retry budget.
+    Unknown {
+        /// Optional session identifier when it could be derived before the
+        /// failure. `None` if the canonical output-root fetch itself failed.
+        session_id: Option<String>,
+        /// The underlying transient error.
+        error: ProposerError,
+    },
+}
 
 /// Outcome returned by [`ProofCollector::collect`] for a single target block.
 #[derive(Debug)]
@@ -51,12 +107,12 @@ pub enum CollectedProof {
     },
 }
 
-/// Polls the prover service for completed proofs of the next-expected target blocks.
+/// Polls the prover service for the proof of a single derived target block.
 ///
-/// Behavior is independent of the proof dispatcher: target blocks are derived
-/// deterministically from `recovered` and `safe_head`, and session IDs are derived
-/// from the canonical claimed output root, so a restarted proposer can still pick
-/// up sessions previously initiated by another instance.
+/// Behavior is independent of the proof dispatcher: the target block is
+/// supplied by the caller, and the session ID is derived from the canonical
+/// claimed output root, so a restarted proposer can still pick up sessions
+/// previously initiated by another instance.
 pub struct ProofCollector<R> {
     proof_requester: Arc<dyn ProofRequesterProvider>,
     rollup_client: Arc<R>,
@@ -104,6 +160,14 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         )
     }
 
+    /// Creates a TEE proof collector for single-target AWS Nitro polling.
+    pub fn target_poller_aws_nitro(
+        proof_requester: Arc<dyn ProofRequesterProvider>,
+        rollup_client: Arc<R>,
+    ) -> Self {
+        Self::new(proof_requester, rollup_client, 0, 1, TeeKind::AwsNitro)
+    }
+
     /// Creates a proof collector for the given TEE implementation.
     pub const fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
@@ -122,15 +186,6 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
 
     /// Returns the next-expected target blocks to poll, derived from `recovered`,
     /// the L2 `safe_head`, and the caller-supplied `is_excluded` predicate.
-    ///
-    /// All eligible targets up to `safe_head` are returned. There is no
-    /// per-tick parallel-poll cap: collection is fundamentally bounded by the
-    /// safe head's distance from the recovered tip, and the prover service
-    /// queues sessions itself.
-    ///
-    /// `is_excluded(target)` should return `true` when the caller already has a
-    /// completed proof for `target` or has begun submitting it; such targets
-    /// are skipped.
     pub fn collectable_targets(
         &self,
         recovered: &RecoveredState,
@@ -157,11 +212,6 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
     }
 
     /// Polls the prover service for each target and returns ready/failed outcomes.
-    ///
-    /// Pending sessions (`Queued` or `Running`) are not returned and are left for the
-    /// caller to retry on the next tick. Targets whose canonical output root cannot
-    /// be fetched are skipped silently; the underlying RPC failure is logged at debug
-    /// level via the standard rollup-client error path.
     pub async fn collect(&self, targets: &[u64]) -> Vec<CollectedProof> {
         if targets.is_empty() {
             return Vec::new();
@@ -174,11 +224,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             let Some(Ok(root)) = roots.get(&target) else { continue };
             let session_id = ProposerProofAdapter::tee_session_id_for_root(*root, self.tee_kind);
 
-            let response = match self
-                .proof_requester
-                .get_proof(GetProofRequest { session_id: session_id.clone() })
-                .await
-            {
+            let response = match self.get_proof(session_id.clone()).await {
                 Ok(response) => response,
                 Err(e) => {
                     debug!(
@@ -246,14 +292,106 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         outcomes
     }
 
-    /// Maps a [`ProofStatus`] to its `proof_status_received_total` label value.
-    const fn status_label(status: ProofStatus) -> &'static str {
-        match status {
-            ProofStatus::Queued => Metrics::PROOF_STATUS_QUEUED,
-            ProofStatus::Running => Metrics::PROOF_STATUS_RUNNING,
-            ProofStatus::Succeeded => Metrics::PROOF_STATUS_SUCCEEDED,
-            ProofStatus::Failed => Metrics::PROOF_STATUS_FAILED,
+    /// Polls the prover service for the proof of `target_block`.
+    ///
+    /// Returns a [`TargetPoll`] describing the next action the caller should
+    /// take. The session ID is derived deterministically from the canonical
+    /// L2 output root at `target_block` and the configured TEE kind, so a
+    /// freshly constructed collector can rediscover an in-flight session
+    /// dispatched by a previous proposer instance.
+    pub async fn poll(&self, target_block: u64) -> TargetPoll {
+        // 1. Fetch the canonical output root needed to derive the session id.
+        let output = match self.rollup_client.output_at_block(target_block).await {
+            Ok(out) => out,
+            Err(e) => {
+                debug!(
+                    target_block,
+                    error = %e,
+                    "Failed to fetch canonical output root for target",
+                );
+                return TargetPoll::Unknown { session_id: None, error: ProposerError::Rpc(e) };
+            }
+        };
+
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(output.output_root, self.tee_kind);
+
+        let response = match self.get_proof(session_id.clone()).await {
+            Ok(response) => response,
+            Err(e) if e.is_not_found() => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    "No prover-service session for target, dispatch needed",
+                );
+                return TargetPoll::NotFound {
+                    session_id,
+                    claimed_l2_output_root: output.output_root,
+                };
+            }
+            Err(e) => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    error = %e,
+                    "Transient failure polling prover service",
+                );
+                return TargetPoll::Unknown {
+                    session_id: Some(session_id),
+                    error: Self::error_from_client(e),
+                };
+            }
+        };
+
+        self.response_to_poll(target_block, session_id, output.output_root, response)
+    }
+
+    /// Polls a specific prover-service session for `target_block`.
+    ///
+    /// Used after a discard retry is dispatched under a retry-specific session
+    /// id. The canonical root is still fetched so a terminal failed session can
+    /// be re-dispatched with a complete proof request.
+    pub async fn poll_session(&self, target_block: u64, session_id: String) -> TargetPoll {
+        let output = match self.rollup_client.output_at_block(target_block).await {
+            Ok(out) => out,
+            Err(e) => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    error = %e,
+                    "Failed to fetch canonical output root for retry session",
+                );
+                return TargetPoll::Unknown {
+                    session_id: Some(session_id),
+                    error: ProposerError::Rpc(e),
+                };
+            }
+        };
+
+        match self.get_proof(session_id.clone()).await {
+            Ok(response) => {
+                self.response_to_poll(target_block, session_id, output.output_root, response)
+            }
+            Err(e) if e.is_not_found() => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    "Retry session missing from prover service, dispatch needed",
+                );
+                TargetPoll::NotFound { session_id, claimed_l2_output_root: output.output_root }
+            }
+            Err(e) => TargetPoll::Unknown {
+                session_id: Some(session_id),
+                error: Self::error_from_client(e),
+            },
         }
+    }
+
+    async fn get_proof(
+        &self,
+        session_id: String,
+    ) -> Result<GetProofResponse, ProverServiceClientError> {
+        self.proof_requester.get_proof(GetProofRequest { session_id }).await
     }
 
     async fn fetch_canonical_root_results(
@@ -277,85 +415,87 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             .collect()
             .await
     }
+
+    fn response_to_poll(
+        &self,
+        target_block: u64,
+        session_id: String,
+        claimed_l2_output_root: B256,
+        response: GetProofResponse,
+    ) -> TargetPoll {
+        Metrics::proof_status_received_total(Self::status_label(response.status)).increment(1);
+        match response.status {
+            ProofStatus::Queued | ProofStatus::Running => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    status = ?response.status,
+                    "Proof request still pending",
+                );
+                TargetPoll::Pending { session_id, status: response.status }
+            }
+            ProofStatus::Failed => {
+                let message = response.error_message.unwrap_or_else(|| {
+                    format!("proof session {session_id} failed without an error message")
+                });
+                TargetPoll::Failed {
+                    session_id,
+                    claimed_l2_output_root,
+                    error: ProposerError::Prover(message),
+                }
+            }
+            ProofStatus::Succeeded => {
+                let result = match response.result {
+                    Some(result) => result,
+                    None => {
+                        let error = ProposerError::Prover(format!(
+                            "proof session {session_id} succeeded without a result"
+                        ));
+                        return TargetPoll::Failed { session_id, claimed_l2_output_root, error };
+                    }
+                };
+                match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
+                    Ok(proof) => TargetPoll::Ready { session_id, proof },
+                    Err(error) => TargetPoll::Failed { session_id, claimed_l2_output_root, error },
+                }
+            }
+        }
+    }
+
+    /// Maps a [`ProverServiceClientError`] into the proposer's error type.
+    fn error_from_client(error: ProverServiceClientError) -> ProposerError {
+        ProposerError::Prover(error.to_string())
+    }
+
+    /// Maps a [`ProofStatus`] to its `proof_status_received_total` label value.
+    const fn status_label(status: ProofStatus) -> &'static str {
+        match status {
+            ProofStatus::Queued => Metrics::PROOF_STATUS_QUEUED,
+            ProofStatus::Running => Metrics::PROOF_STATUS_RUNNING,
+            ProofStatus::Succeeded => Metrics::PROOF_STATUS_SUCCEEDED,
+            ProofStatus::Failed => Metrics::PROOF_STATUS_FAILED,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::HashMap;
 
-    use alloy_primitives::Address;
+    use alloy_primitives::{Address, B256};
 
     use super::*;
     use crate::{
-        driver::RecoveredState,
+        proof_adapter::ProofRequesterDispatcher,
         test_utils::{MockProofRequester, MockRollupClient, test_sync_status},
     };
-
-    fn make_collector(block_interval: u64) -> ProofCollector<MockRollupClient> {
-        let proof_requester: Arc<dyn ProofRequesterProvider> =
-            Arc::new(MockProofRequester::default());
-        let rollup_client = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(0, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        ProofCollector::aws_nitro(proof_requester, rollup_client, block_interval, 4)
-    }
-
-    fn recovered(block: u64) -> RecoveredState {
-        RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::ZERO,
-            l2_block_number: block,
-        }
-    }
-
-    #[test]
-    fn collectable_targets_returns_next_expected_blocks_excluding_proved_and_submitting() {
-        let collector = make_collector(100);
-
-        let proved: BTreeSet<u64> = [200, 400].into_iter().collect();
-        let submitting: Option<u64> = Some(300);
-
-        let targets = collector.collectable_targets(&recovered(100), 700, |t| {
-            proved.contains(&t) || submitting == Some(t)
-        });
-
-        // From recovered=100, step=100, safe_head=700 → candidates 200..=700.
-        // Excluded: 200 (proved), 300 (submitting), 400 (proved).
-        // Expected: 500, 600, 700.
-        assert_eq!(targets, vec![500, 600, 700]);
-    }
-
-    /// All eligible targets up to `safe_head` are returned: there is no
-    /// per-tick parallel-poll cap. The safe head is the only natural bound.
-    #[test]
-    fn collectable_targets_returns_all_eligible_targets_up_to_safe_head() {
-        let collector = make_collector(100);
-
-        let targets = collector.collectable_targets(&recovered(100), 1000, |_| false);
-
-        assert_eq!(targets, vec![200, 300, 400, 500, 600, 700, 800, 900, 1000]);
-    }
-
-    #[test]
-    fn collectable_targets_returns_empty_when_safe_head_below_first_target() {
-        let collector = make_collector(100);
-
-        let targets = collector.collectable_targets(&recovered(500), 550, |_| false);
-
-        // Next target = 600 > safe_head=550, so no targets.
-        assert!(targets.is_empty());
-    }
 
     /// Restart/recovery: the collector derives the prover-service session id
     /// solely from the canonical L2 output root + tee kind, so a freshly
     /// constructed collector (mirroring a proposer restart) can pick up an
     /// in-flight session that a previous run dispatched.
     #[tokio::test]
-    async fn collector_recovers_in_flight_session_across_restart() {
-        use crate::proof_adapter::ProofRequesterDispatcher;
-
+    async fn poll_recovers_in_flight_session_across_restart() {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::new(MockProofRequester::default());
 
@@ -392,16 +532,42 @@ mod tests {
         // It must rederive the session id from the canonical chain root and
         // recover the in-flight session.
         let collector =
-            ProofCollector::aws_nitro(Arc::clone(&proof_requester), rollup_client, 100, 4);
-        let outcomes = collector.collect(&[target_block]).await;
+            ProofCollector::target_poller_aws_nitro(Arc::clone(&proof_requester), rollup_client);
 
-        assert_eq!(outcomes.len(), 1);
-        match &outcomes[0] {
-            CollectedProof::Ready { target_block: t, session_id, .. } => {
-                assert_eq!(*t, target_block);
-                assert_eq!(session_id, &expected_session_id);
+        match collector.poll(target_block).await {
+            TargetPoll::Ready { session_id, .. } => {
+                assert_eq!(session_id, expected_session_id);
             }
             other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    /// When the prover service has no record of a session, `poll()` returns
+    /// [`TargetPoll::NotFound`] so the caller can dispatch a new request.
+    #[tokio::test]
+    async fn poll_returns_not_found_for_unknown_session() {
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+        let target_block = 200u64;
+        let mut output_roots = HashMap::new();
+        output_roots.insert(target_block, B256::repeat_byte(0xAA));
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(target_block, B256::ZERO),
+            output_roots,
+            max_safe_block: None,
+        });
+
+        let collector = ProofCollector::target_poller_aws_nitro(proof_requester, rollup_client);
+        match collector.poll(target_block).await {
+            TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
+                assert!(!session_id.is_empty());
+                assert_eq!(
+                    claimed_l2_output_root,
+                    B256::repeat_byte(0xAA),
+                    "should surface the canonical root already fetched",
+                );
+            }
+            other => panic!("expected NotFound, got {other:?}"),
         }
     }
 }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -375,6 +375,12 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                 return TargetPoll::NotFound { session_id, claimed_l2_output_root };
             }
             Err(e) => {
+                debug!(
+                    target_block,
+                    session_id = %session_id,
+                    error = %e,
+                    "Transient failure polling retry session",
+                );
                 return TargetPoll::Unknown {
                     session_id: Some(session_id),
                     error: Self::error_from_client(e),

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -28,6 +28,7 @@ use base_prover_service_protocol::{
     ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
     ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
 };
+use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
 use crate::{error::ProposerError, output_proposer::OutputProposer};
 
@@ -412,6 +413,10 @@ pub fn test_proposal(block_number: u64) -> Proposal {
 pub struct MockProofRequester {
     /// Requests accepted through `prove_block_range`.
     pub requests: std::sync::Mutex<HashMap<String, ProveBlockRangeRequest>>,
+    /// Sessions that should return a terminal failed status from `get_proof`.
+    pub failed_sessions: std::sync::Mutex<HashMap<String, String>>,
+    /// Number of `prove_block_range` calls accepted.
+    pub prove_count: AtomicUsize,
 }
 
 #[async_trait]
@@ -421,6 +426,7 @@ impl ProofRequesterProvider for MockProofRequester {
         request: ProveBlockRangeRequest,
     ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
         let session_id = request.proof.session_id.clone();
+        self.prove_count.fetch_add(1, Ordering::SeqCst);
         self.requests.lock().unwrap().insert(session_id.clone(), request);
         Ok(ProveBlockRangeResponse { session_id })
     }
@@ -429,10 +435,28 @@ impl ProofRequesterProvider for MockProofRequester {
         &self,
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
+        if let Some(message) = self.failed_sessions.lock().unwrap().get(&request.session_id) {
+            return Ok(GetProofResponse {
+                status: ProofStatus::Failed,
+                error_message: Some(message.clone()),
+                result: None,
+            });
+        }
+
         let requests = self.requests.lock().unwrap();
-        let request = requests
-            .get(&request.session_id)
-            .ok_or_else(|| ProverServiceClientError::MissingResult("unknown session".to_owned()))?;
+        let request = requests.get(&request.session_id).ok_or_else(|| {
+            // Mirror the production prover-service: an unknown session_id surfaces
+            // as a JSON-RPC NotFound error. The proposer pipeline relies
+            // on this to distinguish "no session yet, dispatch needed" from other
+            // transient or terminal errors.
+            ProverServiceClientError::RpcTransport(JsonRpcClientError::Call(
+                ErrorObjectOwned::owned(
+                    ProverServiceClientError::ERROR_NOT_FOUND,
+                    "Proof request not found",
+                    None::<()>,
+                ),
+            ))
+        })?;
         let ApiProofRequestKind::Tee(tee_request) = &request.proof.request else {
             return Err(ProverServiceClientError::UnexpectedResultPayload(
                 "expected TEE request".to_owned(),

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -25,8 +25,9 @@ use base_proof_rpc::{
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
     GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
+    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
+    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    TeeKind, TeeProofResult,
 };
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
@@ -452,7 +453,7 @@ impl ProofRequesterProvider for MockProofRequester {
             ProverServiceClientError::RpcTransport(JsonRpcClientError::Call(
                 ErrorObjectOwned::owned(
                     ProverServiceClientError::ERROR_NOT_FOUND,
-                    "Proof request not found",
+                    PROOF_REQUEST_NOT_FOUND_MESSAGE,
                     None::<()>,
                 ),
             ))

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -38,6 +38,9 @@ pub enum ProverServiceClientError {
 }
 
 impl ProverServiceClientError {
+    /// JSON-RPC code used by the prover service when the requested session does not exist.
+    pub const ERROR_NOT_FOUND: i32 = -32004;
+
     /// JSON-RPC code used by the prover service when a dependency is unavailable.
     pub const ERROR_UNAVAILABLE: i32 = -32014;
 
@@ -58,6 +61,16 @@ impl ProverServiceClientError {
             | Self::MissingResult(_)
             | Self::UnexpectedResultPayload(_) => false,
         }
+    }
+
+    /// Returns `true` when the prover service responded that the session does not exist.
+    ///
+    /// The proposer's self-driving loop uses this to distinguish "no session yet,
+    /// dispatch needed" from other transient or terminal errors.
+    #[must_use]
+    pub fn is_not_found(&self) -> bool {
+        let Self::RpcTransport(JsonRpcClientError::Call(call)) = self else { return false };
+        call.code() == Self::ERROR_NOT_FOUND
     }
 
     /// Returns `true` when the JSON-RPC error is classified as transient.
@@ -146,5 +159,21 @@ mod tests {
         #[case] expected_retryable: bool,
     ) {
         assert_eq!(error.is_retryable(), expected_retryable);
+    }
+
+    #[test]
+    fn is_not_found_matches_only_call_with_not_found_code() {
+        let not_found = rpc_call_error(ProverServiceClientError::ERROR_NOT_FOUND, "missing");
+        assert!(not_found.is_not_found());
+
+        let other_call = rpc_call_error(ProverServiceClientError::ERROR_UNAVAILABLE, "down");
+        assert!(!other_call.is_not_found());
+
+        let transport: ProverServiceClientError =
+            JsonRpcClientError::Transport(io::Error::other("connection refused").into()).into();
+        assert!(!transport.is_not_found());
+
+        let timeout = ProverServiceClientError::Timeout("not ready".into());
+        assert!(!timeout.is_not_found());
     }
 }

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -1,5 +1,6 @@
 //! Shared prover-service client error types.
 
+use base_prover_service_protocol::PROOF_REQUEST_NOT_FOUND_MESSAGE;
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorCode};
 use thiserror::Error;
 
@@ -71,7 +72,7 @@ impl ProverServiceClientError {
     #[must_use]
     pub fn is_not_found(&self) -> bool {
         let Self::RpcTransport(JsonRpcClientError::Call(call)) = self else { return false };
-        call.code() == Self::ERROR_NOT_FOUND && call.message() == "Proof request not found"
+        call.code() == Self::ERROR_NOT_FOUND && call.message() == PROOF_REQUEST_NOT_FOUND_MESSAGE
     }
 
     /// Returns `true` when the JSON-RPC error is classified as transient.
@@ -164,14 +165,14 @@ mod tests {
 
     #[test]
     fn is_not_found_matches_only_missing_session_not_found() {
-        let not_found =
-            rpc_call_error(ProverServiceClientError::ERROR_NOT_FOUND, "Proof request not found");
+        let not_found = rpc_call_error(
+            ProverServiceClientError::ERROR_NOT_FOUND,
+            PROOF_REQUEST_NOT_FOUND_MESSAGE,
+        );
         assert!(not_found.is_not_found());
 
-        let missing_result = rpc_call_error(
-            ProverServiceClientError::ERROR_NOT_FOUND,
-            "proof result not available",
-        );
+        let missing_result =
+            rpc_call_error(ProverServiceClientError::ERROR_NOT_FOUND, "proof result not available");
         assert!(!missing_result.is_not_found());
 
         let other_call = rpc_call_error(ProverServiceClientError::ERROR_UNAVAILABLE, "down");

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -65,12 +65,13 @@ impl ProverServiceClientError {
 
     /// Returns `true` when the prover service responded that the session does not exist.
     ///
-    /// The proposer's self-driving loop uses this to distinguish "no session yet,
-    /// dispatch needed" from other transient or terminal errors.
+    /// The proposer uses this to distinguish "no session yet, dispatch needed"
+    /// from other `NOT_FOUND` cases, such as a succeeded session whose result
+    /// payload is unexpectedly unavailable.
     #[must_use]
     pub fn is_not_found(&self) -> bool {
         let Self::RpcTransport(JsonRpcClientError::Call(call)) = self else { return false };
-        call.code() == Self::ERROR_NOT_FOUND
+        call.code() == Self::ERROR_NOT_FOUND && call.message() == "Proof request not found"
     }
 
     /// Returns `true` when the JSON-RPC error is classified as transient.
@@ -162,9 +163,16 @@ mod tests {
     }
 
     #[test]
-    fn is_not_found_matches_only_call_with_not_found_code() {
-        let not_found = rpc_call_error(ProverServiceClientError::ERROR_NOT_FOUND, "missing");
+    fn is_not_found_matches_only_missing_session_not_found() {
+        let not_found =
+            rpc_call_error(ProverServiceClientError::ERROR_NOT_FOUND, "Proof request not found");
         assert!(not_found.is_not_found());
+
+        let missing_result = rpc_call_error(
+            ProverServiceClientError::ERROR_NOT_FOUND,
+            "proof result not available",
+        );
+        assert!(!missing_result.is_not_found());
 
         let other_call = rpc_call_error(ProverServiceClientError::ERROR_UNAVAILABLE, "down");
         assert!(!other_call.is_not_found());

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -13,9 +13,9 @@ pub use session::ProofSessionId;
 mod types;
 pub use types::{
     GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse, HeartbeatRequest,
-    HeartbeatResponse, ListProofsRequest, ListProofsResponse, ProofJob, ProofJobStatus,
-    ProofRequest, ProofRequestKind, ProofResult, ProofStatus, ProofSummary, ProofType,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, SnarkGroth16ProofRequest,
-    SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
+    HeartbeatResponse, ListProofsRequest, ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE,
+    ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind, ProofResult, ProofStatus,
+    ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult,
+    WorkerSubmitProofRequest, WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -5,6 +5,9 @@ use base_proof_primitives::{ProofRequest as PrimitiveProofRequest, Proposal};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// JSON-RPC error message returned when a proof request session cannot be found.
+pub const PROOF_REQUEST_NOT_FOUND_MESSAGE: &str = "Proof request not found";
+
 /// Type of proof requested from the prover service.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -3,7 +3,8 @@ use base_prover_service_db::{
     canonical_session_id,
 };
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ProofResult, ProofStatus, ZkProofResult, ZkVm,
+    GetProofRequest, GetProofResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofResult, ProofStatus,
+    ZkProofResult, ZkVm,
 };
 use jsonrpsee::core::RpcResult;
 use tracing::{Instrument, info};
@@ -76,7 +77,7 @@ impl ProverServiceServer {
             .get_by_session_id(&session_id)
             .await
             .map_err(|e| internal(format!("Database error: {e}")))?
-            .ok_or_else(|| not_found("Proof request not found"))?;
+            .ok_or_else(|| not_found(PROOF_REQUEST_NOT_FOUND_MESSAGE))?;
         let proof_request_id = proof_req.id;
 
         info!(
@@ -103,7 +104,7 @@ impl ProverServiceServer {
                     .get(proof_request_id)
                     .await
                     .map_err(|e| internal(format!("Database error: {e}")))?
-                    .ok_or_else(|| not_found("Proof request not found"))?;
+                    .ok_or_else(|| not_found(PROOF_REQUEST_NOT_FOUND_MESSAGE))?;
 
                 match updated_proof_req.status {
                     DbProofStatus::Succeeded => (

--- a/crates/proof/prover-service/tests/mock_backend_e2e.rs
+++ b/crates/proof/prover-service/tests/mock_backend_e2e.rs
@@ -9,7 +9,8 @@ use std::time::{Duration, Instant};
 mod common;
 
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ProofResult, ProofStatus, ProverRequesterApiClient,
+    GetProofRequest, GetProofResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofResult, ProofStatus,
+    ProverRequesterApiClient,
 };
 use common::{ProveBlockRequest, connect, prove_block};
 use jsonrpsee::http_client::HttpClient;
@@ -336,7 +337,7 @@ async fn test_get_proof_nonexistent_session() {
         .expect_err("nonexistent session should return error");
 
     assert!(
-        err.to_string().contains("Proof request not found"),
+        err.to_string().contains(PROOF_REQUEST_NOT_FOUND_MESSAGE),
         "error should mention missing proof request, got: {err}"
     );
     println!("  Correctly returned NotFound for nonexistent session: {err}");


### PR DESCRIPTION
## Summary

Adds proposer collector/prover-service support needed for the concurrent proving pipeline split.

This keeps the existing `CollectedProof` / `collect()` API used by the current pipeline, while adding the single-target polling API needed by the final wiring PR.

## Changes

- Add `ProverServiceClientError::is_not_found()` for JSON-RPC NotFound classification.
- Add `TargetPoll` with `Ready`, `Pending`, `NotFound`, `Failed`, and `Unknown` outcomes.
- Add `ProofCollector::poll(target_block)` for deterministic root-derived sessions.
- Add `ProofCollector::poll_session(target_block, session_id)` for retry-specific sessions.
- Add retry-session NotFound handling so missing retry sessions can be re-dispatched.
- Add proof adapter helpers for root-derived and discard retry-specific TEE session ids.
- Update the test prover-service mock to return JSON-RPC NotFound for unknown sessions and support failed-session tests.

## Verification

- `cargo +nightly fmt -p base-proposer`
- `cargo test -p base-proposer --lib`
- `cargo test -p base-proposer --lib --features metrics`
- `cargo clippy -p base-proposer --all-targets -- -D warnings`
- `cargo clippy -p base-proposer --all-targets --features metrics -- -D warnings`
