### PR TITLE
fix(precompile-macros): reject duplicate args() option regardless of argument count

### DIFF
--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -92,6 +92,7 @@ impl Parse for PrecompileConfig {
         let mut storage = None;
         let mut macro_path = None;
         let mut args = Vec::new();
+        let mut args_seen = false;
         let mut install = None;
 
         while !input.is_empty() {
@@ -113,9 +114,10 @@ impl Parse for PrecompileConfig {
                     macro_path = Some(input.parse()?);
                 }
                 "args" => {
-                    if !args.is_empty() {
+                    if args_seen {
                         return Err(syn::Error::new_spanned(key, "duplicate `args` option"));
                     }
+                    args_seen = true;
                     let content;
                     parenthesized!(content in input);
                     args = content
@@ -270,5 +272,19 @@ mod tests {
         let err = parse_config(quote! { install(address = X, extra) }).err().unwrap();
 
         assert!(err.to_string().contains("unexpected `install` option"));
+    }
+
+    #[test]
+    fn config_rejects_duplicate_empty_args() {
+        let err = parse_config(quote! { args(), args() }).err().unwrap();
+
+        assert!(err.to_string().contains("duplicate `args` option"));
+    }
+
+    #[test]
+    fn config_rejects_duplicate_args_where_first_is_empty() {
+        let err = parse_config(quote! { args(), args(x: u8) }).err().unwrap();
+
+        assert!(err.to_string().contains("duplicate `args` option"));
     }
 }


### PR DESCRIPTION
## Motivation

The `args` option in `#[precompile]` used `!args.is_empty()` to detect duplicate declarations. This check fails when the first `args()` call has zero arguments -- the vec stays empty, so a second `args(...)` is accepted without error. Every other option (`id`, `storage`, `macro_path`, `install`) rejects duplicates via `reject_duplicate`, which keys off whether the key was seen at all.

## What changed

- Added an `args_seen: bool` flag to `PrecompileConfig::parse` in `crates/common/precompile-macros/src/precompile.rs`. The flag is set on the first encounter of the `args` key regardless of argument count, matching the `reject_duplicate` pattern.
- Added two regression tests: `config_rejects_duplicate_empty_args` and `config_rejects_duplicate_args_where_first_is_empty`.

## What was tried / considered

The alternative was to call `reject_duplicate` directly on `args`, but that helper requires the value to implement `IsNone`, which `Vec` does not. A boolean flag is the minimal targeted fix.
