### PR TITLE
fix(precompile-storage): remove redundant drop in with_caller and harden CallerGuard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,7 @@ dependencies = [
  "revm",
  "rstest",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -47,5 +47,6 @@ std = [
 	"derive_more/std",
 	"revm/std",
 	"thiserror/std",
+	"tracing/std",
 ]
 test-utils = [ "std" ]

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -26,6 +26,7 @@ base-precompile-macros.workspace = true
 
 # misc
 thiserror.workspace = true
+tracing.workspace = true
 derive_more = { workspace = true, features = ["from", "try_into"] }
 
 [dev-dependencies]

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -261,10 +261,10 @@ struct CallerGuard<'a> {
 
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
-        if let Some(previous) = self.previous.take() {
-            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
-                guard.replace_caller(previous);
-            }
+        if let Some(previous) = self.previous.take()
+            && let Ok(mut guard) = self.storage.storage.try_borrow_mut()
+        {
+            guard.replace_caller(previous);
         }
     }
 }
@@ -290,10 +290,10 @@ impl CheckpointGuard<'_> {
 
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
-        if let Some(cp) = self.checkpoint.take() {
-            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
-                guard.checkpoint_revert(cp);
-            }
+        if let Some(cp) = self.checkpoint.take()
+            && let Ok(mut guard) = self.storage.storage.try_borrow_mut()
+        {
+            guard.checkpoint_revert(cp);
         }
     }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -261,10 +261,10 @@ struct CallerGuard<'a> {
 
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
-        if let Some(previous) = self.previous.take()
-            && let Ok(mut guard) = self.storage.storage.try_borrow_mut()
-        {
-            guard.replace_caller(previous);
+        if let Some(previous) = self.previous.take() {
+            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
+                guard.replace_caller(previous);
+            }
         }
     }
 }
@@ -295,10 +295,10 @@ impl CheckpointGuard<'_> {
 
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
-        if let Some(cp) = self.checkpoint.take()
-            && let Ok(mut guard) = self.storage.storage.try_borrow_mut()
-        {
-            guard.checkpoint_revert(cp);
+        if let Some(cp) = self.checkpoint.take() {
+            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
+                guard.checkpoint_revert(cp);
+            }
         }
     }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -178,10 +178,8 @@ impl<'a> StorageCtx<'a> {
     /// Executes `f` with a temporary caller override, restoring the previous caller on exit.
     pub fn with_caller<R>(&self, caller: Address, f: impl FnOnce() -> R) -> R {
         let previous = self.with_storage(|s| s.replace_caller(caller));
-        let guard = CallerGuard { storage: *self, previous: Some(previous) };
-        let result = f();
-        drop(guard);
-        result
+        let _guard = CallerGuard { storage: *self, previous: Some(previous) };
+        f()
     }
 
     /// Deducts gas from the remaining gas, returning `OutOfGas` if insufficient.
@@ -264,9 +262,9 @@ struct CallerGuard<'a> {
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
         if let Some(previous) = self.previous.take() {
-            self.storage.with_storage(|s| {
-                s.replace_caller(previous);
-            });
+            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
+                guard.replace_caller(previous);
+            }
         }
     }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -281,6 +281,11 @@ pub struct CheckpointGuard<'a> {
 
 impl CheckpointGuard<'_> {
     /// Commits all state changes since the checkpoint.
+    ///
+    /// Uses `borrow_mut` (panicking) intentionally: `commit` is an explicit
+    /// caller action, so a conflicting borrow here is a logic bug that should
+    /// surface loudly. Contrast with `drop` below, which uses `try_borrow_mut`
+    /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
         if self.checkpoint.take().is_some() {
             self.storage.with_storage(|s| s.checkpoint_commit());

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -291,7 +291,9 @@ impl CheckpointGuard<'_> {
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
         if let Some(cp) = self.checkpoint.take() {
-            self.storage.with_storage(|s| s.checkpoint_revert(cp));
+            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
+                guard.checkpoint_revert(cp);
+            }
         }
     }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -262,8 +262,13 @@ struct CallerGuard<'a> {
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
         if let Some(previous) = self.previous.take() {
-            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
-                guard.replace_caller(previous);
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => {
+                    guard.replace_caller(previous);
+                }
+                Err(_) => tracing::warn!(
+                    "skipping caller restore: RefCell already borrowed (likely during unwind)"
+                ),
             }
         }
     }
@@ -296,8 +301,11 @@ impl CheckpointGuard<'_> {
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
         if let Some(cp) = self.checkpoint.take() {
-            if let Ok(mut guard) = self.storage.storage.try_borrow_mut() {
-                guard.checkpoint_revert(cp);
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => guard.checkpoint_revert(cp),
+                Err(_) => tracing::warn!(
+                    "skipping checkpoint revert: RefCell already borrowed (likely during unwind)"
+                ),
             }
         }
     }


### PR DESCRIPTION
## Motivation

Two issues in `StorageCtx` RAII guards:

1. `with_caller` used an explicit `drop(guard)` + separate `result` binding, when the guard's `Drop` impl already restores the caller at end of scope. Redundant and harder to read.
2. `CallerGuard::drop` and `CheckpointGuard::drop` called `borrow_mut()` internally. If a panic unwinds the stack while the `RefCell` is already mutably borrowed, this triggers a second panic during `drop`, which causes a process abort. `try_borrow_mut` silently skips the restore instead, which is the correct behavior during unwinding.

## What changed

- Simplified `with_caller` to `let _guard = ...; f()` -- RAII is the sole restore mechanism.
- Changed `CallerGuard::drop` from `self.storage.storage.borrow_mut()` to `try_borrow_mut`, skipping the restore on a conflicting borrow.
- Applied the same `try_borrow_mut` hardening to `CheckpointGuard::drop` which had the identical risk.

## What was tried / considered

An alternative was to use `std::panic::catch_unwind` inside `drop`, but that is significantly more complex and overkill for this case. Silently skipping the restore on a conflicting borrow is the established Rust pattern for `Drop` impls that interact with shared state.
