### PR TITLE
feat(common): add output_bytes and gas_consumed_total precompile metrics

### DIFF
--- a/crates/common/evm/src/beryl_metrics.rs
+++ b/crates/common/evm/src/beryl_metrics.rs
@@ -80,6 +80,18 @@ base_metrics::define_metrics! {
     #[label(method)]
     #[label(variant)]
     internal_call_bytes: histogram,
+    #[describe("Beryl native precompile response payload byte size")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    output_bytes: histogram,
+    #[describe("Cumulative gas consumed by Beryl native precompile calls")]
+    #[label(precompile)]
+    #[label(method)]
+    #[label(variant)]
+    #[label(status)]
+    gas_consumed_total: counter,
 }
 
 #[cfg(test)]
@@ -130,6 +142,15 @@ impl PrecompileCallObserver for BerylPrecompileMetricsObserver {
             .record(outcome.state_gas_used as f64);
             BerylPrecompileMetrics::gas_refunded(call.precompile, method.clone(), variant, status)
                 .record(gas_refunded);
+            BerylPrecompileMetrics::output_bytes(call.precompile, method.clone(), variant, status)
+                .record(outcome.output_bytes as f64);
+            BerylPrecompileMetrics::gas_consumed_total(
+                call.precompile,
+                method.clone(),
+                variant,
+                status,
+            )
+            .increment(outcome.gas_used);
 
             if let Some(duration_seconds) = outcome.duration_seconds {
                 BerylPrecompileMetrics::duration_seconds(

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -112,6 +112,8 @@ pub struct PrecompileCallOutcome {
     pub duration_seconds: Option<f64>,
     /// Optional bounded error class.
     pub error: Option<BerylErrorKind>,
+    /// Output payload byte length.
+    pub output_bytes: usize,
 }
 
 impl PrecompileCallOutcome {
@@ -130,6 +132,7 @@ impl PrecompileCallOutcome {
                 gas_refunded: 0,
                 duration_seconds,
                 error: Some(BerylErrorKind::from_precompile_error(error)),
+                output_bytes: 0,
             },
         }
     }
@@ -158,6 +161,7 @@ impl PrecompileCallOutcome {
             gas_refunded: output.gas_refunded,
             duration_seconds,
             error,
+            output_bytes: output.bytes.len(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `output_bytes` histogram to `PrecompileCallOutcome` and `BerylPrecompileMetrics` — tracks response payload byte size per call, the symmetric counterpart to `input_bytes`. Enables input/output size correlation and detecting unexpectedly large responses.
- Adds `gas_consumed_total` counter to `BerylPrecompileMetrics` — a monotonically-increasing cumulative gas total per `precompile/method/variant/status`. Enables `rate()`-based moving averages and gas throughput dashboards in Datadog without relying on histogram sum aggregation.

Both metrics carry the same four labels as the existing `calls_total` and `gas_used` metrics (`precompile`, `method`, `variant`, `status`), so they slice consistently with the rest of the Beryl observability surface.

## Changes

- `crates/common/precompiles/src/metrics.rs`: added `output_bytes: usize` field to `PrecompileCallOutcome`, populated from `output.bytes.len()` in `from_output` and `0` in the fatal error path.
- `crates/common/evm/src/beryl_metrics.rs`: declared `output_bytes: histogram` and `gas_consumed_total: counter` in `BerylPrecompileMetrics`, emitted both in `BerylPrecompileMetricsObserver::record_call`.

## Test plan

- [ ] `cargo test -p base-common-evm -p base-common-precompiles` passes (364 tests)
- [ ] Verify `base.beryl.precompile.output_bytes` and `base.beryl.precompile.gas_consumed_total` appear in Datadog after a Beryl precompile call in devnet