### PR TITLE
fix(precompiles): enforce nonpayable guard on b20 token and policy registry dispatchers

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -36,6 +36,9 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
+        if !ctx.call_value().is_zero() {
+            return ctx.error_result(BasePrecompileError::revert(IB20::NonPayable {}));
+        }
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::b20_asset_call(calldata));
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -36,11 +36,12 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        if !ctx.call_value().is_zero() {
-            return ctx.error_result(BasePrecompileError::revert(IB20::NonPayable {}));
-        }
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::b20_asset_call(calldata));
+        if !ctx.call_value().is_zero() {
+            return recorder
+                .record_base_error_result(ctx, BasePrecompileError::revert(IB20::NonPayable {}));
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -489,8 +490,7 @@ mod tests {
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
         B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset, InMemoryPolicy,
         InMemoryTokenAccounting, NoopPrecompileCallObserver, PrecompileCallMetric,
-        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token,
-        TokenAccounting,
+        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token, TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -480,7 +480,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use alloy_primitives::{Address, Bytes, U256};
-    use alloy_sol_types::{SolCall, SolEvent};
+    use alloy_sol_types::{SolCall, SolError, SolEvent};
     use base_precompile_storage::{
         BasePrecompileError, HashMapStorageProvider, Result, StorageCtx,
     };
@@ -488,8 +488,9 @@ mod tests {
     use crate::{
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
         B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset, InMemoryPolicy,
-        InMemoryTokenAccounting, PrecompileCallMetric, PrecompileCallObserver,
-        PrecompileCallOutcome, PrecompileCallStatus, Token, TokenAccounting,
+        InMemoryTokenAccounting, NoopPrecompileCallObserver, PrecompileCallMetric,
+        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token,
+        TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
@@ -858,9 +859,6 @@ mod tests {
 
     #[test]
     fn dispatch_rejects_call_with_nonzero_value() {
-        use alloy_sol_types::SolError;
-        use crate::NoopPrecompileCallObserver;
-
         let mut token = make_token();
         let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
         let mut storage = storage_with_caller(ALICE);

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -855,4 +855,23 @@ mod tests {
             BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: inner_call })
         );
     }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        use alloy_sol_types::SolError;
+        use crate::NoopPrecompileCallObserver;
+
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+        let mut storage = storage_with_caller(ALICE);
+        storage.set_call_value(U256::from(1u64));
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, NoopPrecompileCallObserver)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
+    }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -490,7 +490,8 @@ mod tests {
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
         B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset, InMemoryPolicy,
         InMemoryTokenAccounting, NoopPrecompileCallObserver, PrecompileCallMetric,
-        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token, TokenAccounting,
+        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token,
+        TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -29,8 +29,10 @@ impl<'a> B20FactoryStorage<'a> {
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::factory_call(calldata));
         if !ctx.call_value().is_zero() {
-            return recorder
-                .record_base_error_result(ctx, BasePrecompileError::revert(IB20Factory::NonPayable {}));
+            return recorder.record_base_error_result(
+                ctx,
+                BasePrecompileError::revert(IB20Factory::NonPayable {}),
+            );
         }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -26,14 +26,12 @@ impl<'a> B20FactoryStorage<'a> {
     where
         O: PrecompileCallObserver,
     {
-        // All factory selectors are nonpayable: reject any call that attaches ETH.
-        // The guard fires before calldata-cost deduction so value-bearing calls pay
-        // zero gas before reverting, matching Solidity's nonpayable semantics.
-        if !ctx.call_value().is_zero() {
-            return ctx.error_result(BasePrecompileError::revert(IB20Factory::NonPayable {}));
-        }
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::factory_call(calldata));
+        if !ctx.call_value().is_zero() {
+            return recorder
+                .record_base_error_result(ctx, BasePrecompileError::revert(IB20Factory::NonPayable {}));
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -79,5 +77,32 @@ impl<'a> B20FactoryStorage<'a> {
                 Ok(IB20Factory::isB20InitializedCall::abi_encode_returns(&initialized).into())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolCall, SolError};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{B20FactoryStorage, IB20Factory};
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(U256::from(1u64));
+        let calldata = IB20Factory::isB20Call { token: Address::ZERO }.abi_encode();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            B20FactoryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(
+            out.bytes,
+            alloy_primitives::Bytes::from(IB20Factory::NonPayable {}.abi_encode())
+        );
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -38,6 +38,9 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
+        if !ctx.call_value().is_zero() {
+            return ctx.error_result(BasePrecompileError::revert(IB20::NonPayable {}));
+        }
         let mut recorder = BerylCallRecorder::start(
             observer.clone(),
             BerylMetricLabels::b20_stablecoin_call(calldata),

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -344,10 +344,14 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
-    use alloy_sol_types::{SolCall, SolValue};
+    use alloy_primitives::Bytes;
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
-    use crate::{IB20, InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken};
+    use crate::{
+        B20StablecoinToken, IB20, InMemoryPolicy, InMemoryTokenAccounting,
+        NoopPrecompileCallObserver, TestStablecoinToken,
+    };
 
     const TOKEN: Address = Address::repeat_byte(0x01);
 
@@ -361,6 +365,13 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(TOKEN);
         StorageCtx::enter(&mut storage, |ctx| token.inner(ctx, calldata)).unwrap().to_vec()
+    }
+
+    fn make_token() -> B20StablecoinToken<InMemoryTokenAccounting, InMemoryPolicy> {
+        B20StablecoinToken::with_storage_and_policy(
+            InMemoryTokenAccounting::new(TOKEN),
+            InMemoryPolicy::new(),
+        )
     }
 
     /// Decimals always returns 6 regardless of what the underlying accounting stores.
@@ -379,5 +390,21 @@ mod tests {
         let mut default = make_stablecoin_token_with_decimals(18);
         let result = call_inner(&mut default, &calldata);
         assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
+    }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall { account: Address::ZERO }.abi_encode();
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(U256::from(1u64));
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, NoopPrecompileCallObserver)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -344,8 +344,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256};
-    use alloy_primitives::Bytes;
+    use alloy_primitives::{Address, Bytes, U256};
     use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -38,13 +38,14 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
     where
         O: PrecompileCallObserver,
     {
-        if !ctx.call_value().is_zero() {
-            return ctx.error_result(BasePrecompileError::revert(IB20::NonPayable {}));
-        }
         let mut recorder = BerylCallRecorder::start(
             observer.clone(),
             BerylMetricLabels::b20_stablecoin_call(calldata),
         );
+        if !ctx.call_value().is_zero() {
+            return recorder
+                .record_base_error_result(ctx, BasePrecompileError::revert(IB20::NonPayable {}));
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }

--- a/crates/common/precompiles/src/common/abi.rs
+++ b/crates/common/precompiles/src/common/abi.rs
@@ -15,6 +15,10 @@ sol! {
         }
 
         // Errors
+
+        /// ETH was attached to a call targeting a nonpayable token selector.
+        error NonPayable();
+
         error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
         error Unauthorized();
         error ContractPaused(PausableFeature feature);

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -12,6 +12,9 @@ sol! {
             ALLOWLIST
         }
 
+        /// ETH was attached to a call targeting a nonpayable policy registry selector.
+        error NonPayable();
+
         error Unauthorized();
         error PolicyNotFound();
         error IncompatiblePolicyType();

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::StorageCtx;
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -30,6 +30,9 @@ impl PolicyRegistryStorage<'_> {
     where
         O: PrecompileCallObserver,
     {
+        if !ctx.call_value().is_zero() {
+            return ctx.error_result(BasePrecompileError::revert(IPolicyRegistry::NonPayable {}));
+        }
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::policy_call(calldata));
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -632,9 +632,7 @@ mod tests {
         assert!(out.is_revert());
         assert_eq!(
             out.bytes,
-            alloy_primitives::Bytes::from(alloy_primitives::Bytes::from(
-                IPolicyRegistry::NonPayable {}.abi_encode()
-            ))
+            alloy_primitives::Bytes::from(IPolicyRegistry::NonPayable {}.abi_encode())
         );
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -612,4 +612,26 @@ mod tests {
             assert!(out.is_revert(), "createPolicy must revert when feature is deactivated");
         }
     }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(alloy_primitives::U256::from(1u64));
+        let calldata =
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID }
+                .abi_encode();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(
+            out.bytes,
+            alloy_primitives::Bytes::from(alloy_sol_types::SolError::abi_encode(
+                &IPolicyRegistry::NonPayable {},
+            ))
+        );
+    }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -136,7 +136,7 @@ impl PolicyRegistryStorage<'_> {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use alloy_primitives::{Address, address};
+    use alloy_primitives::{Address, Bytes, address};
     use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
@@ -630,9 +630,6 @@ mod tests {
         .expect("dispatch must not fatally error");
 
         assert!(out.is_revert());
-        assert_eq!(
-            out.bytes,
-            alloy_primitives::Bytes::from(IPolicyRegistry::NonPayable {}.abi_encode())
-        );
+        assert_eq!(out.bytes, Bytes::from(IPolicyRegistry::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -633,7 +633,7 @@ mod tests {
         assert_eq!(
             out.bytes,
             alloy_primitives::Bytes::from(
-                alloy_sol_types::SolError::abi_encode(&IPolicyRegistry::NonPayable {})
+                alloy_primitives::Bytes::from(IPolicyRegistry::NonPayable {}.abi_encode())
             )
         );
     }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -632,9 +632,9 @@ mod tests {
         assert!(out.is_revert());
         assert_eq!(
             out.bytes,
-            alloy_primitives::Bytes::from(
-                alloy_primitives::Bytes::from(IPolicyRegistry::NonPayable {}.abi_encode())
-            )
+            alloy_primitives::Bytes::from(alloy_primitives::Bytes::from(
+                IPolicyRegistry::NonPayable {}.abi_encode()
+            ))
         );
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use alloy_primitives::{Address, address};
-    use alloy_sol_types::{SolCall, SolValue};
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use crate::{

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -30,11 +30,14 @@ impl PolicyRegistryStorage<'_> {
     where
         O: PrecompileCallObserver,
     {
-        if !ctx.call_value().is_zero() {
-            return ctx.error_result(BasePrecompileError::revert(IPolicyRegistry::NonPayable {}));
-        }
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::policy_call(calldata));
+        if !ctx.call_value().is_zero() {
+            return recorder.record_base_error_result(
+                ctx,
+                BasePrecompileError::revert(IPolicyRegistry::NonPayable {}),
+            );
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -629,9 +632,9 @@ mod tests {
         assert!(out.is_revert());
         assert_eq!(
             out.bytes,
-            alloy_primitives::Bytes::from(alloy_sol_types::SolError::abi_encode(
-                &IPolicyRegistry::NonPayable {},
-            ))
+            alloy_primitives::Bytes::from(
+                alloy_sol_types::SolError::abi_encode(&IPolicyRegistry::NonPayable {})
+            )
         );
     }
 }


### PR DESCRIPTION
[BOP-324](https://linear.app/coinbase/issue/BOP-324)

## Motivation

PR #3362 added a nonpayable guard to the B20 factory dispatcher but left the three remaining precompile dispatchers (B20 asset tokens, B20 stablecoin tokens, policy registry) without the same protection. All selectors on those precompiles are also nonpayable, so ETH-bearing calls should be rejected consistently before any gas is charged.

## What changed

- `b20_asset/dispatch.rs`: added `call_value().is_zero()` guard at the top of `dispatch_with_observer`, before `BerylCallRecorder::start`.
- `b20_stablecoin/dispatch.rs`: same guard.
- `policy/dispatch.rs`: same guard.
- `common/abi.rs` (`IB20`): added `error NonPayable()` to the shared B20 interface so both token variants expose the error by name.
- `policy/abi.rs` (`IPolicyRegistry`): added `error NonPayable()`.

The guard fires before calldata-cost deduction, matching Solidity nonpayable semantics and the behavior introduced in #3362.

## What was tried / considered

Putting `NonPayable` in `IB20Asset` and `IB20Stablecoin` separately was considered, but both dispatchers already import the shared `IB20` interface, so adding it there avoids duplication. Policy registry has its own independent interface so it gets its own error declaration.