### PR TITLE
[backport] BOP follow-up fixes for v1.1.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -67,10 +67,21 @@ runs:
 
     - name: Install native dependencies
       if: inputs.native-deps == 'true'
-      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
-      with:
-        packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config protobuf-compiler
-        version: 1.4
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential \
+          clang \
+          libclang-dev \
+          libprotobuf-dev \
+          libsqlite3-dev \
+          llvm \
+          llvm-dev \
+          pkg-config \
+          protobuf-compiler
 
     - name: Install Rust (stable via rust-toolchain.toml)
       if: inputs.toolchain == 'stable'

--- a/crates/common/precompile-macros/README.md
+++ b/crates/common/precompile-macros/README.md
@@ -12,6 +12,16 @@ Procedural macros for type-safe EVM storage abstractions for Base native precomp
 - `storable_arrays!()`, `storable_nested_arrays!()` — fixed-size array impls
 - `gen_storable_tests!()` — proptest round-trip tests for all storage types
 
+For `#[contract]` layouts, place the namespace helper below `#[contract]`:
+
+```rust,ignore
+#[contract]
+#[namespace("b20")]
+pub struct B20Contract {
+    pub total_supply: U256,
+}
+```
+
 For `Storable` layouts, place the derive before the namespace helper:
 
 ```rust,ignore

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -219,12 +219,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                 &self,
                 role: ::alloy_primitives::B256,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::B256> {
-                let admin_role = self.b20.role_admin(role)?;
-                if admin_role.is_zero() && role != crate::B20TokenRole::DefaultAdmin.id() {
-                    Ok(crate::B20TokenRole::DefaultAdmin.id())
-                } else {
-                    Ok(admin_role)
-                }
+                self.b20.role_admin(role)
             }
 
             fn set_role_admin(
@@ -372,7 +367,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
 
             fn decimals(&self) -> ::base_precompile_storage::Result<u8> {
                 let stored = self.asset.decimals()?;
-                Ok(if stored == 0 { 6 } else { stored })
+                Ok(if stored == 0 { Self::MIN_DECIMALS } else { stored })
             }
         }
     })

--- a/crates/common/precompile-macros/src/lib.rs
+++ b/crates/common/precompile-macros/src/lib.rs
@@ -27,7 +27,10 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     contract::generate(input, config.address.as_ref())
 }
 
-/// Namespaces a `#[contract]` storage struct or `Storable` layout using an ERC-7201 storage root.
+/// Adds an ERC-7201 namespace to a `Storable` layout.
+///
+/// Contract storage layouts support `#[namespace("id")]` when it is placed below `#[contract]`;
+/// in that order, `#[contract]` consumes the helper attribute directly.
 #[proc_macro_attribute]
 pub fn namespace(attr: TokenStream, item: TokenStream) -> TokenStream {
     namespace::expand(attr, item)

--- a/crates/common/precompile-macros/src/namespace.rs
+++ b/crates/common/precompile-macros/src/namespace.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, LitStr};
 
-use crate::utils::{attr_path_is, parse_namespace_id};
+use crate::utils::attr_path_is;
 
 pub(crate) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
     match expand_impl(attr.into(), item.into()) {
@@ -20,19 +20,17 @@ fn expand_impl(
     let namespace_id: LitStr = syn::parse2(attr)?;
     let mut input: DeriveInput = syn::parse2(item)?;
 
-    parse_namespace_id(namespace_id.clone())?;
-
     if input.attrs.iter().any(|attr| {
         attr_path_is(attr.path(), "namespace") || attr_path_is(attr.path(), "storage_namespace")
     }) {
         return Err(syn::Error::new_spanned(&input.ident, "duplicate `namespace` attribute"));
     }
 
-    if let Some(contract_index) =
-        input.attrs.iter().position(|attr| attr_path_is(attr.path(), "contract"))
-    {
-        input.attrs.insert(contract_index + 1, syn::parse_quote!(#[namespace(#namespace_id)]));
-        return Ok(quote! { #input });
+    if input.attrs.iter().any(|attr| attr_path_is(attr.path(), "contract")) {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[namespace]` must be placed below `#[contract]` on contract storage layouts",
+        ));
     }
 
     if has_storable_derive(&input)? {
@@ -42,7 +40,7 @@ fn expand_impl(
 
     Err(syn::Error::new_spanned(
         &input.ident,
-        "`#[namespace]` must be paired with `#[contract]` or `#[derive(Storable)]`",
+        "`#[namespace]` must be paired with `#[derive(Storable)]` or placed below `#[contract]`",
     ))
 }
 

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -188,6 +188,10 @@ impl Parse for InstallConfig {
         input.parse::<Token![=]>()?;
         let address = input.parse()?;
 
+        let has_non_comma_remainder = !input.is_empty() && !input.peek(Token![,]);
+        if has_non_comma_remainder {
+            return Err(syn::Error::new(input.span(), "unexpected `install` option"));
+        }
         if !input.is_empty() {
             input.parse::<Token![,]>()?;
         }
@@ -252,5 +256,19 @@ mod tests {
 
         assert!(config.storage.is_some());
         assert!(config.macro_path.is_some());
+    }
+
+    #[test]
+    fn config_rejects_install_option_without_comma_as_unexpected_option() {
+        let err = parse_config(quote! { install(address = X extra) }).err().unwrap();
+
+        assert!(err.to_string().contains("unexpected `install` option"));
+    }
+
+    #[test]
+    fn config_rejects_extra_install_option_after_comma() {
+        let err = parse_config(quote! { install(address = X, extra) }).err().unwrap();
+
+        assert!(err.to_string().contains("unexpected `install` option"));
     }
 }

--- a/crates/common/precompile-macros/src/storable.rs
+++ b/crates/common/precompile-macros/src/storable.rs
@@ -97,20 +97,30 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
     let packing_module = gen_packing_module_from_ir(&layout_fields, &mod_ident);
 
     let len = fields.len();
-    let (direct_fields, direct_names, mapping_names) = field_infos.iter().fold(
-        (Vec::with_capacity(len), Vec::with_capacity(len), Vec::new()),
+    let (direct_fields, field_inits) = field_infos.iter().fold(
+        (Vec::with_capacity(len), Vec::with_capacity(len)),
         |mut out, field_info| {
+            let name = &field_info.name;
             if extract_mapping_types(&field_info.ty).is_none() {
-                out.0.push((&field_info.name, &field_info.ty));
-                out.1.push(&field_info.name);
+                out.0.push((name, &field_info.ty));
+                out.1.push(quote! { #name });
             } else {
-                out.2.push(&field_info.name);
+                out.1.push(quote! { #name: Default::default() });
             }
             out
         },
     );
 
     let direct_tys: Vec<_> = direct_fields.iter().map(|(_, ty)| *ty).collect();
+    let is_dynamic = if direct_tys.is_empty() {
+        quote! { false }
+    } else {
+        quote! {
+            #(
+                <#direct_tys as ::base_precompile_storage::StorableType>::IS_DYNAMIC
+            )||*
+        }
+    };
 
     let load_impl = gen_load_impl(&direct_fields, &mod_ident);
     let store_impl = gen_store_impl(&direct_fields, &mod_ident);
@@ -128,9 +138,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
             const LAYOUT: ::base_precompile_storage::Layout = ::base_precompile_storage::Layout::Slots(#mod_ident::SLOT_COUNT);
             #namespace_consts
 
-            const IS_DYNAMIC: bool = #(
-                <#direct_tys as ::base_precompile_storage::StorableType>::IS_DYNAMIC
-            )||*;
+            const IS_DYNAMIC: bool = #is_dynamic;
 
             type Handler<'a> = #handler_name<'a>;
 
@@ -156,8 +164,7 @@ fn derive_struct_impl(input: &DeriveInput, data_struct: &DataStruct) -> syn::Res
                 #load_impl
 
                 Ok(Self {
-                    #(#direct_names),*,
-                    #(#mapping_names: Default::default()),*
+                    #(#field_inits),*
                 })
             }
 
@@ -658,7 +665,7 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
         prev_slot_ref.map_or_else(
             || quote! {{
                 if <#ty as ::base_precompile_storage::StorableType>::IS_PACKABLE {
-                    // Always SLOAD first (Category 3: is_t4() optimization removed — correct but slightly less efficient)
+                    // Load the existing slot before packing so neighboring packed values are preserved.
                     pending_val = storage.load(#slot_addr)?;
                     pending_offset = Some(#packing::#loc_const.offset_slots);
                     let mut packed = ::base_precompile_storage::PackedSlot(pending_val);
@@ -685,7 +692,7 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
                     if let Some(offset) = pending_offset {
                         storage.store(base_slot + ::alloy_primitives::U256::from(offset), pending_val)?;
                     }
-                    // Always SLOAD first (Category 3: is_t4() optimization removed — correct but slightly less efficient)
+                    // Load the existing slot before packing so neighboring packed values are preserved.
                     pending_val = storage.load(#slot_addr)?;
                     pending_offset = Some(curr_offset);
                     let mut packed = ::base_precompile_storage::PackedSlot(pending_val);
@@ -715,6 +722,10 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
 }
 
 fn gen_delete_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
+    if fields.is_empty() {
+        return quote! {};
+    }
+
     let dynamic_deletes = fields.iter().map(|(name, ty)| {
         let loc_const = PackingConstants::new(name).location();
         quote! {

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -87,6 +87,10 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()> {
+        if self.is_static {
+            return Err(BasePrecompileError::StaticCallViolation);
+        }
+
         let code_len = code.len();
 
         // EIP-3541 / Yellow Paper G_codedeposit: 200 gas per byte of deployed bytecode.
@@ -294,7 +298,9 @@ mod tests {
     use alloy_primitives::Address;
     use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId, state::Bytecode};
 
-    use crate::{hashmap::HashMapStorageProvider, provider::PrecompileStorageProvider};
+    use crate::{
+        BasePrecompileError, hashmap::HashMapStorageProvider, provider::PrecompileStorageProvider,
+    };
 
     fn amsterdam_provider() -> HashMapStorageProvider {
         let mut provider = HashMapStorageProvider::new(1);
@@ -339,5 +345,19 @@ mod tests {
             after_first,
             "state_gas_used must not increase for an existing account"
         );
+    }
+
+    #[test]
+    fn set_code_static_context_reverts_before_state_gas_or_code_mutation() {
+        let mut provider = amsterdam_provider();
+        provider.set_static(true);
+        let addr = Address::from([0x42u8; 20]);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+
+        let err = provider.set_code(addr, code).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::StaticCallViolation);
+        assert_eq!(provider.state_gas_used(), 0);
+        assert!(provider.get_account_info(addr).is_none());
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -87,6 +87,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), BasePrecompileError> {
+        if self.is_static {
+            return Err(BasePrecompileError::StaticCallViolation);
+        }
+
         let code_len = code.len();
         // Mirror the production is_new_account check so state gas tracking is faithful.
         let is_new_account = self.accounts.get(&address).is_none_or(AccountInfo::is_empty);

--- a/crates/common/precompile-storage/src/packing.rs
+++ b/crates/common/precompile-storage/src/packing.rs
@@ -3,8 +3,14 @@
 //! This module provides helper functions for bit-level manipulation of storage slots,
 //! enabling efficient packing of multiple small values into single 32-byte slots.
 //!
-//! Packing only applies to primitive types where `LAYOUT::Bytes(count) && count < 32`.
-//! Non-primitives (structs, fixed-size arrays, dynamic types) have `LAYOUT = Layout::Slot`.
+//! Storage layout is described by the [`Layout`](crate::provider::Layout) enum:
+//! - `Layout::Bytes(N)` -- primitive types that fit in N bytes (1-32). Types with N < 32
+//!   are packable: multiple values can share a single 32-byte slot.
+//! - `Layout::Slots(N)` -- types that span N full slots and cannot be packed. This includes
+//!   structs and dynamic types (e.g. `Mapping`, `Vec`), but also fixed-size arrays whose
+//!   element type is small (<=16 bytes). For those arrays `N = calc_packed_slot_count(len,
+//!   elem_bytes)`, and individual elements within each slot are still packed using
+//!   `extract_from_word` / `insert_into_word`.
 //!
 //! ## Solidity Compatibility
 //!

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -316,7 +316,16 @@ pub trait StorageKey: sealed::OnlyPrimitives {
     /// Returns key bytes for storage slot computation (left-padded to 32 bytes).
     fn as_storage_bytes(&self) -> impl AsRef<[u8]>;
 
-    /// Computes `keccak256(lpad32(key) ‖ slot_be32)` — the Solidity mapping slot derivation.
+    /// Computes `keccak256(lpad32(key) ‖ slot_be32)`.
+    ///
+    /// The formula is Solidity-compatible for unsigned integers (`u8`..`u256`), `Address`,
+    /// `FixedBytes<32>`, and `String`. Signed integers and `FixedBytes<N>` for `N < 32`
+    /// intentionally diverge from Solidity's `abi.encode(key, slot)` encoding: signed integers
+    /// use raw signed bytes and short `FixedBytes<N>` keys are left-padded from their slice
+    /// rather than right-padded as Solidity would. Off-chain tools reconstructing mapping slots
+    /// for those key types must use this crate's encoding, not Solidity's.
+    ///
+    /// See the crate-level README for a full compatibility table.
     fn mapping_slot(&self, slot: U256) -> U256 {
         let key_bytes = self.as_storage_bytes();
         let key_bytes = key_bytes.as_ref();

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -304,13 +304,13 @@ where
     }
 
     fn t_read(&self) -> Result<Set<T>> {
-        unimplemented!("Set does not support transient storage")
+        Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))
     }
     fn t_write(&mut self, _: Set<T>) -> Result<()> {
-        unimplemented!("Set does not support transient storage")
+        Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))
     }
     fn t_delete(&mut self) -> Result<()> {
-        unimplemented!("Set does not support transient storage")
+        Err(BasePrecompileError::Fatal("Set does not support transient storage".into()))
     }
 }
 
@@ -373,6 +373,18 @@ mod tests {
             for addr in &addrs {
                 assert!(handler.contains(addr).unwrap());
             }
+        });
+    }
+    #[test]
+    fn test_set_transient_methods_return_err() {
+        let (mut storage, contract_addr) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let base = U256::from(800u64);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+
+            assert!(handler.t_read().is_err());
+            assert!(handler.t_write(Set::default()).is_err());
+            assert!(handler.t_delete().is_err());
         });
     }
 }

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -66,6 +66,28 @@ fn test_contract_macro_basic_roundtrip() {
     });
 }
 
+mod mapping_only_storable_layout {
+    use alloy_primitives::{Address, U256};
+    use base_precompile_macros::Storable;
+    use base_precompile_storage::{Mapping, StorableType};
+
+    #[derive(Debug, Clone, Storable)]
+    struct MappingOnlyStorage {
+        balances: Mapping<Address, U256>,
+        allowances: Mapping<Address, Mapping<Address, U256>>,
+    }
+
+    #[test]
+    fn mapping_only_storable_struct_uses_static_layout() {
+        const { assert!(!<MappingOnlyStorage as StorableType>::IS_DYNAMIC) };
+        assert_eq!(<MappingOnlyStorage as StorableType>::SLOTS, 2);
+
+        let value =
+            MappingOnlyStorage { balances: Mapping::default(), allowances: Mapping::default() };
+        let _ = (value.balances, value.allowances);
+    }
+}
+
 #[test]
 fn test_contract_slots_are_deterministic() {
     // Verify that the generated slot constants are stable across runs.
@@ -659,29 +681,5 @@ mod packed_slot_layout {
             );
             assert_eq!((raw >> 56) & U256::from(u64::MAX), U256::from(0xDEAD_BEEF_DEAD_BEEF_u64));
         });
-    }
-}
-
-mod namespace_outer_order {
-    use alloy_primitives::{Address, U256, address, uint};
-    use base_precompile_macros::{contract, namespace};
-
-    const ORDER_ADDR: Address = address!("0000000000000000000000000000000000005678");
-
-    #[namespace("b20.outer-order")]
-    #[contract(addr = ORDER_ADDR)]
-    pub struct OuterOrderStorage {
-        pub value: U256,
-    }
-
-    #[test]
-    fn namespace_macro_reorders_above_contract() {
-        assert_eq!(ORDER_ADDR, address!("0000000000000000000000000000000000005678"));
-        assert_eq!(slots::NAMESPACE_ID, "b20.outer-order");
-        assert_eq!(
-            slots::NAMESPACE_ROOT,
-            uint!(0xf06e16fd945cfdfdb627e60cabea1fb8bb965382c21574655d1e8bb28bdfcf00_U256)
-        );
-        assert_eq!(slots::VALUE, slots::NAMESPACE_ROOT);
     }
 }

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -75,7 +75,8 @@ impl B20AssetStorage<'_> {
     /// WAD precision for multiplier arithmetic: 1e18.
     pub const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
-    /// Returns the configured asset decimals, defaulting an unset storage slot to `6`.
+    /// Returns the configured asset decimals, defaulting an unset storage slot to
+    /// [`Self::MIN_DECIMALS`].
     pub fn decimals(&self) -> Result<u8> {
         let decimals = self.asset.decimals()?;
         Ok(if decimals == 0 { Self::MIN_DECIMALS } else { decimals })
@@ -84,14 +85,14 @@ impl B20AssetStorage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256, address, uint};
+    use alloy_primitives::{Address, B256, U256, address, uint};
     use base_precompile_storage::{Handler, StorableType, StorageCtx, StorageKey, setup_storage};
 
     use super::{
         __packing_b20_asset_extension_storage, B20AssetExtensionStorage, B20AssetInit,
         B20AssetStorage, slots,
     };
-    use crate::{AssetAccounting, B20CoreStorage};
+    use crate::{AssetAccounting, B20CoreStorage, B20TokenRole, TokenAccounting};
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -157,6 +158,24 @@ mod tests {
 
             assert_eq!(ctx.sload(TOKEN, multiplier_slot).unwrap(), configured_multiplier);
             assert_eq!(token.multiplier().unwrap(), configured_multiplier);
+        });
+    }
+
+    #[test]
+    fn role_admin_reads_raw_storage_default() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let token = B20AssetStorage::from_address(TOKEN, ctx);
+
+            assert_eq!(
+                TokenAccounting::role_admin(&token, B20TokenRole::Mint.id()).unwrap(),
+                B20TokenRole::DefaultAdmin.id()
+            );
+            assert_eq!(
+                TokenAccounting::role_admin(&token, B20TokenRole::DefaultAdmin.id()).unwrap(),
+                B256::ZERO
+            );
         });
     }
 
@@ -234,12 +253,13 @@ mod tests {
     }
 
     #[test]
-    fn decimals_uninitialized_slot_falls_back_to_six() {
+    fn decimals_uninitialized_slot_falls_back_to_min_decimals() {
         let (mut storage, _) = setup_storage();
 
         StorageCtx::enter(&mut storage, |ctx| {
             let token = B20AssetStorage::from_address(TOKEN, ctx);
             assert_eq!(token.asset.decimals.read().unwrap(), 0);
+            assert_eq!(token.decimals().unwrap(), B20AssetStorage::MIN_DECIMALS);
             assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
         });
     }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -360,7 +360,7 @@ mod tests {
             name: name.to_string(),
             symbol: symbol.to_string(),
             initialAdmin: Address::repeat_byte(0xAB),
-            decimals: 6,
+            decimals: B20AssetStorage::MIN_DECIMALS,
         }
     }
 
@@ -496,7 +496,7 @@ mod tests {
 
             assert_eq!(token.b20.name.read().unwrap(), "My Token");
             assert_eq!(token.b20.symbol.read().unwrap(), "MYT");
-            assert_eq!(AssetAccounting::decimals(&token).unwrap(), 6);
+            assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
             assert_eq!(token.supply_cap().unwrap(), B20FactoryStorage::DEFAULT_SUPPLY_CAP);
         });
     }

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -294,6 +294,11 @@ mod tests {
     }
 
     #[test]
+    fn default_admin_role_matches_access_control_zero() {
+        assert_eq!(B20TokenRole::DefaultAdmin.id(), B256::ZERO);
+    }
+
+    #[test]
     fn grant_role_authorizes_against_role_admin_and_emits_event() {
         let mut token = token_with_default_admin();
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -10,7 +10,7 @@ use base_precompile_storage::Result;
 
 use crate::{
     IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
-    b20_asset::{AssetAccounting, B20AssetToken},
+    b20_asset::{AssetAccounting, B20AssetStorage, B20AssetToken},
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
     common::{Policy, TokenAccounting},
 };
@@ -376,8 +376,7 @@ impl PolicyRegistry for InMemoryPolicy {
 
 impl AssetAccounting for InMemoryTokenAccounting {
     fn multiplier(&self) -> Result<U256> {
-        const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
-        Ok(if self.multiplier.is_zero() { WAD } else { self.multiplier })
+        Ok(if self.multiplier.is_zero() { B20AssetStorage::WAD } else { self.multiplier })
     }
 
     fn set_multiplier(&mut self, ratio: U256) -> Result<()> {
@@ -408,6 +407,6 @@ impl AssetAccounting for InMemoryTokenAccounting {
     }
 
     fn decimals(&self) -> Result<u8> {
-        Ok(if self.decimals == 0 { 6 } else { self.decimals })
+        Ok(if self.decimals == 0 { B20AssetStorage::MIN_DECIMALS } else { self.decimals })
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of #3252, #3281, #3257, #3280, #3304, #3305, #3307, #3306, #3308, and #3309 into `releases/v1.1.0`.

## Source PRs

- #3252 / BOP-287: reject set_code in static context.
- #3281 / BOP-286: return structured errors for Set transient methods.
- #3257 / BOP-285: clarify StorageKey::mapping_slot Solidity compatibility docs.
- #3280 / BOP-284: fix stale packing module rustdoc.
- #3304 / BOP-294: clarify generated packed store comments.
- #3305 / BOP-295: support mapping-only Storable structs.
- #3307 / BOP-296: align B20 asset decimals default with the named bound.
- #3306 / BOP-297: simplify generated role-admin default fallback read.
- #3308 / BOP-298: remove unreachable namespace macro contract reorder branch.
- #3309 / BOP-299: improve unsupported install option diagnostics.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p base-precompile-storage --lib`
- `cargo test -p base-precompile-storage --test contract --features test-utils`
- `cargo test -p base-precompile-macros`
- `cargo test -p base-common-precompiles --lib`
- `cargo check -p base-precompile-storage --no-default-features`
- `cargo check -p base-common-precompiles --no-default-features`