### PR TITLE
fix(precompile-storage): remove unused token arg from checkpoint_commit (BOP-350)

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -285,8 +285,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         self.internals.checkpoint()
     }
 
-    fn checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint) {
-        // alloy-evm's checkpoint_commit pops the top checkpoint; the arg is unused.
+    fn checkpoint_commit(&mut self) {
         self.internals.checkpoint_commit();
     }
 

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -256,12 +256,8 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         JournalCheckpoint { log_i: 0, journal_i: idx, selfdestructed_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self, checkpoint: JournalCheckpoint) {
-        assert_eq!(
-            checkpoint.journal_i,
-            self.snapshots.len() - 1,
-            "out-of-order checkpoint commit (expected top of stack)"
-        );
+    fn checkpoint_commit(&mut self) {
+        assert!(!self.snapshots.is_empty(), "checkpoint_commit called with no active checkpoint");
         self.snapshots.pop();
     }
 
@@ -549,7 +545,7 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         let cp = p.checkpoint();
         p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
-        p.checkpoint_commit(cp);
+        p.checkpoint_commit();
         assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -543,7 +543,7 @@ mod tests {
     #[test]
     fn checkpoint_commit_does_not_revert_mutations() {
         let mut p = HashMapStorageProvider::new(1);
-        let cp = p.checkpoint();
+        p.checkpoint();
         p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
         p.checkpoint_commit();
         assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -87,8 +87,8 @@ pub trait PrecompileStorageProvider {
 
     /// Creates a new journal checkpoint for atomic state management.
     fn checkpoint(&mut self) -> JournalCheckpoint;
-    /// Commits all state changes since the given checkpoint.
-    fn checkpoint_commit(&mut self, checkpoint: JournalCheckpoint);
+    /// Commits all state changes since the last checkpoint.
+    fn checkpoint_commit(&mut self);
     /// Reverts all state changes back to the given checkpoint.
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint);
 

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -284,8 +284,8 @@ pub struct CheckpointGuard<'a> {
 impl CheckpointGuard<'_> {
     /// Commits all state changes since the checkpoint.
     pub fn commit(mut self) {
-        if let Some(cp) = self.checkpoint.take() {
-            self.storage.with_storage(|s| s.checkpoint_commit(cp));
+        if self.checkpoint.take().is_some() {
+            self.storage.with_storage(|s| s.checkpoint_commit());
         }
     }
 }


### PR DESCRIPTION
## Summary
- `checkpoint_commit` in `PrecompileStorageProvider` accepted a `JournalCheckpoint` token that was silently discarded by the EVM implementation — alloy-evm's `checkpoint_commit` takes no token argument and always pops the stack top
- Removes the parameter from the trait, both implementations, and the `CheckpointGuard::commit()` call site
- `HashMapStorageProvider` now asserts `!self.snapshots.is_empty()` internally rather than relying on the caller to pass the correct token

Fixes audit finding BOP-350 (Cantina #30): the misleading token-based API implied per-checkpoint commit semantics that the production implementation could never honour.

## Test plan
- [ ] `cargo check -p base-precompile-storage` passes (verified)
- [ ] Existing checkpoint tests in `hashmap.rs` and `storage_ctx.rs` continue to pass