### PR TITLE
feat: read Base/OP-format L1 transactions in the derivation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4197,6 +4197,7 @@ dependencies = [
  "base-metrics",
  "base-protocol",
  "c-kzg",
+ "derive_more 2.1.1",
  "http-body-util",
  "httpmock",
  "lru 0.16.4",

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -251,6 +251,8 @@ impl ConsensusFollowNodeArgs {
             trust_rpc: self.config.l1_rpc_args.l1_trust_rpc,
             beacon_client: l1_beacon,
             engine_provider: RootProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone()),
+            l1_eth_rpc: self.config.l1_rpc_args.l1_eth_rpc.clone(),
+            l1_tx_format: self.config.l1_rpc_args.l1_tx_format,
             finalized_poll_interval: L1Config::default_finalized_poll_interval(cfg.l1_chain_id),
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,
         })

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -1,5 +1,6 @@
 //! L1 Client CLI arguments.
 
+use base_consensus_node::L1TxFormat;
 use eyre::WrapErr;
 use tracing::{info, warn};
 use url::Url;
@@ -38,6 +39,17 @@ pub struct L1ClientArgs {
     /// parent chain must batch via calldata (or alt-DA).
     #[arg(long, visible_alias = "l1.calldata-only", env = "BASE_NODE_L1_CALLDATA_ONLY")]
     pub l1_calldata_only: bool,
+    /// The transaction format of the L1 chain: `ethereum` (default) or `base`.
+    ///
+    /// `base` (an appchain settling to Base) carries deposit (`0x7E`)/EIP-8130 (`0x7D`) txs the
+    /// Ethereum envelopes can't deserialize; pair it with `--l1.calldata-only` (no beacon/blob DA).
+    #[arg(
+        long,
+        visible_alias = "l1.tx-format",
+        env = "BASE_NODE_L1_TX_FORMAT",
+        default_value_t = L1TxFormat::default()
+    )]
+    pub l1_tx_format: L1TxFormat,
     /// Duration in seconds of an L1 slot.
     ///
     /// This is an optional argument that can be used to use a fixed slot duration for l1 blocks
@@ -63,6 +75,7 @@ impl Default for L1ClientArgs {
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
             l1_beacon: Some("http://localhost:5052".to_string()),
             l1_calldata_only: false,
+            l1_tx_format: L1TxFormat::default(),
             l1_slot_duration_override: None,
             l1_verifier_confs: 0,
         }
@@ -90,28 +103,45 @@ impl L1ClientArgs {
     /// - neither: error - the operator must state intent.
     /// - both: error - conflicting flags.
     pub fn validate(&self) -> eyre::Result<()> {
-        match (self.l1_beacon()?.is_some(), self.l1_calldata_only) {
-            (true, false) | (false, true) => Ok(()),
-            (false, false) => Err(eyre::eyre!(
-                "no L1 derivation mode selected: provide --l1.beacon <url> for the main Base chain, \
-                 or pass --l1.calldata-only for an appchain parent with no beacon API"
-            )),
-            (true, true) => Err(eyre::eyre!(
-                "conflicting L1 derivation modes: --l1.beacon and --l1.calldata-only are mutually \
-                 exclusive"
-            )),
+        let has_beacon = self.l1_beacon()?.is_some();
+        match (has_beacon, self.l1_calldata_only) {
+            (true, false) | (false, true) => {}
+            (false, false) => {
+                return Err(eyre::eyre!(
+                    "no L1 derivation mode selected: provide --l1.beacon <url> for the main Base \
+                     chain, or pass --l1.calldata-only for an appchain parent with no beacon API"
+                ));
+            }
+            (true, true) => {
+                return Err(eyre::eyre!(
+                    "conflicting L1 derivation modes: --l1.beacon and --l1.calldata-only are \
+                     mutually exclusive"
+                ));
+            }
         }
+
+        // A Base L1 has no beacon/blob DA, so reject a beacon URL paired with
+        // `--l1.tx-format base`.
+        if self.l1_tx_format == L1TxFormat::Base && has_beacon {
+            return Err(eyre::eyre!(
+                "--l1.tx-format base has no beacon/blob DA: do not pass --l1.beacon; run with \
+                 --l1.calldata-only"
+            ));
+        }
+
+        Ok(())
     }
 
-    /// Logs the active L1 derivation mode at startup. Call after [`Self::validate`], which has
-    /// already vetted the beacon URL.
+    /// Logs the active L1 derivation mode and L1 transaction format
+    /// at startup. Call after [`Self::validate`], which has already vetted the
+    /// beacon URL.
     pub fn log_derivation_mode(&self) {
         match self.l1_beacon().ok().flatten() {
             Some(beacon) => {
-                info!(target: "rollup_node", l1_beacon = %beacon, "L1 beacon mode: deriving blob-based batches")
+                info!(target: "rollup_node", l1_tx_format = %self.l1_tx_format, l1_beacon = %beacon, "L1 beacon mode: deriving blob-based batches")
             }
             None => {
-                warn!(target: "rollup_node", "L1 calldata-only mode: no beacon API configured; blob-based batches cannot be derived")
+                warn!(target: "rollup_node", l1_tx_format = %self.l1_tx_format, "L1 calldata-only mode: no beacon API configured; blob-based batches cannot be derived")
             }
         }
     }
@@ -147,6 +177,28 @@ mod tests {
     #[test]
     fn both_flags_are_an_error() {
         assert!(args(Some("http://localhost:5052"), true).validate().is_err());
+    }
+
+    #[test]
+    fn base_tx_format_with_beacon_is_an_error() {
+        // Base parent has no beacon DA: beacon URL is rejected even though beacon-mode alone is valid.
+        let mut a = args(Some("http://localhost:5052"), false);
+        a.l1_tx_format = L1TxFormat::Base;
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn base_tx_format_calldata_only_is_valid() {
+        let mut a = args(None, true);
+        a.l1_tx_format = L1TxFormat::Base;
+        assert!(a.validate().is_ok());
+    }
+
+    #[test]
+    fn ethereum_tx_format_beacon_mode_is_valid() {
+        let mut a = args(Some("http://localhost:5052"), false);
+        a.l1_tx_format = L1TxFormat::Ethereum;
+        assert!(a.validate().is_ok());
     }
 
     #[test]

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -255,6 +255,7 @@ impl ConsensusNodeArgs {
             trust_rpc: self.config.l1_rpc_args.l1_trust_rpc,
             beacon: self.config.l1_rpc_args.l1_beacon()?,
             rpc_url: self.config.l1_rpc_args.l1_eth_rpc.clone(),
+            l1_tx_format: self.config.l1_rpc_args.l1_tx_format,
             slot_duration_override: self.config.l1_rpc_args.l1_slot_duration_override,
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,
         };

--- a/crates/consensus/cli/src/p2p.rs
+++ b/crates/consensus/cli/src/p2p.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use alloy_primitives::{B256, b256};
-use alloy_provider::Provider;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::ChainProvider;
@@ -446,12 +445,11 @@ impl P2PArgs {
 
             // Fetch the unsafe block signer address from the system config.
             let unsafe_block_signer_address = provider
-                .inner
                 .get_storage_at(
                     rollup_config.l1_system_config_address,
                     UNSAFE_BLOCK_SIGNER_ADDRESS_STORAGE_SLOT.into(),
+                    block_info.hash.into(),
                 )
-                .hash(block_info.hash)
                 .await?;
 
             // Convert the unsafe block signer address to the correct type.

--- a/crates/consensus/providers/Cargo.toml
+++ b/crates/consensus/providers/Cargo.toml
@@ -46,6 +46,7 @@ http-body-util.workspace = true
 serde = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["time"] }
+derive_more = { workspace = true, features = ["display", "from_str"] }
 
 c-kzg.workspace = true
 tracing.workspace = true

--- a/crates/consensus/providers/src/chain_provider.rs
+++ b/crates/consensus/providers/src/chain_provider.rs
@@ -4,22 +4,24 @@ use std::{boxed::Box, num::NonZeroUsize, vec::Vec};
 
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_eips::BlockId;
-use alloy_primitives::B256;
-use alloy_provider::{Provider, RootProvider};
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::{Network, Provider, RootProvider};
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
+use base_common_consensus::BaseReceiptEnvelope;
+use base_common_network::Base;
 use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind, ResetError};
 use base_protocol::BlockInfo;
 use lru::LruCache;
 
-use crate::Metrics;
+use crate::{L1TxFormat, Metrics};
 
 /// The [`AlloyChainProvider`] is a concrete implementation of the [`ChainProvider`] trait, providing
 /// data over Ethereum JSON-RPC using an alloy provider as the backend.
 #[derive(Debug, Clone)]
 pub struct AlloyChainProvider {
-    /// The inner Ethereum JSON-RPC provider.
-    pub inner: RootProvider,
+    /// The inner JSON-RPC provider.
+    inner: L1RpcProvider,
     /// Whether to trust the RPC without verification.
     pub trust_rpc: bool,
     /// `header_by_hash` LRU cache.
@@ -28,6 +30,171 @@ pub struct AlloyChainProvider {
     receipts_by_hash_cache: LruCache<B256, Vec<Receipt>>,
     /// `block_info_and_transactions_by_hash` LRU cache.
     block_info_and_transactions_by_hash_cache: LruCache<B256, (BlockInfo, Vec<TxEnvelope>)>,
+}
+
+/// The L1 JSON-RPC provider.
+///
+/// A node derives from a single L1 chain, so the transaction format is fixed at construction. Neither
+/// transaction envelope is a superset of the other — Ethereum has EIP-4844 blobs that Base lacks;
+/// Base has deposit (`0x7E`) and EIP-8130 (`0x7D`) txs that Ethereum lacks — so the full-decode
+/// path is necessarily format-specific.
+#[derive(Debug, Clone)]
+enum L1RpcProvider {
+    /// Ethereum-typed provider; decodes standard blocks including EIP-4844.
+    Ethereum(RootProvider),
+    /// Base/OP-typed provider; decodes deposit and EIP-8130 entries the Ethereum envelopes reject.
+    Base(RootProvider<Base>),
+}
+
+impl L1RpcProvider {
+    /// Returns the latest block number.
+    async fn get_block_number(&self) -> Result<u64, RpcError<TransportErrorKind>> {
+        match self {
+            Self::Ethereum(p) => p.get_block_number().await,
+            Self::Base(p) => p.get_block_number().await,
+        }
+    }
+
+    /// Returns the chain ID.
+    async fn get_chain_id(&self) -> Result<u64, RpcError<TransportErrorKind>> {
+        match self {
+            Self::Ethereum(p) => p.get_chain_id().await,
+            Self::Base(p) => p.get_chain_id().await,
+        }
+    }
+
+    /// Reads a storage slot at the given block. Format-agnostic.
+    async fn get_storage_at(
+        &self,
+        address: Address,
+        slot: U256,
+        block: BlockId,
+    ) -> Result<U256, RpcError<TransportErrorKind>> {
+        match self {
+            Self::Ethereum(p) => p.get_storage_at(address, slot).block_id(block).await,
+            Self::Base(p) => p.get_storage_at(address, slot).block_id(block).await,
+        }
+    }
+
+    /// Fetches the consensus [`Header`] for a block hash, header-only (no tx bodies).
+    async fn header_by_hash(&self, hash: B256) -> Result<Header, AlloyChainProviderError> {
+        base_metrics::time!(Metrics::request_duration("header_by_hash"), {
+            match self {
+                Self::Ethereum(p) => {
+                    p.get_block_by_hash(hash).await.map(|b| b.map(|b| b.header.into_consensus()))
+                }
+                Self::Base(p) => {
+                    p.get_block_by_hash(hash).await.map(|b| b.map(|b| b.header.into_consensus()))
+                }
+            }
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("header_by_hash").increment(1);
+        })?
+        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))
+    }
+
+    /// Fetches the consensus [`Header`] for a block number, header-only (no tx bodies).
+    async fn header_by_number(&self, number: u64) -> Result<Header, AlloyChainProviderError> {
+        base_metrics::time!(Metrics::request_duration("block_by_number"), {
+            match self {
+                Self::Ethereum(p) => p
+                    .get_block_by_number(number.into())
+                    .await
+                    .map(|b| b.map(|b| b.header.into_consensus())),
+                Self::Base(p) => p
+                    .get_block_by_number(number.into())
+                    .await
+                    .map(|b| b.map(|b| b.header.into_consensus())),
+            }
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("block_by_number").increment(1);
+        })?
+        .ok_or(AlloyChainProviderError::BlockNotFound(number.into()))
+    }
+
+    /// Fetches a block's receipts and reduces each to its consensus [`Receipt`].
+    ///
+    /// All receipts are kept (incl. the index-0 deposit on a Base L1) so block-wide log-index
+    /// numbering is preserved.
+    async fn receipts_by_hash(&self, hash: B256) -> Result<Vec<Receipt>, AlloyChainProviderError> {
+        match self {
+            Self::Base(p) => Ok(fetch_block_receipts(p, hash)
+                .await?
+                .into_iter()
+                .map(|r| Receipt::from(BaseReceiptEnvelope::from(r)))
+                .collect()),
+            Self::Ethereum(p) => fetch_block_receipts(p, hash)
+                .await?
+                .into_iter()
+                .map(|r| r.inner.into_primitives_receipt().as_receipt().cloned())
+                .collect::<Option<Vec<_>>>()
+                .ok_or(AlloyChainProviderError::ReceiptsConversion(hash)),
+        }
+    }
+
+    /// Fetches a full block and returns its consensus [`Header`] and transactions.
+    ///
+    /// On a Base L1, deposit (`0x7E`) and EIP-8130 (`0x7D`) txs have no Ethereum representation,
+    /// so [`TxEnvelope::try_from`] drops them. This is required for safety: it keeps an L1 deposit
+    /// out of the batcher-auth path (deposits are never batcher submissions, and L1→L2 deposits
+    /// derive from receipts).
+    async fn header_and_transactions_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<(Header, Vec<TxEnvelope>), AlloyChainProviderError> {
+        match self {
+            Self::Base(p) => {
+                let block = fetch_full_block(p, hash).await?;
+                let header = block.header.into_consensus();
+                let transactions = block
+                    .transactions
+                    .into_transactions()
+                    .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
+                    .collect();
+                Ok((header, transactions))
+            }
+            Self::Ethereum(p) => {
+                let block = fetch_full_block(p, hash)
+                    .await?
+                    .into_consensus()
+                    .map_transactions(|t| t.inner.into_inner());
+                Ok((block.header, block.body.transactions))
+            }
+        }
+    }
+}
+
+/// Fetches a block's receipts over JSON-RPC with timing/error metrics. Generic over the network so
+/// both providers share the fetch path; the caller converts the response into consensus receipts.
+async fn fetch_block_receipts<N: Network>(
+    provider: &RootProvider<N>,
+    hash: B256,
+) -> Result<Vec<N::ReceiptResponse>, AlloyChainProviderError> {
+    base_metrics::time!(Metrics::request_duration("receipts_by_hash"), {
+        provider.get_block_receipts(hash.into()).await
+    })
+    .inspect_err(|_e| {
+        Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
+    })?
+    .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))
+}
+
+/// Fetches a full block (with transactions) over JSON-RPC with timing/error metrics. Generic over
+/// the network so both providers share the fetch path; the caller converts the response into a
+/// [`BlockInfo`] and consensus transactions.
+async fn fetch_full_block<N: Network>(
+    provider: &RootProvider<N>,
+    hash: B256,
+) -> Result<N::BlockResponse, AlloyChainProviderError> {
+    base_metrics::time!(Metrics::request_duration("block_by_hash"), {
+        provider.get_block_by_hash(hash).full().await
+    })
+    .inspect_err(|_e| {
+        Metrics::chain_rpc_errors("block_by_hash").increment(1);
+    })?
+    .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))
 }
 
 impl AlloyChainProvider {
@@ -45,7 +212,7 @@ impl AlloyChainProvider {
     /// - Panics if `cache_size` is zero.
     pub fn new_with_trust(inner: RootProvider, cache_size: usize, trust_rpc: bool) -> Self {
         Self {
-            inner,
+            inner: L1RpcProvider::Ethereum(inner),
             trust_rpc,
             header_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
             receipts_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
@@ -59,6 +226,29 @@ impl AlloyChainProvider {
     pub fn new_http(url: url::Url, cache_size: usize) -> Self {
         let inner = RootProvider::new_http(url);
         Self::new(inner, cache_size)
+    }
+
+    /// Creates an [`AlloyChainProvider`] from a URL, decoding full tx/receipt reads in the given
+    /// [`L1TxFormat`].
+    pub fn new_http_with_format(
+        url: url::Url,
+        cache_size: usize,
+        trust_rpc: bool,
+        format: L1TxFormat,
+    ) -> Self {
+        let inner = match format {
+            L1TxFormat::Base => L1RpcProvider::Base(RootProvider::<Base>::new_http(url)),
+            L1TxFormat::Ethereum => L1RpcProvider::Ethereum(RootProvider::new_http(url)),
+        };
+        Self {
+            inner,
+            trust_rpc,
+            header_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
+            receipts_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
+            block_info_and_transactions_by_hash_cache: LruCache::new(
+                NonZeroUsize::new(cache_size).unwrap(),
+            ),
+        }
     }
 
     /// Returns the latest L2 block number.
@@ -79,6 +269,16 @@ impl AlloyChainProvider {
     /// Returns the chain ID.
     pub async fn chain_id(&mut self) -> Result<u64, RpcError<TransportErrorKind>> {
         self.inner.get_chain_id().await
+    }
+
+    /// Reads a storage slot at the given block over the underlying provider.
+    pub async fn get_storage_at(
+        &self,
+        address: Address,
+        slot: U256,
+        block: BlockId,
+    ) -> Result<U256, RpcError<TransportErrorKind>> {
+        self.inner.get_storage_at(address, slot, block).await
     }
 
     /// Verifies that a header's hash matches the expected hash when `trust_rpc` is false.
@@ -162,14 +362,7 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("header_by_hash").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration("header_by_hash"), {
-            self.inner.get_block_by_hash(hash).await
-        })
-        .inspect_err(|_e| {
-            Metrics::chain_rpc_errors("header_by_hash").increment(1);
-        })?
-        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
-        let header = block.header.into_consensus();
+        let header = self.inner.header_by_hash(hash).await?;
 
         // Verify the header hash matches what we requested
         self.verify_header_hash(&header, hash)?;
@@ -184,14 +377,7 @@ impl ChainProvider for AlloyChainProvider {
     async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error> {
         Metrics::chain_rpc_calls("block_by_number").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration("block_by_number"), {
-            self.inner.get_block_by_number(number.into()).await
-        })
-        .inspect_err(|_e| {
-            Metrics::chain_rpc_errors("block_by_number").increment(1);
-        })?
-        .ok_or(AlloyChainProviderError::BlockNotFound(number.into()))?;
-        let header = block.header.into_consensus();
+        let header = self.inner.header_by_number(number).await?;
 
         let block_info = BlockInfo {
             hash: header.hash_slow(),
@@ -212,18 +398,7 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("receipts_by_hash").increment(1);
 
-        let receipts = base_metrics::time!(Metrics::request_duration("receipts_by_hash"), {
-            self.inner.get_block_receipts(hash.into()).await
-        })
-        .inspect_err(|_e| {
-            Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
-        })?
-        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
-        let consensus_receipts = receipts
-            .into_iter()
-            .map(|r| r.inner.into_primitives_receipt().as_receipt().cloned())
-            .collect::<Option<Vec<_>>>()
-            .ok_or(AlloyChainProviderError::ReceiptsConversion(hash))?;
+        let consensus_receipts = self.inner.receipts_by_hash(hash).await?;
 
         self.receipts_by_hash_cache.put(hash, consensus_receipts.clone());
 
@@ -246,38 +421,32 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("block_by_hash").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration("block_by_hash"), {
-            self.inner.get_block_by_hash(hash).full().await
-        })
-        .inspect_err(|_e| {
-            Metrics::chain_rpc_errors("block_by_hash").increment(1);
-        })?
-        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?
-        .into_consensus()
-        .map_transactions(|t| t.inner.into_inner());
+        let (header, transactions) = self.inner.header_and_transactions_by_hash(hash).await?;
 
-        // Verify the block hash matches what we requested
-        self.verify_header_hash(&block.header, hash)?;
+        // Verify the header hash matches what we requested
+        self.verify_header_hash(&header, hash)?;
 
         let block_info = BlockInfo {
             hash, // Use the already verified hash instead of recomputing
-            number: block.header.number,
-            parent_hash: block.header.parent_hash,
-            timestamp: block.header.timestamp,
+            number: header.number,
+            parent_hash: header.parent_hash,
+            timestamp: header.timestamp,
         };
 
         self.block_info_and_transactions_by_hash_cache
-            .put(hash, (block_info, block.body.transactions.clone()));
+            .put(hash, (block_info, transactions.clone()));
 
         Metrics::cache_entries("block_info_and_tx").increment(1);
 
-        Ok((block_info, block.body.transactions))
+        Ok((block_info, transactions))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
+    use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
+    use serde_json::{Value, json};
 
     use super::*;
 
@@ -312,5 +481,155 @@ mod tests {
             matches!(kind, PipelineErrorKind::Temporary(_)),
             "number-based BlockNotFound must stay Temporary (block not yet produced)"
         );
+    }
+
+    fn json_rpc_response(req: &HttpMockRequest, result: Value) -> String {
+        let id = serde_json::from_slice::<Value>(&req.body_vec())
+            .ok()
+            .and_then(|body| body.get("id").cloned())
+            .unwrap_or(Value::Null);
+        json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
+    }
+
+    /// A type-`0x7e` deposit transaction, as a Base/OP JSON-RPC endpoint returns it.
+    fn deposit_tx_json() -> Value {
+        json!({
+            "type": "0x7e",
+            "hash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
+            "nonce": "0x0",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "transactionIndex": "0x0",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "to": "0x4200000000000000000000000000000000000015",
+            "value": "0x0",
+            "gasPrice": "0x0",
+            "gas": "0xf4240",
+            "input": "0x",
+            "v": "0x0",
+            "r": "0x0",
+            "s": "0x0",
+            "sourceHash": "0x990d7122a1f121f3a6bc45723e28f4921c269037a77e77ffee3c8585136d1a92",
+            "mint": "0x0",
+            "depositReceiptVersion": "0x1"
+        })
+    }
+
+    /// A Base-format block whose only transaction is a `0x7e` deposit.
+    fn base_block_with_deposit() -> Value {
+        json!({
+            "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "parentHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "stateRoot": "0x3333333333333333333333333333333333333333333333333333333333333333",
+            "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "difficulty": "0x0",
+            "number": "0x2a",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "timestamp": "0x1",
+            "extraData": "0x",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce": "0x0000000000000000",
+            "baseFeePerGas": "0x1",
+            "transactions": [deposit_tx_json()],
+            "uncles": [],
+            "withdrawals": [],
+            "blobGasUsed": "0x0",
+            "excessBlobGas": "0x0"
+        })
+    }
+
+    /// A type-`0x7e` deposit receipt, as a Base/OP JSON-RPC endpoint returns it.
+    fn deposit_receipt_json() -> Value {
+        json!({
+            "type": "0x7e",
+            "status": "0x1",
+            "cumulativeGasUsed": "0x0",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "logs": [],
+            "transactionHash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
+            "transactionIndex": "0x0",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "to": "0x4200000000000000000000000000000000000015",
+            "gasUsed": "0x0",
+            "effectiveGasPrice": "0x0",
+            "contractAddress": null,
+            "depositNonce": "0x0",
+            "depositReceiptVersion": "0x1"
+        })
+    }
+
+    fn base_provider(server: &MockServer) -> AlloyChainProvider {
+        let url: url::Url = server.url("/").parse().unwrap();
+        AlloyChainProvider::new_http_with_format(url, 16, true, L1TxFormat::Base)
+    }
+
+    /// Regression: a Base-format block carrying a `0x7e` deposit must decode through the
+    /// `RootProvider<Base>` path, and the deposit must be dropped from the down-converted txs
+    /// (never surfaced to the calldata scanner / batcher-auth path).
+    #[tokio::test]
+    async fn base_format_block_decodes_and_drops_deposit() {
+        let server = MockServer::start_async().await;
+        let block = base_block_with_deposit();
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, block.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let mut provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let (info, txs) = provider.block_info_and_transactions_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(info.number, 0x2a);
+        assert!(
+            txs.is_empty(),
+            "the 0x7e deposit must be decoded then dropped from the down-converted transactions"
+        );
+    }
+
+    /// Regression: a Base-format `0x7e` deposit receipt must decode and be kept — unlike the tx
+    /// path, receipts preserve deposits, since the index-0 deposit anchors block-wide log indices.
+    #[tokio::test]
+    async fn base_format_receipts_decode_and_preserve_deposit() {
+        let server = MockServer::start_async().await;
+        let receipts = json!([deposit_receipt_json()]);
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, receipts.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let mut provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let receipts = provider.receipts_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(receipts.len(), 1, "the 0x7e deposit receipt must be decoded and preserved");
     }
 }

--- a/crates/consensus/providers/src/lib.rs
+++ b/crates/consensus/providers/src/lib.rs
@@ -31,3 +31,6 @@ pub use l2_chain_provider::{AlloyL2ChainProvider, AlloyL2ChainProviderError};
 
 mod pipeline;
 pub use pipeline::OnlinePipeline;
+
+mod tx_format;
+pub use tx_format::L1TxFormat;

--- a/crates/consensus/providers/src/tx_format.rs
+++ b/crates/consensus/providers/src/tx_format.rs
@@ -1,0 +1,19 @@
+//! L1 transaction format selection for the derivation-pipeline reader.
+
+/// The transaction format of the L1 chain the derivation pipeline reads from.
+///
+/// A `Base` L1 carries deposit (`0x7E`) and EIP-8130 (`0x7D`) transactions (and the receipts
+/// mirroring them) the default Ethereum envelopes cannot deserialize. Selected at startup via
+/// `--l1.tx-format`.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, derive_more::Display, derive_more::FromStr,
+)]
+pub enum L1TxFormat {
+    /// An Ethereum-format L1 chain (alloy's standard envelopes, blob DA).
+    #[display("ethereum")]
+    #[default]
+    Ethereum,
+    /// A Base/OP-format L1 chain (deposit/EIP-8130 transactions, calldata DA).
+    #[display("base")]
+    Base,
+}

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -12,7 +12,7 @@ extern crate tracing;
 mod service;
 pub use service::{
     DerivationDelegateConfig, FollowNode, FollowNodeConfig, HEAD_STREAM_POLL_INTERVAL, L1Config,
-    L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder, ShutdownSignal,
+    L1ConfigBuilder, L1TxFormat, NodeMode, RollupNode, RollupNodeBuilder, ShutdownSignal,
 };
 
 mod follow;

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -13,8 +13,8 @@ use base_consensus_rpc::RpcBuilder;
 use url::Url;
 
 use crate::{
-    EngineConfig, NetworkConfig, RollupNode, SequencerConfig, actors::DerivationDelegateClient,
-    service::node::L1Config,
+    EngineConfig, L1TxFormat, NetworkConfig, RollupNode, SequencerConfig,
+    actors::DerivationDelegateClient, service::node::L1Config,
 };
 
 /// Configuration for Derivation Delegate mode.
@@ -38,10 +38,12 @@ pub struct L1ConfigBuilder {
     pub chain_config: ChainConfig,
     /// Whether to trust the L1 RPC.
     pub trust_rpc: bool,
-    /// The L1 beacon API, or `None` when the L1 parent has no beacon (blob) DA endpoint.
+    /// The L1 beacon API, or `None` when the L1 has no beacon (blob) DA endpoint.
     pub beacon: Option<Url>,
     /// The L1 RPC URL.
     pub rpc_url: Url,
+    /// The transaction format of the L1 chain (Ethereum or Base/OP).
+    pub l1_tx_format: L1TxFormat,
     /// The duration in seconds of an L1 slot. This can be used to hardcode a fixed slot
     /// duration if the l1-beacon's slot configuration is not available.
     pub slot_duration_override: Option<u64>,
@@ -191,6 +193,8 @@ impl RollupNodeBuilder {
             trust_rpc: self.l1_config_builder.trust_rpc,
             beacon_client: l1_beacon,
             engine_provider: RootProvider::new_http(self.l1_config_builder.rpc_url.clone()),
+            l1_eth_rpc: self.l1_config_builder.rpc_url,
+            l1_tx_format: self.l1_config_builder.l1_tx_format,
             finalized_poll_interval,
             verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
         };
@@ -264,6 +268,7 @@ mod tests {
             trust_rpc: true,
             beacon: Some(Url::parse("http://127.0.0.1:5052").unwrap()),
             rpc_url: Url::parse("http://127.0.0.1:8545").unwrap(),
+            l1_tx_format: L1TxFormat::default(),
             slot_duration_override: None,
             verifier_l1_confs: 0,
         };

--- a/crates/consensus/service/src/service/mod.rs
+++ b/crates/consensus/service/src/service/mod.rs
@@ -9,6 +9,7 @@ pub use builder::{DerivationDelegateConfig, L1ConfigBuilder, RollupNodeBuilder};
 pub use crate::follow::{FollowNode, FollowNodeConfig};
 
 mod mode;
+pub use base_consensus_providers::L1TxFormat;
 pub use mode::NodeMode;
 
 mod node;

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -23,14 +23,15 @@ use base_consensus_safedb::{DisabledSafeDB, SafeDB, SafeDBReader, SafeHeadListen
 use base_protocol::L2BlockInfo;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
+use url::Url;
 
 use crate::{
     AlloyL1BlockFetcher, CheckpointActor, CheckpointClient, CheckpointDB, CheckpointWriter,
     Conductor, ConductorClient, DelayedL1OriginSelectorProvider, DelegateDerivationActor,
     DerivationActor, DerivationDelegateClient, DerivationError, EngineActor, EngineActorRequest,
     EngineConfig, EngineProcessor, EngineProcessorOptions, EngineRpcProcessor, L1OriginSelector,
-    L1WatcherActor, L1WatcherQueryProcessor, NetworkActor, NetworkBuilder, NetworkConfig,
-    NodeActor, NodeMode, PayloadBuilder, QueuedDerivationEngineClient,
+    L1TxFormat, L1WatcherActor, L1WatcherQueryProcessor, NetworkActor, NetworkBuilder,
+    NetworkConfig, NodeActor, NodeMode, PayloadBuilder, QueuedDerivationEngineClient,
     QueuedEngineDerivationClient, QueuedEngineRpcClient, QueuedL1WatcherDerivationClient,
     QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient,
     RecoveryModeGuard, RpcActor, RpcContext, SequencerActor, SequencerConfig,
@@ -51,8 +52,13 @@ pub struct L1Config {
     /// The L1 beacon client, or `None` when no beacon endpoint is configured (e.g. an L2
     /// parent chain with no blob DA, running calldata-only).
     pub beacon_client: Option<OnlineBeaconClient>,
-    /// The L1 engine provider.
+    /// Ethereum-typed L1 provider for origin selection, block fetching and the head/finalized
+    /// streams — format-agnostic reads only. The derivation reader is built from [`Self::l1_eth_rpc`].
     pub engine_provider: RootProvider,
+    /// L1 RPC URL, used to build the format-aware derivation reader.
+    pub l1_eth_rpc: Url,
+    /// The transaction format of the L1 chain (Ethereum or Base/OP).
+    pub l1_tx_format: L1TxFormat,
     /// How frequently to poll L1 for a new finalized block.
     ///
     /// The right value depends on the L1 finality cadence:
@@ -183,10 +189,11 @@ impl RollupNode {
     fn create_attributes_builder(
         &self,
     ) -> StatefulAttributesBuilder<AlloyChainProvider, AlloyL2ChainProvider> {
-        let l1_derivation_provider = AlloyChainProvider::new_with_trust(
-            self.l1_config.engine_provider.clone(),
+        let l1_derivation_provider = AlloyChainProvider::new_http_with_format(
+            self.l1_config.l1_eth_rpc.clone(),
             DERIVATION_PROVIDER_CACHE_SIZE,
             self.l1_config.trust_rpc,
+            self.l1_config.l1_tx_format,
         );
         let l2_derivation_provider = AlloyL2ChainProvider::new_with_trust(
             self.l2_provider.clone(),
@@ -208,10 +215,11 @@ impl RollupNode {
         l1_head_number: base_consensus_providers::L1HeadNumber,
     ) -> OnlinePipeline {
         // Create the caching L1/L2 EL providers for derivation.
-        let l1_derivation_provider = AlloyChainProvider::new_with_trust(
-            self.l1_config.engine_provider.clone(),
+        let l1_derivation_provider = AlloyChainProvider::new_http_with_format(
+            self.l1_config.l1_eth_rpc.clone(),
             DERIVATION_PROVIDER_CACHE_SIZE,
             self.l1_config.trust_rpc,
+            self.l1_config.l1_tx_format,
         );
         let l2_derivation_provider = AlloyL2ChainProvider::new_with_trust(
             self.l2_provider.clone(),

--- a/etc/docker/devnet-l3-env
+++ b/etc/docker/devnet-l3-env
@@ -10,6 +10,9 @@ L1_MODE=base
 # beaconless mode must be opted into explicitly via --l1.calldata-only, otherwise the consensus
 # node refuses to start (guards against a main-chain node silently running without a beacon API).
 BASE_NODE_L1_CALLDATA_ONLY=true
+# The L1 parent is Base/OP-format: blocks carry deposit (0x7E) txs the Ethereum envelopes can't
+# deserialize. Tell the consensus node's parent-chain reader to decode Base-format transactions.
+BASE_NODE_L1_TX_FORMAT=base
 # L1 slot duration matches base-anvil's --block-time (2s).
 BASE_NODE_L1_SLOT_DURATION_OVERRIDE=2
 

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -215,6 +215,7 @@ services:
       - BASE_NODE_L1_BEACON
       - BASE_NODE_L1_CALLDATA_ONLY
       - BASE_NODE_L1_SLOT_DURATION_OVERRIDE
+      - BASE_NODE_L1_TX_FORMAT
     command:
       - node
       - --chain
@@ -354,6 +355,7 @@ services:
       - BASE_NODE_L1_BEACON
       - BASE_NODE_L1_CALLDATA_ONLY
       - BASE_NODE_L1_SLOT_DURATION_OVERRIDE
+      - BASE_NODE_L1_TX_FORMAT
     command:
       - node
       - --chain

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -429,6 +429,7 @@ services:
       - BASE_NODE_L1_BEACON
       - BASE_NODE_L1_CALLDATA_ONLY
       - BASE_NODE_L1_SLOT_DURATION_OVERRIDE
+      - BASE_NODE_L1_TX_FORMAT
     entrypoint: /app/base-consensus
     command:
       - node
@@ -636,6 +637,7 @@ services:
       - BASE_NODE_L1_BEACON
       - BASE_NODE_L1_CALLDATA_ONLY
       - BASE_NODE_L1_SLOT_DURATION_OVERRIDE
+      - BASE_NODE_L1_TX_FORMAT
     entrypoint: /app/base-consensus
     command:
       - node
@@ -713,6 +715,7 @@ services:
       - BASE_NODE_L1_BEACON
       - BASE_NODE_L1_CALLDATA_ONLY
       - BASE_NODE_L1_SLOT_DURATION_OVERRIDE
+      - BASE_NODE_L1_TX_FORMAT
     entrypoint: /app/base
     command:
       - rpc

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -19,7 +19,8 @@ use base_builder_core::test_utils::get_available_port;
 use base_common_genesis::RollupConfig;
 use base_consensus_disc::LocalNode;
 use base_consensus_node::{
-    EngineConfig, L1ConfigBuilder, NetworkConfig, NodeMode, RollupNodeBuilder, SequencerConfig,
+    EngineConfig, L1ConfigBuilder, L1TxFormat, NetworkConfig, NodeMode, RollupNodeBuilder,
+    SequencerConfig,
 };
 use base_consensus_peers::{PeerScoreLevel, SecretKeyLoader};
 use base_consensus_rpc::{AdminApiClient, BaseP2PApiClient, RollupNodeApiClient, RpcBuilder};
@@ -143,6 +144,7 @@ impl InProcessConsensus {
             trust_rpc: true,
             beacon: Some(config.l1_beacon_url),
             rpc_url: config.l1_rpc_url.clone(),
+            l1_tx_format: L1TxFormat::default(),
             slot_duration_override: config.l1_slot_duration_override,
             verifier_l1_confs: config.verifier_l1_confs,
         };


### PR DESCRIPTION
The parent-chain reader assumed an Ethereum L1. An L1 whose blocks carry Base/OP transactions — deposit (0x7E) and EIP-8130 (0x7D) — failed to deserialize over RPC, which blocked use as an L3 that settles to Base.

AlloyChainProvider now decodes the L1 wire format chosen at construction. A new L1TxFormat enum selects an Ethereum- or Base-typed RootProvider. Full transaction and receipt reads down-convert to the standard alloy_consensus types the pipeline already consumes, so the ChainProvider trait and its consumers stay unchanged. The down-conversion drops deposit and EIP-8130 transactions — they are never batcher submissions, and L1→L2 deposits derive from receipts — but keeps every receipt to preserve block-wide log-index numbering.

A new --l1.tx-format flag (BASE_NODE_L1_TX_FORMAT) selects the format and threads through the node, follow, and builder configs. Validation rejects a beacon URL on a Base L1, which has no blob DA. The base-anvil L3 devnet and docker compose files set the flag.

Closes PRIV-1923