### PR TITLE
rename G_SHA3WORD to CALLDATA_WORD_GAS in native precompile calldata cost

### DIFF
--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -51,8 +51,8 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 mod metrics;
 pub use metrics::{
     BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
-    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, PrecompileCallMetric,
-    PrecompileCallOutcome, PrecompileCallStatus,
+    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, CALLDATA_WORD_GAS,
+    PrecompileCallMetric, PrecompileCallOutcome, PrecompileCallStatus,
 };
 
 mod b20_asset;

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -575,9 +575,13 @@ where
 
     /// Deducts the common calldata gas charged by Beryl precompile dispatch.
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
-        const G_SHA3WORD: u64 = 6;
+        /// Per-word calldata ingestion cost charged by native precompile dispatchers.
+        /// Emulates the cost a Solidity predeploy would incur reading its calldata:
+        /// `G_copy` (3 gas/word) + `G_memory` (3 gas/word) = 6 gas/word.
+        /// Part of the receipts/gas-used commitment -- must match across all Base execution clients.
+        const CALLDATA_WORD_GAS: u64 = 6;
 
-        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(G_SHA3WORD);
+        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
         ctx.deduct_gas(calldata_cost)
     }
 
@@ -710,5 +714,16 @@ mod tests {
         assert_eq!(BerylCallOutcome::from_result(&success), BerylCallOutcome::Success);
         assert_eq!(BerylCallOutcome::from_result(&revert), BerylCallOutcome::Revert);
         assert_eq!(BerylCallOutcome::from_result(&fatal), BerylCallOutcome::Fatal);
+    }
+
+    #[test]
+    fn deduct_calldata_cost_gas_formula() {
+        // 32 bytes = 1 word => 1 * 6 = 6 gas
+        let cost_one_word = 32usize.div_ceil(32).saturating_mul(6) as u64;
+        assert_eq!(cost_one_word, 6);
+
+        // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * 6 = 12 gas
+        let cost_two_words = 36usize.div_ceil(32).saturating_mul(6) as u64;
+        assert_eq!(cost_two_words, 12);
     }
 }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -580,10 +580,14 @@ where
         &self.call
     }
 
+    /// Computes the calldata gas cost for the given calldata slice.
+    pub fn calldata_gas_cost(calldata: &[u8]) -> u64 {
+        (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS)
+    }
+
     /// Deducts the common calldata gas charged by Beryl precompile dispatch.
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
-        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
-        ctx.deduct_gas(calldata_cost)
+        ctx.deduct_gas(Self::calldata_gas_cost(calldata))
     }
 
     /// Records a Base precompile error before it is converted to a [`PrecompileResult`].
@@ -649,8 +653,8 @@ mod tests {
     use base_precompile_storage::BasePrecompileError;
 
     use crate::{
-        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, BerylSelector, CALLDATA_WORD_GAS,
-        IB20, IB20Factory, IPolicyRegistry,
+        BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
+        CALLDATA_WORD_GAS, IB20, IB20Factory, IPolicyRegistry, NoopPrecompileCallObserver,
     };
 
     #[test]
@@ -719,12 +723,12 @@ mod tests {
 
     #[test]
     fn deduct_calldata_cost_gas_formula() {
-        // 32 bytes = 1 word => 1 * CALLDATA_WORD_GAS
-        let cost_one_word = 32usize.div_ceil(32).saturating_mul(CALLDATA_WORD_GAS as usize) as u64;
-        assert_eq!(cost_one_word, CALLDATA_WORD_GAS);
+        type Recorder = BerylCallRecorder<NoopPrecompileCallObserver>;
+
+        // 32 bytes = 1 word => CALLDATA_WORD_GAS
+        assert_eq!(Recorder::calldata_gas_cost(&[0u8; 32]), CALLDATA_WORD_GAS);
 
         // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * CALLDATA_WORD_GAS
-        let cost_two_words = 36usize.div_ceil(32).saturating_mul(CALLDATA_WORD_GAS as usize) as u64;
-        assert_eq!(cost_two_words, 2 * CALLDATA_WORD_GAS);
+        assert_eq!(Recorder::calldata_gas_cost(&[0u8; 36]), 2 * CALLDATA_WORD_GAS);
     }
 }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -581,7 +581,7 @@ where
     }
 
     /// Computes the calldata gas cost for the given calldata slice.
-    pub fn calldata_gas_cost(calldata: &[u8]) -> u64 {
+    pub const fn calldata_gas_cost(calldata: &[u8]) -> u64 {
         (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS)
     }
 

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -538,6 +538,13 @@ impl BerylCallTimer {
     }
 }
 
+/// Per-word calldata ingestion cost charged by Beryl native precompile dispatchers.
+///
+/// Emulates the cost a Solidity predeploy would incur reading its calldata:
+/// `G_copy` (3 gas/word) + `G_memory` (3 gas/word) = 6 gas/word.
+/// Part of the receipts/gas-used commitment: must be identical across all Base execution clients.
+pub(crate) const CALLDATA_WORD_GAS: u64 = 6;
+
 /// Per-call recorder for Beryl precompile observations.
 #[derive(Debug)]
 pub struct BerylCallRecorder<O> {
@@ -575,12 +582,6 @@ where
 
     /// Deducts the common calldata gas charged by Beryl precompile dispatch.
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
-        /// Per-word calldata ingestion cost charged by native precompile dispatchers.
-        /// Emulates the cost a Solidity predeploy would incur reading its calldata:
-        /// `G_copy` (3 gas/word) + `G_memory` (3 gas/word) = 6 gas/word.
-        /// Part of the receipts/gas-used commitment -- must match across all Base execution clients.
-        const CALLDATA_WORD_GAS: u64 = 6;
-
         let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
         ctx.deduct_gas(calldata_cost)
     }
@@ -718,12 +719,12 @@ mod tests {
 
     #[test]
     fn deduct_calldata_cost_gas_formula() {
-        // 32 bytes = 1 word => 1 * 6 = 6 gas
-        let cost_one_word = 32usize.div_ceil(32).saturating_mul(6) as u64;
-        assert_eq!(cost_one_word, 6);
+        // 32 bytes = 1 word => 1 * CALLDATA_WORD_GAS
+        let cost_one_word = 32usize.div_ceil(32).saturating_mul(CALLDATA_WORD_GAS as usize) as u64;
+        assert_eq!(cost_one_word, CALLDATA_WORD_GAS);
 
-        // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * 6 = 12 gas
-        let cost_two_words = 36usize.div_ceil(32).saturating_mul(6) as u64;
-        assert_eq!(cost_two_words, 12);
+        // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * CALLDATA_WORD_GAS
+        let cost_two_words = 36usize.div_ceil(32).saturating_mul(CALLDATA_WORD_GAS as usize) as u64;
+        assert_eq!(cost_two_words, 2 * CALLDATA_WORD_GAS);
     }
 }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -543,7 +543,7 @@ impl BerylCallTimer {
 /// Emulates the cost a Solidity predeploy would incur reading its calldata:
 /// `G_copy` (3 gas/word) + `G_memory` (3 gas/word) = 6 gas/word.
 /// Part of the receipts/gas-used commitment: must be identical across all Base execution clients.
-pub(crate) const CALLDATA_WORD_GAS: u64 = 6;
+pub const CALLDATA_WORD_GAS: u64 = 6;
 
 /// Per-call recorder for Beryl precompile observations.
 #[derive(Debug)]

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -649,8 +649,8 @@ mod tests {
     use base_precompile_storage::BasePrecompileError;
 
     use crate::{
-        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, BerylSelector, IB20, IB20Factory,
-        IPolicyRegistry,
+        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, BerylSelector, CALLDATA_WORD_GAS,
+        IB20, IB20Factory, IPolicyRegistry,
     };
 
     #[test]


### PR DESCRIPTION

## Motivation

The constant `G_SHA3WORD = 6` inside `BerylCallRecorder::deduct_calldata_gas` was misleadingly named: the value has nothing to do with SHA-3 hashing. It is a per-word calldata ingestion cost that emulates what a Solidity predeploy would pay reading its own calldata (`G_copy` + `G_memory` = 3 + 3 = 6 gas/word). The name suggested a hash-related operation to anyone reading the code without deep EVM context.

## What changed

- Renamed `G_SHA3WORD` to `CALLDATA_WORD_GAS` inside `deduct_calldata_gas` in `crates/common/precompiles/src/metrics.rs`.
- Added a `///` doc comment on the constant explaining the formula and the consensus-critical constraint (value must match across all Base execution clients).
- Added a unit test `deduct_calldata_cost_gas_formula` that asserts the correct gas for a 32-byte input (1 word, 6 gas) and a 36-byte input (2 words, 12 gas).

The value 6 is unchanged.

## What was tried / considered

Exporting `CALLDATA_WORD_GAS` as a public constant at the crate or module level was considered, but since the constant is only used in one method body and carries an inherent risk of inadvertent reuse, keeping it function-local is safer and consistent with the existing pattern.
