### PR TITLE
[backport] Backport BOP fixes to releases/v1.1.0

### DIFF
--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -181,8 +181,13 @@ struct InstallConfig {
 impl Parse for InstallConfig {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let key: Ident = input.parse()?;
-        if key != "address" && key != "addr" {
-            return Err(syn::Error::new_spanned(key, "`install` supports only `address = ...`"));
+        if key != "addr" {
+            return Err(syn::Error::new_spanned(
+                &key,
+                format!(
+                    "unrecognized install argument `{key}`, the supported argument is `addr = \"0x...\"`"
+                ),
+            ));
         }
 
         input.parse::<Token![=]>()?;
@@ -259,15 +264,33 @@ mod tests {
     }
 
     #[test]
-    fn config_rejects_install_option_without_comma_as_unexpected_option() {
-        let err = parse_config(quote! { install(address = X extra) }).err().unwrap();
+    fn install_config_rejects_address_alias_with_helpful_diagnostic() {
+        let err = parse_config(quote! { install(address = X) }).err().unwrap();
+
+        let msg = err.to_string();
+        assert!(msg.contains("unrecognized install argument `address`"), "got: {msg}");
+        assert!(msg.contains("addr"), "got: {msg}");
+    }
+
+    #[test]
+    fn install_config_rejects_typo_with_helpful_diagnostic() {
+        let err = parse_config(quote! { install(a = X) }).err().unwrap();
+
+        let msg = err.to_string();
+        assert!(msg.contains("unrecognized install argument `a`"), "got: {msg}");
+        assert!(msg.contains("addr"), "got: {msg}");
+    }
+
+    #[test]
+    fn install_config_rejects_extra_option_without_comma() {
+        let err = parse_config(quote! { install(addr = X extra) }).err().unwrap();
 
         assert!(err.to_string().contains("unexpected `install` option"));
     }
 
     #[test]
-    fn config_rejects_extra_install_option_after_comma() {
-        let err = parse_config(quote! { install(address = X, extra) }).err().unwrap();
+    fn install_config_rejects_extra_option_after_comma() {
+        let err = parse_config(quote! { install(addr = X, extra) }).err().unwrap();
 
         assert!(err.to_string().contains("unexpected `install` option"));
     }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -188,19 +188,30 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         if self.gas.remaining() <= self.gas_params.call_stipend() {
             return Err(BasePrecompileError::OutOfGas);
         }
-        let s = self
-            .internals
-            .sstore(address, key, value)
-            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+        let checkpoint = self.internals.checkpoint();
+        let result = (|| {
+            let s = self
+                .internals
+                .sstore(address, key, value)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
 
-        // EIP-2929: static warm base cost
-        self.deduct_gas(self.gas_params.sstore_static_gas())?;
-        // EIP-2929 + EIP-2200: dynamic cost (cold penalty + net-metering)
-        self.deduct_gas(self.gas_params.sstore_dynamic_gas(true, &s.data, s.is_cold))?;
-        // EIP-3529: net-metering refund
-        self.refund_gas(self.gas_params.sstore_refund(true, &s.data));
+            // EIP-2929: static warm base cost
+            self.deduct_gas(self.gas_params.sstore_static_gas())?;
+            // EIP-2929 + EIP-2200: dynamic cost (cold penalty + net-metering)
+            self.deduct_gas(self.gas_params.sstore_dynamic_gas(true, &s.data, s.is_cold))?;
+            // EIP-3529: net-metering refund
+            self.refund_gas(self.gas_params.sstore_refund(true, &s.data));
 
-        Ok(())
+            Ok(())
+        })();
+
+        if result.is_ok() {
+            self.internals.checkpoint_commit();
+        } else {
+            self.internals.checkpoint_revert(checkpoint);
+        }
+
+        result
     }
 
     fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
@@ -281,8 +292,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         self.internals.checkpoint()
     }
 
-    fn checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint) {
-        // alloy-evm's checkpoint_commit pops the top checkpoint; the arg is unused.
+    fn checkpoint_commit(&mut self) {
         self.internals.checkpoint_commit();
     }
 
@@ -310,8 +320,12 @@ impl From<alloy_evm::EvmInternalsError> for BasePrecompileError {
 
 #[cfg(test)]
 mod tests {
+    use alloy_evm::{EvmInternals, eth::EthEvmContext, precompiles::PrecompileInput};
     use alloy_primitives::{Address, U256};
-    use revm::{context_interface::cfg::GasParams, primitives::hardfork::SpecId, state::Bytecode};
+    use revm::{
+        context_interface::cfg::GasParams, database::EmptyDB, primitives::hardfork::SpecId,
+        state::Bytecode,
+    };
 
     use crate::{
         BasePrecompileError, hashmap::HashMapStorageProvider, provider::PrecompileStorageProvider,
@@ -339,6 +353,60 @@ mod tests {
             2300,
             "call_stipend must equal 2300 as required by EIP-2200"
         );
+    }
+
+    #[test]
+    fn sstore_oog_reverts_local_journal_mutation() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let address = Address::repeat_byte(0x42);
+        let key = U256::from(7);
+        let value = U256::from(99);
+
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: gas_params
+                    .call_stipend()
+                    .saturating_add(gas_params.sstore_static_gas())
+                    .saturating_add(1),
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+
+            let err = provider.sstore(address, key, value).unwrap_err();
+
+            assert_eq!(err, BasePrecompileError::OutOfGas);
+        }
+
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+
+            assert_eq!(provider.sload(address, key).unwrap(), U256::ZERO);
+            assert_eq!(
+                provider.gas_used(),
+                gas_params
+                    .warm_storage_read_cost()
+                    .saturating_add(gas_params.cold_storage_additional_cost())
+            );
+        }
     }
 
     /// `set_code` on a brand-new account must charge both `create_state_gas` and

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -254,12 +254,8 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         JournalCheckpoint { log_i: 0, journal_i: idx, selfdestructed_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self, checkpoint: JournalCheckpoint) {
-        assert_eq!(
-            checkpoint.journal_i,
-            self.snapshots.len() - 1,
-            "out-of-order checkpoint commit (expected top of stack)"
-        );
+    fn checkpoint_commit(&mut self) {
+        assert!(!self.snapshots.is_empty(), "checkpoint_commit called with no active checkpoint");
         self.snapshots.pop();
     }
 

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -87,8 +87,8 @@ pub trait PrecompileStorageProvider {
 
     /// Creates a new journal checkpoint for atomic state management.
     fn checkpoint(&mut self) -> JournalCheckpoint;
-    /// Commits all state changes since the given checkpoint.
-    fn checkpoint_commit(&mut self, checkpoint: JournalCheckpoint);
+    /// Commits all state changes since the last checkpoint.
+    fn checkpoint_commit(&mut self);
     /// Reverts all state changes back to the given checkpoint.
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint);
 

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -284,8 +284,8 @@ pub struct CheckpointGuard<'a> {
 impl CheckpointGuard<'_> {
     /// Commits all state changes since the checkpoint.
     pub fn commit(mut self) {
-        if let Some(cp) = self.checkpoint.take() {
-            self.storage.with_storage(|s| s.checkpoint_commit(cp));
+        if self.checkpoint.take().is_some() {
+            self.storage.with_storage(|s| s.checkpoint_commit());
         }
     }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -448,6 +448,13 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
         self.begin_announcement();
 
+        // Each internal call is dispatched via `inner_with_privilege`, a direct Rust function
+        // call. Unlike the base-std Solidity reference which routes each `internalCalls` entry
+        // through a DELEGATECALL (~100 gas opcode overhead + memory expansion), the native
+        // precompile replaces the entire EVM execution path so per-opcode call overhead does not
+        // apply. The cheaper batched cost is intentional: the native precompile pays for the
+        // storage work of each sub-call (the same SLOAD/SSTORE operations as the Solidity
+        // reference) but not for EVM call-frame overhead that exists only in the interpreter.
         for call in &internal_calls {
             let call_bytes: &[u8] = call.as_ref();
             if call_bytes.len() < 4 {


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of #3310, #3363, #3383, and #3406 into `releases/v1.1.0`.

Source PRs:
- #3310 - fix(common): Make SSTORE OOG Atomic
- #3363 - docs(b20-asset): document intentional announce batched-call gas model and pin storage op count
- #3383 - fix(precompile-macros): improve install arg diagnostics and reject address alias
- #3406 - fix(precompile-storage): remove unused token arg from checkpoint_commit (BOP-350)

Validation:
- cargo +nightly fmt
- cargo test -p base-precompile-storage --features test-utils
- cargo test -p base-common-precompiles --features test-utils
- cargo test -p base-precompile-macros
- cargo check -p base-precompile-storage --no-default-features
- git diff --check origin/releases/v1.1.0