### PR TITLE
[backport] BOP precompile fixes for v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5108,6 +5108,7 @@ dependencies = [
  "derive_more 2.1.1",
  "proptest",
  "revm",
+ "rstest",
  "thiserror 2.0.18",
 ]
 

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -31,6 +31,7 @@ derive_more = { workspace = true, features = ["from", "try_into"] }
 [dev-dependencies]
 proptest.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
+rstest.workspace = true
 
 [[test]]
 name = "contract"

--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -129,12 +129,24 @@ impl BasePrecompileError {
 }
 
 /// Extension trait to convert `Result<T, BasePrecompileError>` into a [`PrecompileResult`].
+///
+/// Prefer [`StorageCtx::result_output`] over calling this trait directly — it reads all gas
+/// accounting fields from the context automatically. Use this trait only when the context is not
+/// available (e.g. in unit tests).
 pub trait IntoPrecompileResult<T> {
     /// Converts `self` into a [`PrecompileResult`] using `encode_ok` for the success path.
+    ///
+    /// On success, the accumulated EIP-3529 gas refund (`gas_refunded`) is copied into
+    /// [`PrecompileOutput::gas_refunded`] so revm can include it in transaction-level refund
+    /// accounting under the EIP-3529 cap (`gas_used / 5`).
+    ///
+    /// On error, `gas_refunded` is not propagated: refunds are only meaningful on successful
+    /// execution and the error arm delegates to [`BasePrecompileError::into_precompile_result`].
     fn into_precompile_result(
         self,
         gas: u64,
         state_gas: u64,
+        gas_refunded: i64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult;
 }
@@ -144,10 +156,15 @@ impl<T> IntoPrecompileResult<T> for Result<T> {
         self,
         gas: u64,
         state_gas: u64,
+        gas_refunded: i64,
         encode_ok: impl FnOnce(T) -> Bytes,
     ) -> PrecompileResult {
         match self {
-            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), state_gas)),
+            Ok(res) => {
+                let mut out = PrecompileOutput::new(gas, encode_ok(res), state_gas);
+                out.gas_refunded = gas_refunded;
+                Ok(out)
+            }
             Err(err) => err.into_precompile_result(gas, state_gas),
         }
     }
@@ -167,5 +184,35 @@ mod tests {
         let output = result.unwrap();
         assert!(output.is_revert());
         assert_eq!(output.bytes, expected);
+    }
+
+    #[test]
+    fn into_precompile_result_propagates_gas_refunded_on_success() {
+        let ok: Result<Bytes> = Ok(Bytes::from("out"));
+        let out = ok.into_precompile_result(500, 0, 200, |b| b).unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.gas_used, 500);
+        assert_eq!(out.gas_refunded, 200);
+    }
+
+    #[test]
+    fn into_precompile_result_zero_refund_on_success() {
+        let ok: Result<Bytes> = Ok(Bytes::new());
+        let out = ok.into_precompile_result(0, 0, 0, |b| b).unwrap();
+
+        assert!(out.is_success());
+        assert_eq!(out.gas_refunded, 0);
+    }
+
+    #[test]
+    fn into_precompile_result_error_path_does_not_expose_refund_field() {
+        // The error path goes through BasePrecompileError::into_precompile_result which
+        // does not set gas_refunded (refunds are only meaningful on success).
+        let err: Result<Bytes> = Err(BasePrecompileError::Revert(Bytes::new()));
+        let out = err.into_precompile_result(100, 0, 999, |b| b).unwrap();
+
+        assert!(out.is_revert());
+        assert_eq!(out.gas_refunded, 0, "error path must not propagate gas_refunded");
     }
 }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -93,16 +93,16 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
 
         let code_len = code.len();
 
-        // EIP-3541 / Yellow Paper G_codedeposit: 200 gas per byte of deployed bytecode.
+        // Yellow Paper G_codedeposit: 200 gas per byte of deployed bytecode.
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
-        // For new (empty) accounts charge the CREATE equivalent costs (Yellow Paper G_create).
-        let is_new_account = {
+        let (is_new_account, has_empty_code) = {
             let state_load = self
                 .internals
                 .load_account(address)
                 .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-            state_load.data.info.is_empty()
+            let info = &state_load.data.info;
+            (info.is_empty(), info.is_empty_code_hash())
         };
 
         if is_new_account {
@@ -111,14 +111,13 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
             // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
             let num_words = code_len.div_ceil(32) as u64;
             self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
-            // EIP-8037: both state gas charges are gated on is_new_account.
-            // create_state_gas covers the new account entry in the state trie.
-            // code_deposit_state_gas covers the new code object. Replacing code on an
-            // existing account is not a state-creating operation in the EIP-8037 model —
-            // the code slot already occupies a trie node — so it is intentionally excluded.
-            // In practice, precompile set_code is only called during factory token creation,
-            // where the target address is always a fresh account.
+            // EIP-8037: charge for the new account entry in the state trie.
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
+        }
+        if has_empty_code {
+            // EIP-8037: charge for depositing code into an account whose code slot is
+            // currently empty. Applies to both new accounts and existent accounts that
+            // have only a nonzero balance or nonce (no prior code).
             self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }
 
@@ -176,6 +175,14 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
+        }
+        // EIP-2200: if remaining gas is at or below the call stipend (2300), halt with
+        // out-of-gas. This is the reentrancy sentry that Solidity's `.transfer()` relies on:
+        // forwarding only 2300 gas guarantees the recipient cannot perform state-changing
+        // SSTOREs. Without this guard, a warm-dirty rewrite (~200 gas) would succeed where
+        // the EVM SSTORE opcode would have halted, breaking the 2300-gas invariant.
+        if self.gas.remaining() <= self.gas_params.call_stipend() {
+            return Err(BasePrecompileError::OutOfGas);
         }
         let s = self
             .internals
@@ -295,7 +302,7 @@ impl From<alloy_evm::EvmInternalsError> for BasePrecompileError {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::Address;
+    use alloy_primitives::{Address, U256};
     use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId, state::Bytecode};
 
     use crate::{
@@ -306,6 +313,24 @@ mod tests {
         let mut provider = HashMapStorageProvider::new(1);
         provider.set_gas_params(GasParams::new_spec(SpecId::AMSTERDAM));
         provider
+    }
+
+    /// The EIP-2200 stipend guard in [`super::EvmPrecompileStorageProvider::sstore`] compares
+    /// `gas.remaining()` against `gas_params.call_stipend()`. This test verifies that the
+    /// call stipend constant returned by `GasParams` is exactly 2300, as required by EIP-2200.
+    ///
+    /// Unit tests cannot directly instantiate [`super::EvmPrecompileStorageProvider`] because
+    /// it requires a live EVM journal via `PrecompileInput`. The stipend guard is therefore not
+    /// exercisable in isolation here. Full coverage of the guard at runtime is provided by the
+    /// B20 fork tests that forward exactly 2300 gas into a stateful precompile call.
+    #[test]
+    fn eip_2200_stipend_guard_constant_is_2300() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        assert_eq!(
+            gas_params.call_stipend(),
+            2300,
+            "call_stipend must equal 2300 as required by EIP-2200"
+        );
     }
 
     /// `set_code` on a brand-new account must charge both `create_state_gas` and
@@ -323,6 +348,30 @@ mod tests {
         let expected = gas_params.create_state_gas() + gas_params.code_deposit_state_gas(code_len);
         assert!(expected > 0, "AMSTERDAM state gas must be non-zero");
         assert_eq!(provider.state_gas_used(), expected);
+    }
+
+    /// `set_code` on a balance-only account (nonzero balance, no code) must charge
+    /// `code_deposit_state_gas` but not `create_state_gas`. This covers the attack where
+    /// a caller prefunds a future token address before calling the factory.
+    #[test]
+    fn set_code_balance_only_account_charges_code_deposit_state_gas_only() {
+        let mut provider = amsterdam_provider();
+        let addr = Address::from([0x42u8; 20]);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        let code_len = code.len();
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+
+        // Simulate a prefunded account: has balance but no code.
+        provider.set_balance(addr, U256::from(1u64));
+
+        provider.set_code(addr, code).unwrap();
+
+        let expected = gas_params.code_deposit_state_gas(code_len);
+        assert_eq!(
+            provider.state_gas_used(),
+            expected,
+            "balance-only account must pay code_deposit_state_gas but not create_state_gas"
+        );
     }
 
     /// `set_code` on an already-initialised account must NOT charge any additional

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -29,6 +29,7 @@ pub struct HashMapStorageProvider {
     snapshots: Vec<Snapshot>,
     gas_params: GasParams,
     state_gas_used: u64,
+    gas_refunded: i64,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -65,6 +66,7 @@ impl HashMapStorageProvider {
             counter_sstore: 0,
             gas_params: GasParams::default(),
             state_gas_used: 0,
+            gas_refunded: 0,
         }
     }
 }
@@ -92,10 +94,13 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
 
         let code_len = code.len();
-        // Mirror the production is_new_account check so state gas tracking is faithful.
         let is_new_account = self.accounts.get(&address).is_none_or(AccountInfo::is_empty);
+        let has_empty_code =
+            self.accounts.get(&address).is_none_or(|info| info.is_empty_code_hash());
         if is_new_account {
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
+        }
+        if has_empty_code {
             self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }
         let account = self.accounts.entry(address).or_default();
@@ -123,8 +128,15 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
         }
+        let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
         self.internals.insert((address, key), value);
+        // Simplified EIP-3529 refund: clearing a previously set slot earns a refund.
+        // Exact EIP-2200/3529 accounting requires original-value tracking; the test provider
+        // approximates with the post-London clear-slot refund to keep the mock simple.
+        if !old.is_zero() && value.is_zero() {
+            self.refund_gas(4_800);
+        }
         Ok(())
     }
 
@@ -171,7 +183,9 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         Ok(())
     }
 
-    fn refund_gas(&mut self, _gas: i64) {}
+    fn refund_gas(&mut self, gas: i64) {
+        self.gas_refunded = self.gas_refunded.saturating_add(gas);
+    }
 
     fn gas_limit(&self) -> u64 {
         0
@@ -186,7 +200,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn gas_refunded(&self) -> i64 {
-        0
+        self.gas_refunded
     }
 
     fn reservoir(&self) -> u64 {
@@ -256,6 +270,12 @@ impl HashMapStorageProvider {
     pub fn set_nonce(&mut self, address: Address, nonce: u64) {
         let account = self.accounts.entry(address).or_default();
         account.nonce = nonce;
+    }
+
+    /// Sets the balance for the given address (test-utils only).
+    pub fn set_balance(&mut self, address: Address, balance: U256) {
+        let account = self.accounts.entry(address).or_default();
+        account.balance = balance;
     }
 
     /// Overrides the block timestamp (test-utils only).
@@ -329,4 +349,63 @@ impl HashMapStorageProvider {
 #[cfg(any(test, feature = "test-utils"))]
 pub fn setup_storage() -> (HashMapStorageProvider, Address) {
     (HashMapStorageProvider::new(1), Address::from([0x42u8; 20]))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+
+    use super::*;
+    use crate::provider::PrecompileStorageProvider;
+
+    const ADDR: Address = Address::ZERO;
+    const KEY: U256 = U256::ZERO;
+
+    #[test]
+    fn refund_gas_accumulates_positive() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(1_000);
+        p.refund_gas(500);
+        assert_eq!(p.gas_refunded(), 1_500);
+    }
+
+    #[test]
+    fn refund_gas_accumulates_negative() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(4_800);
+        p.refund_gas(-4_800);
+        assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn refund_gas_starts_at_zero() {
+        let p = HashMapStorageProvider::new(1);
+        assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn sstore_clearing_slot_generates_refund() {
+        let mut p = HashMapStorageProvider::new(1);
+        // Write a non-zero value first.
+        p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
+        assert_eq!(p.gas_refunded(), 0, "writing non-zero to zero slot earns no refund");
+        // Clear it — should earn EIP-3529 refund.
+        p.sstore(ADDR, KEY, U256::ZERO).unwrap();
+        assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
+    }
+
+    #[test]
+    fn sstore_nonzero_to_nonzero_earns_no_refund() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(1u64)).unwrap();
+        p.sstore(ADDR, KEY, U256::from(2u64)).unwrap();
+        assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn sstore_zero_to_nonzero_earns_no_refund() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
+        assert_eq!(p.gas_refunded(), 0);
+    }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -18,7 +18,7 @@ use revm::{
 };
 
 use crate::{
-    error::{BasePrecompileError, Result},
+    error::{BasePrecompileError, IntoPrecompileResult, Result},
     provider::PrecompileStorageProvider,
 };
 
@@ -225,6 +225,29 @@ impl<'a> StorageCtx<'a> {
     pub fn error_result(&self, error: impl Into<BasePrecompileError>) -> PrecompileResult {
         error.into().into_precompile_result(self.gas_used(), self.state_gas_used())
     }
+
+    /// Converts a `Result<T>` into a [`PrecompileResult`], reading all gas accounting fields
+    /// from the current context.
+    ///
+    /// On success, `encode_ok` encodes the value and the output carries `gas_used`,
+    /// `state_gas_used`, and `gas_refunded` from the context — the same fields that
+    /// [`success_output`](Self::success_output) sets. On error, delegates to
+    /// [`BasePrecompileError::into_precompile_result`].
+    ///
+    /// Use this instead of calling [`IntoPrecompileResult::into_precompile_result`] directly,
+    /// so callers do not have to manually thread gas values through.
+    pub fn result_output<T>(
+        &self,
+        result: Result<T>,
+        encode_ok: impl FnOnce(T) -> Bytes,
+    ) -> PrecompileResult {
+        result.into_precompile_result(
+            self.gas_used(),
+            self.state_gas_used(),
+            self.gas_refunded(),
+            encode_ok,
+        )
+    }
 }
 
 /// RAII guard for temporary caller overrides.
@@ -416,5 +439,55 @@ mod tests {
             }
             assert_eq!(ctx.sload(addr, key).unwrap(), U256::from(99));
         });
+    }
+
+    #[test]
+    fn result_output_success_propagates_gas_refunded() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        let addr = Address::ZERO;
+        let key = U256::from(1);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            // Write a non-zero value then clear it to generate an EIP-3529 refund.
+            ctx.sstore(addr, key, U256::from(42)).unwrap();
+            ctx.sstore(addr, key, U256::ZERO).unwrap();
+
+            ctx.result_output::<Bytes>(Ok(Bytes::new()), |b| b)
+        })
+        .unwrap();
+
+        assert!(output.is_success());
+        assert!(output.gas_refunded > 0, "clearing a slot must propagate a non-zero refund");
+    }
+
+    #[test]
+    fn result_output_error_does_not_expose_refund() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+        let addr = Address::ZERO;
+        let key = U256::from(1);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ctx.sstore(addr, key, U256::from(1)).unwrap();
+            ctx.sstore(addr, key, U256::ZERO).unwrap();
+
+            ctx.result_output::<Bytes>(Err(BasePrecompileError::Revert(Bytes::new())), |b| b)
+        })
+        .unwrap();
+
+        assert!(output.is_revert());
+        assert_eq!(output.gas_refunded, 0, "error path must not propagate gas_refunded");
+    }
+
+    #[test]
+    fn result_output_success_no_refund() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ctx.result_output::<Bytes>(Ok(Bytes::new()), |b| b)
+        })
+        .unwrap();
+
+        assert!(output.is_success());
+        assert_eq!(output.gas_refunded, 0);
     }
 }

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -218,12 +218,12 @@ where
         let index = (position - 1) as usize;
 
         if index != last_index {
-            let last_value = self.values[last_index].read()?;
+            let last_value = self.values.at_with_len(last_index, len)?.read()?;
             self.positions.at_mut(&last_value).write(position)?;
-            self.values[index].write(last_value)?;
+            self.values.at_mut_with_len(index, len)?.write(last_value)?;
         }
 
-        self.values[last_index].delete()?;
+        self.values.at_mut_with_len(last_index, len)?.delete()?;
         Slot::<U256>::new(self.values.len_slot(), self.address, self.storage)
             .write(U256::from(last_index))?;
         self.positions.at_mut(value).delete()?;
@@ -235,10 +235,11 @@ where
     where
         T::Handler<'a>: Handler<T>,
     {
-        if index >= self.len()? {
+        let len = self.len()?;
+        if index >= len {
             return Ok(None);
         }
-        Ok(Some(self.values[index].read()?))
+        Ok(Some(self.values.at_with_len(index, len)?.read()?))
     }
 
     /// Reads a contiguous range of elements from the set.
@@ -251,7 +252,7 @@ where
         let start = start.min(end);
         let mut result = Vec::new();
         for i in start..end {
-            result.push(self.values[i].read()?);
+            result.push(self.values.at_with_len(i, len)?.read()?);
         }
         Ok(result)
     }
@@ -266,7 +267,7 @@ where
         let len = self.len()?;
         let mut vec = Vec::new();
         for i in 0..len {
-            vec.push(self.values[i].read()?);
+            vec.push(self.values.at_with_len(i, len)?.read()?);
         }
         Ok(Set(vec))
     }
@@ -276,28 +277,31 @@ where
         let new_len = value.0.len();
 
         for i in 0..old_len {
-            let old_value = self.values[i].read()?;
+            let old_value = self.values.at_with_len(i, old_len)?.read()?;
             self.positions.at_mut(&old_value).delete()?;
         }
 
         for (index, new_value) in value.0.into_iter().enumerate() {
             self.positions.at_mut(&new_value).write(checked_position(index)?)?;
-            self.values[index].write(new_value)?;
+            self.values.at_mut_with_len(index, new_len)?.write(new_value)?;
         }
-
-        Slot::<U256>::new(self.values.len_slot(), self.address, self.storage)
-            .write(U256::from(new_len))?;
 
         for i in new_len..old_len {
-            self.values[i].delete()?;
+            self.values.at_mut_with_len(i, old_len)?.delete()?;
         }
+
+        if new_len != old_len {
+            Slot::<U256>::new(self.values.len_slot(), self.address, self.storage)
+                .write(U256::from(new_len))?;
+        }
+
         Ok(())
     }
 
     fn delete(&mut self) -> Result<()> {
         let len = self.len()?;
         for i in 0..len {
-            let value = self.values[i].read()?;
+            let value = self.values.at_with_len(i, len)?.read()?;
             self.positions.at_mut(&value).delete()?;
         }
         self.values.delete()
@@ -326,6 +330,7 @@ where
 #[cfg(test)]
 mod tests {
     use alloy_primitives::Address;
+    use rstest::rstest;
 
     use super::*;
     use crate::{hashmap::setup_storage, storage_ctx::StorageCtx};
@@ -375,6 +380,38 @@ mod tests {
             }
         });
     }
+    /// (`initial_size`, `final_size`) - covers grow, shrink, and equal-size rewrite.
+    #[rstest]
+    #[case(3, 7)] // grow
+    #[case(7, 3)] // shrink
+    #[case(4, 4)] // same size, different contents
+    fn test_set_write_len_slot_updated(#[case] initial: u8, #[case] final_size: u8) {
+        let (mut storage, contract_addr) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let base = U256::from(700u64);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+
+            // Use disjoint ranges so first and second share no elements.
+            let first: Vec<Address> = (0..initial).map(|i| Address::from([i; 20])).collect();
+            handler.write(Set::from(first.clone())).unwrap();
+            assert_eq!(handler.len().unwrap(), initial as usize);
+
+            let second: Vec<Address> =
+                (100..100 + final_size).map(|i| Address::from([i; 20])).collect();
+            handler.write(Set::from(second.clone())).unwrap();
+
+            assert_eq!(handler.len().unwrap(), final_size as usize);
+            let loaded = handler.read().unwrap();
+            assert_eq!(loaded.len(), final_size as usize);
+            for addr in &second {
+                assert!(handler.contains(addr).unwrap());
+            }
+            for addr in &first {
+                assert!(!handler.contains(addr).unwrap());
+            }
+        });
+    }
+
     #[test]
     fn test_set_transient_methods_return_err() {
         let (mut storage, contract_addr) = setup_storage();

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -7,7 +7,6 @@
 //! - **Data slots**: Start at `keccak256(len_slot)`; elements packed where possible.
 
 use alloc::vec::Vec;
-use core::ops::{Index, IndexMut};
 
 use alloy_primitives::{Address, U256, keccak256};
 
@@ -254,27 +253,44 @@ where
     }
 }
 
-impl<'a, T> Index<usize> for VecHandler<'a, T>
+impl<'a, T> VecHandler<'a, T>
 where
     T: Storable,
 {
-    type Output = T::Handler<'a>;
-    fn index(&self, index: usize) -> &Self::Output {
+    /// Returns a handler for the element at `index`, bounds-checked against a caller-supplied
+    /// `len` (no `sload` — pure integer comparison).
+    ///
+    /// Callers must supply a `len` freshly read from `self.len()` and not invalidated by a
+    /// subsequent `push`/`pop`. Returns `Err(Fatal)` if `index >= len`.
+    #[inline]
+    pub(crate) fn at_with_len(&self, index: usize, len: usize) -> Result<&T::Handler<'a>> {
+        if index >= len {
+            return Err(BasePrecompileError::Fatal(
+                "vec index out of bounds: position invariant violated".into(),
+            ));
+        }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        self.cache
-            .get_or_insert(&index, || Self::compute_handler(data_start, address, storage, index))
+        Ok(self
+            .cache
+            .get_or_insert(&index, || Self::compute_handler(data_start, address, storage, index)))
     }
-}
 
-impl<'a, T> IndexMut<usize> for VecHandler<'a, T>
-where
-    T: Storable,
-{
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    /// Mutable variant of [`at_with_len`].
+    #[inline]
+    pub(crate) fn at_mut_with_len(
+        &mut self,
+        index: usize,
+        len: usize,
+    ) -> Result<&mut T::Handler<'a>> {
+        if index >= len {
+            return Err(BasePrecompileError::Fatal(
+                "vec index out of bounds: position invariant violated".into(),
+            ));
+        }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        self.cache.get_or_insert_mut(&index, || {
+        Ok(self.cache.get_or_insert_mut(&index, || {
             Self::compute_handler(data_start, address, storage, index)
-        })
+        }))
     }
 }
 
@@ -471,6 +487,28 @@ mod tests {
             }
             assert_eq!(handler.len().unwrap(), 0);
             assert_eq!(handler.pop().unwrap(), None);
+        });
+    }
+
+    #[test]
+    fn test_vec_at_oob_returns_none() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(900u64);
+            let handler = VecHandler::<U256>::new(len_slot, address, ctx);
+            assert!(handler.at(0).unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn test_vec_at_with_len_oob_returns_err() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(901u64);
+            let handler = VecHandler::<U256>::new(len_slot, address, ctx);
+            assert!(handler.at_with_len(0, 0).is_err());
+            assert!(handler.at_with_len(5, 5).is_err());
+            assert!(handler.at_with_len(0, 1).is_ok());
         });
     }
 

--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -17,9 +17,6 @@ sol! {
         /// Feature is already activated.
         error AlreadyActivated(bytes32 feature);
 
-        /// Feature is already deactivated.
-        error AlreadyDeactivated(bytes32 feature);
-
         /// Feature is not activated.
         error FeatureNotActivated(bytes32 feature);
 

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -2,9 +2,7 @@
 
 use alloy_primitives::{Address, B256, Bytes, address, b256};
 use base_precompile_macros::contract;
-use base_precompile_storage::{
-    BasePrecompileError, Handler, IntoPrecompileResult, Mapping, Result,
-};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
 use revm::precompile::PrecompileResult;
 
 use crate::IActivationRegistry;
@@ -77,11 +75,7 @@ impl ActivationRegistryStorage<'_> {
     /// [`revm::precompile::PrecompileOutput::reverted`] to distinguish an activated feature from an
     /// ABI revert.
     pub fn assert_activated(&self, feature: B256) -> PrecompileResult {
-        self.ensure_activated(feature).into_precompile_result(
-            self.storage.gas_used(),
-            self.storage.state_gas_used(),
-            |()| Bytes::new(),
-        )
+        self.storage.result_output(self.ensure_activated(feature), |()| Bytes::new())
     }
 
     /// Returns `Ok(())` when the feature is activated.
@@ -115,7 +109,7 @@ impl ActivationRegistryStorage<'_> {
     pub fn set_activated(
         &mut self,
         feature: B256,
-        activated: bool,
+        to_activated_state: bool,
         activation_admin_address: Option<Address>,
     ) -> Result<()> {
         // Keep this guard at the shared mutation boundary so `activate`, `deactivate`, and direct
@@ -132,20 +126,24 @@ impl ActivationRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         }
 
-        let current = self.features.at(&feature).read()?;
-        if current == activated {
-            if activated {
-                return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyActivated {
-                    feature,
-                }));
-            }
+        let current_activated_state = self.features.at(&feature).read()?;
 
+        let is_activating_and_already_activated = to_activated_state && current_activated_state;
+        let is_deactivating_and_already_deactivated =
+            !to_activated_state && !current_activated_state;
+
+        if is_activating_and_already_activated {
+            return Err(BasePrecompileError::revert(IActivationRegistry::AlreadyActivated {
+                feature,
+            }));
+        }
+        if is_deactivating_and_already_deactivated {
             return Err(BasePrecompileError::revert(IActivationRegistry::FeatureNotActivated {
                 feature,
             }));
         }
 
-        if activated {
+        if to_activated_state {
             self.__initialize()?;
             self.features.at_mut(&feature).write(true)?;
             self.emit_event(IActivationRegistry::FeatureActivated { feature, caller })?;
@@ -479,5 +477,52 @@ mod tests {
                 feature: FEATURE,
             })
         );
+    }
+
+    /// End-to-end test: activate a feature, then deactivate it through `dispatch`. Deactivation
+    /// clears the feature storage slot (nonzero to zero SSTORE), which earns an EIP-3529 refund
+    /// that must appear in `PrecompileOutput::gas_refunded`.
+    #[test]
+    fn dispatch_deactivate_propagates_sstore_refund() {
+        use alloy_sol_types::SolCall;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        // Activate first so deactivation has a nonzero slot to clear.
+        activate_feature(&mut storage).unwrap();
+
+        let calldata = IActivationRegistry::deactivateCall { feature: FEATURE }.abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, Some(ADMIN))
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(output.is_success(), "deactivate must succeed");
+        assert!(
+            output.gas_refunded > 0,
+            "deactivating a feature clears a storage slot and must propagate an EIP-3529 refund"
+        );
+    }
+
+    /// Activating a feature writes to a zero slot (nonzero-to-zero refunds do not apply to
+    /// zero-to-nonzero writes), so `gas_refunded` must be zero on the activate path.
+    #[test]
+    fn dispatch_activate_has_no_sstore_refund() {
+        use alloy_sol_types::SolCall;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        let calldata = IActivationRegistry::activateCall { feature: FEATURE }.abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, Some(ADMIN))
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(output.is_success());
+        assert_eq!(output.gas_refunded, 0, "writing to a zero slot earns no refund");
     }
 }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -603,7 +603,12 @@ where
         if let Err(error) = &result {
             self.record_base_error(error);
         }
-        let result = result.into_precompile_result(ctx.gas_used(), ctx.state_gas_used(), encode_ok);
+        let result = result.into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            ctx.gas_refunded(),
+            encode_ok,
+        );
         self.record_result(&result);
         result
     }


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of #3207, #3230, #3253, #3285, #3374, and #3258 into `releases/v1.1.0`.
> #3374 is still open upstream; this PR uses its current head commit `1679a822398bd294276a4d679cecfd49997c6734`.

## Source PRs

- #3207 / BOP-273: fix VecHandler-backed SetHandler out-of-bounds storage access.
- #3230 / BOP-276: fix the misleading EIP-3541 attribution in the set_code comment.
- #3253 / BOP-292: remove unreachable B20 announcement guard and redundant activation error.
- #3285 / BOP-291: enforce the EIP-2200 SSTORE gas-stipend guard.
- #3374 / BOP-290: charge code_deposit_state_gas for balance-only set_code accounts.
- #3258 / BOP-289: propagate SSTORE refunds through precompile outputs.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p base-precompile-storage --lib`
- `cargo test -p base-common-precompiles --lib`
- `cargo check -p base-precompile-storage --no-default-features`
- `cargo check -p base-common-precompiles --no-default-features`