### PR TITLE
fix(ci): Use Release Crates In Tests

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -80,6 +80,10 @@ jobs:
           cargo \
             --config "patch.\"https://github.com/base/base.git\".base-common-precompiles.path=\"$GITHUB_WORKSPACE/crates/common/precompiles\"" \
             --config "patch.\"https://github.com/base/base.git\".base-common-chains.path=\"$GITHUB_WORKSPACE/crates/common/chains\"" \
+            update -p base-common-precompiles -p base-common-chains
+          cargo \
+            --config "patch.\"https://github.com/base/base.git\".base-common-precompiles.path=\"$GITHUB_WORKSPACE/crates/common/precompiles\"" \
+            --config "patch.\"https://github.com/base/base.git\".base-common-chains.path=\"$GITHUB_WORKSPACE/crates/common/chains\"" \
             build --release --no-default-features --features anvil/cli -p anvil -p forge
 
           "$BASE_ANVIL_DIR/target/release/anvil" --version

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -16,6 +16,9 @@ sol! {
         /// `updateExtraMetadata` was called with an empty metadata key.
         error InvalidMetadataKey();
 
+        /// `updateMultiplier` was called with a zero multiplier.
+        error InvalidMultiplier();
+
         /// A batched function was called with parallel arrays of differing lengths.
         error LengthMismatch(uint256 leftLen, uint256 rightLen);
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -214,6 +214,9 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         privileged: bool,
     ) -> Result<()> {
         self.ensure_operator_role(caller, privileged)?;
+        if new_multiplier.is_zero() {
+            return Err(BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+        }
         self.accounting_mut().set_multiplier(new_multiplier)?;
         self.accounting_mut().emit_event(
             IB20Asset::MultiplierUpdated { multiplier: new_multiplier }.encode_log_data(),
@@ -280,6 +283,7 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, U256, keccak256};
+    use alloy_sol_types::SolEvent;
     use base_precompile_storage::BasePrecompileError;
     use rstest::rstest;
 
@@ -421,5 +425,28 @@ mod tests {
         let err = token.update_policy(CALLER, invalid_scope, 999, false).unwrap_err();
 
         assert_eq!(err, expected_update_policy_error(setup, invalid_scope));
+    }
+
+    #[test]
+    fn update_multiplier_rejects_zero() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, CALLER), true);
+
+        let err = token.update_multiplier(CALLER, U256::ZERO, false).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+    }
+
+    #[test]
+    fn update_multiplier_emits_wad_event() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, CALLER), true);
+
+        token.update_multiplier(CALLER, B20AssetStorage::WAD, false).unwrap();
+
+        assert_eq!(token.accounting().events.len(), 1);
+        let decoded =
+            IB20Asset::MultiplierUpdated::decode_log_data(&token.accounting().events[0]).unwrap();
+        assert_eq!(decoded.multiplier, B20AssetStorage::WAD);
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the release-branch Base Std Interface Tests so the temporary base-anvil build refreshes its Base package lock entries after applying the local release-crate patches. Without that refresh, Cargo keeps compiling the old v0.0.0 git-locked precompile crates and misses fixes already present on releases/v1.1.0. It also backports the main-branch B20Asset zero-multiplier guard from #3367 because the refreshed fork suite now reaches that current base-std expectation. Local validation passes with 610 passed, 0 failed, and 12 skipped fork tests.