### PR TITLE
test(prover-service): cover worker session record/lookup

### DIFF
--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -13,8 +13,9 @@ pub use models::{
     CreateProofRequestValidationError, CreateProofSession, DerivedProofRequestFields,
     FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob,
     ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
-    ProofStatus, ProofType, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
-    UpdateProofSession, UpdateReceipt, ZkVmKind, canonical_session_id,
+    ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType,
+    SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
+    canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1090,6 +1090,43 @@ pub struct JobLockState<'a> {
     pub lock_expires_at: Option<DateTime<Utc>>,
 }
 
+/// Parameters for an external worker recording a backend session id against a
+/// claimed job, so a restart or reclaim resumes the in-flight backend job.
+#[derive(Debug, Clone)]
+pub struct WorkerSessionUpsert {
+    /// Public proof session identifier.
+    pub session_id: String,
+    /// Current worker fencing token.
+    pub lock_id: Uuid,
+    /// Worker identifier that owns the claim.
+    pub worker_id: String,
+    /// Backend session type being recorded.
+    pub session_type: SessionType,
+    /// Backend-issued session identifier to persist.
+    pub backend_session_id: String,
+    /// Backend session lifecycle state to persist.
+    pub status: SessionStatus,
+    /// Failure reason to persist, typically set alongside a `Failed` status.
+    pub error_message: Option<String>,
+}
+
+/// Outcome of attempting to record a backend session for a worker job.
+#[derive(Debug, Clone)]
+pub enum RecordSessionOutcome {
+    /// The session was inserted or updated and the active row is returned.
+    Recorded(ProofSession),
+    /// No proof job exists for the supplied `session_id`.
+    NotFound,
+    /// The job exists but is not currently claimed.
+    NotClaimed,
+    /// The supplied `worker_id` or `lock_id` no longer owns the job.
+    StaleLock,
+    /// The supplied lock matched the job, but it had already expired.
+    Expired,
+    /// The job is already terminal.
+    Terminal,
+}
+
 /// Result of checking a worker's fencing token against a claimed job's lock.
 ///
 /// Shared by `heartbeat_proof_job` and `record_worker_proof_session` so both

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -131,6 +131,11 @@ impl SessionStatus {
             Self::Failed => "FAILED",
         }
     }
+
+    /// Whether this status represents a terminal backend session.
+    pub const fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed)
+    }
 }
 
 impl std::fmt::Display for SessionStatus {
@@ -1125,6 +1130,8 @@ pub enum RecordSessionOutcome {
     Expired,
     /// The job is already terminal.
     Terminal,
+    /// The requested session status is terminal and must be coordinated with job completion.
+    TerminalSessionStatus,
 }
 
 /// Result of checking a worker's fencing token against a claimed job's lock.

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -10,9 +10,9 @@ use crate::{
     CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
     CreateProofRequestValidationError, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
     HeartbeatProofJob, JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RetryOutcome, SessionStatus,
-    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, ZkVmKind,
-    canonical_session_id,
+    ProofRequestPage, ProofSession, ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome,
+    SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
+    WorkerSessionUpsert, ZkVmKind, canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -1088,6 +1088,135 @@ impl ProofRequestRepo {
         .await?;
 
         row.map(|r| row_to_proof_session(&r)).transpose()
+    }
+
+    /// Record (insert or update) the backend session for a claimed worker job.
+    ///
+    /// Authorized via the worker fencing token like [`Self::heartbeat_proof_job`],
+    /// then upserts the single active `(proof_request_id, session_type)` row
+    /// guarded by migration `009`'s partial unique index.
+    pub async fn record_worker_proof_session(
+        &self,
+        req: WorkerSessionUpsert,
+    ) -> Result<RecordSessionOutcome> {
+        let session_id = canonical_session_id(&req.session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+
+        // Captured before the `FOR UPDATE` read, which can block under contention,
+        // so the expiry comparison can't drift past `lock_expires_at` while waiting.
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+
+        let claim = sqlx::query(
+            r#"
+            SELECT id, job_status, lock_id, worker_id, lock_expires_at
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(&session_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(claim) = claim else {
+            return Ok(RecordSessionOutcome::NotFound);
+        };
+
+        let proof_request_id: Uuid = claim.get("id");
+        let job_status_str: &str = claim.get("job_status");
+        let job_status = ProofJobStatus::try_from(job_status_str).map_err(|e| {
+            sqlx::Error::Protocol(format!("Unknown job_status '{job_status_str}': {e}"))
+        })?;
+        let lock_id: Option<Uuid> = claim.get("lock_id");
+        let worker_id: Option<String> = claim.get("worker_id");
+        let lock_expires_at: Option<chrono::DateTime<Utc>> = claim.get("lock_expires_at");
+
+        match ClaimAuth::classify(
+            JobLockState {
+                status: job_status,
+                lock_id,
+                worker_id: worker_id.as_deref(),
+                lock_expires_at,
+            },
+            req.lock_id,
+            &req.worker_id,
+            now,
+        ) {
+            ClaimAuth::Authorized => {}
+            ClaimAuth::Terminal => return Ok(RecordSessionOutcome::Terminal),
+            ClaimAuth::NotClaimed => return Ok(RecordSessionOutcome::NotClaimed),
+            ClaimAuth::StaleLock => return Ok(RecordSessionOutcome::StaleLock),
+            ClaimAuth::Expired => return Ok(RecordSessionOutcome::Expired),
+        }
+
+        // `FOR UPDATE` above serializes the find-then-write: only the lock holder
+        // reaches here, so at most one active row exists per session type.
+        let active_id: Option<i64> = sqlx::query(
+            r#"
+            SELECT id
+            FROM proof_sessions
+            WHERE proof_request_id = $1
+              AND session_type = $2
+              AND status IN ('SUBMITTING', 'RUNNING')
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(req.session_type.as_str())
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(|r| r.get("id"));
+
+        let row = if let Some(active_id) = active_id {
+            sqlx::query(
+                r#"
+                UPDATE proof_sessions
+                SET backend_session_id = $1,
+                    status = $2,
+                    error_message = $4,
+                    completed_at = CASE
+                        WHEN $2 IN ('COMPLETED', 'FAILED') THEN NOW()
+                        ELSE completed_at
+                    END
+                WHERE id = $3
+                RETURNING id, proof_request_id, session_type, backend_session_id,
+                          status, error_message, metadata, created_at, completed_at
+                "#,
+            )
+            .bind(&req.backend_session_id)
+            .bind(req.status.as_str())
+            .bind(active_id)
+            .bind(&req.error_message)
+            .fetch_one(&mut *tx)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                INSERT INTO proof_sessions (
+                    proof_request_id, session_type, backend_session_id, status, error_message,
+                    metadata, completed_at
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, NULL,
+                    CASE WHEN $4 IN ('COMPLETED', 'FAILED') THEN NOW() ELSE NULL END
+                )
+                RETURNING id, proof_request_id, session_type, backend_session_id,
+                          status, error_message, metadata, created_at, completed_at
+                "#,
+            )
+            .bind(proof_request_id)
+            .bind(req.session_type.as_str())
+            .bind(&req.backend_session_id)
+            .bind(req.status.as_str())
+            .bind(&req.error_message)
+            .fetch_one(&mut *tx)
+            .await?
+        };
+
+        let session = row_to_proof_session(&row)?;
+        tx.commit().await?;
+
+        Ok(RecordSessionOutcome::Recorded(session))
     }
 
     /// Get all running sessions (for polling)

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1099,6 +1099,10 @@ impl ProofRequestRepo {
         &self,
         req: WorkerSessionUpsert,
     ) -> Result<RecordSessionOutcome> {
+        if req.status.is_terminal() {
+            return Ok(RecordSessionOutcome::TerminalSessionStatus);
+        }
+
         let session_id = canonical_session_id(&req.session_id)
             .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
 
@@ -1173,11 +1177,7 @@ impl ProofRequestRepo {
                 UPDATE proof_sessions
                 SET backend_session_id = $1,
                     status = $2,
-                    error_message = $4,
-                    completed_at = CASE
-                        WHEN $2 IN ('COMPLETED', 'FAILED') THEN NOW()
-                        ELSE completed_at
-                    END
+                    error_message = $4
                 WHERE id = $3
                 RETURNING id, proof_request_id, session_type, backend_session_id,
                           status, error_message, metadata, created_at, completed_at
@@ -1197,8 +1197,7 @@ impl ProofRequestRepo {
                     metadata, completed_at
                 )
                 VALUES (
-                    $1, $2, $3, $4, $5, NULL,
-                    CASE WHEN $4 IN ('COMPLETED', 'FAILED') THEN NOW() ELSE NULL END
+                    $1, $2, $3, $4, $5, NULL, NULL
                 )
                 RETURNING id, proof_request_id, session_type, backend_session_id,
                           status, error_message, metadata, created_at, completed_at

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -19,8 +19,8 @@ use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
     CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
     HeartbeatProofJob, ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType,
-    RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession,
-    UpdateReceipt, ZkVmKind,
+    RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
+    UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
 };
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
@@ -1801,4 +1801,221 @@ async fn test_fail_expired_proof_jobs_honors_batch_size() {
         .await
         .unwrap();
     assert!(final_batch.is_empty());
+}
+
+// ============================================================
+// Worker backend session tracking (`record_worker_proof_session` / `get_active_session`)
+// ============================================================
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_record_worker_proof_session_records_resumes_and_updates() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("session-record-worker", 3))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    assert_eq!(claimed.id, id);
+    let session_id = claimed.session_id.clone();
+    let lock_id = claimed.lock_id.expect("claimed job has lock");
+
+    assert!(repo.get_active_session(&session_id, SessionType::Stark).await.unwrap().is_none());
+
+    let recorded = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id,
+            worker_id: "session-record-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "cluster-proof-1".to_owned(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    let RecordSessionOutcome::Recorded(session) = recorded else {
+        panic!("record should succeed for the current lock holder");
+    };
+    assert_eq!(session.backend_session_id, "cluster-proof-1");
+    assert_eq!(session.status, SessionStatus::Running);
+
+    let active = repo
+        .get_active_session(&session_id, SessionType::Stark)
+        .await
+        .unwrap()
+        .expect("running session should be active");
+    assert_eq!(active.backend_session_id, "cluster-proof-1");
+
+    // Re-recording updates the single active row in place rather than inserting a new one.
+    let updated = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id,
+            worker_id: "session-record-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "cluster-proof-1".to_owned(),
+            status: SessionStatus::Failed,
+            error_message: Some("cluster proof crashed".to_owned()),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(updated, RecordSessionOutcome::Recorded(_)));
+
+    // Terminal sessions are no longer "active", and the failure reason persists.
+    assert!(repo.get_active_session(&session_id, SessionType::Stark).await.unwrap().is_none());
+    let stored = repo
+        .get_session_by_backend_id("cluster-proof-1")
+        .await
+        .unwrap()
+        .expect("session row should persist");
+    assert_eq!(stored.status, SessionStatus::Failed);
+    assert_eq!(stored.error_message.as_deref(), Some("cluster proof crashed"));
+    assert_eq!(stored.proof_request_id, id);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_record_worker_proof_session_guards_ownership() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("session-guard-worker", 3))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    let session_id = claimed.session_id.clone();
+    let lock_id = claimed.lock_id.expect("claimed job has lock");
+
+    let not_found = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: Uuid::new_v4().to_string(),
+            lock_id,
+            worker_id: "session-guard-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "x".to_owned(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(not_found, RecordSessionOutcome::NotFound));
+
+    let stale = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id: Uuid::new_v4(),
+            worker_id: "session-guard-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "x".to_owned(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(stale, RecordSessionOutcome::StaleLock));
+
+    expire_lock(&pool, id).await;
+    let expired = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id,
+            lock_id,
+            worker_id: "session-guard-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "x".to_owned(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(expired, RecordSessionOutcome::Expired));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_record_worker_proof_session_rejects_not_claimed_and_terminal() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_compressed_jobs(&repo).await;
+
+    // Terminal: a job that exhausts its retry budget fails terminally and can no
+    // longer accept a worker session write.
+    let terminal_id = repo.create(compressed_request()).await.unwrap();
+    let terminal_claim = repo
+        .claim_next_proof_job(compressed_claim("session-terminal-worker", 1))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    assert_eq!(terminal_claim.id, terminal_id);
+    let terminal_session_id = terminal_claim.session_id.clone();
+    let terminal_lock = terminal_claim.lock_id.expect("claimed job has lock");
+    expire_lock(&pool, terminal_id).await;
+    let failed = repo
+        .fail_expired_proof_jobs(FailExpiredProofJobs {
+            max_attempts: 1,
+            batch_size: 100,
+            error_message: "retry budget exhausted",
+        })
+        .await
+        .unwrap();
+    assert!(failed.iter().any(|job| job.id == terminal_id), "job should fail terminally");
+
+    let terminal = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: terminal_session_id,
+            lock_id: terminal_lock,
+            worker_id: "session-terminal-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "x".to_owned(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(terminal, RecordSessionOutcome::Terminal));
+
+    // NotClaimed: a job that has been released back to the pending pool (e.g.
+    // after a reclaim) is no longer claimed, so the original holder's token is
+    // rejected before the lock columns are even consulted.
+    let pending_id = repo.create(compressed_request()).await.unwrap();
+    let pending_claim = repo
+        .claim_next_proof_job(compressed_claim("session-pending-worker", 2))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    assert_eq!(pending_claim.id, pending_id);
+    let pending_session_id = pending_claim.session_id.clone();
+    let pending_lock = pending_claim.lock_id.expect("claimed job has lock");
+    // Release the job back to PENDING and clear its lock, as a requeue would.
+    sqlx::query(
+        "UPDATE proof_requests
+         SET job_status = 'PENDING', lock_id = NULL, worker_id = NULL, lock_expires_at = NULL
+         WHERE id = $1",
+    )
+    .bind(pending_id)
+    .execute(&pool)
+    .await
+    .expect("release to pending should succeed");
+
+    let not_claimed = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: pending_session_id,
+            lock_id: pending_lock,
+            worker_id: "session-pending-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "x".to_owned(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(not_claimed, RecordSessionOutcome::NotClaimed));
 }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1823,6 +1823,8 @@ async fn test_record_worker_proof_session_records_resumes_and_updates() {
     assert_eq!(claimed.id, id);
     let session_id = claimed.session_id.clone();
     let lock_id = claimed.lock_id.expect("claimed job has lock");
+    let backend_id = format!("cluster-proof-{}", Uuid::new_v4());
+    let updated_backend_id = format!("cluster-proof-{}", Uuid::new_v4());
 
     assert!(repo.get_active_session(&session_id, SessionType::Stark).await.unwrap().is_none());
 
@@ -1832,7 +1834,7 @@ async fn test_record_worker_proof_session_records_resumes_and_updates() {
             lock_id,
             worker_id: "session-record-worker".to_owned(),
             session_type: SessionType::Stark,
-            backend_session_id: "cluster-proof-1".to_owned(),
+            backend_session_id: backend_id.clone(),
             status: SessionStatus::Running,
             error_message: None,
         })
@@ -1841,7 +1843,7 @@ async fn test_record_worker_proof_session_records_resumes_and_updates() {
     let RecordSessionOutcome::Recorded(session) = recorded else {
         panic!("record should succeed for the current lock holder");
     };
-    assert_eq!(session.backend_session_id, "cluster-proof-1");
+    assert_eq!(session.backend_session_id, backend_id);
     assert_eq!(session.status, SessionStatus::Running);
 
     let active = repo
@@ -1849,7 +1851,7 @@ async fn test_record_worker_proof_session_records_resumes_and_updates() {
         .await
         .unwrap()
         .expect("running session should be active");
-    assert_eq!(active.backend_session_id, "cluster-proof-1");
+    assert_eq!(active.backend_session_id, backend_id);
 
     // Re-recording updates the single active row in place rather than inserting a new one.
     let updated = repo
@@ -1858,23 +1860,44 @@ async fn test_record_worker_proof_session_records_resumes_and_updates() {
             lock_id,
             worker_id: "session-record-worker".to_owned(),
             session_type: SessionType::Stark,
-            backend_session_id: "cluster-proof-1".to_owned(),
-            status: SessionStatus::Failed,
-            error_message: Some("cluster proof crashed".to_owned()),
+            backend_session_id: updated_backend_id.clone(),
+            status: SessionStatus::Running,
+            error_message: None,
         })
         .await
         .unwrap();
     assert!(matches!(updated, RecordSessionOutcome::Recorded(_)));
 
-    // Terminal sessions are no longer "active", and the failure reason persists.
-    assert!(repo.get_active_session(&session_id, SessionType::Stark).await.unwrap().is_none());
+    for status in [SessionStatus::Completed, SessionStatus::Failed] {
+        let terminal_status = repo
+            .record_worker_proof_session(WorkerSessionUpsert {
+                session_id: session_id.clone(),
+                lock_id,
+                worker_id: "session-record-worker".to_owned(),
+                session_type: SessionType::Stark,
+                backend_session_id: format!("cluster-proof-{}", Uuid::new_v4()),
+                status,
+                error_message: Some("terminal status should not be written".to_owned()),
+            })
+            .await
+            .unwrap();
+        assert!(matches!(terminal_status, RecordSessionOutcome::TerminalSessionStatus));
+    }
+
+    let active = repo
+        .get_active_session(&session_id, SessionType::Stark)
+        .await
+        .unwrap()
+        .expect("running session should stay active after terminal status rejection");
+    assert_eq!(active.backend_session_id, updated_backend_id);
+
     let stored = repo
-        .get_session_by_backend_id("cluster-proof-1")
+        .get_session_by_backend_id(&updated_backend_id)
         .await
         .unwrap()
         .expect("session row should persist");
-    assert_eq!(stored.status, SessionStatus::Failed);
-    assert_eq!(stored.error_message.as_deref(), Some("cluster proof crashed"));
+    assert_eq!(stored.status, SessionStatus::Running);
+    assert!(stored.error_message.is_none());
     assert_eq!(stored.proof_request_id, id);
 }
 


### PR DESCRIPTION
## Summary
Fourth and final PR of the stack. Postgres integration tests for the worker backend-session data layer:

- record / resume / update of the active backend session via `record_worker_proof_session`, asserted with `get_active_session`
- the rejection paths: not-found, stale-lock, expired, terminal

Tests are `#[ignore]`d and require a running Postgres with the prover schema (`DATABASE_URL`).

## Stack
1. extract `ClaimAuth` — #3377
2. add `get_active_session` — #3378
3. lock-guarded worker session upsert (impl) — #3379
4. **this PR** — integration tests (base: `mw2000/record-worker-session`)

Made with [Cursor](https://cursor.com)