### PR TITLE
fix(b20-stablecoin): hard-code decimals to 6 to eliminate zero-return window

### DIFF
--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -13,8 +13,8 @@ use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20StablecoinToken, B20TokenRole, BerylCallRecorder, BerylMetricLabels, BerylSelector,
-    Burnable, Configurable,
+    B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder, BerylMetricLabels,
+    BerylSelector, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -124,7 +124,16 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
                 // --- Pure reads: direct to accounting ---
                 C::name(_) => self.accounting().name()?.abi_encode().into(),
                 C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
-                C::decimals(_) => U256::from(self.accounting().decimals()?).abi_encode().into(),
+                // Stablecoin precision is fixed at 6 by the protocol spec; never read from
+                // storage to avoid the zero-return window during the factory bootstrap
+                // (BOP-349/PSRC-27).
+                C::decimals(_) => U256::from(
+                    B20Variant::Stablecoin
+                        .decimals()
+                        .expect("stablecoin has fixed 6-decimal precision"),
+                )
+                .abi_encode()
+                .into(),
                 C::totalSupply(_) => self.accounting().total_supply()?.abi_encode().into(),
                 C::balanceOf(c) => self.accounting().balance_of(c.account)?.abi_encode().into(),
                 C::allowance(c) => {
@@ -326,5 +335,46 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             SC::currency(_) => self.accounting().currency()?.abi_encode().into(),
         };
         Ok(encoded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolCall, SolValue};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{IB20, InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken};
+
+    const TOKEN: Address = Address::repeat_byte(0x01);
+
+    fn make_stablecoin_token_with_decimals(decimals: u8) -> TestStablecoinToken {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
+        accounting.decimals = decimals;
+        TestStablecoinToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
+    }
+
+    fn call_inner(token: &mut TestStablecoinToken, calldata: &[u8]) -> Vec<u8> {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(TOKEN);
+        StorageCtx::enter(&mut storage, |ctx| token.inner(ctx, calldata)).unwrap().to_vec()
+    }
+
+    /// Decimals always returns 6 regardless of what the underlying accounting stores.
+    ///
+    /// During the factory bootstrap window the storage slot is uninitialized and would
+    /// return 0 if read directly. Hard-coding 6 in the dispatch eliminates that window.
+    #[test]
+    fn decimals_returns_fixed_six_regardless_of_storage() {
+        // Token with decimals = 0 in storage (simulates an uninitialized slot).
+        let mut uninitialized = make_stablecoin_token_with_decimals(0);
+        let calldata = IB20::decimalsCall {}.abi_encode();
+        let result = call_inner(&mut uninitialized, &calldata);
+        assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
+
+        // Token with decimals = 18 in storage (default for InMemoryTokenAccounting).
+        let mut default = make_stablecoin_token_with_decimals(18);
+        let result = call_inner(&mut default, &calldata);
+        assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
     }
 }


### PR DESCRIPTION
[BOP-342](https://linear.app/coinbase/issue/BOP-342) [BOP-349](https://linear.app/coinbase/issue/BOP-349)

## Motivation

`B20StablecoinToken::decimals()` previously delegated to the storage adapter via `TokenAccounting::decimals()`, which returns `0` for an uninitialized slot. During the factory bootstrap window -- after `set_code` installs the marker bytecode but before the `initCalls` chain writes the token fields -- any external call to `decimals()` would return `0` instead of the correct stablecoin precision of `6`. This is incorrect: stablecoin precision is a protocol-level constant, not a per-token configuration value.

## What changed

- In `B20StablecoinToken`'s dispatch, the `decimals` selector now returns `B20Variant::Stablecoin.decimals()` (always `6`) instead of reading from the `TokenAccounting` storage adapter.
- A unit test is added verifying that `decimals()` returns `6` regardless of the value held in the backing accounting (including `0`, which simulates the uninitialized-slot case).

## What was tried / considered

The recommendation in the audit finding suggested adding a method override directly on `B20StablecoinToken`. Because the dispatch layer already handles per-variant logic and `B20Variant::Stablecoin.decimals()` already encodes this constant (used by the factory storage when emitting `B20Created`), routing through that existing constant keeps the source of truth in one place and avoids adding a new method to the trait hierarchy.
