### PR TITLE
ci(base-std-fork-tests): pin base-anvil to a commit (SHA-capable clone)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -10,7 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BASE_ANVIL_REF: base-anvil-fork
+  # Pinned base-anvil commit so this job is decoupled from base-anvil-fork
+  # branch movement. Bump in lockstep with base/base's reth/revm version; a
+  # cutover to a new base-anvil (e.g. reth 2.3.0) rides in the same base/base PR.
+  BASE_ANVIL_REF: 85f5a0e2867cb88c55e9af29b348511f91cbc383
   BASE_STD_REF: main
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
@@ -62,8 +65,9 @@ jobs:
           gh repo clone base/base-std "$workdir/base-std" -- \
             --depth 1 --single-branch --branch "$BASE_STD_REF" \
             --recurse-submodules --shallow-submodules
-          git clone --depth 1 --single-branch --branch "$BASE_ANVIL_REF" \
+          git clone --filter=blob:none --no-checkout \
             https://github.com/base/base-anvil.git "$workdir/base-anvil"
+          git -C "$workdir/base-anvil" checkout --detach "$BASE_ANVIL_REF"
 
           echo "BASE_STD_DIR=$workdir/base-std" >> "$GITHUB_ENV"
           echo "BASE_ANVIL_DIR=$workdir/base-anvil" >> "$GITHUB_ENV"


### PR DESCRIPTION
## What
Pin the Base Std Interface job to a specific base-anvil **commit** instead of building the moving `base-anvil-fork` branch:
- `BASE_ANVIL_REF` is now a commit SHA (current `base-anvil-fork` HEAD `85f5a0e2`), immutable and never pruned.
- Clone is now SHA-capable (`git clone --filter=blob:none --no-checkout` + `git checkout --detach`), so the ref can be a branch, tag, or SHA.

## Why
The interface job compiles base/base's precompiles *into* base-anvil, so the two must share a revm/reth version. Building the moving `base-anvil-fork` branch means any base-anvil change (or a reth-version mismatch) can break every base/base PR's interface check. Pinning decouples that.

## Behavior
No-op today: the pinned SHA == current `base-anvil-fork` HEAD, so the job builds the exact same base-anvil. Tradeoff (intended): the job no longer auto-follows `base-anvil-fork`; bumping `BASE_ANVIL_REF` is now a deliberate step.

## Follow-up (separate, coordinated)
When base/base moves to reth 2.3.0, bump `BASE_ANVIL_REF` to the matching reth-2.3.0 base-anvil commit **in that same base/base PR** (#proj-b20). Pre-2.3.0 PRs keep using this pin, so nothing breaks in between.

Part of the base-anvil external-dev-testing effort (Linear BOP-371).
