### PR TITLE
[backport] BOP Batch 4 fixes for releases/v1.1.0

### DIFF
--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -61,15 +61,16 @@ pub(crate) fn generate(input: DeriveInput, address: Option<&Expr>) -> proc_macro
 fn gen_output(input: DeriveInput, address: Option<&Expr>) -> syn::Result<TokenStream> {
     let (ident, vis) = (input.ident.clone(), input.vis.clone());
     let namespace = extract_namespace(&input.attrs)?;
-    let derives = input
+    let passthrough_attrs = input
         .attrs
         .iter()
-        .filter(|attr| attr.path().is_ident("derive"))
+        .filter(|attr| !attr.path().is_ident("namespace"))
         .cloned()
         .collect::<Vec<_>>();
     let fields = parse_fields(input, namespace.is_some())?;
 
-    let storage_output = gen_storage(&ident, &vis, &derives, &fields, address, namespace.as_ref())?;
+    let storage_output =
+        gen_storage(&ident, &vis, &passthrough_attrs, &fields, address, namespace.as_ref())?;
     Ok(quote! { #storage_output })
 }
 

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -124,11 +124,15 @@ pub(crate) fn gen_struct(
     allocated_fields: &[LayoutField<'_>],
 ) -> proc_macro2::TokenStream {
     let handler_fields = allocated_fields.iter().map(gen_handler_field_decl);
-    let doc_str = format!("Storage layout for the [`{name}`] precompile.");
+    let has_user_doc = attrs.iter().any(|attr| attr.path().is_ident("doc"));
+    let fallback_doc = (!has_user_doc).then(|| {
+        let doc_str = format!("Storage layout for the [`{name}`] precompile.");
+        quote! { #[doc = #doc_str] }
+    });
 
     quote! {
         #(#attrs)*
-        #[doc = #doc_str]
+        #fallback_doc
         #vis struct #name<'a> {
             #(#handler_fields,)*
             address: ::alloy_primitives::Address,

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -92,6 +92,7 @@ impl Parse for PrecompileConfig {
         let mut storage = None;
         let mut macro_path = None;
         let mut args = Vec::new();
+        let mut args_seen = false;
         let mut install = None;
 
         while !input.is_empty() {
@@ -113,9 +114,10 @@ impl Parse for PrecompileConfig {
                     macro_path = Some(input.parse()?);
                 }
                 "args" => {
-                    if !args.is_empty() {
+                    if args_seen {
                         return Err(syn::Error::new_spanned(key, "duplicate `args` option"));
                     }
+                    args_seen = true;
                     let content;
                     parenthesized!(content in input);
                     args = content
@@ -270,5 +272,19 @@ mod tests {
         let err = parse_config(quote! { install(address = X, extra) }).err().unwrap();
 
         assert!(err.to_string().contains("unexpected `install` option"));
+    }
+
+    #[test]
+    fn config_rejects_duplicate_empty_args() {
+        let err = parse_config(quote! { args(), args() }).err().unwrap();
+
+        assert!(err.to_string().contains("duplicate `args` option"));
+    }
+
+    #[test]
+    fn config_rejects_duplicate_args_where_first_is_empty() {
+        let err = parse_config(quote! { args(), args(x: u8) }).err().unwrap();
+
+        assert!(err.to_string().contains("duplicate `args` option"));
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -37,7 +37,11 @@ pub struct HashMapStorageProvider {
 #[derive(Debug)]
 struct Snapshot {
     internals: HashMap<(Address, U256), U256>,
+    transient: HashMap<(Address, U256), U256>,
+    accounts: HashMap<Address, AccountInfo>,
     events: HashMap<Address, Vec<LogData>>,
+    gas_refunded: i64,
+    state_gas_used: u64,
 }
 
 impl HashMapStorageProvider {
@@ -221,8 +225,14 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn checkpoint(&mut self) -> JournalCheckpoint {
         let idx = self.snapshots.len();
-        self.snapshots
-            .push(Snapshot { internals: self.internals.clone(), events: self.events.clone() });
+        self.snapshots.push(Snapshot {
+            internals: self.internals.clone(),
+            transient: self.transient.clone(),
+            accounts: self.accounts.clone(),
+            events: self.events.clone(),
+            gas_refunded: self.gas_refunded,
+            state_gas_used: self.state_gas_used,
+        });
         JournalCheckpoint { log_i: 0, journal_i: idx, selfdestructed_i: 0 }
     }
 
@@ -243,7 +253,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         );
         if let Some(snapshot) = self.snapshots.drain(checkpoint.journal_i..).next() {
             self.internals = snapshot.internals;
+            self.transient = snapshot.transient;
+            self.accounts = snapshot.accounts;
             self.events = snapshot.events;
+            self.gas_refunded = snapshot.gas_refunded;
+            self.state_gas_used = snapshot.state_gas_used;
         }
     }
 }
@@ -407,5 +421,88 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_internals() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(1u64)).unwrap();
+        let cp = p.checkpoint();
+        p.sstore(ADDR, KEY, U256::from(2u64)).unwrap();
+        p.checkpoint_revert(cp);
+        assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(1u64));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_transient() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.tstore(ADDR, KEY, U256::from(10u64)).unwrap();
+        let cp = p.checkpoint();
+        p.tstore(ADDR, KEY, U256::from(99u64)).unwrap();
+        p.checkpoint_revert(cp);
+        assert_eq!(p.tload(ADDR, KEY).unwrap(), U256::from(10u64));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_accounts() {
+        let mut p = HashMapStorageProvider::new(1);
+        let code_before = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        p.set_code(ADDR, code_before.clone()).unwrap();
+        let cp = p.checkpoint();
+        let code_after = Bytecode::new_raw([0x60u8, 0x01].as_ref().into());
+        p.set_code(ADDR, code_after).unwrap();
+        p.checkpoint_revert(cp);
+        let mut seen_hash = None;
+        p.with_account_info(ADDR, &mut |info| {
+            seen_hash = Some(info.code_hash);
+        })
+        .unwrap();
+        assert_eq!(seen_hash.unwrap(), code_before.hash_slow());
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_events() {
+        use alloy_primitives::Bytes;
+        let mut p = HashMapStorageProvider::new(1);
+        let event_before = LogData::new_unchecked(vec![], Bytes::from_static(b"before"));
+        p.emit_event(ADDR, event_before).unwrap();
+        let cp = p.checkpoint();
+        let event_after = LogData::new_unchecked(vec![], Bytes::from_static(b"after"));
+        p.emit_event(ADDR, event_after).unwrap();
+        p.checkpoint_revert(cp);
+        let events = p.get_events(ADDR);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, Bytes::from_static(b"before"));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_gas_refunded() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(1_000);
+        let cp = p.checkpoint();
+        p.refund_gas(500);
+        assert_eq!(p.gas_refunded(), 1_500);
+        p.checkpoint_revert(cp);
+        assert_eq!(p.gas_refunded(), 1_000);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_state_gas_used() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.deduct_state_gas(100).unwrap();
+        let cp = p.checkpoint();
+        p.deduct_state_gas(50).unwrap();
+        assert_eq!(p.state_gas_used(), 150);
+        p.checkpoint_revert(cp);
+        assert_eq!(p.state_gas_used(), 100);
+    }
+
+    #[test]
+    fn checkpoint_commit_does_not_revert_mutations() {
+        let mut p = HashMapStorageProvider::new(1);
+        let cp = p.checkpoint();
+        p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
+        p.checkpoint_commit(cp);
+        assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -83,11 +83,14 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
-                base_slot + U256::from(location.offset_slots),
+                base_slot.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
-            (base_slot + U256::from(index * T::SLOTS), LayoutCtx::FULL)
+            (
+                base_slot.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                LayoutCtx::FULL,
+            )
         };
         T::handle(slot, layout_ctx, address, storage)
     }

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -73,6 +73,10 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         )
     }
 
+    // Called from `Index` and `IndexMut` impls, which return `&T` / `&mut T` — not `Result`.
+    // The `Index` trait is infallible by design, so error propagation is impossible here.
+    // Overflow is unreachable in practice: `base_slot` is a keccak256 output (never U256::MAX)
+    // and `N` is a compile-time constant bounded by the `storable_arrays!` macro (N ≤ 32).
     #[inline]
     fn compute_handler(
         base_slot: U256,
@@ -83,12 +87,16 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
-                base_slot.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
+                base_slot
+                    .checked_add(U256::from(location.offset_slots))
+                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
-                base_slot.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                base_slot
+                    .checked_add(U256::from(index * T::SLOTS))
+                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
                 LayoutCtx::FULL,
             )
         };

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -4,12 +4,10 @@
 //! - **Base slot**: Arrays start directly at `base_slot` (not at keccak256)
 //! - Small elements (`T::BYTES` ≤ 16) are packed; larger elements use full slots.
 
-use core::ops::{Index, IndexMut};
-
 use alloy_primitives::{Address, U256};
 
 use crate::{
-    error::Result,
+    error::{BasePrecompileError, Result},
     packing,
     provider::{Handler, LayoutCtx, Storable, StorableType},
     types::{HandlerCache, Slot},
@@ -61,66 +59,52 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
 
     /// Returns a handler for the element at the given index, or `None` if out of bounds.
     #[inline]
-    pub fn at(&mut self, index: usize) -> Option<&T::Handler<'a>> {
+    pub fn at(&self, index: usize) -> Result<Option<&T::Handler<'a>>> {
         if index >= N {
-            return None;
+            return Ok(None);
         }
         let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        Some(
-            self.cache.get_or_insert(&index, || {
-                Self::compute_handler(base_slot, address, storage, index)
-            }),
-        )
+        Ok(Some(self.cache.get_or_try_insert(&index, || {
+            Self::try_compute_handler(base_slot, address, storage, index)
+        })?))
     }
 
-    // Called from `Index` and `IndexMut` impls, which return `&T` / `&mut T` — not `Result`.
-    // The `Index` trait is infallible by design, so error propagation is impossible here.
-    // Overflow is unreachable in practice: `base_slot` is a keccak256 output (never U256::MAX)
-    // and `N` is a compile-time constant bounded by the `storable_arrays!` macro (N ≤ 32).
+    /// Returns a mutable handler for the element at the given index, or `None` if out of bounds.
     #[inline]
-    fn compute_handler(
+    pub fn at_mut(&mut self, index: usize) -> Result<Option<&mut T::Handler<'a>>> {
+        if index >= N {
+            return Ok(None);
+        }
+        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
+        Ok(Some(self.cache.get_or_try_insert_mut(&index, || {
+            Self::try_compute_handler(base_slot, address, storage, index)
+        })?))
+    }
+
+    #[inline]
+    fn try_compute_handler(
         base_slot: U256,
         address: Address,
         storage: crate::StorageCtx<'a>,
         index: usize,
-    ) -> T::Handler<'a> {
+    ) -> Result<T::Handler<'a>> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
                 base_slot
                     .checked_add(U256::from(location.offset_slots))
-                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
                 base_slot
                     .checked_add(U256::from(index * T::SLOTS))
-                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::FULL,
             )
         };
-        T::handle(slot, layout_ctx, address, storage)
-    }
-}
-
-impl<'a, T: StorableType, const N: usize> Index<usize> for ArrayHandler<'a, T, N> {
-    type Output = T::Handler<'a>;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        assert!(index < N, "index out of bounds: {index} >= {N}");
-        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache
-            .get_or_insert(&index, || Self::compute_handler(base_slot, address, storage, index))
-    }
-}
-
-impl<'a, T: StorableType, const N: usize> IndexMut<usize> for ArrayHandler<'a, T, N> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        assert!(index < N, "index out of bounds: {index} >= {N}");
-        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache
-            .get_or_insert_mut(&index, || Self::compute_handler(base_slot, address, storage, index))
+        Ok(T::handle(slot, layout_ctx, address, storage))
     }
 }
 

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -194,7 +194,8 @@ where
         let mut data = Vec::new();
 
         for i in 0..chunks {
-            let slot = slot_start + U256::from(i);
+            let slot =
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_value = storage.load(slot)?;
             let chunk_bytes = chunk_value.to_be_bytes::<32>();
             let bytes_to_take = if i == chunks - 1 { length - (i * 32) } else { 32 };
@@ -219,7 +220,8 @@ fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U25
         let chunks = calc_chunks(length);
 
         for i in 0..chunks {
-            let slot = slot_start + U256::from(i);
+            let slot =
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_start = i * 32;
             let chunk_end = (chunk_start + 32).min(length);
             let chunk = &bytes[chunk_start..chunk_end];
@@ -242,7 +244,10 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
         let slot_start = calc_data_slot(base_slot);
         let chunks = calc_chunks(length);
         for i in 0..chunks {
-            storage.store(slot_start + U256::from(i), U256::ZERO)?;
+            storage.store(
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?,
+                U256::ZERO,
+            )?;
         }
     }
 

--- a/crates/common/precompile-storage/src/types/mod.rs
+++ b/crates/common/precompile-storage/src/types/mod.rs
@@ -64,6 +64,20 @@ impl<K: Ord + Clone, H> HandlerCache<K, H> {
         unsafe { &*(boxed.as_ref() as *const H) }
     }
 
+    /// Fallible variant of [`get_or_insert`]: the initializer may return `Err`, in which
+    /// case nothing is inserted and the error is propagated.
+    pub fn get_or_try_insert<E>(&self, key: &K, f: impl FnOnce() -> Result<H, E>) -> Result<&H, E> {
+        let mut cache = self.inner.borrow_mut();
+        if let Some(boxed) = cache.get(key) {
+            // SAFETY: Same as `get_or_insert` — stable boxed allocation, append-only cache.
+            return Ok(unsafe { &*(boxed.as_ref() as *const H) });
+        }
+        cache.insert(key.clone(), Box::new(f()?));
+        let boxed = cache.get(key).expect("handler cache was just populated");
+        // SAFETY: See above.
+        Ok(unsafe { &*(boxed.as_ref() as *const H) })
+    }
+
     /// Returns a mutable reference to a lazily initialized handler for the given key.
     pub fn get_or_insert_mut(&mut self, key: &K, f: impl FnOnce() -> H) -> &mut H {
         // Using get_mut() requires &mut self (exclusive access) — no borrow guard needed.
@@ -72,5 +86,18 @@ impl<K: Ord + Clone, H> HandlerCache<K, H> {
             cache.insert(key.clone(), Box::new(f()));
         }
         cache.get_mut(key).expect("handler cache was just populated").as_mut()
+    }
+
+    /// Fallible variant of [`get_or_insert_mut`]: the initializer may return `Err`.
+    pub fn get_or_try_insert_mut<E>(
+        &mut self,
+        key: &K,
+        f: impl FnOnce() -> Result<H, E>,
+    ) -> Result<&mut H, E> {
+        let cache = self.inner.get_mut();
+        if !cache.contains_key(key) {
+            cache.insert(key.clone(), Box::new(f()?));
+        }
+        Ok(cache.get_mut(key).expect("handler cache was just populated").as_mut())
     }
 }

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -134,7 +134,9 @@ where
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         let values: Vec<T> = Vec::load(storage, slot, LayoutCtx::FULL)?;
         for value in values {
-            let pos_slot = value.mapping_slot(slot + U256::ONE);
+            let pos_slot = value.mapping_slot(
+                slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?,
+            );
             <U256 as Storable>::delete(storage, pos_slot, LayoutCtx::FULL)?;
         }
         <Vec<T> as Storable>::delete(storage, slot, ctx)
@@ -154,10 +156,14 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
         Self {
             values: VecHandler::new(base_slot, address, storage),
-            positions: MappingHandler::new(base_slot + U256::ONE, address, storage),
+            positions: MappingHandler::new(
+                base_slot.checked_add(U256::ONE).expect("slot overflow"),
+                address,
+                storage,
+            ),
             base_slot,
             address,
             storage,

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -112,6 +112,7 @@ where
         storage: crate::StorageCtx<'a>,
     ) -> Self::Handler<'a> {
         SetHandler::new(slot, address, storage)
+            .expect("slot overflow: keccak-derived base slots cannot be U256::MAX")
     }
 }
 
@@ -156,18 +157,16 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
-        Self {
+    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Result<Self> {
+        let positions_slot =
+            base_slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?;
+        Ok(Self {
             values: VecHandler::new(base_slot, address, storage),
-            positions: MappingHandler::new(
-                base_slot.checked_add(U256::ONE).expect("slot overflow"),
-                address,
-                storage,
-            ),
+            positions: MappingHandler::new(positions_slot, address, storage),
             base_slot,
             address,
             storage,
-        }
+        })
     }
 
     /// Returns the base storage slot for this set.
@@ -346,7 +345,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(500u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             let a = Address::from([0x11; 20]);
             let b = Address::from([0x22; 20]);
@@ -373,7 +372,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(600u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             let addrs: Vec<Address> = (0..5u8).map(|i| Address::from([i; 20])).collect();
             let set = Set::from(addrs.clone());
@@ -386,7 +385,21 @@ mod tests {
             }
         });
     }
-    /// (`initial_size`, `final_size`) - covers grow, shrink, and equal-size rewrite.
+
+    #[test]
+    fn test_set_transient_methods_return_err() {
+        let (mut storage, contract_addr) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let base = U256::from(800u64);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+
+            assert!(handler.t_read().is_err());
+            assert!(handler.t_write(Set::default()).is_err());
+            assert!(handler.t_delete().is_err());
+        });
+    }
+
+    /// (`initial_size`, `final_size`) -- covers grow, shrink, and equal-size rewrite.
     #[rstest]
     #[case(3, 7)] // grow
     #[case(7, 3)] // shrink
@@ -395,7 +408,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(700u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             // Use disjoint ranges so first and second share no elements.
             let first: Vec<Address> = (0..initial).map(|i| Address::from([i; 20])).collect();

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -346,7 +346,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(500u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             let a = Address::from([0x11; 20]);
             let b = Address::from([0x22; 20]);
@@ -373,7 +373,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(600u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             let addrs: Vec<Address> = (0..5u8).map(|i| Address::from([i; 20])).collect();
             let set = Set::from(addrs.clone());
@@ -409,7 +409,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(700u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             // Use disjoint ranges so first and second share no elements.
             let first: Vec<Address> = (0..initial).map(|i| Address::from([i; 20])).collect();

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -432,17 +432,4 @@ mod tests {
             }
         });
     }
-
-    #[test]
-    fn test_set_transient_methods_return_err() {
-        let (mut storage, contract_addr) = setup_storage();
-        StorageCtx::enter(&mut storage, |ctx| {
-            let base = U256::from(800u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
-
-            assert!(handler.t_read().is_err());
-            assert!(handler.t_write(Set::default()).is_err());
-            assert!(handler.t_delete().is_err());
-        });
-    }
 }

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -112,7 +112,6 @@ where
         storage: crate::StorageCtx<'a>,
     ) -> Self::Handler<'a> {
         SetHandler::new(slot, address, storage)
-            .expect("slot overflow: keccak-derived base slots cannot be U256::MAX")
     }
 }
 
@@ -157,16 +156,18 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Result<Self> {
-        let positions_slot =
-            base_slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?;
-        Ok(Self {
+    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+        // positions_slot = base_slot + 1. Slot addresses are keccak256 outputs and wrapping
+        // is correct here: U256::MAX is not a reachable slot address in the EVM storage model,
+        // so wrapping_add is equivalent to checked_add for all practical inputs.
+        let positions_slot = base_slot.wrapping_add(U256::ONE);
+        Self {
             values: VecHandler::new(base_slot, address, storage),
             positions: MappingHandler::new(positions_slot, address, storage),
             base_slot,
             address,
             storage,
-        })
+        }
     }
 
     /// Returns the base storage slot for this set.

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -156,7 +156,7 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
         // positions_slot = base_slot + 1. Slot addresses are keccak256 outputs and wrapping
         // is correct here: U256::MAX is not a reachable slot address in the EVM storage model,
         // so wrapping_add is equivalent to checked_add for all practical inputs.

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -157,10 +157,11 @@ where
 {
     /// Creates a new handler for the set at the given base slot.
     pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
-        // positions_slot = base_slot + 1. Slot addresses are keccak256 outputs and wrapping
-        // is correct here: U256::MAX is not a reachable slot address in the EVM storage model,
-        // so wrapping_add is equivalent to checked_add for all practical inputs.
-        let positions_slot = base_slot.wrapping_add(U256::ONE);
+        // positions_slot = base_slot + 1. Base slots are keccak256-derived and never U256::MAX,
+        // so overflow is unreachable in practice.
+        let positions_slot = base_slot
+            .checked_add(U256::ONE)
+            .expect("slot overflow: base slot is keccak256-derived and cannot be U256::MAX");
         Self {
             values: VecHandler::new(base_slot, address, storage),
             positions: MappingHandler::new(positions_slot, address, storage),

--- a/crates/common/precompile-storage/src/types/slot.rs
+++ b/crates/common/precompile-storage/src/types/slot.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use alloy_primitives::{Address, U256};
 
 use crate::{
-    error::Result,
+    error::{BasePrecompileError, Result},
     packing::FieldLocation,
     provider::{Handler, LayoutCtx, Storable, StorableType, StorageOps},
     storage_ctx::StorageCtx,
@@ -41,19 +41,21 @@ impl<'a, T> Slot<'a, T> {
 
     /// Creates a full-slot accessor at `base_slot + offset_slots`.
     #[inline]
-    pub const fn new_at_offset(
+    pub fn new_at_offset(
         base_slot: U256,
         offset_slots: usize,
         address: Address,
         storage: StorageCtx<'a>,
-    ) -> Self {
-        Self {
-            slot: base_slot.saturating_add(U256::from_limbs([offset_slots as u64, 0, 0, 0])),
+    ) -> Result<Self> {
+        Ok(Self {
+            slot: base_slot
+                .checked_add(U256::from_limbs([offset_slots as u64, 0, 0, 0]))
+                .ok_or(BasePrecompileError::SlotOverflow)?,
             ctx: LayoutCtx::FULL,
             address,
             storage,
             _ty: PhantomData,
-        }
+        })
     }
 
     /// Creates a packed-field accessor using a [`FieldLocation`] from `#[derive(Storable)]`.
@@ -63,18 +65,20 @@ impl<'a, T> Slot<'a, T> {
         loc: FieldLocation,
         address: Address,
         storage: StorageCtx<'a>,
-    ) -> Self
+    ) -> Result<Self>
     where
         T: StorableType,
     {
         debug_assert!(T::IS_PACKABLE, "`fn new_at_loc` can only be used with packable types");
-        Self {
-            slot: base_slot.saturating_add(U256::from_limbs([loc.offset_slots as u64, 0, 0, 0])),
+        Ok(Self {
+            slot: base_slot
+                .checked_add(U256::from_limbs([loc.offset_slots as u64, 0, 0, 0]))
+                .ok_or(BasePrecompileError::SlotOverflow)?,
             ctx: LayoutCtx::packed(loc.offset_bytes),
             address,
             storage,
             _ty: PhantomData,
-        }
+        })
     }
 
     /// Returns the storage slot number.
@@ -249,7 +253,7 @@ mod tests {
             let base = pair_key.mapping_slot(U256::ZERO);
             let test_addr = Address::from([0x22; 20]);
 
-            let mut slot = Slot::<Address>::new_at_offset(base, 0, address, ctx);
+            let mut slot = Slot::<Address>::new_at_offset(base, 0, address, ctx)?;
             slot.write(test_addr)?;
             assert_eq!(slot.read()?, test_addr);
             slot.delete()?;

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -85,11 +85,18 @@ where
         if T::BYTES <= 16 {
             let slot_count = calc_packed_slot_count(length, T::BYTES);
             for slot_idx in 0..slot_count {
-                storage.store(data_start + U256::from(slot_idx), U256::ZERO)?;
+                storage.store(
+                    data_start
+                        .checked_add(U256::from(slot_idx))
+                        .ok_or(BasePrecompileError::SlotOverflow)?,
+                    U256::ZERO,
+                )?;
             }
         } else {
             for elem_idx in 0..length {
-                let elem_slot = data_start + U256::from(elem_idx * T::SLOTS);
+                let elem_slot = data_start
+                    .checked_add(U256::from(elem_idx * T::SLOTS))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
                 T::delete(storage, elem_slot, LayoutCtx::FULL)?;
             }
         }
@@ -191,11 +198,14 @@ where
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = calc_element_loc(index, T::BYTES);
             (
-                data_start + U256::from(location.offset_slots),
+                data_start.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
-            (data_start + U256::from(index * T::SLOTS), LayoutCtx::FULL)
+            (
+                data_start.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                LayoutCtx::FULL,
+            )
         };
         T::handle(slot, layout_ctx, address, storage)
     }
@@ -324,7 +334,9 @@ where
     let mut current_offset = 0;
 
     for slot_idx in 0..slot_count {
-        let slot_addr = data_start + U256::from(slot_idx);
+        let slot_addr = data_start
+            .checked_add(U256::from(slot_idx))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         let slot_value = storage.load(slot_addr)?;
         let slot_packed = PackedSlot(slot_value);
 
@@ -363,7 +375,9 @@ where
     let slot_count = calc_packed_slot_count(elements.len(), byte_count);
 
     for slot_idx in 0..slot_count {
-        let slot_addr = data_start + U256::from(slot_idx);
+        let slot_addr = data_start
+            .checked_add(U256::from(slot_idx))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         let start_elem = slot_idx * elements_per_slot;
         let end_elem = (start_elem + elements_per_slot).min(elements.len());
         let slot_value = build_packed_slot(&elements[start_elem..end_elem], byte_count)?;
@@ -393,7 +407,9 @@ where
 {
     let mut result = Vec::new();
     for index in 0..length {
-        let elem_slot = data_start + U256::from(index * T::SLOTS);
+        let elem_slot = data_start
+            .checked_add(U256::from(index * T::SLOTS))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         result.push(T::load(storage, elem_slot, LayoutCtx::FULL)?);
     }
     Ok(result)
@@ -405,7 +421,9 @@ where
     S: StorageOps,
 {
     for (idx, elem) in elements.iter().enumerate() {
-        let elem_slot = data_start + U256::from(idx * T::SLOTS);
+        let elem_slot = data_start
+            .checked_add(U256::from(idx * T::SLOTS))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         elem.store(storage, elem_slot, LayoutCtx::FULL)?;
     }
     Ok(())

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, U256, keccak256};
 
 use crate::{
     error::{BasePrecompileError, Result},
-    packing::{PackedSlot, calc_element_loc, calc_packed_slot_count},
+    packing::{PackedSlot, calc_element_loc, calc_packed_slot_count, create_element_mask},
     provider::{Handler, Layout, LayoutCtx, Storable, StorableType, StorageOps},
     types::{HandlerCache, Slot},
 };

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -189,25 +189,29 @@ where
     }
 
     #[inline]
-    fn compute_handler(
+    fn try_compute_handler(
         data_start: U256,
         address: Address,
         storage: crate::StorageCtx<'a>,
         index: usize,
-    ) -> T::Handler<'a> {
+    ) -> Result<T::Handler<'a>> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = calc_element_loc(index, T::BYTES);
             (
-                data_start.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
+                data_start
+                    .checked_add(U256::from(location.offset_slots))
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
-                data_start.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                data_start
+                    .checked_add(U256::from(index * T::SLOTS))
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::FULL,
             )
         };
-        T::handle(slot, layout_ctx, address, storage)
+        Ok(T::handle(slot, layout_ctx, address, storage))
     }
 
     /// Returns a handler for the element at the given index, or `None` if out of bounds.
@@ -216,11 +220,9 @@ where
             return Ok(None);
         }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        Ok(Some(
-            self.cache.get_or_insert(&index, || {
-                Self::compute_handler(data_start, address, storage, index)
-            }),
-        ))
+        Ok(Some(self.cache.get_or_try_insert(&index, || {
+            Self::try_compute_handler(data_start, address, storage, index)
+        })?))
     }
 
     /// Pushes a new element to the end of the vector.
@@ -235,7 +237,7 @@ where
             return Err(BasePrecompileError::Fatal("Vec is at max capacity".into()));
         }
         let mut elem_slot =
-            Self::compute_handler(self.data_slot(), self.address, self.storage, length);
+            Self::try_compute_handler(self.data_slot(), self.address, self.storage, length)?;
         elem_slot.write(value)?;
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
         length_slot.write(U256::from(length + 1))
@@ -254,12 +256,93 @@ where
         }
         let last_index = length - 1;
         let mut elem_slot =
-            Self::compute_handler(self.data_slot(), self.address, self.storage, last_index);
+            Self::try_compute_handler(self.data_slot(), self.address, self.storage, last_index)?;
         let element = elem_slot.read()?;
         elem_slot.delete()?;
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
         length_slot.write(U256::from(last_index))?;
         Ok(Some(element))
+    }
+
+    /// Shortens the vector to `new_len` elements, clearing all vacated storage slots.
+    ///
+    /// If `new_len` is greater than or equal to the current length, this has no effect.
+    /// Each element slot is explicitly zeroed before the length counter is decremented,
+    /// preventing stale tail data from being exposed by a future length-slot corruption.
+    ///
+    /// For packed element types (`T::BYTES <= 16`), elements in the "boundary" slot (the
+    /// last slot that contains both kept and removed elements) are cleared individually
+    /// using read-modify-write. Slots that are fully removed are zeroed in a single store.
+    pub fn truncate(&self, new_len: usize) -> Result<()>
+    where
+        T: Storable,
+        T::Handler<'a>: Handler<T>,
+    {
+        let old_len = self.len()?;
+        if new_len >= old_len {
+            return Ok(());
+        }
+        let data_start = self.data_slot();
+        if T::BYTES <= 16 {
+            let elems_per_slot = 32 / T::BYTES;
+            // `first_full_tail_slot` is the index of the first slot that contains only
+            // elements being removed (no kept elements). Slots before it may contain a
+            // mix of kept and removed elements and require element-by-element clearing.
+            let first_full_tail_slot = new_len.div_ceil(elems_per_slot);
+
+            // Clear elements in the partial boundary slot (if any) with a single
+            // SLOAD + mask + SSTORE. These elements share the slot with kept elements,
+            // so we compute one combined clear-mask for all removed positions and apply
+            // it in one read-modify-write rather than one per element.
+            let boundary_slot_end = (first_full_tail_slot * elems_per_slot).min(old_len);
+            if boundary_slot_end > new_len {
+                let boundary_slot_addr = data_start
+                    .checked_add(U256::from(new_len / elems_per_slot))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
+                let current = self.storage.sload(self.address, boundary_slot_addr)?;
+                let mut combined_clear_mask = U256::ZERO;
+                for index in new_len..boundary_slot_end {
+                    let byte_offset = (index % elems_per_slot) * T::BYTES;
+                    combined_clear_mask |= create_element_mask(T::BYTES) << (byte_offset * 8);
+                }
+                self.storage.sstore(
+                    self.address,
+                    boundary_slot_addr,
+                    current & !combined_clear_mask,
+                )?;
+            }
+
+            // Zero all fully-removed tail slots in a single store each.
+            let last_slot = calc_packed_slot_count(old_len, T::BYTES);
+            for slot_idx in first_full_tail_slot..last_slot {
+                let slot_addr = data_start
+                    .checked_add(U256::from(slot_idx))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
+                self.storage.sstore(self.address, slot_addr, U256::ZERO)?;
+            }
+        } else {
+            // Unpacked types: each element occupies one or more full slots;
+            // delegate to the element handler's delete to zero every occupied slot.
+            for index in new_len..old_len {
+                let mut elem =
+                    Self::try_compute_handler(data_start, self.address, self.storage, index)?;
+                elem.delete()?;
+            }
+        }
+        // Update the length counter only after all vacated slots are cleared.
+        let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
+        length_slot.write(U256::from(new_len))
+    }
+
+    /// Clears the vector, removing all elements and zeroing all data slots.
+    ///
+    /// Equivalent to `truncate(0)`. Matches Solidity's `delete arr` semantics.
+    pub fn clear(&self) -> Result<()>
+    where
+        T: Storable,
+        T::Handler<'a>: Handler<T>,
+    {
+        self.truncate(0)
     }
 }
 
@@ -280,9 +363,9 @@ where
             ));
         }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        Ok(self
-            .cache
-            .get_or_insert(&index, || Self::compute_handler(data_start, address, storage, index)))
+        self.cache.get_or_try_insert(&index, || {
+            Self::try_compute_handler(data_start, address, storage, index)
+        })
     }
 
     /// Mutable variant of [`at_with_len`].
@@ -298,9 +381,9 @@ where
             ));
         }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        Ok(self.cache.get_or_insert_mut(&index, || {
-            Self::compute_handler(data_start, address, storage, index)
-        }))
+        self.cache.get_or_try_insert_mut(&index, || {
+            Self::try_compute_handler(data_start, address, storage, index)
+        })
     }
 }
 

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -517,6 +517,65 @@ mod namespaced_fields {
     }
 }
 
+mod struct_level_attribute_passthrough {
+    //! Verifies that `#[contract]` forwards all struct-level attributes except its own
+    //! `#[namespace]` to the generated layout struct — doc comments, `#[allow]`, `#[cfg_attr]`.
+
+    mod allow_and_doc {
+        use alloy_primitives::{Address, U256, address};
+        use base_precompile_macros::contract;
+        use base_precompile_storage::{Handler, StorageCtx, setup_storage};
+
+        const ATTR_ADDR: Address = address!("0000000000000000000000000000000000007777");
+
+        /// User-supplied doc comment on the contract struct.
+        ///
+        /// The macro must forward this rather than replace it with the generic fallback.
+        #[allow(dead_code)]
+        #[contract(addr = ATTR_ADDR)]
+        pub struct AttrForwardStorage {
+            pub value: U256,
+            pub flag: bool,
+        }
+
+        #[test]
+        fn allow_and_doc_attrs_are_forwarded_to_generated_struct() {
+            let (mut storage, _) = setup_storage();
+            StorageCtx::enter(&mut storage, |ctx| {
+                let mut layout = AttrForwardStorage::new(ctx);
+                layout.value.write(U256::from(42u64)).unwrap();
+                layout.flag.write(true).unwrap();
+                assert_eq!(layout.value.read().unwrap(), U256::from(42u64));
+                assert!(layout.flag.read().unwrap());
+            });
+        }
+    }
+
+    mod cfg_attr {
+        use alloy_primitives::{Address, address};
+        use base_precompile_macros::contract;
+        use base_precompile_storage::{Handler, StorageCtx, setup_storage};
+
+        const CFG_ATTR_ADDR: Address = address!("0000000000000000000000000000000000007778");
+
+        #[cfg_attr(test, allow(dead_code))]
+        #[contract(addr = CFG_ATTR_ADDR)]
+        pub struct CfgAttrForwardStorage {
+            pub x: Address,
+        }
+
+        #[test]
+        fn cfg_attr_is_forwarded_to_generated_struct() {
+            let (mut storage, _) = setup_storage();
+            StorageCtx::enter(&mut storage, |ctx| {
+                let mut layout = CfgAttrForwardStorage::new(ctx);
+                layout.x.write(Address::from([0xab; 20])).unwrap();
+                assert_eq!(layout.x.read().unwrap(), Address::from([0xab; 20]));
+            });
+        }
+    }
+}
+
 mod packed_slot_layout {
     //! End-to-end bit-level verification of multi-field packed storage slots.
     //!
@@ -533,10 +592,10 @@ mod packed_slot_layout {
     /// A layout where four sub-word primitives share a single storage slot.
     ///
     /// Packing order (low-to-high bytes within the slot):
-    /// - `low_byte`  : u8  → offset_bytes 0, bits  [0..7]
-    /// - `mid_short` : u16 → offset_bytes 1, bits  [8..23]
-    /// - `mid_int`   : u32 → offset_bytes 3, bits  [24..55]
-    /// - `high_long` : u64 → offset_bytes 7, bits  [56..119]
+    /// - `low_byte`  : u8  → `offset_bytes` 0, bits  [0..7]
+    /// - `mid_short` : u16 → `offset_bytes` 1, bits  [8..23]
+    /// - `mid_int`   : u32 → `offset_bytes` 3, bits  [24..55]
+    /// - `high_long` : u64 → `offset_bytes` 7, bits  [56..119]
     ///
     /// Total: 15 bytes → all packed into slot 0.
     /// `big_val` (U256, full slot) goes to slot 1.

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -208,8 +208,8 @@ mod namespaced_layout {
             layout.policy.label.write(long_label.clone()).unwrap();
             layout.policy.balances.at_mut(&owner).write(U256::from(500)).unwrap();
             layout.policy.checkpoints.write([U256::from(1), U256::from(2), U256::from(3)]).unwrap();
-            layout.policy.packed_flags[0].write(0x1111).unwrap();
-            layout.policy.packed_flags[16].write(0x2222).unwrap();
+            layout.policy.packed_flags.at_mut(&0).unwrap().unwrap().write(0x1111).unwrap();
+            layout.policy.packed_flags.at_mut(&16).unwrap().unwrap().write(0x2222).unwrap();
             layout.policy.amounts.write(amounts.clone()).unwrap();
             layout.total_supply.write(U256::from(1_000)).unwrap();
             layout.policy_owner.write(policy_owner).unwrap();
@@ -217,9 +217,15 @@ mod namespaced_layout {
             assert_eq!(layout.admin.read().unwrap(), owner);
             assert_eq!(layout.policy.label.read().unwrap(), long_label);
             assert_eq!(layout.policy.balances.at(&owner).read().unwrap(), U256::from(500));
-            assert_eq!(layout.policy.checkpoints[2].read().unwrap(), U256::from(3));
-            assert_eq!(layout.policy.packed_flags[0].read().unwrap(), 0x1111);
-            assert_eq!(layout.policy.packed_flags[16].read().unwrap(), 0x2222);
+            assert_eq!(
+                layout.policy.checkpoints.at(&2).unwrap().unwrap().read().unwrap(),
+                U256::from(3)
+            );
+            assert_eq!(layout.policy.packed_flags.at(&0).unwrap().unwrap().read().unwrap(), 0x1111);
+            assert_eq!(
+                layout.policy.packed_flags.at(&16).unwrap().unwrap().read().unwrap(),
+                0x2222
+            );
             assert_eq!(layout.policy.amounts.read().unwrap(), amounts);
             assert_eq!(layout.total_supply.read().unwrap(), U256::from(1_000));
             assert_eq!(layout.policy_owner.read().unwrap(), policy_owner);

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -208,8 +208,8 @@ mod namespaced_layout {
             layout.policy.label.write(long_label.clone()).unwrap();
             layout.policy.balances.at_mut(&owner).write(U256::from(500)).unwrap();
             layout.policy.checkpoints.write([U256::from(1), U256::from(2), U256::from(3)]).unwrap();
-            layout.policy.packed_flags.at_mut(&0).unwrap().unwrap().write(0x1111).unwrap();
-            layout.policy.packed_flags.at_mut(&16).unwrap().unwrap().write(0x2222).unwrap();
+            layout.policy.packed_flags.at_mut(0).unwrap().unwrap().write(0x1111).unwrap();
+            layout.policy.packed_flags.at_mut(16).unwrap().unwrap().write(0x2222).unwrap();
             layout.policy.amounts.write(amounts.clone()).unwrap();
             layout.total_supply.write(U256::from(1_000)).unwrap();
             layout.policy_owner.write(policy_owner).unwrap();
@@ -218,12 +218,12 @@ mod namespaced_layout {
             assert_eq!(layout.policy.label.read().unwrap(), long_label);
             assert_eq!(layout.policy.balances.at(&owner).read().unwrap(), U256::from(500));
             assert_eq!(
-                layout.policy.checkpoints.at(&2).unwrap().unwrap().read().unwrap(),
+                layout.policy.checkpoints.at(2).unwrap().unwrap().read().unwrap(),
                 U256::from(3)
             );
-            assert_eq!(layout.policy.packed_flags.at(&0).unwrap().unwrap().read().unwrap(), 0x1111);
+            assert_eq!(layout.policy.packed_flags.at(0).unwrap().unwrap().read().unwrap(), 0x1111);
             assert_eq!(
-                layout.policy.packed_flags.at(&16).unwrap().unwrap().read().unwrap(),
+                layout.policy.packed_flags.at(16).unwrap().unwrap().read().unwrap(),
                 0x2222
             );
             assert_eq!(layout.policy.amounts.read().unwrap(), amounts);

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -222,10 +222,7 @@ mod namespaced_layout {
                 U256::from(3)
             );
             assert_eq!(layout.policy.packed_flags.at(0).unwrap().unwrap().read().unwrap(), 0x1111);
-            assert_eq!(
-                layout.policy.packed_flags.at(16).unwrap().unwrap().read().unwrap(),
-                0x2222
-            );
+            assert_eq!(layout.policy.packed_flags.at(16).unwrap().unwrap().read().unwrap(), 0x2222);
             assert_eq!(layout.policy.amounts.read().unwrap(), amounts);
             assert_eq!(layout.total_supply.read().unwrap(), U256::from(1_000));
             assert_eq!(layout.policy_owner.read().unwrap(), policy_owner);


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of BOP Batch 4 audit fixes into `releases/v1.1.0`.

## Source PRs

- https://github.com/base/base/pull/3405 -- fix(precompile-macros): reject duplicate args() option regardless of argument count
- https://github.com/base/base/pull/3407 -- fix(precompile-macros): forward all struct-level attrs through #[contract]
- https://github.com/base/base/pull/3415 -- fix(precompile-storage): replace saturating/unchecked slot arithmetic with checked_add
- https://github.com/base/base/pull/3387 (fix commit only) -- fix(precompile-storage): restore all mutable fields in checkpoint_revert
- https://github.com/base/base/pull/3427 -- fix(precompile-storage): complete slot arithmetic checked-add migration (VecHandler::truncate, ArrayHandler, SetHandler::new)

Note: only the checkpoint_revert fix commit from https://github.com/base/base/pull/3387 is included. The BOP-291 stipend guard test commits are not needed in the release branch.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p base-precompile-storage`
- `cargo test -p base-precompile-macros`
- `cargo check -p base-precompile-storage --no-default-features`
- `cargo check -p base-common-precompiles --no-default-features`
