### PR TITLE
fix(b20-variant): make decimals() return Option<u8> to prevent asset misuse

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -20,6 +20,13 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "b20")?;
     let has_asset = has_field(&input, "asset");
     let name = input.ident;
+    // This branch is only generated for token structs that do NOT have an `asset` field —
+    // i.e. stablecoin token structs. Asset token structs always have an `asset` field and
+    // take the `has_asset` branch above (which delegates to `AssetAccounting::decimals` and
+    // reads per-token decimals from storage). Therefore `B20Variant::Asset` is structurally
+    // unreachable in the generated code below; `B20Variant::Asset.decimals()` returning `None`
+    // cannot occur here. The only `None` case from `from_address` is an unrecognized (non-B20)
+    // address, which `unwrap_or(0)` handles the same way the original `map_or(0, ...)` did.
     let decimals_impl = if has_asset {
         quote! { crate::AssetAccounting::decimals(self) }
     } else {

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -27,7 +27,8 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
             Ok(crate::B20Variant::from_address(
                 ::base_precompile_storage::ContractStorage::address(self),
             )
-            .map_or(0, crate::B20Variant::decimals))
+            .and_then(|v| v.decimals())
+            .unwrap_or(0))
         }
     };
 

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -121,7 +121,9 @@ impl<'a> B20FactoryStorage<'a> {
             variant: B20Variant::Stablecoin.abi(),
             name,
             symbol,
-            decimals: B20Variant::Stablecoin.decimals(),
+            decimals: B20Variant::Stablecoin
+                .decimals()
+                .expect("stablecoin has fixed 6-decimal precision"),
             variantParams: encode_stablecoin_variant_params(&currency),
         })?;
 
@@ -1262,5 +1264,41 @@ mod tests {
         // constant sharing.
         assert!(B20Variant::Stablecoin.supported_version() > 0);
         assert!(B20Variant::Asset.supported_version() > 0);
+    }
+
+    #[test]
+    fn b20created_asset_event_emits_token_specific_decimals() {
+        // Regression: B20Created.decimals for an asset token must reflect init.decimals
+        // (per-token), not any variant constant. Use 12 to distinguish from both the
+        // Stablecoin fixed value (6) and the Asset MIN_DECIMALS sentinel (6).
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::ASSET,
+            salt: B256::repeat_byte(0x72),
+            params: IB20Factory::B20AssetCreateParams {
+                version: 1,
+                name: "Custom Decimals Asset".to_string(),
+                symbol: "CDA".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                decimals: 12,
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+        storage.set_caller(Address::repeat_byte(0x01));
+        StorageCtx::enter(&mut storage, |ctx| {
+            dispatch_factory_success(ctx, call);
+        });
+        let event = storage
+            .get_events(B20FactoryStorage::ADDRESS)
+            .iter()
+            .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
+            .expect("B20Created must be emitted");
+        assert_eq!(
+            event.decimals, 12,
+            "B20Created.decimals must equal init.decimals, not any variant constant"
+        );
     }
 }

--- a/crates/common/precompiles/src/b20_factory/variant.rs
+++ b/crates/common/precompiles/src/b20_factory/variant.rs
@@ -93,10 +93,12 @@ impl B20Variant {
         }
     }
 
-    /// Returns the default fixed decimal precision for variants without stored decimals.
-    pub const fn decimals(self) -> u8 {
+    /// Returns the fixed decimal precision for this variant, or `None` for variants (like
+    /// `Asset`) where decimals are per-token and supplied at creation time via init params.
+    pub const fn decimals(self) -> Option<u8> {
         match self {
-            Self::Asset | Self::Stablecoin => 6,
+            Self::Stablecoin => Some(6),
+            Self::Asset => None,
         }
     }
 


### PR DESCRIPTION
[BOP-323](https://linear.app/coinbase/issue/BOP-323)

## Motivation

`B20Variant::decimals()` previously returned `6` for both `Stablecoin` and `Asset` variants, despite asset decimals being a per-token value supplied at creation time via `B20AssetInit::decimals`. The factory correctly used `init.decimals` (not the variant constant) when emitting the `B20Created` event for asset tokens, but the misleading method signature invited future callers to assume `6` is always correct for any B-20 token address.

## What changed

- `variant.rs`: `decimals()` now returns `Option<u8>`. Returns `Some(6)` for `Stablecoin` and `None` for `Asset`, making the absence of a fixed constant explicit at the type level.
- `accounting.rs`: The proc-macro `expand_token` call site changed from `.map_or(0, crate::B20Variant::decimals)` to `.and_then(|v| v.decimals()).unwrap_or(0)` to match the new return type. Semantics are unchanged for all existing variants.
- `storage.rs`: The `init_stablecoin` call site changed to `.expect("stablecoin has fixed 6-decimal precision")` to surface the invariant explicitly.
- `storage.rs` (tests): Added `b20created_asset_event_emits_token_specific_decimals`, which creates an asset token with `decimals: 12` and asserts the emitted `B20Created` event carries `12`, not any variant constant.

## What was tried / considered

An alternative was to rename the method to `stablecoin_decimals()` and keep the `u8` return type. This was rejected because it would still leave a `Self::Asset` match arm that either returns a wrong value or panics, and callers would need to know to only call it on the right variant. Returning `Option<u8>` encodes the constraint in the type system and forces all call sites to handle the `None` case explicitly.