### PR TITLE
fix(b20-asset): propagate system errors through announce inner calls unchanged

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -448,8 +448,14 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
                 return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
             }
-            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|_| {
-                BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
+            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|err| {
+                if err.is_system_error() {
+                    err
+                } else {
+                    BasePrecompileError::revert(IB20Asset::InternalCallFailed {
+                        call: call.clone(),
+                    })
+                }
             })?;
         }
 
@@ -784,6 +790,58 @@ mod tests {
         assert_eq!(
             token.to_scaled_balance(U256::from(2u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
+        );
+    }
+
+    /// System errors produced by an inner `announce` call must propagate unchanged and must
+    /// not be wrapped as [`IB20Asset::InternalCallFailed`]. A deliberately overflowing
+    /// `toScaledBalance` produces `Panic(UnderOverflow)`, which `is_system_error()` returns
+    /// `true` for.
+    #[test]
+    fn announce_inner_system_error_propagates_unchanged() {
+        let mut token = make_token();
+        // Any balance > 1 overflows when multiplied by this multiplier.
+        token.accounting_mut().multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, ALICE), true);
+
+        let inner_call = Bytes::from(
+            IB20Asset::toScaledBalanceCall { rawBalance: U256::from(2u64) }.abi_encode(),
+        );
+        let calldata = IB20Asset::announceCall {
+            internalCalls: alloc::vec![inner_call],
+            id: String::from("test-sys-err"),
+            description: String::from("test"),
+            uri: String::new(),
+        }
+        .abi_encode();
+
+        let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::under_overflow());
+    }
+
+    /// A non-system revert produced by an inner `announce` call must be wrapped as
+    /// [`IB20Asset::InternalCallFailed`], preserving the original calldata in the error field.
+    #[test]
+    fn announce_inner_ordinary_revert_wraps_as_internal_call_failed() {
+        let mut token = make_token();
+        // ALICE has OPERATOR_ROLE (needed for announce) but not MINT_ROLE (needed for mint).
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, ALICE), true);
+
+        let inner_call = Bytes::from(IB20::mintCall { to: BOB, amount: U256::ONE }.abi_encode());
+        let calldata = IB20Asset::announceCall {
+            internalCalls: alloc::vec![inner_call.clone()],
+            id: String::from("test-ord-revert"),
+            description: String::from("test"),
+            uri: String::new(),
+        }
+        .abi_encode();
+
+        let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
+
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: inner_call })
         );
     }
 }


### PR DESCRIPTION
[BOP-327](https://linear.app/coinbase/issue/BOP-327)

## Motivation

`B20AssetToken::announce` dispatches each `internalCalls` entry through `inner_with_privilege`. The error handler previously used `map_err(|_| ...)`, which discarded the original error and unconditionally wrapped every failure, including system errors (`OutOfGas`, `Fatal`, `Panic`, `SlotOverflow`), as `InternalCallFailed`. System errors represent EVM-level conditions that must abort the entire call frame; substituting a user-level revert breaks that invariant and can mask critical failures from callers.

## What changed

- In the `announce` inner-call dispatch loop in `dispatch.rs`, replaced the wildcard `map_err(|_| ...)` with an `is_system_error()` guard: system errors propagate unchanged, non-system failures are still wrapped as `InternalCallFailed`.
- Added two regression tests:
  - `announce_inner_system_error_propagates_unchanged`: triggers an arithmetic overflow inside `toScaledBalance` (a `Panic(UnderOverflow)` system error) and asserts it surfaces directly rather than as `InternalCallFailed`.
  - `announce_inner_ordinary_revert_wraps_as_internal_call_failed`: triggers an access-control revert from a `mint` call without `MINT_ROLE` and asserts it is still wrapped as `InternalCallFailed`.

## What was considered

`B20FactoryStorage::map_init_call_error` already handles this correctly: it passes system errors through verbatim and wraps only non-system failures. This fix adopts the same `is_system_error()` guard. The factory helper also preserves non-empty `Revert(bytes)` intact rather than wrapping them, but `announce` intentionally keeps the `InternalCallFailed` wrapping for ordinary reverts, since the call field already captures the offending calldata for debugging.