### PR TITLE
[backport] PSRC precompile fixes for v1.1.0

### DIFF
--- a/actions/harness/tests/beryl/factory.rs
+++ b/actions/harness/tests/beryl/factory.rs
@@ -2,9 +2,9 @@
 
 use alloy_consensus::TxReceipt;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use alloy_sol_types::{SolCall, SolEvent};
+use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_consensus::BaseBlock;
-use base_common_precompiles::{B20FactoryStorage, IB20Factory};
+use base_common_precompiles::{B20FactoryStorage, B20Variant, IB20Factory};
 
 use crate::env::BerylTestEnv;
 
@@ -253,6 +253,145 @@ async fn b20_factory_views_and_events_are_available_after_beryl_activation() {
         10,
     )
     .await;
+}
+
+#[tokio::test]
+async fn b20_factory_rejects_invalid_creation_parameters() {
+    let mut env = BerylTestEnv::new();
+
+    let block1 = env.sequencer.build_empty_block().await;
+    let activate_asset = env.activate_feature_tx(BerylTestEnv::b20_asset_feature());
+    let activate_stablecoin = env.activate_feature_tx(BerylTestEnv::b20_stablecoin_feature());
+    let block2 = env
+        .sequencer
+        .build_next_block_with_transactions(vec![activate_asset, activate_stablecoin])
+        .await;
+    assert!(env.user_tx_succeeded(&block2, 0), "B20_ASSET activation must succeed");
+    assert!(env.user_tx_succeeded(&block2, 1), "B20_STABLECOIN activation must succeed");
+
+    let invalid_variant = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::__Invalid,
+                salt: BerylTestEnv::ALT_SALT,
+                params: Bytes::new(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let unsupported_asset_version = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::ASSET,
+                salt: BerylTestEnv::ALT_SALT,
+                params: IB20Factory::B20AssetCreateParams {
+                    version: B20Variant::Asset.supported_version() + 1,
+                    name: "Bad Version".to_string(),
+                    symbol: "BADV".to_string(),
+                    initialAdmin: BerylTestEnv::alice(),
+                    decimals: BerylTestEnv::B20_DECIMALS,
+                }
+                .abi_encode()
+                .into(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let invalid_asset_decimals = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::ASSET,
+                salt: BerylTestEnv::ALT_SALT,
+                params: IB20Factory::B20AssetCreateParams {
+                    version: B20Variant::Asset.supported_version(),
+                    name: "Bad Decimals".to_string(),
+                    symbol: "BADD".to_string(),
+                    initialAdmin: BerylTestEnv::alice(),
+                    decimals: 5,
+                }
+                .abi_encode()
+                .into(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let missing_currency = env.create_tx(
+        TxKind::Call(B20FactoryStorage::ADDRESS),
+        Bytes::from(
+            IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::STABLECOIN,
+                salt: BerylTestEnv::ALT_SALT,
+                params: IB20Factory::B20StablecoinCreateParams {
+                    version: B20Variant::Stablecoin.supported_version(),
+                    name: "Missing Currency".to_string(),
+                    symbol: "MISS".to_string(),
+                    initialAdmin: BerylTestEnv::alice(),
+                    currency: String::new(),
+                }
+                .abi_encode()
+                .into(),
+                initCalls: Vec::new(),
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_GAS_LIMIT,
+    );
+    let block3 = env
+        .sequencer
+        .build_next_block_with_transactions(vec![
+            invalid_variant,
+            unsupported_asset_version,
+            invalid_asset_decimals,
+            missing_currency,
+        ])
+        .await;
+
+    for index in 0..4 {
+        assert!(!env.user_tx_succeeded(&block3, index), "invalid factory call {index} must revert");
+    }
+    let invalid_asset =
+        B20Variant::Asset.compute_address(BerylTestEnv::alice(), BerylTestEnv::ALT_SALT).0;
+    let invalid_stablecoin =
+        B20Variant::Stablecoin.compute_address(BerylTestEnv::alice(), BerylTestEnv::ALT_SALT).0;
+    assert!(!env.sequencer.has_code(invalid_asset), "invalid asset creations must not deploy code");
+    assert!(
+        !env.sequencer.has_code(invalid_stablecoin),
+        "invalid stablecoin creation must not deploy code"
+    );
+
+    let (probe, deploy_probe) = env.deploy_staticcall_probe_tx(B20FactoryStorage::ADDRESS);
+    let block4 = env.sequencer.build_next_block_with_transactions(vec![deploy_probe]).await;
+    assert!(env.user_tx_succeeded(&block4, 0), "factory staticcall probe must deploy");
+
+    let invalid_address = env.call_staticcall_probe_tx(
+        probe,
+        Bytes::from(
+            IB20Factory::getB20AddressCall {
+                variant: IB20Factory::B20Variant::__Invalid,
+                sender: BerylTestEnv::alice(),
+                salt: BerylTestEnv::ALT_SALT,
+            }
+            .abi_encode(),
+        ),
+        BerylTestEnv::B20_PROBE_GAS_LIMIT,
+    );
+    let block5 = env.sequencer.build_next_block_with_transactions(vec![invalid_address]).await;
+    assert!(env.user_tx_succeeded(&block5, 0), "invalid getB20Address probe tx must succeed");
+    assert!(
+        !env.probe_call_succeeded(probe),
+        "getB20Address(__Invalid) staticcall must revert with strict ABI decoding"
+    );
+
+    env.derive_blocks([(block1, 1), (block2, 2), (block3, 3), (block4, 4), (block5, 5)], 5).await;
 }
 
 struct B20FactoryPrecompiles;

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -98,7 +98,11 @@ pub struct ChainConfig {
     /// Unsafe block signer address.
     pub unsafe_block_signer: Option<Address>,
     /// Activation registry admin address.
-    pub activation_admin_address: Option<Address>,
+    ///
+    /// Required and non-zero for all Base chains: every Base chain has Beryl scheduled, and
+    /// Beryl's activation registry precompile needs an admin at genesis. `Address::ZERO` is
+    /// rejected by chainspec validation.
+    pub activation_admin_address: Address,
 
     // Gas limits
     /// Maximum gas limit for L2 blocks.
@@ -369,7 +373,7 @@ const MAINNET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
 
     unsafe_block_signer: Some(address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a")),
-    activation_admin_address: Some(address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771")),
+    activation_admin_address: address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"),
 
     max_gas_limit: 105_000_000,
     prune_delete_limit: 20_000,
@@ -443,7 +447,7 @@ const SEPOLIA: ChainConfig = ChainConfig {
     protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
 
     unsafe_block_signer: Some(address!("b830b99c95Ea32300039624Cb567d324D4b1D83C")),
-    activation_admin_address: Some(address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59")),
+    activation_admin_address: address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"),
 
     max_gas_limit: 45_000_000,
     prune_delete_limit: 10_000,
@@ -508,7 +512,7 @@ const DEVNET: ChainConfig = ChainConfig {
     protocol_versions_address: Address::ZERO,
 
     unsafe_block_signer: None,
-    activation_admin_address: Some(address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc")),
+    activation_admin_address: address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc"),
 
     max_gas_limit: 30_000_000,
     prune_delete_limit: 20_000,
@@ -562,7 +566,7 @@ const ZERONET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("646c8604cf62b23e0cf094f2e790c6c75547ff85"),
 
     unsafe_block_signer: Some(address!("cf17274338d3128f6C96d9af54511a17e8b38a08")),
-    activation_admin_address: Some(address!("F5969A85a555671EeD766C4ff0C61426AA626b11")),
+    activation_admin_address: address!("F5969A85a555671EeD766C4ff0C61426AA626b11"),
 
     max_gas_limit: 25_000_000,
     prune_delete_limit: 10_000,

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -20,6 +20,13 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
     require_field(&input, "b20")?;
     let has_asset = has_field(&input, "asset");
     let name = input.ident;
+    // This branch is only generated for token structs that do NOT have an `asset` field —
+    // i.e. stablecoin token structs. Asset token structs always have an `asset` field and
+    // take the `has_asset` branch above (which delegates to `AssetAccounting::decimals` and
+    // reads per-token decimals from storage). Therefore `B20Variant::Asset` is structurally
+    // unreachable in the generated code below; `B20Variant::Asset.decimals()` returning `None`
+    // cannot occur here. The only `None` case from `from_address` is an unrecognized (non-B20)
+    // address, which `unwrap_or(0)` handles the same way the original `map_or(0, ...)` did.
     let decimals_impl = if has_asset {
         quote! { crate::AssetAccounting::decimals(self) }
     } else {
@@ -27,7 +34,8 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
             Ok(crate::B20Variant::from_address(
                 ::base_precompile_storage::ContractStorage::address(self),
             )
-            .map_or(0, crate::B20Variant::decimals))
+            .and_then(|v| v.decimals())
+            .unwrap_or(0))
         }
     };
 

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -31,6 +31,7 @@ use crate::{
 pub struct EvmPrecompileStorageProvider<'a> {
     internals: alloy_evm::EvmInternals<'a>,
     caller: Address,
+    call_value: U256,
     gas: Gas,
     gas_params: GasParams,
     is_static: bool,
@@ -47,7 +48,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
     /// `gas_params` drives all EIP-2929/2200/3529 cost calculations.
     /// Pass [`GasParams::default`] when the active spec is unknown at call site.
     pub fn new(input: PrecompileInput<'a>, gas_params: GasParams) -> Self {
-        let PrecompileInput { gas, caller, is_static, internals, .. } = input;
+        let PrecompileInput { gas, caller, value, is_static, internals, .. } = input;
 
         let block_number = internals.block_env().number().to::<u64>();
         let timestamp = internals.block_env().timestamp();
@@ -57,6 +58,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         Self {
             internals,
             caller,
+            call_value: value,
             gas: Gas::new(gas),
             gas_params,
             is_static,
@@ -105,12 +107,14 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
             (info.is_empty(), info.is_empty_code_hash())
         };
 
-        if is_new_account {
+        if has_empty_code {
             // Yellow Paper G_create: base cost for creating a new contract account.
             self.deduct_gas(self.gas_params.create_cost())?;
             // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
             let num_words = code_len.div_ceil(32) as u64;
             self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
+        }
+        if is_new_account {
             // EIP-8037: charge for the new account entry in the state trie.
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
         }
@@ -261,6 +265,10 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         self.is_static
     }
 
+    fn call_value(&self) -> U256 {
+        self.call_value
+    }
+
     fn caller(&self) -> Address {
         self.caller
     }
@@ -282,7 +290,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         self.internals.checkpoint_revert(checkpoint);
     }
 
-    fn keccak256(&mut self, data: &[u8]) -> Result<B256> {
+    fn metered_keccak256(&mut self, data: &[u8]) -> Result<B256> {
         let num_words =
             u64::try_from(data.len().div_ceil(32)).map_err(|_| BasePrecompileError::OutOfGas)?;
         let price = KECCAK256WORD
@@ -371,6 +379,29 @@ mod tests {
             provider.state_gas_used(),
             expected,
             "balance-only account must pay code_deposit_state_gas but not create_state_gas"
+        );
+    }
+
+    /// `set_code` on a prefunded account (balance > 0, no code) must charge the same regular gas
+    /// as a fully empty account.
+    #[test]
+    fn set_code_prefunded_account_charges_same_gas_as_empty_account() {
+        let addr = Address::from([0x43u8; 20]);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+
+        let mut empty_provider = amsterdam_provider();
+        empty_provider.set_code(addr, code.clone()).unwrap();
+        let gas_for_empty = empty_provider.gas_deducted();
+
+        let mut prefunded_provider = amsterdam_provider();
+        prefunded_provider.set_balance(addr, U256::from(1u64));
+        prefunded_provider.set_code(addr, code).unwrap();
+        let gas_for_prefunded = prefunded_provider.gas_deducted();
+
+        assert!(gas_for_empty > 0, "set_code must charge non-zero gas");
+        assert_eq!(
+            gas_for_empty, gas_for_prefunded,
+            "prefunded account must pay identical regular gas to an empty account"
         );
     }
 

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{Address, LogData, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
     context_interface::cfg::GasParams,
+    interpreter::gas::{KECCAK256, KECCAK256WORD},
     state::{AccountInfo, Bytecode},
 };
 
@@ -23,9 +24,12 @@ pub struct HashMapStorageProvider {
     beneficiary: Address,
     block_number: u64,
     caller: Address,
+    call_value: U256,
     is_static: bool,
     counter_sload: u64,
     counter_sstore: u64,
+    gas_deducted: u64,
+    counter_keccak256: u64,
     snapshots: Vec<Snapshot>,
     gas_params: GasParams,
     state_gas_used: u64,
@@ -61,9 +65,12 @@ impl HashMapStorageProvider {
             beneficiary: Address::ZERO,
             block_number: 0,
             caller: Address::ZERO,
+            call_value: U256::ZERO,
             is_static: false,
             counter_sload: 0,
             counter_sstore: 0,
+            gas_deducted: 0,
+            counter_keccak256: 0,
             gas_params: GasParams::default(),
             state_gas_used: 0,
             gas_refunded: 0,
@@ -97,12 +104,20 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         let is_new_account = self.accounts.get(&address).is_none_or(AccountInfo::is_empty);
         let has_empty_code =
             self.accounts.get(&address).is_none_or(|info| info.is_empty_code_hash());
+        self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
+
+        if has_empty_code {
+            self.deduct_gas(self.gas_params.create_cost())?;
+            let num_words = code_len.div_ceil(32) as u64;
+            self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
+        }
         if is_new_account {
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
         }
         if has_empty_code {
             self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }
+
         let account = self.accounts.entry(address).or_default();
         account.code_hash = code.hash_slow();
         account.code = Some(code);
@@ -173,8 +188,17 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         Ok(self.transient.get(&(address, key)).copied().unwrap_or(U256::ZERO))
     }
 
-    fn deduct_gas(&mut self, _gas: u64) -> Result<(), BasePrecompileError> {
+    fn deduct_gas(&mut self, gas: u64) -> Result<(), BasePrecompileError> {
+        self.gas_deducted = self.gas_deducted.saturating_add(gas);
         Ok(())
+    }
+
+    fn metered_keccak256(
+        &mut self,
+        data: &[u8],
+    ) -> core::result::Result<alloy_primitives::B256, BasePrecompileError> {
+        self.counter_keccak256 += 1;
+        Ok(alloy_primitives::keccak256(data))
     }
 
     fn deduct_state_gas(&mut self, gas: u64) -> Result<(), BasePrecompileError> {
@@ -209,6 +233,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn is_static(&self) -> bool {
         self.is_static
+    }
+
+    fn call_value(&self) -> U256 {
+        self.call_value
     }
 
     fn caller(&self) -> alloy_primitives::Address {
@@ -266,16 +294,16 @@ impl HashMapStorageProvider {
         self.events.get(&address).unwrap_or(&EMPTY)
     }
 
-    /// Sets the nonce for the given address (test-utils only).
-    pub fn set_nonce(&mut self, address: Address, nonce: u64) {
-        let account = self.accounts.entry(address).or_default();
-        account.nonce = nonce;
-    }
-
     /// Sets the balance for the given address (test-utils only).
     pub fn set_balance(&mut self, address: Address, balance: U256) {
         let account = self.accounts.entry(address).or_default();
         account.balance = balance;
+    }
+
+    /// Sets the nonce for the given address (test-utils only).
+    pub fn set_nonce(&mut self, address: Address, nonce: u64) {
+        let account = self.accounts.entry(address).or_default();
+        account.nonce = nonce;
     }
 
     /// Overrides the block timestamp (test-utils only).
@@ -296,6 +324,11 @@ impl HashMapStorageProvider {
     /// Sets the caller address (test-utils only).
     pub const fn set_caller(&mut self, caller: Address) {
         self.caller = caller;
+    }
+
+    /// Sets the native call value in wei (test-utils only).
+    pub const fn set_call_value(&mut self, value: U256) {
+        self.call_value = value;
     }
 
     /// Sets whether the current call is static (test-utils only).
@@ -323,10 +356,21 @@ impl HashMapStorageProvider {
         self.counter_sstore
     }
 
-    /// Resets the SLOAD/SSTORE counters (test-utils only).
+    /// Returns the total gas deducted via [`PrecompileStorageProvider::deduct_gas`] (test-utils only).
+    pub const fn gas_deducted(&self) -> u64 {
+        self.gas_deducted
+    }
+
+    /// Returns the number of times [`PrecompileStorageProvider::metered_keccak256`] was called.
+    pub const fn counter_keccak256(&self) -> u64 {
+        self.counter_keccak256
+    }
+
+    /// Resets the SLOAD/SSTORE/keccak256 counters (test-utils only).
     pub const fn reset_counters(&mut self) {
         self.counter_sload = 0;
         self.counter_sstore = 0;
+        self.counter_keccak256 = 0;
     }
 
     /// Returns an iterator over all stored (address, slot, value) triples (test-utils only).

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -77,6 +77,9 @@ pub trait PrecompileStorageProvider {
     /// Returns whether the current call context is static.
     fn is_static(&self) -> bool;
 
+    /// Returns the native value (in wei) attached to this precompile call.
+    fn call_value(&self) -> U256;
+
     /// Returns the address that called this precompile.
     fn caller(&self) -> Address;
     /// Replaces the current caller address and returns the previous caller.
@@ -90,7 +93,7 @@ pub trait PrecompileStorageProvider {
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint);
 
     /// Computes keccak256 and charges the appropriate gas.
-    fn keccak256(&mut self, data: &[u8]) -> Result<B256> {
+    fn metered_keccak256(&mut self, data: &[u8]) -> Result<B256> {
         let num_words =
             u64::try_from(data.len().div_ceil(32)).map_err(|_| BasePrecompileError::OutOfGas)?;
         let price = KECCAK256WORD

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -166,6 +166,10 @@ impl<'a> StorageCtx<'a> {
     pub fn is_static(&self) -> bool {
         self.with_storage(|s| s.is_static())
     }
+    /// Returns the native value (in wei) attached to this precompile call.
+    pub fn call_value(&self) -> U256 {
+        self.with_storage(|s| s.call_value())
+    }
     /// Returns the address that called this precompile.
     pub fn caller(&self) -> Address {
         self.with_storage(|s| s.caller())
@@ -186,8 +190,8 @@ impl<'a> StorageCtx<'a> {
     }
 
     /// Computes keccak256 and charges the appropriate gas.
-    pub fn keccak256(&self, data: &[u8]) -> Result<B256> {
-        self.try_with_storage(|s| s.keccak256(data))
+    pub fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+        self.try_with_storage(|s| s.metered_keccak256(data))
     }
 
     /// Creates a journal checkpoint and returns a RAII guard that auto-reverts on drop.

--- a/crates/common/precompile-storage/src/types/primitives.rs
+++ b/crates/common/precompile-storage/src/types/primitives.rs
@@ -43,7 +43,11 @@ impl FromWord for bool {
     }
     #[inline]
     fn from_word(word: U256) -> crate::error::Result<Self> {
-        Ok(!word.is_zero())
+        match word {
+            w if w == U256::ZERO => Ok(false),
+            w if w == U256::ONE => Ok(true),
+            _ => Err(crate::error::BasePrecompileError::enum_conversion_error()),
+        }
     }
 }
 
@@ -123,6 +127,16 @@ mod tests {
 
     // Generate property tests for all primitive storage types
     base_precompile_macros::gen_storable_tests!();
+
+    #[test]
+    fn bool_from_word_rejects_noncanonical() {
+        for bad in [U256::from(2u64), U256::from(0xffu64), U256::MAX] {
+            assert!(
+                <bool as FromWord>::from_word(bad).is_err(),
+                "expected error for non-canonical bool word {bad}"
+            );
+        }
+    }
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(500))]

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -56,7 +56,12 @@ impl ActivationRegistryStorage<'_> {
     /// Activation registry precompile address.
     pub const ADDRESS: Address = address!("8453000000000000000000000000000000000001");
 
-    /// Returns the activation admin.
+    /// Returns the activation admin address, or [`Address::ZERO`] if no admin is configured.
+    ///
+    /// [`Address::ZERO`] here means "no admin is set": it is not a valid admin address.
+    /// Configuration-time validation rejects `Some(Address::ZERO)`, so in a correctly
+    /// constructed chain spec the zero return always means `activation_admin_address` was
+    /// `None`. Callers must not treat the zero return as a meaningful admin address.
     pub const fn admin(&self, activation_admin_address: Option<Address>) -> Address {
         match activation_admin_address {
             Some(address) => address,
@@ -119,6 +124,9 @@ impl ActivationRegistryStorage<'_> {
         }
 
         let caller = self.storage.caller();
+        if caller.is_zero() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
         let Some(admin) = activation_admin_address else {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         };
@@ -524,5 +532,22 @@ mod tests {
 
         assert!(output.is_success());
         assert_eq!(output.gas_refunded, 0, "writing to a zero slot earns no refund");
+    }
+
+    /// A zero-address caller must be rejected even when the admin is also configured as
+    /// `Address::ZERO`. This prevents deposit transactions with `msg.sender == Address::ZERO` from
+    /// toggling activation state on a misconfigured chain.
+    #[test]
+    fn zero_address_caller_with_zero_admin_is_rejected() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(Address::ZERO);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+        assert_activated(&mut storage, false);
     }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -38,6 +38,10 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
     {
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::b20_asset_call(calldata));
+        if !ctx.call_value().is_zero() {
+            return recorder
+                .record_base_error_result(ctx, BasePrecompileError::revert(IB20::NonPayable {}));
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -106,9 +110,10 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
         if let Some(selector) = BerylSelector::selector(calldata)
             && IB20Asset::IB20AssetCalls::valid_selector(selector)
         {
-            let call = IB20Asset::IB20AssetCalls::abi_decode(calldata).map_err(|error| {
-                BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
-            })?;
+            let call =
+                IB20Asset::IB20AssetCalls::abi_decode_validate(calldata).map_err(|error| {
+                    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+                })?;
             let label = call.as_label();
             let asset_observer = observer.clone();
             return observer.observe(label, move || {
@@ -453,8 +458,14 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
                 return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
             }
-            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|_| {
-                BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
+            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|err| {
+                if err.is_system_error() {
+                    err
+                } else {
+                    BasePrecompileError::revert(IB20Asset::InternalCallFailed {
+                        call: call.clone(),
+                    })
+                }
             })?;
         }
 
@@ -468,7 +479,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use alloy_primitives::{Address, Bytes, U256};
-    use alloy_sol_types::{SolCall, SolEvent};
+    use alloy_sol_types::{SolCall, SolError, SolEvent};
     use base_precompile_storage::{
         BasePrecompileError, HashMapStorageProvider, Result, StorageCtx,
     };
@@ -476,8 +487,9 @@ mod tests {
     use crate::{
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
         B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset, InMemoryPolicy,
-        InMemoryTokenAccounting, PrecompileCallMetric, PrecompileCallObserver,
-        PrecompileCallOutcome, PrecompileCallStatus, Token, TokenAccounting,
+        InMemoryTokenAccounting, NoopPrecompileCallObserver, PrecompileCallMetric,
+        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token,
+        TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, InMemoryPolicy>;
@@ -790,5 +802,73 @@ mod tests {
             token.to_scaled_balance(U256::from(2u64)).unwrap_err(),
             BasePrecompileError::under_overflow()
         );
+    }
+
+    /// System errors produced by an inner `announce` call must propagate unchanged and must
+    /// not be wrapped as [`IB20Asset::InternalCallFailed`]. A deliberately overflowing
+    /// `toScaledBalance` produces `Panic(UnderOverflow)`, which `is_system_error()` returns
+    /// `true` for.
+    #[test]
+    fn announce_inner_system_error_propagates_unchanged() {
+        let mut token = make_token();
+        // Any balance > 1 overflows when multiplied by this multiplier.
+        token.accounting_mut().multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, ALICE), true);
+
+        let inner_call = Bytes::from(
+            IB20Asset::toScaledBalanceCall { rawBalance: U256::from(2u64) }.abi_encode(),
+        );
+        let calldata = IB20Asset::announceCall {
+            internalCalls: alloc::vec![inner_call],
+            id: String::from("test-sys-err"),
+            description: String::from("test"),
+            uri: String::new(),
+        }
+        .abi_encode();
+
+        let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::under_overflow());
+    }
+
+    /// A non-system revert produced by an inner `announce` call must be wrapped as
+    /// [`IB20Asset::InternalCallFailed`], preserving the original calldata in the error field.
+    #[test]
+    fn announce_inner_ordinary_revert_wraps_as_internal_call_failed() {
+        let mut token = make_token();
+        // ALICE has OPERATOR_ROLE (needed for announce) but not MINT_ROLE (needed for mint).
+        token.accounting_mut().roles.insert((TestAssetToken::OPERATOR_ROLE, ALICE), true);
+
+        let inner_call = Bytes::from(IB20::mintCall { to: BOB, amount: U256::ONE }.abi_encode());
+        let calldata = IB20Asset::announceCall {
+            internalCalls: alloc::vec![inner_call.clone()],
+            id: String::from("test-ord-revert"),
+            description: String::from("test"),
+            uri: String::new(),
+        }
+        .abi_encode();
+
+        let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
+
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: inner_call })
+        );
+    }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+        let mut storage = storage_with_caller(ALICE);
+        storage.set_call_value(U256::from(1u64));
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, NoopPrecompileCallObserver)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/b20_factory/abi.rs
+++ b/crates/common/precompiles/src/b20_factory/abi.rs
@@ -32,6 +32,9 @@ sol! {
 
         // ── Errors ───────────────────────────────────────────────────────────
 
+        /// ETH was sent to a nonpayable factory function.
+        error NonPayable();
+
         /// A token already exists at the address derived from `(variant, msg.sender, salt)`.
         error TokenAlreadyExists(address token);
 

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -1,8 +1,8 @@
 //! ABI dispatch for the `B20Factory` precompile.
 
-use alloy_primitives::{Address, Bytes};
-use alloy_sol_types::SolCall;
-use base_precompile_storage::StorageCtx;
+use alloy_primitives::Bytes;
+use alloy_sol_types::{SolCall, SolValue};
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -28,6 +28,12 @@ impl<'a> B20FactoryStorage<'a> {
     {
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::factory_call(calldata));
+        if !ctx.call_value().is_zero() {
+            return recorder.record_base_error_result(
+                ctx,
+                BasePrecompileError::revert(IB20Factory::NonPayable {}),
+            );
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -46,19 +52,22 @@ impl<'a> B20FactoryStorage<'a> {
         match decode_precompile_call!(calldata, IB20Factory::IB20FactoryCalls) {
             IB20Factory::IB20FactoryCalls::createB20(call) => {
                 let caller = ctx.caller();
-                let variant = B20Variant::from_abi(call.variant);
-                let token = self.create_b20_with_observer(caller, call, observer.clone())?;
-                if let Some(variant) = variant {
-                    observer.record_b20_created(variant.as_label());
-                }
+                // abi_decode_validate rejects non-canonical discriminants before dispatch,
+                // so from_abi returning None here would be an internal invariant violation.
+                let variant = B20Variant::from_abi(call.variant).expect(
+                    "abi_decode_validate rejects non-canonical discriminants before dispatch",
+                );
+                let address_hash = ctx.metered_keccak256(&(caller, call.salt).abi_encode())?;
+                let token = self.create_b20_with_observer(call, address_hash, observer.clone())?;
+                observer.record_b20_created(variant.as_label());
                 Ok(IB20Factory::createB20Call::abi_encode_returns(&token).into())
             }
             IB20Factory::IB20FactoryCalls::getB20Address(call) => {
-                // Returns zero for an unrecognized variant to match base-std, which documents
-                // this function as "Never reverts."
-                let addr = B20Variant::from_abi(call.variant)
-                    .map(|v| v.compute_address(call.sender, call.salt).0)
-                    .unwrap_or(Address::ZERO);
+                let v = B20Variant::from_abi(call.variant).expect(
+                    "abi_decode_validate rejects non-canonical discriminants before dispatch",
+                );
+                let hash = ctx.metered_keccak256(&(call.sender, call.salt).abi_encode())?;
+                let addr = v.compute_address_from_hash(hash).0;
                 Ok(IB20Factory::getB20AddressCall::abi_encode_returns(&addr).into())
             }
             IB20Factory::IB20FactoryCalls::isB20(call) => {
@@ -70,5 +79,32 @@ impl<'a> B20FactoryStorage<'a> {
                 Ok(IB20Factory::isB20InitializedCall::abi_encode_returns(&initialized).into())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolCall, SolError};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{B20FactoryStorage, IB20Factory};
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(U256::from(1u64));
+        let calldata = IB20Factory::isB20Call { token: Address::ZERO }.abi_encode();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            B20FactoryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(
+            out.bytes,
+            alloy_primitives::Bytes::from(IB20Factory::NonPayable {}.abi_encode())
+        );
     }
 }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -1,6 +1,6 @@
 use alloc::{string::ToString, vec::Vec};
 
-use alloy_primitives::{Address, Bytes, U256, address};
+use alloy_primitives::{Address, B256, Bytes, U256, address, b256, keccak256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_precompile_macros::contract;
 use base_precompile_storage::{BasePrecompileError, Result};
@@ -33,6 +33,10 @@ const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
 /// Initial multiplier storage value. Reads treat zero as WAD precision (1:1).
 const INITIAL_MULTIPLIER: U256 = U256::ZERO;
 
+/// keccak256(0xef)
+const FACTORY_MARKER_CODE_HASH: B256 =
+    b256!("309b8896ee4c1ff7ec1966155373dee42663b6b40c3fedc70ba501684848d2a3");
+
 /// The B-20 token factory precompile.
 #[contract(addr = Self::ADDRESS)]
 pub struct B20FactoryStorage {}
@@ -50,14 +54,19 @@ impl<'a> B20FactoryStorage<'a> {
         caller: Address,
         call: IB20Factory::createB20Call,
     ) -> Result<Address> {
-        self.create_b20_with_observer(caller, call, NoopPrecompileCallObserver)
+        let address_hash = keccak256((caller, call.salt).abi_encode());
+        self.create_b20_with_observer(call, address_hash, NoopPrecompileCallObserver)
     }
 
     /// Creates a token at a deterministic address and records observer-only metrics.
+    ///
+    /// `address_hash` must be `keccak256(abi_encode(caller, call.salt))`. The caller is
+    /// responsible for computing this hash (and charging gas via `ctx.metered_keccak256`
+    /// before calling this method from a dispatch context).
     pub fn create_b20_with_observer<O>(
         &mut self,
-        caller: Address,
         call: IB20Factory::createB20Call,
+        address_hash: B256,
         observer: O,
     ) -> Result<Address>
     where
@@ -70,7 +79,7 @@ impl<'a> B20FactoryStorage<'a> {
         let params = TokenCreateParams::decode(variant, &call.params)?;
         Self::check_version(params.version(), variant)?;
         params.validate()?;
-        let (token_address, _) = variant.compute_address(caller, call.salt);
+        let (token_address, _) = variant.compute_address_from_hash(address_hash);
 
         let already_deployed =
             self.storage.with_account_info(token_address, |info| Ok(!info.is_empty_code_hash()))?;
@@ -106,13 +115,11 @@ impl<'a> B20FactoryStorage<'a> {
     }
 
     /// Returns whether `token` is a B-20 address that has been initialized by this factory.
-    ///
-    /// Returns `false` for addresses without the B-20 prefix, even if they have bytecode.
     pub fn is_b20_initialized(&self, token: Address) -> Result<bool> {
         if !B20Variant::has_b20_prefix(token) {
             return Ok(false);
         }
-        self.storage.with_account_info(token, |info| Ok(!info.is_empty_code_hash()))
+        self.storage.with_account_info(token, |info| Ok(info.code_hash == FACTORY_MARKER_CODE_HASH))
     }
 
     fn init_stablecoin<O>(
@@ -139,7 +146,9 @@ impl<'a> B20FactoryStorage<'a> {
             variant: B20Variant::Stablecoin.abi(),
             name,
             symbol,
-            decimals: B20Variant::Stablecoin.decimals(),
+            decimals: B20Variant::Stablecoin
+                .decimals()
+                .expect("stablecoin has fixed 6-decimal precision"),
             variantParams: encode_stablecoin_variant_params(&currency),
         })?;
 
@@ -283,7 +292,7 @@ impl TokenCreateParams {
     pub fn decode(variant: B20Variant, params: &Bytes) -> Result<Self> {
         match variant {
             B20Variant::Stablecoin => {
-                let p = IB20Factory::B20StablecoinCreateParams::abi_decode(params)
+                let p = IB20Factory::B20StablecoinCreateParams::abi_decode_validate(params)
                     .map_err(Self::invalid_params)?;
                 Ok(Self::Stablecoin {
                     common: CommonParams { version: p.version, initial_admin: p.initialAdmin },
@@ -296,7 +305,7 @@ impl TokenCreateParams {
                 })
             }
             B20Variant::Asset => {
-                let p = IB20Factory::B20AssetCreateParams::abi_decode(params)
+                let p = IB20Factory::B20AssetCreateParams::abi_decode_validate(params)
                     .map_err(Self::invalid_params)?;
                 Ok(Self::Asset {
                     common: CommonParams { version: p.version, initial_admin: p.initialAdmin },
@@ -365,7 +374,9 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, U256, address};
     use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
     use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
+    use revm::state::Bytecode;
 
+    use super::FACTORY_MARKER_CODE_HASH;
     use crate::{
         ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
         B20AssetToken, B20FactoryStorage, B20StablecoinStorage, B20TokenRole, B20Variant, IB20,
@@ -597,6 +608,26 @@ mod tests {
             factory.create_b20(caller, b20_call(salt)).unwrap();
             let result = factory.create_b20(caller, b20_call(salt));
             assert!(result.is_err());
+        });
+    }
+
+    /// A prefunded token address (balance > 0, no code) must not block `create_b20`.
+    /// The factory collision check rejects only accounts that already have code, so a
+    /// prefunded address is a valid deployment target and `set_code` must succeed.
+    #[test]
+    fn test_create_token_at_prefunded_address_succeeds() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xF0);
+        let (token_addr, _) = B20Variant::Asset.compute_address(caller, salt);
+
+        storage.set_balance(token_addr, U256::from(1u64));
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut factory = B20FactoryStorage::new(ctx);
+            factory.create_b20(caller, b20_call(salt)).unwrap();
         });
     }
 
@@ -894,6 +925,35 @@ mod tests {
     }
 
     #[test]
+    fn test_factory_marker_code_hash_constant_matches_keccak256_of_marker_byte() {
+        use alloy_primitives::keccak256;
+        assert_eq!(
+            FACTORY_MARKER_CODE_HASH,
+            keccak256([0xef_u8]),
+            "FACTORY_MARKER_CODE_HASH must equal keccak256([0xef])"
+        );
+    }
+
+    #[test]
+    fn test_is_b20_initialized_rejects_arbitrary_code_at_b20_prefix_address() {
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0x22);
+        let (addr, _) = B20Variant::Asset.compute_address(caller, salt);
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ctx.set_code(addr, Bytecode::new_legacy(Bytes::from_static(&[0x60, 0x00]))).unwrap();
+
+            let factory = B20FactoryStorage::new(ctx);
+            assert!(factory.is_b20(addr).unwrap(), "address must have B20 prefix");
+            assert!(
+                !factory.is_b20_initialized(addr).unwrap(),
+                "arbitrary code at B20-prefix address must not be reported as factory-initialized"
+            );
+        });
+    }
+
+    #[test]
     fn test_transfer_and_mint_lifecycle() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
@@ -993,18 +1053,6 @@ mod tests {
                 ),
                 IB20Factory::getB20AddressCall::abi_encode_returns(&expected_token),
             );
-            assert_output(
-                dispatch_factory_success(
-                    ctx,
-                    IB20Factory::getB20AddressCall {
-                        variant: IB20Factory::B20Variant::__Invalid,
-                        sender: creator,
-                        salt,
-                    },
-                ),
-                IB20Factory::getB20AddressCall::abi_encode_returns(&Address::ZERO),
-            );
-
             assert_output(
                 dispatch_factory_success(ctx, call),
                 IB20Factory::createB20Call::abi_encode_returns(&expected_token),
@@ -1272,23 +1320,22 @@ mod tests {
     }
 
     #[test]
-    fn get_b20_address_returns_zero_for_invalid_variant() {
+    fn get_b20_address_reverts_for_invalid_variant() {
         let mut storage = HashMapStorageProvider::new(1);
         activate_precompiles(&mut storage);
         let sender = Address::repeat_byte(0x11);
         let salt = B256::repeat_byte(0xAB);
 
         StorageCtx::enter(&mut storage, |ctx| {
-            assert_output(
-                dispatch_factory_success(
-                    ctx,
-                    IB20Factory::getB20AddressCall {
-                        variant: IB20Factory::B20Variant::__Invalid,
-                        sender,
-                        salt,
-                    },
-                ),
-                IB20Factory::getB20AddressCall::abi_encode_returns(&Address::ZERO),
+            // Strict ABI decoding rejects non-canonical enum discriminants, so an
+            // out-of-range variant produces an ABI decode error rather than Address::ZERO.
+            dispatch_factory_revert(
+                ctx,
+                IB20Factory::getB20AddressCall {
+                    variant: IB20Factory::B20Variant::__Invalid,
+                    sender,
+                    salt,
+                },
             );
         });
     }
@@ -1300,5 +1347,92 @@ mod tests {
         // constant sharing.
         assert!(B20Variant::Stablecoin.supported_version() > 0);
         assert!(B20Variant::Asset.supported_version() > 0);
+    }
+
+    #[test]
+    fn b20created_asset_event_emits_token_specific_decimals() {
+        // Regression: B20Created.decimals for an asset token must reflect init.decimals
+        // (per-token), not any variant constant. Use 12 to distinguish from both the
+        // Stablecoin fixed value (6) and the Asset MIN_DECIMALS sentinel (6).
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let call = IB20Factory::createB20Call {
+            variant: IB20Factory::B20Variant::ASSET,
+            salt: B256::repeat_byte(0x72),
+            params: IB20Factory::B20AssetCreateParams {
+                version: 1,
+                name: "Custom Decimals Asset".to_string(),
+                symbol: "CDA".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                decimals: 12,
+            }
+            .abi_encode()
+            .into(),
+            initCalls: Vec::new(),
+        };
+        storage.set_caller(Address::repeat_byte(0x01));
+        StorageCtx::enter(&mut storage, |ctx| {
+            dispatch_factory_success(ctx, call);
+        });
+        let event = storage
+            .get_events(B20FactoryStorage::ADDRESS)
+            .iter()
+            .find_map(|l| IB20Factory::B20Created::decode_log_data(l).ok())
+            .expect("B20Created must be emitted");
+        assert_eq!(
+            event.decimals, 12,
+            "B20Created.decimals must equal init.decimals, not any variant constant"
+        );
+    }
+
+    #[test]
+    fn factory_address_hashing_is_metered_for_valid_variant() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let sender = Address::repeat_byte(0x20);
+        let salt = B256::repeat_byte(0x30);
+        let (expected_asset_addr, _) = B20Variant::Asset.compute_address(sender, salt);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            // Valid variant: keccak is charged and the correct address is returned.
+            assert_output(
+                dispatch_factory_success(
+                    ctx,
+                    IB20Factory::getB20AddressCall {
+                        variant: IB20Factory::B20Variant::ASSET,
+                        sender,
+                        salt,
+                    },
+                ),
+                IB20Factory::getB20AddressCall::abi_encode_returns(&expected_asset_addr),
+            );
+        });
+        // One keccak call for the valid getB20Address.
+        assert_eq!(
+            storage.counter_keccak256(),
+            1,
+            "getB20Address must call keccak256 exactly once for a valid variant"
+        );
+
+        // createB20 also meters the keccak hash for valid variants. Verify the token
+        // is created at the same address that getB20Address predicted.
+        storage.reset_counters();
+        storage.set_caller(sender);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let call = create_call(
+                IB20Factory::B20Variant::ASSET,
+                token_params("Metered Token", "MTR"),
+                salt,
+            );
+            assert_output(
+                dispatch_factory_success(ctx, call),
+                IB20Factory::createB20Call::abi_encode_returns(&expected_asset_addr),
+            );
+        });
+        assert_eq!(
+            storage.counter_keccak256(),
+            1,
+            "createB20 must call keccak256 exactly once for a valid variant"
+        );
     }
 }

--- a/crates/common/precompiles/src/b20_factory/variant.rs
+++ b/crates/common/precompiles/src/b20_factory/variant.rs
@@ -93,10 +93,12 @@ impl B20Variant {
         }
     }
 
-    /// Returns the default fixed decimal precision for variants without stored decimals.
-    pub const fn decimals(self) -> u8 {
+    /// Returns the fixed decimal precision for this variant, or `None` for variants (like
+    /// `Asset`) where decimals are per-token and supplied at creation time via init params.
+    pub const fn decimals(self) -> Option<u8> {
         match self {
-            Self::Asset | Self::Stablecoin => 6,
+            Self::Stablecoin => Some(6),
+            Self::Asset => None,
         }
     }
 
@@ -126,7 +128,14 @@ impl B20Variant {
     /// Returns the address and the 9-byte hash tail embedded in the address.
     pub fn compute_address(self, creator: Address, salt: B256) -> (Address, [u8; 9]) {
         let hash = keccak256((creator, salt).abi_encode());
+        self.compute_address_from_hash(hash)
+    }
 
+    /// Computes the deterministic token address from a pre-computed `keccak256(creator, salt)` hash.
+    ///
+    /// Use when the hash is already available (e.g. after charging keccak gas via `ctx.metered_keccak256`)
+    /// to avoid re-encoding and re-hashing.
+    pub fn compute_address_from_hash(self, hash: B256) -> (Address, [u8; 9]) {
         let mut tail = [0u8; 9];
         tail.copy_from_slice(&hash[..9]);
 

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -13,8 +13,8 @@ use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    B20StablecoinToken, B20TokenRole, BerylCallRecorder, BerylMetricLabels, BerylSelector,
-    Burnable, Configurable,
+    B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder, BerylMetricLabels,
+    BerylSelector, Burnable, Configurable,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
@@ -42,6 +42,10 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             observer.clone(),
             BerylMetricLabels::b20_stablecoin_call(calldata),
         );
+        if !ctx.call_value().is_zero() {
+            return recorder
+                .record_base_error_result(ctx, BasePrecompileError::revert(IB20::NonPayable {}));
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -109,10 +113,9 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         if let Some(selector) = BerylSelector::selector(calldata)
             && IB20Stablecoin::IB20StablecoinCalls::valid_selector(selector)
         {
-            let call =
-                IB20Stablecoin::IB20StablecoinCalls::abi_decode(calldata).map_err(|error| {
-                    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
-                })?;
+            let call = IB20Stablecoin::IB20StablecoinCalls::abi_decode_validate(calldata).map_err(
+                |error| BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() },
+            )?;
             let label = call.as_label();
             return observer.observe(label, || self.handle_stablecoin_call(call));
         }
@@ -125,7 +128,15 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
                 // --- Pure reads: direct to accounting ---
                 C::name(_) => self.accounting().name()?.abi_encode().into(),
                 C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
-                C::decimals(_) => U256::from(self.accounting().decimals()?).abi_encode().into(),
+                // Stablecoin precision is fixed at 6 by the protocol spec; never read from
+                // storage to avoid the zero-return window during the factory bootstrap.
+                C::decimals(_) => U256::from(
+                    B20Variant::Stablecoin
+                        .decimals()
+                        .expect("stablecoin has fixed 6-decimal precision"),
+                )
+                .abi_encode()
+                .into(),
                 C::totalSupply(_) => self.accounting().total_supply()?.abi_encode().into(),
                 C::balanceOf(c) => self.accounting().balance_of(c.account)?.abi_encode().into(),
                 C::allowance(c) => {
@@ -327,5 +338,71 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
             SC::currency(_) => self.accounting().currency()?.abi_encode().into(),
         };
         Ok(encoded)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_sol_types::{SolCall, SolError, SolValue};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{
+        B20StablecoinToken, IB20, InMemoryPolicy, InMemoryTokenAccounting,
+        NoopPrecompileCallObserver, TestStablecoinToken,
+    };
+
+    const TOKEN: Address = Address::repeat_byte(0x01);
+
+    fn make_stablecoin_token_with_decimals(decimals: u8) -> TestStablecoinToken {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN);
+        accounting.decimals = decimals;
+        TestStablecoinToken::with_storage_and_policy(accounting, InMemoryPolicy::new())
+    }
+
+    fn call_inner(token: &mut TestStablecoinToken, calldata: &[u8]) -> Vec<u8> {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(TOKEN);
+        StorageCtx::enter(&mut storage, |ctx| token.inner(ctx, calldata)).unwrap().to_vec()
+    }
+
+    fn make_token() -> B20StablecoinToken<InMemoryTokenAccounting, InMemoryPolicy> {
+        B20StablecoinToken::with_storage_and_policy(
+            InMemoryTokenAccounting::new(TOKEN),
+            InMemoryPolicy::new(),
+        )
+    }
+
+    /// Decimals always returns 6 regardless of what the underlying accounting stores.
+    ///
+    /// During the factory bootstrap window the storage slot is uninitialized and would
+    /// return 0 if read directly. Hard-coding 6 in the dispatch eliminates that window.
+    #[test]
+    fn decimals_returns_fixed_six_regardless_of_storage() {
+        // Token with decimals = 0 in storage (simulates an uninitialized slot).
+        let mut uninitialized = make_stablecoin_token_with_decimals(0);
+        let calldata = IB20::decimalsCall {}.abi_encode();
+        let result = call_inner(&mut uninitialized, &calldata);
+        assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
+
+        // Token with decimals = 18 in storage (default for InMemoryTokenAccounting).
+        let mut default = make_stablecoin_token_with_decimals(18);
+        let result = call_inner(&mut default, &calldata);
+        assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
+    }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall { account: Address::ZERO }.abi_encode();
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(U256::from(1u64));
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, NoopPrecompileCallObserver)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/common/abi.rs
+++ b/crates/common/precompiles/src/common/abi.rs
@@ -15,6 +15,10 @@ sol! {
         }
 
         // Errors
+
+        /// ETH was attached to a call targeting a nonpayable token selector.
+        error NonPayable();
+
         error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
         error Unauthorized();
         error ContractPaused(PausableFeature feature);

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -51,8 +51,8 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 mod metrics;
 pub use metrics::{
     BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
-    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, PrecompileCallMetric,
-    PrecompileCallOutcome, PrecompileCallStatus,
+    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, CALLDATA_WORD_GAS,
+    PrecompileCallMetric, PrecompileCallOutcome, PrecompileCallStatus,
 };
 
 mod b20_asset;

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -65,7 +65,7 @@ macro_rules! decode_precompile_call {
             }
         };
 
-        match <$call_ty as ::alloy_sol_types::SolInterface>::abi_decode(calldata) {
+        match <$call_ty as ::alloy_sol_types::SolInterface>::abi_decode_validate(calldata) {
             Ok(call) => call,
             Err(error)
                 if <$call_ty as ::alloy_sol_types::SolInterface>::valid_selector(selector) =>
@@ -132,5 +132,23 @@ mod tests {
         let call = decode_policy_call(&calldata).unwrap();
 
         assert!(matches!(call, IPolicyRegistry::IPolicyRegistryCalls::policyExists(_)));
+    }
+
+    #[test]
+    fn decode_precompile_call_rejects_dirty_padding_bytes() {
+        // policyExists(uint64 policyId) encodes policyId as a right-aligned 32-byte word.
+        // Injecting 0xFF into the high-padding byte triggers abi_decode_validate's canonical
+        // check, confirming the macro uses the validating decoder.
+        let mut calldata = IPolicyRegistry::policyExistsCall { policyId: 0 }.abi_encode();
+        calldata[4] = 0xFF;
+        let err = decode_policy_call(&calldata).unwrap_err();
+
+        assert!(matches!(
+            err,
+            BasePrecompileError::AbiDecodeFailed {
+                selector: IPolicyRegistry::policyExistsCall::SELECTOR,
+                ..
+            }
+        ));
     }
 }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -538,6 +538,13 @@ impl BerylCallTimer {
     }
 }
 
+/// Per-word calldata ingestion cost charged by Beryl native precompile dispatchers.
+///
+/// Emulates the cost a Solidity predeploy would incur reading its calldata:
+/// `G_copy` (3 gas/word) + `G_memory` (3 gas/word) = 6 gas/word.
+/// Part of the receipts/gas-used commitment: must be identical across all Base execution clients.
+pub const CALLDATA_WORD_GAS: u64 = 6;
+
 /// Per-call recorder for Beryl precompile observations.
 #[derive(Debug)]
 pub struct BerylCallRecorder<O> {
@@ -573,12 +580,14 @@ where
         &self.call
     }
 
+    /// Computes the calldata gas cost for the given calldata slice.
+    pub const fn calldata_gas_cost(calldata: &[u8]) -> u64 {
+        (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS)
+    }
+
     /// Deducts the common calldata gas charged by Beryl precompile dispatch.
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
-        const G_SHA3WORD: u64 = 6;
-
-        let calldata_cost = (calldata.len() as u64).div_ceil(32).saturating_mul(G_SHA3WORD);
-        ctx.deduct_gas(calldata_cost)
+        ctx.deduct_gas(Self::calldata_gas_cost(calldata))
     }
 
     /// Records a Base precompile error before it is converted to a [`PrecompileResult`].
@@ -649,8 +658,8 @@ mod tests {
     use base_precompile_storage::BasePrecompileError;
 
     use crate::{
-        BerylCallOutcome, BerylErrorKind, BerylMetricLabels, BerylSelector, IB20, IB20Factory,
-        IPolicyRegistry,
+        BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
+        CALLDATA_WORD_GAS, IB20, IB20Factory, IPolicyRegistry, NoopPrecompileCallObserver,
     };
 
     #[test]
@@ -715,5 +724,16 @@ mod tests {
         assert_eq!(BerylCallOutcome::from_result(&success), BerylCallOutcome::Success);
         assert_eq!(BerylCallOutcome::from_result(&revert), BerylCallOutcome::Revert);
         assert_eq!(BerylCallOutcome::from_result(&fatal), BerylCallOutcome::Fatal);
+    }
+
+    #[test]
+    fn deduct_calldata_cost_gas_formula() {
+        type Recorder = BerylCallRecorder<NoopPrecompileCallObserver>;
+
+        // 32 bytes = 1 word => CALLDATA_WORD_GAS
+        assert_eq!(Recorder::calldata_gas_cost(&[0u8; 32]), CALLDATA_WORD_GAS);
+
+        // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * CALLDATA_WORD_GAS
+        assert_eq!(Recorder::calldata_gas_cost(&[0u8; 36]), 2 * CALLDATA_WORD_GAS);
     }
 }

--- a/crates/common/precompiles/src/policy/abi.rs
+++ b/crates/common/precompiles/src/policy/abi.rs
@@ -12,6 +12,9 @@ sol! {
             ALLOWLIST
         }
 
+        /// ETH was attached to a call targeting a nonpayable policy registry selector.
+        error NonPayable();
+
         error Unauthorized();
         error PolicyNotFound();
         error IncompatiblePolicyType();

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::StorageCtx;
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -32,6 +32,12 @@ impl PolicyRegistryStorage<'_> {
     {
         let mut recorder =
             BerylCallRecorder::start(observer.clone(), BerylMetricLabels::policy_call(calldata));
+        if !ctx.call_value().is_zero() {
+            return recorder.record_base_error_result(
+                ctx,
+                BasePrecompileError::revert(IPolicyRegistry::NonPayable {}),
+            );
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -130,8 +136,8 @@ impl PolicyRegistryStorage<'_> {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use alloy_primitives::{Address, Bytes, U256, address};
-    use alloy_sol_types::{Panic, PanicKind, SolCall, SolError, SolValue};
+    use alloy_primitives::{Address, Bytes, address};
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use crate::{
@@ -310,10 +316,7 @@ mod tests {
         })
         .expect("dispatch should not fatally error");
 
-        let expected: Bytes =
-            Panic { code: U256::from(PanicKind::EnumConversionError as u32) }.abi_encode().into();
         assert!(output.is_revert());
-        assert_eq!(output.bytes, expected);
 
         let valid_calldata = IPolicyRegistry::createPolicyCall {
             admin: ADMIN,
@@ -611,5 +614,22 @@ mod tests {
             .unwrap();
             assert!(out.is_revert(), "createPolicy must revert when feature is deactivated");
         }
+    }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(alloy_primitives::U256::from(1u64));
+        let calldata =
+            IPolicyRegistry::policyExistsCall { policyId: PolicyRegistryStorage::ALWAYS_ALLOW_ID }
+                .abi_encode();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(out.bytes, Bytes::from(IPolicyRegistry::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -41,7 +41,9 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             BaseUpgrade::Granite | BaseUpgrade::Holocene => Self::granite(),
             BaseUpgrade::Isthmus => Self::isthmus(),
             BaseUpgrade::Jovian => Self::jovian(),
-            BaseUpgrade::Azul | BaseUpgrade::Beryl | BaseUpgrade::Cobalt => Self::azul(),
+            BaseUpgrade::Azul => Self::azul(),
+            BaseUpgrade::Beryl => Self::beryl(),
+            BaseUpgrade::Cobalt => Self::cobalt(),
             upgrade => panic!("unsupported Base precompile upgrade: {upgrade}"),
         };
 
@@ -163,6 +165,13 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     /// Static precompiles are the same as Azul; Beryl adds dynamic precompiles at install time.
     pub fn beryl() -> &'static Precompiles {
         Self::azul()
+    }
+
+    /// Returns precompiles for the Base Cobalt spec.
+    ///
+    /// Static precompiles are the same as Beryl; Cobalt adds dynamic precompiles at install time.
+    pub fn cobalt() -> &'static Precompiles {
+        Self::beryl()
     }
 
     /// Builds a [`PrecompilesMap`] with all Base precompiles for this spec installed.

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -31,6 +31,12 @@ pub enum BaseChainSpecError {
         /// Chain ID whose Beryl-enabled configuration lacks an activation admin address.
         chain_id: u64,
     },
+    /// Beryl is scheduled but the activation registry admin address is `Address::ZERO`.
+    #[error("activation admin address must not be zero for Beryl-enabled chain ID: {chain_id}")]
+    ZeroActivationAdminAddress {
+        /// Chain ID whose Beryl-enabled configuration has a zero activation admin address.
+        chain_id: u64,
+    },
 }
 
 /// Genesis info extracted from a Base genesis config.
@@ -226,16 +232,21 @@ impl BaseChainSpec {
         Ok(Self { inner: value, activation_admin_address })
     }
 
-    /// Validates that Beryl-enabled chains include an activation registry admin address.
+    /// Validates that Beryl-enabled chains have a valid activation registry admin address:
+    /// present (not `None`) and non-zero.
     pub fn validate_beryl_activation_admin(
         hardforks: &ChainHardforks,
         activation_admin_address: Option<Address>,
         chain_id: u64,
     ) -> Result<(), BaseChainSpecError> {
-        if activation_admin_address.is_none()
-            && !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never)
-        {
+        let beryl_scheduled = !matches!(hardforks.fork(BaseUpgrade::Beryl), ForkCondition::Never);
+
+        if activation_admin_address.is_none() && beryl_scheduled {
             return Err(BaseChainSpecError::MissingActivationAdminAddress { chain_id });
+        }
+
+        if matches!(activation_admin_address, Some(addr) if addr.is_zero()) && beryl_scheduled {
+            return Err(BaseChainSpecError::ZeroActivationAdminAddress { chain_id });
         }
 
         Ok(())
@@ -285,7 +296,7 @@ impl TryFrom<&ChainConfig> for BaseChainSpec {
             .to_chain_hardforks();
         Self::validate_beryl_activation_admin(
             &hardforks,
-            cfg.activation_admin_address,
+            Some(cfg.activation_admin_address),
             cfg.chain_id,
         )?;
         let genesis_header = match cfg.genesis_l2_hash {
@@ -324,7 +335,7 @@ impl TryFrom<&ChainConfig> for BaseChainSpec {
                 prune_delete_limit: cfg.prune_delete_limit,
                 ..Default::default()
             },
-            activation_admin_address: cfg.activation_admin_address,
+            activation_admin_address: Some(cfg.activation_admin_address),
         })
     }
 }
@@ -458,7 +469,7 @@ mod tests {
     use alloy_consensus::proofs::storage_root_unhashed;
     use alloy_genesis::{ChainConfig as AlloyChainConfig, Genesis};
     use alloy_hardforks::Hardfork;
-    use alloy_primitives::{B256, U256, address, b256};
+    use alloy_primitives::{Address, B256, U256, address, b256};
     use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
     use base_common_rpc_types::FeeInfo;
     use reth_chainspec::{
@@ -699,19 +710,6 @@ mod tests {
     }
 
     #[test]
-    fn beryl_chain_config_without_activation_admin_is_rejected() {
-        let mut config = ChainConfig::devnet().clone();
-        config.beryl_timestamp = Some(0);
-        config.activation_admin_address = None;
-
-        let err = BaseChainSpec::try_from(&config)
-            .expect_err("Beryl chain config without activation admin should be rejected");
-        assert!(
-            matches!(err, BaseChainSpecError::MissingActivationAdminAddress { chain_id } if chain_id == config.chain_id)
-        );
-    }
-
-    #[test]
     fn beryl_builder_without_activation_admin_is_rejected() {
         let chain_id = ChainConfig::mainnet().chain_id;
         let err = BaseChainSpecBuilder::base_mainnet()
@@ -722,6 +720,51 @@ mod tests {
 
         assert!(
             matches!(err, BaseChainSpecError::MissingActivationAdminAddress { chain_id: id } if id == chain_id)
+        );
+    }
+
+    #[test]
+    fn beryl_genesis_with_zero_activation_admin_is_rejected() {
+        let chain_id = 987_654;
+        let mut genesis = Genesis::default();
+        genesis.config.chain_id = chain_id;
+        genesis.config.extra_fields.insert("base".to_string(), serde_json::json!({ "beryl": 0 }));
+        genesis.config.extra_fields.insert(
+            "activationAdminAddress".to_string(),
+            serde_json::json!("0x0000000000000000000000000000000000000000"),
+        );
+
+        let err = BaseChainSpec::try_from_genesis(genesis)
+            .expect_err("Beryl genesis with zero activation admin should be rejected");
+        assert!(
+            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id: id } if id == chain_id)
+        );
+    }
+
+    #[test]
+    fn beryl_chain_config_with_zero_activation_admin_is_rejected() {
+        let mut config = ChainConfig::devnet().clone();
+        config.beryl_timestamp = Some(0);
+        config.activation_admin_address = Address::ZERO;
+
+        let err = BaseChainSpec::try_from(&config)
+            .expect_err("Beryl chain config with zero activation admin should be rejected");
+        assert!(
+            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id } if chain_id == config.chain_id)
+        );
+    }
+
+    #[test]
+    fn beryl_builder_with_zero_activation_admin_is_rejected() {
+        let chain_id = ChainConfig::mainnet().chain_id;
+        let err = BaseChainSpecBuilder::base_mainnet()
+            .optional_activation_admin_address(Some(Address::ZERO))
+            .beryl_activated()
+            .try_build()
+            .expect_err("Beryl builder with zero activation admin should be rejected");
+
+        assert!(
+            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id: id } if id == chain_id)
         );
     }
 

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -246,7 +246,7 @@ impl BootInfo {
 
         let built_in_chain_config = base_common_chains::ChainConfig::by_chain_id(chain_id);
         let activation_admin_address =
-            built_in_chain_config.and_then(|config| config.activation_admin_address);
+            built_in_chain_config.map(|config| config.activation_admin_address);
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
@@ -435,7 +435,7 @@ mod tests {
 
         let boot_info = BootInfo::load(&oracle).await.expect("boot info should load");
 
-        assert_eq!(boot_info.activation_admin_address, chain_config.activation_admin_address);
+        assert_eq!(boot_info.activation_admin_address, Some(chain_config.activation_admin_address));
     }
 
     #[tokio::test]

--- a/crates/proof/succinct/utils/client/src/boot.rs
+++ b/crates/proof/succinct/utils/client/src/boot.rs
@@ -85,7 +85,7 @@ mod tests {
             claimed_l2_output_root: B256::repeat_byte(0x33),
             claimed_l2_block_number,
             chain_id: rollup_config.l2_chain_id.id(),
-            activation_admin_address: ChainConfig::MAINNET.activation_admin_address,
+            activation_admin_address: Some(ChainConfig::MAINNET.activation_admin_address),
             rollup_config,
             l1_config,
             proposer: Address::ZERO,


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of #3342, #3344, #3345, #3359, #3360, #3362, #3364, #3368, #3369, #3371, #3381, and #3382 into `releases/v1.1.0`.

## Summary

Backports the remaining PSRC precompile fixes for the v1.1.0 release branch:

- #3364 / BOP-317 / PSRC #6: reject non-canonical bool storage words.
- #3344 / BOP-318 / PSRC #7: reject zero activation admin address.
- #3369 / BOP-319 / PSRC #8: meter B20 factory address-derivation hashing.
- #3371 / BOP-320 / PSRC #10: charge create costs for prefunded B20 addresses.
- #3382 / BOP-311 / PSRC #11: verify the exact factory marker code hash in `isB20Initialized`.
- #3345 / BOP-323 / PSRC #14: make B20 variant decimals explicit and prevent stablecoin decimal misuse.
- #3362 and #3381 / BOP-324 / PSRC #15: enforce nonpayable ABI guards across factory, token, and policy dispatchers.
- #3368 / BOP-325 / PSRC #16: reject dirty ABI words with strict decoding in factory dispatch.
- #3360 / BOP-327 / PSRC #18: propagate B20 asset announce system errors unchanged.
- #3342 / BOP-329 / PSRC #20: give Beryl and Cobalt their own named constructors in fork dispatch.
- #3359 / BOP-330 / PSRC #21: rename the native precompile calldata word gas constant.

## Already Present On Target

- #3367 / BOP-328 / PSRC #19 was already included on `releases/v1.1.0` through #3394.
- #3370 / BOP-321 / PSRC #12 was already represented on `releases/v1.1.0`; the `set_code` static-call guard is present and covered by existing release-branch tests, so this backport does not duplicate that patch.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p base-precompile-storage --lib`
- `cargo test -p base-common-precompiles --lib`
- `cargo check -p base-precompile-storage --no-default-features`
- `cargo check -p base-common-precompiles --no-default-features`
- `cargo test -p base-action-harness --test beryl factory`
