### PR TITLE
feat(proof): add zk host base crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5791,6 +5791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-proof-zk-host"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "base-prover-service-protocol",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "base-proofs-extension"
 version = "0.0.0"
 dependencies = [
@@ -6015,6 +6025,14 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "base-prover-service-worker-host"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "base-prover-service-protocol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,13 @@ members = [
   "crates/proof/prover-service/client",
   "crates/proof/prover-service/protocol",
   "crates/proof/prover-service/db",
+  "crates/proof/prover-service/worker-host",
   "crates/proof/tee/nitro-host",
   "crates/proof/tee/nitro-enclave",
   "crates/proof/tee/registrar",
   "crates/proof/tee/nitro-verifier",
   "crates/proof/tee/nitro-attestation-prover",
+  "crates/proof/zk/host",
   "crates/proof/zk/client",
   "crates/proof/zk/db",
   "crates/proof/zk/outbox",
@@ -234,6 +236,7 @@ base-zk-db = { path = "crates/proof/zk/db" }
 base-zk-outbox = { path = "crates/proof/zk/outbox" }
 base-zk-service = { path = "crates/proof/zk/service" }
 base-challenger = { path = "crates/proof/challenge" }
+base-proof-zk-host = { path = "crates/proof/zk/host" }
 base-proof-contracts = { path = "crates/proof/contracts" }
 base-prover-service = { path = "crates/proof/prover-service" }
 base-proof-tee-registrar = { path = "crates/proof/tee/registrar" }
@@ -250,6 +253,7 @@ base-proof-driver = { path = "crates/proof/driver", default-features = false }
 base-prover-service-protocol = { path = "crates/proof/prover-service/protocol" }
 base-proof-executor = { path = "crates/proof/executor", default-features = false }
 base-proof-preimage = { path = "crates/proof/preimage", default-features = false }
+base-prover-service-worker-host = { path = "crates/proof/prover-service/worker-host" }
 base-proof-primitives = { path = "crates/proof/primitives", default-features = false }
 base-proof-tee-nitro-attestation-prover = { path = "crates/proof/tee/nitro-attestation-prover" }
 

--- a/crates/proof/prover-service/worker-host/Cargo.toml
+++ b/crates/proof/prover-service/worker-host/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "base-prover-service-worker-host"
+description = "Shared prover-service worker host primitives."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# base
+base-prover-service-protocol.workspace = true
+
+# async
+async-trait.workspace = true

--- a/crates/proof/prover-service/worker-host/README.md
+++ b/crates/proof/prover-service/worker-host/README.md
@@ -1,0 +1,7 @@
+# base-prover-service-worker-host
+
+Shared prover-service worker host primitives.
+
+This crate contains backend-neutral worker host contracts used by concrete proof
+hosts. Higher-level polling, heartbeat, and submission loops can build on these
+contracts without coupling to a specific proving backend.

--- a/crates/proof/prover-service/worker-host/src/claimed_job.rs
+++ b/crates/proof/prover-service/worker-host/src/claimed_job.rs
@@ -1,0 +1,22 @@
+//! Claimed proof job handling contract.
+
+use async_trait::async_trait;
+use base_prover_service_protocol::ProofJob;
+
+/// Backend-specific claimed-job handler used by worker host loops.
+#[async_trait]
+pub trait ClaimedProofJobHandler: Send + Sync + 'static {
+    /// Error returned while handling a claimed proof job.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Returns whether this worker should attempt to claim a job now.
+    async fn ready_to_claim(&self, _worker_id: &str) -> bool {
+        true
+    }
+
+    /// Handles a claimed proof job.
+    async fn handle_claimed_job(&self, job: ProofJob) -> Result<(), Self::Error>;
+
+    /// Signals backend-specific spawned work to stop during shutdown.
+    fn shutdown(&self) {}
+}

--- a/crates/proof/prover-service/worker-host/src/lib.rs
+++ b/crates/proof/prover-service/worker-host/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod claimed_job;
+pub use claimed_job::ClaimedProofJobHandler;

--- a/crates/proof/zk/host/Cargo.toml
+++ b/crates/proof/zk/host/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "base-proof-zk-host"
+description = "Host-side ZK proving primitives for the prover service."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# base
+base-prover-service-protocol.workspace = true
+
+# async
+async-trait.workspace = true
+
+# misc
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/proof/zk/host/README.md
+++ b/crates/proof/zk/host/README.md
@@ -1,0 +1,7 @@
+# base-proof-zk-host
+
+Host-side ZK proving primitives for prover-service workers.
+
+The `ZkProver` trait captures the backend proving step independently from worker
+job discovery and submission. Concrete backends implement this trait so worker
+hosts can submit, poll, and download proofs through a common interface.

--- a/crates/proof/zk/host/src/lib.rs
+++ b/crates/proof/zk/host/src/lib.rs
@@ -1,0 +1,6 @@
+#![doc = include_str!("../README.md")]
+
+mod prover;
+pub use prover::{
+    UnimplementedZkProver, ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState,
+};

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -1,0 +1,158 @@
+//! ZK proving abstraction used by prover-service worker hosts.
+
+use async_trait::async_trait;
+use base_prover_service_protocol::{ProofResult, SnarkGroth16ProofRequest, ZkProofRequest};
+use thiserror::Error;
+
+/// Concrete ZK proof request claimed from the prover service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZkProofRequestKind {
+    /// Request for a compressed ZK proof.
+    Compressed(ZkProofRequest),
+    /// Request for a Groth16 SNARK proof.
+    SnarkGroth16(SnarkGroth16ProofRequest),
+}
+
+impl ZkProofRequestKind {
+    /// Returns the first L2 block number covered by this request.
+    pub const fn start_block_number(&self) -> u64 {
+        match self {
+            Self::Compressed(request) => request.start_block_number,
+            Self::SnarkGroth16(request) => request.proof.start_block_number,
+        }
+    }
+
+    /// Returns the number of consecutive L2 blocks to prove.
+    pub const fn number_of_blocks_to_prove(&self) -> u64 {
+        match self {
+            Self::Compressed(request) => request.number_of_blocks_to_prove,
+            Self::SnarkGroth16(request) => request.proof.number_of_blocks_to_prove,
+        }
+    }
+
+    /// Returns whether this request asks for a Groth16 SNARK proof.
+    pub const fn is_snark_groth16(&self) -> bool {
+        matches!(self, Self::SnarkGroth16(_))
+    }
+}
+
+/// Current state of a backend proving session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZkSessionState {
+    /// The backend session is still running.
+    Running,
+    /// The backend session completed successfully and the proof can be downloaded.
+    Completed,
+    /// The backend session failed with the given reason.
+    Failed(String),
+    /// The backend has no record of the session id.
+    NotFound,
+}
+
+/// Errors raised while generating a ZK proof.
+#[derive(Debug, Error)]
+pub enum ZkProverError {
+    /// ZK proving is not yet implemented for this prover.
+    #[error("zk proving is not yet implemented")]
+    Unimplemented,
+    /// The proving backend failed to produce a proof.
+    #[error("zk proving backend failed")]
+    Backend(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// Recording or reading backend session state via the prover service failed.
+    #[error("zk session tracking failed")]
+    Session(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Drives a single ZK proving job on a backend.
+#[async_trait]
+pub trait ZkProver: Send + Sync + std::fmt::Debug {
+    /// Submit the proving job to the backend and return its backend session id.
+    ///
+    /// `request_session_id` is the prover-service public session id. Backends may
+    /// use it to derive deterministic backend ids for idempotent resubmission.
+    async fn submit(
+        &self,
+        request: &ZkProofRequestKind,
+        request_session_id: &str,
+    ) -> Result<String, ZkProverError>;
+
+    /// Poll the backend session, returning its current state.
+    async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError>;
+
+    /// Download the completed proof for a backend session.
+    async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError>;
+}
+
+/// Placeholder [`ZkProver`] that always reports proving as unimplemented.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UnimplementedZkProver;
+
+#[async_trait]
+impl ZkProver for UnimplementedZkProver {
+    async fn submit(
+        &self,
+        _request: &ZkProofRequestKind,
+        _request_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        Err(ZkProverError::Unimplemented)
+    }
+
+    async fn poll(&self, _backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+        Err(ZkProverError::Unimplemented)
+    }
+
+    async fn download(&self, _backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
+        Err(ZkProverError::Unimplemented)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
+
+    use super::*;
+
+    fn zk_request() -> ZkProofRequest {
+        ZkProofRequest {
+            start_block_number: 100,
+            number_of_blocks_to_prove: 5,
+            sequence_window: None,
+            l1_head: None,
+            intermediate_root_interval: None,
+            zk_vm: ZkVm::Sp1,
+        }
+    }
+
+    #[test]
+    fn request_kind_exposes_block_range() {
+        let compressed = ZkProofRequestKind::Compressed(zk_request());
+        assert_eq!(compressed.start_block_number(), 100);
+        assert_eq!(compressed.number_of_blocks_to_prove(), 5);
+        assert!(!compressed.is_snark_groth16());
+
+        let snark = ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+            proof: zk_request(),
+            prover_address: Default::default(),
+        });
+        assert!(snark.is_snark_groth16());
+    }
+
+    #[tokio::test]
+    async fn unimplemented_prover_reports_unimplemented() {
+        let prover = UnimplementedZkProver;
+        let error = prover
+            .submit(&ZkProofRequestKind::Compressed(zk_request()), "session-1")
+            .await
+            .expect_err("stub prover should not produce a proof");
+
+        assert!(matches!(error, ZkProverError::Unimplemented));
+    }
+
+    #[test]
+    fn prover_error_preserves_source() {
+        let error = ZkProverError::Backend(Box::new(std::io::Error::other("backend down")));
+        let source = std::error::Error::source(&error).expect("source should be preserved");
+
+        assert_eq!(source.to_string(), "backend down");
+    }
+}


### PR DESCRIPTION
## Summary
- add base-prover-service-worker-host with the claimed-job handler contract
- add base-proof-zk-host with the ZkProver abstraction and request/session/error types
- keep host setup minimal so backend implementation PRs can depend on the intended crate boundary

## Stack
- this PR: worker-host and zk-host base crates
- #3422: backend crate shell
- #3430: mock backend
- #3431: dry-run backend
- #3428: cluster backend
- #3429: network backend

## Tests
- cargo fmt --check --package base-prover-service-worker-host --package base-proof-zk-host
- cargo check -p base-prover-service-worker-host -p base-proof-zk-host
- cargo test -p base-proof-zk-host
- cargo clippy -p base-prover-service-worker-host -p base-proof-zk-host --all-targets -- -D warnings