### PR TITLE
feat(BASE-103): zero delayedWETHWithdrawalDelay in devnet config

### DIFF
--- a/etc/scripts/devnet/templates/deploy-config.json.template
+++ b/etc/scripts/devnet/templates/deploy-config.json.template
@@ -4,7 +4,7 @@
   "baseFeeVaultWithdrawalNetwork": 0,
   "batchSenderAddress": "${BATCHER_ADDR}",
   "disputeGameFinalityDelaySeconds": 0,
-  "delayedWETHWithdrawalDelay": 302400,
+  "delayedWETHWithdrawalDelay": 0,
   "eip1559Denominator": 50,
   "eip1559DenominatorCanyon": 250,
   "eip1559Elasticity": 6,


### PR DESCRIPTION
The immediate TEE finality PR (#3355) zeroed all withdrawal delay parameters but missed `delayedWETHWithdrawalDelay` (still 302400 / 3.5 days). This blocks dispute game bond recovery in devnet — WETH bonds cannot be withdrawn from `DelayedWETH` for 3.5 days after game resolution, despite all other delays being zero.

Sets `delayedWETHWithdrawalDelay` to 0 in the devnet deploy config template.

Linear: BASE-103

Made with [Cursor](https://cursor.com)