### PR TITLE
feat(prover): add prover-service binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5990,6 +5990,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-prover-service-bin"
+version = "0.0.0"
+dependencies = [
+ "base-cli-utils",
+ "base-prover-service",
+ "base-prover-service-db",
+ "base-prover-service-protocol",
+ "clap",
+ "eyre",
+ "jsonrpsee",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "base-prover-service-client"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "bin/prover/nitro-enclave",
   "bin/prover/snark-e2e",
   "bin/prover/zk",
+  "bin/prover/service",
   "crates/consensus/*",
   "crates/proof/mpt",
   "crates/proof/proof",
@@ -71,6 +72,7 @@ default-members = [
   "bin/prover/nitro-enclave",
   "bin/prover/zk",
   "bin/prover/snark-e2e",
+  "bin/prover/service",
   "bin/prover-registrar",
 ]
 

--- a/bin/prover/service/Cargo.toml
+++ b/bin/prover/service/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "base-prover-service-bin"
+description = "Prover service JSON-RPC binary"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-prover-service"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Workspace – prover service
+base-prover-service.workspace = true
+base-prover-service-db.workspace = true
+base-prover-service-protocol = { workspace = true, features = ["rpc-server"] }
+
+# CLI
+eyre.workspace = true
+base-cli-utils.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+serde = { workspace = true, features = ["derive", "std"] }
+
+# RPC
+jsonrpsee = { workspace = true, features = ["server"] }
+
+# Async
+tokio = { workspace = true, features = ["full"] }
+
+# Tracing
+tracing.workspace = true

--- a/bin/prover/service/README.md
+++ b/bin/prover/service/README.md
@@ -1,0 +1,11 @@
+# `base-prover-service`
+
+Standalone JSON-RPC binary for the Base prover service.
+
+Runs the prover-service requester and worker APIs, backed by Postgres. It queues
+proof requests, leases work to external workers, tracks heartbeats, and stores
+submitted results.
+
+This binary does not run proving backends in-process. ZK and TEE proof
+generation runs in separate worker processes that claim jobs through the worker
+API.

--- a/bin/prover/service/src/cli.rs
+++ b/bin/prover/service/src/cli.rs
@@ -10,11 +10,13 @@ use base_prover_service_db::{DatabaseConfig, ProofRequestRepo};
 use base_prover_service_protocol::{ProverRequesterApiServer, ProverWorkerApiServer};
 use clap::Parser;
 use eyre::eyre;
-use jsonrpsee::server::Server;
+use jsonrpsee::server::{Server, ServerConfig as JsonRpcServerConfig};
 use tracing::info;
 
 base_cli_utils::define_log_args!("BASE_PROVER_SERVICE");
 base_cli_utils::define_metrics_args!("BASE_PROVER_SERVICE", 7302);
+
+const DEFAULT_RPC_MAX_BODY_BYTES: u32 = 256 * 1024 * 1024;
 
 /// Prover service binary.
 #[derive(Parser)]
@@ -91,8 +93,27 @@ struct ServiceArgs {
     )]
     worker_queue_reaper_batch_size: u32,
 
-    #[arg(long, env = "RPC_LISTEN_ADDR", default_value = "0.0.0.0:9000")]
-    rpc_listen_addr: SocketAddr,
+    #[arg(long = "rpc-listen-addr", env = "RPC_LISTEN_ADDR", default_value = "0.0.0.0:9000")]
+    requester_rpc_listen_addr: SocketAddr,
+
+    #[arg(long, env = "WORKER_RPC_LISTEN_ADDR", default_value = "127.0.0.1:9001")]
+    worker_rpc_listen_addr: SocketAddr,
+
+    #[arg(
+        long,
+        env = "RPC_MAX_REQUEST_BODY_BYTES",
+        default_value_t = DEFAULT_RPC_MAX_BODY_BYTES,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    rpc_max_request_body_bytes: u32,
+
+    #[arg(
+        long,
+        env = "RPC_MAX_RESPONSE_BODY_BYTES",
+        default_value_t = DEFAULT_RPC_MAX_BODY_BYTES,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    rpc_max_response_body_bytes: u32,
 }
 
 impl Cli {
@@ -145,26 +166,56 @@ impl ServiceArgs {
 
         let prover_server = ProverServiceServer::new(repo, server_config);
 
-        let mut rpc_module = ProverWorkerApiServer::into_rpc(prover_server.clone());
-        rpc_module
-            .merge(ProverRequesterApiServer::into_rpc(prover_server))
-            .map_err(|e| eyre!("failed to merge requester and worker RPC modules: {e}"))?;
+        let json_rpc_config = JsonRpcServerConfig::builder()
+            .max_request_body_size(self.rpc_max_request_body_bytes)
+            .max_response_body_size(self.rpc_max_response_body_bytes)
+            .build();
 
-        let rpc_server = Server::builder()
-            .build(self.rpc_listen_addr)
+        let requester_rpc_module = ProverRequesterApiServer::into_rpc(prover_server.clone());
+        let requester_rpc_server = Server::builder()
+            .set_config(json_rpc_config.clone())
+            .build(self.requester_rpc_listen_addr)
             .await
-            .map_err(|e| eyre!("failed to bind RPC server: {e}"))?;
-        let local_addr =
-            rpc_server.local_addr().map_err(|e| eyre!("failed to read RPC server address: {e}"))?;
-        info!(addr = %local_addr, "starting prover JSON-RPC service");
-        let server_handle = rpc_server.start(rpc_module);
+            .map_err(|e| eyre!("failed to bind requester RPC server: {e}"))?;
+        let requester_local_addr = requester_rpc_server
+            .local_addr()
+            .map_err(|e| eyre!("failed to read requester RPC server address: {e}"))?;
+        info!(
+            addr = %requester_local_addr,
+            max_request_body_bytes = self.rpc_max_request_body_bytes,
+            max_response_body_bytes = self.rpc_max_response_body_bytes,
+            "starting prover requester JSON-RPC service"
+        );
+        let requester_server_handle = requester_rpc_server.start(requester_rpc_module);
+
+        let worker_rpc_module = ProverWorkerApiServer::into_rpc(prover_server);
+        let worker_rpc_server = Server::builder()
+            .set_config(json_rpc_config)
+            .build(self.worker_rpc_listen_addr)
+            .await
+            .map_err(|e| eyre!("failed to bind worker RPC server: {e}"))?;
+        let worker_local_addr = worker_rpc_server
+            .local_addr()
+            .map_err(|e| eyre!("failed to read worker RPC server address: {e}"))?;
+        info!(
+            addr = %worker_local_addr,
+            max_request_body_bytes = self.rpc_max_request_body_bytes,
+            max_response_body_bytes = self.rpc_max_response_body_bytes,
+            "starting prover worker JSON-RPC service"
+        );
+        let worker_server_handle = worker_rpc_server.start(worker_rpc_module);
 
         let result: eyre::Result<()> = tokio::select! {
             res = status_handle => match res {
                 Ok(()) => Err(eyre!("status poller exited unexpectedly")),
                 Err(e) => Err(eyre!("status poller panicked: {e}")),
             },
-            () = server_handle.stopped() => Err(eyre!("RPC server stopped unexpectedly")),
+            () = requester_server_handle.stopped() => {
+                Err(eyre!("requester RPC server stopped unexpectedly"))
+            },
+            () = worker_server_handle.stopped() => {
+                Err(eyre!("worker RPC server stopped unexpectedly"))
+            },
         };
 
         result

--- a/bin/prover/service/src/cli.rs
+++ b/bin/prover/service/src/cli.rs
@@ -16,7 +16,7 @@ use tracing::info;
 base_cli_utils::define_log_args!("BASE_PROVER_SERVICE");
 base_cli_utils::define_metrics_args!("BASE_PROVER_SERVICE", 7302);
 
-const DEFAULT_RPC_MAX_BODY_BYTES: u32 = 256 * 1024 * 1024;
+const DEFAULT_RPC_MAX_BODY_BYTES: u32 = 32 * 1024 * 1024;
 
 /// Prover service binary.
 #[derive(Parser)]
@@ -160,7 +160,7 @@ impl ServiceArgs {
             self.max_proof_retries,
             server_config.worker_queue,
         );
-        let status_handle = tokio::spawn(async move {
+        let mut status_handle = tokio::spawn(async move {
             status_poller.run().await;
         });
 
@@ -206,7 +206,7 @@ impl ServiceArgs {
         let worker_server_handle = worker_rpc_server.start(worker_rpc_module);
 
         let result: eyre::Result<()> = tokio::select! {
-            res = status_handle => match res {
+            res = &mut status_handle => match res {
                 Ok(()) => Err(eyre!("status poller exited unexpectedly")),
                 Err(e) => Err(eyre!("status poller panicked: {e}")),
             },
@@ -217,6 +217,8 @@ impl ServiceArgs {
                 Err(eyre!("worker RPC server stopped unexpectedly"))
             },
         };
+
+        status_handle.abort();
 
         result
     }

--- a/bin/prover/service/src/cli.rs
+++ b/bin/prover/service/src/cli.rs
@@ -1,0 +1,184 @@
+//! CLI definition for the prover-service JSON-RPC binary.
+
+use std::net::SocketAddr;
+
+use base_cli_utils::{LogConfig, RuntimeManager};
+use base_prover_service::{
+    ProverServiceServer, ServerConfig, StatusPoller, WorkerApiConfig, WorkerQueueConfig,
+};
+use base_prover_service_db::{DatabaseConfig, ProofRequestRepo};
+use base_prover_service_protocol::{ProverRequesterApiServer, ProverWorkerApiServer};
+use clap::Parser;
+use eyre::eyre;
+use jsonrpsee::server::Server;
+use tracing::info;
+
+base_cli_utils::define_log_args!("BASE_PROVER_SERVICE");
+base_cli_utils::define_metrics_args!("BASE_PROVER_SERVICE", 7302);
+
+/// Prover service binary.
+#[derive(Parser)]
+#[command(author, version)]
+pub(crate) struct Cli {
+    #[command(flatten)]
+    args: ServiceArgs,
+
+    /// Logging arguments.
+    #[command(flatten)]
+    logging: LogArgs,
+
+    /// Metrics arguments.
+    #[command(flatten)]
+    metrics: MetricsArgs,
+}
+
+/// Prover service for proving Base blocks over JSON-RPC.
+#[derive(Parser, Debug)]
+struct ServiceArgs {
+    #[arg(
+        long,
+        env = "STATUS_POLLER_INTERVAL_SECS",
+        default_value_t = 30,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    status_poller_interval_secs: u64,
+
+    #[arg(
+        long,
+        env = "STUCK_REQUEST_TIMEOUT_MINS",
+        default_value_t = 10,
+        value_parser = clap::value_parser!(i32).range(1..)
+    )]
+    stuck_request_timeout_mins: i32,
+
+    #[arg(
+        long,
+        env = "MAX_PROOF_RETRIES",
+        default_value_t = 3,
+        value_parser = clap::value_parser!(i32).range(0..)
+    )]
+    max_proof_retries: i32,
+
+    #[arg(
+        long,
+        env = "WORKER_DEFAULT_LOCK_DURATION_SECONDS",
+        default_value_t = 300,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    worker_default_lock_duration_seconds: u32,
+
+    #[arg(
+        long,
+        env = "WORKER_MAX_LOCK_DURATION_SECONDS",
+        default_value_t = 3600,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    worker_max_lock_duration_seconds: u32,
+
+    #[arg(
+        long,
+        env = "WORKER_QUEUE_RECLAIM_ATTEMPTS",
+        default_value_t = 5,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    worker_queue_reclaim_attempts: u32,
+
+    #[arg(
+        long,
+        env = "WORKER_QUEUE_REAPER_BATCH_SIZE",
+        default_value_t = 100,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    worker_queue_reaper_batch_size: u32,
+
+    #[arg(long, env = "RPC_LISTEN_ADDR", default_value = "0.0.0.0:9000")]
+    rpc_listen_addr: SocketAddr,
+}
+
+impl Cli {
+    /// Run the prover service.
+    pub(crate) fn run(self) -> eyre::Result<()> {
+        let Self { args, logging, metrics } = self;
+        LogConfig::from(logging).init_tracing_subscriber()?;
+        base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
+            base_cli_utils::register_version_metrics!();
+            base_prover_service::ProverMetrics::init();
+        })?;
+        RuntimeManager::new().run_until_ctrl_c(async move { args.run().await })
+    }
+}
+
+impl ServiceArgs {
+    /// Runs the prover service.
+    async fn run(self) -> eyre::Result<()> {
+        self.validate_config()?;
+
+        info!("initializing database connection");
+        let db_config = DatabaseConfig::from_env().map_err(|e| eyre!(e))?;
+        let pool = db_config.init_pool().await.map_err(|e| eyre!(e))?;
+        let repo = ProofRequestRepo::new(pool);
+        info!("database connection initialized");
+
+        let server_config = ServerConfig {
+            max_proof_retries: self.max_proof_retries,
+            worker: WorkerApiConfig::new(
+                self.worker_default_lock_duration_seconds,
+                self.worker_max_lock_duration_seconds,
+            ),
+            worker_queue: WorkerQueueConfig {
+                reclaim_attempts: self.worker_queue_reclaim_attempts,
+                reaper_batch_size: self.worker_queue_reaper_batch_size,
+            },
+        };
+
+        info!("starting status poller");
+        let status_poller = StatusPoller::new(
+            repo.clone(),
+            self.status_poller_interval_secs,
+            self.stuck_request_timeout_mins,
+            self.max_proof_retries,
+            server_config.worker_queue,
+        );
+        let status_handle = tokio::spawn(async move {
+            status_poller.run().await;
+        });
+
+        let prover_server = ProverServiceServer::new(repo, server_config);
+
+        let mut rpc_module = ProverWorkerApiServer::into_rpc(prover_server.clone());
+        rpc_module
+            .merge(ProverRequesterApiServer::into_rpc(prover_server))
+            .map_err(|e| eyre!("failed to merge requester and worker RPC modules: {e}"))?;
+
+        let rpc_server = Server::builder()
+            .build(self.rpc_listen_addr)
+            .await
+            .map_err(|e| eyre!("failed to bind RPC server: {e}"))?;
+        let local_addr =
+            rpc_server.local_addr().map_err(|e| eyre!("failed to read RPC server address: {e}"))?;
+        info!(addr = %local_addr, "starting prover JSON-RPC service");
+        let server_handle = rpc_server.start(rpc_module);
+
+        let result: eyre::Result<()> = tokio::select! {
+            res = status_handle => match res {
+                Ok(()) => Err(eyre!("status poller exited unexpectedly")),
+                Err(e) => Err(eyre!("status poller panicked: {e}")),
+            },
+            () = server_handle.stopped() => Err(eyre!("RPC server stopped unexpectedly")),
+        };
+
+        result
+    }
+
+    fn validate_config(&self) -> eyre::Result<()> {
+        if self.worker_default_lock_duration_seconds > self.worker_max_lock_duration_seconds {
+            eyre::bail!(
+                "WORKER_DEFAULT_LOCK_DURATION_SECONDS must be less than or equal to \
+                 WORKER_MAX_LOCK_DURATION_SECONDS"
+            );
+        }
+
+        info!("configuration validated");
+        Ok(())
+    }
+}

--- a/bin/prover/service/src/main.rs
+++ b/bin/prover/service/src/main.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use serde as _;
+
+mod cli;
+
+fn main() {
+    base_cli_utils::run_cli_main!(cli::Cli);
+}


### PR DESCRIPTION
## Summary
Add the standalone base-prover-service JSON-RPC binary that wires Postgres, queue maintenance, and requester/worker APIs.