### PR TITLE
docs(b20-asset): document authorization boundary invariant in batch_mint

### DIFF
--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -231,7 +231,19 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Mints tokens to multiple recipients. All-or-nothing.
     ///
-    /// Check order: PAUSE → ROLE → INPUT → BUSINESS
+    /// # Authorization boundary
+    ///
+    /// The `ensure_not_paused` and `ensure_token_role` calls below are the **sole**
+    /// authorization gate for all batch-mint operations. The inner [`Mintable::mint`]
+    /// calls pass `privileged = true` only to avoid re-running the same checks once
+    /// per recipient, which is safe because the outer guards have already fired.
+    ///
+    /// **Do not remove or conditionalize the outer guards.** Doing so would leave a
+    /// fully open privileged path, since the inner mints unconditionally bypass
+    /// their own checks. The tests `batch_mint_check_order` in this module pin this
+    /// invariant and will fail if either guard is dropped.
+    ///
+    /// Check order: PAUSE -> ROLE -> INPUT -> BUSINESS
     pub fn batch_mint(
         &mut self,
         caller: Address,


### PR DESCRIPTION
[BOP-275](https://linear.app/coinbase/issue/BOP-275)

## Context

`batch_mint` enforces `ensure_not_paused` and `ensure_token_role` once at the outer boundary, then calls the inner `Mintable::mint` with `privileged = true` so those same checks are not repeated per recipient. This is intentional: the outer guards are the sole authorization gate, and the inner `privileged = true` is a performance optimization, not a privilege escalation.

The audit finding noted that if a future refactor were to drop the outer guards, the inner mints would silently become fully open with no compile-time or test failure to catch the regression.

## What changed

- Added an `# Authorization boundary` doc section to `batch_mint` explaining why `privileged = true` is passed to the inner mints and why the outer guards must not be removed or conditionalized.
- Preserved the existing `Check order: PAUSE -> ROLE -> INPUT -> BUSINESS` summary line.

## What was tried / considered

Adding a new test was considered, but the existing `batch_mint_check_order` rstest cases already cover both the `Paused` and `NoRole` invariants: removing either outer guard causes those test cases to fail. A documentation-only fix is sufficient to satisfy the finding without adding redundant test coverage.