### PR TITLE
fix(b20-factory): enforce nonpayable guard on all factory selectors

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -31,6 +31,7 @@ use crate::{
 pub struct EvmPrecompileStorageProvider<'a> {
     internals: alloy_evm::EvmInternals<'a>,
     caller: Address,
+    call_value: U256,
     gas: Gas,
     gas_params: GasParams,
     is_static: bool,
@@ -47,7 +48,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
     /// `gas_params` drives all EIP-2929/2200/3529 cost calculations.
     /// Pass [`GasParams::default`] when the active spec is unknown at call site.
     pub fn new(input: PrecompileInput<'a>, gas_params: GasParams) -> Self {
-        let PrecompileInput { gas, caller, is_static, internals, .. } = input;
+        let PrecompileInput { gas, caller, value, is_static, internals, .. } = input;
 
         let block_number = internals.block_env().number().to::<u64>();
         let timestamp = internals.block_env().timestamp();
@@ -57,6 +58,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         Self {
             internals,
             caller,
+            call_value: value,
             gas: Gas::new(gas),
             gas_params,
             is_static,
@@ -271,6 +273,10 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
 
     fn is_static(&self) -> bool {
         self.is_static
+    }
+
+    fn call_value(&self) -> U256 {
+        self.call_value
     }
 
     fn caller(&self) -> Address {

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -23,6 +23,7 @@ pub struct HashMapStorageProvider {
     beneficiary: Address,
     block_number: u64,
     caller: Address,
+    call_value: U256,
     is_static: bool,
     counter_sload: u64,
     counter_sstore: u64,
@@ -61,6 +62,7 @@ impl HashMapStorageProvider {
             beneficiary: Address::ZERO,
             block_number: 0,
             caller: Address::ZERO,
+            call_value: U256::ZERO,
             is_static: false,
             counter_sload: 0,
             counter_sstore: 0,
@@ -208,6 +210,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         self.is_static
     }
 
+    fn call_value(&self) -> U256 {
+        self.call_value
+    }
+
     fn caller(&self) -> alloy_primitives::Address {
         self.caller
     }
@@ -287,6 +293,11 @@ impl HashMapStorageProvider {
     /// Sets the caller address (test-utils only).
     pub const fn set_caller(&mut self, caller: Address) {
         self.caller = caller;
+    }
+
+    /// Sets the native call value in wei (test-utils only).
+    pub const fn set_call_value(&mut self, value: U256) {
+        self.call_value = value;
     }
 
     /// Sets whether the current call is static (test-utils only).

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -77,6 +77,9 @@ pub trait PrecompileStorageProvider {
     /// Returns whether the current call context is static.
     fn is_static(&self) -> bool;
 
+    /// Returns the native value (in wei) attached to this precompile call.
+    fn call_value(&self) -> U256;
+
     /// Returns the address that called this precompile.
     fn caller(&self) -> Address;
     /// Replaces the current caller address and returns the previous caller.

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -166,6 +166,10 @@ impl<'a> StorageCtx<'a> {
     pub fn is_static(&self) -> bool {
         self.with_storage(|s| s.is_static())
     }
+    /// Returns the native value (in wei) attached to this precompile call.
+    pub fn call_value(&self) -> U256 {
+        self.with_storage(|s| s.call_value())
+    }
     /// Returns the address that called this precompile.
     pub fn caller(&self) -> Address {
         self.with_storage(|s| s.caller())

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -32,6 +32,9 @@ sol! {
 
         // ── Errors ───────────────────────────────────────────────────────────
 
+        /// ETH was sent to a nonpayable factory function.
+        error NonPayable();
+
         /// A token already exists at the address derived from `(variant, msg.sender, salt)`.
         error TokenAlreadyExists(address token);
 

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::StorageCtx;
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -26,6 +26,12 @@ impl<'a> B20FactoryStorage<'a> {
     where
         O: PrecompileCallObserver,
     {
+        // All factory selectors are nonpayable: reject any call that attaches ETH.
+        // The guard fires before calldata-cost deduction so value-bearing calls pay
+        // zero gas before reverting, matching Solidity's nonpayable semantics.
+        if !ctx.call_value().is_zero() {
+            return ctx.error_result(BasePrecompileError::revert(IB20Factory::NonPayable {}));
+        }
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::factory_call(calldata));
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {


### PR DESCRIPTION

## Motivation

The B20 factory declares `createB20` and its view functions as nonpayable, but the native precompile did not enforce this. Any call with ETH attached would succeed and the ETH would be permanently locked at the factory address with no way to recover it.

## What changed

The factory now rejects any call that arrives with ETH attached. If a caller sends value to `createB20`, `getB20Address`, `isB20`, or `isB20Initialized`, the call reverts immediately with a `NonPayable()` error before any other logic runs — matching how Solidity handles nonpayable functions.

The `NonPayable()` error is also now part of the factory's published ABI, so tooling (block explorers, trace decoders, front-ends) can surface a meaningful name instead of a raw revert byte string.

## What was considered

A shared hook in the `base_precompile!` macro could enforce this for every precompile at once. That approach was deferred — it would require auditing every precompile to confirm it's nonpayable and is not currently deployed with live funds. The targeted fix is lower risk.
