### PR TITLE
feat(trie): add RocksDB proof storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,6 +4656,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-common",
+ "rocksdb",
  "secp256k1 0.30.0",
  "serde",
  "serial_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4632,6 +4632,7 @@ dependencies = [
  "base-metrics",
  "bincode 2.0.1",
  "bytes",
+ "criterion",
  "derive_more 2.1.1",
  "eyre",
  "metrics",

--- a/crates/execution/trie/Cargo.toml
+++ b/crates/execution/trie/Cargo.toml
@@ -20,7 +20,7 @@ reth-execution-errors.workspace = true
 reth-primitives-traits.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-codecs.workspace = true
-reth-revm.workspace = true
+reth-revm = { workspace = true, features = ["witness"] }
 reth-trie = { workspace = true, features = ["serde"] }
 reth-trie-common = { workspace = true, features = ["serde"] }
 
@@ -53,6 +53,8 @@ parking_lot.workspace = true
 derive_more.workspace = true
 eyre = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
+rocksdb = { workspace = true, features = ["lz4", "zstd"] }
+
 [dev-dependencies]
 eyre.workspace = true
 mockall.workspace = true
@@ -78,6 +80,11 @@ tokio = { workspace = true, features = ["test-util", "rt-multi-thread", "macros"
 
 # misc
 serial_test.workspace = true
+criterion = { workspace = true, features = ["html_reports"] }
+
+[[bench]]
+name = "witness_reads"
+harness = false
 
 [features]
 serde-bincode-compat = [

--- a/crates/execution/trie/README.md
+++ b/crates/execution/trie/README.md
@@ -20,9 +20,9 @@ base-execution-trie = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_trie::{BaseProofStoragePruner, MdbxProofsStorage};
+use base_execution_trie::{BaseProofStoragePruner, RocksdbProofsStorage};
 
-let storage = MdbxProofsStorage::open(db_path)?;
+let storage = RocksdbProofsStorage::new(db_path)?;
 let pruner = BaseProofStoragePruner::new(storage.clone(), retention_blocks);
 ```
 

--- a/crates/execution/trie/benches/witness_reads.rs
+++ b/crates/execution/trie/benches/witness_reads.rs
@@ -1,0 +1,258 @@
+//! Benchmarks the proofs-history read path used by debug witness generation.
+//!
+//! This benchmark seeds a `RocksDB` proofs-history store with deterministic
+//! account and storage data, then repeatedly performs the DB-bound reads that
+//! `debug_executionWitness` drives through `StateProviderDatabase` and
+//! `revm::State` while EVM execution records touched state.
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_eips::BlockNumHash;
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_trie::{
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, RocksdbProofsStorage,
+    provider::BaseProofsStateProviderRef,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand_08::{RngCore, SeedableRng, rngs::StdRng};
+use reth_primitives_traits::Account;
+use reth_provider::{AccountReader, StateProofProvider, StateProvider, noop::NoopProvider};
+use reth_revm::{
+    Database, State, database::StateProviderDatabase, witness::ExecutionWitnessRecord,
+};
+use reth_trie_common::TrieInput;
+use tempfile::TempDir;
+
+const BASE_ACCOUNTS: usize = 10_000;
+const SLOTS_PER_ACCOUNT: usize = 8;
+const TARGET_ACCOUNTS: usize = 256;
+const MISSING_ACCOUNTS: usize = 64;
+
+#[derive(Clone)]
+struct SeedAccount {
+    address: Address,
+    hashed_address: B256,
+    account: Account,
+    slots: Vec<(B256, B256, U256)>,
+}
+
+struct WitnessReadFixture {
+    _dir: TempDir,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    targets: Vec<SeedAccount>,
+    missing_addresses: Vec<Address>,
+}
+
+fn random_bytes<const N: usize>(rng: &mut StdRng) -> [u8; N] {
+    let mut bytes = [0; N];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
+fn account_for(index: usize) -> Account {
+    Account {
+        nonce: index as u64,
+        balance: U256::from((index as u64 + 1) * 1_000),
+        bytecode_hash: None,
+    }
+}
+
+fn generate_accounts(count: usize, slots_per_account: usize) -> Vec<SeedAccount> {
+    let mut rng = StdRng::seed_from_u64(0xBEEF_F00D);
+    (0..count)
+        .map(|index| {
+            let address = Address::from(random_bytes::<20>(&mut rng));
+            let hashed_address = keccak256(address);
+            let account = account_for(index);
+            let slots = (0..slots_per_account)
+                .map(|slot_index| {
+                    let storage_key = B256::from(random_bytes::<32>(&mut rng));
+                    let hashed_storage_key = keccak256(storage_key);
+                    let value = U256::from((index as u64 + 1) * 10_000 + slot_index as u64);
+                    (storage_key, hashed_storage_key, value)
+                })
+                .collect();
+            SeedAccount { address, hashed_address, account, slots }
+        })
+        .collect()
+}
+
+fn missing_addresses() -> Vec<Address> {
+    (0..MISSING_ACCOUNTS).map(|index| Address::repeat_byte(0x80 | index as u8)).collect()
+}
+
+fn create_fixture(compact: bool) -> WitnessReadFixture {
+    let dir = TempDir::new().expect("create temp dir");
+    let rocksdb = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("create RocksDB storage"));
+    let accounts = generate_accounts(BASE_ACCOUNTS, SLOTS_PER_ACCOUNT);
+
+    rocksdb
+        .store_hashed_accounts(
+            accounts
+                .iter()
+                .map(|account| (account.hashed_address, Some(account.account)))
+                .collect(),
+        )
+        .expect("store hashed accounts");
+
+    for account in &accounts {
+        let storages = account
+            .slots
+            .iter()
+            .map(|(_, hashed_storage_key, value)| (*hashed_storage_key, *value));
+        rocksdb
+            .store_hashed_storages(account.hashed_address, storages.collect())
+            .expect("store hashed storage");
+    }
+
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("set initial state anchor");
+    rocksdb.commit_initial_state().expect("commit initial state");
+
+    if compact {
+        rocksdb.flush_and_compact().expect("flush and compact RocksDB fixture");
+    }
+
+    let targets = accounts.into_iter().take(TARGET_ACCOUNTS).collect::<Vec<_>>();
+    let storage = BaseProofsStorage::from(rocksdb);
+    let fixture =
+        WitnessReadFixture { _dir: dir, storage, targets, missing_addresses: missing_addresses() };
+    validate_fixture(&fixture);
+    fixture
+}
+
+fn validate_fixture(fixture: &WitnessReadFixture) {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+
+    for target in &fixture.targets {
+        let account =
+            provider.basic_account(&target.address).expect("read account").expect("account exists");
+        assert_eq!(account, target.account);
+
+        for (storage_key, _, value) in &target.slots {
+            let storage_value = provider
+                .storage(target.address, *storage_key)
+                .expect("read storage")
+                .expect("storage exists");
+            assert_eq!(storage_value, *value);
+        }
+
+        assert!(
+            provider
+                .storage(target.address, B256::repeat_byte(0xFE))
+                .expect("read missing storage")
+                .is_none()
+        );
+    }
+
+    for missing_address in &fixture.missing_addresses {
+        assert!(provider.basic_account(missing_address).expect("read missing account").is_none());
+    }
+}
+
+fn read_accounts_and_storage_with_provider<Storage>(
+    provider: &BaseProofsStateProviderRef<'_, Storage>,
+    fixture: &WitnessReadFixture,
+) -> usize
+where
+    Storage: BaseProofsStore + Clone,
+{
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(provider))
+        .with_bundle_update()
+        .build();
+    read_accounts_and_storage_with_state(&mut state, fixture)
+}
+
+fn read_accounts_and_storage_with_state<DB>(
+    state: &mut State<StateProviderDatabase<DB>>,
+    fixture: &WitnessReadFixture,
+) -> usize
+where
+    State<StateProviderDatabase<DB>>: reth_revm::Database,
+{
+    let mut reads = 0;
+
+    for target in &fixture.targets {
+        black_box(state.basic(target.address).expect("read account").expect("account exists"));
+        reads += 1;
+
+        for (storage_key, _, _) in &target.slots {
+            black_box(state.storage(target.address, (*storage_key).into()).expect("read storage"));
+            reads += 1;
+        }
+
+        black_box(
+            state
+                .storage(target.address, B256::repeat_byte(0xFE).into())
+                .expect("read missing storage"),
+        );
+        reads += 1;
+    }
+
+    for missing_address in &fixture.missing_addresses {
+        black_box(state.basic(*missing_address).expect("read missing account"));
+        reads += 1;
+    }
+
+    reads
+}
+
+fn read_accounts_and_storage(fixture: &WitnessReadFixture) -> usize {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+    read_accounts_and_storage_with_provider(&provider, fixture)
+}
+
+fn read_accounts_storage_and_witness(fixture: &WitnessReadFixture) -> usize {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+    let reads = read_accounts_and_storage_with_state(&mut state, fixture);
+    let ExecutionWitnessRecord { hashed_state, codes, keys, lowest_block_number } =
+        ExecutionWitnessRecord::from_executed_state(&state);
+    black_box(codes);
+    black_box(keys);
+    black_box(lowest_block_number);
+    black_box(provider.witness(TrieInput::default(), hashed_state).expect("build witness"));
+    reads
+}
+
+fn witness_read_benches(c: &mut Criterion) {
+    let fixture = create_fixture(false);
+    let compacted_fixture = create_fixture(true);
+    let mut group = c.benchmark_group("debug_execution_witness/proofs_history_reads");
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("account_storage_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_and_storage(&fixture)));
+    });
+
+    group.bench_function(BenchmarkId::new("reads_plus_witness_overlay", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_storage_and_witness(&fixture)));
+    });
+
+    group.bench_function(
+        BenchmarkId::new("account_storage_reads_compacted", TARGET_ACCOUNTS),
+        |b| {
+            b.iter(|| black_box(read_accounts_and_storage(&compacted_fixture)));
+        },
+    );
+
+    group.bench_function(
+        BenchmarkId::new("reads_plus_witness_overlay_compacted", TARGET_ACCOUNTS),
+        |b| {
+            b.iter(|| black_box(read_accounts_storage_and_witness(&compacted_fixture)));
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, witness_read_benches);
+criterion_main!(benches);

--- a/crates/execution/trie/benches/witness_reads.rs
+++ b/crates/execution/trie/benches/witness_reads.rs
@@ -20,7 +20,7 @@ use reth_provider::{AccountReader, StateProofProvider, StateProvider, noop::Noop
 use reth_revm::{
     Database, State, database::StateProviderDatabase, witness::ExecutionWitnessRecord,
 };
-use reth_trie_common::TrieInput;
+use reth_trie_common::{ExecutionWitnessMode, TrieInput};
 use tempfile::TempDir;
 
 const BASE_ACCOUNTS: usize = 10_000;
@@ -215,11 +215,15 @@ fn read_accounts_storage_and_witness(fixture: &WitnessReadFixture) -> usize {
         .build();
     let reads = read_accounts_and_storage_with_state(&mut state, fixture);
     let ExecutionWitnessRecord { hashed_state, codes, keys, lowest_block_number } =
-        ExecutionWitnessRecord::from_executed_state(&state);
+        ExecutionWitnessRecord::from_executed_state(&state, ExecutionWitnessMode::default());
     black_box(codes);
     black_box(keys);
     black_box(lowest_block_number);
-    black_box(provider.witness(TrieInput::default(), hashed_state).expect("build witness"));
+    black_box(
+        provider
+            .witness(TrieInput::default(), hashed_state, ExecutionWitnessMode::default())
+            .expect("build witness"),
+    );
     reads
 }
 

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -20,6 +20,9 @@ use crate::{
     db::{HashedStorageKey, StorageTrieKey},
 };
 
+/// Type alias for bulk storage branch entries: a list of (hashed address, storage nodes) pairs.
+pub type StorageBranchEntries = Vec<(B256, Vec<(Nibbles, Option<BranchNodeCompact>)>)>;
+
 /// Diff of trie updates and post state for a block.
 #[derive(Debug, Clone, Default)]
 pub struct BlockStateDiff {
@@ -213,14 +216,14 @@ pub trait BaseProofsStore: Send + Sync + Debug {
     ) -> BaseProofsStorageResult<()>;
 }
 
-/// Session-scoped store of trie updates that share a single underlying transaction.
+/// Session-scoped store of trie updates that amortizes write overhead across multiple
+/// block writes within a single batch.
 ///
-/// A session opened via [`BaseProofsBatchStore::with_batch_session`] amortizes MDBX commit
-/// cost across multiple block writes: reads through the session observe uncommitted writes
-/// from earlier `store_trie_updates` calls in the same session, enabling cold catch-up of
-/// `block N+1` against `block N` written but not yet committed.
+/// Reads through the session observe writes from earlier [`BaseProofsBatchSession::store_trie_updates`]
+/// calls in the same session, enabling cold catch-up where `block N+1` is computed against
+/// `block N` written earlier in the same session.
 ///
-/// All cursor methods mirror [`BaseProofsStore`] but read from the active transaction.
+/// All cursor methods mirror [`BaseProofsStore`] but read through the session's active view.
 #[auto_impl(&mut)]
 pub trait BaseProofsBatchSession: Send + Sync + Debug {
     /// Cursor for iterating over storage trie branches in the active session.
@@ -246,8 +249,8 @@ pub trait BaseProofsBatchSession: Send + Sync + Debug {
     /// Earliest stored block number/hash visible to the active transaction.
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>>;
 
-    /// Latest stored block number/hash visible to the active transaction (including
-    /// uncommitted writes from earlier calls in this session).
+    /// Latest stored block number/hash visible to this session (including writes from
+    /// earlier [`store_trie_updates`] calls in this session).
     fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>>;
 
     /// Storage trie cursor reading through the active transaction.
@@ -276,9 +279,9 @@ pub trait BaseProofsBatchSession: Send + Sync + Debug {
         max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>>;
 
-    /// Append-only write of `block_state_diff` for `block_ref` to the active transaction.
-    /// Subsequent reads through this session observe the new state immediately, but the
-    /// changes are not durable until the enclosing session commits.
+    /// Append-only write of `block_state_diff` for `block_ref` to the active session.
+    /// Subsequent reads through this session observe the new state immediately.
+    /// Durability semantics are backend-dependent; see [`BaseProofsBatchStore`].
     fn store_trie_updates(
         &mut self,
         block_ref: BlockWithParent,
@@ -286,20 +289,25 @@ pub trait BaseProofsBatchSession: Send + Sync + Debug {
     ) -> BaseProofsStorageResult<WriteCounts>;
 }
 
-/// Storage that can open a [`BaseProofsBatchSession`] holding a single underlying
-/// transaction across multiple block writes.
+/// Storage that can open a [`BaseProofsBatchSession`] for amortized multi-block writes.
 ///
-/// The MDBX implementation commits atomically on `Ok` and aborts on `Err`, leaving no
-/// writes visible to subsequent reads. The in-memory implementation is a test double
-/// that lacks transactional rollback — partial writes from a failing batch remain
-/// visible. Production code must rely on MDBX semantics.
+/// **Atomicity is backend-dependent.** Callers must not rely on rollback:
+/// - MDBX: commits atomically on `Ok`, rolls back on `Err`.
+/// - RocksDB: each [`BaseProofsBatchSession::store_trie_updates`] call commits immediately;
+///   if the closure returns `Err` after writing N blocks, those N blocks remain durable.
+/// - In-memory (test double): no transactional rollback; partial writes remain visible.
+///
+/// The invariant all backends guarantee is **write ordering**: blocks are stored in strictly
+/// ascending order of block number. Callers that need crash recovery must unwind to the last
+/// consistent block rather than relying on atomic rollback.
 pub trait BaseProofsBatchStore: BaseProofsStore {
-    /// Session type bound to the active transaction.
+    /// Session type for this backend.
     type BatchSession<'a>: BaseProofsBatchSession + 'a
     where
         Self: 'a;
 
-    /// Run `f` inside one batch session. Commits if `f` returns `Ok`, aborts on `Err`.
+    /// Run `f` inside one batch session. Atomicity and error-recovery semantics are
+    /// backend-dependent; see the trait-level documentation.
     fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
     where
         F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>;
@@ -373,6 +381,21 @@ pub trait BaseProofsInitialStateStore: Send + Sync + Debug {
         storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
     ) -> BaseProofsStorageResult<()>;
 
+    /// Store storage trie branches for multiple addresses in a single batch operation.
+    ///
+    /// The default implementation loops and calls [`Self::store_storage_branches`] per address.
+    /// Override this method on backends that can merge all writes into one durable commit (e.g.
+    /// a single `RocksDB` `WriteBatch`) to avoid the per-address fsync cost during initialization.
+    fn store_storage_branches_bulk(
+        &self,
+        entries: StorageBranchEntries,
+    ) -> BaseProofsStorageResult<()> {
+        for (hashed_address, nodes) in entries {
+            self.store_storage_branches(hashed_address, nodes)?;
+        }
+        Ok(())
+    }
+
     /// Store a batch of account trie leaf nodes. Used for saving existing state.
     fn store_hashed_accounts(
         &self,
@@ -385,6 +408,21 @@ pub trait BaseProofsInitialStateStore: Send + Sync + Debug {
         hashed_address: B256,
         storages: Vec<(B256, U256)>,
     ) -> BaseProofsStorageResult<()>;
+
+    /// Store hashed storage slots for multiple addresses in a single batch operation.
+    ///
+    /// The default implementation loops and calls [`Self::store_hashed_storages`] per address.
+    /// Override this method on backends that can merge all writes into one durable commit (e.g.
+    /// a single `RocksDB` `WriteBatch`) to avoid the per-address fsync cost during initialization.
+    fn store_hashed_storages_bulk(
+        &self,
+        entries: Vec<(B256, Vec<(B256, U256)>)>,
+    ) -> BaseProofsStorageResult<()> {
+        for (hashed_address, storages) in entries {
+            self.store_hashed_storages(hashed_address, storages)?;
+        }
+        Ok(())
+    }
 
     /// Commit the initial state - mark the anchor as completed and also set the earliest block
     /// number to anchor.

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -1,15 +1,19 @@
-//! MDBX implementation of [`BaseProofsStore`](crate::BaseProofsStore).
+//! Database-backed implementations of [`BaseProofsStore`](crate::BaseProofsStore).
 //!
-//! This module provides a complete MDBX implementation of the
-//! [`BaseProofsStore`](crate::BaseProofsStore) trait. It uses the [`reth_db`]
-//! crate for database interactions and defines the necessary tables and models for storing trie
-//! branches, accounts, and storage leaves.
+//! This module defines the schema models and storage backends used for storing trie branches,
+//! accounts, and storage leaves.
 
 mod models;
 pub use models::*;
 
 mod store;
 pub use store::MdbxProofsStorage;
+
+mod rocksdb;
+pub use rocksdb::{
+    RocksdbAccountCursor, RocksdbProofsCompression, RocksdbProofsStorage,
+    RocksdbProofsStorageOptions, RocksdbReadSnapshot, RocksdbStorageCursor, RocksdbTrieCursor,
+};
 
 mod cursor;
 pub use cursor::{

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -11,7 +11,7 @@ pub use store::MdbxProofsStorage;
 
 mod rocksdb;
 pub use rocksdb::{
-    RocksdbAccountCursor, RocksdbProofsCompression, RocksdbProofsStorage,
+    RocksdbAccountCursor, RocksdbBatchSession, RocksdbProofsCompression, RocksdbProofsStorage,
     RocksdbProofsStorageOptions, RocksdbReadSnapshot, RocksdbStorageCursor, RocksdbTrieCursor,
 };
 

--- a/crates/execution/trie/src/db/rocksdb.rs
+++ b/crates/execution/trie/src/db/rocksdb.rs
@@ -1,0 +1,3541 @@
+//! `RocksDB` implementation of proofs storage.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+    marker::PhantomData,
+    ops::{Bound, RangeBounds},
+    path::Path,
+    sync::Arc,
+    time::Instant,
+};
+
+use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
+use alloy_primitives::{B256, U256, map::HashMap};
+#[cfg(feature = "metrics")]
+use metrics::Label;
+use parking_lot::{Mutex, RwLock};
+use reth_db::{
+    DatabaseError,
+    table::{Compress, Decompress, DupSort, Encode, Table},
+};
+use reth_primitives_traits::Account;
+use reth_trie::{
+    hashed_cursor::{HashedCursor, HashedStorageCursor},
+    trie_cursor::{TrieCursor, TrieStorageCursor},
+};
+use reth_trie_common::{
+    BranchNodeCompact, HashedPostState, Nibbles, StoredNibbles,
+    updates::{StorageTrieUpdates, TrieUpdates},
+};
+use rocksdb::{
+    BlockBasedIndexType, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
+    CompactionPri, DBCompressionType, DBWithThreadMode, Direction, IteratorMode, MultiThreaded,
+    Options, ReadOptions, SliceTransform, SnapshotWithThreadMode, WriteBatch, WriteOptions,
+};
+use tracing::info;
+
+use super::{BlockNumberHash, ProofWindow, ProofWindowKey};
+use crate::{
+    BaseProofsStorageError,
+    BaseProofsStorageError::NoBlocksFound,
+    BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
+    api::{
+        BaseProofsBatchSession, BaseProofsBatchStore, BaseProofsInitialStateStore,
+        InitialStateAnchor, InitialStateStatus, WriteCounts,
+    },
+    db::{
+        AccountTrieHistory, BlockChangeSet, ChangeSet, HashedAccountHistory, HashedStorageHistory,
+        HashedStorageKey, IntoKV, MaybeDeleted, StorageTrieHistory, StorageTrieKey, StorageValue,
+        VersionedValue,
+    },
+};
+
+type RocksDb = DBWithThreadMode<MultiThreaded>;
+type RocksDbLatestVersionResult<T> =
+    Result<Option<(<T as Table>::Key, <T as Table>::Value)>, DatabaseError>;
+
+const HASH_KEY_LEN: usize = 32;
+const PACKED_NIBBLES_KEY_LEN: usize = 33;
+const BLOCK_NUMBER_KEY_LEN: usize = 8;
+const DEFAULT_BLOCK_CACHE_SIZE: usize = 1024 << 20;
+const DEFAULT_BLOCK_SIZE: usize = 16 * 1024;
+const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
+const DEFAULT_COMPACTION_READAHEAD_SIZE: usize = 0;
+const DEFAULT_DIRECT_IO_FOR_FLUSH_AND_COMPACTION: bool = true;
+const DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: i32 = 4;
+const DEFAULT_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER: i32 = 20;
+const DEFAULT_LEVEL_ZERO_STOP_WRITES_TRIGGER: i32 = 36;
+const DEFAULT_RATE_LIMITER_FAIRNESS: i32 = 10;
+const DEFAULT_RATE_LIMITER_REFILL_PERIOD_US: i64 = 100_000;
+const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 4;
+const DEFAULT_MAX_SUBCOMPACTIONS: u32 = 1;
+const DEFAULT_MAX_OPEN_FILES: i32 = -1;
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: i32 = 3;
+const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 256 * 1024 * 1024;
+const DEFAULT_WRITE_BUFFER_SIZE: usize = 64 * 1024 * 1024;
+const DEFAULT_BLOOM_BITS_PER_KEY: f64 = 10.0;
+
+/// Compression policy for `RocksDB` proof-history column families.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RocksdbProofsCompression {
+    /// Disable compression for new files.
+    None,
+    /// Use LZ4 compression for new files.
+    #[default]
+    Lz4,
+    /// Use ZSTD compression for new files.
+    Zstd,
+}
+
+impl RocksdbProofsCompression {
+    /// Returns the corresponding `RocksDB` compression type.
+    pub const fn db_compression_type(self) -> DBCompressionType {
+        match self {
+            Self::None => DBCompressionType::None,
+            Self::Lz4 => DBCompressionType::Lz4,
+            Self::Zstd => DBCompressionType::Zstd,
+        }
+    }
+}
+
+/// Options for opening [`RocksdbProofsStorage`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RocksdbProofsStorageOptions {
+    /// Compression for non-bottommost proof-history files.
+    pub compression: RocksdbProofsCompression,
+    /// Compression for bottommost proof-history files.
+    pub bottommost_compression: RocksdbProofsCompression,
+    /// LRU block cache size in bytes.
+    pub block_cache_size: usize,
+    /// Number of bytes `RocksDB` should write before asking the OS to start syncing.
+    pub bytes_per_sync: u64,
+    /// Readahead size in bytes for compaction input reads.
+    pub compaction_readahead_size: usize,
+    /// Number of L0 files that triggers compaction.
+    pub level_zero_file_num_compaction_trigger: i32,
+    /// Number of L0 files that triggers write slowdown.
+    pub level_zero_slowdown_writes_trigger: i32,
+    /// Number of L0 files that stops writes.
+    pub level_zero_stop_writes_trigger: i32,
+    /// Maximum number of `RocksDB` background jobs.
+    pub max_background_jobs: i32,
+    /// Maximum number of subcompactions per compaction.
+    pub max_subcompactions: u32,
+    /// Maximum total WAL size in bytes.
+    pub max_total_wal_size: Option<u64>,
+    /// Maximum number of write buffers per column family.
+    pub max_write_buffer_number: i32,
+    /// Write buffer size per column family in bytes.
+    pub write_buffer_size: usize,
+    /// Base target file size in bytes.
+    pub target_file_size_base: u64,
+    /// Whether flush and compaction files should use direct I/O.
+    pub use_direct_io_for_flush_and_compaction: bool,
+    /// Optional `RocksDB` write rate limit in bytes per second.
+    pub rate_limit_bytes_per_sec: Option<i64>,
+    /// Rate limiter refill period in microseconds.
+    pub rate_limiter_refill_period_us: i64,
+    /// Rate limiter fairness.
+    pub rate_limiter_fairness: i32,
+}
+
+impl Default for RocksdbProofsStorageOptions {
+    fn default() -> Self {
+        Self {
+            compression: RocksdbProofsCompression::Lz4,
+            bottommost_compression: RocksdbProofsCompression::Lz4,
+            block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
+            bytes_per_sync: DEFAULT_BYTES_PER_SYNC,
+            compaction_readahead_size: DEFAULT_COMPACTION_READAHEAD_SIZE,
+            level_zero_file_num_compaction_trigger: DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
+            level_zero_slowdown_writes_trigger: DEFAULT_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER,
+            level_zero_stop_writes_trigger: DEFAULT_LEVEL_ZERO_STOP_WRITES_TRIGGER,
+            max_background_jobs: DEFAULT_MAX_BACKGROUND_JOBS,
+            max_subcompactions: DEFAULT_MAX_SUBCOMPACTIONS,
+            max_total_wal_size: None,
+            max_write_buffer_number: DEFAULT_MAX_WRITE_BUFFER_NUMBER,
+            write_buffer_size: DEFAULT_WRITE_BUFFER_SIZE,
+            target_file_size_base: DEFAULT_TARGET_FILE_SIZE_BASE,
+            use_direct_io_for_flush_and_compaction: DEFAULT_DIRECT_IO_FOR_FLUSH_AND_COMPACTION,
+            rate_limit_bytes_per_sec: None,
+            rate_limiter_refill_period_us: DEFAULT_RATE_LIMITER_REFILL_PERIOD_US,
+            rate_limiter_fairness: DEFAULT_RATE_LIMITER_FAIRNESS,
+        }
+    }
+}
+
+impl RocksdbProofsStorageOptions {
+    fn max_total_wal_size(self, column_family_count: usize) -> u64 {
+        self.max_total_wal_size.unwrap_or_else(|| {
+            column_family_count as u64
+                * self.write_buffer_size as u64
+                * self.max_write_buffer_number.max(1) as u64
+        })
+    }
+}
+
+trait RocksDbHistoryTable: Table + DupSort<SubKey = u64> {
+    /// Fixed encoded table-key length before the block-number suffix.
+    const KEY_LEN: usize;
+
+    /// Encodes the table key prefix used before the block-number suffix.
+    fn encode_history_key_prefix(key: &Self::Key) -> Result<Vec<u8>, DatabaseError>;
+
+    /// Decodes the table key prefix used before the block-number suffix.
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError>;
+}
+
+/// `RocksDB` implementation of [`BaseProofsStore`].
+pub struct RocksdbProofsStorage {
+    db: Arc<RocksDb>,
+    write_options: WriteOptions,
+    // Serializes append-only writers that read LatestBlock before writing LatestBlock + 1.
+    append_lock: Mutex<()>,
+    // Serializes prune plans that assume a stable EarliestBlock across prepare and commit.
+    prune_lock: Mutex<()>,
+    // Append and prune share read access. History rewrites take write access.
+    history_gate: RwLock<()>,
+}
+
+/// Preprocessed prune plan for a target block number.
+#[derive(Debug, Clone)]
+struct RocksdbPrunePlan {
+    earliest_block: u64,
+    earliest_hash: B256,
+    acc_survivors: Vec<(StoredNibbles, u64)>,
+    storage_survivors: Vec<(StorageTrieKey, u64)>,
+    hashed_acc_survivors: Vec<(B256, u64)>,
+    hashed_storage_survivors: Vec<(HashedStorageKey, u64)>,
+}
+
+impl RocksdbPrunePlan {
+    const fn total_survivors(&self) -> usize {
+        self.acc_survivors.len()
+            + self.storage_survivors.len()
+            + self.hashed_acc_survivors.len()
+            + self.hashed_storage_survivors.len()
+    }
+}
+
+/// Preprocessed delete work for a prune commit.
+#[derive(Debug, Clone)]
+struct RocksdbPreparedPrune {
+    expected_earliest_block: u64,
+    expected_earliest_hash: B256,
+    target_block: u64,
+    target_hash: B256,
+    deletes: RocksdbPreparedHistoryDeletes,
+    counts: WriteCounts,
+}
+
+/// Raw history keys to delete during a prune commit.
+#[derive(Debug, Default, Clone)]
+struct RocksdbPreparedHistoryDeletes {
+    account_trie: Vec<Vec<u8>>,
+    storage_trie: Vec<Vec<u8>>,
+    hashed_account: Vec<Vec<u8>>,
+    hashed_storage: Vec<Vec<u8>>,
+}
+
+impl RocksdbPreparedHistoryDeletes {
+    const fn total(&self) -> usize {
+        self.account_trie.len()
+            + self.storage_trie.len()
+            + self.hashed_account.len()
+            + self.hashed_storage.len()
+    }
+}
+
+/// Preprocessed delete work for a prune range.
+#[derive(Debug, Default)]
+struct RocksdbHistoryDeleteBatch {
+    block_numbers: Vec<u64>,
+    account_trie: Vec<(<AccountTrieHistory as Table>::Key, u64)>,
+    storage_trie: Vec<(<StorageTrieHistory as Table>::Key, u64)>,
+    hashed_account: Vec<(<HashedAccountHistory as Table>::Key, u64)>,
+    hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
+}
+
+/// Request-scoped read snapshot for [`RocksdbProofsStorage`].
+///
+/// This type is public because it is the [`BaseProofsStore::Tx`] associated type for the
+/// `RocksDB` backend. Callers that need several cursors to read the same database view should
+/// acquire one snapshot with [`BaseProofsStore::ro_tx`] and pass it to the `*_with_tx` cursor
+/// factories.
+pub struct RocksdbReadSnapshot<'db> {
+    db: &'db RocksDb,
+    snapshot: SnapshotWithThreadMode<'db, RocksDb>,
+}
+
+/// Cursor over `RocksDB` versioned history rows.
+struct RocksdbVersionedCursor<'db, T: Table + DupSort> {
+    snapshot: Arc<RocksdbReadSnapshot<'db>>,
+    max_block_number: u64,
+    current_key: Option<T::Key>,
+    _table: PhantomData<T>,
+}
+
+/// `RocksDB` implementation of [`TrieCursor`].
+pub struct RocksdbTrieCursor<'db, T: Table + DupSort> {
+    inner: RocksdbVersionedCursor<'db, T>,
+    hashed_address: Option<B256>,
+}
+
+/// `RocksDB` implementation of [`HashedCursor`] for storage state.
+pub struct RocksdbStorageCursor<'db> {
+    inner: RocksdbVersionedCursor<'db, HashedStorageHistory>,
+    hashed_address: B256,
+}
+
+/// `RocksDB` implementation of [`HashedCursor`] for account state.
+pub struct RocksdbAccountCursor<'db> {
+    inner: RocksdbVersionedCursor<'db, HashedAccountHistory>,
+}
+
+#[derive(Debug, Default)]
+struct RocksdbReplacementState {
+    storage_trie: BTreeMap<StorageTrieKey, Option<BranchNodeCompact>>,
+    hashed_storage: BTreeMap<HashedStorageKey, Option<StorageValue>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProofWindowValue {
+    earliest: NumHash,
+    latest: NumHash,
+}
+
+impl fmt::Debug for RocksdbProofsStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbProofsStorage").finish_non_exhaustive()
+    }
+}
+
+impl<'db> RocksdbReadSnapshot<'db> {
+    fn new(db: &'db RocksDb) -> Self {
+        Self::assert_send_sync();
+
+        let snapshot = db.snapshot();
+        Self { db, snapshot }
+    }
+
+    const fn assert_send_sync()
+    where
+        Self: Send + Sync,
+    {
+    }
+
+    fn cf(&self, name: &'static str) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
+        self.db
+            .cf_handle(name)
+            .ok_or_else(|| DatabaseError::Other(format!("missing RocksDB column family {name}")))
+    }
+
+    const fn snapshot(&self) -> &SnapshotWithThreadMode<'db, RocksDb> {
+        &self.snapshot
+    }
+}
+
+impl fmt::Debug for RocksdbReadSnapshot<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbReadSnapshot").finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for RocksdbVersionedCursor<'_, T>
+where
+    T: Table + DupSort,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbVersionedCursor")
+            .field("max_block_number", &self.max_block_number)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for RocksdbTrieCursor<'_, T>
+where
+    T: Table + DupSort,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbTrieCursor")
+            .field("hashed_address", &self.hashed_address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for RocksdbStorageCursor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbStorageCursor")
+            .field("hashed_address", &self.hashed_address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for RocksdbAccountCursor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksdbAccountCursor").finish_non_exhaustive()
+    }
+}
+
+impl RocksdbReplacementState {
+    fn storage_trie_wipe_entries(
+        &self,
+        storage: &RocksdbProofsStorage,
+        base_block_number: u64,
+        hashed_address: B256,
+    ) -> BaseProofsStorageResult<BTreeMap<Nibbles, Option<BranchNodeCompact>>> {
+        let mut entries = BTreeMap::new();
+        let mut cursor = storage.storage_trie_cursor(hashed_address, base_block_number)?;
+
+        while let Some((path, _)) = cursor.next()? {
+            entries.insert(path, None);
+        }
+
+        for (key, value) in &self.storage_trie {
+            if key.hashed_address != hashed_address {
+                continue;
+            }
+
+            let path = key.path.0;
+            if value.is_some() {
+                entries.insert(path, None);
+            } else {
+                entries.remove(&path);
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn apply_storage_trie_entries(
+        &mut self,
+        hashed_address: B256,
+        entries: impl IntoIterator<Item = (Nibbles, Option<BranchNodeCompact>)>,
+    ) {
+        for (path, node) in entries {
+            self.storage_trie
+                .insert(StorageTrieKey::new(hashed_address, StoredNibbles::from(path)), node);
+        }
+    }
+
+    fn hashed_storage_wipe_entries(
+        &self,
+        storage: &RocksdbProofsStorage,
+        base_block_number: u64,
+        hashed_address: B256,
+    ) -> BaseProofsStorageResult<BTreeMap<B256, Option<StorageValue>>> {
+        let mut entries = BTreeMap::new();
+        let mut cursor = storage.storage_hashed_cursor(hashed_address, base_block_number)?;
+
+        while let Some((slot, _)) = cursor.next()? {
+            entries.insert(slot, None);
+        }
+
+        for (key, value) in &self.hashed_storage {
+            if key.hashed_address != hashed_address {
+                continue;
+            }
+
+            if let Some(value) = value
+                && !value.0.is_zero()
+            {
+                entries.insert(key.hashed_storage_key, None);
+            } else {
+                entries.remove(&key.hashed_storage_key);
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn apply_hashed_storage_entries(
+        &mut self,
+        hashed_address: B256,
+        entries: impl IntoIterator<Item = (B256, Option<StorageValue>)>,
+    ) {
+        for (hashed_storage_key, value) in entries {
+            self.hashed_storage
+                .insert(HashedStorageKey::new(hashed_address, hashed_storage_key), value);
+        }
+    }
+}
+
+impl RocksdbProofsStorage {
+    /// Creates a new [`RocksdbProofsStorage`] instance with the given path.
+    pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
+        Self::new_with_options(path, RocksdbProofsStorageOptions::default())
+    }
+
+    /// Flushes and compacts every proofs-history column family.
+    pub fn flush_and_compact(&self) -> BaseProofsStorageResult<()> {
+        for name in Self::column_families() {
+            let cf = self.cf(name)?;
+            self.db.flush_cf(&cf).map_err(rocksdb_error)?;
+            self.db.compact_range_cf::<&[u8], &[u8]>(&cf, None, None);
+        }
+
+        Ok(())
+    }
+
+    /// Creates a new [`RocksdbProofsStorage`] instance with the given path and options.
+    pub fn new_with_options(
+        path: &Path,
+        storage_options: RocksdbProofsStorageOptions,
+    ) -> Result<Self, BaseProofsStorageError> {
+        let block_cache = Cache::new_lru_cache(storage_options.block_cache_size);
+        let db_options = Self::db_options(&block_cache, storage_options);
+        let descriptors = Self::column_families().into_iter().map(|name| {
+            ColumnFamilyDescriptor::new(name, Self::cf_options(name, &block_cache, storage_options))
+        });
+        let db = RocksDb::open_cf_descriptors(&db_options, path, descriptors)
+            .map_err(|e| DatabaseError::Other(format!("failed to open RocksDB database: {e}")))?;
+
+        let mut write_options = WriteOptions::default();
+        // Proof history writes must be durable once the ExEx emits progress. Keep this hard-coded
+        // rather than threading it through runtime tuning options.
+        write_options.set_sync(true);
+
+        Ok(Self {
+            db: Arc::new(db),
+            write_options,
+            append_lock: Mutex::new(()),
+            prune_lock: Mutex::new(()),
+            history_gate: RwLock::new(()),
+        })
+    }
+
+    fn db_options(block_cache: &Cache, storage_options: RocksdbProofsStorageOptions) -> Options {
+        let table_options = Self::table_options(block_cache);
+        let mut options = Options::default();
+        options.set_block_based_table_factory(&table_options);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+        options.set_max_background_jobs(storage_options.max_background_jobs);
+        options.set_max_subcompactions(storage_options.max_subcompactions);
+        options.set_bytes_per_sync(storage_options.bytes_per_sync);
+        options.set_compaction_readahead_size(storage_options.compaction_readahead_size);
+        options.set_compaction_pri(CompactionPri::MinOverlappingRatio);
+        options.set_max_open_files(DEFAULT_MAX_OPEN_FILES);
+        options.set_max_total_wal_size(Self::max_total_wal_size(storage_options));
+        options.set_use_direct_io_for_flush_and_compaction(
+            storage_options.use_direct_io_for_flush_and_compaction,
+        );
+        if let Some(rate_limit_bytes_per_sec) = storage_options.rate_limit_bytes_per_sec {
+            options.set_ratelimiter(
+                rate_limit_bytes_per_sec,
+                storage_options.rate_limiter_refill_period_us,
+                storage_options.rate_limiter_fairness,
+            );
+        }
+        options.set_wal_ttl_seconds(0);
+        options.set_wal_size_limit_mb(0);
+        options
+    }
+
+    fn max_total_wal_size(storage_options: RocksdbProofsStorageOptions) -> u64 {
+        storage_options.max_total_wal_size(Self::column_families().len())
+    }
+
+    fn table_options(block_cache: &Cache) -> BlockBasedOptions {
+        let mut table_options = BlockBasedOptions::default();
+        table_options.set_block_size(DEFAULT_BLOCK_SIZE);
+        table_options.set_cache_index_and_filter_blocks(true);
+        table_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        table_options.set_block_cache(block_cache);
+        table_options
+    }
+
+    fn history_table_options(block_cache: &Cache) -> BlockBasedOptions {
+        let mut table_options = Self::table_options(block_cache);
+        table_options.set_bloom_filter(DEFAULT_BLOOM_BITS_PER_KEY, false);
+        table_options.set_whole_key_filtering(true);
+        table_options.set_optimize_filters_for_memory(true);
+        table_options.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
+        table_options.set_partition_filters(true);
+        table_options.set_pin_top_level_index_and_filter(true);
+        table_options
+    }
+
+    fn cf_options(
+        name: &'static str,
+        block_cache: &Cache,
+        storage_options: RocksdbProofsStorageOptions,
+    ) -> Options {
+        let history_prefix_len = Self::history_prefix_len(name);
+        let table_options = if history_prefix_len.is_some() {
+            Self::history_table_options(block_cache)
+        } else {
+            Self::table_options(block_cache)
+        };
+        let mut options = Options::default();
+        options.set_block_based_table_factory(&table_options);
+        if let Some(prefix_len) = history_prefix_len {
+            options.set_prefix_extractor(SliceTransform::create_fixed_prefix(prefix_len));
+        }
+        options.set_level_compaction_dynamic_level_bytes(true);
+        options.set_level_zero_file_num_compaction_trigger(
+            storage_options.level_zero_file_num_compaction_trigger,
+        );
+        options.set_level_zero_slowdown_writes_trigger(
+            storage_options.level_zero_slowdown_writes_trigger,
+        );
+        options.set_level_zero_stop_writes_trigger(storage_options.level_zero_stop_writes_trigger);
+        options.set_max_write_buffer_number(storage_options.max_write_buffer_number);
+        options.set_target_file_size_base(storage_options.target_file_size_base);
+        options.set_write_buffer_size(storage_options.write_buffer_size);
+        if name == <ProofWindow as Table>::NAME {
+            options.set_compression_type(DBCompressionType::None);
+            options.set_bottommost_compression_type(DBCompressionType::None);
+        } else {
+            options.set_compression_type(storage_options.compression.db_compression_type());
+            options.set_bottommost_compression_type(
+                storage_options.bottommost_compression.db_compression_type(),
+            );
+        }
+        options
+    }
+
+    fn history_prefix_len(name: &'static str) -> Option<usize> {
+        match name {
+            <AccountTrieHistory as Table>::NAME => {
+                Some(<AccountTrieHistory as RocksDbHistoryTable>::KEY_LEN)
+            }
+            <StorageTrieHistory as Table>::NAME => {
+                Some(<StorageTrieHistory as RocksDbHistoryTable>::KEY_LEN)
+            }
+            <HashedAccountHistory as Table>::NAME => {
+                Some(<HashedAccountHistory as RocksDbHistoryTable>::KEY_LEN)
+            }
+            <HashedStorageHistory as Table>::NAME => {
+                Some(<HashedStorageHistory as RocksDbHistoryTable>::KEY_LEN)
+            }
+            _ => None,
+        }
+    }
+
+    const fn column_families() -> [&'static str; 6] {
+        [
+            <AccountTrieHistory as Table>::NAME,
+            <StorageTrieHistory as Table>::NAME,
+            <HashedAccountHistory as Table>::NAME,
+            <HashedStorageHistory as Table>::NAME,
+            <ProofWindow as Table>::NAME,
+            <BlockChangeSet as Table>::NAME,
+        ]
+    }
+
+    fn cf(&self, name: &'static str) -> BaseProofsStorageResult<Arc<BoundColumnFamily<'_>>> {
+        self.db
+            .cf_handle(name)
+            .ok_or_else(|| DatabaseError::Other(format!("missing RocksDB column family {name}")))
+            .map_err(Into::into)
+    }
+
+    fn put_table<T: Table>(
+        &self,
+        batch: &mut WriteBatch,
+        key: T::Key,
+        value: &T::Value,
+    ) -> BaseProofsStorageResult<()> {
+        let cf = self.cf(T::NAME)?;
+        batch.put_cf(&cf, encode_table_key::<T>(key), encode_table_value::<T>(value));
+        Ok(())
+    }
+
+    fn get_table<T: Table>(&self, key: T::Key) -> BaseProofsStorageResult<Option<T::Value>> {
+        let cf = self.cf(T::NAME)?;
+        self.db
+            .get_cf(&cf, encode_table_key::<T>(key))
+            .map_err(rocksdb_error)?
+            .map(|value| T::Value::decompress(&value).map_err(Into::into))
+            .transpose()
+    }
+
+    fn get_table_from_snapshot<T: Table>(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        key: T::Key,
+    ) -> BaseProofsStorageResult<Option<T::Value>> {
+        let cf = self.cf(T::NAME)?;
+        snapshot
+            .get_cf(&cf, encode_table_key::<T>(key))
+            .map_err(rocksdb_error)?
+            .map(|value| T::Value::decompress(&value).map_err(Into::into))
+            .transpose()
+    }
+
+    fn persist_history_batch<T, I, V>(
+        &self,
+        batch: &mut WriteBatch,
+        block_number: u64,
+        items: I,
+        append_mode: bool,
+    ) -> BaseProofsStorageResult<Vec<T::Key>>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        T::Key: Clone,
+        I: IntoIterator,
+        I::Item: IntoKV<T>,
+    {
+        let cf = self.cf(T::NAME)?;
+        let mut keys = Vec::<T::Key>::new();
+        let mut pairs = Vec::<(T::Key, T::Value)>::new();
+
+        for item in items {
+            let (key, value) = item.into_kv(block_number);
+            keys.push(key.clone());
+            pairs.push((key, value));
+        }
+
+        if append_mode {
+            for (key, value) in pairs {
+                batch.put_cf(
+                    &cf,
+                    encode_history_key::<T>(&key, value.block_number)?,
+                    encode_table_value::<T>(&value),
+                );
+            }
+            return Ok(keys);
+        }
+
+        for (key, value) in pairs {
+            batch.delete_cf(&cf, encode_history_key::<T>(&key, 0)?);
+            if value.value.0.is_some() {
+                batch.put_cf(
+                    &cf,
+                    encode_history_key::<T>(&key, 0)?,
+                    encode_table_value::<T>(&value),
+                );
+            }
+        }
+
+        Ok(keys)
+    }
+
+    fn delete_dup_sorted<T, I, V>(
+        &self,
+        batch: &mut WriteBatch,
+        items: I,
+    ) -> BaseProofsStorageResult<()>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        T::Key: Clone,
+        I: IntoIterator<Item = (T::Key, u64)>,
+    {
+        let cf = self.cf(T::NAME)?;
+        for (key, block_number) in items {
+            batch.delete_cf(&cf, encode_history_key::<T>(&key, block_number)?);
+        }
+        Ok(())
+    }
+
+    fn collect_history_preceding_deletes<T, V>(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        cutoff_items: Vec<(T::Key, u64)>,
+    ) -> BaseProofsStorageResult<Vec<Vec<u8>>>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        T::Key: Clone + Ord,
+        T::Value: Decompress,
+    {
+        let started = Instant::now();
+        let cutoff_items_len = cutoff_items.len();
+        info!(
+            target: "trie::pruner",
+            table = T::NAME,
+            cutoff_items = cutoff_items_len,
+            "Collecting RocksDB proof storage prune deletes",
+        );
+        if cutoff_items.is_empty() {
+            info!(
+                target: "trie::pruner",
+                table = T::NAME,
+                cutoff_items = cutoff_items_len,
+                deletes = 0usize,
+                elapsed = ?started.elapsed(),
+                "Collected RocksDB proof storage prune deletes",
+            );
+            return Ok(Vec::new());
+        }
+
+        let cf = self.cf(T::NAME)?;
+        let mut deletes = Vec::new();
+
+        for (key, survivor_block) in cutoff_items {
+            let prefix = encode_history_key_prefix::<T>(&key)?;
+            // Under the reversed block-suffix encoding, seeking at
+            // `survivor_block` lands on the newest stored version V with
+            // `V <= survivor_block` and then iterates DESCENDING through
+            // older versions. This is strictly cheaper than the legacy
+            // "start at block 0, walk up" pattern because newer-than-survivor
+            // rows are skipped entirely instead of being scanned past.
+            let start_key = encode_history_key::<T>(&key, survivor_block)?;
+            let read_options = exact_prefix_read_options(&prefix);
+            let iter = snapshot.iterator_cf_opt(
+                &cf,
+                read_options,
+                IteratorMode::From(&start_key, Direction::Forward),
+            );
+
+            for item in iter {
+                let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+                if !raw_key.starts_with(&prefix) {
+                    break;
+                }
+
+                let (_, block_number) = decode_history_key::<T>(&raw_key)?;
+                if block_number > survivor_block {
+                    continue;
+                }
+                if block_number == survivor_block {
+                    let value = T::Value::decompress(&raw_value)?;
+                    if value.value.0.is_none() {
+                        deletes.push(raw_key.to_vec());
+                    }
+                    continue;
+                }
+                deletes.push(raw_key.to_vec());
+            }
+        }
+
+        info!(
+            target: "trie::pruner",
+            table = T::NAME,
+            cutoff_items = cutoff_items_len,
+            deletes = deletes.len(),
+            elapsed = ?started.elapsed(),
+            "Collected RocksDB proof storage prune deletes",
+        );
+
+        Ok(deletes)
+    }
+
+    fn delete_raw_history_keys<T>(
+        &self,
+        batch: &mut WriteBatch,
+        keys: Vec<Vec<u8>>,
+    ) -> BaseProofsStorageResult<()>
+    where
+        T: Table,
+    {
+        let cf = self.cf(T::NAME)?;
+        for key in keys {
+            batch.delete_cf(&cf, key);
+        }
+        Ok(())
+    }
+
+    fn wipe_and_overlay<T, Next, I, K, VV, V>(
+        &self,
+        batch: &mut WriteBatch,
+        block_number: u64,
+        hashed_address: B256,
+        mut next: Next,
+        new_entries: I,
+    ) -> BaseProofsStorageResult<Vec<T::Key>>
+    where
+        T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+        T: RocksDbHistoryTable,
+        Next: FnMut() -> BaseProofsStorageResult<Option<(K, VV)>>,
+        I: IntoIterator<Item = (K, Option<V>)>,
+        (B256, K, Option<V>): IntoKV<T>,
+        T::Key: Clone,
+        K: Ord,
+    {
+        let cf = self.cf(T::NAME)?;
+        let mut merged: BTreeMap<K, Option<V>> = BTreeMap::new();
+        while let Some((key, _)) = next()? {
+            merged.insert(key, None);
+        }
+        for (key, value) in new_entries {
+            merged.insert(key, value);
+        }
+
+        let mut keys = Vec::with_capacity(merged.len());
+        for (key, value) in merged {
+            let db_key: T::Key = (hashed_address, key, Option::<V>::None).into_key();
+            let db_value: T::Value = VersionedValue { block_number, value: MaybeDeleted(value) };
+            batch.put_cf(
+                &cf,
+                encode_history_key::<T>(&db_key, block_number)?,
+                encode_table_value::<T>(&db_value),
+            );
+            keys.push(db_key);
+        }
+
+        Ok(keys)
+    }
+
+    fn store_trie_updates_for_block(
+        &self,
+        batch: &mut WriteBatch,
+        block_number: u64,
+        block_state_diff: BlockStateDiff,
+        append_mode: bool,
+    ) -> BaseProofsStorageResult<ChangeSet> {
+        let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
+
+        let storage_trie_len = sorted_trie_updates.storage_tries_ref().len();
+        let hashed_storage_len = sorted_post_state.storages.len();
+
+        let account_trie_keys = self.persist_history_batch::<AccountTrieHistory, _, _>(
+            batch,
+            block_number,
+            sorted_trie_updates.account_nodes_ref().iter().cloned(),
+            append_mode,
+        )?;
+        let hashed_account_keys = self.persist_history_batch::<HashedAccountHistory, _, _>(
+            batch,
+            block_number,
+            sorted_post_state.accounts.iter().copied(),
+            append_mode,
+        )?;
+
+        let mut storage_trie_keys = Vec::with_capacity(storage_trie_len);
+        for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
+            if nodes.is_deleted && append_mode {
+                let mut cursor =
+                    self.storage_trie_cursor(*hashed_address, block_number.saturating_sub(1))?;
+                let keys = self.wipe_and_overlay::<StorageTrieHistory, _, _, _, _, _>(
+                    batch,
+                    block_number,
+                    *hashed_address,
+                    || Ok(cursor.next()?),
+                    nodes.storage_nodes_ref().iter().cloned(),
+                )?;
+                storage_trie_keys.extend(keys);
+                continue;
+            }
+
+            let keys = self.persist_history_batch::<StorageTrieHistory, _, _>(
+                batch,
+                block_number,
+                nodes
+                    .storage_nodes_ref()
+                    .iter()
+                    .cloned()
+                    .map(|(path, node)| (*hashed_address, path, node)),
+                append_mode,
+            )?;
+            storage_trie_keys.extend(keys);
+        }
+
+        let mut hashed_storage_keys = Vec::with_capacity(hashed_storage_len);
+        for (hashed_address, storage) in sorted_post_state.storages {
+            if append_mode && storage.is_wiped() {
+                let mut cursor =
+                    self.storage_hashed_cursor(hashed_address, block_number.saturating_sub(1))?;
+                let keys = self.wipe_and_overlay::<HashedStorageHistory, _, _, _, _, _>(
+                    batch,
+                    block_number,
+                    hashed_address,
+                    || Ok(cursor.next()?),
+                    storage
+                        .storage_slots_ref()
+                        .iter()
+                        .map(|(slot, value)| (*slot, Some(StorageValue(*value)))),
+                )?;
+                hashed_storage_keys.extend(keys);
+                continue;
+            }
+
+            let keys = self.persist_history_batch::<HashedStorageHistory, _, _>(
+                batch,
+                block_number,
+                storage
+                    .storage_slots_ref()
+                    .iter()
+                    .map(|(key, value)| (hashed_address, *key, Some(StorageValue(*value)))),
+                append_mode,
+            )?;
+            hashed_storage_keys.extend(keys);
+        }
+
+        Ok(ChangeSet {
+            account_trie_keys,
+            storage_trie_keys,
+            hashed_account_keys,
+            hashed_storage_keys,
+        })
+    }
+
+    fn store_trie_updates_append_only(
+        &self,
+        batch: &mut WriteBatch,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let block_number = block_ref.block.number;
+        // This DB read intentionally assumes `batch` has no pending `LatestBlock` update. RocksDB
+        // reads do not observe uncommitted `WriteBatch` entries.
+        let latest_block_hash =
+            self.get_latest_block_number_hash()?.map_or(B256::ZERO, |(_, hash)| hash);
+
+        if latest_block_hash != block_ref.parent {
+            return Err(BaseProofsStorageError::OutOfOrder {
+                block_number,
+                parent_block_hash: block_ref.parent,
+                latest_block_hash,
+            });
+        }
+
+        let change_set =
+            self.store_trie_updates_for_block(batch, block_number, block_state_diff, true)?;
+        self.put_table::<BlockChangeSet>(batch, block_number, &change_set)?;
+        self.put_proof_window(
+            batch,
+            ProofWindowKey::LatestBlock,
+            block_number,
+            block_ref.block.hash,
+        )?;
+
+        Ok(WriteCounts {
+            account_trie_updates_written_total: change_set.account_trie_keys.len() as u64,
+            storage_trie_updates_written_total: change_set.storage_trie_keys.len() as u64,
+            hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
+            hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
+        })
+    }
+
+    fn store_replacement_trie_updates_append_only(
+        &self,
+        batch: &mut WriteBatch,
+        base_block_number: u64,
+        replacement_state: &mut RocksdbReplacementState,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let block_number = block_ref.block.number;
+        let change_set = self.store_replacement_trie_updates_for_block(
+            batch,
+            base_block_number,
+            replacement_state,
+            block_number,
+            block_state_diff,
+        )?;
+
+        self.put_table::<BlockChangeSet>(batch, block_number, &change_set)?;
+        self.put_proof_window(
+            batch,
+            ProofWindowKey::LatestBlock,
+            block_number,
+            block_ref.block.hash,
+        )?;
+
+        Ok(WriteCounts {
+            account_trie_updates_written_total: change_set.account_trie_keys.len() as u64,
+            storage_trie_updates_written_total: change_set.storage_trie_keys.len() as u64,
+            hashed_accounts_written_total: change_set.hashed_account_keys.len() as u64,
+            hashed_storages_written_total: change_set.hashed_storage_keys.len() as u64,
+        })
+    }
+
+    fn store_replacement_trie_updates_for_block(
+        &self,
+        batch: &mut WriteBatch,
+        base_block_number: u64,
+        replacement_state: &mut RocksdbReplacementState,
+        block_number: u64,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<ChangeSet> {
+        let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
+
+        let storage_trie_len = sorted_trie_updates.storage_tries_ref().len();
+        let hashed_storage_len = sorted_post_state.storages.len();
+
+        let account_trie_keys = self.persist_history_batch::<AccountTrieHistory, _, _>(
+            batch,
+            block_number,
+            sorted_trie_updates.account_nodes_ref().iter().cloned(),
+            true,
+        )?;
+        let hashed_account_keys = self.persist_history_batch::<HashedAccountHistory, _, _>(
+            batch,
+            block_number,
+            sorted_post_state.accounts.iter().copied(),
+            true,
+        )?;
+
+        let mut storage_trie_keys = Vec::with_capacity(storage_trie_len);
+        for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
+            let storage_entries = if nodes.is_deleted {
+                let mut entries = replacement_state.storage_trie_wipe_entries(
+                    self,
+                    base_block_number,
+                    *hashed_address,
+                )?;
+                for (path, node) in nodes.storage_nodes_ref().iter().cloned() {
+                    entries.insert(path, node);
+                }
+                entries.into_iter().collect::<Vec<_>>()
+            } else {
+                nodes.storage_nodes_ref().to_vec()
+            };
+
+            let keys = self.persist_history_batch::<StorageTrieHistory, _, _>(
+                batch,
+                block_number,
+                storage_entries.iter().cloned().map(|(path, node)| (*hashed_address, path, node)),
+                true,
+            )?;
+            replacement_state.apply_storage_trie_entries(*hashed_address, storage_entries);
+            storage_trie_keys.extend(keys);
+        }
+
+        let mut hashed_storage_keys = Vec::with_capacity(hashed_storage_len);
+        for (hashed_address, storage) in sorted_post_state.storages {
+            let storage_entries = if storage.is_wiped() {
+                let mut entries = replacement_state.hashed_storage_wipe_entries(
+                    self,
+                    base_block_number,
+                    hashed_address,
+                )?;
+                for (slot, value) in storage.storage_slots_ref() {
+                    entries.insert(*slot, Some(StorageValue(*value)));
+                }
+                entries.into_iter().collect::<Vec<_>>()
+            } else {
+                storage
+                    .storage_slots_ref()
+                    .iter()
+                    .map(|(key, value)| (*key, Some(StorageValue(*value))))
+                    .collect::<Vec<_>>()
+            };
+
+            let keys = self.persist_history_batch::<HashedStorageHistory, _, _>(
+                batch,
+                block_number,
+                storage_entries.iter().map(|(key, value)| (hashed_address, *key, *value)),
+                true,
+            )?;
+            replacement_state.apply_hashed_storage_entries(hashed_address, storage_entries);
+            hashed_storage_keys.extend(keys);
+        }
+
+        Ok(ChangeSet {
+            account_trie_keys,
+            storage_trie_keys,
+            hashed_account_keys,
+            hashed_storage_keys,
+        })
+    }
+
+    fn get_block_number_hash(
+        &self,
+        key: ProofWindowKey,
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        Ok(self.get_table::<ProofWindow>(key)?.map(|value| (value.number(), *value.hash())))
+    }
+
+    fn get_block_number_hash_from_snapshot(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        key: ProofWindowKey,
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        Ok(self
+            .get_table_from_snapshot::<ProofWindow>(snapshot, key)?
+            .map(|value| (value.number(), *value.hash())))
+    }
+
+    fn get_latest_block_number_hash(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        let block = self.get_block_number_hash(ProofWindowKey::LatestBlock)?;
+        if block.is_some() {
+            return Ok(block);
+        }
+
+        self.get_block_number_hash(ProofWindowKey::EarliestBlock)
+    }
+
+    fn get_proof_window(&self) -> BaseProofsStorageResult<Option<ProofWindowValue>> {
+        let Some((earliest_number, earliest_hash)) =
+            self.get_block_number_hash(ProofWindowKey::EarliestBlock)?
+        else {
+            return Ok(None);
+        };
+
+        let latest = self.get_block_number_hash(ProofWindowKey::LatestBlock)?.map_or_else(
+            || NumHash::new(earliest_number, earliest_hash),
+            |(number, hash)| NumHash::new(number, hash),
+        );
+
+        Ok(Some(ProofWindowValue {
+            earliest: NumHash::new(earliest_number, earliest_hash),
+            latest,
+        }))
+    }
+
+    fn put_proof_window(
+        &self,
+        batch: &mut WriteBatch,
+        key: ProofWindowKey,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.put_table::<ProofWindow>(batch, key, &BlockNumberHash::new(block_number, hash))
+    }
+
+    fn set_earliest_block_number_hash(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        let _guard = self.history_gate.write();
+        self.set_earliest_block_number_hash_unlocked(block_number, hash)
+    }
+
+    fn set_earliest_block_number_hash_unlocked(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        let mut batch = WriteBatch::default();
+        self.put_proof_window(&mut batch, ProofWindowKey::EarliestBlock, block_number, hash)?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn calculate_prune_plan(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        target_block: u64,
+    ) -> BaseProofsStorageResult<Option<RocksdbPrunePlan>> {
+        let started = Instant::now();
+        info!(
+            target: "trie::pruner",
+            target_block,
+            "Calculating RocksDB proof storage prune plan",
+        );
+        let Some((earliest, earliest_hash)) =
+            self.get_block_number_hash_from_snapshot(snapshot, ProofWindowKey::EarliestBlock)?
+        else {
+            info!(
+                target: "trie::pruner",
+                target_block,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune plan because earliest block is missing",
+            );
+            return Ok(None);
+        };
+
+        if earliest >= target_block {
+            info!(
+                target: "trie::pruner",
+                earliest_block = earliest,
+                target_block,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune plan because target is not newer",
+            );
+            return Ok(None);
+        }
+
+        let mut acc_candidates: HashMap<StoredNibbles, u64> = HashMap::default();
+        let mut storage_candidates: HashMap<StorageTrieKey, u64> = HashMap::default();
+        let mut hashed_acc_candidates: HashMap<B256, u64> = HashMap::default();
+        let mut hashed_storage_candidates: HashMap<HashedStorageKey, u64> = HashMap::default();
+
+        for (block_number, change_set) in self
+            .iter_change_sets_from_snapshot(snapshot, (earliest.saturating_add(1))..=target_block)?
+        {
+            for key in change_set.account_trie_keys {
+                acc_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            for key in change_set.storage_trie_keys {
+                storage_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            for key in change_set.hashed_account_keys {
+                hashed_acc_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            for key in change_set.hashed_storage_keys {
+                hashed_storage_candidates
+                    .entry(key)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+        }
+
+        let plan = RocksdbPrunePlan {
+            earliest_block: earliest,
+            earliest_hash,
+            acc_survivors: flatten_and_sort(acc_candidates),
+            storage_survivors: flatten_and_sort(storage_candidates),
+            hashed_acc_survivors: flatten_and_sort(hashed_acc_candidates),
+            hashed_storage_survivors: flatten_and_sort(hashed_storage_candidates),
+        };
+
+        info!(
+            target: "trie::pruner",
+            earliest_block = plan.earliest_block,
+            target_block,
+            account_trie_survivors = plan.acc_survivors.len(),
+            storage_trie_survivors = plan.storage_survivors.len(),
+            hashed_account_survivors = plan.hashed_acc_survivors.len(),
+            hashed_storage_survivors = plan.hashed_storage_survivors.len(),
+            total_survivors = plan.total_survivors(),
+            elapsed = ?started.elapsed(),
+            "Calculated RocksDB proof storage prune plan",
+        );
+
+        Ok(Some(plan))
+    }
+
+    fn collect_history_ranged(
+        &self,
+        block_range: impl RangeBounds<u64>,
+    ) -> BaseProofsStorageResult<RocksdbHistoryDeleteBatch> {
+        let mut history = RocksdbHistoryDeleteBatch::default();
+
+        for (block_number, change_set) in self.iter_change_sets(block_range)? {
+            history.block_numbers.push(block_number);
+            history
+                .account_trie
+                .extend(change_set.account_trie_keys.into_iter().map(|key| (key, block_number)));
+            history
+                .storage_trie
+                .extend(change_set.storage_trie_keys.into_iter().map(|key| (key, block_number)));
+            history
+                .hashed_account
+                .extend(change_set.hashed_account_keys.into_iter().map(|key| (key, block_number)));
+            history
+                .hashed_storage
+                .extend(change_set.hashed_storage_keys.into_iter().map(|key| (key, block_number)));
+        }
+
+        history.account_trie.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+        history.storage_trie.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+        history.hashed_account.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+        history.hashed_storage.sort_by(|(k1, b1), (k2, b2)| k1.cmp(k2).then_with(|| b1.cmp(b2)));
+
+        Ok(history)
+    }
+
+    fn delete_history_ranged(
+        &self,
+        batch: &mut WriteBatch,
+        history: RocksdbHistoryDeleteBatch,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        for block_number in &history.block_numbers {
+            batch.delete_cf(&cf, encode_block_number(*block_number));
+        }
+
+        let RocksdbHistoryDeleteBatch {
+            block_numbers: _,
+            account_trie,
+            storage_trie,
+            hashed_account,
+            hashed_storage,
+        } = history;
+        let counts = WriteCounts {
+            account_trie_updates_written_total: account_trie.len() as u64,
+            storage_trie_updates_written_total: storage_trie.len() as u64,
+            hashed_accounts_written_total: hashed_account.len() as u64,
+            hashed_storages_written_total: hashed_storage.len() as u64,
+        };
+
+        self.delete_dup_sorted::<AccountTrieHistory, _, _>(batch, account_trie)?;
+        self.delete_dup_sorted::<StorageTrieHistory, _, _>(batch, storage_trie)?;
+        self.delete_dup_sorted::<HashedAccountHistory, _, _>(batch, hashed_account)?;
+        self.delete_dup_sorted::<HashedStorageHistory, _, _>(batch, hashed_storage)?;
+
+        Ok(counts)
+    }
+
+    fn iter_change_sets(
+        &self,
+        block_range: impl RangeBounds<u64>,
+    ) -> BaseProofsStorageResult<Vec<(u64, ChangeSet)>> {
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        let start = range_start(&block_range);
+        let start_key = encode_block_number(start);
+        let iter = self.db.iterator_cf(&cf, IteratorMode::From(&start_key, Direction::Forward));
+        let mut rows = Vec::new();
+
+        for item in iter {
+            let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+            let block_number = decode_block_number(&raw_key)?;
+            if !block_range.contains(&block_number) {
+                break;
+            }
+            rows.push((block_number, ChangeSet::decompress(&raw_value)?));
+        }
+
+        Ok(rows)
+    }
+
+    fn iter_change_sets_from_snapshot(
+        &self,
+        snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+        block_range: impl RangeBounds<u64>,
+    ) -> BaseProofsStorageResult<Vec<(u64, ChangeSet)>> {
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        let start = range_start(&block_range);
+        let start_key = encode_block_number(start);
+        let iter = snapshot.iterator_cf(&cf, IteratorMode::From(&start_key, Direction::Forward));
+        let mut rows = Vec::new();
+
+        for item in iter {
+            let (raw_key, raw_value) = item.map_err(rocksdb_error)?;
+            let block_number = decode_block_number(&raw_key)?;
+            if !block_range.contains(&block_number) {
+                break;
+            }
+            rows.push((block_number, ChangeSet::decompress(&raw_value)?));
+        }
+
+        Ok(rows)
+    }
+
+    fn prepare_prune(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<Option<RocksdbPreparedPrune>> {
+        let started = Instant::now();
+        let requested_target = new_earliest_block_ref.block.number;
+        info!(
+            target: "trie::pruner",
+            requested_target,
+            "Preparing RocksDB proof storage prune",
+        );
+        let snapshot = self.db.snapshot();
+        let Some((earliest_block, earliest_hash)) =
+            self.get_block_number_hash_from_snapshot(&snapshot, ProofWindowKey::EarliestBlock)?
+        else {
+            info!(
+                target: "trie::pruner",
+                requested_target,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune because earliest block is missing",
+            );
+            return Ok(None);
+        };
+
+        let (latest_block, latest_hash) = self
+            .get_block_number_hash_from_snapshot(&snapshot, ProofWindowKey::LatestBlock)?
+            .unwrap_or((earliest_block, earliest_hash));
+
+        // Bound the prune to rows visible in this snapshot. Appends may commit while pruning, but
+        // they must always land above this effective target.
+        let (target_block, target_hash) = if requested_target > latest_block {
+            (latest_block, latest_hash)
+        } else {
+            (requested_target, new_earliest_block_ref.block.hash)
+        };
+
+        info!(
+            target: "trie::pruner",
+            earliest_block,
+            latest_block,
+            requested_target,
+            target_block,
+            clamped_to_latest = requested_target > latest_block,
+            "Calculated RocksDB proof storage prune target",
+        );
+
+        if earliest_block >= target_block {
+            info!(
+                target: "trie::pruner",
+                earliest_block,
+                target_block,
+                elapsed = ?started.elapsed(),
+                "Skipped RocksDB proof storage prune because target is not newer",
+            );
+            return Ok(None);
+        }
+
+        let Some(plan) = self.calculate_prune_plan(&snapshot, target_block)? else {
+            return Ok(None);
+        };
+
+        let account_trie = self.collect_history_preceding_deletes::<AccountTrieHistory, _>(
+            &snapshot,
+            plan.acc_survivors,
+        )?;
+        let storage_trie = self.collect_history_preceding_deletes::<StorageTrieHistory, _>(
+            &snapshot,
+            plan.storage_survivors,
+        )?;
+        let hashed_account = self.collect_history_preceding_deletes::<HashedAccountHistory, _>(
+            &snapshot,
+            plan.hashed_acc_survivors,
+        )?;
+        let hashed_storage = self.collect_history_preceding_deletes::<HashedStorageHistory, _>(
+            &snapshot,
+            plan.hashed_storage_survivors,
+        )?;
+
+        let counts = WriteCounts {
+            account_trie_updates_written_total: account_trie.len() as u64,
+            storage_trie_updates_written_total: storage_trie.len() as u64,
+            hashed_accounts_written_total: hashed_account.len() as u64,
+            hashed_storages_written_total: hashed_storage.len() as u64,
+        };
+
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block = plan.earliest_block,
+            target_block,
+            account_trie_deletes = account_trie.len(),
+            storage_trie_deletes = storage_trie.len(),
+            hashed_account_deletes = hashed_account.len(),
+            hashed_storage_deletes = hashed_storage.len(),
+            total_deletes = counts.account_trie_updates_written_total
+                + counts.storage_trie_updates_written_total
+                + counts.hashed_accounts_written_total
+                + counts.hashed_storages_written_total,
+            elapsed = ?started.elapsed(),
+            "Prepared RocksDB proof storage prune",
+        );
+
+        Ok(Some(RocksdbPreparedPrune {
+            expected_earliest_block: plan.earliest_block,
+            expected_earliest_hash: plan.earliest_hash,
+            target_block,
+            target_hash,
+            deletes: RocksdbPreparedHistoryDeletes {
+                account_trie,
+                storage_trie,
+                hashed_account,
+                hashed_storage,
+            },
+            counts,
+        }))
+    }
+
+    fn commit_prepared_prune(
+        &self,
+        prepared: RocksdbPreparedPrune,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let started = Instant::now();
+        let RocksdbPreparedPrune {
+            expected_earliest_block,
+            expected_earliest_hash,
+            target_block,
+            target_hash,
+            deletes,
+            counts,
+        } = prepared;
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block,
+            target_block,
+            account_trie_deletes = deletes.account_trie.len(),
+            storage_trie_deletes = deletes.storage_trie.len(),
+            hashed_account_deletes = deletes.hashed_account.len(),
+            hashed_storage_deletes = deletes.hashed_storage.len(),
+            total_deletes = deletes.total(),
+            "Committing RocksDB proof storage prune",
+        );
+        let expected_earliest = Some((expected_earliest_block, expected_earliest_hash));
+        let current_earliest = self.get_block_number_hash(ProofWindowKey::EarliestBlock)?;
+        if current_earliest != expected_earliest {
+            info!(
+                target: "trie::pruner",
+                current_earliest = ?current_earliest,
+                expected_earliest = ?expected_earliest,
+                target_block,
+                elapsed = ?started.elapsed(),
+                "skipping stale prune plan"
+            );
+            return Ok(WriteCounts::default());
+        }
+
+        let mut batch = WriteBatch::default();
+
+        self.delete_raw_history_keys::<AccountTrieHistory>(&mut batch, deletes.account_trie)?;
+        self.delete_raw_history_keys::<StorageTrieHistory>(&mut batch, deletes.storage_trie)?;
+        self.delete_raw_history_keys::<HashedAccountHistory>(&mut batch, deletes.hashed_account)?;
+        self.delete_raw_history_keys::<HashedStorageHistory>(&mut batch, deletes.hashed_storage)?;
+
+        let cf = self.cf(<BlockChangeSet as Table>::NAME)?;
+        let start = encode_block_number(expected_earliest_block.saturating_add(1));
+        if let Some(end_block) = target_block.checked_add(1) {
+            batch.delete_range_cf(&cf, start, encode_block_number(end_block));
+        } else {
+            batch.delete_range_cf(&cf, start, encode_block_number(u64::MAX));
+            batch.delete_cf(&cf, encode_block_number(u64::MAX));
+        }
+
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::EarliestBlock,
+            target_block,
+            target_hash,
+        )?;
+
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block,
+            target_block,
+            elapsed = ?started.elapsed(),
+            "Writing RocksDB proof storage prune batch",
+        );
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        info!(
+            target: "trie::pruner",
+            expected_earliest_block,
+            target_block,
+            account_trie_deletes = counts.account_trie_updates_written_total,
+            storage_trie_deletes = counts.storage_trie_updates_written_total,
+            hashed_account_deletes = counts.hashed_accounts_written_total,
+            hashed_storage_deletes = counts.hashed_storages_written_total,
+            total_deletes = counts.account_trie_updates_written_total
+                + counts.storage_trie_updates_written_total
+                + counts.hashed_accounts_written_total
+                + counts.hashed_storages_written_total,
+            elapsed = ?started.elapsed(),
+            "Committed RocksDB proof storage prune",
+        );
+        Ok(counts)
+    }
+
+    fn get_initial_state_anchor(&self) -> BaseProofsStorageResult<Option<BlockNumHash>> {
+        Ok(self.get_table::<ProofWindow>(ProofWindowKey::InitialStateAnchor)?.map(Into::into))
+    }
+
+    fn get_latest_history_key<T>(&self) -> BaseProofsStorageResult<Option<T::Key>>
+    where
+        T: RocksDbHistoryTable,
+    {
+        let cf = self.cf(T::NAME)?;
+        // This returns the lexicographically LARGEST user-key prefix that has
+        // any history entry, used as a resume cursor during initial state
+        // population. The block-suffix encoding (forward or reversed) is
+        // irrelevant here: only the tiebreak among rows sharing a user-key
+        // prefix changes, so `IteratorMode::End` still lands on a row whose
+        // user-key prefix is the maximum.
+        let mut iter = self.db.iterator_cf(&cf, IteratorMode::End);
+        let Some(item) = iter.next() else {
+            return Ok(None);
+        };
+        let (raw_key, _) = item.map_err(rocksdb_error)?;
+        decode_history_key::<T>(&raw_key).map(|(key, _)| Some(key)).map_err(Into::into)
+    }
+}
+
+impl BaseProofsStore for RocksdbProofsStorage {
+    type StorageTrieCursor<'tx>
+        = RocksdbTrieCursor<'tx, StorageTrieHistory>
+    where
+        Self: 'tx;
+    type AccountTrieCursor<'tx>
+        = RocksdbTrieCursor<'tx, AccountTrieHistory>
+    where
+        Self: 'tx;
+    type StorageCursor<'tx>
+        = RocksdbStorageCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountHashedCursor<'tx>
+        = RocksdbAccountCursor<'tx>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = Arc<RocksdbReadSnapshot<'tx>>
+    where
+        Self: 'tx;
+
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
+        Ok(Arc::new(RocksdbReadSnapshot::new(self.db.as_ref())))
+    }
+
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.get_block_number_hash(ProofWindowKey::EarliestBlock)
+    }
+
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.get_latest_block_number_hash()
+    }
+
+    fn storage_trie_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+        // Standalone cursor factories intentionally create independent snapshots. Use `ro_tx` and
+        // the `*_with_tx` factories when multiple cursors need one consistent view.
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new(
+            self.db.as_ref(),
+            max_block_number,
+            Some(hashed_address),
+        ))
+    }
+
+    fn account_trie_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new(self.db.as_ref(), max_block_number, None))
+    }
+
+    fn storage_hashed_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
+        Ok(RocksdbStorageCursor::new(self.db.as_ref(), max_block_number, hashed_address))
+    }
+
+    fn account_hashed_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        Ok(RocksdbAccountCursor::new(self.db.as_ref(), max_block_number))
+    }
+
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            Some(hashed_address),
+        ))
+    }
+
+    fn account_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            None,
+        ))
+    }
+
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbStorageCursor::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            hashed_address,
+        ))
+    }
+
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        Ok(RocksdbAccountCursor::new_with_snapshot(Arc::clone(tx), max_block_number))
+    }
+
+    fn store_trie_updates(
+        &self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let _append_guard = self.append_lock.lock();
+        let _history_guard = self.history_gate.read();
+        let mut batch = WriteBatch::default();
+        let counts =
+            self.store_trie_updates_append_only(&mut batch, block_ref, block_state_diff)?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(counts)
+    }
+
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        let snapshot = self.db.snapshot();
+        let change_set = self
+            .get_table_from_snapshot::<BlockChangeSet>(&snapshot, block_number)?
+            .ok_or(BaseProofsStorageError::NoChangeSetForBlock(block_number))?;
+
+        let mut trie_updates = TrieUpdates::default();
+        for key in change_set.account_trie_keys {
+            let entry = match get_history_exact::<AccountTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingAccountTrieHistory(
+                        key.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            if let Some(value) = entry {
+                trie_updates.account_nodes.insert(key.0, value);
+            } else {
+                trie_updates.removed_nodes.insert(key.0);
+            }
+        }
+
+        for key in change_set.storage_trie_keys {
+            let entry = match get_history_exact::<StorageTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingStorageTrieHistory(
+                        key.hashed_address,
+                        key.path.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            let storage_updates = trie_updates
+                .storage_tries
+                .entry(key.hashed_address)
+                .or_insert_with(StorageTrieUpdates::default);
+            if let Some(value) = entry {
+                storage_updates.storage_nodes.insert(key.path.0, value);
+            } else {
+                storage_updates.removed_nodes.insert(key.path.0);
+            }
+        }
+
+        let mut post_state = HashedPostState::with_capacity(change_set.hashed_account_keys.len());
+        for key in change_set.hashed_account_keys {
+            let entry = match get_history_exact::<HashedAccountHistory, _>(
+                &snapshot,
+                &self.db,
+                key,
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedAccountHistory(
+                        key,
+                        block_number,
+                    ));
+                }
+            };
+            post_state.accounts.insert(key, entry);
+        }
+
+        for key in change_set.hashed_storage_keys {
+            let entry = match get_history_exact::<HashedStorageHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedStorageHistory {
+                        hashed_address: key.hashed_address,
+                        hashed_storage_key: key.hashed_storage_key,
+                        block_number,
+                    });
+                }
+            };
+
+            let storage = post_state.storages.entry(key.hashed_address).or_default();
+            if let Some(value) = entry {
+                storage.storage.insert(key.hashed_storage_key, value.0);
+            } else {
+                storage.storage.insert(key.hashed_storage_key, U256::ZERO);
+            }
+        }
+
+        Ok(BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        })
+    }
+
+    fn prune_earliest_state(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let started = Instant::now();
+        info!(
+            target: "trie::pruner",
+            target_block = new_earliest_block_ref.block.number,
+            "Acquiring RocksDB proof storage prune locks",
+        );
+        let _prune_guard = self.prune_lock.lock();
+        let _history_guard = self.history_gate.read();
+        info!(
+            target: "trie::pruner",
+            target_block = new_earliest_block_ref.block.number,
+            elapsed = ?started.elapsed(),
+            "Acquired RocksDB proof storage prune locks",
+        );
+        let Some(prepared) = self.prepare_prune(new_earliest_block_ref)? else {
+            info!(
+                target: "trie::pruner",
+                target_block = new_earliest_block_ref.block.number,
+                elapsed = ?started.elapsed(),
+                "No RocksDB proof storage prune work prepared",
+            );
+            return Ok(WriteCounts::default());
+        };
+
+        let counts = self.commit_prepared_prune(prepared)?;
+        info!(
+            target: "trie::pruner",
+            target_block = new_earliest_block_ref.block.number,
+            elapsed = ?started.elapsed(),
+            "Finished RocksDB proof storage prune request",
+        );
+        Ok(counts)
+    }
+
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
+        let _guard = self.history_gate.write();
+        let Some(proof_window) = self.get_proof_window()? else {
+            return Ok(());
+        };
+
+        if to.block.number > proof_window.latest.number {
+            return Ok(());
+        }
+
+        if to.block.number <= proof_window.earliest.number {
+            return Err(BaseProofsStorageError::UnwindBeyondEarliest {
+                unwind_block_number: to.block.number,
+                earliest_block_number: proof_window.earliest.number,
+            });
+        }
+
+        // Keep collection and deletion under the same exclusive history gate so another history
+        // rewrite cannot change the proof window or history rows between choosing keys and
+        // committing the batch.
+        let history_to_delete = self.collect_history_ranged(to.block.number..)?;
+        let mut batch = WriteBatch::default();
+        self.delete_history_ranged(&mut batch, history_to_delete)?;
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::LatestBlock,
+            to.block.number.saturating_sub(1),
+            to.parent,
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn replace_updates(
+        &self,
+        latest_common_block: BlockNumHash,
+        mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<()> {
+        blocks_to_add.sort_unstable_by_key(|(block, _)| block.block.number);
+
+        let mut latest_block_hash = latest_common_block.hash;
+        for (block_with_parent, _) in &blocks_to_add {
+            let block_number = block_with_parent.block.number;
+            if latest_block_hash != block_with_parent.parent {
+                return Err(BaseProofsStorageError::OutOfOrder {
+                    block_number,
+                    parent_block_hash: block_with_parent.parent,
+                    latest_block_hash,
+                });
+            }
+            latest_block_hash = block_with_parent.block.hash;
+        }
+
+        let _guard = self.history_gate.write();
+        let history_to_delete = if let Some(start_block) = latest_common_block.number.checked_add(1)
+        {
+            self.collect_history_ranged(start_block..)?
+        } else {
+            RocksdbHistoryDeleteBatch::default()
+        };
+        let mut batch = WriteBatch::default();
+        self.delete_history_ranged(&mut batch, history_to_delete)?;
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::LatestBlock,
+            latest_common_block.number,
+            latest_common_block.hash,
+        )?;
+
+        let mut replacement_state = RocksdbReplacementState::default();
+        for (block_with_parent, diff) in blocks_to_add {
+            self.store_replacement_trie_updates_append_only(
+                &mut batch,
+                latest_common_block.number,
+                &mut replacement_state,
+                block_with_parent,
+                diff,
+            )?;
+        }
+
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.set_earliest_block_number_hash(block_number, hash)
+    }
+}
+
+impl BaseProofsInitialStateStore for RocksdbProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
+        let Some(block) = self.get_initial_state_anchor()? else {
+            return Ok(InitialStateAnchor::default());
+        };
+
+        let completed = self.get_earliest_block_number()?.is_some();
+
+        Ok(InitialStateAnchor {
+            block: Some(block),
+            status: if completed {
+                InitialStateStatus::Completed
+            } else {
+                InitialStateStatus::InProgress
+            },
+            latest_account_trie_key: self.get_latest_history_key::<AccountTrieHistory>()?,
+            latest_storage_trie_key: self.get_latest_history_key::<StorageTrieHistory>()?,
+            latest_hashed_account_key: self.get_latest_history_key::<HashedAccountHistory>()?,
+            latest_hashed_storage_key: self.get_latest_history_key::<HashedStorageHistory>()?,
+        })
+    }
+
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
+        let _guard = self.history_gate.write();
+        if self.get_initial_state_anchor()?.is_some() {
+            return Err(DatabaseError::Other("initial state anchor already set".to_owned()).into());
+        }
+
+        let mut batch = WriteBatch::default();
+        self.put_table::<ProofWindow>(
+            &mut batch,
+            ProofWindowKey::InitialStateAnchor,
+            &anchor.into(),
+        )?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_account_branches(
+        &self,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        let mut account_nodes = account_nodes;
+        if account_nodes.is_empty() {
+            return Ok(());
+        }
+
+        account_nodes.sort_by_key(|(key, _)| *key);
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        self.persist_history_batch::<AccountTrieHistory, _, _>(&mut batch, 0, account_nodes, true)?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_storage_branches(
+        &self,
+        hashed_address: B256,
+        storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.store_storage_branches_bulk(vec![(hashed_address, storage_nodes)])
+    }
+
+    fn store_storage_branches_bulk(
+        &self,
+        entries: Vec<(B256, Vec<(Nibbles, Option<BranchNodeCompact>)>)>,
+    ) -> BaseProofsStorageResult<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        for (hashed_address, mut storage_nodes) in entries {
+            if storage_nodes.is_empty() {
+                continue;
+            }
+            storage_nodes.sort_by_key(|(key, _)| *key);
+            self.persist_history_batch::<StorageTrieHistory, _, _>(
+                &mut batch,
+                0,
+                storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
+                true,
+            )?;
+        }
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_hashed_accounts(
+        &self,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> BaseProofsStorageResult<()> {
+        let mut accounts = accounts;
+        if accounts.is_empty() {
+            return Ok(());
+        }
+
+        accounts.sort_by_key(|(key, _)| *key);
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        self.persist_history_batch::<HashedAccountHistory, _, _>(&mut batch, 0, accounts, true)?;
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn store_hashed_storages(
+        &self,
+        hashed_address: B256,
+        storages: Vec<(B256, U256)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.store_hashed_storages_bulk(vec![(hashed_address, storages)])
+    }
+
+    fn store_hashed_storages_bulk(
+        &self,
+        entries: Vec<(B256, Vec<(B256, U256)>)>,
+    ) -> BaseProofsStorageResult<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let _guard = self.history_gate.write();
+        let mut batch = WriteBatch::default();
+        for (hashed_address, mut storages) in entries {
+            if storages.is_empty() {
+                continue;
+            }
+            storages.sort_by_key(|(key, _)| *key);
+            self.persist_history_batch::<HashedStorageHistory, _, _>(
+                &mut batch,
+                0,
+                storages
+                    .into_iter()
+                    .map(|(key, value)| (hashed_address, key, Some(StorageValue(value)))),
+                true,
+            )?;
+        }
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
+    }
+
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
+        let _guard = self.history_gate.write();
+        let anchor = self.get_initial_state_anchor()?.ok_or(NoBlocksFound)?;
+        self.set_earliest_block_number_hash_unlocked(anchor.number, anchor.hash)?;
+        Ok(anchor)
+    }
+}
+
+/// Batch session for [`RocksdbProofsStorage`].
+///
+/// Unlike the MDBX implementation, `RocksDB` does not expose a transaction cursor readable
+/// mid-session; each `store_trie_updates` call commits immediately via a write batch. To
+/// avoid the per-cursor cost of `db.snapshot()` (which pins SST files against compaction
+/// and is expensive enough at the thousands-per-block scale to stall sync), the session
+/// holds ONE snapshot and reuses it across all cursor reads. The snapshot is refreshed
+/// after each `store_trie_updates` so subsequent block reads observe the prior commit.
+#[derive(Debug)]
+pub struct RocksdbBatchSession<'a> {
+    storage: &'a RocksdbProofsStorage,
+    snapshot: Arc<RocksdbReadSnapshot<'a>>,
+}
+
+impl<'a> RocksdbBatchSession<'a> {
+    fn new(storage: &'a RocksdbProofsStorage) -> Self {
+        let snapshot = Arc::new(RocksdbReadSnapshot::new(storage.db.as_ref()));
+        Self { storage, snapshot }
+    }
+}
+
+impl BaseProofsBatchSession for RocksdbBatchSession<'_> {
+    type StorageTrieCursor<'a>
+        = RocksdbTrieCursor<'a, StorageTrieHistory>
+    where
+        Self: 'a;
+    type AccountTrieCursor<'a>
+        = RocksdbTrieCursor<'a, AccountTrieHistory>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = RocksdbStorageCursor<'a>
+    where
+        Self: 'a;
+    type AccountHashedCursor<'a>
+        = RocksdbAccountCursor<'a>
+    where
+        Self: 'a;
+
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_earliest_block_number()
+    }
+
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_latest_block_number()
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'_>> {
+        self.storage.storage_trie_cursor_with_tx(&self.snapshot, hashed_address, max_block_number)
+    }
+
+    fn account_trie_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>> {
+        self.storage.account_trie_cursor_with_tx(&self.snapshot, max_block_number)
+    }
+
+    fn storage_hashed_cursor(
+        &self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'_>> {
+        self.storage.storage_hashed_cursor_with_tx(&self.snapshot, hashed_address, max_block_number)
+    }
+
+    fn account_hashed_cursor(
+        &self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>> {
+        self.storage.account_hashed_cursor_with_tx(&self.snapshot, max_block_number)
+    }
+
+    fn store_trie_updates(
+        &mut self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        let counts = self.storage.store_trie_updates(block_ref, block_state_diff)?;
+        // Refresh the snapshot so the next block's cursor reads observe this commit.
+        self.snapshot = Arc::new(RocksdbReadSnapshot::new(self.storage.db.as_ref()));
+        Ok(counts)
+    }
+}
+
+impl BaseProofsBatchStore for RocksdbProofsStorage {
+    type BatchSession<'a>
+        = RocksdbBatchSession<'a>
+    where
+        Self: 'a;
+
+    fn with_batch_session<R, F>(&self, f: F) -> BaseProofsStorageResult<R>
+    where
+        F: FnOnce(&mut Self::BatchSession<'_>) -> BaseProofsStorageResult<R>,
+    {
+        let mut session = RocksdbBatchSession::new(self);
+        f(&mut session)
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl reth_db::database_metrics::DatabaseMetrics for RocksdbProofsStorage {
+    fn gauge_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
+        let mut metrics = Vec::new();
+
+        for table in Self::column_families() {
+            let Some(cf) = self.db.cf_handle(table) else {
+                continue;
+            };
+
+            let estimated_num_keys = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let sst_size = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::LIVE_SST_FILES_SIZE)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let memtable_size = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::SIZE_ALL_MEM_TABLES)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let pending_compaction_bytes = self
+                .db
+                .property_int_value_cf(&cf, rocksdb::properties::ESTIMATE_PENDING_COMPACTION_BYTES)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+
+            metrics.push((
+                "base_proof_storage.table_size",
+                (sst_size + memtable_size) as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.table_entries",
+                estimated_num_keys as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.pending_compaction_bytes",
+                pending_compaction_bytes as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.sst_size",
+                sst_size as f64,
+                vec![Label::new("table", table)],
+            ));
+            metrics.push((
+                "base_proof_storage.memtable_size",
+                memtable_size as f64,
+                vec![Label::new("table", table)],
+            ));
+        }
+
+        let wal_size: u64 = std::fs::read_dir(self.db.path())
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
+                    .filter_map(|entry| entry.metadata().ok())
+                    .map(|metadata| metadata.len())
+                    .sum()
+            })
+            .unwrap_or(0);
+
+        metrics.push(("base_proof_storage.wal_size", wal_size as f64, vec![]));
+
+        metrics
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl reth_db::database_metrics::DatabaseMetrics for RocksdbProofsStorage {}
+
+impl<'db, T, V> RocksdbVersionedCursor<'db, T>
+where
+    T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+    T: RocksDbHistoryTable,
+    T::Key: Clone + Default + Ord,
+    T::Value: Decompress,
+{
+    /// Creates a cursor over a `RocksDB` history column family.
+    fn new(db: &'db RocksDb, max_block_number: u64) -> Self {
+        let snapshot = Arc::new(RocksdbReadSnapshot::new(db));
+        Self::new_with_snapshot(snapshot, max_block_number)
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+    ) -> Self {
+        Self { snapshot, max_block_number, current_key: None, _table: PhantomData }
+    }
+
+    fn cf(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
+        self.snapshot.cf(T::NAME)
+    }
+
+    fn exact_lookup_bounds(&self, key: &T::Key) -> Result<(Vec<u8>, Vec<u8>), DatabaseError> {
+        let mut target = encode_history_key_prefix::<T>(key)?;
+        let prefix = target.clone();
+        // History keys are encoded with the block-number suffix complemented
+        // (`u64::MAX - block_number`), so larger block numbers produce SMALLER
+        // suffixes. The "target" is therefore the smallest encoded key that
+        // could match: a forward `seek(target)` lands on the first stored
+        // version V with `complement(V) >= complement(max_block_number)`, i.e.
+        // `V <= max_block_number` — the newest version at or below the bound.
+        target.extend_from_slice(&encode_history_block_suffix(self.max_block_number));
+        Ok((prefix, target))
+    }
+
+    fn latest_version_for_key(&self, key: T::Key) -> RocksDbLatestVersionResult<T> {
+        let cf = self.cf()?;
+        let (prefix, target) = self.exact_lookup_bounds(&key)?;
+        let read_options = exact_prefix_read_options(&prefix);
+        let mut iter = self.snapshot.snapshot().raw_iterator_cf_opt(&cf, read_options);
+        // Forward `seek` is the fast path: with reversed block-suffix encoding
+        // the newest version-at-or-below `max_block_number` sorts FIRST within
+        // the prefix box, so we land directly on it instead of paying the
+        // documented 7-8x penalty of `seek_for_prev` (RocksDB PR #5535).
+        iter.seek(&target);
+        if !iter.valid() {
+            iter.status().map_err(rocksdb_error)?;
+            return Ok(None);
+        }
+
+        let raw_key = iter.key().ok_or(DatabaseError::Decode)?;
+        if !raw_key.starts_with(&prefix) {
+            return Ok(None);
+        }
+
+        let (decoded_key, _) = decode_history_key::<T>(raw_key)?;
+        let raw_value = iter.value().ok_or(DatabaseError::Decode)?;
+        let value = T::Value::decompress(raw_value)?;
+        Ok(Some((decoded_key, value)))
+    }
+
+    fn seek_exact(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.current_key = Some(key.clone());
+        if let Some((latest_key, latest_value)) = self.latest_version_for_key(key)?
+            && let MaybeDeleted(Some(value)) = latest_value.value
+        {
+            return Ok(Some((latest_key, value)));
+        }
+        Ok(None)
+    }
+
+    fn seek(&mut self, start_key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_from(start_key)
+    }
+
+    fn next(&mut self) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        if let Some(key) = self.current_key.clone() {
+            self.next_live_after(key)
+        } else {
+            self.next_live_from(T::Key::default())
+        }
+    }
+
+    fn next_live_from(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, false, total_order_read_options())
+    }
+
+    fn next_live_after(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, true, total_order_read_options())
+    }
+
+    fn seek_with_prefix(
+        &mut self,
+        key: T::Key,
+        prefix: Vec<u8>,
+    ) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, false, prefix_read_options(&prefix))
+    }
+
+    fn next_with_prefix(&mut self, prefix: Vec<u8>) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        if let Some(key) = self.current_key.clone() {
+            self.next_live_candidate(key, true, prefix_read_options(&prefix))
+        } else {
+            self.next_live_candidate(T::Key::default(), false, prefix_read_options(&prefix))
+        }
+    }
+
+    fn next_live_candidate(
+        &mut self,
+        key: T::Key,
+        exclusive: bool,
+        read_options: ReadOptions,
+    ) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        let found = {
+            let cf = self.cf()?;
+            // Under the reversed block-suffix encoding, within a given key's
+            // prefix the SMALLEST encoded suffix is `u64::MAX - u64::MAX = 0`
+            // (i.e. block `u64::MAX`) and the LARGEST is `u64::MAX - 0 =
+            // u64::MAX` (i.e. block `0`). So to start a forward scan at the
+            // first encoded row of `key`, use block `u64::MAX`; to start
+            // strictly after all of `key`'s rows, use block `0` (the
+            // `before_start` filter below then skips the equal-key row).
+            let start_block = if exclusive { 0 } else { u64::MAX };
+            let start_key = encode_history_key::<T>(&key, start_block)?;
+            let iter = self.snapshot.snapshot().iterator_cf_opt(
+                &cf,
+                read_options,
+                IteratorMode::From(&start_key, Direction::Forward),
+            );
+            let mut last_candidate = None;
+            let mut found = None;
+
+            for item in iter {
+                let (raw_key, _) = item.map_err(rocksdb_error)?;
+                let (candidate, _) = decode_history_key::<T>(&raw_key)?;
+                let before_start = if exclusive { candidate <= key } else { candidate < key };
+                if before_start || last_candidate.as_ref() == Some(&candidate) {
+                    continue;
+                }
+
+                last_candidate = Some(candidate.clone());
+                if let Some((live_key, latest_value)) = self.latest_version_for_key(candidate)?
+                    && let MaybeDeleted(Some(value)) = latest_value.value
+                {
+                    found = Some((live_key, value));
+                    break;
+                }
+            }
+
+            found
+        };
+
+        if let Some((key, value)) = found {
+            self.current_key = Some(key.clone());
+            return Ok(Some((key, value)));
+        }
+
+        self.current_key = None;
+        Ok(None)
+    }
+
+    const fn is_positioned(&self) -> bool {
+        self.current_key.is_some()
+    }
+}
+
+impl<'db> RocksdbTrieCursor<'db, AccountTrieHistory> {
+    /// Creates a `RocksDB` trie cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: Option<B256>) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: Option<B256>,
+    ) -> Self {
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
+    }
+}
+
+impl<'db> RocksdbTrieCursor<'db, StorageTrieHistory> {
+    /// Creates a `RocksDB` trie cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: Option<B256>) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: Option<B256>,
+    ) -> Self {
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
+    }
+}
+
+impl TrieCursor for RocksdbTrieCursor<'_, AccountTrieHistory> {
+    fn seek_exact(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        Ok(self
+            .inner
+            .seek_exact(StoredNibbles(path))?
+            .map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
+    }
+
+    fn seek(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        Ok(self
+            .inner
+            .seek(StoredNibbles(path))?
+            .map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
+    }
+
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        Ok(self.inner.next()?.map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
+    }
+
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+        Ok(self.inner.current_key.clone().map(|StoredNibbles(nibbles)| nibbles))
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+impl TrieCursor for RocksdbTrieCursor<'_, StorageTrieHistory> {
+    fn seek_exact(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        let key = StorageTrieKey::new(address, StoredNibbles(path));
+        Ok(self
+            .inner
+            .seek_exact(key)?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
+    }
+
+    fn seek(
+        &mut self,
+        path: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        let key = StorageTrieKey::new(address, StoredNibbles(path));
+        Ok(self
+            .inner
+            .seek_with_prefix(key, hashed_address_prefix(address))?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
+    }
+
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        if !self.inner.is_positioned() {
+            return self.seek(Nibbles::default());
+        }
+        Ok(self
+            .inner
+            .next_with_prefix(hashed_address_prefix(address))?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
+    }
+
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        Ok(self
+            .inner
+            .current_key
+            .clone()
+            .and_then(|key| (key.hashed_address == address).then_some(key.path.0)))
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+impl TrieStorageCursor for RocksdbTrieCursor<'_, StorageTrieHistory> {
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = Some(hashed_address);
+        self.inner.current_key = None;
+    }
+}
+
+impl<'db> RocksdbStorageCursor<'db> {
+    /// Creates a `RocksDB` storage cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: B256) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: B256,
+    ) -> Self {
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
+    }
+}
+
+impl HashedCursor for RocksdbStorageCursor<'_> {
+    type Value = U256;
+
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        let storage_key = HashedStorageKey::new(self.hashed_address, key);
+        let result = self
+            .inner
+            .seek_with_prefix(storage_key, hashed_address_prefix(self.hashed_address))?
+            .and_then(|(key, value)| {
+                (key.hashed_address == self.hashed_address)
+                    .then_some((key.hashed_storage_key, value.0))
+            });
+
+        if let Some((_, value)) = result
+            && value.is_zero()
+        {
+            return self.next();
+        }
+
+        Ok(result)
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        if !self.inner.is_positioned() {
+            return self.seek(B256::ZERO);
+        }
+
+        loop {
+            let result = self
+                .inner
+                .next_with_prefix(hashed_address_prefix(self.hashed_address))?
+                .and_then(|(key, value)| {
+                    (key.hashed_address == self.hashed_address)
+                        .then_some((key.hashed_storage_key, value.0))
+                });
+
+            let Some((key, value)) = result else {
+                return Ok(None);
+            };
+            if value.is_zero() {
+                continue;
+            }
+            return Ok(Some((key, value)));
+        }
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+impl HashedStorageCursor for RocksdbStorageCursor<'_> {
+    fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
+        Ok(self.seek(B256::ZERO)?.is_none())
+    }
+
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = hashed_address;
+        self.inner.current_key = None;
+    }
+}
+
+impl<'db> RocksdbAccountCursor<'db> {
+    /// Creates a `RocksDB` account cursor.
+    pub fn new(db: &'db RocksDb, max_block_number: u64) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number) }
+    }
+
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+    ) -> Self {
+        Self { inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number) }
+    }
+}
+
+impl HashedCursor for RocksdbAccountCursor<'_> {
+    type Value = Account;
+
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.inner.seek(key)
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.inner.next()
+    }
+
+    fn reset(&mut self) {
+        self.inner.current_key = None;
+    }
+}
+
+fn rocksdb_error(error: rocksdb::Error) -> DatabaseError {
+    DatabaseError::Other(error.to_string())
+}
+
+fn encode_table_key<T: Table>(key: T::Key) -> Vec<u8> {
+    key.encode().as_ref().to_vec()
+}
+
+fn encode_table_value<T: Table>(value: &T::Value) -> Vec<u8> {
+    let mut encoded = <T::Value as Compress>::Compressed::default();
+    value.compress_to_buf(&mut encoded);
+    encoded.into()
+}
+
+fn encode_history_key<T>(key: &T::Key, block_number: u64) -> Result<Vec<u8>, DatabaseError>
+where
+    T: RocksDbHistoryTable,
+{
+    let mut encoded = encode_history_key_prefix::<T>(key)?;
+    encoded.extend_from_slice(&encode_history_block_suffix(block_number));
+    Ok(encoded)
+}
+
+fn encode_history_key_prefix<T>(key: &T::Key) -> Result<Vec<u8>, DatabaseError>
+where
+    T: RocksDbHistoryTable,
+{
+    T::encode_history_key_prefix(key)
+}
+
+fn decode_history_key<T>(raw_key: &[u8]) -> Result<(T::Key, u64), DatabaseError>
+where
+    T: RocksDbHistoryTable,
+{
+    if raw_key.len() != T::KEY_LEN + BLOCK_NUMBER_KEY_LEN {
+        return Err(DatabaseError::Decode);
+    }
+    let split = T::KEY_LEN;
+    let key = T::decode_history_key_prefix(&raw_key[..split])?;
+    let block_number = decode_history_block_suffix(&raw_key[split..])?;
+    Ok((key, block_number))
+}
+
+fn get_history_exact<T, V>(
+    snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
+    db: &Arc<RocksDb>,
+    key: T::Key,
+    block_number: u64,
+) -> BaseProofsStorageResult<Option<T::Value>>
+where
+    T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
+    T::Key: Clone,
+    T::Value: Decompress,
+    T: RocksDbHistoryTable,
+{
+    let cf = db.cf_handle(T::NAME).ok_or_else(|| {
+        DatabaseError::Other(format!("missing RocksDB column family {}", T::NAME))
+    })?;
+    snapshot
+        .get_cf(&cf, encode_history_key::<T>(&key, block_number)?)
+        .map_err(rocksdb_error)?
+        .map(|value| T::Value::decompress(&value).map_err(Into::into))
+        .transpose()
+}
+
+impl RocksDbHistoryTable for AccountTrieHistory {
+    const KEY_LEN: usize = PACKED_NIBBLES_KEY_LEN;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Result<Vec<u8>, DatabaseError> {
+        Ok(encode_packed_nibbles(&key.0)?.to_vec())
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        decode_packed_nibbles(raw_key).map(StoredNibbles)
+    }
+}
+
+impl RocksDbHistoryTable for StorageTrieHistory {
+    const KEY_LEN: usize = HASH_KEY_LEN + PACKED_NIBBLES_KEY_LEN;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Result<Vec<u8>, DatabaseError> {
+        let mut encoded = Vec::with_capacity(Self::KEY_LEN);
+        encoded.extend_from_slice(key.hashed_address.as_slice());
+        encoded.extend_from_slice(&encode_packed_nibbles(&key.path.0)?);
+        Ok(encoded)
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        if raw_key.len() != Self::KEY_LEN {
+            return Err(DatabaseError::Decode);
+        }
+        let hashed_address = B256::from_slice(&raw_key[..HASH_KEY_LEN]);
+        let path = StoredNibbles(decode_packed_nibbles(&raw_key[HASH_KEY_LEN..])?);
+        Ok(StorageTrieKey::new(hashed_address, path))
+    }
+}
+
+impl RocksDbHistoryTable for HashedAccountHistory {
+    const KEY_LEN: usize = HASH_KEY_LEN;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Result<Vec<u8>, DatabaseError> {
+        Ok(key.as_slice().to_vec())
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        if raw_key.len() != Self::KEY_LEN {
+            return Err(DatabaseError::Decode);
+        }
+        Ok(B256::from_slice(raw_key))
+    }
+}
+
+impl RocksDbHistoryTable for HashedStorageHistory {
+    const KEY_LEN: usize = HASH_KEY_LEN * 2;
+
+    fn encode_history_key_prefix(key: &Self::Key) -> Result<Vec<u8>, DatabaseError> {
+        let mut encoded = Vec::with_capacity(Self::KEY_LEN);
+        encoded.extend_from_slice(key.hashed_address.as_slice());
+        encoded.extend_from_slice(key.hashed_storage_key.as_slice());
+        Ok(encoded)
+    }
+
+    fn decode_history_key_prefix(raw_key: &[u8]) -> Result<Self::Key, DatabaseError> {
+        if raw_key.len() != Self::KEY_LEN {
+            return Err(DatabaseError::Decode);
+        }
+        Ok(HashedStorageKey::new(
+            B256::from_slice(&raw_key[..HASH_KEY_LEN]),
+            B256::from_slice(&raw_key[HASH_KEY_LEN..]),
+        ))
+    }
+}
+
+fn encode_packed_nibbles(nibbles: &Nibbles) -> Result<[u8; PACKED_NIBBLES_KEY_LEN], DatabaseError> {
+    if nibbles.len() > 64 {
+        return Err(DatabaseError::Other(format!(
+            "trie path has {} nibbles, max is 64",
+            nibbles.len()
+        )));
+    }
+    let mut encoded = [0; PACKED_NIBBLES_KEY_LEN];
+    nibbles.pack_to(&mut encoded[..HASH_KEY_LEN]);
+    encoded[HASH_KEY_LEN] = nibbles.len() as u8;
+    Ok(encoded)
+}
+
+fn decode_packed_nibbles(raw_key: &[u8]) -> Result<Nibbles, DatabaseError> {
+    if raw_key.len() != PACKED_NIBBLES_KEY_LEN {
+        return Err(DatabaseError::Decode);
+    }
+
+    let nibble_count = raw_key[HASH_KEY_LEN] as usize;
+    if nibble_count > 64 {
+        return Err(DatabaseError::Decode);
+    }
+
+    let packed_len = nibble_count.div_ceil(2);
+    if nibble_count % 2 == 1 && raw_key[packed_len - 1] & 0x0f != 0 {
+        return Err(DatabaseError::Decode);
+    }
+    if raw_key[packed_len..HASH_KEY_LEN].iter().any(|byte| *byte != 0) {
+        return Err(DatabaseError::Decode);
+    }
+
+    let mut nibbles = Vec::with_capacity(nibble_count);
+    for index in 0..nibble_count {
+        let byte = raw_key[index / 2];
+        let nibble = if index % 2 == 0 { byte >> 4 } else { byte & 0x0f };
+        nibbles.push(nibble);
+    }
+    Ok(Nibbles::from_nibbles_unchecked(nibbles))
+}
+
+const fn encode_block_number(block_number: u64) -> [u8; 8] {
+    block_number.to_be_bytes()
+}
+
+fn decode_block_number(raw_key: &[u8]) -> Result<u64, DatabaseError> {
+    if raw_key.len() != 8 {
+        return Err(DatabaseError::Decode);
+    }
+    Ok(u64::from_be_bytes(raw_key.try_into().map_err(|_| DatabaseError::Decode)?))
+}
+
+/// Encodes the block-number suffix attached to history-table keys so that newer
+/// blocks sort BEFORE older blocks under the default `BytewiseComparator`.
+///
+/// This is the standard "complement key" trick (`u64::MAX - block_number`) used
+/// to make "find latest version at or below block N" fast on an LSM-tree: a
+/// forward `seek(target)` followed by `next()` lands on the answer rather than
+/// requiring the much slower `seek_for_prev()` / `prev()` path.
+///
+/// Used ONLY for history-table key suffixes (`AccountTrieHistory`,
+/// `StorageTrieHistory`, `HashedAccountHistory`, `HashedStorageHistory`).
+/// `BlockChangeSet` keys remain plain big-endian (forward range scans).
+const fn encode_history_block_suffix(block_number: u64) -> [u8; 8] {
+    (u64::MAX - block_number).to_be_bytes()
+}
+
+/// Inverse of [`encode_history_block_suffix`].
+fn decode_history_block_suffix(raw_suffix: &[u8]) -> Result<u64, DatabaseError> {
+    if raw_suffix.len() != BLOCK_NUMBER_KEY_LEN {
+        return Err(DatabaseError::Decode);
+    }
+    let complement = u64::from_be_bytes(raw_suffix.try_into().map_err(|_| DatabaseError::Decode)?);
+    Ok(u64::MAX - complement)
+}
+
+fn range_start(range: &impl RangeBounds<u64>) -> u64 {
+    match range.start_bound() {
+        Bound::Included(start) => *start,
+        Bound::Excluded(start) => start.saturating_add(1),
+        Bound::Unbounded => 0,
+    }
+}
+
+fn flatten_and_sort<K: Ord>(map: HashMap<K, u64>) -> Vec<(K, u64)> {
+    let mut values: Vec<_> = map.into_iter().collect();
+    values.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    values
+}
+
+fn prefix_read_options(prefix: &[u8]) -> ReadOptions {
+    let mut read_options = ReadOptions::default();
+    read_options.set_iterate_lower_bound(prefix.to_vec());
+    if let Some(upper_bound) = prefix_upper_bound(prefix) {
+        read_options.set_iterate_upper_bound(upper_bound);
+    }
+    // The provided `prefix` is shorter than the CF-configured fixed_prefix
+    // extractor (which spans the full key prefix incl. inner sub-key bytes).
+    // Without total_order_seek=true, the bloom filter would skip SST blocks
+    // whose extracted prefix doesn't match the seek key's, silently dropping
+    // all entries except the one whose full CF prefix matches exactly.
+    // total_order_seek bypasses the prefix-domain restriction; the explicit
+    // iterate_lower_bound/iterate_upper_bound above still bound the scan.
+    read_options.set_total_order_seek(true);
+    read_options
+}
+
+fn exact_prefix_read_options(prefix: &[u8]) -> ReadOptions {
+    let mut read_options = prefix_read_options(prefix);
+    read_options.set_prefix_same_as_start(true);
+    read_options
+}
+
+fn total_order_read_options() -> ReadOptions {
+    let mut read_options = ReadOptions::default();
+    read_options.set_total_order_seek(true);
+    read_options
+}
+
+fn hashed_address_prefix(hashed_address: B256) -> Vec<u8> {
+    hashed_address.as_slice().to_vec()
+}
+
+fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut upper_bound = prefix.to_vec();
+    for index in (0..upper_bound.len()).rev() {
+        if upper_bound[index] != u8::MAX {
+            upper_bound[index] += 1;
+            upper_bound.truncate(index + 1);
+            return Some(upper_bound);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    };
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn temp_storage() -> (Arc<RocksdbProofsStorage>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).unwrap());
+        (storage, dir)
+    }
+
+    #[test]
+    fn max_total_wal_size_tracks_column_family_write_buffers() {
+        let options = RocksdbProofsStorageOptions::default();
+        assert_eq!(
+            RocksdbProofsStorage::max_total_wal_size(options),
+            RocksdbProofsStorage::column_families().len() as u64
+                * options.write_buffer_size as u64
+                * options.max_write_buffer_number as u64
+        );
+    }
+
+    #[test]
+    fn max_total_wal_size_uses_explicit_override() {
+        let options = RocksdbProofsStorageOptions {
+            max_total_wal_size: Some(512 * 1024 * 1024),
+            ..Default::default()
+        };
+        assert_eq!(RocksdbProofsStorage::max_total_wal_size(options), 512 * 1024 * 1024);
+    }
+
+    #[test]
+    fn default_options_use_sync_friendly_settings() {
+        let options = RocksdbProofsStorageOptions::default();
+        assert_eq!(options.compression, RocksdbProofsCompression::Lz4);
+        assert_eq!(options.bottommost_compression, RocksdbProofsCompression::Lz4);
+        assert_eq!(options.compression.db_compression_type(), DBCompressionType::Lz4);
+        assert_eq!(options.bottommost_compression.db_compression_type(), DBCompressionType::Lz4);
+        assert_eq!(options.block_cache_size, DEFAULT_BLOCK_CACHE_SIZE);
+        assert_eq!(options.bytes_per_sync, DEFAULT_BYTES_PER_SYNC);
+        assert_eq!(options.compaction_readahead_size, DEFAULT_COMPACTION_READAHEAD_SIZE);
+        assert_eq!(
+            options.level_zero_file_num_compaction_trigger,
+            DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+        );
+        assert_eq!(
+            options.level_zero_slowdown_writes_trigger,
+            DEFAULT_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER
+        );
+        assert_eq!(options.level_zero_stop_writes_trigger, DEFAULT_LEVEL_ZERO_STOP_WRITES_TRIGGER);
+        assert_eq!(options.max_background_jobs, DEFAULT_MAX_BACKGROUND_JOBS);
+        assert_eq!(options.max_subcompactions, DEFAULT_MAX_SUBCOMPACTIONS);
+        assert_eq!(options.max_write_buffer_number, DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        assert_eq!(options.target_file_size_base, DEFAULT_TARGET_FILE_SIZE_BASE);
+        assert_eq!(options.write_buffer_size, DEFAULT_WRITE_BUFFER_SIZE);
+        assert!(options.use_direct_io_for_flush_and_compaction);
+        assert_eq!(options.rate_limit_bytes_per_sec, None);
+    }
+
+    #[test]
+    fn history_prefix_lengths_match_encoded_key_prefixes() {
+        let account_path = StoredNibbles(Nibbles::from_nibbles_unchecked([1, 2, 3]));
+        let storage_path = StorageTrieKey::new(
+            B256::repeat_byte(0x01),
+            StoredNibbles(Nibbles::from_nibbles_unchecked([4, 5, 6])),
+        );
+        let hashed_account = B256::repeat_byte(0x02);
+        let hashed_storage =
+            HashedStorageKey::new(B256::repeat_byte(0x03), B256::repeat_byte(0x04));
+
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<AccountTrieHistory as Table>::NAME),
+            Some(PACKED_NIBBLES_KEY_LEN)
+        );
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<StorageTrieHistory as Table>::NAME),
+            Some(HASH_KEY_LEN + PACKED_NIBBLES_KEY_LEN)
+        );
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<HashedAccountHistory as Table>::NAME),
+            Some(HASH_KEY_LEN)
+        );
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<HashedStorageHistory as Table>::NAME),
+            Some(HASH_KEY_LEN * 2)
+        );
+        assert_eq!(RocksdbProofsStorage::history_prefix_len(<ProofWindow as Table>::NAME), None);
+
+        assert_eq!(
+            encode_history_key_prefix::<AccountTrieHistory>(&account_path).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<AccountTrieHistory as Table>::NAME).unwrap()
+        );
+        assert_eq!(
+            encode_history_key_prefix::<StorageTrieHistory>(&storage_path).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<StorageTrieHistory as Table>::NAME).unwrap()
+        );
+        assert_eq!(
+            encode_history_key_prefix::<HashedAccountHistory>(&hashed_account).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<HashedAccountHistory as Table>::NAME)
+                .unwrap()
+        );
+        assert_eq!(
+            encode_history_key_prefix::<HashedStorageHistory>(&hashed_storage).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<HashedStorageHistory as Table>::NAME)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn opens_with_history_prefix_filter_options() {
+        let dir = TempDir::new().unwrap();
+        let storage = RocksdbProofsStorage::new_with_options(
+            dir.path(),
+            RocksdbProofsStorageOptions::default(),
+        )
+        .unwrap();
+        let account = B256::repeat_byte(0x55);
+
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+        storage.store_trie_updates(block(1, B256::ZERO), account_update(account, 1)).unwrap();
+
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        let (key, acc) = storage
+            .account_hashed_cursor(1)
+            .unwrap()
+            .seek(account)
+            .unwrap()
+            .expect("account exists");
+        assert_eq!(key, account);
+        assert_eq!(acc.nonce, 1);
+    }
+
+    fn block(number: u64, parent: B256) -> BlockWithParent {
+        BlockWithParent {
+            parent,
+            block: BlockNumHash {
+                number,
+                hash: if number == 0 { B256::ZERO } else { B256::repeat_byte(number as u8) },
+            },
+        }
+    }
+
+    fn account_update(address: B256, nonce: u64) -> BlockStateDiff {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdates::default().into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    }
+
+    fn assert_completes(rx: mpsc::Receiver<BaseProofsStorageResult<()>>) {
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("operation should complete")
+            .expect("operation should succeed");
+    }
+
+    #[test]
+    fn packed_nibbles_round_trip() {
+        let nibbles = Nibbles::from_nibbles_unchecked([0, 1, 0, 2, 15, 0, 3]);
+        let encoded = encode_packed_nibbles(&nibbles).unwrap();
+
+        assert_eq!(encoded[HASH_KEY_LEN], 7);
+        assert_eq!(decode_packed_nibbles(&encoded).unwrap(), nibbles);
+    }
+
+    #[test]
+    fn packed_nibbles_preserve_lexicographic_order() {
+        let keys = [
+            vec![],
+            vec![0],
+            vec![0, 0],
+            vec![0, 1],
+            vec![1],
+            vec![1, 0],
+            vec![1, 1],
+            vec![2],
+            vec![15],
+            vec![15, 15],
+        ];
+
+        for left in &keys {
+            for right in &keys {
+                let left = Nibbles::from_nibbles_unchecked(left);
+                let right = Nibbles::from_nibbles_unchecked(right);
+                assert_eq!(
+                    left.cmp(&right),
+                    encode_packed_nibbles(&left)
+                        .unwrap()
+                        .cmp(&encode_packed_nibbles(&right).unwrap())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hashed_history_keys_preserve_full_byte_ordering() {
+        let keys = [B256::ZERO, B256::repeat_byte(2), B256::repeat_byte(255)];
+
+        for left in keys {
+            for right in keys {
+                assert_eq!(
+                    left.cmp(&right),
+                    encode_history_key_prefix::<HashedAccountHistory>(&left)
+                        .unwrap()
+                        .cmp(&encode_history_key_prefix::<HashedAccountHistory>(&right).unwrap())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn history_block_suffix_round_trip_covers_endpoints_and_interior() {
+        for block_number in [0u64, 1, 42, 1 << 20, u64::MAX / 2, u64::MAX - 1, u64::MAX] {
+            let encoded = encode_history_block_suffix(block_number);
+            let decoded = decode_history_block_suffix(&encoded).unwrap();
+            assert_eq!(decoded, block_number, "round-trip failed at block {block_number}");
+        }
+    }
+
+    #[test]
+    fn history_block_suffix_reverses_lexicographic_order() {
+        // Complement encoding: newer block must sort BEFORE older block under the default
+        // BytewiseComparator, so a forward seek(target) + next() finds "latest version <= N".
+        let blocks = [0u64, 1, 2, 100, 1_000_000, u64::MAX - 1, u64::MAX];
+        for left in blocks {
+            for right in blocks {
+                let encoded_cmp =
+                    encode_history_block_suffix(left).cmp(&encode_history_block_suffix(right));
+                assert_eq!(
+                    encoded_cmp,
+                    right.cmp(&left),
+                    "expected reversed ordering for ({left}, {right})",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn history_block_suffix_boundary_values_are_complementary() {
+        assert_eq!(encode_history_block_suffix(0), [0xFF; BLOCK_NUMBER_KEY_LEN]);
+        assert_eq!(encode_history_block_suffix(u64::MAX), [0x00; BLOCK_NUMBER_KEY_LEN]);
+        assert_eq!(decode_history_block_suffix(&[0xFF; BLOCK_NUMBER_KEY_LEN]).unwrap(), 0);
+        assert_eq!(decode_history_block_suffix(&[0x00; BLOCK_NUMBER_KEY_LEN]).unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn decode_history_block_suffix_rejects_wrong_length() {
+        assert!(decode_history_block_suffix(&[]).is_err());
+        assert!(decode_history_block_suffix(&[0u8; BLOCK_NUMBER_KEY_LEN - 1]).is_err());
+        assert!(decode_history_block_suffix(&[0u8; BLOCK_NUMBER_KEY_LEN + 1]).is_err());
+    }
+
+    #[test]
+    fn encoded_history_key_orders_newer_blocks_before_older_for_same_prefix() {
+        let prefix = B256::repeat_byte(0x7F);
+        let older = encode_history_key::<HashedAccountHistory>(&prefix, 10).unwrap();
+        let newer = encode_history_key::<HashedAccountHistory>(&prefix, 100).unwrap();
+        assert!(newer < older, "newer block must sort before older under complement encoding");
+
+        // Shared prefix preservation is what keeps RocksDB prefix bloom filters correct
+        // for forward seeks on history tables.
+        let prefix_bytes = encode_history_key_prefix::<HashedAccountHistory>(&prefix).unwrap();
+        assert!(older.starts_with(&prefix_bytes));
+        assert!(newer.starts_with(&prefix_bytes));
+    }
+
+    #[test]
+    fn packed_nibbles_reject_invalid_padding() {
+        let mut encoded =
+            encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1, 2, 3])).unwrap();
+        encoded[HASH_KEY_LEN - 1] = 1;
+        assert!(decode_packed_nibbles(&encoded).is_err());
+
+        let mut encoded = encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1])).unwrap();
+        encoded[0] |= 1;
+        assert!(decode_packed_nibbles(&encoded).is_err());
+    }
+
+    #[test]
+    fn append_can_run_while_prune_holds_history_read_gate() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert_completes(rx);
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+    }
+
+    #[test]
+    fn exclusive_history_gate_blocks_append() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let history_guard = storage.history_gate.write();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_lock_serializes_append_writers() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let append_guard = storage.append_lock.lock();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(append_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn prune_history_read_gate_blocks_history_rewrite() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage.replace_updates(BlockNumHash::new(0, B256::ZERO), vec![]);
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_during_prepared_prune_preserves_latest_block() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+        storage.store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default()).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), BlockStateDiff::default())
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared =
+            storage.prepare_prune(block(1, B256::ZERO)).unwrap().expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), BlockStateDiff::default())
+            .unwrap();
+        storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert!(latest_diff.sorted_trie_updates.account_nodes_ref().is_empty());
+        assert!(latest_diff.sorted_trie_updates.storage_tries_ref().is_empty());
+        assert!(latest_diff.sorted_post_state.accounts.is_empty());
+        assert!(latest_diff.sorted_post_state.storages.is_empty());
+    }
+
+    #[test]
+    fn append_inside_requested_prune_range_survives() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let address = B256::repeat_byte(0xAA);
+        storage.store_trie_updates(block(1, B256::ZERO), account_update(address, 1)).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), account_update(address, 2))
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared = storage
+            .prepare_prune(block(10, B256::repeat_byte(2)))
+            .unwrap()
+            .expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), account_update(address, 3))
+            .unwrap();
+        let counts = storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(counts.hashed_accounts_written_total, 1);
+        assert_eq!(counts.account_trie_updates_written_total, 0);
+        assert_eq!(counts.storage_trie_updates_written_total, 0);
+        assert_eq!(counts.hashed_storages_written_total, 0);
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((2, B256::repeat_byte(2))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert_eq!(
+            &latest_diff.sorted_post_state.accounts[..],
+            &[(address, Some(Account { nonce: 3, ..Default::default() }))]
+        );
+
+        let mut cursor = storage.account_hashed_cursor(3).unwrap();
+        assert_eq!(
+            cursor.seek(address).unwrap(),
+            Some((address, Account { nonce: 3, ..Default::default() }))
+        );
+    }
+
+    #[test]
+    fn storage_trie_cursor_finds_all_nibble_paths_after_flush() {
+        let (storage, _dir) = temp_storage();
+        let address = B256::repeat_byte(0xAA);
+
+        let nibble_paths = [
+            Nibbles::from_nibbles_unchecked(vec![0, 1]),
+            Nibbles::from_nibbles_unchecked(vec![1, 0]),
+            Nibbles::from_nibbles_unchecked(vec![2, 3, 4]),
+            Nibbles::from_nibbles_unchecked(vec![15, 0, 1]),
+        ];
+
+        let branch = BranchNodeCompact::new(
+            reth_trie_common::TrieMask::new(0b11),
+            reth_trie_common::TrieMask::default(),
+            reth_trie_common::TrieMask::default(),
+            vec![],
+            None,
+        );
+
+        let mut parent_hash = B256::ZERO;
+        for (i, path) in nibble_paths.iter().enumerate() {
+            let block_number = (i + 1) as u64;
+            let parent = block(block_number.saturating_sub(1), parent_hash);
+
+            let mut trie_updates = TrieUpdates::default();
+            let mut storage_updates = StorageTrieUpdates::default();
+            storage_updates.storage_nodes.insert(*path, branch.clone());
+            trie_updates.storage_tries.insert(address, storage_updates);
+
+            let diff = BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostState::default().into_sorted(),
+            };
+
+            parent_hash = parent.block.hash;
+            storage.store_trie_updates(parent, diff).expect("store should succeed");
+
+            storage.flush_and_compact().expect("flush should succeed");
+        }
+
+        // seek_exact uses exact_prefix_read_options (with prefix_same_as_start)
+        // and should find each entry individually.
+        for path in &nibble_paths {
+            let mut cursor =
+                storage.storage_trie_cursor(address, u64::MAX).expect("cursor should open");
+            let result = cursor.seek_exact(*path).expect("seek_exact should succeed");
+            assert!(result.is_some(), "seek_exact should find entry for path {path:?}");
+        }
+
+        // seek/next use prefix_read_options with a 32-byte address prefix
+        // on a CF with a 65-byte prefix extractor. After flush, the bloom
+        // filter can cause the iterator to skip SST blocks whose 65-byte
+        // prefix doesn't match the one extracted from the seek key.
+        let mut cursor =
+            storage.storage_trie_cursor(address, u64::MAX).expect("cursor should open");
+
+        let first = cursor.seek(Nibbles::default()).expect("seek should succeed");
+        assert!(first.is_some(), "seek should find at least one entry");
+
+        let mut found = vec![first.unwrap().0];
+        while let Some((path, _)) = cursor.next().expect("next should succeed") {
+            found.push(path);
+        }
+
+        let expected: Vec<Nibbles> = nibble_paths.to_vec();
+        assert_eq!(
+            found, expected,
+            "cursor should find all nibble paths for the address after flush"
+        );
+    }
+}

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -480,7 +480,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::MdbxProofsStorage;
+    use crate::RocksdbProofsStorage;
 
     /// Helper function to create a key
     fn k(b: u8) -> B256 {
@@ -508,7 +508,7 @@ mod tests {
     fn test_initialize_hashed_accounts() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test accounts into database
         let tx = db.tx_mut().unwrap();
@@ -559,7 +559,7 @@ mod tests {
     fn test_initialize_hashed_storage() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test storage into database
         let tx = db.tx_mut().unwrap();
@@ -618,7 +618,7 @@ mod tests {
     fn test_initialize_accounts_trie() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test trie nodes into database
         let tx = db.tx_mut().unwrap();
@@ -656,7 +656,7 @@ mod tests {
     fn test_initialize_storages_trie() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert test storage trie nodes into database
         let tx = db.tx_mut().unwrap();
@@ -725,7 +725,7 @@ mod tests {
     fn test_full_initialize_run() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // Insert some test data
         let tx = db.tx_mut().unwrap();
@@ -806,7 +806,7 @@ mod tests {
     fn test_initialize_run_skips_if_already_done() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         // set and commit initial state anchor
         storage
@@ -839,7 +839,7 @@ mod tests {
     fn test_initialize_resumes_hashed_accounts_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 
@@ -919,7 +919,7 @@ mod tests {
     fn test_initialize_resumes_hashed_storages_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 
@@ -1010,7 +1010,7 @@ mod tests {
     fn test_initialize_resumes_accounts_trie_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 
@@ -1078,7 +1078,7 @@ mod tests {
     fn test_initialize_resumes_storages_trie_with_no_dups() {
         let db = create_test_rw_db();
         let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
+        let store = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env"));
 
         store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
 

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -29,6 +29,8 @@ pub use in_memory::{
 pub mod db;
 pub use db::{
     MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor,
+    RocksdbAccountCursor, RocksdbProofsCompression, RocksdbProofsStorage,
+    RocksdbProofsStorageOptions, RocksdbReadSnapshot, RocksdbStorageCursor, RocksdbTrieCursor,
 };
 
 pub mod metrics;

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -29,7 +29,7 @@ pub use in_memory::{
 pub mod db;
 pub use db::{
     MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor,
-    RocksdbAccountCursor, RocksdbProofsCompression, RocksdbProofsStorage,
+    RocksdbAccountCursor, RocksdbBatchSession, RocksdbProofsCompression, RocksdbProofsStorage,
     RocksdbProofsStorageOptions, RocksdbReadSnapshot, RocksdbStorageCursor, RocksdbTrieCursor,
 };
 

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
 use reth_provider::BlockHashReader;
 use tokio::time::Instant;
-use tracing::{debug, error, info, trace};
+use tracing::{error, info, trace};
 
 use crate::{
     BaseProofsStorage, BaseProofsStore,
@@ -59,6 +59,15 @@ where
         };
 
         let target_earliest_block = self.target_earliest_block(latest_block);
+        info!(
+            target: "trie::pruner",
+            earliest_block,
+            latest_block,
+            target_earliest_block,
+            retention_blocks = self.retention_blocks,
+            prune_batch_size = self.prune_batch_size,
+            "Calculated proof storage pruning target",
+        );
         if earliest_block >= target_earliest_block {
             trace!(target: "trie::pruner", "Nothing to prune");
             return Ok(PrunerOutput::default());
@@ -110,7 +119,7 @@ where
     /// Prunes a single batch of blocks.
     fn prune_batch(&self, start_block: u64, end_block: u64) -> Result<PrunerOutput, PrunerError> {
         let batch_start_time = Instant::now();
-        debug!(
+        info!(
             target: "trie::pruner",
             start_block,
             end_block,
@@ -154,7 +163,7 @@ where
             block: BlockNumHash { number: end_block, hash: new_earliest_block_hash },
         };
 
-        debug!(
+        info!(
             target: "trie::pruner",
             start_block,
             end_block,
@@ -162,7 +171,7 @@ where
             "Resolved proof storage prune batch block hashes",
         );
 
-        debug!(
+        info!(
             target: "trie::pruner",
             start_block,
             end_block,
@@ -196,7 +205,6 @@ where
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -215,7 +223,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::{BlockStateDiff, db::MdbxProofsStorage};
+    use crate::{BlockStateDiff, db::RocksdbProofsStorage};
 
     mock! (
         #[derive(Debug)]
@@ -250,8 +258,8 @@ mod tests {
     async fn run_inner_and_and_verify_updated_state() {
         // --- env/store ---
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
@@ -533,8 +541,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_where_latest_block_is_none() {
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         let earliest = store.get_earliest_block_number().unwrap();
         let latest = store.get_latest_block_number().unwrap();
@@ -551,8 +559,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_earliest_none_real_db() {
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         // Write a single block to set *latest* only.
         store
@@ -574,8 +582,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_interval_too_small_real_db() {
         let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")));
 
         // Set earliest=4 explicitly
         let earliest_num = 4u64;

--- a/crates/execution/trie/tests/branch_cursors/mod.rs
+++ b/crates/execution/trie/tests/branch_cursors/mod.rs
@@ -1,0 +1,693 @@
+//! Branch trie cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+// =============================================================================
+// 1. Basic Cursor Operations
+// =============================================================================
+
+/// Test cursor operations on empty trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // All operations should return None on empty trie
+    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
+    assert!(cursor.seek(Nibbles::default())?.is_none());
+    assert!(cursor.next()?.is_none());
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with single entry
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    // Store single entry
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test seek_exact
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Test current position
+    assert_eq!(cursor.current()?.unwrap(), path);
+
+    // Test next from end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with multiple entries
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![2, 3]),
+    ];
+    let branch = create_test_branch();
+
+    // Store multiple entries
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test that we can iterate through all entries
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    assert_eq!(found_paths.len(), 4);
+    // Paths should be in lexicographic order
+    for i in 0..paths.len() {
+        assert_eq!(found_paths[i], paths[i]);
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// 2. Seek Operations
+// =============================================================================
+
+/// Test `seek_exact` with existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test `seek_exact` with non-existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let non_existing = nibbles_from(vec![4, 5, 6]);
+    assert!(cursor.seek_exact(non_existing)?.is_none());
+
+    Ok(())
+}
+
+/// Test `seek_exact` with empty path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
+    assert_eq!(result.0, Nibbles::default());
+
+    Ok(())
+}
+
+/// Test seek to existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test seek between existing nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path between 1 and 3, should return path 3
+    let seek_path = nibbles_from(vec![2]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test seek after all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path after all nodes
+    let seek_path = nibbles_from(vec![9]);
+    assert!(cursor.seek(seek_path)?.is_none());
+
+    Ok(())
+}
+
+/// Test seek before all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![5]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path before all nodes, should return first node
+    let seek_path = nibbles_from(vec![1]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+// =============================================================================
+// 3. Navigation Tests
+// =============================================================================
+
+/// Test next without prior seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // next() without prior seek should start from beginning
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test next after seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path1)?;
+
+    // next() should return second node
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test next at end of trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path)?;
+
+    // next() at end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test multiple consecutive next calls
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Iterate through all with consecutive next() calls
+    for expected_path in &paths {
+        let result = cursor.next()?.unwrap();
+        assert_eq!(result.0, *expected_path);
+    }
+
+    // Final next() should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test current after operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None initially
+    assert!(cursor.current()?.is_none());
+
+    // After seek, current should track position
+    cursor.seek(path1)?;
+    assert_eq!(cursor.current()?.unwrap(), path1);
+
+    // After next, current should update
+    cursor.next()?;
+    assert_eq!(cursor.current()?.unwrap(), path2);
+
+    Ok(())
+}
+
+/// Test current with no prior operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None when no operations performed
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 4. Block Number Filtering
+// =============================================================================
+
+/// Test same path with different blocks
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch1 = create_test_branch();
+    let branch2 = create_test_branch_variant();
+
+    // Store same path at different blocks
+    storage.store_account_branches(vec![(path, Some(branch1))])?;
+    storage.store_account_branches(vec![(path, Some(branch2))])?;
+
+    // Cursor with max_block_number=75 should see only block 50 data
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    let result75 = cursor75.seek_exact(path)?.unwrap();
+    assert_eq!(result75.0, path);
+
+    // Cursor with max_block_number=150 should see block 100 data (latest)
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    let result150 = cursor150.seek_exact(path)?.unwrap();
+    assert_eq!(result150.0, path);
+
+    Ok(())
+}
+
+/// Test deleted branch nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Store branch node, then delete it (store None)
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // Cursor before deletion should see the node
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    assert!(cursor75.seek_exact(path)?.is_some());
+
+    let mut block_state_diff_trie_updates = TrieUpdates::default();
+    block_state_diff_trie_updates.removed_nodes.insert(path);
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should not see the node
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    assert!(cursor150.seek_exact(path)?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 5. Hashed Address Filtering
+// =============================================================================
+
+/// Test account-specific cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr1 = B256::repeat_byte(0x01);
+    let addr2 = B256::repeat_byte(0x02);
+    let branch = create_test_branch();
+
+    // Store same path for different accounts (using storage branches)
+    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
+    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
+
+    // Cursor for addr1 should only see addr1 data
+    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
+    let result1 = cursor1.seek_exact(path)?.unwrap();
+    assert_eq!(result1.0, path);
+
+    // Cursor for addr2 should only see addr2 data
+    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
+    let result2 = cursor2.seek_exact(path)?.unwrap();
+    assert_eq!(result2.0, path);
+
+    // Cursor for addr1 should not see addr2 data when iterating
+    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
+    let mut found_count = 0;
+    while cursor1_iter.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
+
+    Ok(())
+}
+
+/// Test state trie cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store data for account trie and state trie
+    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // State trie cursor (None address) should only see state trie data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let result = state_cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Verify state cursor doesn't see account data when iterating
+    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
+    let mut found_count = 0;
+    while state_cursor_iter.next()?.is_some() {
+        found_count += 1;
+    }
+
+    assert_eq!(found_count, 1); // Should only see state trie entry
+
+    Ok(())
+}
+
+/// Test mixed account and state data
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store mixed account and state trie data
+    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    // Account cursor should only see account data
+    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
+    let mut account_paths = Vec::new();
+    while let Some((path, _)) = account_cursor.next()? {
+        account_paths.push(path);
+    }
+    assert_eq!(account_paths.len(), 1);
+    assert_eq!(account_paths[0], path1);
+
+    // State cursor should only see state data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let mut state_paths = Vec::new();
+    while let Some((path, _)) = state_cursor.next()? {
+        state_paths.push(path);
+    }
+    assert_eq!(state_paths.len(), 1);
+    assert_eq!(state_paths[0], path2);
+
+    Ok(())
+}
+
+// =============================================================================
+// 6. Path Ordering Tests
+// =============================================================================
+
+/// Test lexicographic ordering
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![3, 1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![1]),
+    ];
+    let branch = create_test_branch();
+
+    // Store paths in random order
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
+    let expected_order = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![3, 1]),
+    ];
+
+    assert_eq!(found_paths, expected_order);
+
+    Ok(())
+}
+
+/// Test path prefix scenarios
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),       // Prefix of next
+        nibbles_from(vec![1, 2]),    // Extends first
+        nibbles_from(vec![1, 2, 3]), // Extends second
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Seek to prefix should find exact match
+    let result = cursor.seek_exact(paths[0])?.unwrap();
+    assert_eq!(result.0, paths[0]);
+
+    // Next should go to next path, not skip prefixed paths
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[1]);
+
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[2]);
+
+    Ok(())
+}
+
+/// Test complex nibble combinations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test various nibble patterns including edge values
+    let paths = vec![
+        nibbles_from(vec![0]),
+        nibbles_from(vec![0, 15]),
+        nibbles_from(vec![15]),
+        nibbles_from(vec![15, 0]),
+        nibbles_from(vec![7, 8, 9]),
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // All paths should be found and in correct order
+    assert_eq!(found_paths.len(), 5);
+
+    // Verify specific ordering for edge cases
+    assert_eq!(found_paths[0], nibbles_from(vec![0]));
+    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
+    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/hashed_cursors/mod.rs
+++ b/crates/execution/trie/tests/hashed_cursors/mod.rs
@@ -535,14 +535,8 @@ fn test_exact_storage_reads_do_not_return_lower_bound_neighbor<
         vec![(left_key, U256::from(100)), (right_key, U256::from(300))],
     )?;
 
-    assert_eq!(
-        storage_exact(&storage, hashed_address, left_key, 100)?,
-        Some(U256::from(100))
-    );
-    assert_eq!(
-        storage_exact(&storage, hashed_address, right_key, 100)?,
-        Some(U256::from(300))
-    );
+    assert_eq!(storage_exact(&storage, hashed_address, left_key, 100)?, Some(U256::from(100)));
+    assert_eq!(storage_exact(&storage, hashed_address, right_key, 100)?, Some(U256::from(300)));
     assert_eq!(storage_exact(&storage, hashed_address, missing_key, 100)?, None);
 
     Ok(())
@@ -639,7 +633,10 @@ fn test_rocksdb_exact_reads_use_supplied_snapshot() -> Result<(), BaseProofsStor
     assert_eq!(k, storage_key);
     assert_eq!(v, U256::from(10));
 
-    assert_eq!(storage_exact(&storage.storage, hashed_address, storage_key, 2)?, Some(U256::from(20)));
+    assert_eq!(
+        storage_exact(&storage.storage, hashed_address, storage_key, 2)?,
+        Some(U256::from(20))
+    );
 
     Ok(())
 }

--- a/crates/execution/trie/tests/hashed_cursors/mod.rs
+++ b/crates/execution/trie/tests/hashed_cursors/mod.rs
@@ -1,0 +1,707 @@
+//! Hashed account and storage cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+fn account_exact<S: BaseProofsStore>(
+    storage: &S,
+    key: B256,
+    max_block: u64,
+) -> Result<Option<Account>, BaseProofsStorageError> {
+    Ok(storage
+        .account_hashed_cursor(max_block)?
+        .seek(key)?
+        .and_then(|(k, v)| (k == key).then_some(v)))
+}
+
+fn storage_exact<S: BaseProofsStore>(
+    storage: &S,
+    hashed_address: B256,
+    key: B256,
+    max_block: u64,
+) -> Result<Option<U256>, BaseProofsStorageError> {
+    Ok(storage
+        .storage_hashed_cursor(hashed_address, max_block)?
+        .seek(key)?
+        .and_then(|(k, v)| (k == key).then_some(v)))
+}
+
+// =============================================================================
+// 7. Leaf Node Tests (Hashed Accounts and Storage)
+// =============================================================================
+
+/// Test store and retrieve single account
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account = create_test_account();
+
+    // Store account
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let result = cursor.seek(account_key)?.unwrap();
+
+    assert_eq!(result.0, account_key);
+    assert_eq!(result.1.nonce, account.nonce);
+    assert_eq!(result.1.balance, account.balance);
+    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
+
+    Ok(())
+}
+
+/// Test account cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let accounts = [
+        (B256::repeat_byte(0x01), create_test_account()),
+        (B256::repeat_byte(0x03), create_test_account()),
+        (B256::repeat_byte(0x05), create_test_account()),
+    ];
+
+    // Store accounts
+    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
+    storage.store_hashed_accounts(accounts_to_store)?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Test seeking to exact key
+    let result = cursor.seek(accounts[1].0)?.unwrap();
+    assert_eq!(result.0, accounts[1].0);
+
+    // Test seeking to key that doesn't exist (should return next greater)
+    let seek_key = B256::repeat_byte(0x02);
+    let result = cursor.seek(seek_key)?.unwrap();
+    assert_eq!(result.0, accounts[1].0); // Should find 0x03
+
+    // Test next() navigation
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, accounts[2].0); // Should find 0x05
+
+    // Test next() at end
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test that a `RocksDB` cursor reads from the snapshot captured when it is created.
+#[test]
+#[serial]
+fn test_rocksdb_account_cursor_uses_creation_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let key1 = B256::repeat_byte(0x01);
+    let key2 = B256::repeat_byte(0x02);
+    let account1 = create_test_account_with_values(1, 100, 0xAA);
+    let account2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(key1, Some(account1));
+    post_state.accounts.insert(key2, Some(account2));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let mut cursor = storage.account_hashed_cursor(1)?;
+    let first = cursor.seek(key1)?.expect("first account exists");
+    assert_eq!(first.0, key1);
+
+    let replacement_block1 =
+        BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x22)));
+    let mut replacement_post_state = HashedPostState::default();
+    replacement_post_state.accounts.insert(key1, Some(account1));
+    storage.replace_updates(
+        BlockNumHash::new(0, B256::ZERO),
+        vec![(
+            replacement_block1,
+            BlockStateDiff {
+                sorted_trie_updates: TrieUpdatesSorted::default(),
+                sorted_post_state: replacement_post_state.into_sorted(),
+            },
+        )],
+    )?;
+
+    let next = cursor.next()?.expect("existing cursor keeps its original snapshot");
+    assert_eq!(next.0, key2);
+    assert_eq!(next.1.nonce, account2.nonce);
+
+    let mut fresh_cursor = storage.account_hashed_cursor(1)?;
+    let fresh_result = fresh_cursor.seek(key2)?;
+    assert!(
+        !matches!(fresh_result, Some((found_key, _)) if found_key == key2),
+        "fresh cursor should not see the replaced account"
+    );
+
+    Ok(())
+}
+
+/// Test account block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
+    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
+
+    // Store account at different blocks
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
+
+    // Cursor with max_block_number=75 should see v1
+    let mut cursor75 = storage.account_hashed_cursor(75)?;
+    let result75 = cursor75.seek(account_key)?.unwrap();
+    assert_eq!(result75.1.nonce, account_v1.nonce);
+    assert_eq!(result75.1.balance, account_v1.balance);
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
+
+    // After update, Cursor with max_block_number=150 should see v2
+    let mut cursor150 = storage.account_hashed_cursor(150)?;
+    let result150 = cursor150.seek(account_key)?.unwrap();
+    assert_eq!(result150.1.nonce, account_v2.nonce);
+    assert_eq!(result150.1.balance, account_v2.balance);
+
+    Ok(())
+}
+
+/// Test store and retrieve storage
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+
+fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+    ];
+
+    // Store storage slots
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Test seeking to each slot
+    for (key, expected_value) in &storage_slots {
+        let result = cursor.seek(*key)?.unwrap();
+        assert_eq!(result.0, *key);
+        assert_eq!(result.1, *expected_value);
+    }
+
+    Ok(())
+}
+
+/// Test storage cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x50), U256::from(500)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Start from beginning with next()
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    assert_eq!(found_slots.len(), 3);
+    assert_eq!(found_slots[0], storage_slots[0]);
+    assert_eq!(found_slots[1], storage_slots[1]);
+    assert_eq!(found_slots[2], storage_slots[2]);
+
+    Ok(())
+}
+
+/// Test storage account isolation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let address1 = B256::repeat_byte(0x01);
+    let address2 = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store same storage key for different accounts
+    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
+    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
+
+    // Verify each account sees only its own storage
+    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
+    let result1 = cursor1.seek(storage_key)?.unwrap();
+    assert_eq!(result1.1, U256::from(100));
+
+    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
+    let result2 = cursor2.seek(storage_key)?.unwrap();
+    assert_eq!(result2.1, U256::from(200));
+
+    // Verify cursor1 doesn't see address2's storage
+    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
+    let mut count = 0;
+    while cursor1_iter.next()?.is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 1); // Should only see one entry
+
+    Ok(())
+}
+
+/// Test storage block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store storage at different blocks
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor with max_block_number=75 should see old value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
+    // Cursor with max_block_number=150 should see new value
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?.unwrap();
+    assert_eq!(result150.1, U256::from(200));
+
+    Ok(())
+}
+
+/// Test storage zero value deletion
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store non-zero value
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor before deletion should see the value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    // "Delete" by storing zero value at block 100
+    let mut block_state_diff_post_state = HashedPostState::default();
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::ZERO);
+    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
+
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: block_state_diff_post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should NOT see the entry (zero values are skipped)
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?;
+    assert!(result150.is_none(), "Zero values should be skipped/deleted");
+
+    Ok(())
+}
+
+/// Test that zero values are skipped during iteration
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+
+    // Create a mix of non-zero and zero value storage slots
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
+        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
+        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
+    ];
+
+    // Store all slots
+    storage.store_hashed_storages(hashed_address, storage_slots)?;
+
+    // Create cursor and iterate through all entries
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    // Should only find 3 non-zero values
+    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
+
+    // Verify the non-zero values are the ones we stored
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
+
+    // Verify seeking to a zero-value slot returns None or skips to next non-zero
+    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
+
+    // Should either return None or skip to the next non-zero value (0x30)
+    if let Some((key, value)) = seek_result {
+        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
+        assert_eq!(value, U256::from(300));
+    }
+
+    Ok(())
+}
+
+/// Test empty cursors
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test empty account cursor
+    let mut account_cursor = storage.account_hashed_cursor(100)?;
+    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
+    assert!(account_cursor.next()?.is_none());
+
+    // Test empty storage cursor
+    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
+    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
+    assert!(storage_cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor boundary conditions
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x80); // Middle value
+    let account = create_test_account();
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Seek to minimum key should find our account
+    let result = cursor.seek(B256::ZERO)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    // Seek to maximum key should find nothing
+    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
+
+    // Seek to key just before our account should find our account
+    let just_before = B256::repeat_byte(0x7F);
+    let result = cursor.seek(just_before)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    Ok(())
+}
+
+/// Test large batch operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Create large batch of accounts
+    let mut accounts = Vec::new();
+    for i in 0..100 {
+        let key = B256::from([i as u8; 32]);
+        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
+        accounts.push((key, Some(account)));
+    }
+
+    // Store in batch
+    storage.store_hashed_accounts(accounts.clone())?;
+
+    // Verify all accounts can be retrieved
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let mut found_count = 0;
+    while cursor.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 100);
+
+    // Test specific account retrieval
+    let test_key = B256::from([42u8; 32]);
+    let result = cursor.seek(test_key)?.unwrap();
+    assert_eq!(result.0, test_key);
+    assert_eq!(result.1.nonce, 42);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_exact_account_reads_do_not_return_lower_bound_neighbor<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let left_key = B256::repeat_byte(0x10);
+    let missing_key = B256::repeat_byte(0x20);
+    let right_key = B256::repeat_byte(0x30);
+    let left_account = create_test_account_with_values(1, 100, 0xAA);
+    let right_account = create_test_account_with_values(2, 200, 0xBB);
+
+    storage.store_hashed_accounts(vec![
+        (left_key, Some(left_account)),
+        (right_key, Some(right_account)),
+    ])?;
+
+    assert_eq!(account_exact(&storage, left_key, 100)?, Some(left_account));
+    assert_eq!(account_exact(&storage, right_key, 100)?, Some(right_account));
+    assert_eq!(account_exact(&storage, missing_key, 100)?, None);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_exact_storage_reads_do_not_return_lower_bound_neighbor<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0xA0);
+    let left_key = B256::repeat_byte(0x10);
+    let missing_key = B256::repeat_byte(0x20);
+    let right_key = B256::repeat_byte(0x30);
+
+    storage.store_hashed_storages(
+        hashed_address,
+        vec![(left_key, U256::from(100)), (right_key, U256::from(300))],
+    )?;
+
+    assert_eq!(
+        storage_exact(&storage, hashed_address, left_key, 100)?,
+        Some(U256::from(100))
+    );
+    assert_eq!(
+        storage_exact(&storage, hashed_address, right_key, 100)?,
+        Some(U256::from(300))
+    );
+    assert_eq!(storage_exact(&storage, hashed_address, missing_key, 100)?, None);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_exact_reads_hide_deleted_account_and_zero_storage<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let deleted_account_key = B256::repeat_byte(0x40);
+    let live_account_key = B256::repeat_byte(0x50);
+    let hashed_address = B256::repeat_byte(0x60);
+    let zero_slot = B256::repeat_byte(0x70);
+    let live_slot = B256::repeat_byte(0x80);
+    let live_account = create_test_account();
+
+    storage.store_hashed_accounts(vec![
+        (deleted_account_key, None),
+        (live_account_key, Some(live_account)),
+    ])?;
+    storage.store_hashed_storages(
+        hashed_address,
+        vec![(zero_slot, U256::ZERO), (live_slot, U256::from(1))],
+    )?;
+
+    assert_eq!(account_exact(&storage, deleted_account_key, 100)?, None);
+    assert_eq!(account_exact(&storage, live_account_key, 100)?, Some(live_account));
+    assert_eq!(storage_exact(&storage, hashed_address, zero_slot, 100)?, None);
+    assert_eq!(storage_exact(&storage, hashed_address, live_slot, 100)?, Some(U256::from(1)));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rocksdb_exact_reads_use_supplied_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x01);
+    let hashed_address = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x03);
+    let account_v1 = create_test_account_with_values(1, 100, 0xAA);
+    let account_v2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::from(10));
+    post_state.storages.insert(hashed_address, hashed_storage);
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let tx = storage.storage.ro_tx()?;
+
+    let block2 = BlockWithParent::new(block1.block.hash, NumHash::new(2, B256::repeat_byte(0x22)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v2));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::from(20));
+    post_state.storages.insert(hashed_address, hashed_storage);
+    storage.store_trie_updates(
+        block2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let (k, v) = storage
+        .storage
+        .account_hashed_cursor_with_tx(&tx, 2)?
+        .seek(account_key)?
+        .expect("account exists in snapshot");
+    assert_eq!(k, account_key);
+    assert_eq!(v, account_v1);
+
+    assert_eq!(account_exact(&storage.storage, account_key, 2)?, Some(account_v2));
+
+    let (k, v) = storage
+        .storage
+        .storage_hashed_cursor_with_tx(&tx, hashed_address, 2)?
+        .seek(storage_key)?
+        .expect("storage exists in snapshot");
+    assert_eq!(k, storage_key);
+    assert_eq!(v, U256::from(10));
+
+    assert_eq!(storage_exact(&storage.storage, hashed_address, storage_key, 2)?, Some(U256::from(20)));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rocksdb_exact_lookup_finds_latest_version_at_or_below_bound()
+-> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x51);
+    let account_v1 = create_test_account_with_values(1, 100, 0xAA);
+    let account_v3 = create_test_account_with_values(3, 300, 0xCC);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v1));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let block3 = BlockWithParent::new(block1.block.hash, NumHash::new(3, B256::repeat_byte(0x33)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v3));
+    storage.store_trie_updates(
+        block3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    assert_eq!(account_exact(&storage.storage, account_key, 2)?, Some(account_v1));
+    assert_eq!(account_exact(&storage.storage, account_key, 3)?, Some(account_v3));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rocksdb_exact_lookup_returns_none_when_versions_are_above_bound()
+-> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x61);
+    let account = create_test_account_with_values(10, 1_000, 0xAA);
+
+    let block10 = BlockWithParent::new(B256::ZERO, NumHash::new(10, B256::repeat_byte(0x10)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account));
+    storage.store_trie_updates(
+        block10,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    assert_eq!(account_exact(&storage.storage, account_key, 9)?, None);
+    assert_eq!(account_exact(&storage.storage, account_key, 10)?, Some(account));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/history/mod.rs
+++ b/crates/execution/trie/tests/history/mod.rs
@@ -1,0 +1,292 @@
+//! History fetch, prune, and unwind behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_fetch_trie_updates_basic<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = test_block(B256::ZERO, 1, 0x11);
+    let account_address = B256::repeat_byte(0x11);
+    let deleted_account = B256::repeat_byte(0x22);
+    let storage_address = B256::repeat_byte(0x33);
+    let trie_storage_address = B256::repeat_byte(0x44);
+    let slot = B256::repeat_byte(0xA1);
+    let account = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(nibbles_from(vec![0, 1, 2, 3]), BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates
+        .storage_nodes
+        .insert(nibbles_from(vec![1, 2, 3, 4]), BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(trie_storage_address, storage_trie_updates);
+
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_address, Some(account));
+    post_state.accounts.insert(deleted_account, None);
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(slot, U256::from(1234));
+    post_state.storages.insert(storage_address, hashed_storage);
+
+    let expected = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, expected.clone())?;
+
+    let actual = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(
+        actual.sorted_trie_updates.account_nodes_ref(),
+        expected.sorted_trie_updates.account_nodes_ref()
+    );
+    assert_eq!(
+        actual.sorted_trie_updates.storage_tries_ref(),
+        expected.sorted_trie_updates.storage_tries_ref()
+    );
+    assert_eq!(actual.sorted_post_state.accounts, expected.sorted_post_state.accounts);
+    assert_eq!(actual.sorted_post_state.storages, expected.sorted_post_state.storages);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_out_of_order_rejects<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let block_42 = test_block(B256::ZERO, 42, 0x42);
+    storage.store_trie_updates(block_42, BlockStateDiff::default())?;
+
+    let bad_block = test_block(B256::repeat_byte(0xFF), 99, 0x99);
+    let error = storage.store_trie_updates(bad_block, BlockStateDiff::default()).unwrap_err();
+    assert!(matches!(error, BaseProofsStorageError::OutOfOrder { .. }));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_address = B256::repeat_byte(1);
+    let storage_slot = B256::repeat_byte(2);
+    let account_path = nibbles_from(vec![1]);
+    let storage_path = nibbles_from(vec![3]);
+    let account_v1 = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+    let account_v2 = Account { nonce: 2, balance: U256::from(200), ..Default::default() };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(account_path, BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates.storage_nodes.insert(storage_path, BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(account_address, storage_trie_updates);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_address, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_slot, U256::from(1234));
+    post_state_1.storages.insert(account_address, hashed_storage);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_address, Some(account_v2));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.prune_earliest_state(block_3)?;
+
+    assert_account_at(&storage, 3, account_address, account_v2)?;
+    assert_storage_at(&storage, account_address, 3, storage_slot, U256::from(1234))?;
+    assert_account_branch_present(&storage, 3, account_path)?;
+
+    let mut storage_cursor = storage.storage_trie_cursor(account_address, 3)?;
+    assert!(storage_cursor.seek_exact(storage_path)?.is_some());
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_returns_correct_counts<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(address, Some(Account { nonce: 1, ..Default::default() }));
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(address, Some(Account { nonce: 2, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+
+    let counts = storage.prune_earliest_state(block_2)?;
+    assert_eq!(counts.hashed_accounts_written_total, 1);
+    assert_eq!(counts.account_trie_updates_written_total, 0);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_with_trie_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let path_1 = nibbles_from(vec![1]);
+    let path_2 = nibbles_from(vec![2]);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    for (block, path) in [(block_1, path_1), (block_2, path_2), (block_3, path_1)] {
+        let mut trie_updates = TrieUpdates::default();
+        trie_updates.account_nodes.insert(path, BranchNodeCompact::default());
+        storage.store_trie_updates(
+            block,
+            BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostStateSorted::default(),
+            },
+        )?;
+    }
+
+    storage.unwind_history(block_2)?;
+    assert_account_branch_present(&storage, 10, path_1)?;
+    assert_account_branch_missing(&storage, 10, path_2)
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_1 = B256::repeat_byte(1);
+    let account_2 = B256::repeat_byte(2);
+    let slot_1 = B256::repeat_byte(3);
+    let slot_2 = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_1, Some(Account::default()));
+    let mut storage_1 = HashedStorage::default();
+    storage_1.storage.insert(slot_1, U256::from(1111));
+    post_state_1.storages.insert(account_1, storage_1);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_2, Some(Account::default()));
+    let mut storage_2 = HashedStorage::default();
+    storage_2.storage.insert(slot_2, U256::from(2222));
+    post_state_2.storages.insert(account_2, storage_2);
+
+    let mut post_state_3 = HashedPostState::default();
+    post_state_3.accounts.insert(account_1, Some(Account { nonce: 9, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_3.into_sorted(),
+        },
+    )?;
+
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    assert_eq!(storage.get_latest_block_number()?, Some((1, block_1.block.hash)));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_idempotent<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(1);
+    let make_diff = |nonce| {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    storage.store_trie_updates(block_1, make_diff(10))?;
+    storage.store_trie_updates(block_2, make_diff(20))?;
+    storage.store_trie_updates(block_3, make_diff(30))?;
+
+    storage.unwind_history(block_2)?;
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    Ok(())
+}

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -5,19 +5,19 @@ use std::sync::Arc;
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    InMemoryProofsStorage, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStorageResult, BaseProofsStore,
+    BlockStateDiff, InMemoryProofsStorage,
+    api::{InitialStateAnchor, WriteCounts},
+    db::{MdbxProofsStorage, RocksdbProofsStorage},
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
     BranchNodeCompact, HashedPostState, HashedPostStateSorted, HashedStorage, Nibbles, TrieMask,
     hashed_cursor::HashedCursor,
     trie_cursor::TrieCursor,
-    updates::{TrieUpdates, TrieUpdatesSorted},
+    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
 };
-use serial_test::serial;
 use tempfile::TempDir;
-use test_case::test_case;
 
 /// Helper to create a simple test branch node
 fn create_test_branch() -> BranchNodeCompact {
@@ -77,1978 +77,265 @@ fn create_mdbx_proofs_storage() -> MdbxProofsStorage {
     MdbxProofsStorage::new(path.path()).unwrap()
 }
 
-/// Test basic storage and retrieval of earliest block number
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Initially should be None
-    let earliest = storage.get_earliest_block_number()?;
-    assert!(earliest.is_none());
-
-    // Set earliest block
-    let block_hash = B256::repeat_byte(0x42);
-    storage.set_earliest_block_number(100, block_hash)?;
-
-    // Should retrieve the same values
-    let earliest = storage.get_earliest_block_number()?;
-    assert_eq!(earliest, Some((100, block_hash)));
-
-    Ok(())
+#[derive(Debug)]
+struct TestRocksdbProofsStorage {
+    storage: RocksdbProofsStorage,
+    _dir: TempDir,
 }
 
-/// Test storing and retrieving trie updates
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-    let sorted_trie_updates = TrieUpdatesSorted::default();
-    let sorted_post_state = HashedPostStateSorted::default();
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: sorted_trie_updates.clone(),
-        sorted_post_state: sorted_post_state.clone(),
-    };
-
-    // Store trie updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Retrieve and verify
-    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
-    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
-
-    Ok(())
+fn create_rocksdb_proofs_storage() -> TestRocksdbProofsStorage {
+    let dir = TempDir::new().unwrap();
+    let storage = RocksdbProofsStorage::new(dir.path()).unwrap();
+    TestRocksdbProofsStorage { storage, _dir: dir }
 }
 
-// =============================================================================
-// 1. Basic Cursor Operations
-// =============================================================================
+impl BaseProofsStore for TestRocksdbProofsStorage {
+    type StorageTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type StorageCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountHashedCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountHashedCursor<'tx>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::Tx<'tx>
+    where
+        Self: 'tx;
 
-/// Test cursor operations on empty trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // All operations should return None on empty trie
-    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
-    assert!(cursor.seek(Nibbles::default())?.is_none());
-    assert!(cursor.next()?.is_none());
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with single entry
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    // Store single entry
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test seek_exact
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Test current position
-    assert_eq!(cursor.current()?.unwrap(), path);
-
-    // Test next from end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with multiple entries
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![2, 3]),
-    ];
-    let branch = create_test_branch();
-
-    // Store multiple entries
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_earliest_block_number()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test that we can iterate through all entries
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_latest_block_number()
     }
 
-    assert_eq!(found_paths.len(), 4);
-    // Paths should be in lexicographic order
-    for i in 0..paths.len() {
-        assert_eq!(found_paths[i], paths[i]);
+    fn storage_trie_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+        self.storage.storage_trie_cursor(hashed_address, max_block_number)
     }
 
-    Ok(())
-}
-
-// =============================================================================
-// 2. Seek Operations
-// =============================================================================
-
-/// Test `seek_exact` with existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test `seek_exact` with non-existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let non_existing = nibbles_from(vec![4, 5, 6]);
-    assert!(cursor.seek_exact(non_existing)?.is_none());
-
-    Ok(())
-}
-
-/// Test `seek_exact` with empty path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
-    assert_eq!(result.0, Nibbles::default());
-
-    Ok(())
-}
-
-/// Test seek to existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test seek between existing nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path between 1 and 3, should return path 3
-    let seek_path = nibbles_from(vec![2]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test seek after all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path after all nodes
-    let seek_path = nibbles_from(vec![9]);
-    assert!(cursor.seek(seek_path)?.is_none());
-
-    Ok(())
-}
-
-/// Test seek before all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![5]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path before all nodes, should return first node
-    let seek_path = nibbles_from(vec![1]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-// =============================================================================
-// 3. Navigation Tests
-// =============================================================================
-
-/// Test next without prior seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // next() without prior seek should start from beginning
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test next after seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path1)?;
-
-    // next() should return second node
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test next at end of trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path)?;
-
-    // next() at end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test multiple consecutive next calls
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+        self.storage.account_trie_cursor(max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Iterate through all with consecutive next() calls
-    for expected_path in &paths {
-        let result = cursor.next()?.unwrap();
-        assert_eq!(result.0, *expected_path);
+    fn storage_hashed_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
+        self.storage.storage_hashed_cursor(hashed_address, max_block_number)
     }
 
-    // Final next() should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test current after operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None initially
-    assert!(cursor.current()?.is_none());
-
-    // After seek, current should track position
-    cursor.seek(path1)?;
-    assert_eq!(cursor.current()?.unwrap(), path1);
-
-    // After next, current should update
-    cursor.next()?;
-    assert_eq!(cursor.current()?.unwrap(), path2);
-
-    Ok(())
-}
-
-/// Test current with no prior operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None when no operations performed
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 4. Block Number Filtering
-// =============================================================================
-
-/// Test same path with different blocks
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch1 = create_test_branch();
-    let branch2 = create_test_branch_variant();
-
-    // Store same path at different blocks
-    storage.store_account_branches(vec![(path, Some(branch1))])?;
-    storage.store_account_branches(vec![(path, Some(branch2))])?;
-
-    // Cursor with max_block_number=75 should see only block 50 data
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    let result75 = cursor75.seek_exact(path)?.unwrap();
-    assert_eq!(result75.0, path);
-
-    // Cursor with max_block_number=150 should see block 100 data (latest)
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    let result150 = cursor150.seek_exact(path)?.unwrap();
-    assert_eq!(result150.0, path);
-
-    Ok(())
-}
-
-/// Test deleted branch nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Store branch node, then delete it (store None)
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // Cursor before deletion should see the node
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    assert!(cursor75.seek_exact(path)?.is_some());
-
-    let mut block_state_diff_trie_updates = TrieUpdates::default();
-    block_state_diff_trie_updates.removed_nodes.insert(path);
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should not see the node
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    assert!(cursor150.seek_exact(path)?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 5. Hashed Address Filtering
-// =============================================================================
-
-/// Test account-specific cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr1 = B256::repeat_byte(0x01);
-    let addr2 = B256::repeat_byte(0x02);
-    let branch = create_test_branch();
-
-    // Store same path for different accounts (using storage branches)
-    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
-    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
-
-    // Cursor for addr1 should only see addr1 data
-    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
-    let result1 = cursor1.seek_exact(path)?.unwrap();
-    assert_eq!(result1.0, path);
-
-    // Cursor for addr2 should only see addr2 data
-    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
-    let result2 = cursor2.seek_exact(path)?.unwrap();
-    assert_eq!(result2.0, path);
-
-    // Cursor for addr1 should not see addr2 data when iterating
-    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
-    let mut found_count = 0;
-    while cursor1_iter.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
-
-    Ok(())
-}
-
-/// Test state trie cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store data for account trie and state trie
-    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // State trie cursor (None address) should only see state trie data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let result = state_cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Verify state cursor doesn't see account data when iterating
-    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
-    let mut found_count = 0;
-    while state_cursor_iter.next()?.is_some() {
-        found_count += 1;
+    fn account_hashed_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        self.storage.account_hashed_cursor(max_block_number)
     }
 
-    assert_eq!(found_count, 1); // Should only see state trie entry
-
-    Ok(())
-}
-
-/// Test mixed account and state data
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store mixed account and state trie data
-    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    // Account cursor should only see account data
-    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
-    let mut account_paths = Vec::new();
-    while let Some((path, _)) = account_cursor.next()? {
-        account_paths.push(path);
-    }
-    assert_eq!(account_paths.len(), 1);
-    assert_eq!(account_paths[0], path1);
-
-    // State cursor should only see state data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let mut state_paths = Vec::new();
-    while let Some((path, _)) = state_cursor.next()? {
-        state_paths.push(path);
-    }
-    assert_eq!(state_paths.len(), 1);
-    assert_eq!(state_paths[0], path2);
-
-    Ok(())
-}
-
-// =============================================================================
-// 6. Path Ordering Tests
-// =============================================================================
-
-/// Test lexicographic ordering
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![3, 1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![1]),
-    ];
-    let branch = create_test_branch();
-
-    // Store paths in random order
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
+        self.storage.ro_tx()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
-    let expected_order = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![3, 1]),
-    ];
-
-    assert_eq!(found_paths, expected_order);
-
-    Ok(())
-}
-
-/// Test path prefix scenarios
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),       // Prefix of next
-        nibbles_from(vec![1, 2]),    // Extends first
-        nibbles_from(vec![1, 2, 3]), // Extends second
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_trie_cursor_with_tx(tx, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Seek to prefix should find exact match
-    let result = cursor.seek_exact(paths[0])?.unwrap();
-    assert_eq!(result.0, paths[0]);
-
-    // Next should go to next path, not skip prefixed paths
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[1]);
-
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[2]);
-
-    Ok(())
-}
-
-/// Test complex nibble combinations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Test various nibble patterns including edge values
-    let paths = vec![
-        nibbles_from(vec![0]),
-        nibbles_from(vec![0, 15]),
-        nibbles_from(vec![15]),
-        nibbles_from(vec![15, 0]),
-        nibbles_from(vec![7, 8, 9]),
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_hashed_cursor_with_tx(tx, max_block_number)
     }
 
-    // All paths should be found and in correct order
-    assert_eq!(found_paths.len(), 5);
-
-    // Verify specific ordering for edge cases
-    assert_eq!(found_paths[0], nibbles_from(vec![0]));
-    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
-    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
-
-    Ok(())
-}
-
-// =============================================================================
-// 7. Leaf Node Tests (Hashed Accounts and Storage)
-// =============================================================================
-
-/// Test store and retrieve single account
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account = create_test_account();
-
-    // Store account
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let result = cursor.seek(account_key)?.unwrap();
-
-    assert_eq!(result.0, account_key);
-    assert_eq!(result.1.nonce, account.nonce);
-    assert_eq!(result.1.balance, account.balance);
-    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
-
-    Ok(())
-}
-
-/// Test account cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let accounts = [
-        (B256::repeat_byte(0x01), create_test_account()),
-        (B256::repeat_byte(0x03), create_test_account()),
-        (B256::repeat_byte(0x05), create_test_account()),
-    ];
-
-    // Store accounts
-    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
-    storage.store_hashed_accounts(accounts_to_store)?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Test seeking to exact key
-    let result = cursor.seek(accounts[1].0)?.unwrap();
-    assert_eq!(result.0, accounts[1].0);
-
-    // Test seeking to key that doesn't exist (should return next greater)
-    let seek_key = B256::repeat_byte(0x02);
-    let result = cursor.seek(seek_key)?.unwrap();
-    assert_eq!(result.0, accounts[1].0); // Should find 0x03
-
-    // Test next() navigation
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, accounts[2].0); // Should find 0x05
-
-    // Test next() at end
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test account block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
-    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
-
-    // Store account at different blocks
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
-
-    // Cursor with max_block_number=75 should see v1
-    let mut cursor75 = storage.account_hashed_cursor(75)?;
-    let result75 = cursor75.seek(account_key)?.unwrap();
-    assert_eq!(result75.1.nonce, account_v1.nonce);
-    assert_eq!(result75.1.balance, account_v1.balance);
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
-
-    // After update, Cursor with max_block_number=150 should see v2
-    let mut cursor150 = storage.account_hashed_cursor(150)?;
-    let result150 = cursor150.seek(account_key)?.unwrap();
-    assert_eq!(result150.1.nonce, account_v2.nonce);
-    assert_eq!(result150.1.balance, account_v2.balance);
-
-    Ok(())
-}
-
-/// Test store and retrieve storage
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-
-fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-    ];
-
-    // Store storage slots
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Test seeking to each slot
-    for (key, expected_value) in &storage_slots {
-        let result = cursor.seek(*key)?.unwrap();
-        assert_eq!(result.0, *key);
-        assert_eq!(result.1, *expected_value);
+    fn store_trie_updates(
+        &self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.store_trie_updates(block_ref, block_state_diff)
     }
 
-    Ok(())
-}
-
-/// Test storage cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x50), U256::from(500)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Start from beginning with next()
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        self.storage.fetch_trie_updates(block_number)
     }
 
-    assert_eq!(found_slots.len(), 3);
-    assert_eq!(found_slots[0], storage_slots[0]);
-    assert_eq!(found_slots[1], storage_slots[1]);
-    assert_eq!(found_slots[2], storage_slots[2]);
-
-    Ok(())
-}
-
-/// Test storage account isolation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let address1 = B256::repeat_byte(0x01);
-    let address2 = B256::repeat_byte(0x02);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store same storage key for different accounts
-    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
-    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
-
-    // Verify each account sees only its own storage
-    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
-    let result1 = cursor1.seek(storage_key)?.unwrap();
-    assert_eq!(result1.1, U256::from(100));
-
-    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
-    let result2 = cursor2.seek(storage_key)?.unwrap();
-    assert_eq!(result2.1, U256::from(200));
-
-    // Verify cursor1 doesn't see address2's storage
-    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
-    let mut count = 0;
-    while cursor1_iter.next()?.is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 1); // Should only see one entry
-
-    Ok(())
-}
-
-/// Test storage block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store storage at different blocks
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor with max_block_number=75 should see old value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
-    // Cursor with max_block_number=150 should see new value
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?.unwrap();
-    assert_eq!(result150.1, U256::from(200));
-
-    Ok(())
-}
-
-/// Test storage zero value deletion
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store non-zero value
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor before deletion should see the value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    // "Delete" by storing zero value at block 100
-    let mut block_state_diff_post_state = HashedPostState::default();
-    let mut hashed_storage = HashedStorage::default();
-    hashed_storage.storage.insert(storage_key, U256::ZERO);
-    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: block_state_diff_post_state.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should NOT see the entry (zero values are skipped)
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?;
-    assert!(result150.is_none(), "Zero values should be skipped/deleted");
-
-    Ok(())
-}
-
-/// Test that zero values are skipped during iteration
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-
-    // Create a mix of non-zero and zero value storage slots
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
-        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
-        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
-    ];
-
-    // Store all slots
-    storage.store_hashed_storages(hashed_address, storage_slots)?;
-
-    // Create cursor and iterate through all entries
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn prune_earliest_state(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.prune_earliest_state(new_earliest_block_ref)
     }
 
-    // Should only find 3 non-zero values
-    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
-
-    // Verify the non-zero values are the ones we stored
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
-
-    // Verify seeking to a zero-value slot returns None or skips to next non-zero
-    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
-
-    // Should either return None or skip to the next non-zero value (0x30)
-    if let Some((key, value)) = seek_result {
-        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
-        assert_eq!(value, U256::from(300));
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
+        self.storage.unwind_history(to)
     }
 
-    Ok(())
+    fn replace_updates(
+        &self,
+        latest_common_block: BlockNumHash,
+        blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.replace_updates(latest_common_block, blocks_to_add)
+    }
+
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.set_earliest_block_number(block_number, hash)
+    }
 }
 
-/// Test empty cursors
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+impl BaseProofsInitialStateStore for TestRocksdbProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
+        self.storage.initial_state_anchor()
+    }
+
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
+        self.storage.set_initial_state_anchor(anchor)
+    }
+
+    fn store_account_branches(
+        &self,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_account_branches(account_nodes)
+    }
+
+    fn store_storage_branches(
+        &self,
+        hashed_address: B256,
+        storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_storage_branches(hashed_address, storage_nodes)
+    }
+
+    fn store_hashed_accounts(
+        &self,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_accounts(accounts)
+    }
+
+    fn store_hashed_storages(
+        &self,
+        hashed_address: B256,
+        storages: Vec<(B256, U256)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_storages(hashed_address, storages)
+    }
+
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
+        self.storage.commit_initial_state()
+    }
+}
+
+const fn test_block(parent: B256, number: u64, hash_byte: u8) -> BlockWithParent {
+    BlockWithParent::new(parent, NumHash::new(number, B256::repeat_byte(hash_byte)))
+}
+
+fn assert_account_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    key: B256,
+    expected: Account,
 ) -> Result<(), BaseProofsStorageError> {
-    // Test empty account cursor
-    let mut account_cursor = storage.account_hashed_cursor(100)?;
-    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
-    assert!(account_cursor.next()?.is_none());
-
-    // Test empty storage cursor
-    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
-    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
-    assert!(storage_cursor.next()?.is_none());
-
+    let mut cursor = storage.account_hashed_cursor(at)?;
+    assert_eq!(cursor.seek(key)?, Some((key, expected)));
     Ok(())
 }
 
-/// Test cursor boundary conditions
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_present<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x80); // Middle value
-    let account = create_test_account();
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Seek to minimum key should find our account
-    let result = cursor.seek(B256::ZERO)?.unwrap();
-    assert_eq!(result.0, account_key);
-
-    // Seek to maximum key should find nothing
-    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
-
-    // Seek to key just before our account should find our account
-    let just_before = B256::repeat_byte(0x7F);
-    let result = cursor.seek(just_before)?.unwrap();
-    assert_eq!(result.0, account_key);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_some());
     Ok(())
 }
 
-/// Test large batch operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_missing<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    // Create large batch of accounts
-    let mut accounts = Vec::new();
-    for i in 0..100 {
-        let key = B256::from([i as u8; 32]);
-        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
-        accounts.push((key, Some(account)));
-    }
-
-    // Store in batch
-    storage.store_hashed_accounts(accounts.clone())?;
-
-    // Verify all accounts can be retrieved
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let mut found_count = 0;
-    while cursor.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 100);
-
-    // Test specific account retrieval
-    let test_key = B256::from([42u8; 32]);
-    let result = cursor.seek(test_key)?.unwrap();
-    assert_eq!(result.0, test_key);
-    assert_eq!(result.1.nonce, 42);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_none());
     Ok(())
 }
 
-/// Test wiped storage in [`HashedPostState`]
-///
-/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
-/// it should iterate all existing values for that address and create deletion entries for them.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_storage_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    hashed_address: B256,
+    at: u64,
+    slot: B256,
+    expected: U256,
 ) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::HashedStorage;
-
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // First, store some storage values at block 50
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x40), U256::from(400)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Verify all values are present at block 75
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        found_slots.push((key, value));
-    }
-    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
-
-    // Now create a HashedPostState with wiped=true for this address at block 100
-    let mut post_state = HashedPostState::default();
-    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
-    post_state.storages.insert(hashed_address, wiped_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the wiped state
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // After wiping, cursor at block 150 should see NO storage values
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found_slots_after_wipe = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found_slots_after_wipe.push((key, value));
-    }
-
-    assert_eq!(
-        found_slots_after_wipe.len(),
-        0,
-        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
-    );
-
-    // Verify individual seeks also return None
-    for (slot, _) in &storage_slots {
-        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
-        let result = seek_cursor.seek(*slot)?;
-        assert!(
-            result.is_none() || result.unwrap().0 != *slot,
-            "Storage slot {slot:?} should be deleted after wipe"
-        );
-    }
-
-    // Verify cursor at block 75 (before wipe) still sees all values
-    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots_before_wipe = Vec::new();
-    while let Some((key, value)) = cursor75_after.next()? {
-        found_slots_before_wipe.push((key, value));
-    }
-    assert_eq!(
-        found_slots_before_wipe.len(),
-        4,
-        "All storage slots should still be present when querying before wipe block"
-    );
-
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, at)?;
+    assert_eq!(cursor.seek(slot)?, Some((slot, expected)));
     Ok(())
 }
 
-/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
-/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
-/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
-/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
-/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
-/// return `None` for the new slots, producing divergent storage / state / output roots
-/// downstream of `LiveTrieCollector`.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage_and_new_slots<
-    S: BaseProofsStore + BaseProofsInitialStateStore,
->(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    let pre_existing_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-    ];
-    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
-
-    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
-    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
-
-    let mut post_state = HashedPostState::default();
-    let wiped_with_new =
-        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
-    post_state.storages.insert(hashed_address, wiped_with_new);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found.push((key, value));
-    }
-
-    assert_eq!(
-        found,
-        vec![new_slot_overwriting_old, new_slot_kept],
-        "After wipe+recreate, only the new post-recreation slots must be visible",
-    );
-
-    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_kept.seek(new_slot_kept.0)?,
-        Some(new_slot_kept),
-        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
-    );
-
-    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_overwritten.seek(new_slot_overwriting_old.0)?,
-        Some(new_slot_overwriting_old),
-        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
-    );
-
-    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_dropped.seek(B256::repeat_byte(0x20))?,
-        Some(new_slot_kept),
-        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
-         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
-    );
-
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut pre_wipe_found = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        pre_wipe_found.push((key, value));
-    }
-    assert_eq!(
-        pre_wipe_found, pre_existing_slots,
-        "Cursor positioned before the wipe block must still see the original slot values",
-    );
-
-    Ok(())
-}
-
-/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
-///
-/// This test verifies that all data stored via `store_trie_updates` can be read back
-/// through the cursor APIs.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Create comprehensive trie updates with branches, leaves, and removals
-    let mut trie_updates = TrieUpdates::default();
-
-    // Add account branch nodes
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let account_branch1 = create_test_branch();
-    let account_branch2 = create_test_branch_variant();
-
-    trie_updates.account_nodes.insert(account_path1, account_branch1);
-    trie_updates.account_nodes.insert(account_path2, account_branch2);
-
-    // Add removed account nodes
-    let removed_account_path = nibbles_from(vec![7, 8, 9]);
-    trie_updates.removed_nodes.insert(removed_account_path);
-
-    // Add storage branch nodes for an address
-    let hashed_address = B256::repeat_byte(0x42);
-    let storage_path1 = nibbles_from(vec![1, 1]);
-    let storage_path2 = nibbles_from(vec![2, 2]);
-    let storage_branch = create_test_branch();
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
-
-    // Add removed storage node
-    let removed_storage_path = nibbles_from(vec![3, 3]);
-    storage_trie.removed_nodes.insert(removed_storage_path);
-
-    trie_updates.insert_storage_updates(hashed_address, storage_trie);
-
-    // Create post state with accounts and storage
-    let mut post_state = HashedPostState::default();
-
-    // Add accounts
-    let account1_addr = B256::repeat_byte(0x10);
-    let account2_addr = B256::repeat_byte(0x20);
-    let account1 = create_test_account_with_values(1, 1000, 0xAA);
-    let account2 = create_test_account_with_values(2, 2000, 0xBB);
-
-    post_state.accounts.insert(account1_addr, Some(account1));
-    post_state.accounts.insert(account2_addr, Some(account2));
-
-    // Add deleted account
-    let deleted_account_addr = B256::repeat_byte(0x30);
-    post_state.accounts.insert(deleted_account_addr, None);
-
-    // Add storage for an address
-    let storage_addr = B256::repeat_byte(0x50);
-    let mut hashed_storage = HashedStorage::new(false);
-    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
-    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
-    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
-    post_state.storages.insert(storage_addr, hashed_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: trie_updates.into_sorted(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // ========== Verify Account Branch Nodes ==========
-    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
-
-    // Should find the added branches
-    let result1 = account_trie_cursor.seek_exact(account_path1)?;
-    assert!(result1.is_some(), "Account branch node 1 should be found");
-    assert_eq!(result1.unwrap().0, account_path1);
-
-    let result2 = account_trie_cursor.seek_exact(account_path2)?;
-    assert!(result2.is_some(), "Account branch node 2 should be found");
-    assert_eq!(result2.unwrap().0, account_path2);
-
-    // Removed node should not be found
-    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
-    assert!(removed_result.is_none(), "Removed account node should not be found");
-
-    // ========== Verify Storage Branch Nodes ==========
-    let mut storage_trie_cursor =
-        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
-
-    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
-    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
-
-    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
-    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
-
-    // Removed storage node should not be found
-    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
-    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
-
-    // ========== Verify Account Leaves ==========
-    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
-
-    let acc1_result = account_cursor.seek(account1_addr)?;
-    assert!(acc1_result.is_some(), "Account 1 should be found");
-    assert_eq!(acc1_result.unwrap().0, account1_addr);
-    assert_eq!(acc1_result.unwrap().1.nonce, 1);
-    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
-
-    let acc2_result = account_cursor.seek(account2_addr)?;
-    assert!(acc2_result.is_some(), "Account 2 should be found");
-    assert_eq!(acc2_result.unwrap().1.nonce, 2);
-
-    // Deleted account should not be found
-    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
-    assert!(
-        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
-        "Deleted account should not be found"
-    );
-
-    // ========== Verify Storage Leaves ==========
-    let mut storage_cursor =
-        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
-
-    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
-    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
-    assert_eq!(slot1_result.unwrap().1, U256::from(111));
-
-    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
-    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
-    assert_eq!(slot2_result.unwrap().1, U256::from(222));
-
-    // Zero-valued storage should not be found (deleted)
-    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
-    assert!(
-        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
-        "Zero-valued storage slot should not be found"
-    );
-
-    // ========== Verify fetch_trie_updates can retrieve the data ==========
-    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-
-    // Check that trie updates are stored
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
-        3,
-        "Should have 3 account nodes, including removed"
-    );
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
-        1,
-        "Should have 1 storage trie"
-    );
-
-    // Check that post state is stored
-    assert_eq!(
-        fetched_diff.sorted_post_state.accounts.len(),
-        3,
-        "Should have 3 accounts (including deleted)"
-    );
-    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
-
-    Ok(())
-}
-
-/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
-///
-/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
-/// and `post_states` directly without populating the internal data structures
-/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
-    let initial_account_addr = B256::repeat_byte(0x10);
-    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
-
-    let initial_storage_addr = B256::repeat_byte(0x20);
-    let initial_storage_slot = B256::repeat_byte(0x01);
-    let initial_storage_value = U256::from(100);
-
-    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
-    let initial_branch = create_test_branch();
-
-    // Store initial data at block 50
-    let mut initial_trie_updates_50 = TrieUpdates::default();
-    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_50 = HashedPostState::default();
-    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
-
-    let initial_diff_50 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
-        sorted_post_state: initial_post_state_50.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
-
-    // Store data at block 100 (common block)
-    let mut initial_trie_updates_100 = TrieUpdates::default();
-    let common_branch_path = nibbles_from(vec![4, 5, 6]);
-    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_100 = HashedPostState::default();
-    let mut initial_storage_100 = HashedStorage::new(false);
-    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
-    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
-
-    let initial_diff_100 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
-        sorted_post_state: initial_post_state_100.into_sorted(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
-
-    // Store data at block 101 (will be replaced)
-    let mut initial_trie_updates_101 = TrieUpdates::default();
-    let old_branch_path = nibbles_from(vec![7, 8, 9]);
-    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
-
-    let mut initial_post_state_101 = HashedPostState::default();
-    let old_account_addr = B256::repeat_byte(0x30);
-    let old_account = create_test_account_with_values(99, 9999, 0xFF);
-    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
-
-    let initial_diff_101 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
-        sorted_post_state: initial_post_state_101.into_sorted(),
-    };
-    let block_ref_101 =
-        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
-    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
-
-    let block_ref_102 =
-        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
-
-    // ========== Verify initial state exists ==========
-    // Verify block 50 data exists
-    let mut cursor_initial = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
-        "Initial branch should exist before replace"
-    );
-
-    // Verify block 101 old data exists
-    let mut cursor_old = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old.seek_exact(old_branch_path)?.is_some(),
-        "Old branch at block 101 should exist before replace"
-    );
-
-    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
-    assert!(
-        account_cursor_old.seek(old_account_addr)?.is_some(),
-        "Old account at block 101 should exist before replace"
-    );
-
-    // ========== Call replace_updates to replace blocks after 100 ==========
-    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
-
-    // New data for block 101
-    let new_account_addr = B256::repeat_byte(0x40);
-    let new_account = create_test_account_with_values(5, 5000, 0xCC);
-
-    let new_storage_addr = B256::repeat_byte(0x50);
-    let new_storage_slot = B256::repeat_byte(0x02);
-    let new_storage_value = U256::from(999);
-
-    let new_branch_path = nibbles_from(vec![10, 11, 12]);
-    let new_branch = create_test_branch_variant();
-
-    let storage_branch_path = nibbles_from(vec![5, 5]);
-    let storage_hashed_addr = B256::repeat_byte(0x60);
-
-    let mut new_trie_updates = TrieUpdates::default();
-    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
-
-    // Add storage trie updates
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
-    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
-
-    let mut new_post_state = HashedPostState::default();
-    new_post_state.accounts.insert(new_account_addr, Some(new_account));
-
-    let mut new_storage = HashedStorage::new(false);
-    new_storage.storage.insert(new_storage_slot, new_storage_value);
-    new_post_state.storages.insert(new_storage_addr, new_storage);
-
-    blocks_to_add.push((
-        block_ref_101,
-        BlockStateDiff {
-            sorted_trie_updates: new_trie_updates.into_sorted(),
-            sorted_post_state: new_post_state.into_sorted(),
-        },
-    ));
-
-    // New data for block 102
-    let block_102_account_addr = B256::repeat_byte(0x70);
-    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
-
-    let mut trie_updates_102 = TrieUpdates::default();
-    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
-    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
-
-    let mut post_state_102 = HashedPostState::default();
-    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
-
-    blocks_to_add.push((
-        block_ref_102,
-        BlockStateDiff {
-            sorted_trie_updates: trie_updates_102.into_sorted(),
-            sorted_post_state: post_state_102.into_sorted(),
-        },
-    ));
-
-    // Execute replace_updates
-    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
-    // ========== Verify that data up to block 100 still exists ==========
-    let mut cursor_50 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_50.seek_exact(initial_branch_path)?.is_some(),
-        "Block 50 branch should still exist after replace"
-    );
-
-    let mut cursor_100 = storage.account_trie_cursor(100)?;
-    assert!(
-        cursor_100.seek_exact(common_branch_path)?.is_some(),
-        "Block 100 branch should still exist after replace"
-    );
-
-    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
-    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
-    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
-    assert_eq!(
-        result_100.unwrap().1,
-        initial_storage_value,
-        "Block 100 storage value should be unchanged"
-    );
-
-    // ========== Verify that old data after block 100 is gone ==========
-    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
-        "Old branch at block 101 should be removed after replace"
-    );
-
-    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
-    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
-    assert!(
-        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
-        "Old account at block 101 should be removed after replace"
-    );
-
-    // ========== Verify new data is properly accessible via cursors ==========
-
-    // Verify new account branch nodes
-    let mut trie_cursor = storage.account_trie_cursor(150)?;
-    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
-    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
-    assert_eq!(branch_result.unwrap().0, new_branch_path);
-
-    // Verify new storage branch nodes
-    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
-    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
-    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
-    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
-
-    // Verify new hashed accounts
-    let mut account_cursor = storage.account_hashed_cursor(150)?;
-    let account_result = account_cursor.seek(new_account_addr)?;
-    assert!(account_result.is_some(), "New account should be accessible via cursor");
-    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
-    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
-    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
-    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
-
-    // Verify new hashed storages
-    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
-    let storage_result = storage_cursor.seek(new_storage_slot)?;
-    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
-    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
-    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
-
-    // Verify block 102 data
-    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
-    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
-    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
-    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
-
-    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
-    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
-    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
-    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
-    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
-
-    // Verify fetch_trie_updates returns the new data
-    let fetched_101 = storage.fetch_trie_updates(101)?;
-    assert_eq!(
-        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
-        1,
-        "Should have 1 account branch node at block 101"
-    );
-    assert!(
-        fetched_101
-            .sorted_trie_updates
-            .account_nodes_ref()
-            .iter()
-            .any(|(addr, _)| *addr == new_branch_path),
-        "New branch path should be in trie_updates"
-    );
-    assert_eq!(
-        fetched_101.sorted_post_state.accounts.len(),
-        1,
-        "Should have 1 account at block 101"
-    );
-    assert!(
-        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
-        "New account should be in post_state"
-    );
-
-    Ok(())
-}
-
-/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
-///
-/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
-/// it is properly stored as a deletion and subsequent queries return None for that path.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let storage_path1 = nibbles_from(vec![7, 8, 9]);
-    let storage_path2 = nibbles_from(vec![10, 11, 12]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
-    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path1)?.is_some(),
-        "Initial account branch 1 should exist at block 75"
-    );
-    assert!(
-        cursor_75.seek_exact(account_path2)?.is_some(),
-        "Initial account branch 2 should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
-        "Initial storage branch 1 should exist at block 75"
-    );
-    assert!(
-        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
-        "Initial storage branch 2 should exist at block 75"
-    );
-
-    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
-    let mut deletion_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes ONLY (no updates)
-    deletion_trie_updates.removed_nodes.insert(account_path1);
-
-    // Do the same for storage branch
-    let mut deletion_storage_trie = StorageTrieUpdates::default();
-    deletion_storage_trie.removed_nodes.insert(storage_path1);
-    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
-
-    let deletion_diff = BlockStateDiff {
-        sorted_trie_updates: deletion_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, deletion_diff)?;
-
-    // ========== Verify that deleted nodes return None at block 150 ==========
-
-    // Deleted account branch should not be found
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path1)?;
-    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
-
-    // Non-deleted account branch should still exist
-    let account_result2 = cursor_150.seek_exact(account_path2)?;
-    assert!(
-        account_result2.is_some(),
-        "Non-deleted account branch should still exist at block 150"
-    );
-
-    // Deleted storage branch should not be found
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
-    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
-
-    // Non-deleted storage branch should still exist
-    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
-    assert!(
-        storage_result2.is_some(),
-        "Non-deleted storage branch should still exist at block 150"
-    );
-
-    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75_after.seek_exact(account_path1)?.is_some(),
-        "Deleted node should still exist at block 75 (before deletion)"
-    );
-
-    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
-        "Deleted storage node should still exist at block 75 (before deletion)"
-    );
-
-    // ========== Verify iteration skips deleted nodes ==========
-    let mut cursor_iter = storage.account_trie_cursor(150)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor_iter.next()? {
-        found_paths.push(path);
-    }
-
-    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
-    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
-
-    Ok(())
-}
-
-/// Test that updates take precedence over removals when both are present
-///
-/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
-/// the update from `account_nodes` takes precedence. This is critical for correctness
-/// when processing trie updates that both remove and update the same node.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path = nibbles_from(vec![1, 2, 3]);
-    let storage_path = nibbles_from(vec![4, 5, 6]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path)?.is_some(),
-        "Initial account branch should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path)?.is_some(),
-        "Initial storage branch should exist at block 75"
-    );
-
-    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
-    // This simulates a scenario where a node is both removed and updated
-    // The update should take precedence
-    let updated_branch = create_test_branch_variant();
-
-    let mut conflicting_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes
-    conflicting_trie_updates.removed_nodes.insert(account_path);
-
-    // Also add to account_nodes (this should take precedence)
-    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
-
-    // Do the same for storage branch
-    let mut conflicting_storage_trie = StorageTrieUpdates::default();
-    conflicting_storage_trie.removed_nodes.insert(storage_path);
-    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
-    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
-
-    let conflicting_diff = BlockStateDiff {
-        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
-
-    // ========== Verify that updates took precedence at block 150 ==========
-
-    // Account branch should exist (not deleted) with the updated value
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path)?;
-    assert!(
-        account_result.is_some(),
-        "Account branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_path, found_branch) = account_result.unwrap();
-    assert_eq!(found_path, account_path);
-    // Verify it's the updated branch, not the initial one
-    assert_eq!(
-        found_branch.state_mask, updated_branch.state_mask,
-        "Account branch should be the updated version, not the initial one"
-    );
-
-    // Storage branch should exist (not deleted) with the updated value
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
-    assert!(
-        storage_result.is_some(),
-        "Storage branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
-    assert_eq!(found_storage_path, storage_path);
-    // Verify it's the updated branch
-    assert_eq!(
-        found_storage_branch.state_mask, updated_branch.state_mask,
-        "Storage branch should be the updated version, not the initial one"
-    );
-
-    // ========== Verify that the old version still exists at block 75 ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    let result_75 = cursor_75_after.seek_exact(account_path)?;
-    assert!(result_75.is_some(), "Initial version should still exist at block 75");
-    let (_, branch_75) = result_75.unwrap();
-    assert_eq!(
-        branch_75.state_mask, initial_branch.state_mask,
-        "Block 75 should see the initial branch, not the updated one"
-    );
-
-    Ok(())
-}
+mod branch_cursors;
+mod hashed_cursors;
+mod history;
+mod proof_window;
+mod trie_updates;

--- a/crates/execution/trie/tests/live.rs
+++ b/crates/execution/trie/tests/live.rs
@@ -1,12 +1,12 @@
 //! End-to-end test of the live trie collector.
 
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
-use alloy_consensus::{BlockHeader, Header, TxEip2930, constants::ETH_TO_WEI};
+use alloy_consensus::{BlockHeader, Header, SignableTransaction, TxEip2930, constants::ETH_TO_WEI};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStorageError, MdbxProofsStorage, initialize::InitializationJob,
+    BaseProofsStorage, BaseProofsStorageError, RocksdbProofsStorage, initialize::InitializationJob,
     live::LiveTrieCollector,
 };
 use derive_more::Constructor;
@@ -17,7 +17,7 @@ use reth_ethereum_primitives::{Block, BlockBody, Receipt, Transaction, Transacti
 use reth_evm::{ConfigureEvm, execute::Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{NodePrimitives, NodeTypesWithDB};
-use reth_primitives_traits::{Block as _, RecoveredBlock};
+use reth_primitives_traits::{Block as _, RecoveredBlock, crypto::secp256k1::sign_message};
 use reth_provider::{
     BlockWriter as _, ExecutionOutcome, HashedPostStateProvider, LatestStateProviderRef,
     ProviderFactory, StateRootProvider,
@@ -28,6 +28,30 @@ use reth_revm::database::StateProviderDatabase;
 use secp256k1::{Keypair, Secp256k1};
 use tempfile::TempDir;
 
+#[cfg(not(feature = "metrics"))]
+fn rocksdb_storage(path: &Path) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::new(RocksdbProofsStorage::new(path).expect("env"))
+}
+
+#[cfg(feature = "metrics")]
+fn rocksdb_storage(path: &Path) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::new(RocksdbProofsStorage::new(path).expect("env")).into()
+}
+
+#[cfg(not(feature = "metrics"))]
+fn clone_storage(
+    storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::clone(storage)
+}
+
+#[cfg(feature = "metrics")]
+fn clone_storage(
+    storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    storage.clone()
+}
+
 /// Converts a secp256k1 public key to an Ethereum address.
 fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
     let hash = keccak256(&pubkey.serialize_uncompressed()[1..]);
@@ -36,8 +60,6 @@ fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
 
 /// Signs a transaction with the given keypair.
 fn sign_tx_with_key_pair(key_pair: Keypair, tx: Transaction) -> TransactionSigned {
-    use alloy_consensus::SignableTransaction;
-    use reth_primitives_traits::crypto::secp256k1::sign_message;
     let secret = B256::from_slice(&key_pair.secret_bytes());
     let sig = sign_message(secret, tx.signature_hash()).unwrap();
     tx.into_signed(sig).into()
@@ -220,7 +242,7 @@ fn run_test_scenario<N>(
     provider_factory: ProviderFactory<N>,
     chain_spec: Arc<ChainSpec>,
     key_pair: Keypair,
-    storage: BaseProofsStorage<Arc<MdbxProofsStorage>>,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
 ) -> eyre::Result<()>
 where
     N: ProviderNodeTypes<
@@ -254,7 +276,7 @@ where
     {
         let provider = provider_factory.db_ref();
         let tx = provider.tx()?;
-        let initialization_job = InitializationJob::new(storage.clone(), tx);
+        let initialization_job = InitializationJob::new(clone_storage(&storage), tx);
         initialization_job.run(last_block_number, last_block_hash)?;
     }
 
@@ -299,8 +321,7 @@ where
 #[test]
 fn test_execute_and_store_block_updates() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     // Create a keypair for signing transactions
     let secp = Secp256k1::new();
@@ -332,8 +353,7 @@ fn test_execute_and_store_block_updates() {
 #[test]
 fn test_execute_and_store_block_updates_missing_parent_block() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -352,7 +372,7 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
         provider_factory.clone(),
         Arc::clone(&chain_spec),
         key_pair,
-        storage.clone(),
+        clone_storage(&storage),
     )
     .unwrap();
 
@@ -386,8 +406,7 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
 #[test]
 fn test_execute_and_store_block_updates_state_root_mismatch() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -409,7 +428,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
         provider_factory.clone(),
         Arc::clone(&chain_spec),
         key_pair,
-        storage.clone(),
+        clone_storage(&storage),
     )
     .unwrap();
 
@@ -451,8 +470,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
 #[test]
 fn test_multiple_blocks_before_and_after_initialization() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -489,8 +507,7 @@ fn test_multiple_blocks_before_and_after_initialization() {
 #[test]
 fn test_blocks_with_multiple_transactions() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());

--- a/crates/execution/trie/tests/proof_window/mod.rs
+++ b/crates/execution/trie/tests/proof_window/mod.rs
@@ -1,0 +1,48 @@
+//! Proof window metadata behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test basic storage and retrieval of earliest block number
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Initially should be None
+    let earliest = storage.get_earliest_block_number()?;
+    assert!(earliest.is_none());
+
+    // Set earliest block
+    let block_hash = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(100, block_hash)?;
+
+    // Should retrieve the same values
+    let earliest = storage.get_earliest_block_number()?;
+    assert_eq!(earliest, Some((100, block_hash)));
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_proof_window<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    assert_eq!(storage.get_earliest_block_number()?, None);
+    let block_hash_42 = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(42, block_hash_42)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((42, block_hash_42)));
+
+    let block_hash_100 = B256::repeat_byte(0x64);
+    storage.set_earliest_block_number(100, block_hash_100)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((100, block_hash_100)));
+    assert_eq!(storage.get_latest_block_number()?, Some((100, block_hash_100)));
+    Ok(())
+}

--- a/crates/execution/trie/tests/trie_updates/mod.rs
+++ b/crates/execution/trie/tests/trie_updates/mod.rs
@@ -1,0 +1,970 @@
+//! Trie update storage and replacement behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test storing and retrieving trie updates
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+    let sorted_trie_updates = TrieUpdatesSorted::default();
+    let sorted_post_state = HashedPostStateSorted::default();
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: sorted_trie_updates.clone(),
+        sorted_post_state: sorted_post_state.clone(),
+    };
+
+    // Store trie updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Retrieve and verify
+    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
+    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
+
+    Ok(())
+}
+
+/// Test wiped storage in [`HashedPostState`]
+///
+/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
+/// it should iterate all existing values for that address and create deletion entries for them.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // First, store some storage values at block 50
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x40), U256::from(400)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Verify all values are present at block 75
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        found_slots.push((key, value));
+    }
+    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
+
+    // Now create a HashedPostState with wiped=true for this address at block 100
+    let mut post_state = HashedPostState::default();
+    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
+    post_state.storages.insert(hashed_address, wiped_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the wiped state
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // After wiping, cursor at block 150 should see NO storage values
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found_slots_after_wipe = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found_slots_after_wipe.push((key, value));
+    }
+
+    assert_eq!(
+        found_slots_after_wipe.len(),
+        0,
+        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
+    );
+
+    // Verify individual seeks also return None
+    for (slot, _) in &storage_slots {
+        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
+        let result = seek_cursor.seek(*slot)?;
+        assert!(
+            result.is_none() || result.unwrap().0 != *slot,
+            "Storage slot {slot:?} should be deleted after wipe"
+        );
+    }
+
+    // Verify cursor at block 75 (before wipe) still sees all values
+    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots_before_wipe = Vec::new();
+    while let Some((key, value)) = cursor75_after.next()? {
+        found_slots_before_wipe.push((key, value));
+    }
+    assert_eq!(
+        found_slots_before_wipe.len(),
+        4,
+        "All storage slots should still be present when querying before wipe block"
+    );
+
+    Ok(())
+}
+
+/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
+/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
+/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
+/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
+/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
+/// return `None` for the new slots, producing divergent storage / state / output roots
+/// downstream of `LiveTrieCollector`.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage_and_new_slots<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    let pre_existing_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+    ];
+    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
+
+    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
+    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
+
+    let mut post_state = HashedPostState::default();
+    let wiped_with_new =
+        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
+    post_state.storages.insert(hashed_address, wiped_with_new);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found.push((key, value));
+    }
+
+    assert_eq!(
+        found,
+        vec![new_slot_overwriting_old, new_slot_kept],
+        "After wipe+recreate, only the new post-recreation slots must be visible",
+    );
+
+    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_kept.seek(new_slot_kept.0)?,
+        Some(new_slot_kept),
+        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
+    );
+
+    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_overwritten.seek(new_slot_overwriting_old.0)?,
+        Some(new_slot_overwriting_old),
+        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
+    );
+
+    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_dropped.seek(B256::repeat_byte(0x20))?,
+        Some(new_slot_kept),
+        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
+         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
+    );
+
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut pre_wipe_found = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        pre_wipe_found.push((key, value));
+    }
+    assert_eq!(
+        pre_wipe_found, pre_existing_slots,
+        "Cursor positioned before the wipe block must still see the original slot values",
+    );
+
+    Ok(())
+}
+
+/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
+///
+/// This test verifies that all data stored via `store_trie_updates` can be read back
+/// through the cursor APIs.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Create comprehensive trie updates with branches, leaves, and removals
+    let mut trie_updates = TrieUpdates::default();
+
+    // Add account branch nodes
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let account_branch1 = create_test_branch();
+    let account_branch2 = create_test_branch_variant();
+
+    trie_updates.account_nodes.insert(account_path1, account_branch1);
+    trie_updates.account_nodes.insert(account_path2, account_branch2);
+
+    // Add removed account nodes
+    let removed_account_path = nibbles_from(vec![7, 8, 9]);
+    trie_updates.removed_nodes.insert(removed_account_path);
+
+    // Add storage branch nodes for an address
+    let hashed_address = B256::repeat_byte(0x42);
+    let storage_path1 = nibbles_from(vec![1, 1]);
+    let storage_path2 = nibbles_from(vec![2, 2]);
+    let storage_branch = create_test_branch();
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
+
+    // Add removed storage node
+    let removed_storage_path = nibbles_from(vec![3, 3]);
+    storage_trie.removed_nodes.insert(removed_storage_path);
+
+    trie_updates.insert_storage_updates(hashed_address, storage_trie);
+
+    // Create post state with accounts and storage
+    let mut post_state = HashedPostState::default();
+
+    // Add accounts
+    let account1_addr = B256::repeat_byte(0x10);
+    let account2_addr = B256::repeat_byte(0x20);
+    let account1 = create_test_account_with_values(1, 1000, 0xAA);
+    let account2 = create_test_account_with_values(2, 2000, 0xBB);
+
+    post_state.accounts.insert(account1_addr, Some(account1));
+    post_state.accounts.insert(account2_addr, Some(account2));
+
+    // Add deleted account
+    let deleted_account_addr = B256::repeat_byte(0x30);
+    post_state.accounts.insert(deleted_account_addr, None);
+
+    // Add storage for an address
+    let storage_addr = B256::repeat_byte(0x50);
+    let mut hashed_storage = HashedStorage::new(false);
+    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
+    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
+    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
+    post_state.storages.insert(storage_addr, hashed_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // ========== Verify Account Branch Nodes ==========
+    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
+
+    // Should find the added branches
+    let result1 = account_trie_cursor.seek_exact(account_path1)?;
+    assert!(result1.is_some(), "Account branch node 1 should be found");
+    assert_eq!(result1.unwrap().0, account_path1);
+
+    let result2 = account_trie_cursor.seek_exact(account_path2)?;
+    assert!(result2.is_some(), "Account branch node 2 should be found");
+    assert_eq!(result2.unwrap().0, account_path2);
+
+    // Removed node should not be found
+    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
+    assert!(removed_result.is_none(), "Removed account node should not be found");
+
+    // ========== Verify Storage Branch Nodes ==========
+    let mut storage_trie_cursor =
+        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
+
+    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
+    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
+
+    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
+    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
+
+    // Removed storage node should not be found
+    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
+    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
+
+    // ========== Verify Account Leaves ==========
+    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
+
+    let acc1_result = account_cursor.seek(account1_addr)?;
+    assert!(acc1_result.is_some(), "Account 1 should be found");
+    assert_eq!(acc1_result.unwrap().0, account1_addr);
+    assert_eq!(acc1_result.unwrap().1.nonce, 1);
+    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
+
+    let acc2_result = account_cursor.seek(account2_addr)?;
+    assert!(acc2_result.is_some(), "Account 2 should be found");
+    assert_eq!(acc2_result.unwrap().1.nonce, 2);
+
+    // Deleted account should not be found
+    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
+    assert!(
+        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
+        "Deleted account should not be found"
+    );
+
+    // ========== Verify Storage Leaves ==========
+    let mut storage_cursor =
+        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
+
+    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
+    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
+    assert_eq!(slot1_result.unwrap().1, U256::from(111));
+
+    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
+    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
+    assert_eq!(slot2_result.unwrap().1, U256::from(222));
+
+    // Zero-valued storage should not be found (deleted)
+    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
+    assert!(
+        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
+        "Zero-valued storage slot should not be found"
+    );
+
+    // ========== Verify fetch_trie_updates can retrieve the data ==========
+    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+
+    // Check that trie updates are stored
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
+        3,
+        "Should have 3 account nodes, including removed"
+    );
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
+        1,
+        "Should have 1 storage trie"
+    );
+
+    // Check that post state is stored
+    assert_eq!(
+        fetched_diff.sorted_post_state.accounts.len(),
+        3,
+        "Should have 3 accounts (including deleted)"
+    );
+    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
+
+    Ok(())
+}
+
+/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
+///
+/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
+/// and `post_states` directly without populating the internal data structures
+/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
+    let initial_account_addr = B256::repeat_byte(0x10);
+    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
+
+    let initial_storage_addr = B256::repeat_byte(0x20);
+    let initial_storage_slot = B256::repeat_byte(0x01);
+    let initial_storage_value = U256::from(100);
+
+    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
+    let initial_branch = create_test_branch();
+
+    // Store initial data at block 50
+    let mut initial_trie_updates_50 = TrieUpdates::default();
+    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_50 = HashedPostState::default();
+    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
+
+    let initial_diff_50 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
+        sorted_post_state: initial_post_state_50.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
+
+    // Store data at block 100 (common block)
+    let mut initial_trie_updates_100 = TrieUpdates::default();
+    let common_branch_path = nibbles_from(vec![4, 5, 6]);
+    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_100 = HashedPostState::default();
+    let mut initial_storage_100 = HashedStorage::new(false);
+    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
+    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
+
+    let initial_diff_100 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
+        sorted_post_state: initial_post_state_100.into_sorted(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
+
+    // Store data at block 101 (will be replaced)
+    let mut initial_trie_updates_101 = TrieUpdates::default();
+    let old_branch_path = nibbles_from(vec![7, 8, 9]);
+    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
+
+    let mut initial_post_state_101 = HashedPostState::default();
+    let old_account_addr = B256::repeat_byte(0x30);
+    let old_account = create_test_account_with_values(99, 9999, 0xFF);
+    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
+
+    let initial_diff_101 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
+        sorted_post_state: initial_post_state_101.into_sorted(),
+    };
+    let block_ref_101 =
+        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
+    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
+
+    let block_ref_102 =
+        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
+
+    // ========== Verify initial state exists ==========
+    // Verify block 50 data exists
+    let mut cursor_initial = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
+        "Initial branch should exist before replace"
+    );
+
+    // Verify block 101 old data exists
+    let mut cursor_old = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old.seek_exact(old_branch_path)?.is_some(),
+        "Old branch at block 101 should exist before replace"
+    );
+
+    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
+    assert!(
+        account_cursor_old.seek(old_account_addr)?.is_some(),
+        "Old account at block 101 should exist before replace"
+    );
+
+    // ========== Call replace_updates to replace blocks after 100 ==========
+    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
+
+    // New data for block 101
+    let new_account_addr = B256::repeat_byte(0x40);
+    let new_account = create_test_account_with_values(5, 5000, 0xCC);
+
+    let new_storage_addr = B256::repeat_byte(0x50);
+    let new_storage_slot = B256::repeat_byte(0x02);
+    let new_storage_value = U256::from(999);
+
+    let new_branch_path = nibbles_from(vec![10, 11, 12]);
+    let new_branch = create_test_branch_variant();
+
+    let storage_branch_path = nibbles_from(vec![5, 5]);
+    let storage_hashed_addr = B256::repeat_byte(0x60);
+
+    let mut new_trie_updates = TrieUpdates::default();
+    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
+
+    // Add storage trie updates
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
+    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
+
+    let mut new_post_state = HashedPostState::default();
+    new_post_state.accounts.insert(new_account_addr, Some(new_account));
+
+    let mut new_storage = HashedStorage::new(false);
+    new_storage.storage.insert(new_storage_slot, new_storage_value);
+    new_post_state.storages.insert(new_storage_addr, new_storage);
+
+    blocks_to_add.push((
+        block_ref_101,
+        BlockStateDiff {
+            sorted_trie_updates: new_trie_updates.into_sorted(),
+            sorted_post_state: new_post_state.into_sorted(),
+        },
+    ));
+
+    // New data for block 102
+    let block_102_account_addr = B256::repeat_byte(0x70);
+    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
+
+    let mut trie_updates_102 = TrieUpdates::default();
+    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
+    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
+
+    let mut post_state_102 = HashedPostState::default();
+    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
+
+    blocks_to_add.push((
+        block_ref_102,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates_102.into_sorted(),
+            sorted_post_state: post_state_102.into_sorted(),
+        },
+    ));
+
+    // Execute replace_updates
+    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
+    // ========== Verify that data up to block 100 still exists ==========
+    let mut cursor_50 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_50.seek_exact(initial_branch_path)?.is_some(),
+        "Block 50 branch should still exist after replace"
+    );
+
+    let mut cursor_100 = storage.account_trie_cursor(100)?;
+    assert!(
+        cursor_100.seek_exact(common_branch_path)?.is_some(),
+        "Block 100 branch should still exist after replace"
+    );
+
+    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
+    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
+    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
+    assert_eq!(
+        result_100.unwrap().1,
+        initial_storage_value,
+        "Block 100 storage value should be unchanged"
+    );
+
+    // ========== Verify that old data after block 100 is gone ==========
+    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
+        "Old branch at block 101 should be removed after replace"
+    );
+
+    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
+    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
+    assert!(
+        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
+        "Old account at block 101 should be removed after replace"
+    );
+
+    // ========== Verify new data is properly accessible via cursors ==========
+
+    // Verify new account branch nodes
+    let mut trie_cursor = storage.account_trie_cursor(150)?;
+    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
+    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
+    assert_eq!(branch_result.unwrap().0, new_branch_path);
+
+    // Verify new storage branch nodes
+    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
+    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
+    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
+    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
+
+    // Verify new hashed accounts
+    let mut account_cursor = storage.account_hashed_cursor(150)?;
+    let account_result = account_cursor.seek(new_account_addr)?;
+    assert!(account_result.is_some(), "New account should be accessible via cursor");
+    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
+    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
+    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
+    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
+
+    // Verify new hashed storages
+    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
+    let storage_result = storage_cursor.seek(new_storage_slot)?;
+    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
+    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
+    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
+
+    // Verify block 102 data
+    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
+    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
+    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
+    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
+
+    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
+    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
+    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
+    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
+    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
+
+    // Verify fetch_trie_updates returns the new data
+    let fetched_101 = storage.fetch_trie_updates(101)?;
+    assert_eq!(
+        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
+        1,
+        "Should have 1 account branch node at block 101"
+    );
+    assert!(
+        fetched_101
+            .sorted_trie_updates
+            .account_nodes_ref()
+            .iter()
+            .any(|(addr, _)| *addr == new_branch_path),
+        "New branch path should be in trie_updates"
+    );
+    assert_eq!(
+        fetched_101.sorted_post_state.accounts.len(),
+        1,
+        "Should have 1 account at block 101"
+    );
+    assert!(
+        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
+        "New account should be in post_state"
+    );
+
+    Ok(())
+}
+
+/// Test that multi-block replacements make wiped storage see storage added earlier in the
+/// replacement chain.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_replace_updates_wipes_storage_added_by_prior_replacement_block<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let common_block = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0xA1)));
+    storage.store_trie_updates(common_block, BlockStateDiff::default())?;
+
+    let old_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xB2)));
+    let old_block_3 =
+        BlockWithParent::new(old_block_2.block.hash, NumHash::new(3, B256::repeat_byte(0xB3)));
+    storage.store_trie_updates(old_block_2, BlockStateDiff::default())?;
+    storage.store_trie_updates(old_block_3, BlockStateDiff::default())?;
+
+    let storage_address = B256::repeat_byte(0x44);
+    let storage_slot = B256::repeat_byte(0x55);
+    let storage_value = U256::from(0x1234);
+
+    let replacement_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xC2)));
+    let replacement_block_3 = BlockWithParent::new(
+        replacement_block_2.block.hash,
+        NumHash::new(3, B256::repeat_byte(0xC3)),
+    );
+
+    let mut replacement_post_state_2 = HashedPostState::default();
+    let mut replacement_storage_2 = HashedStorage::new(false);
+    replacement_storage_2.storage.insert(storage_slot, storage_value);
+    replacement_post_state_2.storages.insert(storage_address, replacement_storage_2);
+
+    let mut replacement_post_state_3 = HashedPostState::default();
+    replacement_post_state_3.storages.insert(storage_address, HashedStorage::new(true));
+
+    storage.replace_updates(
+        BlockNumHash::new(common_block.block.number, common_block.block.hash),
+        vec![
+            (
+                replacement_block_2,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_2.into_sorted(),
+                },
+            ),
+            (
+                replacement_block_3,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_3.into_sorted(),
+                },
+            ),
+        ],
+    )?;
+
+    let mut storage_cursor = storage.storage_hashed_cursor(storage_address, 3)?;
+    let storage_result = storage_cursor.seek(storage_slot)?;
+    assert!(
+        !matches!(storage_result, Some((found_slot, _)) if found_slot == storage_slot),
+        "storage added by replacement block 2 should be wiped by replacement block 3"
+    );
+
+    Ok(())
+}
+
+/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
+///
+/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
+/// it is properly stored as a deletion and subsequent queries return None for that path.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let storage_path1 = nibbles_from(vec![7, 8, 9]);
+    let storage_path2 = nibbles_from(vec![10, 11, 12]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
+    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path1)?.is_some(),
+        "Initial account branch 1 should exist at block 75"
+    );
+    assert!(
+        cursor_75.seek_exact(account_path2)?.is_some(),
+        "Initial account branch 2 should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
+        "Initial storage branch 1 should exist at block 75"
+    );
+    assert!(
+        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
+        "Initial storage branch 2 should exist at block 75"
+    );
+
+    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
+    let mut deletion_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes ONLY (no updates)
+    deletion_trie_updates.removed_nodes.insert(account_path1);
+
+    // Do the same for storage branch
+    let mut deletion_storage_trie = StorageTrieUpdates::default();
+    deletion_storage_trie.removed_nodes.insert(storage_path1);
+    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
+
+    let deletion_diff = BlockStateDiff {
+        sorted_trie_updates: deletion_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, deletion_diff)?;
+
+    // ========== Verify that deleted nodes return None at block 150 ==========
+
+    // Deleted account branch should not be found
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path1)?;
+    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
+
+    // Non-deleted account branch should still exist
+    let account_result2 = cursor_150.seek_exact(account_path2)?;
+    assert!(
+        account_result2.is_some(),
+        "Non-deleted account branch should still exist at block 150"
+    );
+
+    // Deleted storage branch should not be found
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
+    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
+
+    // Non-deleted storage branch should still exist
+    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
+    assert!(
+        storage_result2.is_some(),
+        "Non-deleted storage branch should still exist at block 150"
+    );
+
+    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75_after.seek_exact(account_path1)?.is_some(),
+        "Deleted node should still exist at block 75 (before deletion)"
+    );
+
+    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
+        "Deleted storage node should still exist at block 75 (before deletion)"
+    );
+
+    // ========== Verify iteration skips deleted nodes ==========
+    let mut cursor_iter = storage.account_trie_cursor(150)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor_iter.next()? {
+        found_paths.push(path);
+    }
+
+    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
+    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
+
+    Ok(())
+}
+
+/// Test that updates take precedence over removals when both are present
+///
+/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
+/// the update from `account_nodes` takes precedence. This is critical for correctness
+/// when processing trie updates that both remove and update the same node.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path = nibbles_from(vec![1, 2, 3]);
+    let storage_path = nibbles_from(vec![4, 5, 6]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path)?.is_some(),
+        "Initial account branch should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path)?.is_some(),
+        "Initial storage branch should exist at block 75"
+    );
+
+    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
+    // This simulates a scenario where a node is both removed and updated
+    // The update should take precedence
+    let updated_branch = create_test_branch_variant();
+
+    let mut conflicting_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes
+    conflicting_trie_updates.removed_nodes.insert(account_path);
+
+    // Also add to account_nodes (this should take precedence)
+    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
+
+    // Do the same for storage branch
+    let mut conflicting_storage_trie = StorageTrieUpdates::default();
+    conflicting_storage_trie.removed_nodes.insert(storage_path);
+    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
+    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
+
+    let conflicting_diff = BlockStateDiff {
+        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
+
+    // ========== Verify that updates took precedence at block 150 ==========
+
+    // Account branch should exist (not deleted) with the updated value
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path)?;
+    assert!(
+        account_result.is_some(),
+        "Account branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_path, found_branch) = account_result.unwrap();
+    assert_eq!(found_path, account_path);
+    // Verify it's the updated branch, not the initial one
+    assert_eq!(
+        found_branch.state_mask, updated_branch.state_mask,
+        "Account branch should be the updated version, not the initial one"
+    );
+
+    // Storage branch should exist (not deleted) with the updated value
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
+    assert!(
+        storage_result.is_some(),
+        "Storage branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
+    assert_eq!(found_storage_path, storage_path);
+    // Verify it's the updated branch
+    assert_eq!(
+        found_storage_branch.state_mask, updated_branch.state_mask,
+        "Storage branch should be the updated version, not the initial one"
+    );
+
+    // ========== Verify that the old version still exists at block 75 ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    let result_75 = cursor_75_after.seek_exact(account_path)?;
+    assert!(result_75.is_some(), "Initial version should still exist at block 75");
+    let (_, branch_75) = result_75.unwrap();
+    assert_eq!(
+        branch_75.state_mask, initial_branch.state_mask,
+        "Block 75 should see the initial branch, not the updated one"
+    );
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -27,7 +27,8 @@ use base_execution_trie::{
 };
 use reth_primitives_traits::Account;
 use reth_provider::{
-    StateProofProvider, StateRootProvider, StorageRootProvider, noop::NoopProvider,
+    AccountReader, StateProofProvider, StateProvider, StateRootProvider, StorageRootProvider,
+    noop::NoopProvider,
 };
 use reth_trie_common::{
     ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProofTargets, TrieInput,
@@ -236,6 +237,19 @@ fn storage_root_acquires_one_tx_per_call() {
         provider
             .storage_multiproof(address, &slots, hashed_storage.clone())
             .expect("storage_multiproof");
+    });
+}
+
+#[test]
+fn evm_state_reads_share_one_lazy_tx_per_provider() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
+
+    assert_tx_acquisitions(&storage, 1, "evm_state_reads", || {
+        provider.basic_account(&address).expect("account");
+        provider.storage(address, slots[0]).expect("storage 0");
+        provider.storage(address, slots[1]).expect("storage 1");
     });
 }
 


### PR DESCRIPTION
## Summary

Implements a full RocksDB-backed proof storage backend. Uses complement-encoded block numbers for history table keys so latest-version lookups use fast forward seeks instead of reverse seeks.

## Changes

- Add `crates/execution/trie/src/db/rocksdb.rs` (~3600 lines): full RocksDB implementation of `BaseProofsStore` with `RocksdbProofsStorage`, `RocksdbAccountCursor`, `RocksdbStorageCursor`, `RocksdbTrieCursor`, `RocksdbReadSnapshot`, `RocksdbBatchSession`
- History table keys use `u64::MAX - block_number` (complement encoding, big-endian) so forward `seek()+next()` finds the latest version ≤ N (~32% faster uncompacted, ~10% faster compacted vs reverse seek)
- Add `benches/witness_reads.rs`
- Add integration tests (5 new test modules)
- Wire `rocksdb` crate dep into `trie/Cargo.toml`

## Stack

This is PR 2/4 in a stack:
1. [PR 1 #3411] `refactor(trie): abstract BaseProofsStore trait`
2. **This PR** — RocksDB backend implementation
3. [PR 3] `feat(node): wire RocksDB proof storage backend into node and CLI`
4. [PR 4] `feat(trie/rocksdb): add RocksdbBatchSession for amortized multi-block writes`

## Testing

`cargo check -p base-execution-trie` passes cleanly. Integration tests under `trie/tests/`.