### PR TITLE
fix(precompile-storage): reject non-canonical bool storage words (BOP-317)

### DIFF
--- a/crates/common/precompile-storage/src/types/primitives.rs
+++ b/crates/common/precompile-storage/src/types/primitives.rs
@@ -43,7 +43,13 @@ impl FromWord for bool {
     }
     #[inline]
     fn from_word(word: U256) -> crate::error::Result<Self> {
-        Ok(!word.is_zero())
+        if word == U256::ZERO {
+            Ok(false)
+        } else if word == U256::ONE {
+            Ok(true)
+        } else {
+            Err(crate::error::BasePrecompileError::enum_conversion_error())
+        }
     }
 }
 
@@ -123,6 +129,16 @@ mod tests {
 
     // Generate property tests for all primitive storage types
     base_precompile_macros::gen_storable_tests!();
+
+    #[test]
+    fn bool_from_word_rejects_noncanonical() {
+        for bad in [U256::from(2u64), U256::from(0xffu64), U256::MAX] {
+            assert!(
+                <bool as FromWord>::from_word(bad).is_err(),
+                "expected error for non-canonical bool word {bad}"
+            );
+        }
+    }
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(500))]

--- a/crates/common/precompile-storage/src/types/primitives.rs
+++ b/crates/common/precompile-storage/src/types/primitives.rs
@@ -43,12 +43,10 @@ impl FromWord for bool {
     }
     #[inline]
     fn from_word(word: U256) -> crate::error::Result<Self> {
-        if word == U256::ZERO {
-            Ok(false)
-        } else if word == U256::ONE {
-            Ok(true)
-        } else {
-            Err(crate::error::BasePrecompileError::enum_conversion_error())
+        match word {
+            w if w == U256::ZERO => Ok(false),
+            w if w == U256::ONE => Ok(true),
+            _ => Err(crate::error::BasePrecompileError::enum_conversion_error()),
         }
     }
 }


### PR DESCRIPTION
## Summary

- `FromWord for bool` previously decoded any non-zero `U256` word as `true`, meaning raw storage values like `2`, `0xff`, or `U256::MAX` would incorrectly enable feature gates, grant policy/role membership, or bypass replay protection
- Now only `0 → false` and `1 → true` are accepted; any other word returns `enum_conversion_error()` (Solidity Panic `0x21`), matching canonical EVM boolean encoding
- Adds regression tests for non-canonical values `2`, `0xff`, and `U256::MAX`

Fixes BOP-317 (Cantina audit finding PSRC #6, Informational severity).

**Affected boolean mappings (all fixed by this single primitive change):**
- `activation/storage.rs` — feature flags (`is_activated`)
- `policy/storage.rs` — policy membership
- `common/core_storage.rs` — B20 role membership (MINT/BURN/PAUSE/etc.)
- `b20_asset/storage.rs` — consumed announcement IDs (replay protection)

## Test plan

- [x] `cargo test -p base-precompile-storage --lib` — all 159 tests pass
- [x] New test `bool_from_word_rejects_noncanonical` explicitly asserts `2`, `0xff`, and `U256::MAX` return errors
- [x] Existing proptest `test_bool_values` continues to pass (canonical `true`/`false` roundtrips unaffected)