### PR TITLE
fix(precompiles): return halt instead of Fatal for oversized crypto precompile inputs

### DIFF
--- a/crates/common/precompiles/src/bls12_381.rs
+++ b/crates/common/precompiles/src/bls12_381.rs
@@ -1,7 +1,6 @@
-use alloc::string::ToString;
-
 use revm::precompile::{
-    self as precompile, Precompile, PrecompileError, PrecompileId, PrecompileResult,
+    self as precompile, Precompile, PrecompileHalt, PrecompileId, PrecompileOutput,
+    PrecompileResult,
     bls12_381_const::{G1_MSM_ADDRESS, G2_MSM_ADDRESS, PAIRING_ADDRESS},
     call_eth_precompile,
 };
@@ -28,10 +27,7 @@ pub const ISTHMUS_G1_MSM: Precompile =
 /// Run the BLS12-381 G1 MSM precompile with Isthmus input limits.
 pub fn run_isthmus_g1_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > ISTHMUS_G1_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G1MSM input length too long for Base input size limitation after the Isthmus Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G1MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g1_msm::g1_msm, input, gas_limit, reservoir))
 }
@@ -43,9 +39,7 @@ pub const ISTHMUS_G2_MSM: Precompile =
 /// Run the BLS12-381 G2 MSM precompile with Isthmus input limits.
 pub fn run_isthmus_g2_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > ISTHMUS_G2_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G2MSM input length too long for Base input size limitation".to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G2MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g2_msm::g2_msm, input, gas_limit, reservoir))
 }
@@ -57,9 +51,7 @@ pub const ISTHMUS_PAIRING: Precompile =
 /// Run the BLS12-381 pairing precompile with Isthmus input limits.
 pub fn run_isthmus_pairing(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > ISTHMUS_PAIRING_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "Pairing input length too long for Base input size limitation".to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381PairingInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::pairing::pairing, input, gas_limit, reservoir))
 }
@@ -71,10 +63,7 @@ pub const JOVIAN_G1_MSM: Precompile =
 /// Run the BLS12-381 G1 MSM precompile with Jovian input limits.
 pub fn run_jovian_g1_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_G1_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G1MSM input length too long for Base input size limitation after the Jovian Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G1MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g1_msm::g1_msm, input, gas_limit, reservoir))
 }
@@ -86,10 +75,7 @@ pub const JOVIAN_G2_MSM: Precompile =
 /// Run the BLS12-381 G2 MSM precompile with Jovian input limits.
 pub fn run_jovian_g2_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_G2_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G2MSM input length too long for Base input size limitation after the Jovian Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G2MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g2_msm::g2_msm, input, gas_limit, reservoir))
 }
@@ -101,20 +87,14 @@ pub const JOVIAN_PAIRING: Precompile =
 /// Run the BLS12-381 pairing precompile with Jovian input limits.
 pub fn run_jovian_pairing(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_PAIRING_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "Pairing input length too long for Base input size limitation after the Jovian Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381PairingInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::pairing::pairing, input, gas_limit, reservoir))
 }
 
 #[cfg(test)]
 mod tests {
-    use revm::{
-        precompile::{Precompile, PrecompileError},
-        primitives::Bytes,
-    };
+    use revm::{precompile::Precompile, primitives::Bytes};
     use rstest::rstest;
 
     use crate::{
@@ -139,8 +119,8 @@ mod tests {
         let input = Bytes::from(vec![0u8; max_input_size + 1]);
         let result = precompile.execute(&input, gas_limit, 0);
         assert!(
-            matches!(&result, Err(PrecompileError::Fatal(msg)) if msg.contains("input length too long")),
-            "expected Fatal error for oversized input, got {result:?}"
+            matches!(&result, Ok(o) if o.halt_reason().is_some()),
+            "expected halt for oversized input, got {result:?}"
         );
     }
 }

--- a/crates/common/precompiles/src/bn254_pair.rs
+++ b/crates/common/precompiles/src/bn254_pair.rs
@@ -1,7 +1,6 @@
-use alloc::string::ToString;
-
 use revm::precompile::{
-    Precompile, PrecompileError, PrecompileId, PrecompileResult, bn254, call_eth_precompile,
+    Precompile, PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult, bn254,
+    call_eth_precompile,
 };
 
 /// Max input size for the bn254 pair precompile after the Granite hardfork.
@@ -13,7 +12,7 @@ pub const GRANITE: Precompile =
 /// Run the bn254 pair precompile with Granite input limit.
 pub fn run_pair_granite(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > GRANITE_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal("Bn254PairLength".to_string()));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bn254PairLength, reservoir));
     }
     Ok(call_eth_precompile(
         |i, g| {
@@ -39,7 +38,7 @@ pub const JOVIAN: Precompile =
 /// Run the bn254 pair precompile with Jovian input limit.
 pub fn run_pair_jovian(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal("Bn254PairLength".to_string()));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bn254PairLength, reservoir));
     }
     Ok(call_eth_precompile(
         |i, g| {
@@ -58,10 +57,7 @@ pub fn run_pair_jovian(input: &[u8], gas_limit: u64, reservoir: u64) -> Precompi
 
 #[cfg(test)]
 mod tests {
-    use revm::{
-        precompile::{PrecompileError, bn254},
-        primitives::hex,
-    };
+    use revm::{precompile::bn254, primitives::hex};
 
     use crate::{JOVIAN_MAX_INPUT_SIZE, run_pair_granite, run_pair_jovian};
 
@@ -111,7 +107,7 @@ mod tests {
         let over_limit = vec![1u8; 587 * bn254::PAIR_ELEMENT_LEN];
         assert!(matches!(
             run_pair_granite(&over_limit, 260_000, 0),
-            Err(PrecompileError::Fatal(_))
+            Ok(o) if o.halt_reason().is_some()
         ));
     }
 
@@ -130,6 +126,6 @@ mod tests {
     #[test]
     fn test_bn254_pair_jovian_bad_input_len() {
         let input = [0u8; JOVIAN_MAX_INPUT_SIZE + 1];
-        assert!(matches!(run_pair_jovian(&input, u64::MAX, 0), Err(PrecompileError::Fatal(_))));
+        assert!(matches!(run_pair_jovian(&input, u64::MAX, 0), Ok(o) if o.halt_reason().is_some()));
     }
 }


### PR DESCRIPTION
[BOP-326](https://linear.app/coinbase/issue/BOP-326)\n\n## Motivation\n\nThe Base size guards for BN254 pairing and BLS12-381 precompiles were returning `PrecompileError::Fatal` when calldata exceeded the configured limit. revm treats `Fatal` as unrecoverable: it propagates as `EVMError::Custom` and aborts the entire EVM transaction. This means any contract calling these precompiles with an oversized input would have its entire transaction reverted, not just the subcall. The correct behavior per EVM semantics is to fail only the CALL and keep the transaction alive. This affects 8 sites across the Granite/Jovian (BN254 pairing) and Isthmus/Jovian (BLS12-381 G1MSM, G2MSM, pairing) size guards.\n\n## What changed\n\n- `bn254_pair.rs`: `run_pair_granite` and `run_pair_jovian` now return `Ok(PrecompileOutput::halt(PrecompileHalt::Bn254PairLength, reservoir))` instead of `Err(PrecompileError::Fatal(...))` when the input exceeds the limit.\n- `bls12_381.rs`: `run_isthmus_g1_msm`, `run_isthmus_g2_msm`, `run_isthmus_pairing`, `run_jovian_g1_msm`, `run_jovian_g2_msm`, and `run_jovian_pairing` similarly return `Ok(PrecompileOutput::halt(...))` with the appropriate typed `PrecompileHalt` variant.\n- Tests in both files updated to assert `Ok(o) if o.halt_reason().is_some()` instead of `Err(PrecompileError::Fatal(_))`.\n- Removed the `use alloc::string::ToString` imports that were only needed for the `Fatal` string construction.\n\n## What was tried / considered\n\nThe finding suggested `PrecompileHalt::other_static(...)` as the fix. However, dedicated typed variants (`Bn254PairLength`, `Bls12381G1MsmInputLength`, `Bls12381G2MsmInputLength`, `Bls12381PairingInputLength`) already exist in the `PrecompileHalt` enum, so those are used instead for better observability and pattern matching.\n