### PR TITLE
feat(cli): Add Unified Sequencer Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,11 +3113,16 @@ name = "base"
 version = "0.0.0"
 dependencies = [
  "alloy-chains",
+ "base-builder-cli",
+ "base-builder-core",
+ "base-builder-metering",
  "base-cli-utils",
  "base-common-chains",
  "base-consensus-cli",
  "base-execution-chainspec",
  "base-execution-cli",
+ "base-node-runner",
+ "base-txpool-rpc",
  "clap",
  "eyre",
  "figment",

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -18,9 +18,14 @@ workspace = true
 [dependencies]
 # workspace
 base-cli-utils.workspace = true
+base-txpool-rpc.workspace = true
+base-node-runner.workspace = true
+base-builder-cli.workspace = true
+base-builder-core.workspace = true
 base-common-chains.workspace = true
 base-consensus-cli.workspace = true
 base-execution-cli.workspace = true
+base-builder-metering.workspace = true
 base-execution-chainspec.workspace = true
 
 # alloy

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -3,7 +3,10 @@
 use clap::Subcommand;
 
 use crate::{
-    commands::{bootnode::BootnodeCommand, rpc::RpcCommand, update::UpdateCommand},
+    commands::{
+        bootnode::BootnodeCommand, rpc::RpcCommand, sequencer::SequencerCommand,
+        update::UpdateCommand,
+    },
     config::ChainResolver,
 };
 
@@ -17,6 +20,9 @@ pub(crate) enum BaseCommand {
     /// Run the integrated node in RPC mode.
     #[command(name = "rpc")]
     Rpc(Box<RpcCommand>),
+    /// Run the integrated node in sequencer mode.
+    #[command(name = "sequencer")]
+    Sequencer(Box<SequencerCommand>),
     /// Update the base binary to the latest release.
     #[command(name = "update")]
     Update(Box<UpdateCommand>),
@@ -28,6 +34,7 @@ impl BaseCommand {
         match self {
             Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?),
             Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?),
+            Self::Sequencer(sequencer) => (*sequencer).run(chain_resolver.resolve()?),
             Self::Update(update) => (*update).run(),
         }
     }

--- a/bin/base/src/commands/mod.rs
+++ b/bin/base/src/commands/mod.rs
@@ -4,4 +4,5 @@ mod bootnode;
 mod command;
 pub(crate) use command::BaseCommand;
 mod rpc;
+mod sequencer;
 mod update;

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -103,7 +103,7 @@ impl RpcCommand {
     }
 }
 
-fn engine_ipc_url(path: &str) -> eyre::Result<Url> {
+pub(super) fn engine_ipc_url(path: &str) -> eyre::Result<Url> {
     let path = Path::new(path);
     let path =
         if path.is_absolute() { path.to_path_buf() } else { std::env::current_dir()?.join(path) };

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -1,0 +1,211 @@
+//! Integrated sequencer node command.
+
+use std::sync::Arc;
+
+use base_builder_cli::Args as BuilderArgs;
+use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
+use base_builder_metering::MeteringStoreExtension;
+use base_consensus_cli::{
+    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
+};
+use base_execution_chainspec::BaseChainSpec;
+use base_execution_cli::{ExecutionNodeConfigArgs, chainspec::chain_value_parser};
+use base_node_runner::BaseNodeRunner;
+use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
+use clap::Args;
+use reth_cli_runner::CliRunner;
+use tokio_util::sync::CancellationToken;
+
+use crate::{commands::rpc::engine_ipc_url, config::ResolvedChainConfig};
+
+/// Arguments for `base sequencer`.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct SequencerCommand {
+    /// Execution chain spec to use instead of the root chain selection.
+    #[arg(long = "execution-chain", value_parser = chain_value_parser)]
+    pub(crate) execution_chain: Option<Arc<BaseChainSpec>>,
+
+    /// Execution node arguments.
+    #[command(flatten)]
+    pub(crate) execution: ExecutionNodeConfigArgs,
+
+    /// Builder node arguments.
+    #[command(flatten)]
+    pub(crate) builder: BuilderArgs,
+
+    /// Consensus node arguments.
+    #[command(flatten)]
+    pub(crate) consensus: EmbeddedSequencerConsensusNodeConfigArgs,
+}
+
+impl SequencerCommand {
+    /// Runs the `sequencer` flavor.
+    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+        let execution_chain = match self.execution_chain {
+            Some(chain) => chain,
+            None => resolved_chain.execution_chain_spec()?,
+        };
+        let consensus_chain = resolved_chain.consensus_chain_args();
+        let consensus_args = ConsensusNodeArgs::new(consensus_chain, self.consensus.into());
+        let rollup_config = consensus_args.load_rollup_config()?;
+
+        let rollup_args = self.builder.rollup_args.clone();
+        let sequencer_rpc = rollup_args.sequencer.clone();
+        let metering_provider: base_builder_core::SharedMeteringProvider =
+            Arc::new(self.builder.build_metering_store());
+        let builder_config = self.builder.into_builder_config(Arc::clone(&metering_provider))?;
+        let da_config = builder_config.da_config.clone();
+        let gas_limit_config = builder_config.gas_limit_config.clone();
+
+        let execution = self.execution.into_runtime_config(execution_chain).with_auth_ipc();
+        let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
+
+        CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
+            let task_executor = ctx.task_executor.clone();
+            let builder = execution.into_default_node_builder(ctx)?;
+            let mut runner = BaseNodeRunner::new(rollup_args)
+                .with_da_config(da_config)
+                .with_gas_limit_config(gas_limit_config)
+                .with_service_builder(FlashblocksServiceBuilder(builder_config));
+            runner.install_ext::<MeteringStoreExtension>(metering_provider);
+            runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
+            runner.install_ext::<BuilderApiExtension>(());
+
+            let launched = runner.launch(builder).await?;
+            let handle = launched.handle;
+            // Keep the execution node handle alive until both services have coordinated shutdown.
+            let execution_node = handle.node;
+            let execution_exit = handle.node_exit_future;
+
+            let overrides = ConsensusNodeOverrides {
+                l2_engine_rpc: Some(l2_engine_rpc),
+                l2_engine_jwt_secret: None,
+            };
+
+            let consensus_cancellation = CancellationToken::new();
+            let consensus_exit = consensus_args.start_with_overrides_and_cancellation(
+                rollup_config,
+                overrides,
+                consensus_cancellation.clone(),
+            );
+            tokio::pin!(execution_exit);
+            tokio::pin!(consensus_exit);
+
+            let result = tokio::select! {
+                result = &mut execution_exit => {
+                    consensus_cancellation.cancel();
+                    let consensus_result = consensus_exit.await;
+                    result?;
+                    consensus_result
+                }
+                result = &mut consensus_exit => {
+                    let consensus_result = result;
+                    task_executor
+                        .initiate_graceful_shutdown()
+                        .map_err(|e| eyre::eyre!("failed to signal execution node shutdown: {e}"))?
+                        .ignore_guard()
+                        .await;
+                    let execution_result = execution_exit.await;
+                    consensus_result?;
+                    execution_result
+                }
+            };
+
+            drop(execution_node);
+            result
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::{cli::BaseCli, commands::BaseCommand};
+
+    const REQUIRED_CONSENSUS_ARGS: &[&str] =
+        &["--l1-eth-rpc", "http://localhost:8545", "--l1-beacon", "http://localhost:5052"];
+    const SEQUENCER_KEY: &str = "bcc617ea05150ff60490d3c6058630ba94ae9f12a02a87efd291349ca0e54e0a";
+
+    fn sequencer_args(args: &'static [&'static str]) -> Vec<&'static str> {
+        let mut full_args = Vec::from(args);
+        full_args.extend_from_slice(REQUIRED_CONSENSUS_ARGS);
+        full_args
+    }
+
+    #[test]
+    fn parses_execution_consensus_builder_and_sequencer_args() {
+        let cli = BaseCli::parse_from(sequencer_args(&[
+            "base",
+            "sequencer",
+            "--port",
+            "30333",
+            "--rpc.port",
+            "9546",
+            "--builder.max_gas_per_txn",
+            "30000000",
+            "--flashblocks.port",
+            "1112",
+            "--rollup.sequencer",
+            "http://localhost:8545",
+            "--rollup.sequencer-headers",
+            "Authorization: Bearer token",
+            "--sequencer.stopped",
+            "--conductor.rpc",
+            "http://localhost:9090",
+            "--p2p.sequencer.key",
+            SEQUENCER_KEY,
+        ]));
+
+        let BaseCommand::Sequencer(sequencer) = cli.command else {
+            panic!("expected sequencer command");
+        };
+
+        assert_eq!(sequencer.execution.network.port, 30333);
+        assert_eq!(sequencer.consensus.rpc_flags.listen_port, 9546);
+        assert_eq!(sequencer.builder.max_gas_per_txn, Some(30_000_000));
+        assert_eq!(sequencer.builder.flashblocks.flashblocks_port, 1112);
+        assert_eq!(
+            sequencer.builder.rollup_args.sequencer.as_deref(),
+            Some("http://localhost:8545")
+        );
+        assert_eq!(
+            sequencer.builder.rollup_args.sequencer_headers,
+            vec!["Authorization: Bearer token"]
+        );
+        assert!(sequencer.consensus.sequencer_flags.stopped);
+        assert_eq!(
+            sequencer.consensus.sequencer_flags.conductor_rpc.as_ref().map(url::Url::as_str),
+            Some("http://localhost:9090/")
+        );
+        assert!(sequencer.consensus.p2p_flags.signer.sequencer_key.is_some());
+    }
+
+    #[test]
+    fn parses_without_l2_engine_rpc() {
+        let cli = BaseCli::parse_from(sequencer_args(&[
+            "base",
+            "sequencer",
+            "--p2p.sequencer.key",
+            SEQUENCER_KEY,
+        ]));
+
+        assert!(matches!(cli.command, BaseCommand::Sequencer(_)));
+    }
+
+    #[test]
+    fn rejects_sequencer_mode_arg() {
+        let err = BaseCli::try_parse_from(sequencer_args(&[
+            "base",
+            "sequencer",
+            "--mode",
+            "sequencer",
+            "--p2p.sequencer.key",
+            SEQUENCER_KEY,
+        ]))
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("--mode"));
+    }
+}

--- a/crates/consensus/cli/src/lib.rs
+++ b/crates/consensus/cli/src/lib.rs
@@ -36,7 +36,7 @@ pub use metrics::CliMetrics;
 mod node;
 pub use node::{
     ConsensusNodeArgs, ConsensusNodeCommand, ConsensusNodeConfigArgs, ConsensusNodeOverrides,
-    EmbeddedConsensusNodeConfigArgs,
+    EmbeddedConsensusNodeConfigArgs, EmbeddedSequencerConsensusNodeConfigArgs,
 };
 
 mod rpc;

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -179,6 +179,46 @@ pub struct EmbeddedConsensusNodeConfigArgs {
     pub checkpoint_path: Option<PathBuf>,
 }
 
+/// Consensus node configuration arguments for embedded sequencer callers.
+#[derive(Args, Clone, Debug)]
+pub struct EmbeddedSequencerConsensusNodeConfigArgs {
+    /// L1 RPC CLI arguments.
+    #[clap(flatten)]
+    pub l1_rpc_args: L1ClientArgs,
+
+    /// L2 engine CLI arguments.
+    #[clap(flatten)]
+    pub l2_client_args: EmbeddedL2ClientArgs,
+
+    /// L1 configuration file.
+    #[clap(flatten)]
+    pub l1_config: L1ConfigFile,
+
+    /// L2 configuration file.
+    #[clap(flatten)]
+    pub l2_config: L2ConfigFile,
+
+    /// P2P CLI arguments.
+    #[command(flatten)]
+    pub p2p_flags: P2PArgs,
+
+    /// RPC CLI arguments.
+    #[command(flatten)]
+    pub rpc_flags: EmbeddedRpcArgs,
+
+    /// SEQUENCER CLI arguments.
+    #[command(flatten)]
+    pub sequencer_flags: SequencerArgs,
+
+    /// Path to the `SafeDB` directory. If not set, safe head tracking is disabled.
+    #[arg(long = "safedb.path", env = "BASE_NODE_SAFEDB_PATH")]
+    pub safedb_path: Option<PathBuf>,
+
+    /// Path to the checkpoint database. If not set, a default path under `~/.base` is used.
+    #[arg(long = "checkpoint.path", env = "BASE_NODE_CHECKPOINT_PATH")]
+    pub checkpoint_path: Option<PathBuf>,
+}
+
 impl From<EmbeddedConsensusNodeConfigArgs> for ConsensusNodeConfigArgs {
     fn from(args: EmbeddedConsensusNodeConfigArgs) -> Self {
         Self {
@@ -190,6 +230,23 @@ impl From<EmbeddedConsensusNodeConfigArgs> for ConsensusNodeConfigArgs {
             p2p_flags: args.p2p_flags.into(),
             rpc_flags: args.rpc_flags.into(),
             sequencer_flags: SequencerArgs::default(),
+            safedb_path: args.safedb_path,
+            checkpoint_path: args.checkpoint_path,
+        }
+    }
+}
+
+impl From<EmbeddedSequencerConsensusNodeConfigArgs> for ConsensusNodeConfigArgs {
+    fn from(args: EmbeddedSequencerConsensusNodeConfigArgs) -> Self {
+        Self {
+            node_mode: NodeMode::Sequencer,
+            l1_rpc_args: args.l1_rpc_args,
+            l2_client_args: args.l2_client_args.into(),
+            l1_config: args.l1_config,
+            l2_config: args.l2_config,
+            p2p_flags: args.p2p_flags,
+            rpc_flags: args.rpc_flags.into(),
+            sequencer_flags: args.sequencer_flags,
             safedb_path: args.safedb_path,
             checkpoint_path: args.checkpoint_path,
         }
@@ -466,5 +523,37 @@ mod tests {
             },
         );
         assert_eq!(args.validate_sequencer_key().is_ok(), expected_ok);
+    }
+
+    #[test]
+    fn embedded_sequencer_args_force_sequencer_mode_and_preserve_flags() {
+        let key = B256::ZERO;
+        let conductor_rpc = Url::parse("http://localhost:9090").unwrap();
+        let args = EmbeddedSequencerConsensusNodeConfigArgs {
+            p2p_flags: P2PArgs {
+                signer: SignerArgs { sequencer_key: Some(key), ..Default::default() },
+                ..P2PArgs::default()
+            },
+            rpc_flags: EmbeddedRpcArgs { listen_port: 9546, ..EmbeddedRpcArgs::default() },
+            sequencer_flags: SequencerArgs {
+                stopped: true,
+                conductor_rpc: Some(conductor_rpc.clone()),
+                ..SequencerArgs::default()
+            },
+            l1_rpc_args: L1ClientArgs::default(),
+            l2_client_args: EmbeddedL2ClientArgs::default(),
+            l1_config: L1ConfigFile::default(),
+            l2_config: L2ConfigFile::default(),
+            safedb_path: None,
+            checkpoint_path: None,
+        };
+
+        let config = ConsensusNodeConfigArgs::from(args);
+
+        assert_eq!(config.node_mode, NodeMode::Sequencer);
+        assert_eq!(config.p2p_flags.signer.sequencer_key, Some(key));
+        assert_eq!(config.rpc_flags.listen_port, 9546);
+        assert!(config.sequencer_flags.stopped);
+        assert_eq!(config.sequencer_flags.conductor_rpc, Some(conductor_rpc));
     }
 }

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -229,6 +229,11 @@ impl ExecutionNodeRuntimeConfig {
 
         Ok(builder)
     }
+
+    /// Converts the runtime config into a reth node builder with the default RPC validator.
+    pub fn into_default_node_builder(self, ctx: CliContext) -> eyre::Result<BaseNodeBuilder> {
+        self.into_node_builder::<LenientRpcModuleValidator>(ctx)
+    }
 }
 
 /// A chain-injected standard execution node configuration ready to launch.


### PR DESCRIPTION
## Summary

This stacks on #3400 and adds a top-level `base sequencer` command for running the unified binary in sequencer mode. The command reuses the shared execution, builder, and embedded consensus argument surfaces, wires the execution node through the builder runner extensions, and hands consensus an IPC Engine API override. It keeps `base rpc` behavior unchanged while adding parser coverage for sequencer, builder, conductor, signer, and embedded-engine defaults.