### PR TITLE
fix(precompiles): give Beryl and Cobalt their own named constructors in fork dispatch

### DIFF
--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -41,7 +41,9 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             BaseUpgrade::Granite | BaseUpgrade::Holocene => Self::granite(),
             BaseUpgrade::Isthmus => Self::isthmus(),
             BaseUpgrade::Jovian => Self::jovian(),
-            BaseUpgrade::Azul | BaseUpgrade::Beryl | BaseUpgrade::Cobalt => Self::azul(),
+            BaseUpgrade::Azul => Self::azul(),
+            BaseUpgrade::Beryl => Self::beryl(),
+            BaseUpgrade::Cobalt => Self::cobalt(),
             upgrade => panic!("unsupported Base precompile upgrade: {upgrade}"),
         };
 
@@ -163,6 +165,13 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     /// Static precompiles are the same as Azul; Beryl adds dynamic precompiles at install time.
     pub fn beryl() -> &'static Precompiles {
         Self::azul()
+    }
+
+    /// Returns precompiles for the Base Cobalt spec.
+    ///
+    /// Static precompiles are the same as Beryl; Cobalt adds dynamic precompiles at install time.
+    pub fn cobalt() -> &'static Precompiles {
+        Self::beryl()
     }
 
     /// Builds a [`PrecompilesMap`] with all Base precompiles for this spec installed.


### PR DESCRIPTION
[BOP-329](https://linear.app/coinbase/issue/BOP-329)

## Motivation

`BasePrecompiles::new_with_spec` collapsed Azul, Beryl, and Cobalt into a single match arm that always called `Self::azul()`. This bypassed the existing `beryl()` constructor entirely and provided no `cobalt()` constructor at all. Every other fork (Fjord, Granite, Isthmus, Jovian, Azul) has its own named constructor that serves as an explicit extension point. The collapsed arm means any future divergence between these forks would require touching the match arm and remembering to update the forwarding chain, with no clear signal that an extension point was expected.

## What changed

- Split `BaseUpgrade::Azul | BaseUpgrade::Beryl | BaseUpgrade::Cobalt => Self::azul()` into three separate match arms, each calling its own constructor.
- Added `pub fn cobalt() -> &'static Precompiles` that forwards to `Self::beryl()`, consistent with how `beryl()` forwards to `azul()`.

## What was tried / considered

The alternative of leaving the collapsed arm and adding a comment was rejected. Named constructors are the established pattern in this file and the forwarding chain (cobalt -> beryl -> azul) makes the extension points explicit and greppable without changing runtime behavior.