### PR TITLE
feat(prover-service): add lock-guarded worker session upsert

### DIFF
--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -13,8 +13,9 @@ pub use models::{
     CreateProofRequestValidationError, CreateProofSession, DerivedProofRequestFields,
     FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob,
     ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
-    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
+    ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType,
+    SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
+    canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1090,6 +1090,43 @@ pub struct JobLockState<'a> {
     pub lock_expires_at: Option<DateTime<Utc>>,
 }
 
+/// Parameters for an external worker recording a backend session id against a
+/// claimed job, so a restart or reclaim resumes the in-flight backend job.
+#[derive(Debug, Clone)]
+pub struct WorkerSessionUpsert {
+    /// Public proof session identifier.
+    pub session_id: String,
+    /// Current worker fencing token.
+    pub lock_id: Uuid,
+    /// Worker identifier that owns the claim.
+    pub worker_id: String,
+    /// Backend session type being recorded.
+    pub session_type: SessionType,
+    /// Backend-issued session identifier to persist.
+    pub backend_session_id: String,
+    /// Backend session lifecycle state to persist.
+    pub status: SessionStatus,
+    /// Failure reason to persist, typically set alongside a `Failed` status.
+    pub error_message: Option<String>,
+}
+
+/// Outcome of attempting to record a backend session for a worker job.
+#[derive(Debug, Clone)]
+pub enum RecordSessionOutcome {
+    /// The session was inserted or updated and the active row is returned.
+    Recorded(ProofSession),
+    /// No proof job exists for the supplied `session_id`.
+    NotFound,
+    /// The job exists but is not currently claimed.
+    NotClaimed,
+    /// The supplied `worker_id` or `lock_id` no longer owns the job.
+    StaleLock,
+    /// The supplied lock matched the job, but it had already expired.
+    Expired,
+    /// The job is already terminal.
+    Terminal,
+}
+
 /// Result of checking a worker's fencing token against a claimed job's lock.
 ///
 /// Shared by `heartbeat_proof_job` and `record_worker_proof_session` so both

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -131,6 +131,11 @@ impl SessionStatus {
             Self::Failed => "FAILED",
         }
     }
+
+    /// Whether this status represents a terminal backend session.
+    pub const fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed)
+    }
 }
 
 impl std::fmt::Display for SessionStatus {
@@ -1125,6 +1130,8 @@ pub enum RecordSessionOutcome {
     Expired,
     /// The job is already terminal.
     Terminal,
+    /// The requested session status is terminal and must be coordinated with job completion.
+    TerminalSessionStatus,
 }
 
 /// Result of checking a worker's fencing token against a claimed job's lock.

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -10,9 +10,9 @@ use crate::{
     CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
     CreateProofRequestValidationError, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
     HeartbeatProofJob, JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
-    canonical_session_id,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome,
+    SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
+    WorkerSessionUpsert, ZkVmKind, canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -1088,6 +1088,135 @@ impl ProofRequestRepo {
         .await?;
 
         row.map(|r| row_to_proof_session(&r)).transpose()
+    }
+
+    /// Record (insert or update) the backend session for a claimed worker job.
+    ///
+    /// Authorized via the worker fencing token like [`Self::heartbeat_proof_job`],
+    /// then upserts the single active `(proof_request_id, session_type)` row
+    /// guarded by migration `009`'s partial unique index.
+    pub async fn record_worker_proof_session(
+        &self,
+        req: WorkerSessionUpsert,
+    ) -> Result<RecordSessionOutcome> {
+        let session_id = canonical_session_id(&req.session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+
+        // Captured before the `FOR UPDATE` read, which can block under contention,
+        // so the expiry comparison can't drift past `lock_expires_at` while waiting.
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+
+        let claim = sqlx::query(
+            r#"
+            SELECT id, job_status, lock_id, worker_id, lock_expires_at
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(&session_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(claim) = claim else {
+            return Ok(RecordSessionOutcome::NotFound);
+        };
+
+        let proof_request_id: Uuid = claim.get("id");
+        let job_status_str: &str = claim.get("job_status");
+        let job_status = ProofJobStatus::try_from(job_status_str).map_err(|e| {
+            sqlx::Error::Protocol(format!("Unknown job_status '{job_status_str}': {e}"))
+        })?;
+        let lock_id: Option<Uuid> = claim.get("lock_id");
+        let worker_id: Option<String> = claim.get("worker_id");
+        let lock_expires_at: Option<chrono::DateTime<Utc>> = claim.get("lock_expires_at");
+
+        match ClaimAuth::classify(
+            JobLockState {
+                status: job_status,
+                lock_id,
+                worker_id: worker_id.as_deref(),
+                lock_expires_at,
+            },
+            req.lock_id,
+            &req.worker_id,
+            now,
+        ) {
+            ClaimAuth::Authorized => {}
+            ClaimAuth::Terminal => return Ok(RecordSessionOutcome::Terminal),
+            ClaimAuth::NotClaimed => return Ok(RecordSessionOutcome::NotClaimed),
+            ClaimAuth::StaleLock => return Ok(RecordSessionOutcome::StaleLock),
+            ClaimAuth::Expired => return Ok(RecordSessionOutcome::Expired),
+        }
+
+        // `FOR UPDATE` above serializes the find-then-write: only the lock holder
+        // reaches here, so at most one active row exists per session type.
+        let active_id: Option<i64> = sqlx::query(
+            r#"
+            SELECT id
+            FROM proof_sessions
+            WHERE proof_request_id = $1
+              AND session_type = $2
+              AND status IN ('SUBMITTING', 'RUNNING')
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(req.session_type.as_str())
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(|r| r.get("id"));
+
+        let row = if let Some(active_id) = active_id {
+            sqlx::query(
+                r#"
+                UPDATE proof_sessions
+                SET backend_session_id = $1,
+                    status = $2,
+                    error_message = $4,
+                    completed_at = CASE
+                        WHEN $2 IN ('COMPLETED', 'FAILED') THEN NOW()
+                        ELSE completed_at
+                    END
+                WHERE id = $3
+                RETURNING id, proof_request_id, session_type, backend_session_id,
+                          status, error_message, metadata, created_at, completed_at
+                "#,
+            )
+            .bind(&req.backend_session_id)
+            .bind(req.status.as_str())
+            .bind(active_id)
+            .bind(&req.error_message)
+            .fetch_one(&mut *tx)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                INSERT INTO proof_sessions (
+                    proof_request_id, session_type, backend_session_id, status, error_message,
+                    metadata, completed_at
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, NULL,
+                    CASE WHEN $4 IN ('COMPLETED', 'FAILED') THEN NOW() ELSE NULL END
+                )
+                RETURNING id, proof_request_id, session_type, backend_session_id,
+                          status, error_message, metadata, created_at, completed_at
+                "#,
+            )
+            .bind(proof_request_id)
+            .bind(req.session_type.as_str())
+            .bind(&req.backend_session_id)
+            .bind(req.status.as_str())
+            .bind(&req.error_message)
+            .fetch_one(&mut *tx)
+            .await?
+        };
+
+        let session = row_to_proof_session(&row)?;
+        tx.commit().await?;
+
+        Ok(RecordSessionOutcome::Recorded(session))
     }
 
     /// Get all running sessions (for polling)

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1099,6 +1099,10 @@ impl ProofRequestRepo {
         &self,
         req: WorkerSessionUpsert,
     ) -> Result<RecordSessionOutcome> {
+        if req.status.is_terminal() {
+            return Ok(RecordSessionOutcome::TerminalSessionStatus);
+        }
+
         let session_id = canonical_session_id(&req.session_id)
             .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
 
@@ -1173,11 +1177,7 @@ impl ProofRequestRepo {
                 UPDATE proof_sessions
                 SET backend_session_id = $1,
                     status = $2,
-                    error_message = $4,
-                    completed_at = CASE
-                        WHEN $2 IN ('COMPLETED', 'FAILED') THEN NOW()
-                        ELSE completed_at
-                    END
+                    error_message = $4
                 WHERE id = $3
                 RETURNING id, proof_request_id, session_type, backend_session_id,
                           status, error_message, metadata, created_at, completed_at
@@ -1197,8 +1197,7 @@ impl ProofRequestRepo {
                     metadata, completed_at
                 )
                 VALUES (
-                    $1, $2, $3, $4, $5, NULL,
-                    CASE WHEN $4 IN ('COMPLETED', 'FAILED') THEN NOW() ELSE NULL END
+                    $1, $2, $3, $4, $5, NULL, NULL
                 )
                 RETURNING id, proof_request_id, session_type, backend_session_id,
                           status, error_message, metadata, created_at, completed_at


### PR DESCRIPTION
## Summary
Third of a 4-PR stack. Adds `ProofRequestRepo::record_worker_proof_session` so an external stateless worker can persist its backend-issued session id (e.g. an SP1 cluster/network proof id) against a claimed job, enabling resume across restarts and reclaims.

- **models**: `WorkerSessionUpsert` input and `RecordSessionOutcome` result
- **repo**: the upsert authorizes via `ClaimAuth` (worker fencing token), then inserts or updates the single active `(proof_request_id, session_type)` row, also transitioning an active row to a terminal state

Integration tests for these paths are in #3380 (next in the stack).

## Stack
1. extract `ClaimAuth` — #3377
2. add `get_active_session` — #3378
3. **this PR** — lock-guarded worker session upsert (base: `mw2000/get-active-session`)
4. integration tests — #3380

The worker-facing RPC/protocol/client wiring that exposes these methods lands separately, alongside its zk-host consumer.