### PR TITLE
fix(cli): Add Base RPC Forwarding

### DIFF
--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -18,8 +18,14 @@ use crate::config::ResolvedChainConfig;
 #[derive(Args, Clone, Debug)]
 #[command(
     mut_arg("builder_disallow", |arg| arg.hide(true).long("__builder-disallow-disabled")),
-    mut_arg("sequencer", |arg| arg.hide(true).long("__rollup-sequencer-disabled")),
-    mut_arg("sequencer_headers", |arg| arg.hide(true).long("__rollup-sequencer-headers-disabled"))
+    mut_arg("sequencer", |arg| arg
+        .hide(true)
+        .long("__rollup-sequencer-disabled")
+        .alias(None::<&'static str>)),
+    mut_arg("sequencer_headers", |arg| arg
+        .hide(true)
+        .long("__rollup-sequencer-headers-disabled")
+        .alias(None::<&'static str>))
 )]
 pub(crate) struct RpcCommand {
     /// Execution chain spec to use instead of the root chain selection.
@@ -108,10 +114,16 @@ fn engine_ipc_url(path: &str) -> eyre::Result<Url> {
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command;
+
+    use base_execution_chainspec::BaseChainSpec;
     use clap::Parser;
 
     use crate::{cli::BaseCli, commands::BaseCommand, config::ChainArg};
 
+    const RPC_FORWARDING_ENDPOINT_ENV: &str = "OP_RETH_SEQUENCER_HTTP";
+    const RPC_FORWARDING_ENDPOINT_ENV_CHILD_TEST: &str =
+        "commands::rpc::tests::parses_rpc_forwarding_endpoint_from_env_child";
     const REQUIRED_CONSENSUS_ARGS: &[&str] =
         &["--l1-eth-rpc", "http://localhost:8545", "--l1-beacon", "http://localhost:5052"];
 
@@ -221,6 +233,70 @@ mod tests {
     }
 
     #[test]
+    fn parses_rpc_forwarding_endpoint_arg() {
+        let cli = BaseCli::parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--rpc.forwarding-endpoint",
+            "http://localhost:8545",
+        ]));
+
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
+
+        assert_eq!(
+            launch_config.standard.rpc.rpc_forwarding_endpoint.as_deref(),
+            Some("http://localhost:8545")
+        );
+        assert_eq!(
+            launch_config.standard.rpc.rollup_args.sequencer.as_deref(),
+            Some("http://localhost:8545")
+        );
+        assert!(!launch_config.standard.enable_tx_forwarding);
+        assert!(launch_config.standard.builder_rpc_urls.is_empty());
+    }
+
+    #[test]
+    fn parses_rpc_forwarding_endpoint_from_env() {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command.arg("--exact").arg(RPC_FORWARDING_ENDPOINT_ENV_CHILD_TEST).arg("--ignored");
+        command.env(RPC_FORWARDING_ENDPOINT_ENV, "http://localhost:8547");
+
+        let output = command.output().unwrap();
+
+        assert!(
+            output.status.success(),
+            "child env parsing test failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    #[ignore = "spawned by parses_rpc_forwarding_endpoint_from_env with isolated process env"]
+    fn parses_rpc_forwarding_endpoint_from_env_child() {
+        let cli = BaseCli::parse_from(rpc_args(&["base", "rpc"]));
+
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
+
+        assert_eq!(
+            launch_config.standard.rpc.rpc_forwarding_endpoint.as_deref(),
+            Some("http://localhost:8547")
+        );
+        assert_eq!(
+            launch_config.standard.rpc.rollup_args.sequencer.as_deref(),
+            Some("http://localhost:8547")
+        );
+    }
+
+    #[test]
     fn rejects_rpc_mode_arg() {
         let err =
             BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--mode", "sequencer"])).unwrap_err();
@@ -283,6 +359,48 @@ mod tests {
 
         let rendered = err.to_string();
         assert!(rendered.contains("--rollup.sequencer"));
+    }
+
+    #[test]
+    fn rejects_rpc_rollup_sequencer_http_alias_arg() {
+        let err = BaseCli::try_parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--rollup.sequencer-http",
+            "http://localhost:8545",
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--rollup.sequencer-http"));
+    }
+
+    #[test]
+    fn rejects_rpc_rollup_sequencer_ws_alias_arg() {
+        let err = BaseCli::try_parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--rollup.sequencer-ws",
+            "ws://localhost:8546",
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--rollup.sequencer-ws"));
+    }
+
+    #[test]
+    fn rejects_rpc_rollup_sequencer_headers_arg() {
+        let err = BaseCli::try_parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--rollup.sequencer-headers",
+            "authorization=token",
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--rollup.sequencer-headers"));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -119,6 +119,14 @@ pub struct RpcStandardNodeArgs {
     #[command(flatten)]
     pub rollup_args: RollupArgs,
 
+    /// RPC endpoint used to forward submitted transactions without enabling sequencer mode.
+    #[arg(
+        long = "rpc.forwarding-endpoint",
+        env = "OP_RETH_SEQUENCER_HTTP",
+        value_name = "RPC_FORWARDING_ENDPOINT"
+    )]
+    pub rpc_forwarding_endpoint: Option<String>,
+
     /// A URL pointing to a secure websocket subscription that streams out flashblocks.
     ///
     /// If given, the flashblocks are received to build pending block. All request with "pending"
@@ -161,7 +169,11 @@ pub struct RpcStandardNodeArgs {
 }
 
 impl From<RpcStandardNodeArgs> for StandardNodeArgs {
-    fn from(args: RpcStandardNodeArgs) -> Self {
+    fn from(mut args: RpcStandardNodeArgs) -> Self {
+        if args.rollup_args.sequencer.is_none() {
+            args.rollup_args.sequencer.clone_from(&args.rpc_forwarding_endpoint);
+        }
+
         Self {
             rpc: args,
             enable_metering: false,
@@ -299,6 +311,19 @@ mod tests {
         args: T,
     }
 
+    fn default_rpc_standard_node_args() -> RpcStandardNodeArgs {
+        RpcStandardNodeArgs {
+            rollup_args: RollupArgs::default(),
+            rpc_forwarding_endpoint: None,
+            flashblocks_url: None,
+            max_pending_blocks_depth: 3,
+            flashblocks_cached_execution: false,
+            flashblocks_ping_interval: Duration::from_secs(30),
+            enable_transaction_tracing: false,
+            enable_transaction_tracing_logs: false,
+        }
+    }
+
     #[test]
     fn test_flashblocks_ping_interval_defaults_to_30_seconds() {
         let args = CommandParser::<RpcStandardNodeArgs>::parse_from([
@@ -349,5 +374,48 @@ mod tests {
             .expect("flashblocks config should exist");
 
         assert_eq!(config.subscriber_ping_interval, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn test_rpc_forwarding_endpoint_flows_into_standard_args() {
+        let args = CommandParser::<RpcStandardNodeArgs>::parse_from([
+            "reth",
+            "--rpc.forwarding-endpoint",
+            "http://localhost:8545",
+        ])
+        .args;
+
+        let standard_args = StandardNodeArgs::from(args);
+
+        assert_eq!(
+            standard_args.rpc.rollup_args.sequencer.as_deref(),
+            Some("http://localhost:8545")
+        );
+    }
+
+    #[test]
+    fn test_rpc_forwarding_endpoint_keeps_tx_forwarding_extension_disabled() {
+        let args = CommandParser::<RpcStandardNodeArgs>::parse_from([
+            "reth",
+            "--rpc.forwarding-endpoint",
+            "http://localhost:8545",
+        ])
+        .args;
+
+        let standard_args = StandardNodeArgs::from(args);
+        let config = TxForwardingConfig::from(&standard_args);
+
+        assert!(!config.enabled);
+        assert!(config.builder_urls.is_empty());
+    }
+
+    #[test]
+    fn test_rpc_default_keeps_forwarding_disabled() {
+        let standard_args = StandardNodeArgs::from(default_rpc_standard_node_args());
+        let config = TxForwardingConfig::from(&standard_args);
+
+        assert_eq!(standard_args.rpc.rollup_args.sequencer, None);
+        assert!(!config.enabled);
+        assert!(config.builder_urls.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This adds an explicit `base rpc` forwarding endpoint that keeps the unified RPC command out of sequencer mode. The new flag and `OP_RETH_SEQUENCER_HTTP` env var populate the existing execution runner forwarding config while leaving tx-forwarding, builder, conductor, metering, and signer-only surfaces rejected. The default read-only RPC behavior remains unchanged when no endpoint is configured.