### PR TITLE
refactor(cli): Share Builder Execution Args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,7 +3370,6 @@ dependencies = [
  "base-builder-metering",
  "base-cli-utils",
  "base-execution-cli",
- "base-node-core",
  "base-node-runner",
  "base-reth-cli",
  "base-txpool-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,10 +3365,9 @@ dependencies = [
 name = "base-builder-bin"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
+ "base-builder-cli",
  "base-builder-core",
  "base-builder-metering",
- "base-bundles",
  "base-cli-utils",
  "base-execution-cli",
  "base-node-core",
@@ -3376,8 +3375,20 @@ dependencies = [
  "base-reth-cli",
  "base-txpool-rpc",
  "clap",
- "eyre",
  "reth-cli-util",
+]
+
+[[package]]
+name = "base-builder-cli"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "base-builder-core",
+ "base-builder-metering",
+ "base-bundles",
+ "base-node-core",
+ "clap",
+ "eyre",
  "rstest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ base-common-precompiles = { path = "crates/common/precompiles", default-features
 base-common-rpc-types-engine = { path = "crates/common/rpc-types-engine", default-features = false }
 
 # Builder
+base-builder-cli = { path = "crates/builder/cli" }
 base-builder-core = { path = "crates/builder/core" }
 base-builder-publish = { path = "crates/builder/publish" }
 base-builder-metering = { path = "crates/builder/metering" }

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -136,7 +136,7 @@ mod tests {
             panic!("expected rpc command");
         };
 
-        assert_eq!(rpc.execution.network.port, 30333);
+        assert_eq!(rpc.execution.node.network.port, 30333);
         assert_eq!(rpc.consensus.rpc_flags.listen_port, 9546);
     }
 
@@ -213,8 +213,8 @@ mod tests {
             panic!("expected rpc command");
         };
 
-        assert_eq!(rpc.execution.rpc.auth_ipc_path, "/data/engine.ipc");
-        assert_eq!(rpc.execution.network.port, 30303);
+        assert_eq!(rpc.execution.node.rpc.auth_ipc_path, "/data/engine.ipc");
+        assert_eq!(rpc.execution.node.network.port, 30303);
         assert!(rpc.execution_chain.is_some());
         assert_eq!(rpc.consensus.rpc_flags.listen_port, 8549);
         assert_eq!(rpc.consensus.p2p_flags.network.listen_tcp_port, 8003);

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 base-cli-utils.workspace = true
 base-txpool-rpc.workspace = true
 base-node-runner.workspace = true
+base-builder-cli.workspace = true
 base-builder-core.workspace = true
 base-builder-metering.workspace = true
 
@@ -31,18 +32,6 @@ base-execution-cli = { workspace = true, features = ["otlp"] }
 
 # cli
 clap.workspace = true
-
-# misc
-eyre.workspace = true
-
-[dev-dependencies]
-# workspace
-base-bundles.workspace = true
-base-builder-core = { workspace = true, features = ["test-utils"] }
-
-# misc
-rstest.workspace = true
-alloy-primitives.workspace = true
 
 [features]
 default = [ "jemalloc" ]

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -27,7 +27,6 @@ base-builder-metering.workspace = true
 # reth
 base-reth-cli.workspace = true
 reth-cli-util.workspace = true
-base-node-core.workspace = true
 base-execution-cli = { workspace = true, features = ["otlp"] }
 
 # cli

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -3,17 +3,16 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-pub mod cli;
-
 use std::sync::Arc;
 
+use base_builder_cli::Args;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
 use base_execution_cli::Cli;
 use base_node_runner::BaseNodeRunner;
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 
-type BuilderCli = Cli<cli::Args>;
+type BuilderCli = Cli<Args>;
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();

--- a/crates/builder/cli/Cargo.toml
+++ b/crates/builder/cli/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "base-builder-cli"
+description = "Base Builder CLI arguments"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+base-node-core.workspace = true
+base-builder-core.workspace = true
+base-builder-metering.workspace = true
+
+# cli
+clap = { workspace = true, features = ["derive", "env"] }
+
+# misc
+eyre.workspace = true
+
+[dev-dependencies]
+# workspace
+base-bundles.workspace = true
+
+# misc
+rstest.workspace = true
+alloy-primitives.workspace = true

--- a/crates/builder/cli/Cargo.toml
+++ b/crates/builder/cli/Cargo.toml
@@ -28,5 +28,5 @@ eyre.workspace = true
 base-bundles.workspace = true
 
 # misc
-rstest.workspace = true
 alloy-primitives.workspace = true
+rstest.workspace = true

--- a/crates/builder/cli/README.md
+++ b/crates/builder/cli/README.md
@@ -1,0 +1,3 @@
+# Base Builder CLI
+
+Reusable CLI arguments and config conversion helpers for Base builder nodes.

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -1,4 +1,4 @@
-//! Contains the CLI arguments
+//! Builder CLI arguments and config conversion helpers.
 
 use core::{net::SocketAddr, time::Duration};
 
@@ -231,13 +231,15 @@ impl Args {
 mod tests {
     use std::sync::Arc;
 
+    use alloy_primitives::{B256, TxHash, U256};
+    use base_builder_core::{MeteringProvider, NoopMeteringProvider};
+    use base_bundles::MeterBundleResponse;
     use rstest::rstest;
 
     use super::*;
 
     fn convert(args: Args) -> BuilderConfig {
-        let metering_provider: SharedMeteringProvider =
-            Arc::new(base_builder_core::NoopMeteringProvider);
+        let metering_provider: SharedMeteringProvider = Arc::new(NoopMeteringProvider);
         args.into_builder_config(metering_provider).expect("conversion should succeed")
     }
 
@@ -293,9 +295,6 @@ mod tests {
 
     #[test]
     fn metering_data_written_to_provider_is_readable_from_config() {
-        use alloy_primitives::{B256, TxHash, U256};
-        use base_bundles::MeterBundleResponse;
-
         let metering_provider: SharedMeteringProvider =
             Arc::new(MeteringStore::new(true, 100, Duration::from_secs(30)));
         let args = Args { enable_resource_metering: true, ..Default::default() };
@@ -344,10 +343,6 @@ mod tests {
 
     #[test]
     fn metering_store_ttl_propagates_to_store() {
-        use alloy_primitives::{B256, TxHash, U256};
-        use base_builder_core::MeteringProvider;
-        use base_bundles::MeterBundleResponse;
-
         let args = Args {
             metering_store_ttl_secs: 60,
             enable_resource_metering: true,

--- a/crates/builder/cli/src/lib.rs
+++ b/crates/builder/cli/src/lib.rs
@@ -1,0 +1,7 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod args;
+pub use args::{Args, FlashblocksArgs};

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -14,7 +14,10 @@ pub mod chainspec;
 /// Base CLI commands.
 pub mod commands;
 mod node;
-pub use node::{ExecutionNodeArgs, ExecutionNodeLaunchConfig};
+pub use node::{
+    ExecutionNodeArgs, ExecutionNodeConfigArgs, ExecutionNodeLaunchConfig,
+    ExecutionNodeRuntimeConfig,
+};
 /// Standard Base execution-node runner wiring.
 pub mod standard_node;
 

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -3,7 +3,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use base_execution_chainspec::BaseChainSpec;
-use base_node_runner::LaunchedBaseNode;
+use base_node_runner::{BaseNodeBuilder, LaunchedBaseNode};
 use clap::{Args, value_parser};
 use reth_cli_runner::CliContext;
 use reth_db::init_db;
@@ -21,9 +21,9 @@ use tracing::info;
 
 use crate::{RpcStandardNodeArgs, StandardNodeArgs};
 
-/// Execution node arguments shared by binaries that provide chain selection themselves.
+/// Chainless execution-node arguments shared by embedded Base commands.
 #[derive(Debug, Clone, Args)]
-pub struct ExecutionNodeArgs {
+pub struct ExecutionNodeConfigArgs {
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment)]
     pub config: Option<PathBuf>,
@@ -92,15 +92,11 @@ pub struct ExecutionNodeArgs {
     /// All storage related arguments with --storage prefix.
     #[command(flatten, next_help_heading = "Storage")]
     pub storage: StorageArgs,
-
-    /// Standard Base execution-node extension arguments.
-    #[command(flatten)]
-    pub standard: RpcStandardNodeArgs,
 }
 
-impl ExecutionNodeArgs {
-    /// Converts parsed args into a launchable execution node configuration.
-    pub fn into_launch_config(self, chain: Arc<BaseChainSpec>) -> ExecutionNodeLaunchConfig {
+impl ExecutionNodeConfigArgs {
+    /// Converts parsed args into a chain-injected execution runtime config.
+    pub fn into_runtime_config(self, chain: Arc<BaseChainSpec>) -> ExecutionNodeRuntimeConfig {
         let Self {
             config,
             metrics,
@@ -118,7 +114,6 @@ impl ExecutionNodeArgs {
             era,
             static_files,
             storage,
-            standard,
         } = self;
 
         let node_config = NodeConfig {
@@ -141,22 +136,44 @@ impl ExecutionNodeArgs {
             storage,
         };
 
-        ExecutionNodeLaunchConfig { node_config, standard: standard.into(), with_unused_ports }
+        ExecutionNodeRuntimeConfig { node_config, with_unused_ports }
     }
 }
 
-/// A chain-injected execution node configuration ready to launch.
+/// Execution node arguments shared by RPC-style binaries that provide chain selection themselves.
+#[derive(Debug, Clone, Args)]
+pub struct ExecutionNodeArgs {
+    /// Shared execution node arguments.
+    #[command(flatten)]
+    pub node: ExecutionNodeConfigArgs,
+
+    /// Standard Base execution-node extension arguments.
+    #[command(flatten)]
+    pub standard: RpcStandardNodeArgs,
+}
+
+impl ExecutionNodeArgs {
+    /// Converts parsed args into a launchable standard execution node configuration.
+    pub fn into_launch_config(self, chain: Arc<BaseChainSpec>) -> ExecutionNodeLaunchConfig {
+        let runtime = self.node.into_runtime_config(chain);
+        ExecutionNodeLaunchConfig {
+            node_config: runtime.node_config,
+            standard: self.standard.into(),
+            with_unused_ports: runtime.with_unused_ports,
+        }
+    }
+}
+
+/// A chain-injected execution-node runtime configuration.
 #[derive(Debug, Clone)]
-pub struct ExecutionNodeLaunchConfig {
+pub struct ExecutionNodeRuntimeConfig {
     /// Reth node configuration.
     pub node_config: NodeConfig<BaseChainSpec>,
-    /// Standard Base execution-node extension arguments.
-    pub standard: StandardNodeArgs,
     /// Whether all ports should be assigned by the OS.
     pub with_unused_ports: bool,
 }
 
-impl ExecutionNodeLaunchConfig {
+impl ExecutionNodeRuntimeConfig {
     /// Enables authenticated Engine API over IPC.
     pub const fn with_auth_ipc(mut self) -> Self {
         self.node_config.rpc.auth_ipc = true;
@@ -168,8 +185,8 @@ impl ExecutionNodeLaunchConfig {
         self.node_config.rpc.auth_ipc_path.as_str()
     }
 
-    /// Launches the execution node and returns its handle.
-    pub async fn launch<Rpc>(mut self, ctx: CliContext) -> eyre::Result<LaunchedBaseNode>
+    /// Converts the runtime config into a reth node builder.
+    pub fn into_node_builder<Rpc>(mut self, ctx: CliContext) -> eyre::Result<BaseNodeBuilder>
     where
         Rpc: RpcModuleValidator,
     {
@@ -201,11 +218,111 @@ impl ExecutionNodeLaunchConfig {
             .with_database(database)
             .with_launch_context(ctx.task_executor);
 
+        Ok(builder)
+    }
+}
+
+/// A chain-injected standard execution node configuration ready to launch.
+#[derive(Debug, Clone)]
+pub struct ExecutionNodeLaunchConfig {
+    /// Reth node configuration.
+    pub node_config: NodeConfig<BaseChainSpec>,
+    /// Standard Base execution-node extension arguments.
+    pub standard: StandardNodeArgs,
+    /// Whether all ports should be assigned by the OS.
+    pub with_unused_ports: bool,
+}
+
+impl ExecutionNodeLaunchConfig {
+    /// Enables authenticated Engine API over IPC.
+    pub const fn with_auth_ipc(mut self) -> Self {
+        self.node_config.rpc.auth_ipc = true;
+        self
+    }
+
+    /// Returns the configured authenticated Engine API IPC path.
+    pub const fn auth_ipc_path(&self) -> &str {
+        self.node_config.rpc.auth_ipc_path.as_str()
+    }
+
+    /// Launches the execution node and returns its handle.
+    pub async fn launch<Rpc>(self, ctx: CliContext) -> eyre::Result<LaunchedBaseNode>
+    where
+        Rpc: RpcModuleValidator,
+    {
+        let execution = ExecutionNodeRuntimeConfig {
+            node_config: self.node_config,
+            with_unused_ports: self.with_unused_ports,
+        };
+        let builder = execution.into_node_builder::<Rpc>(ctx)?;
         crate::StandardBaseRethNode::launch(builder, self.standard).await
     }
 
     /// Launches the execution node with the default RPC module validator.
     pub async fn launch_default(self, ctx: CliContext) -> eyre::Result<LaunchedBaseNode> {
         self.launch::<LenientRpcModuleValidator>(ctx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use url::Url;
+
+    use super::*;
+
+    #[derive(Debug, Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn shared_execution_args_parse_without_standard_node_args() {
+        let args = CommandParser::<ExecutionNodeConfigArgs>::parse_from([
+            "reth",
+            "--port",
+            "30333",
+            "--auth-ipc.path=/tmp/engine.ipc",
+        ])
+        .args;
+
+        assert_eq!(args.network.port, 30333);
+
+        let runtime = args.into_runtime_config(Arc::new(BaseChainSpec::devnet()));
+        assert_eq!(runtime.node_config.rpc.auth_ipc_path, "/tmp/engine.ipc");
+        assert!(!runtime.node_config.rpc.auth_ipc);
+    }
+
+    #[test]
+    fn standard_execution_args_keep_base_extension_args_separate() {
+        let args = CommandParser::<ExecutionNodeArgs>::parse_from([
+            "reth",
+            "--port",
+            "30333",
+            "--flashblocks-url",
+            "wss://example.com/ws",
+        ])
+        .args;
+
+        assert_eq!(args.node.network.port, 30333);
+        assert_eq!(
+            args.standard.flashblocks_url.as_ref().map(Url::as_str),
+            Some("wss://example.com/ws")
+        );
+    }
+
+    #[test]
+    fn runtime_config_can_enable_auth_ipc_without_standard_node_args() {
+        let args = CommandParser::<ExecutionNodeConfigArgs>::parse_from([
+            "reth",
+            "--auth-ipc.path=/tmp/engine.ipc",
+        ])
+        .args;
+
+        let runtime = args.into_runtime_config(Arc::new(BaseChainSpec::devnet())).with_auth_ipc();
+
+        assert!(runtime.node_config.rpc.auth_ipc);
+        assert_eq!(runtime.auth_ipc_path(), "/tmp/engine.ipc");
     }
 }

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -221,8 +221,7 @@ impl ExecutionNodeRuntimeConfig {
         let data_dir = self.node_config.datadir();
         let db_path = data_dir.db();
         info!(target: "reth::cli", path = ?db_path, "Opening database");
-        let database =
-            init_db(db_path.clone(), self.node_config.db.database_args())?.with_metrics();
+        let database = init_db(db_path, self.node_config.db.database_args())?.with_metrics();
 
         let builder = NodeBuilder::new(self.node_config)
             .with_database(database)

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -174,15 +174,25 @@ pub struct ExecutionNodeRuntimeConfig {
 }
 
 impl ExecutionNodeRuntimeConfig {
+    /// Enables authenticated Engine API over IPC on the supplied node config.
+    pub const fn enable_auth_ipc(node_config: &mut NodeConfig<BaseChainSpec>) {
+        node_config.rpc.auth_ipc = true;
+    }
+
+    /// Returns the configured authenticated Engine API IPC path from the supplied node config.
+    pub const fn auth_ipc_path_for(node_config: &NodeConfig<BaseChainSpec>) -> &str {
+        node_config.rpc.auth_ipc_path.as_str()
+    }
+
     /// Enables authenticated Engine API over IPC.
     pub const fn with_auth_ipc(mut self) -> Self {
-        self.node_config.rpc.auth_ipc = true;
+        Self::enable_auth_ipc(&mut self.node_config);
         self
     }
 
     /// Returns the configured authenticated Engine API IPC path.
     pub const fn auth_ipc_path(&self) -> &str {
-        self.node_config.rpc.auth_ipc_path.as_str()
+        Self::auth_ipc_path_for(&self.node_config)
     }
 
     /// Converts the runtime config into a reth node builder.
@@ -234,15 +244,21 @@ pub struct ExecutionNodeLaunchConfig {
 }
 
 impl ExecutionNodeLaunchConfig {
+    /// Converts this standard launch config into the shared runtime config plus standard args.
+    pub fn into_runtime_config(self) -> (ExecutionNodeRuntimeConfig, StandardNodeArgs) {
+        let Self { node_config, standard, with_unused_ports } = self;
+        (ExecutionNodeRuntimeConfig { node_config, with_unused_ports }, standard)
+    }
+
     /// Enables authenticated Engine API over IPC.
     pub const fn with_auth_ipc(mut self) -> Self {
-        self.node_config.rpc.auth_ipc = true;
+        ExecutionNodeRuntimeConfig::enable_auth_ipc(&mut self.node_config);
         self
     }
 
     /// Returns the configured authenticated Engine API IPC path.
     pub const fn auth_ipc_path(&self) -> &str {
-        self.node_config.rpc.auth_ipc_path.as_str()
+        ExecutionNodeRuntimeConfig::auth_ipc_path_for(&self.node_config)
     }
 
     /// Launches the execution node and returns its handle.
@@ -250,12 +266,9 @@ impl ExecutionNodeLaunchConfig {
     where
         Rpc: RpcModuleValidator,
     {
-        let execution = ExecutionNodeRuntimeConfig {
-            node_config: self.node_config,
-            with_unused_ports: self.with_unused_ports,
-        };
+        let (execution, standard) = self.into_runtime_config();
         let builder = execution.into_node_builder::<Rpc>(ctx)?;
-        crate::StandardBaseRethNode::launch(builder, self.standard).await
+        crate::StandardBaseRethNode::launch(builder, standard).await
     }
 
     /// Launches the execution node with the default RPC module validator.
@@ -322,6 +335,24 @@ mod tests {
 
         let runtime = args.into_runtime_config(Arc::new(BaseChainSpec::devnet())).with_auth_ipc();
 
+        assert!(runtime.node_config.rpc.auth_ipc);
+        assert_eq!(runtime.auth_ipc_path(), "/tmp/engine.ipc");
+    }
+
+    #[test]
+    fn launch_config_delegates_auth_ipc_to_runtime_config() {
+        let args = CommandParser::<ExecutionNodeArgs>::parse_from([
+            "reth",
+            "--auth-ipc.path=/tmp/engine.ipc",
+        ])
+        .args;
+
+        let launch = args.into_launch_config(Arc::new(BaseChainSpec::devnet())).with_auth_ipc();
+
+        assert!(launch.node_config.rpc.auth_ipc);
+        assert_eq!(launch.auth_ipc_path(), "/tmp/engine.ipc");
+
+        let (runtime, _standard) = launch.into_runtime_config();
         assert!(runtime.node_config.rpc.auth_ipc);
         assert_eq!(runtime.auth_ipc_path(), "/tmp/engine.ipc");
     }


### PR DESCRIPTION
## Summary

This extracts the base-builder CLI args and builder config conversion into a reusable base-builder-cli crate while keeping the base-builder binary behavior unchanged. It also splits chainless execution-node args from RpcStandardNodeArgs so future unified commands can build an execution runtime config without depending on RPC-specific Base extension flags. Existing base rpc parser coverage was updated to follow the new field layout.

## Motivation

Refactoring cli this way will allow the unified binary to re-use these same cli arguments.