### PR TITLE
chore(common): Schedule Sepolia Beryl Upgrade

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -237,7 +237,10 @@ mod tests {
             base_sepolia_forks[Azul],
             ForkCondition::Timestamp(ChainConfig::sepolia().azul_timestamp.unwrap())
         );
-        assert_eq!(base_sepolia_forks[Beryl], ForkCondition::Never);
+        assert_eq!(
+            base_sepolia_forks[Beryl],
+            ForkCondition::Timestamp(ChainConfig::sepolia().beryl_timestamp.unwrap())
+        );
         assert_eq!(base_sepolia_forks[Cobalt], ForkCondition::Never);
     }
 
@@ -302,6 +305,12 @@ mod tests {
 
     #[test]
     fn is_beryl_active_at_timestamp() {
+        let base_sepolia_forks = ChainUpgrades::sepolia();
+        assert!(!base_sepolia_forks.is_beryl_active_at_timestamp(0));
+        assert!(!base_sepolia_forks.is_beryl_active_at_timestamp(1_781_805_599));
+        assert!(base_sepolia_forks.is_beryl_active_at_timestamp(1_781_805_600));
+        assert!(base_sepolia_forks.is_beryl_active_at_timestamp(u64::MAX));
+
         let zeronet_forks = ChainUpgrades::zeronet();
         assert!(!zeronet_forks.is_beryl_active_at_timestamp(0));
         assert!(!zeronet_forks.is_beryl_active_at_timestamp(1_780_678_799));

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -424,7 +424,7 @@ const SEPOLIA: ChainConfig = ChainConfig {
     isthmus_timestamp: 1_744_905_600,
     jovian_timestamp: 1_763_568_001,
     azul_timestamp: Some(1_776_708_000),
-    beryl_timestamp: None,
+    beryl_timestamp: Some(1_781_805_600),
     cobalt_timestamp: None,
 
     genesis_l1_hash: b256!("cac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed"),

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -242,6 +242,11 @@ mod tests {
                 BaseUpgrade::Azul,
             ),
             (
+                Chain::base_sepolia(),
+                ChainConfig::sepolia().beryl_timestamp.unwrap(),
+                BaseUpgrade::Beryl,
+            ),
+            (
                 Chain::from_id(ChainConfig::zeronet().chain_id),
                 ChainConfig::zeronet().beryl_timestamp.unwrap(),
                 BaseUpgrade::Beryl,

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -471,6 +471,7 @@ mod tests {
         let mut rollup_config_value =
             serde_json::to_value(&rollup_config).expect("rollup config should convert to value");
         rollup_config_value["l2_chain_id"] = serde_json::json!(ORACLE_CHAIN_ID);
+        rollup_config_value["base"]["beryl"] = serde_json::Value::Null;
 
         let mut oracle = MockOracle::new();
         oracle.insert(L1_HEAD_KEY, B256::repeat_byte(0x11).to_vec());


### PR DESCRIPTION
## Summary

This schedules the Base Sepolia Beryl upgrade for June 18, 2026 at 2:00 PM EDT. The common chain config now carries the Beryl timestamp, and the schedule tests cover Sepolia activation and reverse lookup behavior.

Raw timestamp: `1781805600`
Unix timestamp viewer: https://www.unixtimestamp.com/