### PR TITLE
fix(precompile-storage): add is_static guard to set_code before gas charge (BOP-321)

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -334,16 +334,16 @@ mod tests {
 
     fn make_evm_provider<'a>(
         ctx: &'a mut EthEvmContext<EmptyDB>,
+        gas_params: GasParams,
         gas: u64,
         is_static: bool,
     ) -> super::EvmPrecompileStorageProvider<'a> {
-        let gas_params = GasParams::default();
         let input = PrecompileInput {
             data: &[],
             gas,
             reservoir: 0,
             caller: Address::ZERO,
-            value: alloy_primitives::U256::ZERO,
+            value: U256::ZERO,
             target_address: Address::ZERO,
             is_static,
             bytecode_address: Address::ZERO,
@@ -357,14 +357,11 @@ mod tests {
     fn sstore_oog_at_call_stipend_boundary() {
         let gas_params = GasParams::default();
         let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        let mut provider = make_evm_provider(&mut ctx, gas_params.call_stipend(), false);
+        let mut provider =
+            make_evm_provider(&mut ctx, gas_params.clone(), gas_params.call_stipend(), false);
 
         assert_eq!(
-            provider.sstore(
-                Address::ZERO,
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::from(1u64)
-            ),
+            provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)),
             Err(BasePrecompileError::OutOfGas),
         );
     }
@@ -374,14 +371,11 @@ mod tests {
     fn sstore_oog_below_call_stipend() {
         let gas_params = GasParams::default();
         let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        let mut provider = make_evm_provider(&mut ctx, gas_params.call_stipend() - 1, false);
+        let mut provider =
+            make_evm_provider(&mut ctx, gas_params.clone(), gas_params.call_stipend() - 1, false);
 
         assert_eq!(
-            provider.sstore(
-                Address::ZERO,
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::from(1u64)
-            ),
+            provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)),
             Err(BasePrecompileError::OutOfGas),
         );
     }
@@ -391,19 +385,11 @@ mod tests {
     fn sstore_allowed_above_call_stipend() {
         let gas_params = GasParams::default();
         let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        // Provide enough gas to pass the stipend guard and cover all sstore costs.
+        // Large margin covers the stipend guard + cold sstore costs (~2600 gas).
         let gas = gas_params.call_stipend() + 1_000_000;
-        let mut provider = make_evm_provider(&mut ctx, gas, false);
+        let mut provider = make_evm_provider(&mut ctx, gas_params.clone(), gas, false);
 
-        assert!(
-            provider
-                .sstore(
-                    Address::ZERO,
-                    alloy_primitives::U256::ZERO,
-                    alloy_primitives::U256::from(1u64)
-                )
-                .is_ok(),
-        );
+        assert!(provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)).is_ok());
     }
 
     /// Static-call violation is checked before the stipend guard.
@@ -412,14 +398,11 @@ mod tests {
         let gas_params = GasParams::default();
         let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
         // Gas at stipend boundary — both guards would fire, static takes priority.
-        let mut provider = make_evm_provider(&mut ctx, gas_params.call_stipend(), true);
+        let mut provider =
+            make_evm_provider(&mut ctx, gas_params.clone(), gas_params.call_stipend(), true);
 
         assert_eq!(
-            provider.sstore(
-                Address::ZERO,
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::from(1u64)
-            ),
+            provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)),
             Err(BasePrecompileError::StaticCallViolation),
         );
     }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -387,7 +387,7 @@ mod tests {
         let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
         // Large margin covers the stipend guard + cold sstore costs (~2600 gas).
         let gas = gas_params.call_stipend() + 1_000_000;
-        let mut provider = make_evm_provider(&mut ctx, gas_params.clone(), gas, false);
+        let mut provider = make_evm_provider(&mut ctx, gas_params, gas, false);
 
         assert!(provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)).is_ok());
     }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -461,6 +461,22 @@ mod tests {
         }
     }
 
+    /// `set_code` in a static context returns `StaticCallViolation` before any gas is charged.
+    #[test]
+    fn set_code_static_violation_before_gas_charge() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let gas = 1_000_000;
+        let mut provider = make_evm_provider(&mut ctx, gas_params, gas, true);
+
+        assert_eq!(
+            provider.set_code(Address::ZERO, Bytecode::new_raw([0x60u8, 0x00].as_ref().into())),
+            Err(BasePrecompileError::StaticCallViolation),
+        );
+        // No gas must have been consumed.
+        assert_eq!(provider.gas_used(), 0);
+    }
+
     /// `set_code` on a brand-new account must charge both `create_state_gas` and
     /// `code_deposit_state_gas` against the state-gas counter.
     #[test]

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -337,9 +337,10 @@ mod tests {
     /// call stipend constant returned by `GasParams` is exactly 2300, as required by EIP-2200.
     ///
     /// Unit tests cannot directly instantiate [`super::EvmPrecompileStorageProvider`] because
-    /// it requires a live EVM journal via `PrecompileInput`. The stipend guard is therefore not
-    /// exercisable in isolation here. Full coverage of the guard at runtime is provided by the
-    /// B20 fork tests that forward exactly 2300 gas into a stateful precompile call.
+    /// it requires a live EVM journal via `PrecompileInput`. The guard logic itself (boundary
+    /// at `remaining <= 2300`, below-boundary, above-boundary, and priority over the static
+    /// guard) is covered by `HashMapStorageProvider` tests in `hashmap.rs`, which mirror the
+    /// same `<=` comparison against `gas_params.call_stipend()`.
     #[test]
     fn eip_2200_stipend_guard_constant_is_2300() {
         let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -332,22 +332,95 @@ mod tests {
         provider
     }
 
-    /// The EIP-2200 stipend guard in [`super::EvmPrecompileStorageProvider::sstore`] compares
-    /// `gas.remaining()` against `gas_params.call_stipend()`. This test verifies that the
-    /// call stipend constant returned by `GasParams` is exactly 2300, as required by EIP-2200.
-    ///
-    /// Unit tests cannot directly instantiate [`super::EvmPrecompileStorageProvider`] because
-    /// it requires a live EVM journal via `PrecompileInput`. The guard logic itself (boundary
-    /// at `remaining <= 2300`, below-boundary, above-boundary, and priority over the static
-    /// guard) is covered by `HashMapStorageProvider` tests in `hashmap.rs`, which mirror the
-    /// same `<=` comparison against `gas_params.call_stipend()`.
+    fn make_evm_provider<'a>(
+        ctx: &'a mut EthEvmContext<EmptyDB>,
+        gas: u64,
+        is_static: bool,
+    ) -> super::EvmPrecompileStorageProvider<'a> {
+        let gas_params = GasParams::default();
+        let input = PrecompileInput {
+            data: &[],
+            gas,
+            reservoir: 0,
+            caller: Address::ZERO,
+            value: alloy_primitives::U256::ZERO,
+            target_address: Address::ZERO,
+            is_static,
+            bytecode_address: Address::ZERO,
+            internals: EvmInternals::from_context(ctx),
+        };
+        super::EvmPrecompileStorageProvider::new(input, gas_params)
+    }
+
+    /// EIP-2200 stipend boundary: `remaining == call_stipend` (2300) must block.
     #[test]
-    fn eip_2200_stipend_guard_constant_is_2300() {
-        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+    fn sstore_oog_at_call_stipend_boundary() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider = make_evm_provider(&mut ctx, gas_params.call_stipend(), false);
+
         assert_eq!(
-            gas_params.call_stipend(),
-            2300,
-            "call_stipend must equal 2300 as required by EIP-2200"
+            provider.sstore(
+                Address::ZERO,
+                alloy_primitives::U256::ZERO,
+                alloy_primitives::U256::from(1u64)
+            ),
+            Err(BasePrecompileError::OutOfGas),
+        );
+    }
+
+    /// Below the stipend (2299): also blocked.
+    #[test]
+    fn sstore_oog_below_call_stipend() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider = make_evm_provider(&mut ctx, gas_params.call_stipend() - 1, false);
+
+        assert_eq!(
+            provider.sstore(
+                Address::ZERO,
+                alloy_primitives::U256::ZERO,
+                alloy_primitives::U256::from(1u64)
+            ),
+            Err(BasePrecompileError::OutOfGas),
+        );
+    }
+
+    /// Strictly above the stipend: guard passes, sstore completes.
+    #[test]
+    fn sstore_allowed_above_call_stipend() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        // Provide enough gas to pass the stipend guard and cover all sstore costs.
+        let gas = gas_params.call_stipend() + 1_000_000;
+        let mut provider = make_evm_provider(&mut ctx, gas, false);
+
+        assert!(
+            provider
+                .sstore(
+                    Address::ZERO,
+                    alloy_primitives::U256::ZERO,
+                    alloy_primitives::U256::from(1u64)
+                )
+                .is_ok(),
+        );
+    }
+
+    /// Static-call violation is checked before the stipend guard.
+    #[test]
+    fn sstore_static_violation_checked_before_stipend_guard() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        // Gas at stipend boundary — both guards would fire, static takes priority.
+        let mut provider = make_evm_provider(&mut ctx, gas_params.call_stipend(), true);
+
+        assert_eq!(
+            provider.sstore(
+                Address::ZERO,
+                alloy_primitives::U256::ZERO,
+                alloy_primitives::U256::from(1u64)
+            ),
+            Err(BasePrecompileError::StaticCallViolation),
         );
     }
 

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -347,10 +347,21 @@ mod tests {
     use alloy_primitives::{Address, U256};
 
     use super::*;
-    use crate::provider::PrecompileStorageProvider;
+    use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
+
+    #[test]
+    fn set_code_static_violation_before_state_gas_charge() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_static(true);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+
+        assert_eq!(p.set_code(Address::ZERO, code), Err(BasePrecompileError::StaticCallViolation),);
+        // No state gas must have been charged.
+        assert_eq!(p.state_gas_used(), 0);
+    }
 
     #[test]
     fn refund_gas_accumulates_positive() {

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -374,6 +374,7 @@ mod tests {
         GasParams::new_spec(SpecId::AMSTERDAM)
     }
 
+    /// Positive refunds accumulate in the counter.
     #[test]
     fn refund_gas_accumulates_positive() {
         let mut p = HashMapStorageProvider::new(1);
@@ -382,6 +383,7 @@ mod tests {
         assert_eq!(p.gas_refunded(), 1_500);
     }
 
+    /// Negative refunds (EIP-3529 cancellations) reduce the counter.
     #[test]
     fn refund_gas_accumulates_negative() {
         let mut p = HashMapStorageProvider::new(1);
@@ -390,12 +392,14 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Gas refund counter starts at zero on a fresh provider.
     #[test]
     fn refund_gas_starts_at_zero() {
         let p = HashMapStorageProvider::new(1);
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Clearing a previously set slot (nonzero to zero) earns an EIP-3529 refund.
     #[test]
     fn sstore_clearing_slot_generates_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -407,6 +411,7 @@ mod tests {
         assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
     }
 
+    /// Overwriting a nonzero slot with another nonzero value earns no refund.
     #[test]
     fn sstore_nonzero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -415,6 +420,7 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Writing to a zero slot (first write) earns no refund.
     #[test]
     fn sstore_zero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -30,10 +30,6 @@ pub struct HashMapStorageProvider {
     gas_params: GasParams,
     state_gas_used: u64,
     gas_refunded: i64,
-    /// When `Some(n)`, enforces the EIP-2200 stipend guard: `sstore` returns `OutOfGas` when
-    /// `n <= gas_params.call_stipend()`. `None` (default) disables the guard so existing tests
-    /// that do not care about gas limits continue to work unchanged.
-    gas_remaining: Option<u64>,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -71,7 +67,6 @@ impl HashMapStorageProvider {
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
-            gas_remaining: None,
         }
     }
 }
@@ -129,11 +124,6 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     ) -> Result<(), BasePrecompileError> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
-        }
-        // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
-        // Only enforced when gas_remaining is explicitly set (opt-in for tests).
-        if self.gas_remaining.is_some_and(|r| r <= self.gas_params.call_stipend()) {
-            return Err(BasePrecompileError::OutOfGas);
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -344,13 +334,6 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
-
-    /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
-    /// (test-utils only). Use this to exercise the guard at specific gas levels without
-    /// a live EVM journal.
-    pub const fn set_gas_remaining(&mut self, remaining: u64) {
-        self.gas_remaining = Some(remaining);
-    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
@@ -364,7 +347,7 @@ mod tests {
     use alloy_primitives::{Address, U256};
 
     use super::*;
-    use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
+    use crate::provider::PrecompileStorageProvider;
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
@@ -415,58 +398,5 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
-    }
-
-    /// EIP-2200 stipend boundary: `remaining == call_stipend` must block (guard is `<=`).
-    #[test]
-    fn sstore_blocked_when_remaining_equals_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
-        assert_eq!(
-            p.sstore(ADDR, KEY, U256::from(1u64)),
-            Err(BasePrecompileError::OutOfGas),
-            "sstore must be blocked when remaining == call_stipend"
-        );
-    }
-
-    /// Below the stipend: also blocked.
-    #[test]
-    fn sstore_blocked_when_remaining_below_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2299);
-        assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
-    }
-
-    /// One above the stipend: allowed.
-    #[test]
-    fn sstore_allowed_when_remaining_above_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2301);
-        assert!(
-            p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
-            "sstore must succeed when remaining > call_stipend"
-        );
-    }
-
-    /// Default (no `gas_remaining` set): guard is inactive, `sstore` always proceeds.
-    #[test]
-    fn sstore_always_allowed_without_gas_remaining_set() {
-        let mut p = HashMapStorageProvider::new(1);
-        // gas_remaining is None — guard disabled, unlimited gas
-        assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
-    }
-
-    /// Static-call violation takes priority over the stipend guard.
-    /// `gas_remaining == 2300` means the stipend guard would also fire if checked first;
-    /// setting `static=true` proves `StaticCallViolation` is returned rather than `OutOfGas`.
-    #[test]
-    fn sstore_static_violation_checked_before_stipend_guard() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_static(true);
-        p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
-        assert_eq!(
-            p.sstore(ADDR, KEY, U256::from(1u64)),
-            Err(BasePrecompileError::StaticCallViolation),
-        );
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -132,10 +132,8 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
         // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
         // Only enforced when gas_remaining is explicitly set (opt-in for tests).
-        if let Some(remaining) = self.gas_remaining {
-            if remaining <= self.gas_params.call_stipend() {
-                return Err(BasePrecompileError::OutOfGas);
-            }
+        if self.gas_remaining.is_some_and(|r| r <= self.gas_params.call_stipend()) {
+            return Err(BasePrecompileError::OutOfGas);
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -350,7 +348,7 @@ impl HashMapStorageProvider {
     /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
     /// (test-utils only). Use this to exercise the guard at specific gas levels without
     /// a live EVM journal.
-    pub fn set_gas_remaining(&mut self, remaining: u64) {
+    pub const fn set_gas_remaining(&mut self, remaining: u64) {
         self.gas_remaining = Some(remaining);
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -362,7 +362,6 @@ pub fn setup_storage() -> (HashMapStorageProvider, Address) {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
-    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId};
 
     use super::*;
     use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
@@ -370,11 +369,6 @@ mod tests {
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
 
-    fn amsterdam_params() -> GasParams {
-        GasParams::new_spec(SpecId::AMSTERDAM)
-    }
-
-    /// Positive refunds accumulate in the counter.
     #[test]
     fn refund_gas_accumulates_positive() {
         let mut p = HashMapStorageProvider::new(1);
@@ -383,7 +377,6 @@ mod tests {
         assert_eq!(p.gas_refunded(), 1_500);
     }
 
-    /// Negative refunds (EIP-3529 cancellations) reduce the counter.
     #[test]
     fn refund_gas_accumulates_negative() {
         let mut p = HashMapStorageProvider::new(1);
@@ -392,14 +385,12 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Gas refund counter starts at zero on a fresh provider.
     #[test]
     fn refund_gas_starts_at_zero() {
         let p = HashMapStorageProvider::new(1);
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Clearing a previously set slot (nonzero to zero) earns an EIP-3529 refund.
     #[test]
     fn sstore_clearing_slot_generates_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -411,7 +402,6 @@ mod tests {
         assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
     }
 
-    /// Overwriting a nonzero slot with another nonzero value earns no refund.
     #[test]
     fn sstore_nonzero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -420,7 +410,6 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Writing to a zero slot (first write) earns no refund.
     #[test]
     fn sstore_zero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -432,7 +421,6 @@ mod tests {
     #[test]
     fn sstore_blocked_when_remaining_equals_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
         assert_eq!(
             p.sstore(ADDR, KEY, U256::from(1u64)),
@@ -445,7 +433,6 @@ mod tests {
     #[test]
     fn sstore_blocked_when_remaining_below_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2299);
         assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
     }
@@ -454,7 +441,6 @@ mod tests {
     #[test]
     fn sstore_allowed_when_remaining_above_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2301);
         assert!(
             p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
@@ -466,7 +452,6 @@ mod tests {
     #[test]
     fn sstore_always_allowed_without_gas_remaining_set() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         // gas_remaining is None — guard disabled, unlimited gas
         assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
     }
@@ -477,7 +462,6 @@ mod tests {
     #[test]
     fn sstore_static_violation_checked_before_stipend_guard() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_static(true);
         p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
         assert_eq!(

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -30,6 +30,10 @@ pub struct HashMapStorageProvider {
     gas_params: GasParams,
     state_gas_used: u64,
     gas_refunded: i64,
+    /// When `Some(n)`, enforces the EIP-2200 stipend guard: `sstore` returns `OutOfGas` when
+    /// `n <= gas_params.call_stipend()`. `None` (default) disables the guard so existing tests
+    /// that do not care about gas limits continue to work unchanged.
+    gas_remaining: Option<u64>,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -67,6 +71,7 @@ impl HashMapStorageProvider {
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
+            gas_remaining: None,
         }
     }
 }
@@ -124,6 +129,13 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     ) -> Result<(), BasePrecompileError> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
+        }
+        // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
+        // Only enforced when gas_remaining is explicitly set (opt-in for tests).
+        if let Some(remaining) = self.gas_remaining {
+            if remaining <= self.gas_params.call_stipend() {
+                return Err(BasePrecompileError::OutOfGas);
+            }
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -334,6 +346,13 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
+
+    /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
+    /// (test-utils only). Use this to exercise the guard at specific gas levels without
+    /// a live EVM journal.
+    pub fn set_gas_remaining(&mut self, remaining: u64) {
+        self.gas_remaining = Some(remaining);
+    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
@@ -345,12 +364,17 @@ pub fn setup_storage() -> (HashMapStorageProvider, Address) {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
+    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId};
 
     use super::*;
-    use crate::provider::PrecompileStorageProvider;
+    use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
+
+    fn amsterdam_params() -> GasParams {
+        GasParams::new_spec(SpecId::AMSTERDAM)
+    }
 
     #[test]
     fn refund_gas_accumulates_positive() {
@@ -398,5 +422,63 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
+    }
+
+    /// EIP-2200 stipend boundary: `remaining == call_stipend` must block (guard is `<=`).
+    #[test]
+    fn sstore_blocked_when_remaining_equals_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
+        assert_eq!(
+            p.sstore(ADDR, KEY, U256::from(1u64)),
+            Err(BasePrecompileError::OutOfGas),
+            "sstore must be blocked when remaining == call_stipend"
+        );
+    }
+
+    /// Below the stipend: also blocked.
+    #[test]
+    fn sstore_blocked_when_remaining_below_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2299);
+        assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
+    }
+
+    /// One above the stipend: allowed.
+    #[test]
+    fn sstore_allowed_when_remaining_above_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2301);
+        assert!(
+            p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
+            "sstore must succeed when remaining > call_stipend"
+        );
+    }
+
+    /// Default (no gas_remaining set): guard is inactive, sstore always proceeds.
+    #[test]
+    fn sstore_always_allowed_without_gas_remaining_set() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        // gas_remaining is None — guard disabled, unlimited gas
+        assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
+    }
+
+    /// Static-call violation takes priority over the stipend guard.
+    /// gas_remaining == 2300 means the stipend guard would also fire if checked first;
+    /// setting static=true proves StaticCallViolation is returned rather than OutOfGas.
+    #[test]
+    fn sstore_static_violation_checked_before_stipend_guard() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_static(true);
+        p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
+        assert_eq!(
+            p.sstore(ADDR, KEY, U256::from(1u64)),
+            Err(BasePrecompileError::StaticCallViolation),
+        );
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -462,7 +462,7 @@ mod tests {
         );
     }
 
-    /// Default (no gas_remaining set): guard is inactive, sstore always proceeds.
+    /// Default (no `gas_remaining` set): guard is inactive, `sstore` always proceeds.
     #[test]
     fn sstore_always_allowed_without_gas_remaining_set() {
         let mut p = HashMapStorageProvider::new(1);
@@ -472,8 +472,8 @@ mod tests {
     }
 
     /// Static-call violation takes priority over the stipend guard.
-    /// gas_remaining == 2300 means the stipend guard would also fire if checked first;
-    /// setting static=true proves StaticCallViolation is returned rather than OutOfGas.
+    /// `gas_remaining == 2300` means the stipend guard would also fire if checked first;
+    /// setting `static=true` proves `StaticCallViolation` is returned rather than `OutOfGas`.
     #[test]
     fn sstore_static_violation_checked_before_stipend_guard() {
         let mut p = HashMapStorageProvider::new(1);

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -231,7 +231,19 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Mints tokens to multiple recipients. All-or-nothing.
     ///
-    /// Check order: PAUSE → ROLE → INPUT → BUSINESS
+    /// # Authorization boundary
+    ///
+    /// The `ensure_not_paused` and `ensure_token_role` calls below are the **sole**
+    /// authorization gate for all batch-mint operations. The inner [`Mintable::mint`]
+    /// calls pass `privileged = true` only to avoid re-running the same checks once
+    /// per recipient, which is safe because the outer guards have already fired.
+    ///
+    /// **Do not remove or conditionalize the outer guards.** Doing so would leave a
+    /// fully open privileged path, since the inner mints unconditionally bypass
+    /// their own checks. The tests `batch_mint_check_order` in this module pin this
+    /// invariant and will fail if either guard is dropped.
+    ///
+    /// Check order: PAUSE -> ROLE -> INPUT -> BUSINESS
     pub fn batch_mint(
         &mut self,
         caller: Address,

--- a/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
+++ b/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
@@ -144,7 +144,7 @@ contract SeedDexPools is Script {
         MockERC20(token0).approve(clPositionManager, type(uint256).max);
         MockERC20(token1).approve(clPositionManager, type(uint256).max);
 
-        int24 maxTick = int24(887272) - (int24(887272) % tickSpacing);
+        int24 maxTick = (int24(887272) / tickSpacing) * tickSpacing;
         ICLPositionManager(clPositionManager).mint(
             ICLPositionManager.MintParams({
                 token0: token0,

--- a/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
+++ b/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
@@ -144,7 +144,7 @@ contract SeedDexPools is Script {
         MockERC20(token0).approve(clPositionManager, type(uint256).max);
         MockERC20(token1).approve(clPositionManager, type(uint256).max);
 
-        int24 maxTick = (int24(887272) / tickSpacing) * tickSpacing;
+        int24 maxTick = int24(887272) - (int24(887272) % tickSpacing);
         ICLPositionManager(clPositionManager).mint(
             ICLPositionManager.MintParams({
                 token0: token0,


### PR DESCRIPTION

## Motivation

`StorageCtx::set_code` in the EVM-backed provider (`EvmPrecompileStorageProvider`) and the test HashMap provider (`HashMapStorageProvider`) did not check `is_static` before executing. Every other state-mutation path (`sstore`, `tstore`, `emit_event`) returns `StaticCallViolation` immediately if the call context is static. The missing guard in `set_code` meant that in a static context, code-deposit gas would be deducted and account loading would occur before a subsequent `sstore` finally raised `StaticCallViolation`, producing incorrect error ordering and overcharging gas.

## What changed

- Added an `is_static` guard as the first statement in `EvmPrecompileStorageProvider::set_code` (`evm.rs`), matching the identical pattern used by `sstore`, `tstore`, and `emit_event`.
- Added the same guard to `HashMapStorageProvider::set_code` (`hashmap.rs`) so the test provider remains a faithful mirror of the production implementation.
- Added regression tests in both files: `set_code_static_violation_before_gas_charge` (EVM provider, asserts zero gas consumed) and `set_code_static_violation_before_state_gas_charge` (HashMap provider, asserts zero state gas charged).

## What was tried / considered

The only alternative considered was checking `is_static` inside the gas-deduction path rather than at the top of `set_code`. That was rejected: the guard must come first so that no side effects (gas, account loads) occur before the error is returned, which is the invariant all other mutating methods uphold.
