### PR TITLE
fix(precompile-storage): restore all mutable fields in checkpoint_revert (BOP-359)

### DIFF
--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -419,6 +419,7 @@ mod tests {
         GasParams::new_spec(SpecId::AMSTERDAM)
     }
 
+    /// Positive refunds accumulate in the counter.
     #[test]
     fn set_code_static_violation_before_state_gas_charge() {
         let mut p = HashMapStorageProvider::new(1);
@@ -438,6 +439,7 @@ mod tests {
         assert_eq!(p.gas_refunded(), 1_500);
     }
 
+    /// Negative refunds (EIP-3529 cancellations) reduce the counter.
     #[test]
     fn refund_gas_accumulates_negative() {
         let mut p = HashMapStorageProvider::new(1);
@@ -446,12 +448,14 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Gas refund counter starts at zero on a fresh provider.
     #[test]
     fn refund_gas_starts_at_zero() {
         let p = HashMapStorageProvider::new(1);
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Clearing a previously set slot (nonzero to zero) earns an EIP-3529 refund.
     #[test]
     fn sstore_clearing_slot_generates_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -463,6 +467,7 @@ mod tests {
         assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
     }
 
+    /// Overwriting a nonzero slot with another nonzero value earns no refund.
     #[test]
     fn sstore_nonzero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -471,6 +476,7 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Writing to a zero slot (first write) earns no refund.
     #[test]
     fn sstore_zero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -407,7 +407,6 @@ pub fn setup_storage() -> (HashMapStorageProvider, Address) {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
-    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId};
 
     use super::*;
     use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
@@ -415,11 +414,6 @@ mod tests {
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
 
-    fn amsterdam_params() -> GasParams {
-        GasParams::new_spec(SpecId::AMSTERDAM)
-    }
-
-    /// Positive refunds accumulate in the counter.
     #[test]
     fn set_code_static_violation_before_state_gas_charge() {
         let mut p = HashMapStorageProvider::new(1);
@@ -439,7 +433,6 @@ mod tests {
         assert_eq!(p.gas_refunded(), 1_500);
     }
 
-    /// Negative refunds (EIP-3529 cancellations) reduce the counter.
     #[test]
     fn refund_gas_accumulates_negative() {
         let mut p = HashMapStorageProvider::new(1);
@@ -448,14 +441,12 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Gas refund counter starts at zero on a fresh provider.
     #[test]
     fn refund_gas_starts_at_zero() {
         let p = HashMapStorageProvider::new(1);
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Clearing a previously set slot (nonzero to zero) earns an EIP-3529 refund.
     #[test]
     fn sstore_clearing_slot_generates_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -467,7 +458,6 @@ mod tests {
         assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
     }
 
-    /// Overwriting a nonzero slot with another nonzero value earns no refund.
     #[test]
     fn sstore_nonzero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -476,7 +466,6 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Writing to a zero slot (first write) earns no refund.
     #[test]
     fn sstore_zero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -488,7 +477,6 @@ mod tests {
     #[test]
     fn sstore_blocked_when_remaining_equals_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
         assert_eq!(
             p.sstore(ADDR, KEY, U256::from(1u64)),
@@ -501,7 +489,6 @@ mod tests {
     #[test]
     fn sstore_blocked_when_remaining_below_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2299);
         assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
     }
@@ -510,7 +497,6 @@ mod tests {
     #[test]
     fn sstore_allowed_when_remaining_above_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2301);
         assert!(
             p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
@@ -522,7 +508,6 @@ mod tests {
     #[test]
     fn sstore_always_allowed_without_gas_remaining_set() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         // gas_remaining is None — guard disabled, unlimited gas
         assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
     }
@@ -533,7 +518,6 @@ mod tests {
     #[test]
     fn sstore_static_violation_checked_before_stipend_guard() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_static(true);
         p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
         assert_eq!(

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -41,7 +41,11 @@ pub struct HashMapStorageProvider {
 #[derive(Debug)]
 struct Snapshot {
     internals: HashMap<(Address, U256), U256>,
+    transient: HashMap<(Address, U256), U256>,
+    accounts: HashMap<Address, AccountInfo>,
     events: HashMap<Address, Vec<LogData>>,
+    gas_refunded: i64,
+    state_gas_used: u64,
 }
 
 impl HashMapStorageProvider {
@@ -241,8 +245,14 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn checkpoint(&mut self) -> JournalCheckpoint {
         let idx = self.snapshots.len();
-        self.snapshots
-            .push(Snapshot { internals: self.internals.clone(), events: self.events.clone() });
+        self.snapshots.push(Snapshot {
+            internals: self.internals.clone(),
+            transient: self.transient.clone(),
+            accounts: self.accounts.clone(),
+            events: self.events.clone(),
+            gas_refunded: self.gas_refunded,
+            state_gas_used: self.state_gas_used,
+        });
         JournalCheckpoint { log_i: 0, journal_i: idx, selfdestructed_i: 0 }
     }
 
@@ -263,7 +273,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         );
         if let Some(snapshot) = self.snapshots.drain(checkpoint.journal_i..).next() {
             self.internals = snapshot.internals;
+            self.transient = snapshot.transient;
+            self.accounts = snapshot.accounts;
             self.events = snapshot.events;
+            self.gas_refunded = snapshot.gas_refunded;
+            self.state_gas_used = snapshot.state_gas_used;
         }
     }
 }
@@ -454,5 +468,88 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_internals() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(1u64)).unwrap();
+        let cp = p.checkpoint();
+        p.sstore(ADDR, KEY, U256::from(2u64)).unwrap();
+        p.checkpoint_revert(cp);
+        assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(1u64));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_transient() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.tstore(ADDR, KEY, U256::from(10u64)).unwrap();
+        let cp = p.checkpoint();
+        p.tstore(ADDR, KEY, U256::from(99u64)).unwrap();
+        p.checkpoint_revert(cp);
+        assert_eq!(p.tload(ADDR, KEY).unwrap(), U256::from(10u64));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_accounts() {
+        let mut p = HashMapStorageProvider::new(1);
+        let code_before = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        p.set_code(ADDR, code_before.clone()).unwrap();
+        let cp = p.checkpoint();
+        let code_after = Bytecode::new_raw([0x60u8, 0x01].as_ref().into());
+        p.set_code(ADDR, code_after).unwrap();
+        p.checkpoint_revert(cp);
+        let mut seen_hash = None;
+        p.with_account_info(ADDR, &mut |info| {
+            seen_hash = Some(info.code_hash);
+        })
+        .unwrap();
+        assert_eq!(seen_hash.unwrap(), code_before.hash_slow());
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_events() {
+        use alloy_primitives::Bytes;
+        let mut p = HashMapStorageProvider::new(1);
+        let event_before = LogData::new_unchecked(vec![], Bytes::from_static(b"before"));
+        p.emit_event(ADDR, event_before).unwrap();
+        let cp = p.checkpoint();
+        let event_after = LogData::new_unchecked(vec![], Bytes::from_static(b"after"));
+        p.emit_event(ADDR, event_after).unwrap();
+        p.checkpoint_revert(cp);
+        let events = p.get_events(ADDR);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, Bytes::from_static(b"before"));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_gas_refunded() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(1_000);
+        let cp = p.checkpoint();
+        p.refund_gas(500);
+        assert_eq!(p.gas_refunded(), 1_500);
+        p.checkpoint_revert(cp);
+        assert_eq!(p.gas_refunded(), 1_000);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_state_gas_used() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.deduct_state_gas(100).unwrap();
+        let cp = p.checkpoint();
+        p.deduct_state_gas(50).unwrap();
+        assert_eq!(p.state_gas_used(), 150);
+        p.checkpoint_revert(cp);
+        assert_eq!(p.state_gas_used(), 100);
+    }
+
+    #[test]
+    fn checkpoint_commit_does_not_revert_mutations() {
+        let mut p = HashMapStorageProvider::new(1);
+        let cp = p.checkpoint();
+        p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
+        p.checkpoint_commit(cp);
+        assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -34,6 +34,10 @@ pub struct HashMapStorageProvider {
     gas_params: GasParams,
     state_gas_used: u64,
     gas_refunded: i64,
+    /// When `Some(n)`, enforces the EIP-2200 stipend guard: `sstore` returns `OutOfGas` when
+    /// `n <= gas_params.call_stipend()`. `None` (default) disables the guard so existing tests
+    /// that do not care about gas limits continue to work unchanged.
+    gas_remaining: Option<u64>,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -74,6 +78,7 @@ impl HashMapStorageProvider {
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
+            gas_remaining: None,
         }
     }
 }
@@ -134,6 +139,13 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     ) -> Result<(), BasePrecompileError> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
+        }
+        // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
+        // Only enforced when gas_remaining is explicitly set (opt-in for tests).
+        if let Some(remaining) = self.gas_remaining {
+            if remaining <= self.gas_params.call_stipend() {
+                return Err(BasePrecompileError::OutOfGas);
+            }
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -379,6 +391,13 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
+
+    /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
+    /// (test-utils only). Use this to exercise the guard at specific gas levels without
+    /// a live EVM journal.
+    pub fn set_gas_remaining(&mut self, remaining: u64) {
+        self.gas_remaining = Some(remaining);
+    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
@@ -390,12 +409,17 @@ pub fn setup_storage() -> (HashMapStorageProvider, Address) {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
+    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId};
 
     use super::*;
     use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
+
+    fn amsterdam_params() -> GasParams {
+        GasParams::new_spec(SpecId::AMSTERDAM)
+    }
 
     #[test]
     fn set_code_static_violation_before_state_gas_charge() {
@@ -454,5 +478,63 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
+    }
+
+    /// EIP-2200 stipend boundary: `remaining == call_stipend` must block (guard is `<=`).
+    #[test]
+    fn sstore_blocked_when_remaining_equals_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
+        assert_eq!(
+            p.sstore(ADDR, KEY, U256::from(1u64)),
+            Err(BasePrecompileError::OutOfGas),
+            "sstore must be blocked when remaining == call_stipend"
+        );
+    }
+
+    /// Below the stipend: also blocked.
+    #[test]
+    fn sstore_blocked_when_remaining_below_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2299);
+        assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
+    }
+
+    /// One above the stipend: allowed.
+    #[test]
+    fn sstore_allowed_when_remaining_above_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2301);
+        assert!(
+            p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
+            "sstore must succeed when remaining > call_stipend"
+        );
+    }
+
+    /// Default (no gas_remaining set): guard is inactive, sstore always proceeds.
+    #[test]
+    fn sstore_always_allowed_without_gas_remaining_set() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        // gas_remaining is None — guard disabled, unlimited gas
+        assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
+    }
+
+    /// Static-call violation takes priority over the stipend guard.
+    /// gas_remaining == 2300 means the stipend guard would also fire if checked first;
+    /// setting static=true proves StaticCallViolation is returned rather than OutOfGas.
+    #[test]
+    fn sstore_static_violation_checked_before_stipend_guard() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_static(true);
+        p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
+        assert_eq!(
+            p.sstore(ADDR, KEY, U256::from(1u64)),
+            Err(BasePrecompileError::StaticCallViolation),
+        );
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -34,10 +34,6 @@ pub struct HashMapStorageProvider {
     gas_params: GasParams,
     state_gas_used: u64,
     gas_refunded: i64,
-    /// When `Some(n)`, enforces the EIP-2200 stipend guard: `sstore` returns `OutOfGas` when
-    /// `n <= gas_params.call_stipend()`. `None` (default) disables the guard so existing tests
-    /// that do not care about gas limits continue to work unchanged.
-    gas_remaining: Option<u64>,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -78,7 +74,6 @@ impl HashMapStorageProvider {
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
-            gas_remaining: None,
         }
     }
 }
@@ -139,11 +134,6 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     ) -> Result<(), BasePrecompileError> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
-        }
-        // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
-        // Only enforced when gas_remaining is explicitly set (opt-in for tests).
-        if self.gas_remaining.is_some_and(|r| r <= self.gas_params.call_stipend()) {
-            return Err(BasePrecompileError::OutOfGas);
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -389,13 +379,6 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
-
-    /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
-    /// (test-utils only). Use this to exercise the guard at specific gas levels without
-    /// a live EVM journal.
-    pub const fn set_gas_remaining(&mut self, remaining: u64) {
-        self.gas_remaining = Some(remaining);
-    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
@@ -409,7 +392,7 @@ mod tests {
     use alloy_primitives::{Address, U256};
 
     use super::*;
-    use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
+    use crate::provider::PrecompileStorageProvider;
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
@@ -471,58 +454,5 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
-    }
-
-    /// EIP-2200 stipend boundary: `remaining == call_stipend` must block (guard is `<=`).
-    #[test]
-    fn sstore_blocked_when_remaining_equals_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
-        assert_eq!(
-            p.sstore(ADDR, KEY, U256::from(1u64)),
-            Err(BasePrecompileError::OutOfGas),
-            "sstore must be blocked when remaining == call_stipend"
-        );
-    }
-
-    /// Below the stipend: also blocked.
-    #[test]
-    fn sstore_blocked_when_remaining_below_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2299);
-        assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
-    }
-
-    /// One above the stipend: allowed.
-    #[test]
-    fn sstore_allowed_when_remaining_above_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2301);
-        assert!(
-            p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
-            "sstore must succeed when remaining > call_stipend"
-        );
-    }
-
-    /// Default (no `gas_remaining` set): guard is inactive, `sstore` always proceeds.
-    #[test]
-    fn sstore_always_allowed_without_gas_remaining_set() {
-        let mut p = HashMapStorageProvider::new(1);
-        // gas_remaining is None — guard disabled, unlimited gas
-        assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
-    }
-
-    /// Static-call violation takes priority over the stipend guard.
-    /// `gas_remaining == 2300` means the stipend guard would also fire if checked first;
-    /// setting `static=true` proves `StaticCallViolation` is returned rather than `OutOfGas`.
-    #[test]
-    fn sstore_static_violation_checked_before_stipend_guard() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_static(true);
-        p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
-        assert_eq!(
-            p.sstore(ADDR, KEY, U256::from(1u64)),
-            Err(BasePrecompileError::StaticCallViolation),
-        );
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -142,10 +142,8 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
         // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
         // Only enforced when gas_remaining is explicitly set (opt-in for tests).
-        if let Some(remaining) = self.gas_remaining {
-            if remaining <= self.gas_params.call_stipend() {
-                return Err(BasePrecompileError::OutOfGas);
-            }
+        if self.gas_remaining.is_some_and(|r| r <= self.gas_params.call_stipend()) {
+            return Err(BasePrecompileError::OutOfGas);
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -395,7 +393,7 @@ impl HashMapStorageProvider {
     /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
     /// (test-utils only). Use this to exercise the guard at specific gas levels without
     /// a live EVM journal.
-    pub fn set_gas_remaining(&mut self, remaining: u64) {
+    pub const fn set_gas_remaining(&mut self, remaining: u64) {
         self.gas_remaining = Some(remaining);
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -518,7 +518,7 @@ mod tests {
         );
     }
 
-    /// Default (no gas_remaining set): guard is inactive, sstore always proceeds.
+    /// Default (no `gas_remaining` set): guard is inactive, `sstore` always proceeds.
     #[test]
     fn sstore_always_allowed_without_gas_remaining_set() {
         let mut p = HashMapStorageProvider::new(1);
@@ -528,8 +528,8 @@ mod tests {
     }
 
     /// Static-call violation takes priority over the stipend guard.
-    /// gas_remaining == 2300 means the stipend guard would also fire if checked first;
-    /// setting static=true proves StaticCallViolation is returned rather than OutOfGas.
+    /// `gas_remaining == 2300` means the stipend guard would also fire if checked first;
+    /// setting `static=true` proves `StaticCallViolation` is returned rather than `OutOfGas`.
     #[test]
     fn sstore_static_violation_checked_before_stipend_guard() {
         let mut p = HashMapStorageProvider::new(1);

--- a/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
+++ b/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
@@ -144,7 +144,7 @@ contract SeedDexPools is Script {
         MockERC20(token0).approve(clPositionManager, type(uint256).max);
         MockERC20(token1).approve(clPositionManager, type(uint256).max);
 
-        int24 maxTick = int24(887272) - (int24(887272) % tickSpacing);
+        int24 maxTick = (int24(887272) / tickSpacing) * tickSpacing;
         ICLPositionManager(clPositionManager).mint(
             ICLPositionManager.MintParams({
                 token0: token0,

--- a/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
+++ b/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
@@ -144,7 +144,7 @@ contract SeedDexPools is Script {
         MockERC20(token0).approve(clPositionManager, type(uint256).max);
         MockERC20(token1).approve(clPositionManager, type(uint256).max);
 
-        int24 maxTick = (int24(887272) / tickSpacing) * tickSpacing;
+        int24 maxTick = int24(887272) - (int24(887272) % tickSpacing);
         ICLPositionManager(clPositionManager).mint(
             ICLPositionManager.MintParams({
                 token0: token0,


### PR DESCRIPTION
[BOP-354](https://linear.app/coinbase/issue/BOP-354)

## Motivation

`HashMapStorageProvider::checkpoint_revert` only restored `internals` and `events` from the saved snapshot, leaving `transient`, `accounts`, `gas_refunded`, and `state_gas_used` in their post-mutation state after a revert. This caused the test mock to silently diverge from production EVM semantics, where all state is fully rolled back on revert. Unit tests that exercise rollback behavior via the hashmap mock could pass while the mock was wrong, masking correctness issues.

## What changed

- Expanded `Snapshot` to include `transient`, `accounts`, `gas_refunded`, and `state_gas_used` (the fields mutated by `tstore`, `set_code`/`with_account_info`, `refund_gas`, and `deduct_state_gas` respectively).
- Updated `checkpoint` to clone and save all four fields.
- Updated `checkpoint_revert` to restore all four fields.
- Added per-field regression tests: `checkpoint_revert_restores_internals`, `checkpoint_revert_restores_transient`, `checkpoint_revert_restores_accounts`, `checkpoint_revert_restores_events`, `checkpoint_revert_restores_gas_refunded`, `checkpoint_revert_restores_state_gas_used`, and `checkpoint_commit_does_not_revert_mutations`.

## What was tried / considered

`caller` and `call_value` were considered for snapshotting but are set once per call and should not change within a checkpoint scope, so they were excluded per the audit recommendation.