### PR TITLE
fix(b20-asset): reject zero multiplier in updateMultiplier (BOP-328)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -16,6 +16,9 @@ sol! {
         /// `updateExtraMetadata` was called with an empty metadata key.
         error InvalidMetadataKey();
 
+        /// `updateMultiplier` was called with a zero multiplier.
+        error InvalidMultiplier();
+
         /// A batched function was called with parallel arrays of differing lengths.
         error LengthMismatch(uint256 leftLen, uint256 rightLen);
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -202,6 +202,9 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         privileged: bool,
     ) -> Result<()> {
         self.ensure_operator_role(caller, privileged)?;
+        if new_multiplier.is_zero() {
+            return Err(BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+        }
         self.accounting_mut().set_multiplier(new_multiplier)?;
         self.accounting_mut().emit_event(
             IB20Asset::MultiplierUpdated { multiplier: new_multiplier }.encode_log_data(),
@@ -280,6 +283,7 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, U256, keccak256};
+    use alloy_sol_types::SolEvent;
     use base_precompile_storage::BasePrecompileError;
     use rstest::rstest;
 
@@ -421,5 +425,28 @@ mod tests {
         let err = token.update_policy(CALLER, invalid_scope, 999, false).unwrap_err();
 
         assert_eq!(err, expected_update_policy_error(setup, invalid_scope));
+    }
+
+    #[test]
+    fn update_multiplier_rejects_zero() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, CALLER), true);
+
+        let err = token.update_multiplier(CALLER, U256::ZERO, false).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+    }
+
+    #[test]
+    fn update_multiplier_emits_wad_event() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, CALLER), true);
+
+        token.update_multiplier(CALLER, B20AssetStorage::WAD, false).unwrap();
+
+        assert_eq!(token.accounting().events.len(), 1);
+        let decoded =
+            IB20Asset::MultiplierUpdated::decode_log_data(&token.accounting().events[0]).unwrap();
+        assert_eq!(decoded.multiplier, B20AssetStorage::WAD);
     }
 }


### PR DESCRIPTION

## Motivation

`updateMultiplier(0)` would write zero to storage and emit `MultiplierUpdated(0)`, but the read path always normalizes stored-zero back to WAD (1e18) because zero is the "uninitialized" sentinel. This created a split: the emitted event said the multiplier was 0, but any onchain read returned 1e18. Indexers and integrations would see a multiplier of zero that the contract itself never actually uses.

## What changed

Calling `updateMultiplier(0)` now reverts with an explicit `InvalidMultiplier()` error. A multiplier of zero has no valid meaning (division-by-zero in balance conversions, scaled balances always zero), so callers get a clear error instead of a misleading event.

## What was considered

An alternative would normalize zero to WAD before writing — emitting `MultiplierUpdated(WAD)` rather than `MultiplierUpdated(0)`. Rejection is cleaner: callers who pass zero are doing something wrong, and a substitution would hide the mistake silently.
