### PR TITLE
fix(precompile-macros): improve #[contract] diagnostic for unrecognized arguments

### DIFF
--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -23,8 +23,13 @@ impl syn::parse::Parse for ContractConfig {
         }
 
         let ident: Ident = input.parse()?;
-        if ident != "addr" && ident != "address" {
-            return Err(syn::Error::new(ident.span(), "only `addr` attribute is supported"));
+        if ident != "addr" {
+            return Err(syn::Error::new(
+                ident.span(),
+                format!(
+                    "unrecognized argument `{ident}`; supported arguments are: addr = \"0x...\""
+                ),
+            ));
         }
 
         input.parse::<Token![=]>()?;


### PR DESCRIPTION
[BOP-340](https://linear.app/coinbase/issue/BOP-340)

## Motivation

The `#[contract]` attribute macro accepted `address` as a silent alias for `addr`, which is inconsistent with the documented API. When a developer used an unrecognized key (or the wrong spelling), the error message read `only 'addr' attribute is supported` without naming the offending argument or showing the expected syntax. This gave no actionable guidance on how to fix the invocation.

## What changed

- `address` is no longer accepted as an alias for `addr`. Only `addr = "0x..."` is the valid form.
- The error message for any unrecognized argument now names the key and shows the correct syntax: `unrecognized argument 'foo'; supported arguments are: addr = "0x..."`.
- Empty `#[contract]` (no arguments) continues to be accepted silently, as it was before.