### PR TITLE
fix(consensus): EIP-8130 transactions fail to deserialize from JSON-RPC

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -54,8 +54,10 @@ pub struct TxEip8130 {
     /// Unix-seconds expiry timestamp; `0` means no expiry.
     pub expiry: u64,
     /// Max priority fee per gas (tip) the sender is willing to pay.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_priority_fee_per_gas: u128,
     /// Max total fee per gas (base + tip cap) the sender is willing to pay.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_fee_per_gas: u128,
     /// Gas limit for the entire AA transaction execution.
     pub gas_limit: u64,
@@ -537,5 +539,50 @@ mod tests {
         tx2.rlp_encode(&mut buf);
         let payer_hash_v2 = keccak256(&buf);
         assert_eq!(payer_hash_v1, payer_hash_v2);
+    }
+
+    /// Proves that EIP-8130 transactions can be deserialized through the
+    /// `BaseTxEnvelope` tagged-enum path with hex-string quantity fields.
+    ///
+    /// Without `#[serde(with = "alloy_serde::quantity")]` on the u128 fee
+    /// fields, this test fails with:
+    ///   "u128 is not supported"
+    /// because serde's internal Content buffer (used for internally-tagged
+    /// enums) cannot handle u128 deserialization.
+    ///
+    /// See: <https://github.com/serde-rs/serde/issues/2230>
+    #[cfg(feature = "serde")]
+    #[test]
+    fn eip8130_deserializes_through_envelope() {
+        use crate::BaseTxEnvelope;
+
+        let json = serde_json::json!({
+            "type": "0x7d",
+            "tx": {
+                "chainId": 1,
+                "sender": null,
+                "nonceKey": "0x0",
+                "nonceSequence": 1,
+                "expiry": 0,
+                "maxPriorityFeePerGas": "0x3b9aca00",
+                "maxFeePerGas": "0x3b9aca00",
+                "gasLimit": 21000,
+                "accountChanges": [],
+                "calls": [],
+                "payer": null
+            },
+            "senderAuth": "0x",
+            "payerAuth": "0x"
+        });
+
+        let result = serde_json::from_value::<BaseTxEnvelope>(json);
+        assert!(
+            result.is_ok(),
+            "EIP-8130 envelope deserialization failed: {:#}",
+            result.unwrap_err()
+        );
+
+        let envelope = result.unwrap();
+        assert!(matches!(envelope, BaseTxEnvelope::Eip8130(_)));
     }
 }


### PR DESCRIPTION
### Summary
Closes #3424 

- `TxEip8130`'s two `u128` gas fee fields (`max_priority_fee_per_gas`, `max_fee_per_gas`) are missing the `alloy_serde::quantity` annotation required for Ethereum JSON-RPC hex-string quantity deserialization
- This causes **all EIP-8130 (0x7D) transactions to fail deserialization** through the `BaseTxEnvelope` tagged-enum path with error: `"u128 is not supported"`
- Root cause: two compounding issues:
  1. Ethereum JSON-RPC sends quantities as hex strings (`"0x3b9aca00"`) — bare `u128` Deserialize expects numbers
  2. `BaseTxEnvelope`'s `TransactionEnvelope` derive uses an internally-tagged enum, which triggers serde's `Content` buffer — this buffer [cannot handle `deserialize_u128`](https://github.com/serde-rs/serde/issues/2230)
- **Impact (High):** Once EIP-8130 transactions appear on-chain, the derivation pipeline's L1 provider will fail to process any block containing them, breaking Base block deserialization once the EIP-8130 hard fork activates.
- **Fix:** Add `#[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]` to both fields — the same pattern `TxDeposit::mint` already uses in this crate. 2-line diff, no new dependencies.

### Reproduction

The included `eip8130_deserializes_through_envelope` test proves the bug deterministically:
- **Without fix:** `serde_json::from_value::<BaseTxEnvelope>(json)` → `Err("u128 is not supported")`
- **With fix:** Deserialization succeeds, returns `BaseTxEnvelope::Eip8130(_)`

Reviewers can verify by removing either annotation and running:
```
cargo test -p base-common-consensus --features serde -- eip8130_deserializes_through_envelope
```

### Verification

- `cargo test -p base-common-consensus --all-features` ✅ (98 passed)
- `cargo clippy -p base-common-consensus --features serde` ✅ (clean)
- `cargo check -p base-common-consensus --no-default-features` ✅ (no-std unaffected)

### Files changed

- `crates/common/consensus/src/transaction/eip8130/tx.rs` — add `alloy_serde::quantity` to 2 fields + reproduction test
