### PR TITLE
feat(docker): Bundle Unified Base Binary

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -61,11 +61,13 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/target,id=client-target,sharing=locked \
     cargo build --profile $PROFILE \
       --bin base-reth-node \
+      --bin base \
       --bin base-consensus \
       --bin basectl \
       --bin snapshotter && \
     target_dir="/app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")" && \
     cp "$target_dir/base-reth-node" /app/base-client && \
+    cp "$target_dir/base" /app/base && \
     cp "$target_dir/base-consensus" /app/base-consensus && \
     cp "$target_dir/basectl" /app/basectl && \
     cp "$target_dir/snapshotter" /app/snapshotter
@@ -154,6 +156,7 @@ WORKDIR /app
 
 FROM runtime-base AS client
 COPY --from=client-builder /app/base-client ./base-client
+COPY --from=client-builder /app/base ./base
 COPY --from=client-builder /app/base-consensus ./base-consensus
 COPY --from=client-builder /app/basectl ./basectl
 COPY --from=client-builder /app/snapshotter ./snapshotter

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -4,7 +4,7 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 
 ## Dockerfiles
 
-`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It bundles `base-consensus`, `basectl`, and `snapshotter`, while preserving the historical `base-client` entrypoint by copying the `base-reth-node` binary into the image under that compatible name.
+`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It bundles `base` (the unified node binary), `base-consensus`, `basectl`, and `snapshotter`, while preserving the historical `base-client` entrypoint by copying the `base-reth-node` binary into the image under that compatible name.
 
 `Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) and setup scripts. This image bootstraps L1 and L2 chain configurations for local development.
 


### PR DESCRIPTION
## Summary

This adds the unified `base` node binary to the shared Rust services Docker image alongside the existing `base-client` compatibility entrypoint. The Docker README now documents that the image bundles `base`, `base-consensus`, `basectl`, and `snapshotter`.