### PR TITLE
fix(precompile-storage): complete slot arithmetic checked-add migration

### DIFF
--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -73,6 +73,10 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         )
     }
 
+    // Called from `Index` and `IndexMut` impls, which return `&T` / `&mut T` — not `Result`.
+    // The `Index` trait is infallible by design, so error propagation is impossible here.
+    // Overflow is unreachable in practice: `base_slot` is a keccak256 output (never U256::MAX)
+    // and `N` is a compile-time constant bounded by the `storable_arrays!` macro (N ≤ 32).
     #[inline]
     fn compute_handler(
         base_slot: U256,
@@ -83,12 +87,16 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
-                base_slot.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
+                base_slot
+                    .checked_add(U256::from(location.offset_slots))
+                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
-                base_slot.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                base_slot
+                    .checked_add(U256::from(index * T::SLOTS))
+                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
                 LayoutCtx::FULL,
             )
         };

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -4,12 +4,10 @@
 //! - **Base slot**: Arrays start directly at `base_slot` (not at keccak256)
 //! - Small elements (`T::BYTES` ≤ 16) are packed; larger elements use full slots.
 
-use core::ops::{Index, IndexMut};
-
 use alloy_primitives::{Address, U256};
 
 use crate::{
-    error::Result,
+    error::{BasePrecompileError, Result},
     packing,
     provider::{Handler, LayoutCtx, Storable, StorableType},
     types::{HandlerCache, Slot},
@@ -61,66 +59,52 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
 
     /// Returns a handler for the element at the given index, or `None` if out of bounds.
     #[inline]
-    pub fn at(&mut self, index: usize) -> Option<&T::Handler<'a>> {
+    pub fn at(&self, index: usize) -> Result<Option<&T::Handler<'a>>> {
         if index >= N {
-            return None;
+            return Ok(None);
         }
         let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        Some(
-            self.cache.get_or_insert(&index, || {
-                Self::compute_handler(base_slot, address, storage, index)
-            }),
-        )
+        Ok(Some(self.cache.get_or_try_insert(&index, || {
+            Self::try_compute_handler(base_slot, address, storage, index)
+        })?))
     }
 
-    // Called from `Index` and `IndexMut` impls, which return `&T` / `&mut T` — not `Result`.
-    // The `Index` trait is infallible by design, so error propagation is impossible here.
-    // Overflow is unreachable in practice: `base_slot` is a keccak256 output (never U256::MAX)
-    // and `N` is a compile-time constant bounded by the `storable_arrays!` macro (N ≤ 32).
+    /// Returns a mutable handler for the element at the given index, or `None` if out of bounds.
     #[inline]
-    fn compute_handler(
+    pub fn at_mut(&mut self, index: usize) -> Result<Option<&mut T::Handler<'a>>> {
+        if index >= N {
+            return Ok(None);
+        }
+        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
+        Ok(Some(self.cache.get_or_try_insert_mut(&index, || {
+            Self::try_compute_handler(base_slot, address, storage, index)
+        })?))
+    }
+
+    #[inline]
+    fn try_compute_handler(
         base_slot: U256,
         address: Address,
         storage: crate::StorageCtx<'a>,
         index: usize,
-    ) -> T::Handler<'a> {
+    ) -> Result<T::Handler<'a>> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
                 base_slot
                     .checked_add(U256::from(location.offset_slots))
-                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
                 base_slot
                     .checked_add(U256::from(index * T::SLOTS))
-                    .expect("slot overflow: unreachable for keccak-derived slots with N ≤ 32"),
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::FULL,
             )
         };
-        T::handle(slot, layout_ctx, address, storage)
-    }
-}
-
-impl<'a, T: StorableType, const N: usize> Index<usize> for ArrayHandler<'a, T, N> {
-    type Output = T::Handler<'a>;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        assert!(index < N, "index out of bounds: {index} >= {N}");
-        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache
-            .get_or_insert(&index, || Self::compute_handler(base_slot, address, storage, index))
-    }
-}
-
-impl<'a, T: StorableType, const N: usize> IndexMut<usize> for ArrayHandler<'a, T, N> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        assert!(index < N, "index out of bounds: {index} >= {N}");
-        let (base_slot, address, storage) = (self.base_slot, self.address, self.storage);
-        self.cache
-            .get_or_insert_mut(&index, || Self::compute_handler(base_slot, address, storage, index))
+        Ok(T::handle(slot, layout_ctx, address, storage))
     }
 }
 

--- a/crates/common/precompile-storage/src/types/mod.rs
+++ b/crates/common/precompile-storage/src/types/mod.rs
@@ -64,6 +64,20 @@ impl<K: Ord + Clone, H> HandlerCache<K, H> {
         unsafe { &*(boxed.as_ref() as *const H) }
     }
 
+    /// Fallible variant of [`get_or_insert`]: the initializer may return `Err`, in which
+    /// case nothing is inserted and the error is propagated.
+    pub fn get_or_try_insert<E>(&self, key: &K, f: impl FnOnce() -> Result<H, E>) -> Result<&H, E> {
+        let mut cache = self.inner.borrow_mut();
+        if let Some(boxed) = cache.get(key) {
+            // SAFETY: Same as `get_or_insert` — stable boxed allocation, append-only cache.
+            return Ok(unsafe { &*(boxed.as_ref() as *const H) });
+        }
+        cache.insert(key.clone(), Box::new(f()?));
+        let boxed = cache.get(key).expect("handler cache was just populated");
+        // SAFETY: See above.
+        Ok(unsafe { &*(boxed.as_ref() as *const H) })
+    }
+
     /// Returns a mutable reference to a lazily initialized handler for the given key.
     pub fn get_or_insert_mut(&mut self, key: &K, f: impl FnOnce() -> H) -> &mut H {
         // Using get_mut() requires &mut self (exclusive access) — no borrow guard needed.
@@ -72,5 +86,18 @@ impl<K: Ord + Clone, H> HandlerCache<K, H> {
             cache.insert(key.clone(), Box::new(f()));
         }
         cache.get_mut(key).expect("handler cache was just populated").as_mut()
+    }
+
+    /// Fallible variant of [`get_or_insert_mut`]: the initializer may return `Err`.
+    pub fn get_or_try_insert_mut<E>(
+        &mut self,
+        key: &K,
+        f: impl FnOnce() -> Result<H, E>,
+    ) -> Result<&mut H, E> {
+        let cache = self.inner.get_mut();
+        if !cache.contains_key(key) {
+            cache.insert(key.clone(), Box::new(f()?));
+        }
+        Ok(cache.get_mut(key).expect("handler cache was just populated").as_mut())
     }
 }

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -112,6 +112,7 @@ where
         storage: crate::StorageCtx<'a>,
     ) -> Self::Handler<'a> {
         SetHandler::new(slot, address, storage)
+            .expect("slot overflow: keccak-derived base slots cannot be U256::MAX")
     }
 }
 
@@ -156,18 +157,16 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
-        Self {
+    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Result<Self> {
+        let positions_slot =
+            base_slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?;
+        Ok(Self {
             values: VecHandler::new(base_slot, address, storage),
-            positions: MappingHandler::new(
-                base_slot.checked_add(U256::ONE).expect("slot overflow"),
-                address,
-                storage,
-            ),
+            positions: MappingHandler::new(positions_slot, address, storage),
             base_slot,
             address,
             storage,
-        }
+        })
     }
 
     /// Returns the base storage slot for this set.
@@ -346,7 +345,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(500u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             let a = Address::from([0x11; 20]);
             let b = Address::from([0x22; 20]);
@@ -373,7 +372,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(600u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             let addrs: Vec<Address> = (0..5u8).map(|i| Address::from([i; 20])).collect();
             let set = Set::from(addrs.clone());
@@ -392,7 +391,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(800u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             assert!(handler.t_read().is_err());
             assert!(handler.t_write(Set::default()).is_err());
@@ -409,7 +408,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(700u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
 
             // Use disjoint ranges so first and second share no elements.
             let first: Vec<Address> = (0..initial).map(|i| Address::from([i; 20])).collect();

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -346,7 +346,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(500u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             let a = Address::from([0x11; 20]);
             let b = Address::from([0x22; 20]);
@@ -373,7 +373,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(600u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             let addrs: Vec<Address> = (0..5u8).map(|i| Address::from([i; 20])).collect();
             let set = Set::from(addrs.clone());
@@ -392,7 +392,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(800u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             assert!(handler.t_read().is_err());
             assert!(handler.t_write(Set::default()).is_err());
@@ -409,7 +409,7 @@ mod tests {
         let (mut storage, contract_addr) = setup_storage();
         StorageCtx::enter(&mut storage, |ctx| {
             let base = U256::from(700u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx).unwrap();
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
 
             // Use disjoint ranges so first and second share no elements.
             let first: Vec<Address> = (0..initial).map(|i| Address::from([i; 20])).collect();

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -112,7 +112,6 @@ where
         storage: crate::StorageCtx<'a>,
     ) -> Self::Handler<'a> {
         SetHandler::new(slot, address, storage)
-            .expect("slot overflow: keccak-derived base slots cannot be U256::MAX")
     }
 }
 
@@ -157,16 +156,18 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Result<Self> {
-        let positions_slot =
-            base_slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?;
-        Ok(Self {
+    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+        // positions_slot = base_slot + 1. Slot addresses are keccak256 outputs and wrapping
+        // is correct here: U256::MAX is not a reachable slot address in the EVM storage model,
+        // so wrapping_add is equivalent to checked_add for all practical inputs.
+        let positions_slot = base_slot.wrapping_add(U256::ONE);
+        Self {
             values: VecHandler::new(base_slot, address, storage),
             positions: MappingHandler::new(positions_slot, address, storage),
             base_slot,
             address,
             storage,
-        })
+        }
     }
 
     /// Returns the base storage slot for this set.

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -156,7 +156,7 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
         // positions_slot = base_slot + 1. Slot addresses are keccak256 outputs and wrapping
         // is correct here: U256::MAX is not a reachable slot address in the EVM storage model,
         // so wrapping_add is equivalent to checked_add for all practical inputs.

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -157,10 +157,11 @@ where
 {
     /// Creates a new handler for the set at the given base slot.
     pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
-        // positions_slot = base_slot + 1. Slot addresses are keccak256 outputs and wrapping
-        // is correct here: U256::MAX is not a reachable slot address in the EVM storage model,
-        // so wrapping_add is equivalent to checked_add for all practical inputs.
-        let positions_slot = base_slot.wrapping_add(U256::ONE);
+        // positions_slot = base_slot + 1. Base slots are keccak256-derived and never U256::MAX,
+        // so overflow is unreachable in practice.
+        let positions_slot = base_slot
+            .checked_add(U256::ONE)
+            .expect("slot overflow: base slot is keccak256-derived and cannot be U256::MAX");
         Self {
             values: VecHandler::new(base_slot, address, storage),
             positions: MappingHandler::new(positions_slot, address, storage),

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -189,25 +189,29 @@ where
     }
 
     #[inline]
-    fn compute_handler(
+    fn try_compute_handler(
         data_start: U256,
         address: Address,
         storage: crate::StorageCtx<'a>,
         index: usize,
-    ) -> T::Handler<'a> {
+    ) -> Result<T::Handler<'a>> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = calc_element_loc(index, T::BYTES);
             (
-                data_start.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
+                data_start
+                    .checked_add(U256::from(location.offset_slots))
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
             (
-                data_start.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                data_start
+                    .checked_add(U256::from(index * T::SLOTS))
+                    .ok_or(BasePrecompileError::SlotOverflow)?,
                 LayoutCtx::FULL,
             )
         };
-        T::handle(slot, layout_ctx, address, storage)
+        Ok(T::handle(slot, layout_ctx, address, storage))
     }
 
     /// Returns a handler for the element at the given index, or `None` if out of bounds.
@@ -216,11 +220,9 @@ where
             return Ok(None);
         }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        Ok(Some(
-            self.cache.get_or_insert(&index, || {
-                Self::compute_handler(data_start, address, storage, index)
-            }),
-        ))
+        Ok(Some(self.cache.get_or_try_insert(&index, || {
+            Self::try_compute_handler(data_start, address, storage, index)
+        })?))
     }
 
     /// Pushes a new element to the end of the vector.
@@ -235,7 +237,7 @@ where
             return Err(BasePrecompileError::Fatal("Vec is at max capacity".into()));
         }
         let mut elem_slot =
-            Self::compute_handler(self.data_slot(), self.address, self.storage, length);
+            Self::try_compute_handler(self.data_slot(), self.address, self.storage, length)?;
         elem_slot.write(value)?;
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
         length_slot.write(U256::from(length + 1))
@@ -254,7 +256,7 @@ where
         }
         let last_index = length - 1;
         let mut elem_slot =
-            Self::compute_handler(self.data_slot(), self.address, self.storage, last_index);
+            Self::try_compute_handler(self.data_slot(), self.address, self.storage, last_index)?;
         let element = elem_slot.read()?;
         elem_slot.delete()?;
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
@@ -294,7 +296,9 @@ where
             // it in one read-modify-write rather than one per element.
             let boundary_slot_end = (first_full_tail_slot * elems_per_slot).min(old_len);
             if boundary_slot_end > new_len {
-                let boundary_slot_addr = data_start + U256::from(new_len / elems_per_slot);
+                let boundary_slot_addr = data_start
+                    .checked_add(U256::from(new_len / elems_per_slot))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
                 let current = self.storage.sload(self.address, boundary_slot_addr)?;
                 let mut combined_clear_mask = U256::ZERO;
                 for index in new_len..boundary_slot_end {
@@ -311,14 +315,17 @@ where
             // Zero all fully-removed tail slots in a single store each.
             let last_slot = calc_packed_slot_count(old_len, T::BYTES);
             for slot_idx in first_full_tail_slot..last_slot {
-                let slot_addr = data_start + U256::from(slot_idx);
+                let slot_addr = data_start
+                    .checked_add(U256::from(slot_idx))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
                 self.storage.sstore(self.address, slot_addr, U256::ZERO)?;
             }
         } else {
             // Unpacked types: each element occupies one or more full slots;
             // delegate to the element handler's delete to zero every occupied slot.
             for index in new_len..old_len {
-                let mut elem = Self::compute_handler(data_start, self.address, self.storage, index);
+                let mut elem =
+                    Self::try_compute_handler(data_start, self.address, self.storage, index)?;
                 elem.delete()?;
             }
         }
@@ -356,9 +363,9 @@ where
             ));
         }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        Ok(self
-            .cache
-            .get_or_insert(&index, || Self::compute_handler(data_start, address, storage, index)))
+        self.cache.get_or_try_insert(&index, || {
+            Self::try_compute_handler(data_start, address, storage, index)
+        })
     }
 
     /// Mutable variant of [`at_with_len`].
@@ -374,9 +381,9 @@ where
             ));
         }
         let (data_start, address, storage) = (self.data_slot(), self.address, self.storage);
-        Ok(self.cache.get_or_insert_mut(&index, || {
-            Self::compute_handler(data_start, address, storage, index)
-        }))
+        self.cache.get_or_try_insert_mut(&index, || {
+            Self::try_compute_handler(data_start, address, storage, index)
+        })
     }
 }
 

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -208,8 +208,8 @@ mod namespaced_layout {
             layout.policy.label.write(long_label.clone()).unwrap();
             layout.policy.balances.at_mut(&owner).write(U256::from(500)).unwrap();
             layout.policy.checkpoints.write([U256::from(1), U256::from(2), U256::from(3)]).unwrap();
-            layout.policy.packed_flags[0].write(0x1111).unwrap();
-            layout.policy.packed_flags[16].write(0x2222).unwrap();
+            layout.policy.packed_flags.at_mut(&0).unwrap().unwrap().write(0x1111).unwrap();
+            layout.policy.packed_flags.at_mut(&16).unwrap().unwrap().write(0x2222).unwrap();
             layout.policy.amounts.write(amounts.clone()).unwrap();
             layout.total_supply.write(U256::from(1_000)).unwrap();
             layout.policy_owner.write(policy_owner).unwrap();
@@ -217,9 +217,15 @@ mod namespaced_layout {
             assert_eq!(layout.admin.read().unwrap(), owner);
             assert_eq!(layout.policy.label.read().unwrap(), long_label);
             assert_eq!(layout.policy.balances.at(&owner).read().unwrap(), U256::from(500));
-            assert_eq!(layout.policy.checkpoints[2].read().unwrap(), U256::from(3));
-            assert_eq!(layout.policy.packed_flags[0].read().unwrap(), 0x1111);
-            assert_eq!(layout.policy.packed_flags[16].read().unwrap(), 0x2222);
+            assert_eq!(
+                layout.policy.checkpoints.at(&2).unwrap().unwrap().read().unwrap(),
+                U256::from(3)
+            );
+            assert_eq!(layout.policy.packed_flags.at(&0).unwrap().unwrap().read().unwrap(), 0x1111);
+            assert_eq!(
+                layout.policy.packed_flags.at(&16).unwrap().unwrap().read().unwrap(),
+                0x2222
+            );
             assert_eq!(layout.policy.amounts.read().unwrap(), amounts);
             assert_eq!(layout.total_supply.read().unwrap(), U256::from(1_000));
             assert_eq!(layout.policy_owner.read().unwrap(), policy_owner);

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -208,8 +208,8 @@ mod namespaced_layout {
             layout.policy.label.write(long_label.clone()).unwrap();
             layout.policy.balances.at_mut(&owner).write(U256::from(500)).unwrap();
             layout.policy.checkpoints.write([U256::from(1), U256::from(2), U256::from(3)]).unwrap();
-            layout.policy.packed_flags.at_mut(&0).unwrap().unwrap().write(0x1111).unwrap();
-            layout.policy.packed_flags.at_mut(&16).unwrap().unwrap().write(0x2222).unwrap();
+            layout.policy.packed_flags.at_mut(0).unwrap().unwrap().write(0x1111).unwrap();
+            layout.policy.packed_flags.at_mut(16).unwrap().unwrap().write(0x2222).unwrap();
             layout.policy.amounts.write(amounts.clone()).unwrap();
             layout.total_supply.write(U256::from(1_000)).unwrap();
             layout.policy_owner.write(policy_owner).unwrap();
@@ -218,12 +218,12 @@ mod namespaced_layout {
             assert_eq!(layout.policy.label.read().unwrap(), long_label);
             assert_eq!(layout.policy.balances.at(&owner).read().unwrap(), U256::from(500));
             assert_eq!(
-                layout.policy.checkpoints.at(&2).unwrap().unwrap().read().unwrap(),
+                layout.policy.checkpoints.at(2).unwrap().unwrap().read().unwrap(),
                 U256::from(3)
             );
-            assert_eq!(layout.policy.packed_flags.at(&0).unwrap().unwrap().read().unwrap(), 0x1111);
+            assert_eq!(layout.policy.packed_flags.at(0).unwrap().unwrap().read().unwrap(), 0x1111);
             assert_eq!(
-                layout.policy.packed_flags.at(&16).unwrap().unwrap().read().unwrap(),
+                layout.policy.packed_flags.at(16).unwrap().unwrap().read().unwrap(),
                 0x2222
             );
             assert_eq!(layout.policy.amounts.read().unwrap(), amounts);

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -222,10 +222,7 @@ mod namespaced_layout {
                 U256::from(3)
             );
             assert_eq!(layout.policy.packed_flags.at(0).unwrap().unwrap().read().unwrap(), 0x1111);
-            assert_eq!(
-                layout.policy.packed_flags.at(16).unwrap().unwrap().read().unwrap(),
-                0x2222
-            );
+            assert_eq!(layout.policy.packed_flags.at(16).unwrap().unwrap().read().unwrap(), 0x2222);
             assert_eq!(layout.policy.amounts.read().unwrap(), amounts);
             assert_eq!(layout.total_supply.read().unwrap(), U256::from(1_000));
             assert_eq!(layout.policy_owner.read().unwrap(), policy_owner);


### PR DESCRIPTION
## Motivation

The initial fix in #3415 replaced `saturating_add` and unchecked `+` with `checked_add().ok_or(SlotOverflow)?` across most slot arithmetic in `base-precompile-storage`, but missed three sites. This PR completes the migration.

## Changes

**`VecHandler::truncate` (two sites -- the #3415 bot finding)**

Two bare `+` expressions in the packed-element branch of `truncate()` that were added by #3384 and not caught by #3415:

```rust
// before
let boundary_slot_addr = data_start + U256::from(new_len / elems_per_slot);
let slot_addr = data_start + U256::from(slot_idx);

// after
let boundary_slot_addr = data_start
    .checked_add(U256::from(new_len / elems_per_slot))
    .ok_or(BasePrecompileError::SlotOverflow)?;
```

**`VecHandler::try_compute_handler` (renamed from `compute_handler`)**

Returns `Result<T::Handler>` instead of panicking. All callers that return `Result` now use `?`. Call sites inside `HandlerCache` closures use two new methods added to `HandlerCache`:

- `get_or_try_insert` -- fallible shared-ref variant of `get_or_insert`
- `get_or_try_insert_mut` -- fallible mut variant of `get_or_insert_mut`

**`SetHandler::new`**

Remains `const fn`. The `positions` slot (`base_slot + 1`) now uses `checked_add().expect()` with an invariant comment (base slots are keccak256-derived and cannot be `U256::MAX`), replacing the previous `wrapping_add`. `StorableType::handle` for `Set<T>` is an infallible trait method so `Result` propagation is structurally impossible here.

**`ArrayHandler` -- replaced `Index`/`IndexMut` with `at()`/`at_mut()`**

`Index` and `IndexMut` require infallible return types, so they silently panicked on slot overflow. Replaced with `at(&self, index: usize) -> Result<Option<&Handler>>` and `at_mut(&mut self, index: usize) -> Result<Option<&mut Handler>>` which propagate `SlotOverflow` as an error. All call sites updated.

## Validation

- `cargo check -p base-precompile-storage`
- `cargo clippy -p base-precompile-storage --all-targets -- -D warnings`
- `cargo test -p base-precompile-storage` (175 tests pass)
- `cargo +nightly fmt --all -- --check`
- `cargo check -p base-precompile-storage --no-default-features` (no_std)
