### PR TITLE
docs(b20-asset): document factory bootstrap policy asymmetry (MintReceiver always enforced)

### DIFF
--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -18,6 +18,11 @@ pub trait Mintable: Token {
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
         }
+        // MintReceiver is always enforced regardless of `privileged`. Unlike transfer-side
+        // policies, we never mint tokens to a policy-denied address, even during factory
+        // bootstrap. Skipping this check would allow an initCalls sequence to mint into a
+        // restricted address set before normal policy enforcement begins, creating an
+        // unrecoverable policy violation.
         B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::MintReceiver, to)?;
         let supply = self.accounting().total_supply()?;
         let cap = self.accounting().supply_cap()?;

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -42,6 +42,10 @@ pub trait Transferable: Token {
         if from == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
+        // Transfer-side policies (TransferSender, TransferReceiver, TransferExecutor) are
+        // intentionally bypassed during factory bootstrap (privileged=true). MintReceiver is
+        // NOT bypassed; see `Mintable::mint` for that asymmetry -- minting to a policy-denied
+        // address is never allowed even during bootstrap.
         if !privileged {
             B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferSender, from)?;
             B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::TransferReceiver, to)?;


### PR DESCRIPTION

## Motivation

During factory bootstrap (`privileged=true`), transfer-side policies (TransferSender, TransferReceiver, TransferExecutor) are intentionally bypassed so that the factory can seed initial balances freely. However, `MintReceiver` is always enforced regardless of `privileged`. This asymmetry is correct by design: minting tokens to a policy-denied address would create an unrecoverable state violation that persists after bootstrap completes. The problem is that the asymmetry was undocumented, making it a latent footgun for integrators: an `initCalls` sequence that sets a restrictive MintReceiver policy and then mints would hit `PolicyForbids` with no explanation at the call site.

## What changed

- Added an inline comment above the `if !privileged {` block in `transferable.rs` explaining that transfer-side policies are bypassed during bootstrap and cross-referencing `Mintable::mint` for the asymmetry.
- Added an inline comment above the unconditional `B20Guards::ensure_policy_type::<Self>(self, B20PolicyType::MintReceiver, to)?` call in `mintable.rs` explaining why MintReceiver is always enforced even under `privileged=true`.

Existing tests (`transfer_privileged_skips_receiver_policy` and `mint_reverts_when_receiver_policy_denies`) already pin both behaviors. No behavior change.

## What was tried / considered

Adding a test that explicitly calls `mint` with `privileged=true` against a denied MintReceiver was considered, but `mint_reverts_when_receiver_policy_denies` already does exactly that (it passes `privileged=true`). A duplicate test would add noise without signal. Comments at the call sites are the minimal targeted fix that directly addresses the documentation gap.
