### PR TITLE
fix(precompile-macros): reject duplicate args() option regardless of argument count

### DIFF
--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -132,10 +132,8 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
         // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
         // Only enforced when gas_remaining is explicitly set (opt-in for tests).
-        if let Some(remaining) = self.gas_remaining {
-            if remaining <= self.gas_params.call_stipend() {
-                return Err(BasePrecompileError::OutOfGas);
-            }
+        if self.gas_remaining.is_some_and(|r| r <= self.gas_params.call_stipend()) {
+            return Err(BasePrecompileError::OutOfGas);
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -350,7 +348,7 @@ impl HashMapStorageProvider {
     /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
     /// (test-utils only). Use this to exercise the guard at specific gas levels without
     /// a live EVM journal.
-    pub fn set_gas_remaining(&mut self, remaining: u64) {
+    pub const fn set_gas_remaining(&mut self, remaining: u64) {
         self.gas_remaining = Some(remaining);
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -374,6 +374,7 @@ mod tests {
         GasParams::new_spec(SpecId::AMSTERDAM)
     }
 
+    /// Positive refunds accumulate in the counter.
     #[test]
     fn set_code_static_violation_before_state_gas_charge() {
         let mut p = HashMapStorageProvider::new(1);
@@ -393,6 +394,7 @@ mod tests {
         assert_eq!(p.gas_refunded(), 1_500);
     }
 
+    /// Negative refunds (EIP-3529 cancellations) reduce the counter.
     #[test]
     fn refund_gas_accumulates_negative() {
         let mut p = HashMapStorageProvider::new(1);
@@ -401,12 +403,14 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Gas refund counter starts at zero on a fresh provider.
     #[test]
     fn refund_gas_starts_at_zero() {
         let p = HashMapStorageProvider::new(1);
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Clearing a previously set slot (nonzero to zero) earns an EIP-3529 refund.
     #[test]
     fn sstore_clearing_slot_generates_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -418,6 +422,7 @@ mod tests {
         assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
     }
 
+    /// Overwriting a nonzero slot with another nonzero value earns no refund.
     #[test]
     fn sstore_nonzero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -426,6 +431,7 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
+    /// Writing to a zero slot (first write) earns no refund.
     #[test]
     fn sstore_zero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -473,7 +473,7 @@ mod tests {
         );
     }
 
-    /// Default (no gas_remaining set): guard is inactive, sstore always proceeds.
+    /// Default (no `gas_remaining` set): guard is inactive, `sstore` always proceeds.
     #[test]
     fn sstore_always_allowed_without_gas_remaining_set() {
         let mut p = HashMapStorageProvider::new(1);
@@ -483,8 +483,8 @@ mod tests {
     }
 
     /// Static-call violation takes priority over the stipend guard.
-    /// gas_remaining == 2300 means the stipend guard would also fire if checked first;
-    /// setting static=true proves StaticCallViolation is returned rather than OutOfGas.
+    /// `gas_remaining == 2300` means the stipend guard would also fire if checked first;
+    /// setting `static=true` proves `StaticCallViolation` is returned rather than `OutOfGas`.
     #[test]
     fn sstore_static_violation_checked_before_stipend_guard() {
         let mut p = HashMapStorageProvider::new(1);

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -30,10 +30,6 @@ pub struct HashMapStorageProvider {
     gas_params: GasParams,
     state_gas_used: u64,
     gas_refunded: i64,
-    /// When `Some(n)`, enforces the EIP-2200 stipend guard: `sstore` returns `OutOfGas` when
-    /// `n <= gas_params.call_stipend()`. `None` (default) disables the guard so existing tests
-    /// that do not care about gas limits continue to work unchanged.
-    gas_remaining: Option<u64>,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -71,7 +67,6 @@ impl HashMapStorageProvider {
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
-            gas_remaining: None,
         }
     }
 }
@@ -129,11 +124,6 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     ) -> Result<(), BasePrecompileError> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
-        }
-        // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
-        // Only enforced when gas_remaining is explicitly set (opt-in for tests).
-        if self.gas_remaining.is_some_and(|r| r <= self.gas_params.call_stipend()) {
-            return Err(BasePrecompileError::OutOfGas);
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -344,13 +334,6 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
-
-    /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
-    /// (test-utils only). Use this to exercise the guard at specific gas levels without
-    /// a live EVM journal.
-    pub const fn set_gas_remaining(&mut self, remaining: u64) {
-        self.gas_remaining = Some(remaining);
-    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
@@ -364,7 +347,7 @@ mod tests {
     use alloy_primitives::{Address, U256};
 
     use super::*;
-    use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
+    use crate::provider::PrecompileStorageProvider;
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
@@ -426,58 +409,5 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
-    }
-
-    /// EIP-2200 stipend boundary: `remaining == call_stipend` must block (guard is `<=`).
-    #[test]
-    fn sstore_blocked_when_remaining_equals_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
-        assert_eq!(
-            p.sstore(ADDR, KEY, U256::from(1u64)),
-            Err(BasePrecompileError::OutOfGas),
-            "sstore must be blocked when remaining == call_stipend"
-        );
-    }
-
-    /// Below the stipend: also blocked.
-    #[test]
-    fn sstore_blocked_when_remaining_below_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2299);
-        assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
-    }
-
-    /// One above the stipend: allowed.
-    #[test]
-    fn sstore_allowed_when_remaining_above_call_stipend() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_remaining(2301);
-        assert!(
-            p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
-            "sstore must succeed when remaining > call_stipend"
-        );
-    }
-
-    /// Default (no `gas_remaining` set): guard is inactive, `sstore` always proceeds.
-    #[test]
-    fn sstore_always_allowed_without_gas_remaining_set() {
-        let mut p = HashMapStorageProvider::new(1);
-        // gas_remaining is None — guard disabled, unlimited gas
-        assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
-    }
-
-    /// Static-call violation takes priority over the stipend guard.
-    /// `gas_remaining == 2300` means the stipend guard would also fire if checked first;
-    /// setting `static=true` proves `StaticCallViolation` is returned rather than `OutOfGas`.
-    #[test]
-    fn sstore_static_violation_checked_before_stipend_guard() {
-        let mut p = HashMapStorageProvider::new(1);
-        p.set_static(true);
-        p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
-        assert_eq!(
-            p.sstore(ADDR, KEY, U256::from(1u64)),
-            Err(BasePrecompileError::StaticCallViolation),
-        );
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -362,7 +362,6 @@ pub fn setup_storage() -> (HashMapStorageProvider, Address) {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
-    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId};
 
     use super::*;
     use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
@@ -370,11 +369,6 @@ mod tests {
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
 
-    fn amsterdam_params() -> GasParams {
-        GasParams::new_spec(SpecId::AMSTERDAM)
-    }
-
-    /// Positive refunds accumulate in the counter.
     #[test]
     fn set_code_static_violation_before_state_gas_charge() {
         let mut p = HashMapStorageProvider::new(1);
@@ -394,7 +388,6 @@ mod tests {
         assert_eq!(p.gas_refunded(), 1_500);
     }
 
-    /// Negative refunds (EIP-3529 cancellations) reduce the counter.
     #[test]
     fn refund_gas_accumulates_negative() {
         let mut p = HashMapStorageProvider::new(1);
@@ -403,14 +396,12 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Gas refund counter starts at zero on a fresh provider.
     #[test]
     fn refund_gas_starts_at_zero() {
         let p = HashMapStorageProvider::new(1);
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Clearing a previously set slot (nonzero to zero) earns an EIP-3529 refund.
     #[test]
     fn sstore_clearing_slot_generates_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -422,7 +413,6 @@ mod tests {
         assert!(p.gas_refunded() > 0, "clearing a non-zero slot must earn a refund");
     }
 
-    /// Overwriting a nonzero slot with another nonzero value earns no refund.
     #[test]
     fn sstore_nonzero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -431,7 +421,6 @@ mod tests {
         assert_eq!(p.gas_refunded(), 0);
     }
 
-    /// Writing to a zero slot (first write) earns no refund.
     #[test]
     fn sstore_zero_to_nonzero_earns_no_refund() {
         let mut p = HashMapStorageProvider::new(1);
@@ -443,7 +432,6 @@ mod tests {
     #[test]
     fn sstore_blocked_when_remaining_equals_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
         assert_eq!(
             p.sstore(ADDR, KEY, U256::from(1u64)),
@@ -456,7 +444,6 @@ mod tests {
     #[test]
     fn sstore_blocked_when_remaining_below_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2299);
         assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
     }
@@ -465,7 +452,6 @@ mod tests {
     #[test]
     fn sstore_allowed_when_remaining_above_call_stipend() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_gas_remaining(2301);
         assert!(
             p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
@@ -477,7 +463,6 @@ mod tests {
     #[test]
     fn sstore_always_allowed_without_gas_remaining_set() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         // gas_remaining is None — guard disabled, unlimited gas
         assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
     }
@@ -488,7 +473,6 @@ mod tests {
     #[test]
     fn sstore_static_violation_checked_before_stipend_guard() {
         let mut p = HashMapStorageProvider::new(1);
-        p.set_gas_params(amsterdam_params());
         p.set_static(true);
         p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
         assert_eq!(

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -30,6 +30,10 @@ pub struct HashMapStorageProvider {
     gas_params: GasParams,
     state_gas_used: u64,
     gas_refunded: i64,
+    /// When `Some(n)`, enforces the EIP-2200 stipend guard: `sstore` returns `OutOfGas` when
+    /// `n <= gas_params.call_stipend()`. `None` (default) disables the guard so existing tests
+    /// that do not care about gas limits continue to work unchanged.
+    gas_remaining: Option<u64>,
     /// Emitted events keyed by contract address.
     pub events: HashMap<Address, Vec<LogData>>,
 }
@@ -67,6 +71,7 @@ impl HashMapStorageProvider {
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
+            gas_remaining: None,
         }
     }
 }
@@ -124,6 +129,13 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     ) -> Result<(), BasePrecompileError> {
         if self.is_static {
             return Err(BasePrecompileError::StaticCallViolation);
+        }
+        // EIP-2200 stipend guard — mirrors EvmPrecompileStorageProvider::sstore.
+        // Only enforced when gas_remaining is explicitly set (opt-in for tests).
+        if let Some(remaining) = self.gas_remaining {
+            if remaining <= self.gas_params.call_stipend() {
+                return Err(BasePrecompileError::OutOfGas);
+            }
         }
         let old = self.internals.get(&(address, key)).copied().unwrap_or(U256::ZERO);
         self.counter_sstore += 1;
@@ -334,6 +346,13 @@ impl HashMapStorageProvider {
     pub fn set_gas_params(&mut self, gas_params: GasParams) {
         self.gas_params = gas_params;
     }
+
+    /// Sets the simulated remaining gas, enabling the EIP-2200 stipend guard in `sstore`
+    /// (test-utils only). Use this to exercise the guard at specific gas levels without
+    /// a live EVM journal.
+    pub fn set_gas_remaining(&mut self, remaining: u64) {
+        self.gas_remaining = Some(remaining);
+    }
 }
 
 /// Test helper: returns a fresh `(HashMapStorageProvider, precompile_address)` pair.
@@ -345,12 +364,17 @@ pub fn setup_storage() -> (HashMapStorageProvider, Address) {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
+    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId};
 
     use super::*;
     use crate::{error::BasePrecompileError, provider::PrecompileStorageProvider};
 
     const ADDR: Address = Address::ZERO;
     const KEY: U256 = U256::ZERO;
+
+    fn amsterdam_params() -> GasParams {
+        GasParams::new_spec(SpecId::AMSTERDAM)
+    }
 
     #[test]
     fn set_code_static_violation_before_state_gas_charge() {
@@ -409,5 +433,63 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
+    }
+
+    /// EIP-2200 stipend boundary: `remaining == call_stipend` must block (guard is `<=`).
+    #[test]
+    fn sstore_blocked_when_remaining_equals_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2300); // exactly at the 2300 stipend boundary
+        assert_eq!(
+            p.sstore(ADDR, KEY, U256::from(1u64)),
+            Err(BasePrecompileError::OutOfGas),
+            "sstore must be blocked when remaining == call_stipend"
+        );
+    }
+
+    /// Below the stipend: also blocked.
+    #[test]
+    fn sstore_blocked_when_remaining_below_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2299);
+        assert_eq!(p.sstore(ADDR, KEY, U256::from(1u64)), Err(BasePrecompileError::OutOfGas),);
+    }
+
+    /// One above the stipend: allowed.
+    #[test]
+    fn sstore_allowed_when_remaining_above_call_stipend() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_gas_remaining(2301);
+        assert!(
+            p.sstore(ADDR, KEY, U256::from(1u64)).is_ok(),
+            "sstore must succeed when remaining > call_stipend"
+        );
+    }
+
+    /// Default (no gas_remaining set): guard is inactive, sstore always proceeds.
+    #[test]
+    fn sstore_always_allowed_without_gas_remaining_set() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        // gas_remaining is None — guard disabled, unlimited gas
+        assert!(p.sstore(ADDR, KEY, U256::from(1u64)).is_ok());
+    }
+
+    /// Static-call violation takes priority over the stipend guard.
+    /// gas_remaining == 2300 means the stipend guard would also fire if checked first;
+    /// setting static=true proves StaticCallViolation is returned rather than OutOfGas.
+    #[test]
+    fn sstore_static_violation_checked_before_stipend_guard() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.set_gas_params(amsterdam_params());
+        p.set_static(true);
+        p.set_gas_remaining(2300); // stipend guard would also fire — proves ordering
+        assert_eq!(
+            p.sstore(ADDR, KEY, U256::from(1u64)),
+            Err(BasePrecompileError::StaticCallViolation),
+        );
     }
 }

--- a/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
+++ b/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
@@ -144,7 +144,7 @@ contract SeedDexPools is Script {
         MockERC20(token0).approve(clPositionManager, type(uint256).max);
         MockERC20(token1).approve(clPositionManager, type(uint256).max);
 
-        int24 maxTick = int24(887272) - (int24(887272) % tickSpacing);
+        int24 maxTick = (int24(887272) / tickSpacing) * tickSpacing;
         ICLPositionManager(clPositionManager).mint(
             ICLPositionManager.MintParams({
                 token0: token0,

--- a/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
+++ b/crates/utilities/test-utils/contracts/script/SeedDexPools.s.sol
@@ -144,7 +144,7 @@ contract SeedDexPools is Script {
         MockERC20(token0).approve(clPositionManager, type(uint256).max);
         MockERC20(token1).approve(clPositionManager, type(uint256).max);
 
-        int24 maxTick = (int24(887272) / tickSpacing) * tickSpacing;
+        int24 maxTick = int24(887272) - (int24(887272) % tickSpacing);
         ICLPositionManager(clPositionManager).mint(
             ICLPositionManager.MintParams({
                 token0: token0,


### PR DESCRIPTION
[BOP-358](https://linear.app/coinbase/issue/BOP-358)

## Motivation

The `#[precompile]` attribute macro parser accepted duplicate `args` options when the first occurrence was empty (`args(), args()` or `args(), args(x: u8)`). Every other option (`id`, `storage`, `macro_path`, `install`) uses the `reject_duplicate` helper which keys off whether a value has been assigned. The `args` branch instead guarded with `!args.is_empty()`, which misses the case where the first `args()` parses zero arguments and leaves the vec empty. The second occurrence would then silently overwrite the first.

## What changed

- Introduced an `args_seen: bool` flag in `PrecompileConfig::parse` that is set on the first encounter of the `args` key, regardless of how many arguments it contains.
- The duplicate check now tests `args_seen` instead of `!args.is_empty()`, matching the presence-tracking pattern used for all other options.
- Added two regression tests: one for `args(), args()` and one for `args(), args(x: u8)`.

## What was tried / considered

Wrapping `args` in an `Option<Vec<PrecompileArg>>` would also work and would unify the representation with the other fields, but it would require touching downstream code that reads `config.args` directly as a `Vec`. The `args_seen` flag achieves the same detection with the smallest diff and no caller changes.