### PR TITLE
feat(prover-service): add get_active_session lookup

### DIFF
--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -8,13 +8,13 @@ pub use conversions::ConversionError;
 
 mod models;
 pub use models::{
-    ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateProofRequest,
-    CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, DerivedProofRequestFields, FailExpiredProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
-    canonical_session_id,
+    ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofRequestValidationError, CreateProofSession, DerivedProofRequestFields,
+    FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob,
+    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
+    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
+    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1073,6 +1073,69 @@ pub enum SubmitProofOutcome {
     Unknown(ProofJob),
 }
 
+/// A proof job's current lock columns, as read under a row lock, against which a
+/// worker write is authorized.
+///
+/// Grouping the job-side values keeps them from being confused with the
+/// worker-supplied fencing token at `ClaimAuth::classify` call sites.
+#[derive(Debug, Clone, Copy)]
+pub struct JobLockState<'a> {
+    /// Current lifecycle status of the job.
+    pub status: ProofJobStatus,
+    /// Active lock identifier, set while the job is claimed.
+    pub lock_id: Option<Uuid>,
+    /// Worker that currently holds the lock, if any.
+    pub worker_id: Option<&'a str>,
+    /// When the active lock expires, if any.
+    pub lock_expires_at: Option<DateTime<Utc>>,
+}
+
+/// Result of checking a worker's fencing token against a claimed job's lock.
+///
+/// Shared by `heartbeat_proof_job` and `record_worker_proof_session` so both
+/// authorize worker writes against identical lock rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimAuth {
+    /// The requesting worker holds the active lock; the write may proceed.
+    Authorized,
+    /// The job has already reached a terminal state.
+    Terminal,
+    /// The job is not currently claimed.
+    NotClaimed,
+    /// The lock is held by another worker or has been rotated.
+    StaleLock,
+    /// The lock has expired.
+    Expired,
+}
+
+impl ClaimAuth {
+    /// Classify a worker claim from a job's current lock columns (`job`) against
+    /// the fencing token (`req_lock_id`, `req_worker_id`) the worker presented.
+    ///
+    /// `now` is supplied by the caller so the expiry check stays pure and
+    /// deterministically testable.
+    pub fn classify(
+        job: JobLockState<'_>,
+        req_lock_id: Uuid,
+        req_worker_id: &str,
+        now: DateTime<Utc>,
+    ) -> Self {
+        if matches!(job.status, ProofJobStatus::Succeeded | ProofJobStatus::Failed) {
+            return Self::Terminal;
+        }
+        if job.status != ProofJobStatus::Claimed {
+            return Self::NotClaimed;
+        }
+        if job.lock_id != Some(req_lock_id) || job.worker_id != Some(req_worker_id) {
+            return Self::StaleLock;
+        }
+        if job.lock_expires_at.is_none_or(|expires_at| expires_at <= now) {
+            return Self::Expired;
+        }
+        Self::Authorized
+    }
+}
+
 /// Parameters for terminally failing expired worker jobs that exhausted attempts.
 #[derive(Debug, Clone)]
 pub struct FailExpiredProofJobs<'a> {
@@ -1212,5 +1275,68 @@ mod tests {
         });
 
         assert!(job.validate_submitted_result(&result).is_err());
+    }
+
+    #[test]
+    fn claim_auth_classify_covers_every_branch() {
+        let now = Utc::now();
+        let lock = Uuid::new_v4();
+        let worker = "worker-1";
+        let unexpired = Some(now + chrono::Duration::seconds(30));
+
+        let claimed = |lock_id, worker_id, lock_expires_at| JobLockState {
+            status: ProofJobStatus::Claimed,
+            lock_id,
+            worker_id,
+            lock_expires_at,
+        };
+
+        let authorized =
+            ClaimAuth::classify(claimed(Some(lock), Some(worker), unexpired), lock, worker, now);
+        assert_eq!(authorized, ClaimAuth::Authorized);
+
+        for status in [ProofJobStatus::Succeeded, ProofJobStatus::Failed] {
+            let job = JobLockState {
+                status,
+                lock_id: Some(lock),
+                worker_id: Some(worker),
+                lock_expires_at: unexpired,
+            };
+            assert_eq!(ClaimAuth::classify(job, lock, worker, now), ClaimAuth::Terminal);
+        }
+
+        let pending = JobLockState {
+            status: ProofJobStatus::Pending,
+            lock_id: Some(lock),
+            worker_id: Some(worker),
+            lock_expires_at: unexpired,
+        };
+        assert_eq!(ClaimAuth::classify(pending, lock, worker, now), ClaimAuth::NotClaimed);
+
+        let wrong_lock = ClaimAuth::classify(
+            claimed(Some(Uuid::new_v4()), Some(worker), unexpired),
+            lock,
+            worker,
+            now,
+        );
+        assert_eq!(wrong_lock, ClaimAuth::StaleLock);
+
+        let wrong_worker = ClaimAuth::classify(
+            claimed(Some(lock), Some("worker-2"), unexpired),
+            lock,
+            worker,
+            now,
+        );
+        assert_eq!(wrong_worker, ClaimAuth::StaleLock);
+
+        // Expiry is evaluated against the supplied `now`, so the boundary is
+        // deterministic: an `expires_at` equal to `now` counts as expired.
+        let expired =
+            ClaimAuth::classify(claimed(Some(lock), Some(worker), Some(now)), lock, worker, now);
+        assert_eq!(expired, ClaimAuth::Expired);
+
+        let missing_expiry =
+            ClaimAuth::classify(claimed(Some(lock), Some(worker), None), lock, worker, now);
+        assert_eq!(missing_expiry, ClaimAuth::Expired);
     }
 }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1059,6 +1059,37 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_session).collect()
     }
 
+    /// Get the active (`SUBMITTING` or `RUNNING`) backend session for a public
+    /// proof `session_id` and `session_type`, so a worker can resume an in-flight
+    /// backend job instead of starting a new one. Migration `009`'s partial unique
+    /// index guarantees at most one active row per `(proof_request_id, session_type)`.
+    pub async fn get_active_session(
+        &self,
+        session_id: &str,
+        session_type: SessionType,
+    ) -> Result<Option<ProofSession>> {
+        let session_id = canonical_session_id(session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+
+        let row = sqlx::query(
+            r#"
+            SELECT ps.id, ps.proof_request_id, ps.session_type, ps.backend_session_id,
+                   ps.status, ps.error_message, ps.metadata, ps.created_at, ps.completed_at
+            FROM proof_sessions ps
+            JOIN proof_requests pr ON pr.id = ps.proof_request_id
+            WHERE COALESCE(pr.session_id, pr.id::text) = $1
+              AND ps.session_type = $2
+              AND ps.status IN ('SUBMITTING', 'RUNNING')
+            "#,
+        )
+        .bind(&session_id)
+        .bind(session_type.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|r| row_to_proof_session(&r)).transpose()
+    }
+
     /// Get all running sessions (for polling)
     pub async fn get_running_sessions(&self) -> Result<Vec<ProofSession>> {
         let rows = sqlx::query(

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -6,12 +6,13 @@ use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult, CreateProofRequest,
-    CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
-    CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, ProofJob,
-    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
-    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
+    ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    CreateProofRequestValidationError, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
+    HeartbeatProofJob, JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
+    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
+    canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -588,20 +589,23 @@ impl ProofRequestRepo {
             return Ok(HeartbeatOutcome::NotFound);
         };
 
-        if matches!(job.job_status, ProofJobStatus::Succeeded | ProofJobStatus::Failed) {
-            return Ok(HeartbeatOutcome::Terminal(job));
+        match ClaimAuth::classify(
+            JobLockState {
+                status: job.job_status,
+                lock_id: job.lock_id,
+                worker_id: job.worker_id.as_deref(),
+                lock_expires_at: job.lock_expires_at,
+            },
+            req.lock_id,
+            &req.worker_id,
+            Utc::now(),
+        ) {
+            ClaimAuth::Authorized => Ok(HeartbeatOutcome::Unknown(job)),
+            ClaimAuth::Terminal => Ok(HeartbeatOutcome::Terminal(job)),
+            ClaimAuth::NotClaimed => Ok(HeartbeatOutcome::NotClaimed(job)),
+            ClaimAuth::StaleLock => Ok(HeartbeatOutcome::StaleLock(job)),
+            ClaimAuth::Expired => Ok(HeartbeatOutcome::Expired(job)),
         }
-        if job.job_status != ProofJobStatus::Claimed {
-            return Ok(HeartbeatOutcome::NotClaimed(job));
-        }
-        if job.lock_id != Some(req.lock_id) || job.worker_id.as_deref() != Some(&req.worker_id) {
-            return Ok(HeartbeatOutcome::StaleLock(job));
-        }
-        if job.lock_expires_at.is_none_or(|expires_at| expires_at <= Utc::now()) {
-            return Ok(HeartbeatOutcome::Expired(job));
-        }
-
-        Ok(HeartbeatOutcome::Unknown(job))
     }
 
     /// Complete the currently owned worker proof job (`submitProof`).


### PR DESCRIPTION
## Summary
Second of a 4-PR stack. Adds `ProofRequestRepo::get_active_session` to fetch the active (`SUBMITTING`/`RUNNING`) backend session for a public proof session id and session type, so a stateless worker can resume an in-flight backend job instead of starting a new one.

Read-only; relies on migration `009`'s partial unique index (at most one active row per `(proof_request_id, session_type)`).

## Stack
1. extract `ClaimAuth` — #3377
2. **this PR** — add `get_active_session` (base: `mw2000/claim-auth-dedup`)
3. lock-guarded worker session upsert — #3379
4. integration tests — #3380

> Coverage for this method ships with the integration tests in #3380.

## Test plan
- [ ] `cargo clippy -p base-prover-service-db --tests`