### PR TITLE
docs(activation-registry): document bytecode marker persistence, add BOP-322 regression test

### DIFF
--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -8,6 +8,13 @@ use revm::precompile::PrecompileResult;
 use crate::IActivationRegistry;
 
 /// Runtime activation registry for Base-native features.
+///
+/// # Bytecode marker
+///
+/// The `0xef` bytecode marker at `Self::ADDRESS` is written on first-ever activation and is an
+/// initialization sentinel only. It is NOT cleared on deactivation and MUST NOT be used to infer
+/// whether any feature is currently active. Use `isActivated(feature)` for authoritative
+/// activation state.
 #[contract(addr = Self::ADDRESS)]
 #[namespace("base.activation_registry")]
 pub struct ActivationRegistryStorage {
@@ -97,6 +104,9 @@ impl ActivationRegistryStorage<'_> {
     }
 
     /// Deactivates the feature.
+    ///
+    /// The initialization bytecode marker at `Self::ADDRESS` is intentionally preserved after
+    /// deactivation. Only the feature's storage slot is cleared.
     pub fn deactivate(
         &mut self,
         feature: B256,
@@ -524,5 +534,33 @@ mod tests {
 
         assert!(output.is_success());
         assert_eq!(output.gas_refunded, 0, "writing to a zero slot earns no refund");
+    }
+
+    #[test]
+    fn bytecode_marker_persists_after_deactivation_bop322() {
+        // BOP-322: code presence is an initialization marker only; it persists after deactivation
+        // by design. EXTCODESIZE/EXTCODEHASH at Self::ADDRESS must not be used as a liveness signal.
+        let mut storage = HashMapStorageProvider::new(1);
+
+        // Before any activation, no bytecode marker is present.
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert!(!ctx.has_bytecode(ActivationRegistryStorage::ADDRESS).unwrap());
+        });
+
+        activate_feature(&mut storage).unwrap();
+
+        // After activation both the bytecode marker and the feature flag are set.
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert!(ctx.has_bytecode(ActivationRegistryStorage::ADDRESS).unwrap());
+        });
+        assert_activated(&mut storage, true);
+
+        deactivate_feature(&mut storage).unwrap();
+
+        // After deactivation isActivated returns false, but the bytecode marker is preserved.
+        assert_activated(&mut storage, false);
+        StorageCtx::enter(&mut storage, |ctx| {
+            assert!(ctx.has_bytecode(ActivationRegistryStorage::ADDRESS).unwrap());
+        });
     }
 }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn bytecode_marker_persists_after_deactivation_bop322() {
-        // BOP-322: code presence is an initialization marker only; it persists after deactivation
+        // Code presence is an initialization marker only; it persists after deactivation
         // by design. EXTCODESIZE/EXTCODEHASH at Self::ADDRESS must not be used as a liveness signal.
         let mut storage = HashMapStorageProvider::new(1);
 


### PR DESCRIPTION

## Motivation

When a feature is first activated, `ActivationRegistryStorage.__initialize()` writes a `0xef`
bytecode sentinel to `Self::ADDRESS`. On deactivation only the feature's storage slot is cleared;
the bytecode is intentionally left in place to avoid the cost and complexity of tracking a live
feature count. This means `EXTCODESIZE` and `EXTCODEHASH` at the registry address remain non-zero
even after all features have been deactivated. Without documentation this is an invisible
invariant that could mislead integrators or future readers into treating code presence as a
liveness signal.

## What changed

- Added a `# Bytecode marker` section to the `ActivationRegistryStorage` struct doc explaining
  that the sentinel is written on first activation, is never cleared, and must not be used to
  infer whether any feature is currently active.
- Added a sentence to `deactivate()` clarifying that only the feature's storage slot is cleared
  and the marker is preserved by design.
- Added a regression test `bytecode_marker_persists_after_deactivation_bop322` that walks the
  activate-then-deactivate lifecycle and asserts: `has_bytecode` is false before first activation,
  true after activation (alongside `is_activated`), and still true after deactivation while
  `is_activated` returns false.

## What was tried / considered

The Cantina finding offered two options: (A) clear the marker bytecode when no features remain
active, or (B) document that code presence is only an initialization marker. Option A would
require tracking an active-feature count (a new storage slot and added mutation surface) and
could have unexpected side effects if any external system observes the bytecode at the registry
address. Because no internal caller in this codebase reads `EXTCODESIZE`/`EXTCODEHASH` at the
registry address as a liveness signal, and the `isActivated(feature)` path is correct, option B
(docs plus a regression test) fully closes the finding at the lowest risk.
