### PR TITLE
chore(load-tester): update metrics reporting

### DIFF
--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -263,10 +263,41 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
 
     if summary.error.is_none() || summary.throughput.total_submitted > 0 {
         println!();
-        println!("=== Results ===");
+        println!("=== Results: First Half (clean window) ===");
         if let Some(ref err) = summary.error {
             println!("Error: {err}");
         }
+        let fh = &summary.first_half;
+        let fhbr = &fh.block_range;
+        match (fhbr.first_block, fhbr.last_block) {
+            (Some(first), Some(last)) => println!(
+                "Blocks: first={first}  last={last}  span={} block(s)  (~{:.1}s)",
+                fhbr.block_count,
+                fh.duration.as_secs_f64()
+            ),
+            _ => println!("Blocks: no confirmed transactions in first half"),
+        }
+        println!("Confirmed: {} | TPS: {:.2} | GPS: {:.0}", fh.confirmed_count, fh.tps, fh.gps);
+        let fhbl = &fh.block_latency;
+        println!(
+            "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+            fhbl.min, fhbl.p50, fhbl.mean, fhbl.p99, fhbl.max
+        );
+        let fhfb = &fh.flashblocks_latency;
+        println!(
+            "FB Latency:    min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
+            fhfb.min, fhfb.p50, fhfb.mean, fhfb.p99, fhfb.max, fhfb.count
+        );
+
+        println!();
+        println!("=== Results: Full Range ===");
+        println!(
+            "NOTE: there is a delay in transaction inclusion which causes metrics to be skewed."
+        );
+        println!(
+            "This is an active investigation and is pending full e2e observability rollout, which"
+        );
+        println!("will help identify the bottleneck.");
         println!(
             "Submitted: {} | Confirmed: {} | Failed: {} | Reverted: {}",
             summary.throughput.total_submitted,

--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -263,77 +263,101 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
 
     if summary.error.is_none() || summary.throughput.total_submitted > 0 {
         println!();
-        println!("=== Results: First Half (clean window) ===");
+        println!("=== Results: Observed Window ===");
         if let Some(ref err) = summary.error {
             println!("Error: {err}");
         }
-        let fh = &summary.first_half;
+        let fh = &summary.observed_window;
         let fhbr = &fh.block_range;
-        match (fhbr.first_block, fhbr.last_block) {
-            (Some(first), Some(last)) => println!(
-                "Blocks: first={first}  last={last}  span={} block(s)  (~{:.1}s)",
-                fhbr.block_count,
+        match fhbr.first_block {
+            Some(first) => println!(
+                "Window: blocks {first}..={} ({} blocks, ~{:.1}s)",
+                first.saturating_add(fh.expected_block_count.saturating_sub(1)),
+                fh.expected_block_count,
                 fh.duration.as_secs_f64()
             ),
-            _ => println!("Blocks: no confirmed transactions in first half"),
+            _ => println!(
+                "Window: {} blocks ({:.1}s) — no test txs landed",
+                fh.expected_block_count,
+                fh.duration.as_secs_f64()
+            ),
         }
         println!("Confirmed: {} | TPS: {:.2} | GPS: {:.0}", fh.confirmed_count, fh.tps, fh.gps);
         let fhbl = &fh.block_latency;
         println!(
-            "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+            "Block Latency:       min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
             fhbl.min, fhbl.p50, fhbl.mean, fhbl.p99, fhbl.max
+        );
+        let fhbrd = &fh.block_receipt_delay;
+        println!(
+            "Block Receipt Delay: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+            fhbrd.min, fhbrd.p50, fhbrd.mean, fhbrd.p99, fhbrd.max
         );
         let fhfb = &fh.flashblocks_latency;
         println!(
-            "FB Latency:    min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
+            "FB Latency:          min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
             fhfb.min, fhfb.p50, fhfb.mean, fhfb.p99, fhfb.max, fhfb.count
         );
 
         println!();
-        println!("=== Results: Full Range ===");
+        println!("=== Results: Tail Inclusion (txs past the observed window) ===");
+        match &summary.tail {
+            None => println!("N/A: continuous run (no configured duration)"),
+            Some(tail) => {
+                if let Some(boundary) = tail.observed_window_end_block {
+                    println!("Boundary: tail = blocks > {boundary} (end of observed window)");
+                } else {
+                    println!("Boundary: no confirmed data");
+                }
+                if tail.count == 0 {
+                    println!(
+                        "Tail: 0 of {} confirmed — no txs landed past the observed window",
+                        summary.throughput.total_confirmed
+                    );
+                } else {
+                    println!(
+                        "Tail: {} of {} confirmed ({:.2}%)",
+                        tail.count, summary.throughput.total_confirmed, tail.confirmed_pct
+                    );
+                    let tbr = &tail.block_range;
+                    if let (Some(first), Some(last)) = (tbr.first_block, tbr.last_block) {
+                        println!(
+                            "Blocks: first={first}  last={last}  span={} block(s)",
+                            tbr.block_count
+                        );
+                    }
+                    let tp = &tail.time_past_observed_window;
+                    println!(
+                        "Time past observed window: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+                        tp.min, tp.p50, tp.mean, tp.p99, tp.max
+                    );
+                    let tbl = &tail.block_latency;
+                    println!(
+                        "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+                        tbl.min, tbl.p50, tbl.mean, tbl.p99, tbl.max
+                    );
+                    let tbrd = &tail.block_receipt_delay;
+                    println!(
+                        "Block Receipt Delay:              min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+                        tbrd.min, tbrd.p50, tbrd.mean, tbrd.p99, tbrd.max
+                    );
+                    let tfb = &tail.flashblocks_latency;
+                    println!(
+                        "FB Latency:                       min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
+                        tfb.min, tfb.p50, tfb.mean, tfb.p99, tfb.max, tfb.count
+                    );
+                }
+            }
+        }
+
+        println!();
         println!(
-            "NOTE: there is a delay in transaction inclusion which causes metrics to be skewed."
-        );
-        println!(
-            "This is an active investigation and is pending full e2e observability rollout, which"
-        );
-        println!("will help identify the bottleneck.");
-        println!(
-            "Submitted: {} | Confirmed: {} | Failed: {} | Reverted: {}",
+            "Totals: Submitted={} | Confirmed={} | Failed={} | Reverted={} | Success={:.1}%",
             summary.throughput.total_submitted,
             summary.throughput.total_confirmed,
             summary.throughput.total_failed,
-            summary.throughput.total_reverted
-        );
-        println!(
-            "TPS: {:.2} | GPS: {:.0} | Success: {:.1}%",
-            summary.throughput.tps,
-            summary.throughput.gps,
+            summary.throughput.total_reverted,
             summary.throughput.success_rate()
-        );
-        let tp = &summary.throughput_percentiles;
-        println!(
-            "TPS Rolling:   p50={:.0}  p90={:.0}  p99={:.0}  max={:.0}",
-            tp.tps_p50, tp.tps_p90, tp.tps_p99, tp.tps_max
-        );
-        println!(
-            "GPS Rolling:   p50={:.0}  p90={:.0}  p99={:.0}  max={:.0}",
-            tp.gps_p50, tp.gps_p90, tp.gps_p99, tp.gps_max
-        );
-        let bl = &summary.block_latency;
-        println!(
-            "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-            bl.min, bl.p50, bl.mean, bl.p99, bl.max
-        );
-        let brd = &summary.block_receipt_delay;
-        println!(
-            "Block Receipt Delay: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-            brd.min, brd.p50, brd.mean, brd.p99, brd.max
-        );
-        let fb = &summary.flashblocks_latency;
-        println!(
-            "FB Latency:    min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
-            fb.min, fb.p50, fb.mean, fb.p99, fb.max, fb.count
         );
         println!("Gas: total={}  avg/tx={}", summary.gas.total_gas, summary.gas.avg_gas);
         let br = &summary.block_range;

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -19,9 +19,9 @@ pub use rpc::{
 
 mod metrics;
 pub use metrics::{
-    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    MetricsAggregator, MetricsCollector, MetricsSummary, RollingWindow, ThroughputMetrics,
-    ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FirstHalfMetrics, FlashblocksLatencyMetrics, GasMetrics,
+    LatencyMetrics, MetricsAggregator, MetricsCollector, MetricsSummary, RollingWindow,
+    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -19,9 +19,9 @@ pub use rpc::{
 
 mod metrics;
 pub use metrics::{
-    BlockRange, ConfigSummary, FirstHalfMetrics, FlashblocksLatencyMetrics, GasMetrics,
-    LatencyMetrics, MetricsAggregator, MetricsCollector, MetricsSummary, RollingWindow,
-    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
+    MetricsAggregator, MetricsCollector, MetricsSummary, ObservedWindowMetrics, RollingWindow,
+    TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -21,7 +21,8 @@ mod metrics;
 pub use metrics::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
     MetricsAggregator, MetricsCollector, MetricsSummary, ObservedWindowMetrics, RollingWindow,
-    TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    SubmissionStats, TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -3,8 +3,9 @@ use std::{collections::HashMap, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FirstHalfMetrics, FlashblocksLatencyMetrics, GasMetrics,
+    LatencyMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    types::BLOCK_INTERVAL,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -41,26 +42,76 @@ impl<'a> MetricsAggregator<'a> {
         let tps_values: Vec<f64> = throughput_samples.iter().map(|s| s.tps).collect();
         let gps_values: Vec<f64> = throughput_samples.iter().map(|s| s.gps).collect();
 
-        let block_range = self.compute_block_range();
+        let block_range = Self::compute_block_range(self.transactions);
         let throughput_duration = block_range.block_time_duration().unwrap_or(wall_clock_duration);
 
         MetricsSummary {
             config,
             error: None,
-            block_latency: self.compute_block_latency(),
-            block_receipt_delay: self.compute_block_receipt_delay(),
-            flashblocks_latency: self.compute_flashblocks_latency(),
-            throughput: self.compute_throughput(throughput_duration, submitted, failed),
+            first_half: Self::compute_first_half(self.transactions, wall_clock_duration),
+            block_latency: Self::compute_block_latency(self.transactions),
+            block_receipt_delay: Self::compute_block_receipt_delay(self.transactions),
+            flashblocks_latency: Self::compute_flashblocks_latency(self.transactions),
+            throughput: Self::compute_throughput(
+                self.transactions,
+                throughput_duration,
+                submitted,
+                failed,
+            ),
             throughput_percentiles: Self::compute_throughput_percentiles(&tps_values, &gps_values),
             throughput_timeseries: throughput_samples.to_vec(),
-            gas: self.compute_gas(),
+            gas: Self::compute_gas(self.transactions),
             block_range,
             top_failure_reasons,
         }
     }
 
-    fn compute_block_range(&self) -> BlockRange {
-        let mut iter = self.transactions.iter().filter_map(|t| t.block_number);
+    /// Computes the "first half" reporting window: transactions in blocks
+    /// `[first_block, first_block + (wall_clock_duration / 2) / BLOCK_INTERVAL]`.
+    /// The window is closed and inclusive at both ends.
+    fn compute_first_half(
+        transactions: &[TransactionMetrics],
+        wall_clock_duration: Duration,
+    ) -> FirstHalfMetrics {
+        let full_range = Self::compute_block_range(transactions);
+        let Some(first_block) = full_range.first_block else {
+            return FirstHalfMetrics::default();
+        };
+
+        let half = wall_clock_duration / 2;
+        let block_span = (half.as_secs_f64() / BLOCK_INTERVAL.as_secs_f64()).round() as u64;
+        let end_block = first_block.saturating_add(block_span);
+
+        let filtered: Vec<TransactionMetrics> = transactions
+            .iter()
+            .filter(|t| t.block_number.is_some_and(|b| b <= end_block))
+            .cloned()
+            .collect();
+
+        let block_range = Self::compute_block_range(&filtered);
+        let duration = block_range.block_time_duration().unwrap_or(half);
+        let confirmed_count = filtered.len() as u64;
+        let total_gas: u64 = filtered.iter().map(|t| t.gas_used).sum();
+        let duration_secs = duration.as_secs_f64();
+        let (tps, gps) = if duration_secs > 0.0 {
+            (confirmed_count as f64 / duration_secs, total_gas as f64 / duration_secs)
+        } else {
+            (0.0, 0.0)
+        };
+
+        FirstHalfMetrics {
+            block_range,
+            duration,
+            confirmed_count,
+            tps,
+            gps,
+            block_latency: Self::compute_block_latency(&filtered),
+            flashblocks_latency: Self::compute_flashblocks_latency(&filtered),
+        }
+    }
+
+    fn compute_block_range(transactions: &[TransactionMetrics]) -> BlockRange {
+        let mut iter = transactions.iter().filter_map(|t| t.block_number);
         let Some(first) = iter.next() else {
             return BlockRange::default();
         };
@@ -68,16 +119,16 @@ impl<'a> MetricsAggregator<'a> {
         BlockRange { first_block: Some(min), last_block: Some(max), block_count: max - min + 1 }
     }
 
-    fn compute_block_latency(&self) -> LatencyMetrics {
+    fn compute_block_latency(transactions: &[TransactionMetrics]) -> LatencyMetrics {
         let mut latencies: Vec<Duration> =
-            self.transactions.iter().filter_map(|t| t.block_latency).collect();
+            transactions.iter().filter_map(|t| t.block_latency).collect();
 
         Self::compute_duration_metrics(&mut latencies)
     }
 
-    fn compute_block_receipt_delay(&self) -> LatencyMetrics {
+    fn compute_block_receipt_delay(transactions: &[TransactionMetrics]) -> LatencyMetrics {
         let mut latencies: Vec<Duration> =
-            self.transactions.iter().filter_map(|t| t.block_receipt_delay).collect();
+            transactions.iter().filter_map(|t| t.block_receipt_delay).collect();
 
         Self::compute_duration_metrics(&mut latencies)
     }
@@ -103,9 +154,11 @@ impl<'a> MetricsAggregator<'a> {
         }
     }
 
-    fn compute_flashblocks_latency(&self) -> FlashblocksLatencyMetrics {
+    fn compute_flashblocks_latency(
+        transactions: &[TransactionMetrics],
+    ) -> FlashblocksLatencyMetrics {
         let mut latencies: Vec<Duration> =
-            self.transactions.iter().filter_map(|t| t.flashblocks_latency).collect();
+            transactions.iter().filter_map(|t| t.flashblocks_latency).collect();
 
         if latencies.is_empty() {
             return FlashblocksLatencyMetrics::default();
@@ -130,14 +183,14 @@ impl<'a> MetricsAggregator<'a> {
     }
 
     fn compute_throughput(
-        &self,
+        transactions: &[TransactionMetrics],
         duration: Duration,
         submitted: u64,
         failed: u64,
     ) -> ThroughputMetrics {
-        let confirmed = self.transactions.len() as u64;
-        let total_reverted = self.transactions.iter().filter(|t| t.reverted).count() as u64;
-        let total_gas: u64 = self.transactions.iter().map(|t| t.gas_used).sum();
+        let confirmed = transactions.len() as u64;
+        let total_reverted = transactions.iter().filter(|t| t.reverted).count() as u64;
+        let total_gas: u64 = transactions.iter().map(|t| t.gas_used).sum();
         let duration_secs = duration.as_secs_f64();
 
         let (tps, gps) = if duration_secs > 0.0 {
@@ -157,15 +210,15 @@ impl<'a> MetricsAggregator<'a> {
         }
     }
 
-    fn compute_gas(&self) -> GasMetrics {
-        if self.transactions.is_empty() {
+    fn compute_gas(transactions: &[TransactionMetrics]) -> GasMetrics {
+        if transactions.is_empty() {
             return GasMetrics::default();
         }
 
-        let total_gas: u64 = self.transactions.iter().map(|t| t.gas_used).sum();
-        let total_cost: u128 = self.transactions.iter().map(|t| t.cost_wei()).sum();
-        let total_gas_price: u128 = self.transactions.iter().map(|t| t.gas_price).sum();
-        let count = self.transactions.len() as u64;
+        let total_gas: u64 = transactions.iter().map(|t| t.gas_used).sum();
+        let total_cost: u128 = transactions.iter().map(|t| t.cost_wei()).sum();
+        let total_gas_price: u128 = transactions.iter().map(|t| t.gas_price).sum();
+        let count = transactions.len() as u64;
 
         GasMetrics {
             total_gas,
@@ -214,6 +267,13 @@ impl<'a> MetricsAggregator<'a> {
 }
 
 /// Summary of all collected metrics.
+///
+/// Reporting is split into two scopes:
+/// * `first_half` covers the first half of the run and is the "clean" window
+///   used for headline TPS / latency comparisons.
+/// * Top-level `throughput`, `block_latency`, `flashblocks_latency`, etc. cover
+///   the full run and include a known late-run degradation that is pending
+///   end-to-end observability rollout.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MetricsSummary {
     /// Test configuration (excludes URLs and secrets).
@@ -222,13 +282,15 @@ pub struct MetricsSummary {
     /// Fatal error that stopped the test (e.g., funding failure).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    /// Block production latency.
+    /// First-half reporting window (clean TPS / block / FB latency).
+    pub first_half: FirstHalfMetrics,
+    /// Block production latency (full run).
     pub block_latency: LatencyMetrics,
-    /// Delay between block production time and receipt observation.
+    /// Delay between block production time and receipt observation (full run).
     pub block_receipt_delay: LatencyMetrics,
-    /// Flashblocks sequencer latency.
+    /// Flashblocks sequencer latency (full run).
     pub flashblocks_latency: FlashblocksLatencyMetrics,
-    /// Throughput statistics.
+    /// Throughput statistics (full run).
     pub throughput: ThroughputMetrics,
     /// Rolling-window throughput percentiles (TPS and GPS).
     pub throughput_percentiles: ThroughputPercentiles,

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use super::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    ObservedWindowMetrics, TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
-    TransactionMetrics, types::BLOCK_INTERVAL,
+    ObservedWindowMetrics, SubmissionStats, TailMetrics, ThroughputMetrics, ThroughputPercentiles,
+    ThroughputSample, TransactionMetrics, types::BLOCK_INTERVAL,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -35,14 +35,12 @@ impl<'a> MetricsAggregator<'a> {
         &self,
         wall_clock_duration: Duration,
         configured_duration: Option<Duration>,
-        submitted: u64,
-        failed: u64,
-        failure_reasons: &HashMap<String, u64>,
+        submission: SubmissionStats<'_>,
         throughput_samples: &[ThroughputSample],
         config: Option<ConfigSummary>,
     ) -> MetricsSummary {
         let mut top_failure_reasons: Vec<(String, u64)> =
-            failure_reasons.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            submission.failure_reasons.iter().map(|(k, v)| (k.clone(), *v)).collect();
         top_failure_reasons.sort_by(|a, b| b.1.cmp(&a.1));
         top_failure_reasons.truncate(3);
 
@@ -53,7 +51,11 @@ impl<'a> MetricsAggregator<'a> {
         let throughput_duration = block_range.block_time_duration().unwrap_or(wall_clock_duration);
         let reference_duration = configured_duration.unwrap_or(wall_clock_duration);
 
-        let observed_window = Self::compute_observed_window(self.transactions, reference_duration);
+        let observed_window = Self::compute_observed_window(
+            self.transactions,
+            reference_duration,
+            block_range.first_block,
+        );
         let tail = configured_duration.map(|_| {
             Self::compute_tail(
                 self.transactions,
@@ -73,8 +75,8 @@ impl<'a> MetricsAggregator<'a> {
             throughput: Self::compute_throughput(
                 self.transactions,
                 throughput_duration,
-                submitted,
-                failed,
+                submission.submitted,
+                submission.failed,
             ),
             throughput_percentiles: Self::compute_throughput_percentiles(&tps_values, &gps_values),
             throughput_timeseries: throughput_samples.to_vec(),
@@ -85,18 +87,21 @@ impl<'a> MetricsAggregator<'a> {
     }
 
     /// Computes the observed reporting window:
-    /// `expected_block_count = reference_duration.as_secs() / 2`, starting at
-    /// `first_block`. TPS / GPS denominator = `expected_block_count *
+    /// `expected_block_count = reference_duration.as_secs() / BLOCK_INTERVAL.as_secs()`,
+    /// starting at `first_block`. TPS / GPS denominator = `expected_block_count *
     /// BLOCK_INTERVAL` (real L2 wall-time spanned by those expected blocks).
+    ///
+    /// `first_block` is taken from the caller's pre-computed full block range
+    /// to avoid re-scanning `transactions`.
     fn compute_observed_window(
         transactions: &[TransactionMetrics],
         reference_duration: Duration,
+        first_block: Option<u64>,
     ) -> ObservedWindowMetrics {
-        let expected_block_count = reference_duration.as_secs() / 2;
+        let expected_block_count = reference_duration.as_secs() / BLOCK_INTERVAL.as_secs();
         let duration =
             Duration::from_secs(expected_block_count.saturating_mul(BLOCK_INTERVAL.as_secs()));
-        let full_range = Self::compute_block_range(transactions);
-        let Some(first_block) = full_range.first_block else {
+        let Some(first_block) = first_block else {
             return ObservedWindowMetrics {
                 expected_block_count,
                 duration,
@@ -105,16 +110,12 @@ impl<'a> MetricsAggregator<'a> {
         };
 
         let end_block = first_block.saturating_add(expected_block_count.saturating_sub(1));
+        let in_window = |t: &&TransactionMetrics| t.block_number.is_some_and(|b| b <= end_block);
 
-        let filtered: Vec<TransactionMetrics> = transactions
+        let (confirmed_count, total_gas) = transactions
             .iter()
-            .filter(|t| t.block_number.is_some_and(|b| b <= end_block))
-            .cloned()
-            .collect();
-
-        let block_range = Self::compute_block_range(&filtered);
-        let confirmed_count = filtered.len() as u64;
-        let total_gas: u64 = filtered.iter().map(|t| t.gas_used).sum();
+            .filter(in_window)
+            .fold((0u64, 0u64), |(n, gas), t| (n + 1, gas + t.gas_used));
         let duration_secs = duration.as_secs_f64();
         let (tps, gps) = if duration_secs > 0.0 {
             (confirmed_count as f64 / duration_secs, total_gas as f64 / duration_secs)
@@ -124,14 +125,18 @@ impl<'a> MetricsAggregator<'a> {
 
         ObservedWindowMetrics {
             expected_block_count,
-            block_range,
+            block_range: Self::compute_block_range(transactions.iter().filter(in_window)),
             duration,
             confirmed_count,
             tps,
             gps,
-            block_latency: Self::compute_block_latency(&filtered),
-            block_receipt_delay: Self::compute_block_receipt_delay(&filtered),
-            flashblocks_latency: Self::compute_flashblocks_latency(&filtered),
+            block_latency: Self::compute_block_latency(transactions.iter().filter(in_window)),
+            block_receipt_delay: Self::compute_block_receipt_delay(
+                transactions.iter().filter(in_window),
+            ),
+            flashblocks_latency: Self::compute_flashblocks_latency(
+                transactions.iter().filter(in_window),
+            ),
         }
     }
 
@@ -151,19 +156,16 @@ impl<'a> MetricsAggregator<'a> {
 
         let observed_window_end_block =
             first_block.saturating_add(observed_window_expected_block_count.saturating_sub(1));
+        let is_tail =
+            |t: &&TransactionMetrics| t.block_number.is_some_and(|b| b > observed_window_end_block);
 
-        let tail: Vec<TransactionMetrics> = transactions
-            .iter()
-            .filter(|t| t.block_number.is_some_and(|b| b > observed_window_end_block))
-            .cloned()
-            .collect();
-
-        let count = tail.len() as u64;
+        let count = transactions.iter().filter(is_tail).count() as u64;
         let confirmed_pct =
             if total_confirmed > 0 { (count as f64 / total_confirmed as f64) * 100.0 } else { 0.0 };
 
-        let mut time_past: Vec<Duration> = tail
+        let mut time_past: Vec<Duration> = transactions
             .iter()
+            .filter(is_tail)
             .filter_map(|t| t.block_number)
             .map(|b| BLOCK_INTERVAL * (b - observed_window_end_block) as u32)
             .collect();
@@ -172,16 +174,22 @@ impl<'a> MetricsAggregator<'a> {
             observed_window_end_block: Some(observed_window_end_block),
             count,
             confirmed_pct,
-            block_range: Self::compute_block_range(&tail),
+            block_range: Self::compute_block_range(transactions.iter().filter(is_tail)),
             time_past_observed_window: Self::compute_duration_metrics(&mut time_past),
-            block_latency: Self::compute_block_latency(&tail),
-            block_receipt_delay: Self::compute_block_receipt_delay(&tail),
-            flashblocks_latency: Self::compute_flashblocks_latency(&tail),
+            block_latency: Self::compute_block_latency(transactions.iter().filter(is_tail)),
+            block_receipt_delay: Self::compute_block_receipt_delay(
+                transactions.iter().filter(is_tail),
+            ),
+            flashblocks_latency: Self::compute_flashblocks_latency(
+                transactions.iter().filter(is_tail),
+            ),
         }
     }
 
-    fn compute_block_range(transactions: &[TransactionMetrics]) -> BlockRange {
-        let mut iter = transactions.iter().filter_map(|t| t.block_number);
+    fn compute_block_range<'t>(
+        transactions: impl IntoIterator<Item = &'t TransactionMetrics>,
+    ) -> BlockRange {
+        let mut iter = transactions.into_iter().filter_map(|t| t.block_number);
         let Some(first) = iter.next() else {
             return BlockRange::default();
         };
@@ -189,16 +197,20 @@ impl<'a> MetricsAggregator<'a> {
         BlockRange { first_block: Some(min), last_block: Some(max), block_count: max - min + 1 }
     }
 
-    fn compute_block_latency(transactions: &[TransactionMetrics]) -> LatencyMetrics {
+    fn compute_block_latency<'t>(
+        transactions: impl IntoIterator<Item = &'t TransactionMetrics>,
+    ) -> LatencyMetrics {
         let mut latencies: Vec<Duration> =
-            transactions.iter().filter_map(|t| t.block_latency).collect();
+            transactions.into_iter().filter_map(|t| t.block_latency).collect();
 
         Self::compute_duration_metrics(&mut latencies)
     }
 
-    fn compute_block_receipt_delay(transactions: &[TransactionMetrics]) -> LatencyMetrics {
+    fn compute_block_receipt_delay<'t>(
+        transactions: impl IntoIterator<Item = &'t TransactionMetrics>,
+    ) -> LatencyMetrics {
         let mut latencies: Vec<Duration> =
-            transactions.iter().filter_map(|t| t.block_receipt_delay).collect();
+            transactions.into_iter().filter_map(|t| t.block_receipt_delay).collect();
 
         Self::compute_duration_metrics(&mut latencies)
     }
@@ -224,11 +236,11 @@ impl<'a> MetricsAggregator<'a> {
         }
     }
 
-    fn compute_flashblocks_latency(
-        transactions: &[TransactionMetrics],
+    fn compute_flashblocks_latency<'t>(
+        transactions: impl IntoIterator<Item = &'t TransactionMetrics>,
     ) -> FlashblocksLatencyMetrics {
         let mut latencies: Vec<Duration> =
-            transactions.iter().filter_map(|t| t.flashblocks_latency).collect();
+            transactions.into_iter().filter_map(|t| t.flashblocks_latency).collect();
 
         if latencies.is_empty() {
             return FlashblocksLatencyMetrics::default();

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BlockRange, ConfigSummary, FirstHalfMetrics, FlashblocksLatencyMetrics, GasMetrics,
-    LatencyMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
-    types::BLOCK_INTERVAL,
+    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
+    ObservedWindowMetrics, TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics, types::BLOCK_INTERVAL,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -25,9 +25,16 @@ impl<'a> MetricsAggregator<'a> {
     /// `wall_clock_duration` is used as a fallback for TPS when block timestamps
     /// are unavailable. When block timestamps are present, TPS is derived from
     /// the first-to-last block time span instead.
+    ///
+    /// `configured_duration` is the user-configured test duration (e.g. `60s`
+    /// from `--duration 60s`). When provided, it anchors the observed-window
+    /// boundary and the "tail" (post-observed-window) classification. When
+    /// `None` (continuous run), `wall_clock_duration` is used for the observed
+    /// window and `tail` is reported as `None`.
     pub fn summarize(
         &self,
         wall_clock_duration: Duration,
+        configured_duration: Option<Duration>,
         submitted: u64,
         failed: u64,
         failure_reasons: &HashMap<String, u64>,
@@ -44,11 +51,22 @@ impl<'a> MetricsAggregator<'a> {
 
         let block_range = Self::compute_block_range(self.transactions);
         let throughput_duration = block_range.block_time_duration().unwrap_or(wall_clock_duration);
+        let reference_duration = configured_duration.unwrap_or(wall_clock_duration);
+
+        let observed_window = Self::compute_observed_window(self.transactions, reference_duration);
+        let tail = configured_duration.map(|_| {
+            Self::compute_tail(
+                self.transactions,
+                observed_window.expected_block_count,
+                block_range.first_block,
+            )
+        });
 
         MetricsSummary {
             config,
             error: None,
-            first_half: Self::compute_first_half(self.transactions, wall_clock_duration),
+            observed_window,
+            tail,
             block_latency: Self::compute_block_latency(self.transactions),
             block_receipt_delay: Self::compute_block_receipt_delay(self.transactions),
             flashblocks_latency: Self::compute_flashblocks_latency(self.transactions),
@@ -66,21 +84,27 @@ impl<'a> MetricsAggregator<'a> {
         }
     }
 
-    /// Computes the "first half" reporting window: transactions in blocks
-    /// `[first_block, first_block + (wall_clock_duration / 2) / BLOCK_INTERVAL]`.
-    /// The window is closed and inclusive at both ends.
-    fn compute_first_half(
+    /// Computes the observed reporting window:
+    /// `expected_block_count = reference_duration.as_secs() / 2`, starting at
+    /// `first_block`. TPS / GPS denominator = `expected_block_count *
+    /// BLOCK_INTERVAL` (real L2 wall-time spanned by those expected blocks).
+    fn compute_observed_window(
         transactions: &[TransactionMetrics],
-        wall_clock_duration: Duration,
-    ) -> FirstHalfMetrics {
+        reference_duration: Duration,
+    ) -> ObservedWindowMetrics {
+        let expected_block_count = reference_duration.as_secs() / 2;
+        let duration =
+            Duration::from_secs(expected_block_count.saturating_mul(BLOCK_INTERVAL.as_secs()));
         let full_range = Self::compute_block_range(transactions);
         let Some(first_block) = full_range.first_block else {
-            return FirstHalfMetrics::default();
+            return ObservedWindowMetrics {
+                expected_block_count,
+                duration,
+                ..ObservedWindowMetrics::default()
+            };
         };
 
-        let half = wall_clock_duration / 2;
-        let block_span = (half.as_secs_f64() / BLOCK_INTERVAL.as_secs_f64()).round() as u64;
-        let end_block = first_block.saturating_add(block_span);
+        let end_block = first_block.saturating_add(expected_block_count.saturating_sub(1));
 
         let filtered: Vec<TransactionMetrics> = transactions
             .iter()
@@ -89,7 +113,6 @@ impl<'a> MetricsAggregator<'a> {
             .collect();
 
         let block_range = Self::compute_block_range(&filtered);
-        let duration = block_range.block_time_duration().unwrap_or(half);
         let confirmed_count = filtered.len() as u64;
         let total_gas: u64 = filtered.iter().map(|t| t.gas_used).sum();
         let duration_secs = duration.as_secs_f64();
@@ -99,14 +122,61 @@ impl<'a> MetricsAggregator<'a> {
             (0.0, 0.0)
         };
 
-        FirstHalfMetrics {
+        ObservedWindowMetrics {
+            expected_block_count,
             block_range,
             duration,
             confirmed_count,
             tps,
             gps,
             block_latency: Self::compute_block_latency(&filtered),
+            block_receipt_delay: Self::compute_block_receipt_delay(&filtered),
             flashblocks_latency: Self::compute_flashblocks_latency(&filtered),
+        }
+    }
+
+    /// Computes the inclusion-delay tail: transactions whose block number is
+    /// strictly greater than the observed-window end block
+    /// (`first_block + observed_window_expected_block_count - 1`). Captures
+    /// straggler receipts that landed past the clean reporting window.
+    fn compute_tail(
+        transactions: &[TransactionMetrics],
+        observed_window_expected_block_count: u64,
+        first_block: Option<u64>,
+    ) -> TailMetrics {
+        let Some(first_block) = first_block else {
+            return TailMetrics::default();
+        };
+        let total_confirmed = transactions.len() as u64;
+
+        let observed_window_end_block =
+            first_block.saturating_add(observed_window_expected_block_count.saturating_sub(1));
+
+        let tail: Vec<TransactionMetrics> = transactions
+            .iter()
+            .filter(|t| t.block_number.is_some_and(|b| b > observed_window_end_block))
+            .cloned()
+            .collect();
+
+        let count = tail.len() as u64;
+        let confirmed_pct =
+            if total_confirmed > 0 { (count as f64 / total_confirmed as f64) * 100.0 } else { 0.0 };
+
+        let mut time_past: Vec<Duration> = tail
+            .iter()
+            .filter_map(|t| t.block_number)
+            .map(|b| BLOCK_INTERVAL * (b - observed_window_end_block) as u32)
+            .collect();
+
+        TailMetrics {
+            observed_window_end_block: Some(observed_window_end_block),
+            count,
+            confirmed_pct,
+            block_range: Self::compute_block_range(&tail),
+            time_past_observed_window: Self::compute_duration_metrics(&mut time_past),
+            block_latency: Self::compute_block_latency(&tail),
+            block_receipt_delay: Self::compute_block_receipt_delay(&tail),
+            flashblocks_latency: Self::compute_flashblocks_latency(&tail),
         }
     }
 
@@ -268,12 +338,16 @@ impl<'a> MetricsAggregator<'a> {
 
 /// Summary of all collected metrics.
 ///
-/// Reporting is split into two scopes:
-/// * `first_half` covers the first half of the run and is the "clean" window
-///   used for headline TPS / latency comparisons.
-/// * Top-level `throughput`, `block_latency`, `flashblocks_latency`, etc. cover
-///   the full run and include a known late-run degradation that is pending
-///   end-to-end observability rollout.
+/// Reporting is split into two diagnostic scopes:
+/// * `observed_window` covers the clean reporting window of the configured
+///   run and is used for headline TPS / latency comparisons.
+/// * `tail` quantifies the inclusion delay: transactions that landed in
+///   blocks past the configured submission window. `None` for continuous runs.
+///
+/// Top-level fields (`throughput`, `block_latency`, `gas`, `block_range`,
+/// `top_failure_reasons`, etc.) are baseline full-run accounting, not headline
+/// metrics — full-run TPS/latency is misleading because it averages the clean
+/// window with the tail.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MetricsSummary {
     /// Test configuration (excludes URLs and secrets).
@@ -283,14 +357,18 @@ pub struct MetricsSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// First-half reporting window (clean TPS / block / FB latency).
-    pub first_half: FirstHalfMetrics,
-    /// Block production latency (full run).
+    pub observed_window: ObservedWindowMetrics,
+    /// Inclusion-delay tail (txs landing after the configured submission
+    /// window). `None` when the run had no configured duration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tail: Option<TailMetrics>,
+    /// Block production latency (full run, baseline accounting).
     pub block_latency: LatencyMetrics,
     /// Delay between block production time and receipt observation (full run).
     pub block_receipt_delay: LatencyMetrics,
-    /// Flashblocks sequencer latency (full run).
+    /// Flashblocks sequencer latency (full run, baseline accounting).
     pub flashblocks_latency: FlashblocksLatencyMetrics,
-    /// Throughput statistics (full run).
+    /// Throughput statistics (full run, baseline accounting).
     pub throughput: ThroughputMetrics,
     /// Rolling-window throughput percentiles (TPS and GPS).
     pub throughput_percentiles: ThroughputPercentiles,

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -7,8 +7,8 @@ use alloy_primitives::TxHash;
 use tracing::debug;
 
 use super::{
-    ConfigSummary, MetricsAggregator, MetricsSummary, RollingWindow, ThroughputSample,
-    TransactionMetrics,
+    ConfigSummary, MetricsAggregator, MetricsSummary, RollingWindow, SubmissionStats,
+    ThroughputSample, TransactionMetrics,
 };
 
 /// Collects transaction metrics during test execution.
@@ -122,9 +122,11 @@ impl MetricsCollector {
         aggregator.summarize(
             wall_clock_duration,
             configured_duration,
-            self.submitted_count,
-            self.failed_count,
-            &self.failure_reasons,
+            SubmissionStats {
+                submitted: self.submitted_count,
+                failed: self.failed_count,
+                failure_reasons: &self.failure_reasons,
+            },
             &self.throughput_samples,
             config,
         )

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -108,14 +108,20 @@ impl MetricsCollector {
     ///
     /// `wall_clock_duration` is used as a fallback when block timestamps are
     /// unavailable. TPS is normally derived from block time span.
+    ///
+    /// `configured_duration` is the user-configured test duration; when present
+    /// it anchors the observed window and enables tail (post-observed-window)
+    /// metrics. Pass `None` for continuous runs.
     pub fn summarize(
         &self,
         wall_clock_duration: Duration,
+        configured_duration: Option<Duration>,
         config: Option<ConfigSummary>,
     ) -> MetricsSummary {
         let aggregator = MetricsAggregator::new(&self.transactions);
         aggregator.summarize(
             wall_clock_duration,
+            configured_duration,
             self.submitted_count,
             self.failed_count,
             &self.failure_reasons,

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -2,8 +2,8 @@
 
 mod types;
 pub use types::{
-    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FirstHalfMetrics, FlashblocksLatencyMetrics, GasMetrics,
+    LatencyMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -3,8 +3,8 @@
 mod types;
 pub use types::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    ObservedWindowMetrics, TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
-    TransactionMetrics,
+    ObservedWindowMetrics, SubmissionStats, TailMetrics, ThroughputMetrics, ThroughputPercentiles,
+    ThroughputSample, TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -2,8 +2,9 @@
 
 mod types;
 pub use types::{
-    BlockRange, ConfigSummary, FirstHalfMetrics, FlashblocksLatencyMetrics, GasMetrics,
-    LatencyMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
+    ObservedWindowMetrics, TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -148,7 +148,7 @@ pub struct ThroughputSample {
 }
 
 /// L2 block interval (2 seconds per block).
-const BLOCK_INTERVAL: Duration = Duration::from_secs(2);
+pub(crate) const BLOCK_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Range of block numbers in which test transactions were included.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -173,6 +173,32 @@ impl BlockRange {
         }
         Some(BLOCK_INTERVAL * (self.block_count - 1) as u32)
     }
+}
+
+/// Throughput + latency over the first half of the test window.
+///
+/// "First half" is defined as transactions confirmed in blocks
+/// `[first_block, first_block + (wall_clock_duration / 2) / BLOCK_INTERVAL]`.
+/// This carves out a "clean" reporting window that excludes the late-run
+/// degradation captured by the full-range metrics. See `MetricsSummary.first_half`
+/// vs `MetricsSummary.throughput` for the disclaimer on the full-range numbers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FirstHalfMetrics {
+    /// Block range covered by the first-half window.
+    pub block_range: BlockRange,
+    /// Duration spanned by `block_range` (using `BLOCK_INTERVAL`), or
+    /// `wall_clock_duration / 2` when the window contains fewer than 2 blocks.
+    pub duration: Duration,
+    /// Confirmed transactions inside the first-half window.
+    pub confirmed_count: u64,
+    /// Transactions per second over the first-half window.
+    pub tps: f64,
+    /// Gas per second over the first-half window.
+    pub gps: f64,
+    /// Block production latency for first-half transactions.
+    pub block_latency: LatencyMetrics,
+    /// Flashblocks sequencer latency for first-half transactions.
+    pub flashblocks_latency: FlashblocksLatencyMetrics,
 }
 
 /// Aggregated flashblocks latency percentiles.

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -175,29 +175,73 @@ impl BlockRange {
     }
 }
 
-/// Throughput + latency over the first half of the test window.
+/// Throughput + latency over the clean reporting window (the expected first
+/// portion of the test, before any inclusion tail).
 ///
-/// "First half" is defined as transactions confirmed in blocks
-/// `[first_block, first_block + (wall_clock_duration / 2) / BLOCK_INTERVAL]`.
-/// This carves out a "clean" reporting window that excludes the late-run
-/// degradation captured by the full-range metrics. See `MetricsSummary.first_half`
-/// vs `MetricsSummary.throughput` for the disclaimer on the full-range numbers.
+/// The observed window is defined as transactions confirmed in blocks
+/// `[first_block, first_block + expected_block_count - 1]`, where
+/// `expected_block_count = reference_duration.as_secs() / 2` and
+/// `reference_duration` is the configured test duration when known and
+/// falls back to the observed wall-clock duration otherwise.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct FirstHalfMetrics {
-    /// Block range covered by the first-half window.
+pub struct ObservedWindowMetrics {
+    /// Expected observed-window block count = `reference_duration.as_secs() / 2`.
+    /// For a 30s test this is 15.
+    pub expected_block_count: u64,
+    /// Block range of confirmed transactions that fell inside the observed
+    /// window. May be smaller than `expected_block_count` blocks if inclusion
+    /// gaps left some expected blocks empty of test txs.
     pub block_range: BlockRange,
-    /// Duration spanned by `block_range` (using `BLOCK_INTERVAL`), or
-    /// `wall_clock_duration / 2` when the window contains fewer than 2 blocks.
+    /// Expected observed-window wall-time = `expected_block_count * BLOCK_INTERVAL`.
+    /// For a 30s test (15 expected blocks at 2s/block), this is 30s of L2 time.
+    /// Used as the denominator for `tps` and `gps`.
     pub duration: Duration,
-    /// Confirmed transactions inside the first-half window.
+    /// Confirmed transactions inside the observed window.
     pub confirmed_count: u64,
-    /// Transactions per second over the first-half window.
+    /// Transactions per second = `confirmed_count / duration.as_secs_f64()`
+    /// (denominator is the expected observed-window in L2 wall-time).
     pub tps: f64,
-    /// Gas per second over the first-half window.
+    /// Gas per second over the observed window (same denominator as `tps`).
     pub gps: f64,
-    /// Block production latency for first-half transactions.
+    /// Block production latency (submit→inclusion) for observed-window transactions.
     pub block_latency: LatencyMetrics,
-    /// Flashblocks sequencer latency for first-half transactions.
+    /// Delay between block production and receipt observation by the block
+    /// watcher, for observed-window transactions.
+    pub block_receipt_delay: LatencyMetrics,
+    /// Flashblocks sequencer latency for observed-window transactions.
+    pub flashblocks_latency: FlashblocksLatencyMetrics,
+}
+
+/// Inclusion-delay metrics for transactions that landed past the observed
+/// window — i.e. straggler receipts that the chain produced well after the
+/// clean reporting window.
+///
+/// A transaction is "tail" iff its block number is strictly greater than
+/// `observed_window_end_block` (the upper bound of the observed window).
+/// Only populated when `configured_duration` is provided to
+/// `MetricsAggregator::summarize`; continuous runs produce `None`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TailMetrics {
+    /// Upper bound of the observed window =
+    /// `first_block + observed_window_expected_block_count - 1`. Transactions
+    /// with `block_number > observed_window_end_block` are classified as tail.
+    /// `None` when the dataset is empty.
+    pub observed_window_end_block: Option<u64>,
+    /// Number of confirmed transactions in the tail.
+    pub count: u64,
+    /// Tail count as a percentage of total confirmed transactions.
+    pub confirmed_pct: f64,
+    /// Block range covered by the tail.
+    pub block_range: BlockRange,
+    /// Per-tx wall-time the block landed past `observed_window_end_block`,
+    /// derived from `(block_number - observed_window_end_block) * BLOCK_INTERVAL`.
+    pub time_past_observed_window: LatencyMetrics,
+    /// Submit→inclusion latency for tail transactions only.
+    pub block_latency: LatencyMetrics,
+    /// Delay between block production and receipt observation by the block
+    /// watcher, for tail transactions only.
+    pub block_receipt_delay: LatencyMetrics,
+    /// Flashblocks sequencer latency for tail transactions only.
     pub flashblocks_latency: FlashblocksLatencyMetrics,
 }
 

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -1,7 +1,23 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::TxHash;
 use serde::{Deserialize, Serialize};
+
+/// Submission outcome counts collected during a load test, passed as a single
+/// input bundle to `MetricsAggregator::summarize`.
+#[derive(Debug, Clone, Copy)]
+pub struct SubmissionStats<'a> {
+    /// Total transactions submitted.
+    pub submitted: u64,
+    /// Total transactions that failed (e.g. rejected, expired without
+    /// confirmation).
+    pub failed: u64,
+    /// Failure reason counts, used to surface the top-N reasons in the summary.
+    pub failure_reasons: &'a HashMap<String, u64>,
+}
 
 /// Metrics for a single transaction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,12 +196,12 @@ impl BlockRange {
 ///
 /// The observed window is defined as transactions confirmed in blocks
 /// `[first_block, first_block + expected_block_count - 1]`, where
-/// `expected_block_count = reference_duration.as_secs() / 2` and
+/// `expected_block_count = reference_duration.as_secs() / BLOCK_INTERVAL` and
 /// `reference_duration` is the configured test duration when known and
 /// falls back to the observed wall-clock duration otherwise.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ObservedWindowMetrics {
-    /// Expected observed-window block count = `reference_duration.as_secs() / 2`.
+    /// Expected observed-window block count = `reference_duration.as_secs() / BLOCK_INTERVAL`.
     /// For a 30s test this is 15.
     pub expected_block_count: u64,
     /// Block range of confirmed transactions that fell inside the observed

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -53,8 +53,8 @@ use crate::{
 const NONCE_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 const SUBMIT_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
 const SUBMIT_WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(12);
-const PENDING_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(60);
-const CONFIRMATION_DRAIN_TIMEOUT: Duration = Duration::from_secs(65);
+const PENDING_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(200);
+const CONFIRMATION_DRAIN_TIMEOUT: Duration = Duration::from_secs(200);
 const TXPOOL_CLEAR_CONCURRENCY: usize = 64;
 /// Executes load tests by generating and submitting transactions at a target rate.
 pub struct LoadRunner {
@@ -1424,7 +1424,11 @@ impl LoadRunner {
         let confirmed = self.collector.confirmed_count();
         info!(confirmed, submitted, "confirmation collection complete");
 
-        Ok(self.collector.summarize(last_confirmed_at, self.config_summary.clone()))
+        Ok(self.collector.summarize(
+            last_confirmed_at,
+            self.config.duration,
+            self.config_summary.clone(),
+        ))
     }
 
     fn build_snapshot(

--- a/crates/infra/load-tests/tests/smoke.rs
+++ b/crates/infra/load-tests/tests/smoke.rs
@@ -149,6 +149,53 @@ fn metrics_summary_latency() {
 }
 
 #[test]
+fn metrics_summary_first_half_split() {
+    let mut collector = MetricsCollector::new();
+
+    // 10 txs across blocks 100..=109 (10 blocks ≈ 20s at 2s/block).
+    // wall_clock_duration = 20s → first half = 10s → 5 blocks → end_block = 100 + 5 = 105.
+    // First-half window = blocks 100..=105 → 6 confirmed txs.
+    for i in 0..10u64 {
+        collector.record_confirmed(TransactionMetrics::new(
+            TxHash::repeat_byte(i as u8),
+            Some(Duration::from_millis(100 + i * 10)),
+            Some(Duration::from_millis(50 + i * 5)),
+            21_000,
+            1_000_000_000,
+            Some(100 + i),
+        ));
+    }
+
+    let summary = collector.summarize(Duration::from_secs(20), None);
+
+    let fh = &summary.first_half;
+    assert_eq!(fh.confirmed_count, 6, "first half should include blocks 100..=105");
+    assert_eq!(fh.block_range.first_block, Some(100));
+    assert_eq!(fh.block_range.last_block, Some(105));
+    assert_eq!(fh.block_range.block_count, 6);
+    // 6 txs over 5 block-intervals (10s) → 0.6 TPS.
+    assert!((fh.tps - 0.6).abs() < 1e-6, "expected tps≈0.6, got {}", fh.tps);
+    // First-half block latencies: 100..=150ms → p50 = 130ms (rank 3 of 6).
+    assert_eq!(fh.block_latency.min, Duration::from_millis(100));
+    assert_eq!(fh.block_latency.max, Duration::from_millis(150));
+    assert_eq!(fh.flashblocks_latency.count, 6);
+
+    // Full-range numbers stay unchanged and span all 10 blocks.
+    assert_eq!(summary.throughput.total_confirmed, 10);
+    assert_eq!(summary.block_range.block_count, 10);
+}
+
+#[test]
+fn metrics_summary_first_half_empty_when_no_confirms() {
+    let collector = MetricsCollector::new();
+    let summary = collector.summarize(Duration::from_secs(60), None);
+
+    assert_eq!(summary.first_half.confirmed_count, 0);
+    assert_eq!(summary.first_half.block_range.block_count, 0);
+    assert_eq!(summary.first_half.tps, 0.0);
+}
+
+#[test]
 fn metrics_summary_gas() {
     let mut collector = MetricsCollector::new();
 

--- a/crates/infra/load-tests/tests/smoke.rs
+++ b/crates/infra/load-tests/tests/smoke.rs
@@ -122,7 +122,7 @@ fn metrics_summary_latency() {
         ));
     }
 
-    let summary = collector.summarize(Duration::from_secs(10), None);
+    let summary = collector.summarize(Duration::from_secs(10), None, None);
 
     assert_eq!(summary.throughput.total_confirmed, 5);
 
@@ -144,18 +144,20 @@ fn metrics_summary_latency() {
     );
     metrics.block_receipt_delay = Some(Duration::from_millis(75));
     collector.record_confirmed(metrics);
-    let summary = collector.summarize(Duration::from_secs(10), None);
+    let summary = collector.summarize(Duration::from_secs(10), None, None);
     assert_eq!(summary.block_receipt_delay.p50, Duration::from_millis(75));
 }
 
 #[test]
-fn metrics_summary_first_half_split() {
+fn metrics_summary_observed_window_split() {
     let mut collector = MetricsCollector::new();
 
-    // 10 txs across blocks 100..=109 (10 blocks ≈ 20s at 2s/block).
-    // wall_clock_duration = 20s → first half = 10s → 5 blocks → end_block = 100 + 5 = 105.
-    // First-half window = blocks 100..=105 → 6 confirmed txs.
-    for i in 0..10u64 {
+    // 30 txs across blocks 100..=129.
+    // configured_duration = 30s
+    // → expected_block_count = 30 / 2 = 15
+    // → end_block = 100 + 15 - 1 = 114
+    // → first half includes blocks 100..=114 (15 txs).
+    for i in 0..30u64 {
         collector.record_confirmed(TransactionMetrics::new(
             TxHash::repeat_byte(i as u8),
             Some(Duration::from_millis(100 + i * 10)),
@@ -166,33 +168,213 @@ fn metrics_summary_first_half_split() {
         ));
     }
 
-    let summary = collector.summarize(Duration::from_secs(20), None);
+    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
 
-    let fh = &summary.first_half;
-    assert_eq!(fh.confirmed_count, 6, "first half should include blocks 100..=105");
+    let fh = &summary.observed_window;
+    assert_eq!(fh.expected_block_count, 15, "30s / 2 = 15 expected blocks");
+    assert_eq!(fh.confirmed_count, 15, "blocks 100..=114");
     assert_eq!(fh.block_range.first_block, Some(100));
-    assert_eq!(fh.block_range.last_block, Some(105));
-    assert_eq!(fh.block_range.block_count, 6);
-    // 6 txs over 5 block-intervals (10s) → 0.6 TPS.
-    assert!((fh.tps - 0.6).abs() < 1e-6, "expected tps≈0.6, got {}", fh.tps);
-    // First-half block latencies: 100..=150ms → p50 = 130ms (rank 3 of 6).
+    assert_eq!(fh.block_range.last_block, Some(114));
+    assert_eq!(fh.block_range.block_count, 15);
+    // duration = expected_block_count * BLOCK_INTERVAL = 15 blocks × 2s/block = 30s.
+    assert_eq!(fh.duration, Duration::from_secs(30), "15 blocks × 2s/block = 30s of L2 time");
+    // TPS = 15 txs / 30s = 0.5.
+    assert!((fh.tps - 0.5).abs() < 1e-6, "tps={}, expected 0.5", fh.tps);
+    // First-half block latencies for txs 0..=14 → 100..=240ms.
     assert_eq!(fh.block_latency.min, Duration::from_millis(100));
-    assert_eq!(fh.block_latency.max, Duration::from_millis(150));
-    assert_eq!(fh.flashblocks_latency.count, 6);
+    assert_eq!(fh.block_latency.max, Duration::from_millis(240));
+    assert_eq!(fh.flashblocks_latency.count, 15);
 
-    // Full-range numbers stay unchanged and span all 10 blocks.
-    assert_eq!(summary.throughput.total_confirmed, 10);
-    assert_eq!(summary.block_range.block_count, 10);
+    // Full-range still spans all 30 blocks.
+    assert_eq!(summary.throughput.total_confirmed, 30);
+    assert_eq!(summary.block_range.block_count, 30);
 }
 
 #[test]
-fn metrics_summary_first_half_empty_when_no_confirms() {
-    let collector = MetricsCollector::new();
-    let summary = collector.summarize(Duration::from_secs(60), None);
+fn metrics_summary_observed_window_inclusion_gap() {
+    let mut collector = MetricsCollector::new();
 
-    assert_eq!(summary.first_half.confirmed_count, 0);
-    assert_eq!(summary.first_half.block_range.block_count, 0);
-    assert_eq!(summary.first_half.tps, 0.0);
+    // 6 txs across blocks 100..=105 with configured_duration=30s.
+    // → expected_block_count = 15
+    // → end_block = 114
+    // → all 6 txs are in the first-half window
+    // → inclusion gap = 15 - 6 = 9 blocks (60% gap) — reproduces the user-reported scenario.
+    for i in 0..6u64 {
+        collector.record_confirmed(TransactionMetrics::new(
+            TxHash::repeat_byte(i as u8),
+            Some(Duration::from_millis(100)),
+            None,
+            21_000,
+            1_000_000_000,
+            Some(100 + i),
+        ));
+    }
+
+    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
+
+    let fh = &summary.observed_window;
+    assert_eq!(fh.expected_block_count, 15, "30s / 2 = 15 expected blocks");
+    assert_eq!(fh.confirmed_count, 6);
+    assert_eq!(fh.block_range.block_count, 6, "only 6 of 15 expected blocks had txs");
+}
+
+#[test]
+fn metrics_summary_block_receipt_delay_per_window() {
+    let mut collector = MetricsCollector::new();
+
+    // 20 txs across blocks 100..=119 with configured_duration = 30s.
+    // → expected_block_count = 15, observed_window_end_block = 114.
+    // First half = txs in blocks 100..=114 (15 txs), receipt delays 100..=240ms.
+    // Tail = txs in blocks 115..=119 (5 txs), receipt delays 250..=290ms.
+    for i in 0..20u64 {
+        let mut metrics = TransactionMetrics::new(
+            TxHash::repeat_byte(i as u8),
+            Some(Duration::from_millis(50)),
+            None,
+            21_000,
+            1_000_000_000,
+            Some(100 + i),
+        );
+        metrics.block_receipt_delay = Some(Duration::from_millis(100 + i * 10));
+        collector.record_confirmed(metrics);
+    }
+
+    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
+
+    let fh_brd = &summary.observed_window.block_receipt_delay;
+    assert_eq!(fh_brd.min, Duration::from_millis(100), "first half receipt delay min");
+    assert_eq!(fh_brd.max, Duration::from_millis(240), "first half receipt delay max");
+
+    let tail_brd = &summary.tail.as_ref().expect("tail Some").block_receipt_delay;
+    assert_eq!(tail_brd.min, Duration::from_millis(250), "tail receipt delay min");
+    assert_eq!(tail_brd.max, Duration::from_millis(290), "tail receipt delay max");
+}
+
+#[test]
+fn metrics_summary_observed_window_empty_when_no_confirms() {
+    let collector = MetricsCollector::new();
+    let summary = collector.summarize(Duration::from_secs(60), None, None);
+
+    assert_eq!(summary.observed_window.confirmed_count, 0);
+    assert_eq!(summary.observed_window.block_range.block_count, 0);
+    assert_eq!(summary.observed_window.tps, 0.0);
+    assert!(summary.tail.is_none(), "tail should be None when no configured_duration");
+}
+
+#[test]
+fn metrics_summary_tail_classification() {
+    let mut collector = MetricsCollector::new();
+
+    // 30 txs across blocks 100..=129.
+    // configured_duration = 30s
+    // → observed_window_expected_block_count = 30 / 2 = 15
+    // → observed_window_end_block = 100 + 15 - 1 = 114
+    // → tail = blocks > 114 → blocks 115..=129 (15 txs).
+    for i in 0..30u64 {
+        collector.record_confirmed(TransactionMetrics::new(
+            TxHash::repeat_byte(i as u8),
+            Some(Duration::from_millis(100 + i * 10)),
+            Some(Duration::from_millis(50 + i * 5)),
+            21_000,
+            1_000_000_000,
+            Some(100 + i),
+        ));
+    }
+
+    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
+
+    let tail = summary.tail.as_ref().expect("tail should be Some when configured_duration is set");
+    assert_eq!(tail.observed_window_end_block, Some(114));
+    assert_eq!(tail.count, 15, "blocks 115..=129 should be classified as tail");
+    assert_eq!(tail.block_range.first_block, Some(115));
+    assert_eq!(tail.block_range.last_block, Some(129));
+    assert_eq!(tail.block_range.block_count, 15);
+    assert!((tail.confirmed_pct - 50.0).abs() < 1e-6, "15 of 30 = 50%, got {}", tail.confirmed_pct);
+
+    // time_past for tail blocks 115..=129 vs observed_window_end_block=114, at 2s/block:
+    // → [2s, 4s, ..., 30s]. min=2s, max=30s, p50 (rank 8 of 15) = 16s.
+    let tp = &tail.time_past_observed_window;
+    assert_eq!(tp.min, Duration::from_secs(2));
+    assert_eq!(tp.max, Duration::from_secs(30));
+    assert_eq!(tp.p50, Duration::from_secs(16));
+
+    // Tail block latencies for txs 15..=29 → 250..=390ms.
+    assert_eq!(tail.block_latency.min, Duration::from_millis(250));
+    assert_eq!(tail.block_latency.max, Duration::from_millis(390));
+    assert_eq!(tail.flashblocks_latency.count, 15);
+}
+
+#[test]
+fn metrics_summary_tail_straggler_after_gap() {
+    let mut collector = MetricsCollector::new();
+
+    // Reproduces the user-reported scenario: tight cluster at the start,
+    // then a "big block of txs 10 blocks later".
+    // configured_duration = 30s → observed_window_expected_block_count = 15
+    // → observed_window_end_block = 100 + 14 = 114
+    //
+    // 6 txs in blocks 100..=105 (clean cluster).
+    for i in 0..6u64 {
+        collector.record_confirmed(TransactionMetrics::new(
+            TxHash::repeat_byte(i as u8),
+            Some(Duration::from_millis(100)),
+            None,
+            21_000,
+            1_000_000_000,
+            Some(100 + i),
+        ));
+    }
+    // Then 20 txs all in block 125 (10 blocks past observed_window_end_block=114).
+    for i in 0..20u64 {
+        collector.record_confirmed(TransactionMetrics::new(
+            TxHash::repeat_byte(50 + i as u8),
+            Some(Duration::from_millis(8000)),
+            None,
+            21_000,
+            1_000_000_000,
+            Some(125),
+        ));
+    }
+
+    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
+
+    let tail = summary.tail.as_ref().expect("tail should be Some");
+    assert_eq!(tail.observed_window_end_block, Some(114));
+    assert_eq!(tail.count, 20, "the 20 stragglers in block 125 are tail");
+    // 20 of 26 ≈ 76.9%.
+    let expected_pct = 20.0 / 26.0 * 100.0;
+    assert!((tail.confirmed_pct - expected_pct).abs() < 1e-6);
+    // All 20 stragglers in block 125 → time_past = (125-114)*2s = 22s for every tx.
+    assert_eq!(tail.time_past_observed_window.min, Duration::from_secs(22));
+    assert_eq!(tail.time_past_observed_window.max, Duration::from_secs(22));
+    assert_eq!(tail.time_past_observed_window.p50, Duration::from_secs(22));
+}
+
+#[test]
+fn metrics_summary_tail_empty_when_all_inside_observed_window() {
+    let mut collector = MetricsCollector::new();
+
+    // 5 txs in blocks 100..=104 with configured_duration = 30s
+    // → observed_window_end_block = 100 + 14 = 114
+    // → no tail (max block 104 < 114).
+    for i in 0..5u64 {
+        collector.record_confirmed(TransactionMetrics::new(
+            TxHash::repeat_byte(i as u8),
+            Some(Duration::from_millis(100)),
+            None,
+            21_000,
+            1_000_000_000,
+            Some(100 + i),
+        ));
+    }
+
+    let summary = collector.summarize(Duration::from_secs(20), Some(Duration::from_secs(30)), None);
+
+    let tail = summary.tail.as_ref().expect("tail should be Some when configured_duration is set");
+    assert_eq!(tail.observed_window_end_block, Some(114));
+    assert_eq!(tail.count, 0, "no txs landed past the first half");
+    assert_eq!(tail.confirmed_pct, 0.0);
+    assert_eq!(tail.block_range.block_count, 0);
 }
 
 #[test]
@@ -217,7 +399,7 @@ fn metrics_summary_gas() {
         Some(2),
     ));
 
-    let summary = collector.summarize(Duration::from_secs(10), None);
+    let summary = collector.summarize(Duration::from_secs(10), None, None);
 
     assert_eq!(summary.gas.total_gas, 63000);
     assert_eq!(summary.gas.avg_gas, 31500);
@@ -236,7 +418,7 @@ fn metrics_summary_json_serialization() {
         Some(1),
     ));
 
-    let summary = collector.summarize(Duration::from_secs(10), None);
+    let summary = collector.summarize(Duration::from_secs(10), None, None);
     let json = summary.to_json().unwrap();
 
     assert!(json.contains("block_latency"));


### PR DESCRIPTION
background context: when given a duration, the submission loop only submits txs for that duration period. the [first_block, last_block] range is not based on the duration, but when all the txs submitted during that period is receives a block receipt. the means that last > first+duration/2. 

however, w.r.t the OKR of achieving 3k swaps/s on the chain, we definitely reached that, and the majority of txs were included in a timely, sustained manner over a period of time. 

therefore, this pr splits the metric reporting into 2 sections.

- the 1st section records the "observed" TPS. with respect to the OKR, this mimics what we manually witness on the chain and the TPS we observe over a period of time
- the 2nd section records the "actual" TPS which includes those remaining txs that were delayed and eventually included. this causes the [first, last] range to be larger and lowering the TPS numbers, and raising the block/FB latency metrics. However, this is important insight that says there's more optimization that needs to be done

```
=== Results: Observed Window ===
Window: blocks 42669629..=42669643 (15 blocks, ~30.0s)
Confirmed: 77409 | TPS: 2580.30 | GPS: 291230716
Block Latency:       min=0.0ns  p50=1.8s  mean=1.7s  p99=3.4s  max=4.7s
Block Receipt Delay: min=3.6s  p50=46.7s  mean=40.1s  p99=70.4s  max=70.4s
FB Latency:          min=240.8µs  p50=852.3ms  mean=910.5ms  p99=2.3s  max=3.5s  (n=61090)

=== Results: Tail Inclusion (txs past the observed window) ===
Boundary: tail = blocks > 42669643 (end of observed window)
Tail: 22565 of 99974 confirmed (22.57%)
Blocks: first=42669648  last=42669670  span=23 block(s)
Time past first half: min=10.0s  p50=42.0s  mean=33.9s  p99=54.0s  max=54.0s
Block Latency: min=12.0s  p50=40.3s  mean=35.7s  p99=56.1s  max=57.2s
Block Receipt Delay:              min=33.7s  p50=40.9s  mean=47.2s  p99=64.7s  max=64.7s
FB Latency:                       min=10.5s  p50=39.6s  mean=34.7s  p99=55.3s  max=56.3s  (n=22565)

Totals: Submitted=109788 | Confirmed=99974 | Failed=10 | Reverted=0 | Success=91.1%
Gas: total=11280095706  avg/tx=112830
Blocks: first=42669629  last=42669670  span=42 block(s)
Top failures:
      10x  expired without confirmation
```