### PR TITLE
fix(precompile-storage): replace saturating/unchecked slot arithmetic with checked_add (BOP-356)

### DIFF
--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -83,16 +83,12 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
-                base_slot
-                    .checked_add(U256::from(location.offset_slots))
-                    .expect("slot overflow"),
+                base_slot.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
-                base_slot
-                    .checked_add(U256::from(index * T::SLOTS))
-                    .expect("slot overflow"),
+                base_slot.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
                 LayoutCtx::FULL,
             )
         };

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -83,11 +83,18 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
-                base_slot + U256::from(location.offset_slots),
+                base_slot
+                    .checked_add(U256::from(location.offset_slots))
+                    .expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
-            (base_slot + U256::from(index * T::SLOTS), LayoutCtx::FULL)
+            (
+                base_slot
+                    .checked_add(U256::from(index * T::SLOTS))
+                    .expect("slot overflow"),
+                LayoutCtx::FULL,
+            )
         };
         T::handle(slot, layout_ctx, address, storage)
     }

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -194,9 +194,8 @@ where
         let mut data = Vec::new();
 
         for i in 0..chunks {
-            let slot = slot_start
-                .checked_add(U256::from(i))
-                .ok_or(BasePrecompileError::SlotOverflow)?;
+            let slot =
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_value = storage.load(slot)?;
             let chunk_bytes = chunk_value.to_be_bytes::<32>();
             let bytes_to_take = if i == chunks - 1 { length - (i * 32) } else { 32 };
@@ -221,9 +220,8 @@ fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U25
         let chunks = calc_chunks(length);
 
         for i in 0..chunks {
-            let slot = slot_start
-                .checked_add(U256::from(i))
-                .ok_or(BasePrecompileError::SlotOverflow)?;
+            let slot =
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_start = i * 32;
             let chunk_end = (chunk_start + 32).min(length);
             let chunk = &bytes[chunk_start..chunk_end];
@@ -247,9 +245,7 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
         let chunks = calc_chunks(length);
         for i in 0..chunks {
             storage.store(
-                slot_start
-                    .checked_add(U256::from(i))
-                    .ok_or(BasePrecompileError::SlotOverflow)?,
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?,
                 U256::ZERO,
             )?;
         }

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -194,7 +194,9 @@ where
         let mut data = Vec::new();
 
         for i in 0..chunks {
-            let slot = slot_start + U256::from(i);
+            let slot = slot_start
+                .checked_add(U256::from(i))
+                .ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_value = storage.load(slot)?;
             let chunk_bytes = chunk_value.to_be_bytes::<32>();
             let bytes_to_take = if i == chunks - 1 { length - (i * 32) } else { 32 };
@@ -219,7 +221,9 @@ fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U25
         let chunks = calc_chunks(length);
 
         for i in 0..chunks {
-            let slot = slot_start + U256::from(i);
+            let slot = slot_start
+                .checked_add(U256::from(i))
+                .ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_start = i * 32;
             let chunk_end = (chunk_start + 32).min(length);
             let chunk = &bytes[chunk_start..chunk_end];
@@ -242,7 +246,12 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
         let slot_start = calc_data_slot(base_slot);
         let chunks = calc_chunks(length);
         for i in 0..chunks {
-            storage.store(slot_start + U256::from(i), U256::ZERO)?;
+            storage.store(
+                slot_start
+                    .checked_add(U256::from(i))
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
+                U256::ZERO,
+            )?;
         }
     }
 

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -134,7 +134,9 @@ where
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         let values: Vec<T> = Vec::load(storage, slot, LayoutCtx::FULL)?;
         for value in values {
-            let pos_slot = value.mapping_slot(slot + U256::ONE);
+            let pos_slot = value.mapping_slot(
+            slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?,
+        );
             <U256 as Storable>::delete(storage, pos_slot, LayoutCtx::FULL)?;
         }
         <Vec<T> as Storable>::delete(storage, slot, ctx)
@@ -154,10 +156,14 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
         Self {
             values: VecHandler::new(base_slot, address, storage),
-            positions: MappingHandler::new(base_slot + U256::ONE, address, storage),
+            positions: MappingHandler::new(
+                base_slot.checked_add(U256::ONE).expect("slot overflow"),
+                address,
+                storage,
+            ),
             base_slot,
             address,
             storage,

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -135,8 +135,8 @@ where
         let values: Vec<T> = Vec::load(storage, slot, LayoutCtx::FULL)?;
         for value in values {
             let pos_slot = value.mapping_slot(
-            slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?,
-        );
+                slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?,
+            );
             <U256 as Storable>::delete(storage, pos_slot, LayoutCtx::FULL)?;
         }
         <Vec<T> as Storable>::delete(storage, slot, ctx)

--- a/crates/common/precompile-storage/src/types/slot.rs
+++ b/crates/common/precompile-storage/src/types/slot.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use alloy_primitives::{Address, U256};
 
 use crate::{
-    error::Result,
+    error::{BasePrecompileError, Result},
     packing::FieldLocation,
     provider::{Handler, LayoutCtx, Storable, StorableType, StorageOps},
     storage_ctx::StorageCtx,
@@ -41,19 +41,21 @@ impl<'a, T> Slot<'a, T> {
 
     /// Creates a full-slot accessor at `base_slot + offset_slots`.
     #[inline]
-    pub const fn new_at_offset(
+    pub fn new_at_offset(
         base_slot: U256,
         offset_slots: usize,
         address: Address,
         storage: StorageCtx<'a>,
-    ) -> Self {
-        Self {
-            slot: base_slot.saturating_add(U256::from_limbs([offset_slots as u64, 0, 0, 0])),
+    ) -> Result<Self> {
+        Ok(Self {
+            slot: base_slot
+                .checked_add(U256::from_limbs([offset_slots as u64, 0, 0, 0]))
+                .ok_or(BasePrecompileError::SlotOverflow)?,
             ctx: LayoutCtx::FULL,
             address,
             storage,
             _ty: PhantomData,
-        }
+        })
     }
 
     /// Creates a packed-field accessor using a [`FieldLocation`] from `#[derive(Storable)]`.
@@ -63,18 +65,20 @@ impl<'a, T> Slot<'a, T> {
         loc: FieldLocation,
         address: Address,
         storage: StorageCtx<'a>,
-    ) -> Self
+    ) -> Result<Self>
     where
         T: StorableType,
     {
         debug_assert!(T::IS_PACKABLE, "`fn new_at_loc` can only be used with packable types");
-        Self {
-            slot: base_slot.saturating_add(U256::from_limbs([loc.offset_slots as u64, 0, 0, 0])),
+        Ok(Self {
+            slot: base_slot
+                .checked_add(U256::from_limbs([loc.offset_slots as u64, 0, 0, 0]))
+                .ok_or(BasePrecompileError::SlotOverflow)?,
             ctx: LayoutCtx::packed(loc.offset_bytes),
             address,
             storage,
             _ty: PhantomData,
-        }
+        })
     }
 
     /// Returns the storage slot number.
@@ -249,7 +253,7 @@ mod tests {
             let base = pair_key.mapping_slot(U256::ZERO);
             let test_addr = Address::from([0x22; 20]);
 
-            let mut slot = Slot::<Address>::new_at_offset(base, 0, address, ctx);
+            let mut slot = Slot::<Address>::new_at_offset(base, 0, address, ctx)?;
             slot.write(test_addr)?;
             assert_eq!(slot.read()?, test_addr);
             slot.delete()?;

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -198,16 +198,12 @@ where
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = calc_element_loc(index, T::BYTES);
             (
-                data_start
-                    .checked_add(U256::from(location.offset_slots))
-                    .expect("slot overflow"),
+                data_start.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
-                data_start
-                    .checked_add(U256::from(index * T::SLOTS))
-                    .expect("slot overflow"),
+                data_start.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
                 LayoutCtx::FULL,
             )
         };

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -85,11 +85,18 @@ where
         if T::BYTES <= 16 {
             let slot_count = calc_packed_slot_count(length, T::BYTES);
             for slot_idx in 0..slot_count {
-                storage.store(data_start + U256::from(slot_idx), U256::ZERO)?;
+                storage.store(
+                    data_start
+                        .checked_add(U256::from(slot_idx))
+                        .ok_or(BasePrecompileError::SlotOverflow)?,
+                    U256::ZERO,
+                )?;
             }
         } else {
             for elem_idx in 0..length {
-                let elem_slot = data_start + U256::from(elem_idx * T::SLOTS);
+                let elem_slot = data_start
+                    .checked_add(U256::from(elem_idx * T::SLOTS))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
                 T::delete(storage, elem_slot, LayoutCtx::FULL)?;
             }
         }
@@ -191,11 +198,18 @@ where
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = calc_element_loc(index, T::BYTES);
             (
-                data_start + U256::from(location.offset_slots),
+                data_start
+                    .checked_add(U256::from(location.offset_slots))
+                    .expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
-            (data_start + U256::from(index * T::SLOTS), LayoutCtx::FULL)
+            (
+                data_start
+                    .checked_add(U256::from(index * T::SLOTS))
+                    .expect("slot overflow"),
+                LayoutCtx::FULL,
+            )
         };
         T::handle(slot, layout_ctx, address, storage)
     }
@@ -324,7 +338,9 @@ where
     let mut current_offset = 0;
 
     for slot_idx in 0..slot_count {
-        let slot_addr = data_start + U256::from(slot_idx);
+        let slot_addr = data_start
+            .checked_add(U256::from(slot_idx))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         let slot_value = storage.load(slot_addr)?;
         let slot_packed = PackedSlot(slot_value);
 
@@ -363,7 +379,9 @@ where
     let slot_count = calc_packed_slot_count(elements.len(), byte_count);
 
     for slot_idx in 0..slot_count {
-        let slot_addr = data_start + U256::from(slot_idx);
+        let slot_addr = data_start
+            .checked_add(U256::from(slot_idx))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         let start_elem = slot_idx * elements_per_slot;
         let end_elem = (start_elem + elements_per_slot).min(elements.len());
         let slot_value = build_packed_slot(&elements[start_elem..end_elem], byte_count)?;
@@ -393,7 +411,9 @@ where
 {
     let mut result = Vec::new();
     for index in 0..length {
-        let elem_slot = data_start + U256::from(index * T::SLOTS);
+        let elem_slot = data_start
+            .checked_add(U256::from(index * T::SLOTS))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         result.push(T::load(storage, elem_slot, LayoutCtx::FULL)?);
     }
     Ok(result)
@@ -405,7 +425,9 @@ where
     S: StorageOps,
 {
     for (idx, elem) in elements.iter().enumerate() {
-        let elem_slot = data_start + U256::from(idx * T::SLOTS);
+        let elem_slot = data_start
+            .checked_add(U256::from(idx * T::SLOTS))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         elem.store(storage, elem_slot, LayoutCtx::FULL)?;
     }
     Ok(())


### PR DESCRIPTION
## Summary

- Cantina audit finding #33 (Low severity, BOP-356): slot offset arithmetic in `base-precompile-storage` used `saturating_add` (which silently aliases two distinct slots to `U256::MAX` on overflow) and unchecked `+` (which panics in debug builds)
- Replace all slot additions with `checked_add`, returning `BasePrecompileError::SlotOverflow` in `Result`-returning functions; use `checked_add().expect("slot overflow")` in constructors and `Index`/`IndexMut` impls where the trait contract requires an infallible signature
- `Slot::new_at_offset` and `Slot::new_at_loc` now return `Result<Self>` instead of `Self`

## Files changed

- `types/slot.rs` — `new_at_offset`, `new_at_loc`: `saturating_add` → `checked_add().ok_or(SlotOverflow)?`, return type changed to `Result<Self>`
- `types/vec.rs` — all five slot-offset sites in free functions; `compute_handler` uses `expect` (infallible cache closure)
- `types/set.rs` — `Storable::delete` uses `?`; `SetHandler::new` constructor uses `expect`; `new` marked `const`
- `types/array.rs` — `compute_handler` uses `expect` (`Index`/`IndexMut` must be infallible)
- `types/bytes_like.rs` — all three chunk-loop sites use `?`

## Test plan

- [x] `cargo test -p base-precompile-storage` — 171 tests pass
- [x] `cargo clippy -p base-precompile-storage` — clean