### PR TITLE
feat: add basectl doctor diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6566,6 +6566,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-tungstenite 0.28.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
 ]

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -21,10 +21,8 @@ base-common-network = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-
-[dev-dependencies]
-serde_json = { workspace = true, features = ["std"] }

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -118,6 +118,38 @@ Important EL RPC note:
 - If the EL RPC does not expose those admin methods, `basectl p2p` degrades gracefully: EL peer count still appears, but EL endpoint fields or EL peer listings show as unavailable / `null`.
 - CL data comes from `opp2p_self`, `opp2p_peerStats`, and `opp2p_peers(true)` on the consensus RPC.
 
+### `basectl doctor`
+
+Runs read-only diagnostics for a single node and prints one row per check. The
+command exits `1` if any check fails, and exits `0` when checks only pass, warn,
+skip, or report informational context.
+
+Doctor reads the selected config the same way as the other non-TUI commands:
+built-in preset, optional YAML override, or explicit config path through global
+`-c/--config`. By default it uses the config's `rpc`, `l1_rpc`, and
+`consensus_node_rpc` values. Pass `--el-rpc` and `--cl-rpc` to point at a
+specific node when the config points at shared/public endpoints.
+
+Checks include declared network vs. live chain ID, p2p endpoint context,
+canonical bootnode config context, advertised endpoint sanity, EL/CL peer counts,
+EL head vs. public tip, safe-head recency, optional `reth.toml` headers/bodies
+limits, consensus-node RPC presence, and L1 RPC reachability. Doctor does not
+mutate node state and does not prove advertised ports are reachable from the
+public internet; it reports what can be observed from local config and exposed
+RPC metadata.
+
+| Flag | Description |
+|------|-------------|
+| `--el-rpc <URL>` | Override the execution-layer RPC URL used for local-node checks. Defaults to the selected config's `rpc` field. |
+| `--cl-rpc <URL>` | Override the consensus-node RPC URL. If omitted and the selected config has no `consensus_node_rpc`, CL-dependent checks are skipped with hints. |
+| `--reth-config <PATH>` | Path to the local `reth.toml` file. If omitted, the reth limits check is skipped. |
+| `--peer-warn-threshold <COUNT>` | Connected peer count below which EL/CL peer checks warn. Default `5`. |
+| `--head-lag-warn-blocks <BLOCKS>` | EL head lag behind the public tip above which doctor warns. Default `10`. |
+| `--head-lag-fail-blocks <BLOCKS>` | EL head lag behind the public tip above which doctor fails. Default `20`. |
+| `--safe-recency-warn-blocks <BLOCKS>` | Safe-head lag behind unsafe head above which doctor warns. Default `150`. |
+| `--safe-recency-fail-blocks <BLOCKS>` | Safe-head lag behind unsafe head above which doctor fails. Default `300`. |
+| `--json` | Emit a humanized JSON report with `inputs`, `summary`, and `checks` instead of pretty text. |
+
 ### `basectl flashblocks`
 
 Streams live flashblocks as newline-delimited JSON to stdout. For the
@@ -177,4 +209,13 @@ basectl -c sepolia p2p peers --el-rpc https://your-el.example/ --cl-rpc https://
 
 # If the EL RPC is restricted, EL peer count still works but EL admin-backed fields may be unavailable
 basectl -c sepolia p2p info --el-rpc https://your-public-el.example/ --cl-rpc https://your-cl.example/
+
+# Run doctor with values from the selected config
+basectl -c mainnet doctor
+
+# Run doctor against a specific node
+basectl -c mainnet doctor --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/
+
+# Include local reth headers/bodies limit validation and JSON output
+basectl -c mainnet doctor --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/ --reth-config /etc/reth/reth.toml --json
 ```

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -1,5 +1,7 @@
 //! Contains the CLI arguments for the basectl binary.
 
+use std::path::PathBuf;
+
 use basectl_cli::ViewId;
 use clap::{Args, Parser, Subcommand};
 use url::Url;
@@ -94,9 +96,49 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: P2pCommands,
     },
+    /// Run read-only diagnostics for a single node.
+    Doctor(DoctorArgs),
     /// Stream flashblocks as JSON lines.
     #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]
     Flashblocks,
+}
+
+/// Flags for `basectl doctor`.
+#[derive(Debug, Args)]
+pub(crate) struct DoctorArgs {
+    /// Override the execution-layer RPC URL.
+    ///
+    /// Defaults to the chain config's `rpc` field. Pass this flag to diagnose
+    /// a specific node instead of a public preset RPC.
+    #[arg(long = "el-rpc", value_name = "URL")]
+    pub(crate) el_rpc: Option<Url>,
+    /// Override the consensus-node RPC URL.
+    ///
+    /// If omitted and the selected config has no `consensus_node_rpc`, CL
+    /// checks are skipped with hints while EL/L1/config checks still run.
+    #[arg(long = "cl-rpc", value_name = "URL")]
+    pub(crate) cl_rpc: Option<Url>,
+    /// Path to the local `reth.toml` file.
+    #[arg(long = "reth-config", value_name = "PATH")]
+    pub(crate) reth_config: Option<PathBuf>,
+    /// Connected peer count below which peer checks warn.
+    #[arg(long = "peer-warn-threshold", value_name = "COUNT", default_value_t = 5)]
+    pub(crate) peer_warn_threshold: u32,
+    /// EL head lag above which `el_head_vs_tip` warns.
+    #[arg(long = "head-lag-warn-blocks", value_name = "BLOCKS", default_value_t = 10)]
+    pub(crate) head_lag_warn_blocks: u64,
+    /// EL head lag above which `el_head_vs_tip` fails.
+    #[arg(long = "head-lag-fail-blocks", value_name = "BLOCKS", default_value_t = 20)]
+    pub(crate) head_lag_fail_blocks: u64,
+    /// Safe-head lag above which `safe_head_recency` warns.
+    #[arg(long = "safe-recency-warn-blocks", value_name = "BLOCKS", default_value_t = 150)]
+    pub(crate) safe_recency_warn_blocks: u64,
+    /// Safe-head lag above which `safe_head_recency` fails.
+    #[arg(long = "safe-recency-fail-blocks", value_name = "BLOCKS", default_value_t = 300)]
+    pub(crate) safe_recency_fail_blocks: u64,
+    /// Emit a humanized JSON report instead of pretty text.
+    #[arg(long)]
+    pub(crate) json: bool,
 }
 
 /// Read-only p2p inspection commands.

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -1,0 +1,241 @@
+//! Implementation of the `basectl doctor` subcommand.
+
+use std::io::{self, Write};
+
+use anyhow::Result;
+use basectl_cli::{
+    Doctor, DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus, DoctorThresholds, JsonOutput,
+    MonitoringConfig,
+};
+
+use crate::cli::DoctorArgs;
+
+const ANSI_RED: &str = "\x1b[31m";
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_CYAN: &str = "\x1b[36m";
+const ANSI_DIM: &str = "\x1b[2m";
+const ANSI_RESET: &str = "\x1b[0m";
+
+/// Runs the `basectl doctor` subcommand.
+pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<bool> {
+    let options = DoctorOptions {
+        el_rpc: args.el_rpc.unwrap_or_else(|| config.rpc.clone()),
+        cl_rpc: args.cl_rpc.or_else(|| config.consensus_node_rpc.clone()),
+        reth_config: args.reth_config,
+        thresholds: DoctorThresholds {
+            peer_warn_threshold: args.peer_warn_threshold,
+            head_lag_warn_blocks: args.head_lag_warn_blocks,
+            head_lag_fail_blocks: args.head_lag_fail_blocks,
+            safe_recency_warn_blocks: args.safe_recency_warn_blocks,
+            safe_recency_fail_blocks: args.safe_recency_fail_blocks,
+        },
+    };
+    let json = args.json;
+    let report = Doctor::run(config, options).await;
+    if json {
+        JsonOutput::print(&report)?;
+    } else {
+        print_pretty(&report)?;
+    }
+    Ok(report.has_failures())
+}
+
+fn print_pretty(report: &DoctorReport) -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    write_pretty(&mut stdout, report)?;
+    Ok(())
+}
+
+fn write_pretty<W: Write>(writer: &mut W, report: &DoctorReport) -> io::Result<()> {
+    writeln!(writer, "network  {}", report.network)?;
+    writeln!(
+        writer,
+        "summary  pass={} warn={} fail={} info={} skip={}",
+        report.summary.pass,
+        report.summary.warn,
+        report.summary.fail,
+        report.summary.info,
+        report.summary.skip,
+    )?;
+    writeln!(writer)?;
+    for check in sorted_checks(report) {
+        write_check(writer, check)?;
+    }
+    Ok(())
+}
+
+fn sorted_checks(report: &DoctorReport) -> Vec<&DoctorCheck> {
+    let mut checks = report.checks.iter().collect::<Vec<_>>();
+    checks.sort_by_key(|check| status_sort_key(check.status));
+    checks
+}
+
+const fn status_sort_key(status: DoctorStatus) -> u8 {
+    match status {
+        DoctorStatus::Fail => 0,
+        DoctorStatus::Warn => 1,
+        DoctorStatus::Skip => 2,
+        DoctorStatus::Info => 3,
+        DoctorStatus::Pass => 4,
+    }
+}
+
+fn write_check<W: Write>(writer: &mut W, check: &DoctorCheck) -> io::Result<()> {
+    writeln!(writer, "{} {}", colored_status(check.status), check.check)?;
+    writeln!(writer, "  message: {}", check.message)?;
+    write_value_block(writer, "value", &check.value, 2)?;
+    write_value_block(writer, "threshold", &check.threshold, 2)?;
+    if let Some(hint) = &check.hint {
+        writeln!(writer, "  hint: {hint}")?;
+    }
+    writeln!(writer)
+}
+
+fn colored_status(status: DoctorStatus) -> String {
+    let color = match status {
+        DoctorStatus::Fail | DoctorStatus::Warn => ANSI_RED,
+        DoctorStatus::Skip => ANSI_DIM,
+        DoctorStatus::Info => ANSI_CYAN,
+        DoctorStatus::Pass => ANSI_GREEN,
+    };
+    format!("{color}{}{ANSI_RESET}", status.as_str())
+}
+
+fn write_value_block<W: Write>(
+    writer: &mut W,
+    label: &str,
+    value: &serde_json::Value,
+    indent: usize,
+) -> io::Result<()> {
+    if is_empty_value(value) {
+        return Ok(());
+    }
+    writeln!(writer, "{0:1$}{label}:", "", indent)?;
+    write_json_value(writer, value, indent + 2)
+}
+
+fn write_json_value<W: Write>(
+    writer: &mut W,
+    value: &serde_json::Value,
+    indent: usize,
+) -> io::Result<()> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, value) in map {
+                if is_empty_value(value) {
+                    continue;
+                }
+                match value {
+                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                        writeln!(writer, "{0:1$}{key}:", "", indent)?;
+                        write_json_value(writer, value, indent + 2)?;
+                    }
+                    _ => writeln!(
+                        writer,
+                        "{:indent$}{}: {}",
+                        "",
+                        key,
+                        scalar_value(value),
+                        indent = indent,
+                    )?,
+                }
+            }
+            Ok(())
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                match value {
+                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                        writeln!(writer, "{0:1$}-", "", indent)?;
+                        write_json_value(writer, value, indent + 2)?;
+                    }
+                    _ => writeln!(
+                        writer,
+                        "{:indent$}- {}",
+                        "",
+                        scalar_value(value),
+                        indent = indent,
+                    )?,
+                }
+            }
+            Ok(())
+        }
+        _ => writeln!(writer, "{:indent$}{}", "", scalar_value(value), indent = indent),
+    }
+}
+
+fn scalar_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        _ => value.to_string(),
+    }
+}
+
+fn is_empty_value(value: &serde_json::Value) -> bool {
+    matches!(value, serde_json::Value::Null)
+        || matches!(value, serde_json::Value::Object(map) if map.values().all(is_empty_value))
+        || matches!(value, serde_json::Value::Array(values) if values.iter().all(is_empty_value))
+}
+
+#[cfg(test)]
+mod tests {
+    use basectl_cli::{DoctorCheck, DoctorStatus};
+    use serde_json::json;
+
+    use super::{ANSI_CYAN, ANSI_GREEN, ANSI_RED, colored_status, status_sort_key, write_check};
+
+    #[test]
+    fn pretty_check_includes_status_value_threshold_and_hint() {
+        let check = DoctorCheck::new(
+            "el_peer_count",
+            DoctorStatus::Warn,
+            "EL peer count is below the warning threshold",
+            json!({ "count": 3 }),
+            json!({ "warnBelow": 5 }),
+            Some("Check p2p config.".to_string()),
+        );
+        let mut out = Vec::new();
+
+        write_check(&mut out, &check).unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+
+        assert!(rendered.contains("WARN"));
+        assert!(rendered.contains("el_peer_count"));
+        assert!(rendered.contains(ANSI_RED));
+        assert!(rendered.contains("  value:\n    count: 3"));
+        assert!(rendered.contains("  threshold:\n    warnBelow: 5"));
+        assert!(rendered.contains("Check p2p config."));
+    }
+
+    #[test]
+    fn pretty_status_order_prioritizes_actionable_rows() {
+        let mut statuses = vec![
+            DoctorStatus::Pass,
+            DoctorStatus::Info,
+            DoctorStatus::Warn,
+            DoctorStatus::Skip,
+            DoctorStatus::Fail,
+        ];
+
+        statuses.sort_by_key(|status| status_sort_key(*status));
+
+        assert_eq!(
+            statuses,
+            vec![
+                DoctorStatus::Fail,
+                DoctorStatus::Warn,
+                DoctorStatus::Skip,
+                DoctorStatus::Info,
+                DoctorStatus::Pass,
+            ],
+        );
+    }
+
+    #[test]
+    fn pretty_status_labels_are_colored() {
+        assert_eq!(colored_status(DoctorStatus::Fail), format!("{ANSI_RED}FAIL\x1b[0m"));
+        assert_eq!(colored_status(DoctorStatus::Warn), format!("{ANSI_RED}WARN\x1b[0m"));
+        assert_eq!(colored_status(DoctorStatus::Info), format!("{ANSI_CYAN}INFO\x1b[0m"));
+        assert_eq!(colored_status(DoctorStatus::Pass), format!("{ANSI_GREEN}PASS\x1b[0m"));
+    }
+}

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -11,6 +11,7 @@ use basectl_cli::{
 use crate::cli::DoctorArgs;
 
 const ANSI_RED: &str = "\x1b[31m";
+const ANSI_YELLOW: &str = "\x1b[33m";
 const ANSI_GREEN: &str = "\x1b[32m";
 const ANSI_CYAN: &str = "\x1b[36m";
 const ANSI_DIM: &str = "\x1b[2m";
@@ -104,7 +105,8 @@ fn write_check<W: Write>(writer: &mut W, check: &DoctorCheck) -> io::Result<()> 
 
 fn colored_status(status: DoctorStatus) -> String {
     let color = match status {
-        DoctorStatus::Fail | DoctorStatus::Warn => ANSI_RED,
+        DoctorStatus::Fail => ANSI_RED,
+        DoctorStatus::Warn => ANSI_YELLOW,
         DoctorStatus::Skip => ANSI_DIM,
         DoctorStatus::Info => ANSI_CYAN,
         DoctorStatus::Pass => ANSI_GREEN,
@@ -197,8 +199,8 @@ mod tests {
     use url::Url;
 
     use super::{
-        ANSI_CYAN, ANSI_GREEN, ANSI_RED, colored_status, status_sort_key, validate_thresholds,
-        write_check,
+        ANSI_CYAN, ANSI_GREEN, ANSI_RED, ANSI_YELLOW, colored_status, status_sort_key,
+        validate_thresholds, write_check,
     };
     use crate::cli::DoctorArgs;
 
@@ -219,7 +221,7 @@ mod tests {
 
         assert!(rendered.contains("WARN"));
         assert!(rendered.contains("el_peer_count"));
-        assert!(rendered.contains(ANSI_RED));
+        assert!(rendered.contains(ANSI_YELLOW));
         assert!(rendered.contains("  value:\n    count: 3"));
         assert!(rendered.contains("  threshold:\n    warnBelow: 5"));
         assert!(rendered.contains("Check p2p config."));
@@ -252,7 +254,7 @@ mod tests {
     #[test]
     fn pretty_status_labels_are_colored() {
         assert_eq!(colored_status(DoctorStatus::Fail), format!("{ANSI_RED}FAIL\x1b[0m"));
-        assert_eq!(colored_status(DoctorStatus::Warn), format!("{ANSI_RED}WARN\x1b[0m"));
+        assert_eq!(colored_status(DoctorStatus::Warn), format!("{ANSI_YELLOW}WARN\x1b[0m"));
         assert_eq!(colored_status(DoctorStatus::Info), format!("{ANSI_CYAN}INFO\x1b[0m"));
         assert_eq!(colored_status(DoctorStatus::Pass), format!("{ANSI_GREEN}PASS\x1b[0m"));
     }

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use basectl_cli::{
     Doctor, DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus, DoctorThresholds, JsonOutput,
     MonitoringConfig,
@@ -18,6 +18,7 @@ const ANSI_RESET: &str = "\x1b[0m";
 
 /// Runs the `basectl doctor` subcommand.
 pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<bool> {
+    validate_thresholds(&args)?;
     let options = DoctorOptions {
         el_rpc: args.el_rpc.unwrap_or_else(|| config.rpc.clone()),
         cl_rpc: args.cl_rpc.or_else(|| config.consensus_node_rpc.clone()),
@@ -38,6 +39,16 @@ pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<bo
         print_pretty(&report)?;
     }
     Ok(report.has_failures())
+}
+
+fn validate_thresholds(args: &DoctorArgs) -> Result<()> {
+    if args.head_lag_warn_blocks >= args.head_lag_fail_blocks {
+        bail!("`--head-lag-warn-blocks` must be less than `--head-lag-fail-blocks`");
+    }
+    if args.safe_recency_warn_blocks >= args.safe_recency_fail_blocks {
+        bail!("`--safe-recency-warn-blocks` must be less than `--safe-recency-fail-blocks`");
+    }
+    Ok(())
 }
 
 fn print_pretty(report: &DoctorReport) -> Result<()> {
@@ -179,10 +190,17 @@ fn is_empty_value(value: &serde_json::Value) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use basectl_cli::{DoctorCheck, DoctorStatus};
     use serde_json::json;
+    use url::Url;
 
-    use super::{ANSI_CYAN, ANSI_GREEN, ANSI_RED, colored_status, status_sort_key, write_check};
+    use super::{
+        ANSI_CYAN, ANSI_GREEN, ANSI_RED, colored_status, status_sort_key, validate_thresholds,
+        write_check,
+    };
+    use crate::cli::DoctorArgs;
 
     #[test]
     fn pretty_check_includes_status_value_threshold_and_hint() {
@@ -237,5 +255,45 @@ mod tests {
         assert_eq!(colored_status(DoctorStatus::Warn), format!("{ANSI_RED}WARN\x1b[0m"));
         assert_eq!(colored_status(DoctorStatus::Info), format!("{ANSI_CYAN}INFO\x1b[0m"));
         assert_eq!(colored_status(DoctorStatus::Pass), format!("{ANSI_GREEN}PASS\x1b[0m"));
+    }
+
+    #[test]
+    fn rejects_invalid_head_lag_thresholds() {
+        let args = test_args(|args| {
+            args.head_lag_warn_blocks = 30;
+            args.head_lag_fail_blocks = 10;
+        });
+
+        let err = validate_thresholds(&args).unwrap_err();
+
+        assert!(err.to_string().contains("--head-lag-warn-blocks"));
+    }
+
+    #[test]
+    fn rejects_invalid_safe_recency_thresholds() {
+        let args = test_args(|args| {
+            args.safe_recency_warn_blocks = 300;
+            args.safe_recency_fail_blocks = 300;
+        });
+
+        let err = validate_thresholds(&args).unwrap_err();
+
+        assert!(err.to_string().contains("--safe-recency-warn-blocks"));
+    }
+
+    fn test_args(update: impl FnOnce(&mut DoctorArgs)) -> DoctorArgs {
+        let mut args = DoctorArgs {
+            el_rpc: Some(Url::parse("http://127.0.0.1:8545").unwrap()),
+            cl_rpc: None,
+            reth_config: Option::<PathBuf>::None,
+            peer_warn_threshold: 5,
+            head_lag_warn_blocks: 10,
+            head_lag_fail_blocks: 20,
+            safe_recency_warn_blocks: 150,
+            safe_recency_fail_blocks: 300,
+            json: false,
+        };
+        update(&mut args);
+        args
     }
 }

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -2,6 +2,7 @@
 
 mod block;
 mod cli;
+mod doctor;
 mod p2p;
 mod sync_status;
 
@@ -39,6 +40,13 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(cli::Commands::P2p { command }) => {
             p2p::run(MonitoringConfig::load(config).await?, command).await
+        }
+        Some(cli::Commands::Doctor(args)) => {
+            let has_failures = doctor::run(MonitoringConfig::load(config).await?, args).await?;
+            if has_failures {
+                std::process::exit(1);
+            }
+            Ok(())
         }
         Some(cli::Commands::Flashblocks) => {
             run_flashblocks_json(MonitoringConfig::load(config).await?).await

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -84,11 +84,11 @@ struct LayerInfoJson {
     advertised_ip: Option<String>,
     tcp_port: Option<u16>,
     discovery: Option<basectl_cli::DiscoveryInfo>,
-    peer_count: u32,
+    peer_count: Option<u32>,
 }
 
 impl LayerInfoJson {
-    fn from_endpoint(endpoint: Option<NodeEndpoint>, peer_count: u32) -> Self {
+    fn from_endpoint(endpoint: Option<NodeEndpoint>, peer_count: Option<u32>) -> Self {
         let (advertised_ip, tcp_port, discovery) = endpoint.map_or((None, None, None), |ep| {
             (Some(ep.advertised_ip.to_string()), Some(ep.tcp_port), Some(ep.discovery))
         });
@@ -113,7 +113,7 @@ impl InfoJson {
         Self {
             network: network.to_string(),
             el: LayerInfoJson::from_endpoint(report.el, peer_stats.el_count),
-            cl: LayerInfoJson::from_endpoint(report.cl, peer_stats.cl.connected),
+            cl: LayerInfoJson::from_endpoint(report.cl, peer_stats.cl.map(|stats| stats.connected)),
         }
     }
 }
@@ -123,7 +123,7 @@ impl InfoJson {
 struct PeersJson {
     network: String,
     el: Option<Vec<PeerSummary>>,
-    cl: Vec<PeerSummary>,
+    cl: Option<Vec<PeerSummary>>,
 }
 
 impl PeersJson {
@@ -173,7 +173,13 @@ fn print_info_pretty(
             "el_discovery",
             el_discovery.unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
         )
-        .row("el_peer_count", peer_stats.el_count.to_string())
+        .row(
+            "el_peer_count",
+            peer_stats
+                .el_count
+                .map(|count| count.to_string())
+                .unwrap_or_else(unavailable_el_peer_count),
+        )
         .row(
             "cl_advertised_ip",
             report
@@ -196,7 +202,13 @@ fn print_info_pretty(
                 .unwrap_or_else(unavailable_cl_endpoint),
         )
         .row("cl_discovery", cl_discovery.unwrap_or_else(unavailable_cl_endpoint))
-        .row("cl_peer_count", peer_stats.cl.connected.to_string());
+        .row(
+            "cl_peer_count",
+            peer_stats
+                .cl
+                .map(|stats| stats.connected.to_string())
+                .unwrap_or_else(unavailable_cl_peer_stats),
+        );
     table.print()?;
     Ok(())
 }
@@ -207,7 +219,7 @@ fn print_peers_pretty(network: &str, report: &PeerListReport) -> Result<()> {
     writeln!(stdout)?;
     write_peer_section(&mut stdout, "execution", report.el.as_deref())?;
     writeln!(stdout)?;
-    write_peer_section(&mut stdout, "consensus", Some(&report.cl))?;
+    write_peer_section(&mut stdout, "consensus", report.cl.as_deref())?;
     Ok(())
 }
 
@@ -252,8 +264,16 @@ fn unavailable_admin_method(method: &str) -> String {
     format!("unavailable (`{method}` not exposed by this RPC)")
 }
 
+fn unavailable_el_peer_count() -> String {
+    "unavailable (`net_peerCount` not exposed by this RPC)".to_string()
+}
+
 fn unavailable_cl_endpoint() -> String {
     "unavailable (could not parse advertised endpoint from `opp2p_self`)".to_string()
+}
+
+fn unavailable_cl_peer_stats() -> String {
+    "unavailable (`opp2p_peerStats` not exposed by this RPC)".to_string()
 }
 
 #[cfg(test)]

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -26,10 +26,11 @@ alloy-transport-http = { workspace = true }
 base-consensus-gossip = { workspace = true }
 base-common-precompiles = { workspace = true }
 base-common-flashblocks = { workspace = true }
+toml = { workspace = true, features = ["parse", "serde"] }
 url = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true, features = ["net", "process", "time"] }
 alloy-eips = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 alloy-sol-types = { workspace = true, features = ["std"] }

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     fs,
     net::{IpAddr, SocketAddr},
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -245,7 +245,13 @@ impl Doctor {
             Self::consensus_rpc_check(options.cl_rpc.as_ref()),
             Self::el_peer_count_check(&el_info, options.thresholds.peer_warn_threshold),
             Self::cl_peer_count_check(cl_info.as_ref(), options.thresholds.peer_warn_threshold),
-            Self::head_vs_tip_check(&local_head, &public_head, &options.thresholds, &config.rpc),
+            Self::head_vs_tip_check(
+                &local_head,
+                &public_head,
+                &options.thresholds,
+                &options.el_rpc,
+                &config.rpc,
+            ),
             Self::safe_head_recency_check(sync_status.as_ref(), &options.thresholds),
             Self::l1_reachability_check(&l1_head, &config.l1_rpc),
         ];
@@ -323,8 +329,8 @@ impl Doctor {
         let el = endpoint_sanity(el_info.as_ref().ok().and_then(|info| info.endpoint));
         let cl = match cl_info {
             Some(Ok(info)) => endpoint_sanity(info.endpoint),
-            Some(Err(err)) => LayerEndpointSanity::unavailable(err.to_string()),
-            None => LayerEndpointSanity::unavailable("consensus-node RPC unavailable".to_string()),
+            Some(Err(err)) => unavailable_endpoint(err.to_string()),
+            None => unavailable_endpoint("consensus-node RPC unavailable"),
         };
         let status = worst_status([el.status, cl.status]);
         DoctorCheck::new(
@@ -432,7 +438,7 @@ impl Doctor {
                 || {
                     DoctorCheck::new(
                         "el_peer_count",
-                        DoctorStatus::Fail,
+                        DoctorStatus::Skip,
                         "could not fetch EL peer count",
                         json!({ "error": info.peer_count_error }),
                         json!({ "failAt": 0, "warnBelow": warn_threshold }),
@@ -497,12 +503,23 @@ impl Doctor {
         local_head: &Result<u64>,
         public_head: &Result<u64>,
         thresholds: &DoctorThresholds,
+        local_rpc: &Url,
         public_rpc: &Url,
     ) -> DoctorCheck {
         let threshold = json!({
             "warnBehindBlocks": thresholds.head_lag_warn_blocks,
             "failBehindBlocks": thresholds.head_lag_fail_blocks,
         });
+        if local_rpc == public_rpc {
+            return DoctorCheck::new(
+                "el_head_vs_tip",
+                DoctorStatus::Skip,
+                "local EL RPC matches the public tip reference",
+                json!({ "localRpc": local_rpc, "publicTipRpc": public_rpc }),
+                threshold,
+                Some("Pass `--el-rpc <URL>` pointing at a specific node to run a meaningful head-vs-tip check.".to_string()),
+            );
+        }
         let Ok(local) = local_head else {
             return DoctorCheck::new(
                 "el_head_vs_tip",
@@ -684,19 +701,6 @@ pub struct LayerEndpointSanity {
     pub reason: String,
 }
 
-impl LayerEndpointSanity {
-    /// Creates an unavailable layer result.
-    pub const fn unavailable(reason: String) -> Self {
-        Self {
-            status: DoctorStatus::Skip,
-            advertised_ip: None,
-            tcp_port: None,
-            discovery_udp_port: None,
-            reason,
-        }
-    }
-}
-
 /// Minimal `reth.toml` shape needed by doctor.
 #[derive(Debug, Deserialize)]
 pub struct RethToml {
@@ -724,7 +728,7 @@ pub struct RethLimits {
 
 impl RethLimits {
     /// Reads the minimal reth limits from a TOML file.
-    pub fn read(path: &PathBuf) -> Result<Self> {
+    pub fn read(path: &Path) -> Result<Self> {
         let contents = fs::read_to_string(path)
             .with_context(|| format!("reading reth config at {}", path.display()))?;
         let parsed: RethToml = toml::from_str(&contents)
@@ -736,7 +740,7 @@ impl RethLimits {
     }
 
     /// Converts parsed limits into a doctor check.
-    pub fn into_check(self, path: &PathBuf) -> DoctorCheck {
+    pub fn into_check(self, path: &Path) -> DoctorCheck {
         let missing = [
             self.headers.is_none().then_some("headers.limit"),
             self.bodies.is_none().then_some("bodies.limit"),
@@ -874,7 +878,7 @@ fn bootnode_addrs(raw: &str) -> Result<(&'static str, Option<SocketAddr>, Option
 
 fn endpoint_sanity(endpoint: Option<NodeEndpoint>) -> LayerEndpointSanity {
     let Some(endpoint) = endpoint else {
-        return LayerEndpointSanity::unavailable("advertised endpoint unavailable".to_string());
+        return unavailable_endpoint("advertised endpoint unavailable");
     };
     let (status, reason) = classify_ip(endpoint.advertised_ip);
     LayerEndpointSanity {
@@ -883,6 +887,16 @@ fn endpoint_sanity(endpoint: Option<NodeEndpoint>) -> LayerEndpointSanity {
         tcp_port: Some(endpoint.tcp_port),
         discovery_udp_port: Some(endpoint.discovery.udp_port),
         reason,
+    }
+}
+
+fn unavailable_endpoint(reason: impl Into<String>) -> LayerEndpointSanity {
+    LayerEndpointSanity {
+        status: DoctorStatus::Skip,
+        advertised_ip: None,
+        tcp_port: None,
+        discovery_udp_port: None,
+        reason: reason.into(),
     }
 }
 
@@ -965,11 +979,12 @@ mod tests {
     };
 
     use serde_json::json;
+    use url::Url;
 
     use super::{
-        DoctorCheck, DoctorStatus, DoctorSummary, DoctorThresholds, RethLimits, bootnode_addrs,
-        bootnode_chain, bootnode_layer_summary, classify_ip, expected_chain_id, peer_count_check,
-        worst_status,
+        Doctor, DoctorCheck, DoctorStatus, DoctorSummary, DoctorThresholds, ElInfoReport,
+        RethLimits, bootnode_addrs, bootnode_chain, bootnode_layer_summary, classify_ip,
+        expected_chain_id, peer_count_check, worst_status,
     };
 
     #[test]
@@ -1033,6 +1048,29 @@ mod tests {
             RethLimits { headers: None, bodies: Some(100) }.into_check(&path).status,
             DoctorStatus::Warn,
         );
+    }
+
+    #[test]
+    fn head_vs_tip_skips_when_local_rpc_is_public_reference() {
+        let rpc = Url::parse("https://sepolia.base.org").unwrap();
+        let thresholds = DoctorThresholds::default();
+
+        let check = Doctor::head_vs_tip_check(&Ok(10), &Ok(10), &thresholds, &rpc, &rpc);
+
+        assert_eq!(check.status, DoctorStatus::Skip);
+    }
+
+    #[test]
+    fn el_peer_count_unavailable_skips_instead_of_failing() {
+        let info = Ok(ElInfoReport {
+            endpoint: None,
+            peer_count: None,
+            peer_count_error: Some("EL `net_peerCount` unavailable from this RPC"),
+        });
+
+        let check = Doctor::el_peer_count_check(&info, 5);
+
+        assert_eq!(check.status, DoctorStatus::Skip);
     }
 
     #[test]

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -1,0 +1,1097 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use alloy_rpc_types_eth::SyncStatus as EthSyncStatus;
+use anyhow::{Context, Result, anyhow};
+use base_common_chains::ChainConfig;
+use base_consensus_peers::{BootNode, NodeRecord};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use url::Url;
+
+use crate::{
+    ClInfoReport, ElInfoReport, MonitoringConfig, NodeEndpoint, SyncStatusReport, TimestampJson,
+    fetch_cl_info, fetch_el_info, fetch_l1_block_number, fetch_l2_block_number, fetch_l2_chain_id,
+    fetch_sync_status,
+};
+
+const RETH_LIMIT_HARDCAP: u64 = 1024;
+
+/// Diagnostic runner for `basectl doctor`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Doctor;
+
+/// Runtime options for a `basectl doctor` run.
+#[derive(Debug, Clone)]
+pub struct DoctorOptions {
+    /// Execution-layer RPC URL to diagnose as the local node.
+    pub el_rpc: Url,
+    /// Optional consensus-node RPC URL to diagnose as the local node.
+    pub cl_rpc: Option<Url>,
+    /// Optional local `reth.toml` path.
+    pub reth_config: Option<PathBuf>,
+    /// Classification thresholds for graded checks.
+    pub thresholds: DoctorThresholds,
+}
+
+/// Configurable classification thresholds for `basectl doctor`.
+#[derive(Debug, Clone, Copy)]
+pub struct DoctorThresholds {
+    /// Connected peer count below which peer checks warn.
+    pub peer_warn_threshold: u32,
+    /// EL head lag above which `el_head_vs_tip` warns.
+    pub head_lag_warn_blocks: u64,
+    /// EL head lag above which `el_head_vs_tip` fails.
+    pub head_lag_fail_blocks: u64,
+    /// Safe-head block lag above which `safe_head_recency` warns.
+    pub safe_recency_warn_blocks: u64,
+    /// Safe-head block lag above which `safe_head_recency` fails.
+    pub safe_recency_fail_blocks: u64,
+}
+
+impl Default for DoctorThresholds {
+    fn default() -> Self {
+        Self {
+            peer_warn_threshold: 5,
+            head_lag_warn_blocks: 10,
+            head_lag_fail_blocks: 20,
+            safe_recency_warn_blocks: 150,
+            safe_recency_fail_blocks: 300,
+        }
+    }
+}
+
+/// Complete humanized `basectl doctor` report.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorReport {
+    /// Selected basectl network/config name.
+    pub network: String,
+    /// Report generation timestamp.
+    pub generated_at: TimestampJson,
+    /// Effective inputs used by the diagnostic run.
+    pub inputs: DoctorInputs,
+    /// Count of checks by status.
+    pub summary: DoctorSummary,
+    /// Individual check results.
+    pub checks: Vec<DoctorCheck>,
+}
+
+impl DoctorReport {
+    /// Returns `true` if any check failed.
+    pub fn has_failures(&self) -> bool {
+        self.checks.iter().any(|check| check.status == DoctorStatus::Fail)
+    }
+
+    fn new(network: String, inputs: DoctorInputs, checks: Vec<DoctorCheck>) -> Self {
+        let summary = DoctorSummary::from_checks(&checks);
+        Self { network, generated_at: current_timestamp(), inputs, summary, checks }
+    }
+}
+
+/// Effective inputs used by a doctor report.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorInputs {
+    /// Local execution-layer RPC URL.
+    pub el_rpc: Url,
+    /// Local consensus-node RPC URL, if configured.
+    pub cl_rpc: Option<Url>,
+    /// Configured L1 RPC URL.
+    pub l1_rpc: Url,
+    /// Public L2 RPC URL used as the tip reference.
+    pub public_tip_rpc: Url,
+    /// Optional local `reth.toml` path.
+    pub reth_config: Option<PathBuf>,
+}
+
+/// Count of doctor checks by status.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct DoctorSummary {
+    /// Passing graded checks.
+    pub pass: usize,
+    /// Warning checks.
+    pub warn: usize,
+    /// Failing checks.
+    pub fail: usize,
+    /// Informational checks.
+    pub info: usize,
+    /// Skipped checks.
+    pub skip: usize,
+}
+
+impl DoctorSummary {
+    /// Builds a summary from individual checks.
+    pub fn from_checks(checks: &[DoctorCheck]) -> Self {
+        let mut summary = Self::default();
+        for check in checks {
+            match check.status {
+                DoctorStatus::Pass => summary.pass += 1,
+                DoctorStatus::Warn => summary.warn += 1,
+                DoctorStatus::Fail => summary.fail += 1,
+                DoctorStatus::Info => summary.info += 1,
+                DoctorStatus::Skip => summary.skip += 1,
+            }
+        }
+        summary
+    }
+}
+
+/// Result of one doctor check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorCheck {
+    /// Stable check identifier.
+    pub check: String,
+    /// Check status.
+    pub status: DoctorStatus,
+    /// Human-readable diagnostic message.
+    pub message: String,
+    /// Observed values relevant to the check.
+    pub value: Value,
+    /// Thresholds relevant to the check.
+    pub threshold: Value,
+    /// Optional remediation hint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+impl DoctorCheck {
+    /// Creates a check result.
+    pub fn new(
+        check: impl Into<String>,
+        status: DoctorStatus,
+        message: impl Into<String>,
+        value: Value,
+        threshold: Value,
+        hint: Option<String>,
+    ) -> Self {
+        Self { check: check.into(), status, message: message.into(), value, threshold, hint }
+    }
+}
+
+/// Status of a doctor check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorStatus {
+    /// The graded check passed.
+    Pass,
+    /// The check found a risky state but not a hard failure.
+    Warn,
+    /// The check found a hard failure.
+    Fail,
+    /// The row is informational context.
+    Info,
+    /// The check could not run because a required input is unavailable.
+    Skip,
+}
+
+impl DoctorStatus {
+    /// Display label for pretty output.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+            Self::Info => "INFO",
+            Self::Skip => "SKIP",
+        }
+    }
+}
+
+impl Doctor {
+    /// Runs doctor checks and returns a complete report.
+    pub async fn run(config: MonitoringConfig, options: DoctorOptions) -> DoctorReport {
+        let inputs = DoctorInputs {
+            el_rpc: options.el_rpc.clone(),
+            cl_rpc: options.cl_rpc.clone(),
+            l1_rpc: config.l1_rpc.clone(),
+            public_tip_rpc: config.rpc.clone(),
+            reth_config: options.reth_config.clone(),
+        };
+
+        let (el_info, cl_info, chain_id, local_head, public_head, sync_status, l1_head) = tokio::join!(
+            fetch_el_info(&options.el_rpc),
+            async {
+                match &options.cl_rpc {
+                    Some(cl_rpc) => Some(fetch_cl_info(cl_rpc).await),
+                    None => None,
+                }
+            },
+            fetch_l2_chain_id(&options.el_rpc),
+            fetch_l2_block_number(&options.el_rpc),
+            fetch_l2_block_number(&config.rpc),
+            async {
+                match &options.cl_rpc {
+                    Some(cl_rpc) => Some(fetch_sync_status(&options.el_rpc, cl_rpc).await),
+                    None => None,
+                }
+            },
+            fetch_l1_block_number(&config.l1_rpc),
+        );
+
+        let checks = vec![
+            Self::p2p_config_check(&el_info, cl_info.as_ref()),
+            Self::bootnode_check(chain_id.as_ref().ok(), &config),
+            Self::advertised_endpoint_check(&el_info, cl_info.as_ref()),
+            Self::declared_network_check(&config, &chain_id),
+            Self::reth_limits_check(options.reth_config.as_ref()),
+            Self::consensus_rpc_check(options.cl_rpc.as_ref()),
+            Self::el_peer_count_check(&el_info, options.thresholds.peer_warn_threshold),
+            Self::cl_peer_count_check(cl_info.as_ref(), options.thresholds.peer_warn_threshold),
+            Self::head_vs_tip_check(&local_head, &public_head, &options.thresholds, &config.rpc),
+            Self::safe_head_recency_check(sync_status.as_ref(), &options.thresholds),
+            Self::l1_reachability_check(&l1_head, &config.l1_rpc),
+        ];
+
+        DoctorReport::new(config.name, inputs, checks)
+    }
+
+    fn p2p_config_check(
+        el_info: &Result<ElInfoReport>,
+        cl_info: Option<&Result<ClInfoReport>>,
+    ) -> DoctorCheck {
+        let value = json!({
+            "el": layer_config_value(el_info.as_ref().ok().and_then(|info| info.endpoint), el_info.as_ref().ok().and_then(|info| info.peer_count), el_info.as_ref().err()),
+            "cl": match cl_info {
+                Some(Ok(info)) => layer_config_value(info.endpoint, info.peer_stats.map(|stats| stats.connected), None),
+                Some(Err(err)) => layer_config_value(None, None, Some(err)),
+                None => json!({ "available": false, "reason": "consensus-node RPC unavailable" }),
+            },
+        });
+        DoctorCheck::new(
+            "p2p_config",
+            DoctorStatus::Info,
+            "p2p advertised endpoint and peer-count context",
+            value,
+            json!(null),
+            Some("Endpoint data is reported from local RPCs and does not prove public inbound reachability.".to_string()),
+        )
+    }
+
+    fn bootnode_check(live_chain_id: Option<&u64>, config: &MonitoringConfig) -> DoctorCheck {
+        let expected = expected_chain_id(&config.name);
+        let chain = bootnode_chain(&config.name, live_chain_id.copied());
+        let Some(chain) = chain else {
+            return DoctorCheck::new(
+                "bootnode_config",
+                DoctorStatus::Skip,
+                "canonical bootnodes are unavailable for this config",
+                json!({ "network": config.name }),
+                json!(null),
+                Some("Use a known Base network config to report canonical bootnodes.".to_string()),
+            );
+        };
+        if chain.bootnodes.total() == 0 {
+            return DoctorCheck::new(
+                "bootnode_config",
+                DoctorStatus::Skip,
+                "canonical bootnode list is empty for this network",
+                json!({ "chainId": chain.chain_id }),
+                json!(null),
+                None,
+            );
+        }
+
+        DoctorCheck::new(
+            "bootnode_config",
+            DoctorStatus::Info,
+            "canonical bootnodes for selected network; reachability is not verified by doctor v1",
+            json!({
+                "network": config.name,
+                "chainId": chain.chain_id,
+                "declaredChainId": expected,
+                "liveChainId": live_chain_id,
+                "execution": bootnode_layer_summary(chain.bootnodes.execution),
+                "consensus": bootnode_layer_summary(chain.bootnodes.consensus),
+            }),
+            json!(null),
+            Some("Bootnodes help cold-start peer discovery. Current peer health is graded by `el_peer_count` and `cl_peer_count`.".to_string()),
+        )
+    }
+
+    fn advertised_endpoint_check(
+        el_info: &Result<ElInfoReport>,
+        cl_info: Option<&Result<ClInfoReport>>,
+    ) -> DoctorCheck {
+        let el = endpoint_sanity(el_info.as_ref().ok().and_then(|info| info.endpoint));
+        let cl = match cl_info {
+            Some(Ok(info)) => endpoint_sanity(info.endpoint),
+            Some(Err(err)) => LayerEndpointSanity::unavailable(err.to_string()),
+            None => LayerEndpointSanity::unavailable("consensus-node RPC unavailable".to_string()),
+        };
+        let status = worst_status([el.status, cl.status]);
+        DoctorCheck::new(
+            "advertised_endpoint_sanity",
+            status,
+            "advertised endpoint IP sanity from exposed node metadata",
+            json!({ "el": el, "cl": cl }),
+            json!({ "fail": "unspecified or loopback IP", "warn": "private or link-local IP" }),
+            Some("This check does not use an external observer and cannot prove public inbound reachability.".to_string()),
+        )
+    }
+
+    fn declared_network_check(config: &MonitoringConfig, chain_id: &Result<u64>) -> DoctorCheck {
+        let expected = expected_chain_id(&config.name);
+        match (expected, chain_id) {
+            (_, Err(err)) => DoctorCheck::new(
+                "declared_network",
+                DoctorStatus::Fail,
+                "could not fetch live chain ID from the local EL RPC",
+                json!({ "network": config.name, "error": err.to_string() }),
+                json!(null),
+                Some("Check `--el-rpc` and the selected `-c/--config` value.".to_string()),
+            ),
+            (Some(expected), Ok(actual)) if expected == *actual => DoctorCheck::new(
+                "declared_network",
+                DoctorStatus::Pass,
+                "declared network matches live chain ID",
+                json!({ "network": config.name, "chainId": actual, "expectedChainId": expected }),
+                json!({ "expectedChainId": expected }),
+                None,
+            ),
+            (Some(expected), Ok(actual)) => DoctorCheck::new(
+                "declared_network",
+                DoctorStatus::Fail,
+                "declared network does not match live chain ID",
+                json!({ "network": config.name, "chainId": actual, "expectedChainId": expected }),
+                json!({ "expectedChainId": expected }),
+                Some("Point `--el-rpc` at a node for the selected config, or select the matching config with `-c`.".to_string()),
+            ),
+            (None, Ok(actual)) => DoctorCheck::new(
+                "declared_network",
+                DoctorStatus::Warn,
+                "selected config has no known expected chain ID",
+                json!({ "network": config.name, "chainId": actual }),
+                json!(null),
+                None,
+            ),
+        }
+    }
+
+    fn reth_limits_check(path: Option<&PathBuf>) -> DoctorCheck {
+        let Some(path) = path else {
+            return DoctorCheck::new(
+                "reth_limits",
+                DoctorStatus::Skip,
+                "reth config path was not provided",
+                json!({ "path": null }),
+                json!({ "failAtOrAbove": RETH_LIMIT_HARDCAP }),
+                Some(
+                    "Pass `--reth-config <PATH>` to check `headers.limit` and `bodies.limit`."
+                        .to_string(),
+                ),
+            );
+        };
+
+        match RethLimits::read(path) {
+            Ok(limits) => limits.into_check(path),
+            Err(err) => DoctorCheck::new(
+                "reth_limits",
+                DoctorStatus::Warn,
+                "could not read or parse reth config limits",
+                json!({ "path": path, "error": err.to_string() }),
+                json!({ "failAtOrAbove": RETH_LIMIT_HARDCAP }),
+                Some("Confirm the path points to a readable `reth.toml`.".to_string()),
+            ),
+        }
+    }
+
+    fn consensus_rpc_check(cl_rpc: Option<&Url>) -> DoctorCheck {
+        cl_rpc.map_or_else(
+            || {
+                DoctorCheck::new(
+                    "consensus_node_rpc",
+                    DoctorStatus::Warn,
+                    "consensus-node RPC is not configured",
+                    json!({ "clRpc": null }),
+                    json!(null),
+                    Some("Pass `--cl-rpc <URL>` or set `consensus_node_rpc` in the selected YAML config to run CL checks.".to_string()),
+                )
+            },
+            |url| DoctorCheck::new(
+                "consensus_node_rpc",
+                DoctorStatus::Pass,
+                "consensus-node RPC is configured",
+                json!({ "clRpc": url }),
+                json!(null),
+                None,
+            ),
+        )
+    }
+
+    fn el_peer_count_check(el_info: &Result<ElInfoReport>, warn_threshold: u32) -> DoctorCheck {
+        match el_info {
+            Ok(info) => info.peer_count.map_or_else(
+                || {
+                    DoctorCheck::new(
+                        "el_peer_count",
+                        DoctorStatus::Fail,
+                        "could not fetch EL peer count",
+                        json!({ "error": info.peer_count_error }),
+                        json!({ "failAt": 0, "warnBelow": warn_threshold }),
+                        Some("Check `--el-rpc` and ensure `net_peerCount` is exposed.".to_string()),
+                    )
+                },
+                |count| peer_count_check("el_peer_count", "EL", count, warn_threshold),
+            ),
+            Err(err) => DoctorCheck::new(
+                "el_peer_count",
+                DoctorStatus::Fail,
+                "could not fetch EL peer count",
+                json!({ "error": err.to_string() }),
+                json!({ "failAt": 0, "warnBelow": warn_threshold }),
+                Some("Check `--el-rpc` and ensure `net_peerCount` is exposed.".to_string()),
+            ),
+        }
+    }
+
+    fn cl_peer_count_check(
+        cl_info: Option<&Result<ClInfoReport>>,
+        warn_threshold: u32,
+    ) -> DoctorCheck {
+        match cl_info {
+            Some(Ok(info)) => info.peer_stats.map_or_else(
+                || {
+                    DoctorCheck::new(
+                        "cl_peer_count",
+                        DoctorStatus::Skip,
+                        "CL peer-count RPC method is unavailable",
+                        json!({ "peerStats": null, "error": info.peer_stats_error }),
+                        json!({ "failAt": 0, "warnBelow": warn_threshold }),
+                        Some(
+                            "Ensure the consensus-node RPC exposes `opp2p_peerStats`.".to_string(),
+                        ),
+                    )
+                },
+                |stats| peer_count_check("cl_peer_count", "CL", stats.connected, warn_threshold),
+            ),
+            Some(Err(err)) => DoctorCheck::new(
+                "cl_peer_count",
+                DoctorStatus::Fail,
+                "could not fetch CL peer count",
+                json!({ "error": err.to_string() }),
+                json!({ "failAt": 0, "warnBelow": warn_threshold }),
+                Some("Check `--cl-rpc` and ensure `opp2p_peerStats` is exposed.".to_string()),
+            ),
+            None => DoctorCheck::new(
+                "cl_peer_count",
+                DoctorStatus::Skip,
+                "consensus-node RPC is unavailable",
+                json!({ "clRpc": null }),
+                json!({ "failAt": 0, "warnBelow": warn_threshold }),
+                Some(
+                    "Pass `--cl-rpc <URL>` or set `consensus_node_rpc` in YAML config.".to_string(),
+                ),
+            ),
+        }
+    }
+
+    fn head_vs_tip_check(
+        local_head: &Result<u64>,
+        public_head: &Result<u64>,
+        thresholds: &DoctorThresholds,
+        public_rpc: &Url,
+    ) -> DoctorCheck {
+        let threshold = json!({
+            "warnBehindBlocks": thresholds.head_lag_warn_blocks,
+            "failBehindBlocks": thresholds.head_lag_fail_blocks,
+        });
+        let Ok(local) = local_head else {
+            return DoctorCheck::new(
+                "el_head_vs_tip",
+                DoctorStatus::Fail,
+                "could not fetch local EL head",
+                json!({ "error": local_head.as_ref().err().map(ToString::to_string) }),
+                threshold,
+                Some("Check `--el-rpc` and local EL availability.".to_string()),
+            );
+        };
+        let Ok(public) = public_head else {
+            return DoctorCheck::new(
+                "el_head_vs_tip",
+                DoctorStatus::Warn,
+                "could not fetch public tip reference",
+                json!({
+                    "localBlockNumber": local,
+                    "publicTipRpc": public_rpc,
+                    "error": public_head.as_ref().err().map(ToString::to_string),
+                }),
+                threshold,
+                Some(
+                    "Public tip comparison is unavailable; retry or check network connectivity."
+                        .to_string(),
+                ),
+            );
+        };
+
+        let delta = i128::from(*public) - i128::from(*local);
+        let status = if delta < 0 {
+            DoctorStatus::Warn
+        } else if delta > i128::from(thresholds.head_lag_fail_blocks) {
+            DoctorStatus::Fail
+        } else if delta > i128::from(thresholds.head_lag_warn_blocks) {
+            DoctorStatus::Warn
+        } else {
+            DoctorStatus::Pass
+        };
+        let message = match status {
+            DoctorStatus::Pass => "local EL head is close to the public tip",
+            DoctorStatus::Warn if delta < 0 => "local EL head is ahead of the public tip reference",
+            DoctorStatus::Warn => "local EL head is behind the public tip",
+            DoctorStatus::Fail => "local EL head is far behind the public tip",
+            _ => "EL head comparison completed",
+        };
+        DoctorCheck::new(
+            "el_head_vs_tip",
+            status,
+            message,
+            json!({
+                "localBlockNumber": local,
+                "publicBlockNumber": public,
+                "deltaBlocks": delta,
+                "publicTipRpc": public_rpc,
+            }),
+            threshold,
+            None,
+        )
+    }
+
+    fn safe_head_recency_check(
+        sync_status: Option<&Result<SyncStatusReport>>,
+        thresholds: &DoctorThresholds,
+    ) -> DoctorCheck {
+        let threshold = json!({
+            "warnBlocks": thresholds.safe_recency_warn_blocks,
+            "failBlocks": thresholds.safe_recency_fail_blocks,
+        });
+        let Some(sync_status) = sync_status else {
+            return DoctorCheck::new(
+                "safe_head_recency",
+                DoctorStatus::Skip,
+                "consensus-node RPC is unavailable",
+                json!({ "clRpc": null }),
+                threshold,
+                Some(
+                    "Pass `--cl-rpc <URL>` or set `consensus_node_rpc` in YAML config.".to_string(),
+                ),
+            );
+        };
+        let Ok(report) = sync_status else {
+            return DoctorCheck::new(
+                "safe_head_recency",
+                DoctorStatus::Fail,
+                "could not fetch sync status",
+                json!({ "error": sync_status.as_ref().err().map(ToString::to_string) }),
+                threshold,
+                Some("Check `--el-rpc`, `--cl-rpc`, `eth_syncing`, and `optimism_syncStatus` availability.".to_string()),
+            );
+        };
+        if matches!(report.el, EthSyncStatus::Info(_)) {
+            return DoctorCheck::new(
+                "safe_head_recency",
+                DoctorStatus::Skip,
+                "EL is actively syncing, so safe-head recency is not graded",
+                json!({ "elActivelySyncing": true }),
+                threshold,
+                None,
+            );
+        }
+
+        let unsafe_number = report.cl.unsafe_l2.block_info.number;
+        let safe_number = report.cl.safe_l2.block_info.number;
+        let lag_blocks = unsafe_number.saturating_sub(safe_number);
+        let lag_seconds = report
+            .cl
+            .unsafe_l2
+            .block_info
+            .timestamp
+            .saturating_sub(report.cl.safe_l2.block_info.timestamp);
+        let status = if lag_blocks > thresholds.safe_recency_fail_blocks {
+            DoctorStatus::Fail
+        } else if lag_blocks > thresholds.safe_recency_warn_blocks {
+            DoctorStatus::Warn
+        } else {
+            DoctorStatus::Pass
+        };
+        let message = match status {
+            DoctorStatus::Pass => "safe head is close to unsafe head",
+            DoctorStatus::Warn => "safe head is lagging unsafe head",
+            DoctorStatus::Fail => "safe head is far behind unsafe head",
+            _ => "safe-head recency check completed",
+        };
+        DoctorCheck::new(
+            "safe_head_recency",
+            status,
+            message,
+            json!({
+                "unsafeBlockNumber": unsafe_number,
+                "safeBlockNumber": safe_number,
+                "lagBlocks": lag_blocks,
+                "lagSeconds": lag_seconds,
+                "unsafeTimestamp": TimestampJson::from_unix(report.cl.unsafe_l2.block_info.timestamp),
+                "safeTimestamp": TimestampJson::from_unix(report.cl.safe_l2.block_info.timestamp),
+            }),
+            threshold,
+            Some("Some sync modes intentionally keep safe behind unsafe; adjust thresholds if this is expected for your node.".to_string()),
+        )
+    }
+
+    fn l1_reachability_check(l1_head: &Result<u64>, l1_rpc: &Url) -> DoctorCheck {
+        match l1_head {
+            Ok(block_number) => DoctorCheck::new(
+                "l1_reachability",
+                DoctorStatus::Pass,
+                "configured L1 RPC is reachable",
+                json!({ "l1Rpc": l1_rpc, "blockNumber": block_number }),
+                json!(null),
+                None,
+            ),
+            Err(err) => DoctorCheck::new(
+                "l1_reachability",
+                DoctorStatus::Fail,
+                "configured L1 RPC is unreachable",
+                json!({ "l1Rpc": l1_rpc, "error": err.to_string() }),
+                json!(null),
+                Some(
+                    "Check the selected config's `l1_rpc` value and network connectivity."
+                        .to_string(),
+                ),
+            ),
+        }
+    }
+}
+
+/// Per-layer advertised endpoint sanity classification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LayerEndpointSanity {
+    /// Layer-specific endpoint status.
+    pub status: DoctorStatus,
+    /// Advertised IP address, when available.
+    pub advertised_ip: Option<IpAddr>,
+    /// Advertised TCP p2p port, when available.
+    pub tcp_port: Option<u16>,
+    /// Advertised UDP discovery port, when available.
+    pub discovery_udp_port: Option<u16>,
+    /// Human-readable classification reason.
+    pub reason: String,
+}
+
+impl LayerEndpointSanity {
+    /// Creates an unavailable layer result.
+    pub const fn unavailable(reason: String) -> Self {
+        Self {
+            status: DoctorStatus::Skip,
+            advertised_ip: None,
+            tcp_port: None,
+            discovery_udp_port: None,
+            reason,
+        }
+    }
+}
+
+/// Minimal `reth.toml` shape needed by doctor.
+#[derive(Debug, Deserialize)]
+pub struct RethToml {
+    /// Header download limit section.
+    pub headers: Option<RethLimitSection>,
+    /// Body download limit section.
+    pub bodies: Option<RethLimitSection>,
+}
+
+/// Minimal reth limit section shape.
+#[derive(Debug, Deserialize)]
+pub struct RethLimitSection {
+    /// Configured request limit.
+    pub limit: Option<u64>,
+}
+
+/// Parsed reth headers/bodies limits.
+#[derive(Debug, Clone, Copy)]
+pub struct RethLimits {
+    /// Parsed `headers.limit` value.
+    pub headers: Option<u64>,
+    /// Parsed `bodies.limit` value.
+    pub bodies: Option<u64>,
+}
+
+impl RethLimits {
+    /// Reads the minimal reth limits from a TOML file.
+    pub fn read(path: &PathBuf) -> Result<Self> {
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("reading reth config at {}", path.display()))?;
+        let parsed: RethToml = toml::from_str(&contents)
+            .with_context(|| format!("parsing reth config at {}", path.display()))?;
+        Ok(Self {
+            headers: parsed.headers.and_then(|section| section.limit),
+            bodies: parsed.bodies.and_then(|section| section.limit),
+        })
+    }
+
+    /// Converts parsed limits into a doctor check.
+    pub fn into_check(self, path: &PathBuf) -> DoctorCheck {
+        let missing = [
+            self.headers.is_none().then_some("headers.limit"),
+            self.bodies.is_none().then_some("bodies.limit"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            return DoctorCheck::new(
+                "reth_limits",
+                DoctorStatus::Warn,
+                "reth config is missing required limit field(s)",
+                json!({ "path": path, "headersLimit": self.headers, "bodiesLimit": self.bodies, "missing": missing }),
+                json!({ "failAtOrAbove": RETH_LIMIT_HARDCAP }),
+                Some("Set both `headers.limit` and `bodies.limit` below 1024.".to_string()),
+            );
+        }
+        let headers = self.headers.unwrap_or_default();
+        let bodies = self.bodies.unwrap_or_default();
+        let status = if headers >= RETH_LIMIT_HARDCAP || bodies >= RETH_LIMIT_HARDCAP {
+            DoctorStatus::Fail
+        } else {
+            DoctorStatus::Pass
+        };
+        let message = match status {
+            DoctorStatus::Pass => "reth headers/bodies limits are below the hardcap",
+            DoctorStatus::Fail => "reth headers/bodies limits are at or above the hardcap",
+            _ => "reth headers/bodies limits were checked",
+        };
+        DoctorCheck::new(
+            "reth_limits",
+            status,
+            message,
+            json!({ "path": path, "headersLimit": headers, "bodiesLimit": bodies }),
+            json!({ "failAtOrAbove": RETH_LIMIT_HARDCAP }),
+            (status == DoctorStatus::Fail)
+                .then(|| "Set both `headers.limit` and `bodies.limit` below 1024.".to_string()),
+        )
+    }
+}
+
+fn current_timestamp() -> TimestampJson {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    TimestampJson::from_unix(secs)
+}
+
+fn layer_config_value(
+    endpoint: Option<NodeEndpoint>,
+    peer_count: Option<u32>,
+    error: Option<&anyhow::Error>,
+) -> Value {
+    endpoint.map_or_else(
+        || json!({
+            "available": false,
+            "peerCount": peer_count,
+            "reason": error.map(ToString::to_string).unwrap_or_else(|| "advertised endpoint unavailable".to_string()),
+        }),
+        |endpoint| json!({
+            "available": true,
+            "advertisedIp": endpoint.advertised_ip,
+            "tcpPort": endpoint.tcp_port,
+            "discoveryUdpPort": endpoint.discovery.udp_port,
+            "discv4": endpoint.discovery.v4_enabled,
+            "discv5": endpoint.discovery.v5_enabled,
+            "peerCount": peer_count,
+        }),
+    )
+}
+
+fn bootnode_layer_summary(raw_bootnodes: &[&str]) -> Value {
+    let mut parsed = 0;
+    let mut parse_failed = 0;
+    let mut enode = 0;
+    let mut enr = 0;
+    let mut tcp_ports = BTreeMap::<u16, usize>::new();
+    let mut udp_ports = BTreeMap::<u16, usize>::new();
+
+    for raw in raw_bootnodes {
+        match bootnode_addrs(raw) {
+            Ok((kind, tcp, udp)) => {
+                parsed += 1;
+                match kind {
+                    "enode" => enode += 1,
+                    "enr" => enr += 1,
+                    _ => {}
+                }
+                if let Some(addr) = tcp {
+                    *tcp_ports.entry(addr.port()).or_default() += 1;
+                }
+                if let Some(addr) = udp {
+                    *udp_ports.entry(addr.port()).or_default() += 1;
+                }
+            }
+            Err(_) => parse_failed += 1,
+        }
+    }
+
+    json!({
+        "total": raw_bootnodes.len(),
+        "parsed": parsed,
+        "parseFailed": parse_failed,
+        "enode": enode,
+        "enr": enr,
+        "tcpPorts": tcp_ports,
+        "udpPorts": udp_ports,
+    })
+}
+
+fn bootnode_addrs(raw: &str) -> Result<(&'static str, Option<SocketAddr>, Option<SocketAddr>)> {
+    if raw.starts_with("enode://") {
+        let record =
+            NodeRecord::from_str(raw).with_context(|| format!("parsing bootnode `{raw}`"))?;
+        return Ok(("enode", Some(record.tcp_addr()), Some(record.udp_addr())));
+    }
+
+    match BootNode::parse_bootnode(raw)? {
+        BootNode::Enode(_) => Err(anyhow!("unsupported non-enode:// Enode bootnode format")),
+        BootNode::Enr(enr) => {
+            let ip = enr
+                .ip4()
+                .map(IpAddr::V4)
+                .or_else(|| enr.ip6().map(IpAddr::V6))
+                .ok_or_else(|| anyhow!("ENR bootnode has no IP address"))?;
+            Ok((
+                "enr",
+                enr.tcp4().or_else(|| enr.tcp6()).map(|port| SocketAddr::new(ip, port)),
+                enr.udp4().or_else(|| enr.udp6()).map(|port| SocketAddr::new(ip, port)),
+            ))
+        }
+    }
+}
+
+fn endpoint_sanity(endpoint: Option<NodeEndpoint>) -> LayerEndpointSanity {
+    let Some(endpoint) = endpoint else {
+        return LayerEndpointSanity::unavailable("advertised endpoint unavailable".to_string());
+    };
+    let (status, reason) = classify_ip(endpoint.advertised_ip);
+    LayerEndpointSanity {
+        status,
+        advertised_ip: Some(endpoint.advertised_ip),
+        tcp_port: Some(endpoint.tcp_port),
+        discovery_udp_port: Some(endpoint.discovery.udp_port),
+        reason,
+    }
+}
+
+fn classify_ip(ip: IpAddr) -> (DoctorStatus, String) {
+    if ip.is_unspecified() || ip.is_loopback() {
+        return (DoctorStatus::Fail, "advertised IP is unspecified or loopback".to_string());
+    }
+    match ip {
+        IpAddr::V4(v4) if v4.is_private() || v4.is_link_local() => {
+            (DoctorStatus::Warn, "advertised IP is private or link-local".to_string())
+        }
+        IpAddr::V6(v6) if v6.is_unique_local() || v6.is_unicast_link_local() => {
+            (DoctorStatus::Warn, "advertised IP is private or link-local".to_string())
+        }
+        _ => (DoctorStatus::Pass, "advertised IP is public-looking".to_string()),
+    }
+}
+
+fn worst_status(statuses: impl IntoIterator<Item = DoctorStatus>) -> DoctorStatus {
+    let statuses = statuses.into_iter().collect::<Vec<_>>();
+    if statuses.contains(&DoctorStatus::Fail) {
+        DoctorStatus::Fail
+    } else if statuses.contains(&DoctorStatus::Warn) {
+        DoctorStatus::Warn
+    } else if statuses.contains(&DoctorStatus::Pass) {
+        DoctorStatus::Pass
+    } else if statuses.contains(&DoctorStatus::Info) {
+        DoctorStatus::Info
+    } else {
+        DoctorStatus::Skip
+    }
+}
+
+fn expected_chain_id(network: &str) -> Option<u64> {
+    match network {
+        "mainnet" => Some(8453),
+        "sepolia" => Some(84532),
+        "devnet" => Some(1337),
+        "zeronet" => Some(763360),
+        _ => None,
+    }
+}
+
+fn bootnode_chain(network: &str, live_chain_id: Option<u64>) -> Option<&'static ChainConfig> {
+    expected_chain_id(network)
+        .and_then(ChainConfig::by_chain_id)
+        .or_else(|| live_chain_id.and_then(ChainConfig::by_chain_id))
+}
+
+fn peer_count_check(check: &str, layer: &str, count: u32, warn_threshold: u32) -> DoctorCheck {
+    let status = if count == 0 {
+        DoctorStatus::Fail
+    } else if count < warn_threshold {
+        DoctorStatus::Warn
+    } else {
+        DoctorStatus::Pass
+    };
+    let message = match status {
+        DoctorStatus::Pass => format!("{layer} peer count is healthy"),
+        DoctorStatus::Warn => format!("{layer} peer count is below the warning threshold"),
+        DoctorStatus::Fail => format!("{layer} peer count is zero"),
+        _ => format!("{layer} peer count check completed"),
+    };
+    DoctorCheck::new(
+        check,
+        status,
+        message,
+        json!({ "count": count }),
+        json!({ "failAt": 0, "warnBelow": warn_threshold }),
+        (status != DoctorStatus::Pass)
+            .then(|| "Check firewall, NAT, and advertised endpoint configuration.".to_string()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+        path::PathBuf,
+    };
+
+    use serde_json::json;
+
+    use super::{
+        DoctorCheck, DoctorStatus, DoctorSummary, DoctorThresholds, RethLimits, bootnode_addrs,
+        bootnode_chain, bootnode_layer_summary, classify_ip, expected_chain_id, peer_count_check,
+        worst_status,
+    };
+
+    #[test]
+    fn summary_counts_all_statuses() {
+        let checks = vec![
+            check(DoctorStatus::Pass),
+            check(DoctorStatus::Warn),
+            check(DoctorStatus::Fail),
+            check(DoctorStatus::Info),
+            check(DoctorStatus::Skip),
+        ];
+
+        let summary = DoctorSummary::from_checks(&checks);
+
+        assert_eq!(summary.pass, 1);
+        assert_eq!(summary.warn, 1);
+        assert_eq!(summary.fail, 1);
+        assert_eq!(summary.info, 1);
+        assert_eq!(summary.skip, 1);
+    }
+
+    #[test]
+    fn peer_thresholds_classify_zero_warn_and_pass() {
+        assert_eq!(peer_count_check("x", "EL", 0, 5).status, DoctorStatus::Fail);
+        assert_eq!(peer_count_check("x", "EL", 4, 5).status, DoctorStatus::Warn);
+        assert_eq!(peer_count_check("x", "EL", 5, 5).status, DoctorStatus::Pass);
+    }
+
+    #[test]
+    fn default_thresholds_match_doctor_plan() {
+        let thresholds = DoctorThresholds::default();
+
+        assert_eq!(thresholds.head_lag_warn_blocks, 10);
+        assert_eq!(thresholds.head_lag_fail_blocks, 20);
+        assert_eq!(thresholds.safe_recency_warn_blocks, 150);
+        assert_eq!(thresholds.safe_recency_fail_blocks, 300);
+    }
+
+    #[test]
+    fn classifies_advertised_ips() {
+        assert_eq!(classify_ip(IpAddr::V4(Ipv4Addr::LOCALHOST)).0, DoctorStatus::Fail);
+        assert_eq!(classify_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED)).0, DoctorStatus::Fail);
+        assert_eq!(classify_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))).0, DoctorStatus::Warn);
+        assert_eq!(classify_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)).0, DoctorStatus::Fail);
+        assert_eq!(classify_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).0, DoctorStatus::Pass);
+    }
+
+    #[test]
+    fn reth_limits_classify_values() {
+        let path = PathBuf::from("reth.toml");
+
+        assert_eq!(
+            RethLimits { headers: Some(100), bodies: Some(100) }.into_check(&path).status,
+            DoctorStatus::Pass,
+        );
+        assert_eq!(
+            RethLimits { headers: Some(1024), bodies: Some(100) }.into_check(&path).status,
+            DoctorStatus::Fail,
+        );
+        assert_eq!(
+            RethLimits { headers: None, bodies: Some(100) }.into_check(&path).status,
+            DoctorStatus::Warn,
+        );
+    }
+
+    #[test]
+    fn maps_known_config_names_to_chain_ids() {
+        assert_eq!(expected_chain_id("mainnet"), Some(8453));
+        assert_eq!(expected_chain_id("sepolia"), Some(84532));
+        assert_eq!(expected_chain_id("devnet"), Some(1337));
+        assert_eq!(expected_chain_id("zeronet"), Some(763360));
+        assert_eq!(expected_chain_id("custom"), None);
+    }
+
+    #[test]
+    fn enr_bootnode_parser_preserves_udp_address() {
+        let enr = "enr:-J64QBbwPjPLZ6IOOToOLsSjtFUjjzN66qmBZdUexpO32Klrc458Q24kbty2PdRaLacHM5z-cZQr8mjeQu3pik6jPSOGAYYFIqBfgmlkgnY0gmlwhDaRWFWHb3BzdGFja4SzlAUAiXNlY3AyNTZrMaECmeSnJh7zjKrDSPoNMGXoopeDF4hhpj5I0OsQUUt4u8uDdGNwgiQGg3VkcIIkBg";
+
+        let (_, _, udp) = bootnode_addrs(enr).unwrap();
+
+        assert!(udp.is_some());
+    }
+
+    #[test]
+    fn bootnode_summary_reports_counts_without_reachability() {
+        let summary = bootnode_layer_summary(&[
+            "enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@127.0.0.1:30304?discport=30301",
+            "not-a-bootnode",
+        ]);
+
+        assert_eq!(summary["total"], 2);
+        assert_eq!(summary["parsed"], 1);
+        assert_eq!(summary["parseFailed"], 1);
+        assert_eq!(summary["enode"], 1);
+        assert_eq!(summary["tcpPorts"]["30304"], 1);
+        assert_eq!(summary["udpPorts"]["30301"], 1);
+    }
+
+    #[test]
+    fn advertised_endpoint_status_uses_checked_layer_over_skip() {
+        assert_eq!(worst_status([DoctorStatus::Pass, DoctorStatus::Skip]), DoctorStatus::Pass);
+        assert_eq!(worst_status([DoctorStatus::Warn, DoctorStatus::Skip]), DoctorStatus::Warn);
+        assert_eq!(worst_status([DoctorStatus::Fail, DoctorStatus::Skip]), DoctorStatus::Fail);
+        assert_eq!(worst_status([DoctorStatus::Skip, DoctorStatus::Skip]), DoctorStatus::Skip);
+        assert_eq!(worst_status([DoctorStatus::Pass, DoctorStatus::Warn]), DoctorStatus::Warn);
+    }
+
+    #[test]
+    fn bootnode_chain_prefers_declared_config_over_live_chain_id() {
+        let chain = bootnode_chain("mainnet", Some(84532)).unwrap();
+
+        assert_eq!(chain.chain_id, 8453);
+    }
+
+    #[test]
+    fn bootnode_chain_falls_back_to_live_chain_for_unknown_config() {
+        let chain = bootnode_chain("custom", Some(84532)).unwrap();
+
+        assert_eq!(chain.chain_id, 84532);
+    }
+
+    fn check(status: DoctorStatus) -> DoctorCheck {
+        DoctorCheck::new("check", status, "message", json!(null), json!(null), None)
+    }
+}

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -1,3 +1,5 @@
+//! Diagnostic checks and report types for `basectl doctor`.
+
 use std::{
     collections::BTreeMap,
     fs,

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -243,7 +243,7 @@ impl Doctor {
             Self::bootnode_check(chain_id.as_ref().ok(), &config),
             Self::advertised_endpoint_check(&el_info, cl_info.as_ref()),
             Self::declared_network_check(&config, &chain_id),
-            Self::reth_limits_check(options.reth_config.as_ref()),
+            Self::reth_limits_check(options.reth_config.as_deref()),
             Self::consensus_rpc_check(options.cl_rpc.as_ref()),
             Self::el_peer_count_check(&el_info, options.thresholds.peer_warn_threshold),
             Self::cl_peer_count_check(cl_info.as_ref(), options.thresholds.peer_warn_threshold),
@@ -383,7 +383,7 @@ impl Doctor {
         }
     }
 
-    fn reth_limits_check(path: Option<&PathBuf>) -> DoctorCheck {
+    fn reth_limits_check(path: Option<&Path>) -> DoctorCheck {
         let Some(path) = path else {
             return DoctorCheck::new(
                 "reth_limits",

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -27,21 +27,29 @@ pub use config::{
     PodGroupConfig, PodsConfig, ProofsConfig, ValidatorNodeConfig,
 };
 
+mod doctor;
+pub use doctor::{
+    Doctor, DoctorCheck, DoctorInputs, DoctorOptions, DoctorReport, DoctorStatus, DoctorSummary,
+    DoctorThresholds, LayerEndpointSanity, RethLimitSection, RethLimits, RethToml,
+};
+
 mod rpc;
 pub use rpc::{
-    BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
-    ConductorPollUpdate, DiscoveryInfo, InitialBacklog, L1BlockInfo, L1ConnectionMode,
-    LatestProposal, NodeEndpoint, NodeInfoReport, PausedPeers, PeerListReport, PeerStatsReport,
-    PeerSummary, PodGroupStatus, PodStatus, PodsPoller, PodsSnapshot, ProofsSnapshot,
-    RawInfoReport, RawPeerCounts, RawPeersReport, SyncStatusReport, TimestampedFlashblock,
-    TxSummary, ValidatorNodeStatus, conductor_pause_all_nodes, conductor_pause_node,
-    conductor_resume_all_nodes, conductor_resume_node, decode_flashblock_transactions, fetch_block,
-    fetch_block_transactions, fetch_connected_peers, fetch_full_system_config, fetch_info,
-    fetch_initial_backlog_with_progress, fetch_raw_info, fetch_raw_peers, fetch_safe_and_latest,
-    fetch_sync_status, pause_sequencer_node, restart_conductor_node, run_block_fetcher,
-    run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher,
-    run_pods_poller, run_proofs_poller, run_safe_head_poller, run_validator_poller,
-    start_sequencer_node, stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
+    BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ClInfoReport,
+    ConductorNodeStatus, ConductorPollUpdate, DiscoveryInfo, ElInfoReport, InitialBacklog,
+    L1BlockInfo, L1ConnectionMode, LatestProposal, NodeEndpoint, NodeInfoReport, PausedPeers,
+    PeerListReport, PeerStatsReport, PeerSummary, PodGroupStatus, PodStatus, PodsPoller,
+    PodsSnapshot, ProofsSnapshot, RawInfoReport, RawPeerCounts, RawPeersReport, SyncStatusReport,
+    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, conductor_pause_all_nodes,
+    conductor_pause_node, conductor_resume_all_nodes, conductor_resume_node,
+    decode_flashblock_transactions, fetch_block, fetch_block_transactions, fetch_cl_info,
+    fetch_connected_peers, fetch_el_info, fetch_full_system_config, fetch_info,
+    fetch_initial_backlog_with_progress, fetch_l1_block_number, fetch_l2_block_number,
+    fetch_l2_chain_id, fetch_raw_info, fetch_raw_peers, fetch_safe_and_latest, fetch_sync_status,
+    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
+    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller,
+    run_proofs_poller, run_safe_head_poller, run_validator_poller, start_sequencer_node,
+    stop_sequencer_node, transfer_conductor_leader, unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/rpc/el.rs
+++ b/crates/infra/basectl/src/rpc/el.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use alloy_consensus::{Transaction, transaction::SignerRecoverable};
 use alloy_eips::{
@@ -7,7 +7,9 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Network, Provider, ProviderBuilder, network::TransactionResponse};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_transport_http::Http;
 use anyhow::{Context, Result, anyhow};
 use base_common_consensus::BaseTxEnvelope;
 use base_common_network::Base;
@@ -43,6 +45,36 @@ pub async fn fetch_block(
         .await
         .with_context(|| format!("fetching block {reference}"))?
         .ok_or_else(|| anyhow!("block {reference} not found"))
+}
+
+/// Fetches the L2 chain ID via `eth_chainId` with an explicit request timeout.
+pub async fn fetch_l2_chain_id(rpc: &Url) -> Result<u64> {
+    connect_l2_provider(rpc)
+        .await?
+        .get_chain_id()
+        .await
+        .with_context(|| format!("fetching eth_chainId from {rpc}"))
+}
+
+/// Fetches the latest L2 block number via `eth_blockNumber` with an explicit request timeout.
+pub async fn fetch_l2_block_number(rpc: &Url) -> Result<u64> {
+    connect_l2_provider(rpc)
+        .await?
+        .get_block_number()
+        .await
+        .with_context(|| format!("fetching eth_blockNumber from {rpc}"))
+}
+
+async fn connect_l2_provider(rpc: &Url) -> Result<impl Provider<Base>> {
+    let http_client = alloy_transport_http::reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .with_context(|| format!("building L2 HTTP client for {rpc}"))?;
+    let transport = Http::with_client(http_client, rpc.clone());
+    Ok(ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .network::<Base>()
+        .connect_client(RpcClient::new(transport, false)))
 }
 
 /// DA and gas information for a single L2 block.

--- a/crates/infra/basectl/src/rpc/l1.rs
+++ b/crates/infra/basectl/src/rpc/l1.rs
@@ -3,13 +3,16 @@ use std::time::Duration;
 use alloy_consensus::Transaction;
 use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder, layers::CallBatchLayer};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_sol_types::sol;
-use anyhow::Result;
+use alloy_transport_http::Http;
+use anyhow::{Context, Result};
 use base_common_genesis::SystemConfig;
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use tracing::warn;
+use url::Url;
 
 use crate::tui::Toast;
 
@@ -87,6 +90,20 @@ pub async fn fetch_full_system_config(
         blob_base_fee_scalar: blobbasefee_scalar.ok().map(|v| v as u64),
         ..Default::default()
     })
+}
+
+/// Fetches the latest L1 block number via `eth_blockNumber` with an explicit request timeout.
+pub async fn fetch_l1_block_number(l1_rpc: &Url) -> Result<u64> {
+    let http_client = alloy_transport_http::reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .with_context(|| format!("building L1 HTTP client for {l1_rpc}"))?;
+    let transport = Http::with_client(http_client, l1_rpc.clone());
+    let provider = ProviderBuilder::new().connect_client(RpcClient::new(transport, false));
+    provider
+        .get_block_number()
+        .await
+        .with_context(|| format!("fetching eth_blockNumber from {l1_rpc}"))
 }
 
 /// Information about an L1 block and its blob counts.

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -16,20 +16,24 @@ mod el;
 pub use el::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, InitialBacklog, TxSummary,
     decode_flashblock_transactions, fetch_block, fetch_block_transactions,
-    fetch_initial_backlog_with_progress, run_block_fetcher,
+    fetch_initial_backlog_with_progress, fetch_l2_block_number, fetch_l2_chain_id,
+    run_block_fetcher,
 };
 
 mod flashblocks;
 pub use flashblocks::{TimestampedFlashblock, run_flashblock_ws, run_flashblock_ws_timestamped};
 
 mod l1;
-pub use l1::{L1BlockInfo, L1ConnectionMode, fetch_full_system_config, run_l1_blob_watcher};
+pub use l1::{
+    L1BlockInfo, L1ConnectionMode, fetch_full_system_config, fetch_l1_block_number,
+    run_l1_blob_watcher,
+};
 
 mod p2p;
 pub use p2p::{
-    DiscoveryInfo, NodeEndpoint, NodeInfoReport, PeerListReport, PeerStatsReport, PeerSummary,
-    RawInfoReport, RawPeerCounts, RawPeersReport, fetch_connected_peers, fetch_info,
-    fetch_raw_info, fetch_raw_peers,
+    ClInfoReport, DiscoveryInfo, ElInfoReport, NodeEndpoint, NodeInfoReport, PeerListReport,
+    PeerStatsReport, PeerSummary, RawInfoReport, RawPeerCounts, RawPeersReport, fetch_cl_info,
+    fetch_connected_peers, fetch_el_info, fetch_info, fetch_raw_info, fetch_raw_peers,
 };
 
 mod pods;

--- a/crates/infra/basectl/src/rpc/p2p.rs
+++ b/crates/infra/basectl/src/rpc/p2p.rs
@@ -14,7 +14,10 @@ use base_common_network::Base;
 use base_consensus_gossip::PeerStats;
 use base_consensus_peers::{BootNode, NodeRecord};
 use base_consensus_rpc::BaseP2PApiClient;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::{
+    core::client::Error as JsonRpcClientError,
+    http_client::{HttpClient, HttpClientBuilder},
+};
 use serde::Serialize;
 use tracing::{debug, warn};
 use url::Url;
@@ -63,9 +66,35 @@ pub struct PeerStatsReport {
     /// `u64` to `u32` so the humanized output reports a uniform peer-count type
     /// across both layers (CL's `PeerStats::connected` is `u32`). The raw path
     /// [`RawPeerCounts::el`] preserves the native `u64`.
-    pub el_count: u32,
+    pub el_count: Option<u32>,
     /// Connected CL peer statistics from `opp2p_peerStats`.
-    pub cl: PeerStats,
+    pub cl: Option<PeerStats>,
+}
+
+/// Execution-layer p2p endpoint and peer-count summary.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElInfoReport {
+    /// Execution-layer advertised endpoint. `None` when the EL RPC does not
+    /// expose `admin_nodeInfo` or its enode/ENR could not be parsed.
+    pub endpoint: Option<NodeEndpoint>,
+    /// Connected EL peer count from `net_peerCount`.
+    pub peer_count: Option<u32>,
+    /// Reason the EL peer count is absent, when applicable.
+    pub peer_count_error: Option<&'static str>,
+}
+
+/// Consensus-layer p2p endpoint and peer-count summary.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClInfoReport {
+    /// Consensus-layer advertised endpoint. `None` when the `opp2p_self` ENR
+    /// was missing or could not be parsed.
+    pub endpoint: Option<NodeEndpoint>,
+    /// Connected CL peer statistics from `opp2p_peerStats`.
+    pub peer_stats: Option<PeerStats>,
+    /// Reason the CL peer statistics are absent, when applicable.
+    pub peer_stats_error: Option<&'static str>,
 }
 
 /// Humanized peer row used by `basectl p2p peers` pretty and JSON output.
@@ -86,8 +115,8 @@ pub struct PeerSummary {
 pub struct PeerListReport {
     /// Connected EL peers.
     pub el: Option<Vec<PeerSummary>>,
-    /// Connected CL peers.
-    pub cl: Vec<PeerSummary>,
+    /// Connected CL peers, or `None` when `opp2p_peers` is not exposed.
+    pub cl: Option<Vec<PeerSummary>>,
 }
 
 /// Raw `p2p info` payload — passthrough RPC wire shapes for `--json --raw`.
@@ -98,8 +127,10 @@ pub struct RawInfoReport {
     pub el: Option<serde_json::Value>,
     /// Reason the EL `admin_nodeInfo` result is absent, when applicable.
     pub el_error: Option<String>,
-    /// Raw `opp2p_self` result.
-    pub cl: serde_json::Value,
+    /// Raw `opp2p_self` result, or `None` when not exposed.
+    pub cl: Option<serde_json::Value>,
+    /// Reason the CL `opp2p_self` result is absent, when applicable.
+    pub cl_error: Option<String>,
     /// Connected peer counts per layer.
     pub peer_counts: RawPeerCounts,
 }
@@ -111,8 +142,10 @@ pub struct RawPeerCounts {
     /// EL peer count from `net_peerCount`, in its native `u64` wire type. The
     /// humanized path [`PeerStatsReport::el_count`] narrows this to `u32`.
     pub el: u64,
-    /// Raw `opp2p_peerStats` result.
-    pub cl: serde_json::Value,
+    /// Raw `opp2p_peerStats` result, or `None` when not exposed.
+    pub cl: Option<serde_json::Value>,
+    /// Reason the CL `opp2p_peerStats` result is absent, when applicable.
+    pub cl_error: Option<String>,
 }
 
 /// Raw `p2p peers` payload — passthrough RPC wire shapes for `--json --raw`.
@@ -123,8 +156,10 @@ pub struct RawPeersReport {
     pub el: Option<serde_json::Value>,
     /// Reason the EL `admin_peers` result is absent, when applicable.
     pub el_error: Option<String>,
-    /// Raw `opp2p_peers(true)` result.
-    pub cl: serde_json::Value,
+    /// Raw `opp2p_peers(true)` result, or `None` when not exposed.
+    pub cl: Option<serde_json::Value>,
+    /// Reason the CL `opp2p_peers` result is absent, when applicable.
+    pub cl_error: Option<String>,
 }
 
 /// Fetches the advertised endpoints and connected peer-count summary for
@@ -133,9 +168,17 @@ pub struct RawPeersReport {
 /// All four RPC calls (EL `admin_nodeInfo` + `net_peerCount`, CL `opp2p_self` +
 /// `opp2p_peerStats`) run concurrently over a single connection per layer.
 pub async fn fetch_info(rpc: &Url, cl_rpc: &Url) -> Result<(NodeInfoReport, PeerStatsReport)> {
-    let (cl_client, el_provider) = connect_layers(rpc, cl_rpc).await?;
+    let (el, cl) = tokio::try_join!(fetch_el_info(rpc), fetch_cl_info(cl_rpc))?;
+    let node_info = NodeInfoReport { el: el.endpoint, cl: cl.endpoint };
+    let peer_stats = PeerStatsReport { el_count: el.peer_count, cl: cl.peer_stats };
+    Ok((node_info, peer_stats))
+}
 
-    let (el, cl_info, el_count, cl_stats) = tokio::try_join!(
+/// Fetches execution-layer advertised endpoint and peer-count summary.
+pub async fn fetch_el_info(rpc: &Url) -> Result<ElInfoReport> {
+    let el_provider = connect_el(rpc).await?;
+
+    let (endpoint, peer_count) = tokio::join!(
         async {
             match el_provider.node_info().await {
                 Ok(info) => match parse_el_node_endpoint(
@@ -145,46 +188,82 @@ pub async fn fetch_info(rpc: &Url, cl_rpc: &Url) -> Result<(NodeInfoReport, Peer
                     info.ports.discovery,
                     info.ports.listener,
                 ) {
-                    Ok(endpoint) => Ok(Some(endpoint)),
+                    Ok(endpoint) => Ok::<Option<NodeEndpoint>, anyhow::Error>(Some(endpoint)),
                     Err(err) => {
                         warn!(error = %err, "failed to parse EL node endpoint; reporting EL as unavailable");
-                        Ok(None)
+                        Ok::<Option<NodeEndpoint>, anyhow::Error>(None)
                     }
                 },
-                Err(err) if is_method_not_found(&err) => Ok(None),
-                Err(err) => Err(err).with_context(|| format!("fetching admin_nodeInfo from {rpc}")),
+                Err(err) if is_method_not_found(&err) => {
+                    Ok::<Option<NodeEndpoint>, anyhow::Error>(None)
+                }
+                Err(err) => {
+                    warn!(error = %err, "failed to fetch EL node endpoint; reporting EL endpoint as unavailable");
+                    Ok::<Option<NodeEndpoint>, anyhow::Error>(None)
+                }
             }
         },
         async {
-            BaseP2PApiClient::opp2p_self(&cl_client)
-                .await
-                .with_context(|| format!("fetching opp2p_self from {cl_rpc}"))
+            match el_provider.net_peer_count().await {
+                Ok(peer_count) => u32::try_from(peer_count).map_or(
+                    (None, Some("EL `net_peerCount` exceeded `u32::MAX`; unexpected RPC value")),
+                    |peer_count| (Some(peer_count), None),
+                ),
+                Err(err) => {
+                    warn!(error = %err, "failed to fetch EL peer count; reporting EL peer count as unavailable");
+                    (None, Some("EL `net_peerCount` unavailable from this RPC"))
+                }
+            }
         },
-        async {
-            el_provider
-                .net_peer_count()
-                .await
-                .with_context(|| format!("fetching net_peerCount from {rpc}"))
-        },
-        async {
-            BaseP2PApiClient::opp2p_peer_stats(&cl_client)
-                .await
-                .with_context(|| format!("fetching opp2p_peerStats from {cl_rpc}"))
-        },
-    )?;
+    );
+    Ok(ElInfoReport {
+        endpoint: endpoint?,
+        peer_count: peer_count.0,
+        peer_count_error: peer_count.1,
+    })
+}
 
-    let cl = match parse_cl_node_endpoint(&cl_info) {
-        Ok(endpoint) => Some(endpoint),
-        Err(err) => {
-            warn!(error = %err, "failed to parse CL node endpoint from opp2p_self; reporting CL as unavailable");
+/// Fetches consensus-layer advertised endpoint and peer-count summary.
+pub async fn fetch_cl_info(cl_rpc: &Url) -> Result<ClInfoReport> {
+    let cl_client = connect_cl(cl_rpc)?;
+
+    let (cl_info, peer_stats) = tokio::join!(
+        async {
+            match BaseP2PApiClient::opp2p_self(&cl_client).await {
+                Ok(info) => Ok(Some(info)),
+                Err(err) if is_jsonrpc_method_not_found(&err) => Ok(None),
+                Err(err) => Err(err).with_context(|| format!("fetching opp2p_self from {cl_rpc}")),
+            }
+        },
+        async {
+            match BaseP2PApiClient::opp2p_peer_stats(&cl_client).await {
+                Ok(stats) => Ok((Some(stats), None)),
+                Err(err) if is_jsonrpc_method_not_found(&err) => {
+                    Ok((None, Some("CL `opp2p_peerStats` not exposed by this RPC")))
+                }
+                Err(err) => {
+                    Err(err).with_context(|| format!("fetching opp2p_peerStats from {cl_rpc}"))
+                }
+            }
+        },
+    );
+    let cl_info = cl_info?;
+    let (peer_stats, peer_stats_error) = peer_stats?;
+
+    let endpoint = cl_info.map_or_else(
+        || {
+            warn!(rpc = %cl_rpc, "CL opp2p_self not exposed by this RPC; reporting CL endpoint as unavailable");
             None
-        }
-    };
-    let node_info = NodeInfoReport { el, cl };
-    let el_count = u32::try_from(el_count)
-        .context("EL `net_peerCount` exceeded `u32::MAX`; unexpected RPC value")?;
-    let peer_stats = PeerStatsReport { el_count, cl: cl_stats };
-    Ok((node_info, peer_stats))
+        },
+        |info| match parse_cl_node_endpoint(&info) {
+            Ok(endpoint) => Some(endpoint),
+            Err(err) => {
+                warn!(error = %err, "failed to parse CL node endpoint from opp2p_self; reporting CL as unavailable");
+                None
+            }
+        },
+    );
+    Ok(ClInfoReport { endpoint, peer_stats, peer_stats_error })
 }
 
 /// Fetches connected EL + CL peer lists for `basectl p2p peers`.
@@ -215,23 +294,29 @@ pub async fn fetch_connected_peers(rpc: &Url, cl_rpc: &Url) -> Result<PeerListRe
             }
         },
         async {
-            BaseP2PApiClient::opp2p_peers(&cl_client, true)
-                .await
-                .with_context(|| format!("fetching opp2p_peers(true) from {cl_rpc}"))
+            match BaseP2PApiClient::opp2p_peers(&cl_client, true).await {
+                Ok(peers) => Ok(Some(peers)),
+                Err(err) if is_jsonrpc_method_not_found(&err) => Ok(None),
+                Err(err) => {
+                    Err(err).with_context(|| format!("fetching opp2p_peers(true) from {cl_rpc}"))
+                }
+            }
         },
     )?;
 
-    let mut cl = cl_peers
-        .peers
-        .into_iter()
-        .map(|(id, peer)| PeerSummary {
-            id,
-            address: peer.addresses.join(", "),
-            direction: peer.direction.to_string(),
-        })
-        .collect::<Vec<_>>();
-    cl.sort_by(|a, b| a.id.cmp(&b.id));
-
+    let cl = cl_peers.map(|peers| {
+        let mut cl = peers
+            .peers
+            .into_iter()
+            .map(|(id, peer)| PeerSummary {
+                id,
+                address: peer.addresses.join(", "),
+                direction: peer.direction.to_string(),
+            })
+            .collect::<Vec<_>>();
+        cl.sort_by(|a, b| a.id.cmp(&b.id));
+        cl
+    });
     Ok(PeerListReport { el, cl })
 }
 
@@ -256,9 +341,11 @@ pub async fn fetch_raw_info(rpc: &Url, cl_rpc: &Url) -> Result<RawInfoReport> {
             }
         },
         async {
-            BaseP2PApiClient::opp2p_self(&cl_client)
-                .await
-                .with_context(|| format!("fetching opp2p_self from {cl_rpc}"))
+            match BaseP2PApiClient::opp2p_self(&cl_client).await {
+                Ok(info) => Ok(Some(info)),
+                Err(err) if is_jsonrpc_method_not_found(&err) => Ok(None),
+                Err(err) => Err(err).with_context(|| format!("fetching opp2p_self from {cl_rpc}")),
+            }
         },
         async {
             el_provider
@@ -267,21 +354,35 @@ pub async fn fetch_raw_info(rpc: &Url, cl_rpc: &Url) -> Result<RawInfoReport> {
                 .with_context(|| format!("fetching net_peerCount from {rpc}"))
         },
         async {
-            BaseP2PApiClient::opp2p_peer_stats(&cl_client)
-                .await
-                .with_context(|| format!("fetching opp2p_peerStats from {cl_rpc}"))
+            match BaseP2PApiClient::opp2p_peer_stats(&cl_client).await {
+                Ok(stats) => Ok(Some(stats)),
+                Err(err) if is_jsonrpc_method_not_found(&err) => Ok(None),
+                Err(err) => {
+                    Err(err).with_context(|| format!("fetching opp2p_peerStats from {cl_rpc}"))
+                }
+            }
         },
     )?;
 
+    let (cl_value, cl_error) = match cl_info {
+        Some(v) => {
+            (Some(serde_json::to_value(&v).context("serializing opp2p_self to JSON value")?), None)
+        }
+        None => (None, Some("CL `opp2p_self` not exposed by this RPC".to_string())),
+    };
+    let (cl_stats_value, cl_stats_error) = match cl_stats {
+        Some(v) => (
+            Some(serde_json::to_value(v).context("serializing opp2p_peerStats to JSON value")?),
+            None,
+        ),
+        None => (None, Some("CL `opp2p_peerStats` not exposed by this RPC".to_string())),
+    };
     Ok(RawInfoReport {
         el: el_value,
         el_error,
-        cl: serde_json::to_value(&cl_info).context("serializing opp2p_self to JSON value")?,
-        peer_counts: RawPeerCounts {
-            el: el_count,
-            cl: serde_json::to_value(cl_stats)
-                .context("serializing opp2p_peerStats to JSON value")?,
-        },
+        cl: cl_value,
+        cl_error,
+        peer_counts: RawPeerCounts { el: el_count, cl: cl_stats_value, cl_error: cl_stats_error },
     })
 }
 
@@ -306,25 +407,40 @@ pub async fn fetch_raw_peers(rpc: &Url, cl_rpc: &Url) -> Result<RawPeersReport> 
             }
         },
         async {
-            BaseP2PApiClient::opp2p_peers(&cl_client, true)
-                .await
-                .with_context(|| format!("fetching opp2p_peers(true) from {cl_rpc}"))
+            match BaseP2PApiClient::opp2p_peers(&cl_client, true).await {
+                Ok(peers) => Ok(Some(peers)),
+                Err(err) if is_jsonrpc_method_not_found(&err) => Ok(None),
+                Err(err) => {
+                    Err(err).with_context(|| format!("fetching opp2p_peers(true) from {cl_rpc}"))
+                }
+            }
         },
     )?;
 
-    Ok(RawPeersReport {
-        el: el_value,
-        el_error,
-        cl: serde_json::to_value(&cl_peers).context("serializing opp2p_peers to JSON value")?,
-    })
+    let (cl_value, cl_error) = match cl_peers {
+        Some(v) => {
+            (Some(serde_json::to_value(&v).context("serializing opp2p_peers to JSON value")?), None)
+        }
+        None => (None, Some("CL `opp2p_peers` not exposed by this RPC".to_string())),
+    };
+    Ok(RawPeersReport { el: el_value, el_error, cl: cl_value, cl_error })
 }
 
 /// Connects to the EL provider and CL RPC client used by every p2p fetch.
 async fn connect_layers(rpc: &Url, cl_rpc: &Url) -> Result<(HttpClient, impl Provider<Base>)> {
-    let cl_client = HttpClientBuilder::default()
+    let cl_client = connect_cl(cl_rpc)?;
+    let el_provider = connect_el(rpc).await?;
+    Ok((cl_client, el_provider))
+}
+
+fn connect_cl(cl_rpc: &Url) -> Result<HttpClient> {
+    HttpClientBuilder::default()
         .request_timeout(Duration::from_secs(10))
         .build(cl_rpc.as_str())
-        .with_context(|| format!("connecting to consensus node RPC at {cl_rpc}"))?;
+        .with_context(|| format!("connecting to consensus node RPC at {cl_rpc}"))
+}
+
+async fn connect_el(rpc: &Url) -> Result<impl Provider<Base>> {
     let http_client = alloy_transport_http::reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
@@ -334,11 +450,15 @@ async fn connect_layers(rpc: &Url, cl_rpc: &Url) -> Result<(HttpClient, impl Pro
         .disable_recommended_fillers()
         .network::<Base>()
         .connect_client(RpcClient::new(transport, false));
-    Ok((cl_client, el_provider))
+    Ok(el_provider)
 }
 
 const fn is_method_not_found(err: &TransportError) -> bool {
     matches!(err, TransportError::ErrorResp(payload) if payload.code == -32601)
+}
+
+fn is_jsonrpc_method_not_found(err: &JsonRpcClientError) -> bool {
+    matches!(err, JsonRpcClientError::Call(payload) if payload.code() == -32601)
 }
 
 /// Parses the EL advertised endpoint from `admin_nodeInfo`'s enode + ENR,
@@ -446,8 +566,11 @@ mod tests {
     use base_consensus_gossip::{
         Connectedness, Direction, GossipScores, PeerInfo, PeerScores, ReqRespScores,
     };
+    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
-    use super::{NodeEndpoint, parse_cl_node_endpoint, parse_el_node_endpoint};
+    use super::{
+        NodeEndpoint, is_jsonrpc_method_not_found, parse_cl_node_endpoint, parse_el_node_endpoint,
+    };
 
     #[test]
     fn parses_el_endpoint_from_enode_and_enr() {
@@ -503,5 +626,16 @@ mod tests {
         assert!(endpoint.discovery.udp_port > 0);
         assert!(!endpoint.discovery.v4_enabled);
         assert!(endpoint.discovery.v5_enabled);
+    }
+
+    #[test]
+    fn detects_jsonrpc_method_not_found_for_cl_p2p_methods() {
+        let err = JsonRpcClientError::Call(ErrorObjectOwned::owned(
+            -32601,
+            "method not found",
+            None::<()>,
+        ));
+
+        assert!(is_jsonrpc_method_not_found(&err));
     }
 }

--- a/crates/infra/basectl/src/rpc/rollup.rs
+++ b/crates/infra/basectl/src/rpc/rollup.rs
@@ -2,9 +2,12 @@ use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256};
 use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::{BlockNumberOrTag, SyncStatus as EthSyncStatus};
 use alloy_sol_types::sol;
+use alloy_transport_http::Http;
 use anyhow::{Context, Result};
+use base_common_network::Base;
 use base_consensus_rpc::{BaseP2PApiClient, RollupNodeApiClient};
 use base_protocol::SyncStatus;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
@@ -46,10 +49,15 @@ pub async fn fetch_sync_status(rpc: &Url, cl_rpc: &Url) -> Result<SyncStatusRepo
         .request_timeout(Duration::from_secs(10))
         .build(cl_rpc.as_str())
         .with_context(|| format!("connecting to consensus node RPC at {cl_rpc}"))?;
+    let http_client = alloy_transport_http::reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .with_context(|| format!("building L2 EL HTTP client for {rpc}"))?;
+    let transport = Http::with_client(http_client, rpc.clone());
     let el_provider = ProviderBuilder::new()
-        .connect(rpc.as_str())
-        .await
-        .with_context(|| format!("connecting to L2 EL RPC at {rpc}"))?;
+        .disable_recommended_fillers()
+        .network::<Base>()
+        .connect_client(RpcClient::new(transport, false));
     let (cl, el) = tokio::try_join!(
         async {
             RollupNodeApiClient::sync_status(&cl_client)


### PR DESCRIPTION
## Summary
- Add `basectl doctor` as a read-only diagnostic command for node operators.
- Compose existing block, sync-status, and p2p helpers with new doctor checks for network/config health.
- Add graceful degradation for restricted RPC methods, concurrent diagnostic fetches, and readable pretty/JSON output.
## Test Plan
- [x] Unit tests pass: `cargo test -p basectl-cli`
- [x] Binary tests pass: `cargo test -p basectl`
- [x] Clippy passes: `cargo clippy -p basectl-cli -p basectl --all-targets -- -D warnings`
- [x] Formatting passes: `cargo +nightly fmt --all -- --check`
- [x] Manual testing completed against Sepolia EL/CL RPC endpoints
- [x] Edge cases considered: missing CL RPC, restricted p2p methods, missing `reth.toml`, wrong chain ID, unavailable peer counts