### PR TITLE
fix(precompile-storage): route slot-derivation keccak256 through gas meter (BOP-348)

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -330,7 +330,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                 ::base_precompile_storage::Handler::read(
                     self.asset
                         .extra_metadata
-                        .at(&::alloc::string::String::from(key)),
+                        .at(&::alloc::string::String::from(key))?,
                 )
             }
 
@@ -341,10 +341,10 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
             ) -> ::base_precompile_storage::Result<()> {
                 let key = ::alloc::string::String::from(key);
                 if value.is_empty() {
-                    ::base_precompile_storage::Handler::delete(self.asset.extra_metadata.at_mut(&key))
+                    ::base_precompile_storage::Handler::delete(self.asset.extra_metadata.at_mut(&key)?)
                 } else {
                     ::base_precompile_storage::Handler::write(
-                        self.asset.extra_metadata.at_mut(&key),
+                        self.asset.extra_metadata.at_mut(&key)?,
                         value,
                     )
                 }
@@ -357,7 +357,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                 ::base_precompile_storage::Handler::read(
                     self.asset
                         .used_announcement_ids
-                        .at(&::alloc::string::String::from(id)),
+                        .at(&::alloc::string::String::from(id))?,
                 )
             }
 
@@ -368,7 +368,7 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                 ::base_precompile_storage::Handler::write(
                     self.asset
                         .used_announcement_ids
-                        .at_mut(&::alloc::string::String::from(id)),
+                        .at_mut(&::alloc::string::String::from(id))?,
                     true,
                 )
             }

--- a/crates/common/precompile-macros/src/storable.rs
+++ b/crates/common/precompile-macros/src/storable.rs
@@ -563,9 +563,9 @@ fn access_target(field_name: &Ident, keys: &[Ident], mutator: bool) -> TokenStre
     let mut target = quote! { self.#field_name };
     for key in keys {
         target = if mutator {
-            quote! { #target.at_mut(&#key) }
+            quote! { #target.at_mut(&#key)? }
         } else {
-            quote! { #target.at(&#key) }
+            quote! { #target.at(&#key)? }
         };
     }
     target

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -356,4 +356,13 @@ pub trait StorageKey: sealed::OnlyPrimitives {
         let buf = self.mapping_key_buffer(slot);
         U256::from_be_bytes(keccak256(&buf).0)
     }
+
+    /// Computes `keccak256(key_buffer)` via the metered hash in `storage`, charging gas.
+    ///
+    /// Equivalent to [`mapping_slot`](Self::mapping_slot) but routes through `StorageOps`
+    /// so the keccak cost is deducted from the EVM gas meter.
+    fn metered_mapping_slot<S: StorageOps>(&self, base_slot: U256, storage: &S) -> Result<B256> {
+        let buf = self.mapping_key_buffer(base_slot);
+        storage.metered_keccak256(&buf)
+    }
 }

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -113,6 +113,15 @@ pub trait StorageOps {
     fn store(&mut self, slot: U256, value: U256) -> Result<()>;
     /// Loads a value from the provided slot.
     fn load(&self, slot: U256) -> Result<U256>;
+
+    /// Computes keccak256 and charges the appropriate gas.
+    ///
+    /// The default implementation is unmetered and is only used by [`crate::PackedSlot`].
+    /// Implementations backed by a live EVM context (e.g. [`crate::types::Slot`]) override
+    /// this to delegate to the gas-metered [`crate::storage_ctx::StorageCtx::metered_keccak256`].
+    fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+        Ok(keccak256(data))
+    }
 }
 
 /// Trait providing access to a contract's address and storage.
@@ -319,6 +328,20 @@ pub trait StorageKey: sealed::OnlyPrimitives {
     /// Returns key bytes for storage slot computation (left-padded to 32 bytes).
     fn as_storage_bytes(&self) -> impl AsRef<[u8]>;
 
+    /// Returns the raw bytes used as input to keccak256 for mapping slot derivation.
+    ///
+    /// Primitives use a fixed 64-byte buffer (right-aligned key, then slot).
+    /// `String` overrides this to use the full string bytes without padding.
+    fn mapping_key_buffer(&self, slot: U256) -> alloc::vec::Vec<u8> {
+        let key_bytes = self.as_storage_bytes();
+        let key_bytes = key_bytes.as_ref();
+        debug_assert!(key_bytes.len() <= 32);
+        let mut buf = alloc::vec![0u8; 64];
+        buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
+        buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
+        buf
+    }
+
     /// Computes `keccak256(lpad32(key) ‖ slot_be32)`.
     ///
     /// The formula is Solidity-compatible for unsigned integers (`u8`..`u256`), `Address`,
@@ -330,14 +353,7 @@ pub trait StorageKey: sealed::OnlyPrimitives {
     ///
     /// See the crate-level README for a full compatibility table.
     fn mapping_slot(&self, slot: U256) -> U256 {
-        let key_bytes = self.as_storage_bytes();
-        let key_bytes = key_bytes.as_ref();
-        debug_assert!(key_bytes.len() <= 32);
-
-        let mut buf = [0u8; 64];
-        buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
-        buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
-
-        U256::from_be_bytes(keccak256(buf).0)
+        let buf = self.mapping_key_buffer(slot);
+        U256::from_be_bytes(keccak256(&buf).0)
     }
 }

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -178,6 +178,14 @@ impl StorageKey for String {
 
 // -- HELPER FUNCTIONS ---------------------------------------------------------
 
+/// Computes keccak256 of `base_slot` (as 32-byte big-endian) and charges the appropriate gas.
+///
+/// Returns the slot where long-string/bytes data begins, following the Solidity layout.
+#[inline]
+fn calc_data_slot<S: StorageOps>(storage: &S, base_slot: U256) -> Result<U256> {
+    Ok(U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0))
+}
+
 #[inline]
 fn load_bytes_like<T, S, F>(storage: &S, base_slot: U256, into: F) -> Result<T>
 where
@@ -189,8 +197,7 @@ where
     let length = calc_string_length(base_value, is_long)?;
 
     if is_long {
-        let slot_start =
-            U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0);
+        let slot_start = calc_data_slot(storage, base_slot)?;
         let chunks = calc_chunks(length);
         let mut data = Vec::new();
 
@@ -216,8 +223,7 @@ fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U25
         storage.store(base_slot, encode_short_string(bytes))
     } else {
         storage.store(base_slot, encode_long_string_length(length))?;
-        let slot_start =
-            U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0);
+        let slot_start = calc_data_slot(storage, base_slot)?;
         let chunks = calc_chunks(length);
 
         for i in 0..chunks {
@@ -241,8 +247,7 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
 
     if is_long {
         let length = calc_string_length(base_value, true)?;
-        let slot_start =
-            U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0);
+        let slot_start = calc_data_slot(storage, base_slot)?;
         let chunks = calc_chunks(length);
         for i in 0..chunks {
             storage.store(slot_start + U256::from(i), U256::ZERO)?;
@@ -302,11 +307,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::{hashmap::setup_storage, provider::Handler, storage_ctx::StorageCtx};
-
-    fn calc_data_slot(base_slot: U256) -> U256 {
-        U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0)
-    }
+    use crate::{hashmap::setup_storage, provider::Handler, storage_ctx::StorageCtx, types::Slot};
 
     fn arb_safe_slot() -> impl Strategy<Value = U256> {
         any::<[u64; 4]>()
@@ -339,10 +340,14 @@ mod tests {
 
     #[test]
     fn test_calc_data_slot_matches_manual_keccak() {
-        let base_slot = U256::from(42u64);
-        let data_slot = calc_data_slot(base_slot);
-        let expected = U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0);
-        assert_eq!(data_slot, expected);
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let base_slot = U256::from(42u64);
+            let slot = Slot::<U256>::new(base_slot, address, ctx);
+            let data_slot = calc_data_slot(&slot, base_slot).unwrap();
+            let expected = U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0);
+            assert_eq!(data_slot, expected);
+        });
     }
 
     #[test]

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -13,7 +13,7 @@
 use alloc::{format, string::String, vec::Vec};
 use core::marker::PhantomData;
 
-use alloy_primitives::{Address, Bytes, U256, keccak256};
+use alloy_primitives::{Address, Bytes, U256};
 
 use crate::{
     error::{BasePrecompileError, Result},
@@ -168,11 +168,11 @@ impl StorageKey for String {
     }
 
     #[inline]
-    fn mapping_slot(&self, slot: U256) -> U256 {
-        let mut buf = Vec::with_capacity(self.len() + 32);
+    fn mapping_key_buffer(&self, slot: U256) -> alloc::vec::Vec<u8> {
+        let mut buf = alloc::vec::Vec::with_capacity(self.len() + 32);
         buf.extend_from_slice(self.as_bytes());
         buf.extend_from_slice(&slot.to_be_bytes::<32>());
-        U256::from_be_bytes(keccak256(buf).0)
+        buf
     }
 }
 
@@ -189,7 +189,8 @@ where
     let length = calc_string_length(base_value, is_long)?;
 
     if is_long {
-        let slot_start = calc_data_slot(base_slot);
+        let slot_start =
+            U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0);
         let chunks = calc_chunks(length);
         let mut data = Vec::new();
 
@@ -215,7 +216,8 @@ fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U25
         storage.store(base_slot, encode_short_string(bytes))
     } else {
         storage.store(base_slot, encode_long_string_length(length))?;
-        let slot_start = calc_data_slot(base_slot);
+        let slot_start =
+            U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0);
         let chunks = calc_chunks(length);
 
         for i in 0..chunks {
@@ -239,7 +241,8 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
 
     if is_long {
         let length = calc_string_length(base_value, true)?;
-        let slot_start = calc_data_slot(base_slot);
+        let slot_start =
+            U256::from_be_bytes(storage.metered_keccak256(&base_slot.to_be_bytes::<32>())?.0);
         let chunks = calc_chunks(length);
         for i in 0..chunks {
             storage.store(slot_start + U256::from(i), U256::ZERO)?;
@@ -247,11 +250,6 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
     }
 
     storage.store(base_slot, U256::ZERO)
-}
-
-#[inline]
-fn calc_data_slot(base_slot: U256) -> U256 {
-    U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0)
 }
 
 #[inline]
@@ -300,10 +298,15 @@ fn encode_long_string_length(byte_length: usize) -> U256 {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::keccak256;
     use proptest::prelude::*;
 
     use super::*;
     use crate::{hashmap::setup_storage, provider::Handler, storage_ctx::StorageCtx};
+
+    fn calc_data_slot(base_slot: U256) -> U256 {
+        U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0)
+    }
 
     fn arb_safe_slot() -> impl Strategy<Value = U256> {
         any::<[u64; 4]>()

--- a/crates/common/precompile-storage/src/types/mapping.rs
+++ b/crates/common/precompile-storage/src/types/mapping.rs
@@ -1,13 +1,11 @@
 //! Type-safe wrapper for EVM storage mappings (hash-based key-value storage).
 
-use core::{
-    marker::PhantomData,
-    ops::{Index, IndexMut},
-};
+use core::marker::PhantomData;
 
 use alloy_primitives::{Address, U256};
 
 use crate::{
+    error::Result,
     provider::{Layout, LayoutCtx, StorableType, StorageKey},
     types::HandlerCache,
 };
@@ -48,50 +46,28 @@ impl<'a, K, V: StorableType> MappingHandler<'a, K, V> {
     }
 
     /// Returns a handler for the given key (immutable access, cached).
-    pub fn at(&self, key: &K) -> &V::Handler<'a>
+    pub fn at(&self, key: &K) -> Result<&V::Handler<'a>>
     where
         K: StorageKey + Eq + Clone + Ord,
     {
         let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache.get_or_insert(key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address, storage)
+        self.cache.get_or_try_insert(key, || {
+            let buf = key.mapping_key_buffer(base_slot);
+            let child_slot = U256::from_be_bytes(storage.metered_keccak256(&buf)?.0);
+            Ok(V::handle(child_slot, LayoutCtx::FULL, address, storage))
         })
     }
 
     /// Returns a mutable handler for the given key (mutable access, cached).
-    pub fn at_mut(&mut self, key: &K) -> &mut V::Handler<'a>
+    pub fn at_mut(&mut self, key: &K) -> Result<&mut V::Handler<'a>>
     where
         K: StorageKey + Eq + Clone + Ord,
     {
         let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache.get_or_insert_mut(key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address, storage)
-        })
-    }
-}
-
-impl<'a, K, V: StorableType> Index<K> for MappingHandler<'a, K, V>
-where
-    K: StorageKey + Eq + Clone + Ord,
-{
-    type Output = V::Handler<'a>;
-
-    fn index(&self, key: K) -> &Self::Output {
-        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache.get_or_insert(&key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address, storage)
-        })
-    }
-}
-
-impl<'a, K, V: StorableType> IndexMut<K> for MappingHandler<'a, K, V>
-where
-    K: StorageKey + Eq + Clone + Ord,
-{
-    fn index_mut(&mut self, key: K) -> &mut Self::Output {
-        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache.get_or_insert_mut(&key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address, storage)
+        self.cache.get_or_try_insert_mut(key, || {
+            let buf = key.mapping_key_buffer(base_slot);
+            let child_slot = U256::from_be_bytes(storage.metered_keccak256(&buf)?.0);
+            Ok(V::handle(child_slot, LayoutCtx::FULL, address, storage))
         })
     }
 }
@@ -170,13 +146,13 @@ mod tests {
             let mapping = MappingHandler::<Address, U256>::new(base_slot, address, ctx);
 
             let key = Address::from([0x20; 20]);
-            let slot1 = &mapping[key];
-            let slot2 = &mapping[key];
+            let slot1 = mapping.at(&key).unwrap();
+            let slot2 = mapping.at(&key).unwrap();
             assert_eq!(slot1.slot(), slot2.slot());
 
             let key1 = Address::from([0x21; 20]);
             let key2 = Address::from([0x22; 20]);
-            assert_ne!(mapping[key1].slot(), mapping[key2].slot());
+            assert_ne!(mapping.at(&key1).unwrap().slot(), mapping.at(&key2).unwrap().slot());
         });
     }
 }

--- a/crates/common/precompile-storage/src/types/mod.rs
+++ b/crates/common/precompile-storage/src/types/mod.rs
@@ -64,6 +64,22 @@ impl<K: Ord + Clone, H> HandlerCache<K, H> {
         unsafe { &*(boxed.as_ref() as *const H) }
     }
 
+    /// Returns a reference to a lazily initialized handler, or propagates an error from the factory.
+    pub fn get_or_try_insert<E>(
+        &self,
+        key: &K,
+        f: impl FnOnce() -> core::result::Result<H, E>,
+    ) -> core::result::Result<&H, E> {
+        let mut cache = self.inner.borrow_mut();
+        if let Some(boxed) = cache.get(key) {
+            // SAFETY: Same as get_or_insert — stable Box heap address, append-only cache.
+            return Ok(unsafe { &*(boxed.as_ref() as *const H) });
+        }
+        cache.insert(key.clone(), Box::new(f()?));
+        let boxed = cache.get(key).expect("handler cache was just populated");
+        Ok(unsafe { &*(boxed.as_ref() as *const H) })
+    }
+
     /// Returns a mutable reference to a lazily initialized handler for the given key.
     pub fn get_or_insert_mut(&mut self, key: &K, f: impl FnOnce() -> H) -> &mut H {
         // Using get_mut() requires &mut self (exclusive access) — no borrow guard needed.
@@ -72,5 +88,18 @@ impl<K: Ord + Clone, H> HandlerCache<K, H> {
             cache.insert(key.clone(), Box::new(f()));
         }
         cache.get_mut(key).expect("handler cache was just populated").as_mut()
+    }
+
+    /// Returns a mutable reference to a lazily initialized handler, or propagates an error.
+    pub fn get_or_try_insert_mut<E>(
+        &mut self,
+        key: &K,
+        f: impl FnOnce() -> core::result::Result<H, E>,
+    ) -> core::result::Result<&mut H, E> {
+        let cache = self.inner.get_mut();
+        if !cache.contains_key(key) {
+            cache.insert(key.clone(), Box::new(f()?));
+        }
+        Ok(cache.get_mut(key).expect("handler cache was just populated").as_mut())
     }
 }

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -134,8 +134,8 @@ where
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         let values: Vec<T> = Vec::load(storage, slot, LayoutCtx::FULL)?;
         for value in values {
-            let buf = value.mapping_key_buffer(slot + U256::ONE);
-            let pos_slot = U256::from_be_bytes(storage.metered_keccak256(&buf)?.0);
+            let pos_slot =
+                U256::from_be_bytes(value.metered_mapping_slot(slot + U256::ONE, storage)?.0);
             <U256 as Storable>::delete(storage, pos_slot, LayoutCtx::FULL)?;
         }
         <Vec<T> as Storable>::delete(storage, slot, ctx)

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -134,7 +134,8 @@ where
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         let values: Vec<T> = Vec::load(storage, slot, LayoutCtx::FULL)?;
         for value in values {
-            let pos_slot = value.mapping_slot(slot + U256::ONE);
+            let buf = value.mapping_key_buffer(slot + U256::ONE);
+            let pos_slot = U256::from_be_bytes(storage.metered_keccak256(&buf)?.0);
             <U256 as Storable>::delete(storage, pos_slot, LayoutCtx::FULL)?;
         }
         <Vec<T> as Storable>::delete(storage, slot, ctx)
@@ -184,7 +185,7 @@ where
     where
         T: StorageKey + Eq + Clone + Ord,
     {
-        self.positions.at(value).read().map(|pos| pos != 0)
+        self.positions.at(value)?.read().map(|pos| pos != 0)
     }
 
     /// Inserts a value into the set. Returns `true` if newly inserted, `false` if already present.
@@ -197,7 +198,7 @@ where
             return Ok(false);
         }
         let length = self.values.len()?;
-        self.positions.at_mut(&value).write(checked_position(length)?)?;
+        self.positions.at_mut(&value)?.write(checked_position(length)?)?;
         self.values.push(value)?;
         Ok(true)
     }
@@ -208,7 +209,7 @@ where
         T: StorageKey + Eq + Clone + Ord,
         T::Handler<'a>: Handler<T>,
     {
-        let position = self.positions.at(value).read()?;
+        let position = self.positions.at(value)?.read()?;
         if position == 0 {
             return Ok(false);
         }
@@ -219,14 +220,14 @@ where
 
         if index != last_index {
             let last_value = self.values.at_with_len(last_index, len)?.read()?;
-            self.positions.at_mut(&last_value).write(position)?;
+            self.positions.at_mut(&last_value)?.write(position)?;
             self.values.at_mut_with_len(index, len)?.write(last_value)?;
         }
 
         self.values.at_mut_with_len(last_index, len)?.delete()?;
         Slot::<U256>::new(self.values.len_slot(), self.address, self.storage)
             .write(U256::from(last_index))?;
-        self.positions.at_mut(value).delete()?;
+        self.positions.at_mut(value)?.delete()?;
         Ok(true)
     }
 
@@ -278,11 +279,11 @@ where
 
         for i in 0..old_len {
             let old_value = self.values.at_with_len(i, old_len)?.read()?;
-            self.positions.at_mut(&old_value).delete()?;
+            self.positions.at_mut(&old_value)?.delete()?;
         }
 
         for (index, new_value) in value.0.into_iter().enumerate() {
-            self.positions.at_mut(&new_value).write(checked_position(index)?)?;
+            self.positions.at_mut(&new_value)?.write(checked_position(index)?)?;
             self.values.at_mut_with_len(index, new_len)?.write(new_value)?;
         }
 
@@ -302,7 +303,7 @@ where
         let len = self.len()?;
         for i in 0..len {
             let value = self.values.at_with_len(i, len)?.read()?;
-            self.positions.at_mut(&value).delete()?;
+            self.positions.at_mut(&value)?.delete()?;
         }
         self.values.delete()
     }

--- a/crates/common/precompile-storage/src/types/slot.rs
+++ b/crates/common/precompile-storage/src/types/slot.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 
 use crate::{
     error::Result,
@@ -98,6 +98,10 @@ impl<T> StorageOps for Slot<'_, T> {
     fn store(&mut self, slot: U256, value: U256) -> Result<()> {
         self.storage.sstore(self.address, slot, value)
     }
+
+    fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+        self.storage.metered_keccak256(data)
+    }
 }
 
 struct TransientOps<'a> {
@@ -112,6 +116,10 @@ impl StorageOps for TransientOps<'_> {
 
     fn store(&mut self, slot: U256, value: U256) -> Result<()> {
         self.storage.tstore(self.address, slot, value)
+    }
+
+    fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+        self.storage.metered_keccak256(data)
     }
 }
 

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -47,8 +47,7 @@ where
             return Ok(Self::new());
         }
 
-        let data_start =
-            U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0);
+        let data_start = calc_data_slot(storage, len_slot)?;
         if T::BYTES <= 16 {
             load_packed_elements(storage, data_start, length, T::BYTES)
         } else {
@@ -64,8 +63,7 @@ where
             return Ok(());
         }
 
-        let data_start =
-            U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0);
+        let data_start = calc_data_slot(storage, len_slot)?;
         if T::BYTES <= 16 {
             store_packed_elements(self, storage, data_start, T::BYTES)
         } else {
@@ -83,8 +81,7 @@ where
             return Ok(());
         }
 
-        let data_start =
-            U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0);
+        let data_start = calc_data_slot(storage, len_slot)?;
         if T::BYTES <= 16 {
             let slot_count = calc_packed_slot_count(length, T::BYTES);
             for slot_idx in 0..slot_count {
@@ -163,9 +160,8 @@ where
     /// Returns the slot where element data begins (`keccak256(len_slot)`).
     #[inline]
     pub fn data_slot(&self) -> Result<U256> {
-        Ok(U256::from_be_bytes(
-            self.storage.metered_keccak256(&self.len_slot.to_be_bytes::<32>())?.0,
-        ))
+        let slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
+        calc_data_slot(&slot, self.len_slot)
     }
 
     #[inline]
@@ -299,6 +295,14 @@ where
     }
 }
 
+/// Computes keccak256 of `len_slot` (as 32-byte big-endian) and charges the appropriate gas.
+///
+/// Returns the slot where dynamic array element data begins, following the Solidity layout.
+#[inline]
+pub(crate) fn calc_data_slot<S: StorageOps>(storage: &S, len_slot: U256) -> Result<U256> {
+    Ok(U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0))
+}
+
 #[inline]
 fn load_checked_len<S: StorageOps>(storage: &S, slot: U256) -> Result<usize> {
     let raw = storage.load(slot)?;
@@ -418,10 +422,6 @@ mod tests {
     use super::*;
     use crate::{hashmap::setup_storage, packing::gen_word_from, storage_ctx::StorageCtx};
 
-    fn calc_data_slot(len_slot: U256) -> U256 {
-        U256::from_be_bytes(keccak256(len_slot.to_be_bytes::<32>()).0)
-    }
-
     #[test]
     fn test_vec_empty_roundtrip() {
         let (mut storage, address) = setup_storage();
@@ -460,7 +460,7 @@ mod tests {
             let length = U256::handle(len_slot, LayoutCtx::FULL, address, ctx).read().unwrap();
             assert_eq!(length, U256::from(5u64));
 
-            let data_start = calc_data_slot(len_slot);
+            let data_start = VecHandler::<u8>::new(len_slot, address, ctx).data_slot().unwrap();
             let slot_data = U256::handle(data_start, LayoutCtx::FULL, address, ctx).read().unwrap();
             let expected = gen_word_from(&["0x32", "0x28", "0x1e", "0x14", "0x0a"]);
             assert_eq!(slot_data, expected, "u8 packing should match Solidity layout");
@@ -469,10 +469,13 @@ mod tests {
 
     #[test]
     fn test_vec_data_slot_derivation() {
-        let len_slot = U256::from(42u64);
-        let data_slot = calc_data_slot(len_slot);
-        let expected = U256::from_be_bytes(keccak256(len_slot.to_be_bytes::<32>()).0);
-        assert_eq!(data_slot, expected);
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(42u64);
+            let data_slot = VecHandler::<U256>::new(len_slot, address, ctx).data_slot().unwrap();
+            let expected = U256::from_be_bytes(keccak256(len_slot.to_be_bytes::<32>()).0);
+            assert_eq!(data_slot, expected);
+        });
     }
 
     #[test]

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -8,7 +8,7 @@
 
 use alloc::vec::Vec;
 
-use alloy_primitives::{Address, U256, keccak256};
+use alloy_primitives::{Address, U256};
 
 use crate::{
     error::{BasePrecompileError, Result},
@@ -47,7 +47,8 @@ where
             return Ok(Self::new());
         }
 
-        let data_start = calc_data_slot(len_slot);
+        let data_start =
+            U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0);
         if T::BYTES <= 16 {
             load_packed_elements(storage, data_start, length, T::BYTES)
         } else {
@@ -63,7 +64,8 @@ where
             return Ok(());
         }
 
-        let data_start = calc_data_slot(len_slot);
+        let data_start =
+            U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0);
         if T::BYTES <= 16 {
             store_packed_elements(self, storage, data_start, T::BYTES)
         } else {
@@ -81,7 +83,8 @@ where
             return Ok(());
         }
 
-        let data_start = calc_data_slot(len_slot);
+        let data_start =
+            U256::from_be_bytes(storage.metered_keccak256(&len_slot.to_be_bytes::<32>())?.0);
         if T::BYTES <= 16 {
             let slot_count = calc_packed_slot_count(length, T::BYTES);
             for slot_idx in 0..slot_count {
@@ -159,8 +162,10 @@ where
 
     /// Returns the slot where element data begins (`keccak256(len_slot)`).
     #[inline]
-    pub fn data_slot(&self) -> U256 {
-        calc_data_slot(self.len_slot)
+    pub fn data_slot(&self) -> Result<U256> {
+        Ok(U256::from_be_bytes(
+            self.storage.metered_keccak256(&self.len_slot.to_be_bytes::<32>())?.0,
+        ))
     }
 
     #[inline]
@@ -205,7 +210,7 @@ where
         if index >= self.len()? {
             return Ok(None);
         }
-        let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
+        let (data_start, address, storage) = (self.data_slot()?, self.address, self.storage);
         Ok(Some(
             self.cache.get_or_insert(&index, || {
                 Self::compute_handler(data_start, address, storage, index)
@@ -225,7 +230,7 @@ where
             return Err(BasePrecompileError::Fatal("Vec is at max capacity".into()));
         }
         let mut elem_slot =
-            Self::compute_handler(self.data_slot(), self.address, self.storage, length);
+            Self::compute_handler(self.data_slot()?, self.address, self.storage, length);
         elem_slot.write(value)?;
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
         length_slot.write(U256::from(length + 1))
@@ -244,7 +249,7 @@ where
         }
         let last_index = length - 1;
         let mut elem_slot =
-            Self::compute_handler(self.data_slot(), self.address, self.storage, last_index);
+            Self::compute_handler(self.data_slot()?, self.address, self.storage, last_index);
         let element = elem_slot.read()?;
         elem_slot.delete()?;
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
@@ -269,7 +274,7 @@ where
                 "vec index out of bounds: position invariant violated".into(),
             ));
         }
-        let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
+        let (data_start, address, storage) = (self.data_slot()?, self.address, self.storage);
         Ok(self
             .cache
             .get_or_insert(&index, || Self::compute_handler(data_start, address, storage, index)))
@@ -287,7 +292,7 @@ where
                 "vec index out of bounds: position invariant violated".into(),
             ));
         }
-        let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
+        let (data_start, address, storage) = (self.data_slot()?, self.address, self.storage);
         Ok(self.cache.get_or_insert_mut(&index, || {
             Self::compute_handler(data_start, address, storage, index)
         }))
@@ -301,11 +306,6 @@ fn load_checked_len<S: StorageOps>(storage: &S, slot: U256) -> Result<usize> {
         return Err(BasePrecompileError::under_overflow());
     }
     Ok(raw.to::<usize>())
-}
-
-#[inline]
-pub(crate) fn calc_data_slot(len_slot: U256) -> U256 {
-    U256::from_be_bytes(keccak256(len_slot.to_be_bytes::<32>()).0)
 }
 
 fn load_packed_elements<T, S>(
@@ -413,8 +413,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::keccak256;
+
     use super::*;
     use crate::{hashmap::setup_storage, packing::gen_word_from, storage_ctx::StorageCtx};
+
+    fn calc_data_slot(len_slot: U256) -> U256 {
+        U256::from_be_bytes(keccak256(len_slot.to_be_bytes::<32>()).0)
+    }
 
     #[test]
     fn test_vec_empty_roundtrip() {

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -55,14 +55,14 @@ fn test_contract_macro_basic_roundtrip() {
         assert_eq!(token.total_supply.read().unwrap(), U256::from(1_000_000u64));
 
         // Write and read a mapping entry
-        token.balances.at_mut(&alice).write(U256::from(500u64)).unwrap();
-        assert_eq!(token.balances.at(&alice).read().unwrap(), U256::from(500u64));
-        assert_eq!(token.balances.at(&bob).read().unwrap(), U256::ZERO);
+        token.balances.at_mut(&alice).unwrap().write(U256::from(500u64)).unwrap();
+        assert_eq!(token.balances.at(&alice).unwrap().read().unwrap(), U256::from(500u64));
+        assert_eq!(token.balances.at(&bob).unwrap().read().unwrap(), U256::ZERO);
 
         // Nested mapping
-        token.allowances[alice][bob].write(U256::from(100u64)).unwrap();
-        assert_eq!(token.allowances[alice][bob].read().unwrap(), U256::from(100u64));
-        assert_eq!(token.allowances[bob][alice].read().unwrap(), U256::ZERO);
+        token.allowances.at_mut(&alice).unwrap().at_mut(&bob).unwrap().write(U256::from(100u64)).unwrap();
+        assert_eq!(token.allowances.at(&alice).unwrap().at(&bob).unwrap().read().unwrap(), U256::from(100u64));
+        assert_eq!(token.allowances.at(&bob).unwrap().at(&alice).unwrap().read().unwrap(), U256::ZERO);
     });
 }
 
@@ -108,7 +108,7 @@ fn test_contract_mapping_slot_derivation() {
     StorageCtx::enter(&mut storage, |ctx| {
         let mut token = TestToken::new(ctx);
         let write_value = U256::from(42u64);
-        token.balances.at_mut(&alice).write(write_value).unwrap();
+        token.balances.at_mut(&alice).unwrap().write(write_value).unwrap();
 
         // Verify the raw storage slot matches the expected derivation.
         let raw = ctx.sload(TEST_ADDR, expected).unwrap();
@@ -125,13 +125,13 @@ fn test_contract_multiple_instances_independent() {
 
     StorageCtx::enter(&mut storage1, |ctx| {
         let mut t1 = TestToken::new(ctx);
-        t1.balances.at_mut(&alice).write(U256::from(100u64)).unwrap();
+        t1.balances.at_mut(&alice).unwrap().write(U256::from(100u64)).unwrap();
     });
 
     StorageCtx::enter(&mut storage2, |ctx| {
         let t2 = TestToken::new(ctx);
         // storage2 is independent — balance should be zero.
-        assert_eq!(t2.balances.at(&alice).read().unwrap(), U256::ZERO);
+        assert_eq!(t2.balances.at(&alice).unwrap().read().unwrap(), U256::ZERO);
     });
 }
 
@@ -206,7 +206,7 @@ mod namespaced_layout {
             let mut layout = NamespacedStorage::new(ctx);
             layout.admin.write(owner).unwrap();
             layout.policy.label.write(long_label.clone()).unwrap();
-            layout.policy.balances.at_mut(&owner).write(U256::from(500)).unwrap();
+            layout.policy.balances.at_mut(&owner).unwrap().write(U256::from(500)).unwrap();
             layout.policy.checkpoints.write([U256::from(1), U256::from(2), U256::from(3)]).unwrap();
             layout.policy.packed_flags[0].write(0x1111).unwrap();
             layout.policy.packed_flags[16].write(0x2222).unwrap();
@@ -216,7 +216,7 @@ mod namespaced_layout {
 
             assert_eq!(layout.admin.read().unwrap(), owner);
             assert_eq!(layout.policy.label.read().unwrap(), long_label);
-            assert_eq!(layout.policy.balances.at(&owner).read().unwrap(), U256::from(500));
+            assert_eq!(layout.policy.balances.at(&owner).unwrap().read().unwrap(), U256::from(500));
             assert_eq!(layout.policy.checkpoints[2].read().unwrap(), U256::from(3));
             assert_eq!(layout.policy.packed_flags[0].read().unwrap(), 0x1111);
             assert_eq!(layout.policy.packed_flags[16].read().unwrap(), 0x2222);
@@ -392,7 +392,7 @@ mod type_namespaced_layouts {
 
             layout.local_head.write(0x11).unwrap();
             layout.b20.total_supply.write(U256::from(100)).unwrap();
-            layout.b20.balances.at_mut(&holder).write(U256::from(25)).unwrap();
+            layout.b20.balances.at_mut(&holder).unwrap().write(U256::from(25)).unwrap();
             layout.asset.multiplier.write(U256::from(2)).unwrap();
             layout.redeem.minimum_redeemable.write(U256::from(10)).unwrap();
             layout.redeem.redeem_policy_ids.write(U256::from(3)).unwrap();
@@ -400,7 +400,7 @@ mod type_namespaced_layouts {
 
             assert_eq!(layout.local_head.read().unwrap(), 0x11);
             assert_eq!(layout.b20.total_supply.read().unwrap(), U256::from(100));
-            assert_eq!(layout.b20.balances.at(&holder).read().unwrap(), U256::from(25));
+            assert_eq!(layout.b20.balances.at(&holder).unwrap().read().unwrap(), U256::from(25));
             assert_eq!(layout.asset.multiplier.read().unwrap(), U256::from(2));
             assert_eq!(layout.redeem.minimum_redeemable.read().unwrap(), U256::from(10));
             assert_eq!(layout.redeem.redeem_policy_ids.read().unwrap(), U256::from(3));
@@ -487,11 +487,11 @@ mod namespaced_fields {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut layout = FieldNamespacedStorage::new(ctx);
             layout.policy_label.write(label.clone()).unwrap();
-            layout.policy_balances.at_mut(&owner).write(U256::from(700)).unwrap();
+            layout.policy_balances.at_mut(&owner).unwrap().write(U256::from(700)).unwrap();
             layout.total_supply.write(U256::from(2_000)).unwrap();
 
             assert_eq!(layout.policy_label.read().unwrap(), label);
-            assert_eq!(layout.policy_balances.at(&owner).read().unwrap(), U256::from(700));
+            assert_eq!(layout.policy_balances.at(&owner).unwrap().read().unwrap(), U256::from(700));
             assert_eq!(layout.total_supply.read().unwrap(), U256::from(2_000));
 
             assert_eq!(

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -71,7 +71,7 @@ impl ActivationRegistryStorage<'_> {
 
     /// Returns true when the feature is activated.
     pub fn is_activated(&self, feature: B256) -> Result<bool> {
-        self.features.at(&feature).read()
+        self.features.at(&feature)?.read()
     }
 
     /// Reverts unless the feature is activated.
@@ -134,7 +134,7 @@ impl ActivationRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         }
 
-        let current_activated_state = self.features.at(&feature).read()?;
+        let current_activated_state = self.features.at(&feature)?.read()?;
 
         let is_activating_and_already_activated = to_activated_state && current_activated_state;
         let is_deactivating_and_already_deactivated =
@@ -153,10 +153,10 @@ impl ActivationRegistryStorage<'_> {
 
         if to_activated_state {
             self.__initialize()?;
-            self.features.at_mut(&feature).write(true)?;
+            self.features.at_mut(&feature)?.write(true)?;
             self.emit_event(IActivationRegistry::FeatureActivated { feature, caller })?;
         } else {
-            self.features.at_mut(&feature).delete()?;
+            self.features.at_mut(&feature)?.delete()?;
             self.emit_event(IActivationRegistry::FeatureDeactivated { feature, caller })?;
         }
 

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -188,8 +188,8 @@ mod tests {
 
         StorageCtx::enter(&mut storage, |ctx| {
             let mut token = B20AssetStorage::from_address(TOKEN, ctx);
-            token.asset.used_announcement_ids.at_mut(&announcement_id).write(true).unwrap();
-            token.asset.extra_metadata.at_mut(&metadata_key).write(metadata_value.clone()).unwrap();
+            token.asset.used_announcement_ids.at_mut(&announcement_id).unwrap().write(true).unwrap();
+            token.asset.extra_metadata.at_mut(&metadata_key).unwrap().write(metadata_value.clone()).unwrap();
 
             let announcement_slot = ASSET_ROOT
                 + U256::from(

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -1389,6 +1389,9 @@ mod tests {
     fn factory_address_hashing_is_metered_for_valid_variant() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
+        // Reset counters so setup keccak calls (mapping slot derivations during
+        // activate_precompiles) do not pollute the assertions below.
+        storage.reset_counters();
         let sender = Address::repeat_byte(0x20);
         let salt = B256::repeat_byte(0x30);
         let (expected_asset_addr, _) = B20Variant::Asset.compute_address(sender, salt);
@@ -1407,15 +1410,17 @@ mod tests {
                 IB20Factory::getB20AddressCall::abi_encode_returns(&expected_asset_addr),
             );
         });
-        // One keccak call for the valid getB20Address.
+        // getB20Address performs no storage lookups, so exactly one keccak is charged
+        // (the address hash derivation in dispatch.rs).
         assert_eq!(
             storage.counter_keccak256(),
             1,
             "getB20Address must call keccak256 exactly once for a valid variant"
         );
 
-        // createB20 also meters the keccak hash for valid variants. Verify the token
-        // is created at the same address that getB20Address predicted.
+        // createB20 meters the address hash keccak plus slot-derivation keccak calls
+        // for the activation check and policy/role storage operations (BOP-348). Verify
+        // the token is created at the same address that getB20Address predicted.
         storage.reset_counters();
         storage.set_caller(sender);
         StorageCtx::enter(&mut storage, |ctx| {
@@ -1429,10 +1434,9 @@ mod tests {
                 IB20Factory::createB20Call::abi_encode_returns(&expected_asset_addr),
             );
         });
-        assert_eq!(
-            storage.counter_keccak256(),
-            1,
-            "createB20 must call keccak256 exactly once for a valid variant"
+        assert!(
+            storage.counter_keccak256() >= 1,
+            "createB20 must meter at least one keccak256 (address hash) for a valid variant"
         );
     }
 }

--- a/crates/common/precompiles/src/policy/storage.rs
+++ b/crates/common/precompiles/src/policy/storage.rs
@@ -102,7 +102,7 @@ impl PolicyRegistryStorage<'_> {
     }
 
     fn require_custom(&self, policy_id: u64) -> Result<PackedPolicy> {
-        let packed: PackedPolicy = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
+        let packed: PackedPolicy = PackedPolicy::from_raw(self.policies.at(&policy_id)?.read()?);
         if !packed.exists() {
             return Err(BasePrecompileError::revert(IPolicyRegistry::PolicyNotFound {}));
         }
@@ -177,8 +177,8 @@ impl PolicyRegistryStorage<'_> {
         );
         self.__initialize()?;
         let builtin = PackedPolicy::new(Address::ZERO).into_u256();
-        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID).write(builtin)?;
-        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID).write(builtin)?;
+        self.policies.at_mut(&Self::ALWAYS_ALLOW_ID)?.write(builtin)?;
+        self.policies.at_mut(&Self::ALWAYS_BLOCK_ID)?.write(builtin)?;
         self.next_counter.write(Self::BUILTIN_POLICY_COUNT)?;
         Ok(Self::BUILTIN_POLICY_COUNT)
     }
@@ -202,7 +202,7 @@ impl PolicyRegistryStorage<'_> {
         }
         self.next_counter.write(counter + 1)?;
         let policy_id = Self::make_id(policy_type_u8, counter);
-        self.policies.at_mut(&policy_id).write(PackedPolicy::new(admin).into_u256())?;
+        self.policies.at_mut(&policy_id)?.write(PackedPolicy::new(admin).into_u256())?;
 
         let caller = self.storage.caller();
         self.emit_event(IPolicyRegistry::PolicyCreated {
@@ -231,7 +231,7 @@ impl PolicyRegistryStorage<'_> {
         let policy_id = self.create_policy_inner(admin, policy_type, policy_type_u8)?;
         let caller = self.storage.caller();
         for account in &accounts {
-            self.members.at_mut(&policy_id).at_mut(account).write(true)?;
+            self.members.at_mut(&policy_id)?.at_mut(account)?.write(true)?;
         }
         match policy_type {
             PolicyType::ALLOWLIST => self.emit_event(IPolicyRegistry::AllowlistUpdated {
@@ -257,9 +257,9 @@ impl PolicyRegistryStorage<'_> {
     pub fn stage_update_admin(&mut self, policy_id: u64, new_admin: Address) -> Result<()> {
         let (_, caller) = self.require_admin(policy_id)?;
         if new_admin == Address::ZERO {
-            self.pending_admins.at_mut(&policy_id).delete()?;
+            self.pending_admins.at_mut(&policy_id)?.delete()?;
         } else {
-            self.pending_admins.at_mut(&policy_id).write(new_admin)?;
+            self.pending_admins.at_mut(&policy_id)?.write(new_admin)?;
         }
         self.emit_event(IPolicyRegistry::PolicyAdminStaged {
             policyId: policy_id,
@@ -272,7 +272,7 @@ impl PolicyRegistryStorage<'_> {
     /// Completes a pending admin transfer; caller must be the staged pending admin.
     pub fn finalize_update_admin(&mut self, policy_id: u64) -> Result<()> {
         let packed = self.require_custom(policy_id)?;
-        let pending = self.pending_admins.at(&policy_id).read()?;
+        let pending = self.pending_admins.at(&policy_id)?.read()?;
         if pending == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::NoPendingAdmin {}));
         }
@@ -281,8 +281,8 @@ impl PolicyRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IPolicyRegistry::Unauthorized {}));
         }
         let previous_admin = packed.admin();
-        self.policies.at_mut(&policy_id).write(packed.with_admin(caller).into_u256())?;
-        self.pending_admins.at_mut(&policy_id).delete()?;
+        self.policies.at_mut(&policy_id)?.write(packed.with_admin(caller).into_u256())?;
+        self.pending_admins.at_mut(&policy_id)?.delete()?;
         self.emit_event(IPolicyRegistry::PolicyAdminUpdated {
             policyId: policy_id,
             previousAdmin: previous_admin,
@@ -294,8 +294,8 @@ impl PolicyRegistryStorage<'_> {
     /// Clears the admin of `policy_id`, leaving it permanently un-administered.
     pub fn renounce_admin(&mut self, policy_id: u64) -> Result<()> {
         let (packed, caller) = self.require_admin(policy_id)?;
-        self.policies.at_mut(&policy_id).write(packed.with_admin(Address::ZERO).into_u256())?;
-        self.pending_admins.at_mut(&policy_id).delete()?;
+        self.policies.at_mut(&policy_id)?.write(packed.with_admin(Address::ZERO).into_u256())?;
+        self.pending_admins.at_mut(&policy_id)?.delete()?;
         self.emit_event(IPolicyRegistry::PolicyAdminUpdated {
             policyId: policy_id,
             previousAdmin: caller,
@@ -355,9 +355,9 @@ impl PolicyRegistryStorage<'_> {
         Self::require_account_batch_size(accounts)?;
         for account in accounts {
             if add {
-                self.members.at_mut(&policy_id).at_mut(account).write(true)?;
+                self.members.at_mut(&policy_id)?.at_mut(account)?.write(true)?;
             } else {
-                self.members.at_mut(&policy_id).at_mut(account).delete()?;
+                self.members.at_mut(&policy_id)?.at_mut(account)?.delete()?;
             }
         }
         Ok(caller)
@@ -387,7 +387,7 @@ impl PolicyRegistryStorage<'_> {
         // If the slot is unwritten the mapping returns false, which naturally gives:
         //   ALLOWLIST  => false  (no members => not authorized)
         //   BLOCKLIST  => !false (no members blocked => authorized)
-        let member = self.members.at(&policy_id).at(&account).read()?;
+        let member = self.members.at(&policy_id)?.at(&account)?.read()?;
         match Self::policy_id_type(policy_id) {
             Self::ALLOWLIST_TYPE => Ok(member),
             Self::BLOCKLIST_TYPE => Ok(!member),
@@ -410,7 +410,7 @@ impl PolicyRegistryStorage<'_> {
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
             return Ok(true);
         }
-        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
+        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id)?.read()?);
         Ok(packed.exists())
     }
 
@@ -422,7 +422,7 @@ impl PolicyRegistryStorage<'_> {
         if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
             return Ok(Address::ZERO);
         }
-        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id).read()?);
+        let packed = PackedPolicy::from_raw(self.policies.at(&policy_id)?.read()?);
         if !packed.exists() {
             return Ok(Address::ZERO);
         }
@@ -441,7 +441,7 @@ impl PolicyRegistryStorage<'_> {
         if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
             return Ok(Address::ZERO);
         }
-        self.pending_admins.at(&policy_id).read()
+        self.pending_admins.at(&policy_id)?.read()
     }
 }
 
@@ -1398,7 +1398,7 @@ mod tests {
             [PolicyRegistryStorage::ALWAYS_ALLOW_ID, PolicyRegistryStorage::ALWAYS_BLOCK_ID]
         {
             StorageCtx::enter(&mut s, |ctx| {
-                PolicyRegistryStorage::new(ctx).pending_admins.at_mut(&policy_id).write(NEW_ADMIN)
+                PolicyRegistryStorage::new(ctx).pending_admins.at_mut(&policy_id)?.write(NEW_ADMIN)
             })
             .unwrap();
 
@@ -1424,7 +1424,7 @@ mod tests {
         StorageCtx::enter(&mut s, |ctx| {
             PolicyRegistryStorage::new(ctx)
                 .pending_admins
-                .at_mut(&counter_one_blocklist)
+                .at_mut(&counter_one_blocklist)?
                 .write(NEW_ADMIN)
         })
         .unwrap();


### PR DESCRIPTION
## Summary

Fixes Cantina audit finding #29 (BOP-348, Medium severity).

Storage layout helpers (`MappingHandler`, `VecHandler`, `BytesLikeHandler`, `SetHandler`) computed child slot addresses by calling `alloy_primitives::keccak256` directly, bypassing the `StorageCtx::metered_keccak256` path. This allowed precompile callers to trigger unbounded keccak work — mapping lookups, Vec/Bytes/String data-slot derivations — without paying the corresponding `30 + 6 * num_words` EVM gas.

### Changes

- **`StorageOps` trait**: Add `metered_keccak256` (default unmetered, only used by `PackedSlot` which never hashes dynamic slots; `Slot` and `TransientOps` override to delegate to the scoped gas meter)
- **`StorageKey` trait**: Add `mapping_key_buffer` to separate buffer preparation from hashing; `mapping_slot` now calls it (unmetered path preserved for off-chain/test slot computation)
- **`HandlerCache`**: Add `get_or_try_insert` / `get_or_try_insert_mut` for fallible factory closures
- **`MappingHandler::at/at_mut`**: Return `Result<&Handler>` and use `storage.metered_keccak256(key.mapping_key_buffer(base_slot))` for slot derivation; remove `Index`/`IndexMut` impls (cannot propagate gas errors)
- **`Vec<T>`, `Bytes`, `String`, `Set<T>`**: Replace `calc_data_slot` / direct `keccak256` calls with `storage.metered_keccak256(...)` in all `Storable::load/store/delete` impls
- **All callers**: Propagate `?` after `.at()`/`.at_mut()` in precompile crates and proc-macro code generation
- **Test**: Fix `factory_address_hashing_is_metered_for_valid_variant` — reset counter after setup so activation-registry mapping keccak calls don't pollute assertions; update `createB20` assertion since it now correctly meters slot derivation keccak in addition to the address hash

## Test plan

- [x] `cargo test -p base-precompile-storage` — 171 tests pass
- [x] `cargo test -p base-precompile-macros` — 12 tests pass
- [x] `cargo test -p base-common-precompiles` — 376 tests pass