### PR TITLE
fix(chainspec,activation): close zero-address admin backdoor in Beryl activation registry

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -100,7 +100,7 @@ pub struct ChainConfig {
     /// Activation registry admin address.
     ///
     /// Required and non-zero for all Base chains: every Base chain has Beryl scheduled, and
-    /// Beryl's activation registry precompile needs an admin at genesis. Address::ZERO is
+    /// Beryl's activation registry precompile needs an admin at genesis. `Address::ZERO` is
     /// rejected by chainspec validation.
     pub activation_admin_address: Address,
 

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -98,7 +98,11 @@ pub struct ChainConfig {
     /// Unsafe block signer address.
     pub unsafe_block_signer: Option<Address>,
     /// Activation registry admin address.
-    pub activation_admin_address: Option<Address>,
+    ///
+    /// Required and non-zero for all Base chains: every Base chain has Beryl scheduled, and
+    /// Beryl's activation registry precompile needs an admin at genesis. Address::ZERO is
+    /// rejected by chainspec validation.
+    pub activation_admin_address: Address,
 
     // Gas limits
     /// Maximum gas limit for L2 blocks.
@@ -369,7 +373,7 @@ const MAINNET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
 
     unsafe_block_signer: Some(address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a")),
-    activation_admin_address: Some(address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771")),
+    activation_admin_address: address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"),
 
     max_gas_limit: 105_000_000,
     prune_delete_limit: 20_000,
@@ -443,7 +447,7 @@ const SEPOLIA: ChainConfig = ChainConfig {
     protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
 
     unsafe_block_signer: Some(address!("b830b99c95Ea32300039624Cb567d324D4b1D83C")),
-    activation_admin_address: Some(address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59")),
+    activation_admin_address: address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"),
 
     max_gas_limit: 45_000_000,
     prune_delete_limit: 10_000,
@@ -508,7 +512,7 @@ const DEVNET: ChainConfig = ChainConfig {
     protocol_versions_address: Address::ZERO,
 
     unsafe_block_signer: None,
-    activation_admin_address: Some(address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc")),
+    activation_admin_address: address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc"),
 
     max_gas_limit: 30_000_000,
     prune_delete_limit: 20_000,
@@ -562,7 +566,7 @@ const ZERONET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("646c8604cf62b23e0cf094f2e790c6c75547ff85"),
 
     unsafe_block_signer: Some(address!("cf17274338d3128f6C96d9af54511a17e8b38a08")),
-    activation_admin_address: Some(address!("F5969A85a555671EeD766C4ff0C61426AA626b11")),
+    activation_admin_address: address!("F5969A85a555671EeD766C4ff0C61426AA626b11"),
 
     max_gas_limit: 25_000_000,
     prune_delete_limit: 10_000,

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -58,7 +58,7 @@ impl ActivationRegistryStorage<'_> {
 
     /// Returns the activation admin address, or [`Address::ZERO`] if no admin is configured.
     ///
-    /// [`Address::ZERO`] here means "no admin is set" — it is not a valid admin address.
+    /// [`Address::ZERO`] here means "no admin is set": it is not a valid admin address.
     /// Configuration-time validation rejects `Some(Address::ZERO)`, so in a correctly
     /// constructed chain spec the zero return always means `activation_admin_address` was
     /// `None`. Callers must not treat the zero return as a meaningful admin address.

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -56,7 +56,12 @@ impl ActivationRegistryStorage<'_> {
     /// Activation registry precompile address.
     pub const ADDRESS: Address = address!("8453000000000000000000000000000000000001");
 
-    /// Returns the activation admin.
+    /// Returns the activation admin address, or [`Address::ZERO`] if no admin is configured.
+    ///
+    /// [`Address::ZERO`] here means "no admin is set" — it is not a valid admin address.
+    /// Configuration-time validation rejects `Some(Address::ZERO)`, so in a correctly
+    /// constructed chain spec the zero return always means `activation_admin_address` was
+    /// `None`. Callers must not treat the zero return as a meaningful admin address.
     pub const fn admin(&self, activation_admin_address: Option<Address>) -> Address {
         match activation_admin_address {
             Some(address) => address,

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -119,6 +119,9 @@ impl ActivationRegistryStorage<'_> {
         }
 
         let caller = self.storage.caller();
+        if caller.is_zero() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
         let Some(admin) = activation_admin_address else {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         };
@@ -477,6 +480,23 @@ mod tests {
                 feature: FEATURE,
             })
         );
+    }
+
+    /// A zero-address caller must be rejected even when the admin is also configured as
+    /// `Address::ZERO`. This prevents deposit transactions with `msg.sender == Address::ZERO` from
+    /// toggling activation state on a misconfigured chain.
+    #[test]
+    fn zero_address_caller_with_zero_admin_is_rejected() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(Address::ZERO);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+        assert_activated(&mut storage, false);
     }
 
     /// End-to-end test: activate a feature, then deactivate it through `dispatch`. Deactivation

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -296,7 +296,7 @@ impl TryFrom<&ChainConfig> for BaseChainSpec {
             .to_chain_hardforks();
         Self::validate_beryl_activation_admin(
             &hardforks,
-            cfg.activation_admin_address,
+            Some(cfg.activation_admin_address),
             cfg.chain_id,
         )?;
         let genesis_header = match cfg.genesis_l2_hash {
@@ -335,7 +335,7 @@ impl TryFrom<&ChainConfig> for BaseChainSpec {
                 prune_delete_limit: cfg.prune_delete_limit,
                 ..Default::default()
             },
-            activation_admin_address: cfg.activation_admin_address,
+            activation_admin_address: Some(cfg.activation_admin_address),
         })
     }
 }
@@ -706,19 +706,6 @@ mod tests {
             .expect_err("Beryl genesis without activation admin should be rejected");
         assert!(
             matches!(err, BaseChainSpecError::MissingActivationAdminAddress { chain_id: id } if id == chain_id)
-        );
-    }
-
-    #[test]
-    fn beryl_chain_config_without_activation_admin_is_rejected() {
-        let mut config = ChainConfig::devnet().clone();
-        config.beryl_timestamp = Some(0);
-        config.activation_admin_address = None;
-
-        let err = BaseChainSpec::try_from(&config)
-            .expect_err("Beryl chain config without activation admin should be rejected");
-        assert!(
-            matches!(err, BaseChainSpecError::MissingActivationAdminAddress { chain_id } if chain_id == config.chain_id)
         );
     }
 

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -232,14 +232,14 @@ impl BaseChainSpec {
         Ok(Self { inner: value, activation_admin_address })
     }
 
-    /// Validates that Beryl-enabled chains include an activation registry admin address.
+    /// Validates that Beryl-enabled chains have a valid activation registry admin address:
+    /// present (not `None`) and non-zero.
     pub fn validate_beryl_activation_admin(
         hardforks: &ChainHardforks,
         activation_admin_address: Option<Address>,
         chain_id: u64,
     ) -> Result<(), BaseChainSpecError> {
-        let beryl_scheduled =
-            !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never);
+        let beryl_scheduled = !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never);
 
         if activation_admin_address.is_none() && beryl_scheduled {
             return Err(BaseChainSpecError::MissingActivationAdminAddress { chain_id });

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -238,15 +238,14 @@ impl BaseChainSpec {
         activation_admin_address: Option<Address>,
         chain_id: u64,
     ) -> Result<(), BaseChainSpecError> {
-        if activation_admin_address.is_none()
-            && !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never)
-        {
+        let beryl_scheduled =
+            !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never);
+
+        if activation_admin_address.is_none() && beryl_scheduled {
             return Err(BaseChainSpecError::MissingActivationAdminAddress { chain_id });
         }
 
-        if matches!(activation_admin_address, Some(addr) if addr.is_zero())
-            && !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never)
-        {
+        if matches!(activation_admin_address, Some(addr) if addr.is_zero()) && beryl_scheduled {
             return Err(BaseChainSpecError::ZeroActivationAdminAddress { chain_id });
         }
 

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -31,6 +31,12 @@ pub enum BaseChainSpecError {
         /// Chain ID whose Beryl-enabled configuration lacks an activation admin address.
         chain_id: u64,
     },
+    /// Beryl is scheduled but the activation registry admin address is `Address::ZERO`.
+    #[error("activation admin address must not be zero for Beryl-enabled chain ID: {chain_id}")]
+    ZeroActivationAdminAddress {
+        /// Chain ID whose Beryl-enabled configuration has a zero activation admin address.
+        chain_id: u64,
+    },
 }
 
 /// Genesis info extracted from a Base genesis config.
@@ -236,6 +242,12 @@ impl BaseChainSpec {
             && !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never)
         {
             return Err(BaseChainSpecError::MissingActivationAdminAddress { chain_id });
+        }
+
+        if matches!(activation_admin_address, Some(addr) if addr.is_zero())
+            && !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never)
+        {
+            return Err(BaseChainSpecError::ZeroActivationAdminAddress { chain_id });
         }
 
         Ok(())
@@ -722,6 +734,53 @@ mod tests {
 
         assert!(
             matches!(err, BaseChainSpecError::MissingActivationAdminAddress { chain_id: id } if id == chain_id)
+        );
+    }
+
+    #[test]
+    fn beryl_genesis_with_zero_activation_admin_is_rejected() {
+        let chain_id = 987_654;
+        let mut genesis = Genesis::default();
+        genesis.config.chain_id = chain_id;
+        genesis.config.extra_fields.insert("base".to_string(), serde_json::json!({ "beryl": 0 }));
+        genesis.config.extra_fields.insert(
+            "activationAdminAddress".to_string(),
+            serde_json::json!("0x0000000000000000000000000000000000000000"),
+        );
+
+        let err = BaseChainSpec::try_from_genesis(genesis)
+            .expect_err("Beryl genesis with zero activation admin should be rejected");
+        assert!(
+            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id: id } if id == chain_id)
+        );
+    }
+
+    #[test]
+    fn beryl_chain_config_with_zero_activation_admin_is_rejected() {
+        use alloy_primitives::Address;
+        let mut config = ChainConfig::devnet().clone();
+        config.beryl_timestamp = Some(0);
+        config.activation_admin_address = Some(Address::ZERO);
+
+        let err = BaseChainSpec::try_from(&config)
+            .expect_err("Beryl chain config with zero activation admin should be rejected");
+        assert!(
+            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id } if chain_id == config.chain_id)
+        );
+    }
+
+    #[test]
+    fn beryl_builder_with_zero_activation_admin_is_rejected() {
+        use alloy_primitives::Address;
+        let chain_id = ChainConfig::mainnet().chain_id;
+        let err = BaseChainSpecBuilder::base_mainnet()
+            .optional_activation_admin_address(Some(Address::ZERO))
+            .beryl_activated()
+            .try_build()
+            .expect_err("Beryl builder with zero activation admin should be rejected");
+
+        assert!(
+            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id: id } if id == chain_id)
         );
     }
 

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -470,7 +470,7 @@ mod tests {
     use alloy_consensus::proofs::storage_root_unhashed;
     use alloy_genesis::{ChainConfig as AlloyChainConfig, Genesis};
     use alloy_hardforks::Hardfork;
-    use alloy_primitives::{B256, U256, address, b256};
+    use alloy_primitives::{Address, B256, U256, address, b256};
     use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
     use base_common_rpc_types::FeeInfo;
     use reth_chainspec::{
@@ -757,7 +757,6 @@ mod tests {
 
     #[test]
     fn beryl_chain_config_with_zero_activation_admin_is_rejected() {
-        use alloy_primitives::Address;
         let mut config = ChainConfig::devnet().clone();
         config.beryl_timestamp = Some(0);
         config.activation_admin_address = Some(Address::ZERO);
@@ -771,7 +770,6 @@ mod tests {
 
     #[test]
     fn beryl_builder_with_zero_activation_admin_is_rejected() {
-        use alloy_primitives::Address;
         let chain_id = ChainConfig::mainnet().chain_id;
         let err = BaseChainSpecBuilder::base_mainnet()
             .optional_activation_admin_address(Some(Address::ZERO))

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -745,7 +745,7 @@ mod tests {
     fn beryl_chain_config_with_zero_activation_admin_is_rejected() {
         let mut config = ChainConfig::devnet().clone();
         config.beryl_timestamp = Some(0);
-        config.activation_admin_address = Some(Address::ZERO);
+        config.activation_admin_address = Address::ZERO;
 
         let err = BaseChainSpec::try_from(&config)
             .expect_err("Beryl chain config with zero activation admin should be rejected");

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -246,7 +246,7 @@ impl BootInfo {
 
         let built_in_chain_config = base_common_chains::ChainConfig::by_chain_id(chain_id);
         let activation_admin_address =
-            built_in_chain_config.and_then(|config| config.activation_admin_address);
+            built_in_chain_config.map(|config| config.activation_admin_address);
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
@@ -435,7 +435,7 @@ mod tests {
 
         let boot_info = BootInfo::load(&oracle).await.expect("boot info should load");
 
-        assert_eq!(boot_info.activation_admin_address, chain_config.activation_admin_address);
+        assert_eq!(boot_info.activation_admin_address, Some(chain_config.activation_admin_address));
     }
 
     #[tokio::test]

--- a/crates/proof/succinct/utils/client/src/boot.rs
+++ b/crates/proof/succinct/utils/client/src/boot.rs
@@ -85,7 +85,7 @@ mod tests {
             claimed_l2_output_root: B256::repeat_byte(0x33),
             claimed_l2_block_number,
             chain_id: rollup_config.l2_chain_id.id(),
-            activation_admin_address: ChainConfig::MAINNET.activation_admin_address,
+            activation_admin_address: Some(ChainConfig::MAINNET.activation_admin_address),
             rollup_config,
             l1_config,
             proposer: Address::ZERO,


### PR DESCRIPTION
## Motivation

`ActivationRegistryStorage::admin()` maps both `None` (no admin configured) and `Some(Address::ZERO)` (zero address explicitly set) to the same return value. A chain misconfigured with `activation_admin_address == Some(Address::ZERO)` therefore creates a backdoor: any deposit transaction whose recovered sender is `Address::ZERO` matches the admin check and can freely toggle Beryl activation state.

## What changed

Two layers of defense:

**Config-time.** `ChainConfig.activation_admin_address` is now a required `Address` rather than `Option<Address>`. Since every Base chain schedules Beryl, an admin was always required — the `Option` was misleading and allowed `Some(Address::ZERO)` to pass without a type error. Chain spec construction (`try_from_genesis`, `try_from_chainspec`, `try_build`) now also rejects `Address::ZERO` explicitly with a new `ZeroActivationAdminAddress` error, alongside the existing check for a missing admin.

**Runtime.** `set_activated` now rejects any caller whose address is `Address::ZERO` before reaching the admin comparison. This ensures that even if a misconfiguration bypasses the config-time guard, a zero-address caller cannot activate or deactivate features.

## What was considered

The `admin()` helper — which maps `None` to `Address::ZERO` for Solidity null-address conventions — is left unchanged. Once the config-time guard is in place, `Some(Address::ZERO)` can no longer reach production, eliminating the ambiguity at the source. The runtime guard is kept as defense-in-depth: it is cheap and protects against any future code path that might construct a chain spec without going through the validated constructors.
