### PR TITLE
Build zk-prover-postgres image with baked migrations

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [client, base, builder, consensus, batcher, zk-prover]
+        target: [client, base, builder, consensus, batcher, zk-prover, zk-prover-postgres]
 
     runs-on: ubuntu-24.04
 

--- a/etc/docker/Dockerfile.zk-prover-postgres
+++ b/etc/docker/Dockerfile.zk-prover-postgres
@@ -1,0 +1,2 @@
+FROM postgres:17-alpine
+COPY crates/proof/zk/db/migrations /docker-entrypoint-initdb.d/

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -42,7 +42,7 @@ group "rust-services" {
 }
 
 group "devnet" {
-  targets = ["builder", "consensus", "client", "base", "batcher", "zk-prover"]
+  targets = ["builder", "consensus", "client", "base", "batcher", "zk-prover", "zk-prover-postgres"]
 }
 
 group "ingress" {
@@ -145,4 +145,10 @@ target "zk-prover" {
     "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
     "type=registry,ref=${REGISTRY_IMAGE}:cache-zk-prover-${PLATFORM_PAIR}",
   ]
+}
+
+target "zk-prover-postgres" {
+  context = "."
+  dockerfile = "etc/docker/Dockerfile.zk-prover-postgres"
+  tags = ["zk-prover-postgres:local"]
 }

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -785,7 +785,10 @@ services:
     restart: unless-stopped
 
   zk-prover-postgres:
-    image: postgres:17-alpine
+    image: zk-prover-postgres:local
+    build:
+      context: ../..
+      dockerfile: etc/docker/Dockerfile.zk-prover-postgres
     container_name: zk-prover-postgres
     ports:
       - "${ZK_PROVER_POSTGRES_PORT}:5432"
@@ -795,7 +798,6 @@ services:
       - POSTGRES_PASSWORD=prover
     volumes:
       - ../../.devnet/zk-prover/postgres:/var/lib/postgresql/data
-      - ../../crates/proof/zk/db/migrations:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U prover -d prover"]
       interval: 250ms

--- a/etc/docker/docker-compose.zk-prover.yml
+++ b/etc/docker/docker-compose.zk-prover.yml
@@ -1,6 +1,9 @@
 services:
   zk-prover-postgres:
-    image: postgres:17-alpine
+    image: zk-prover-postgres:local
+    build:
+      context: ../..
+      dockerfile: etc/docker/Dockerfile.zk-prover-postgres
     ports:
       - "${ZK_PROVER_POSTGRES_PORT:-5433}:5432"
     environment:
@@ -9,7 +12,6 @@ services:
       - POSTGRES_PASSWORD=prover
     volumes:
       - ../../.zk-prover/${ZK_PROVER_NETWORK:-local}/postgres:/var/lib/postgresql/data
-      - ../../crates/proof/zk/db/migrations:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U prover -d prover"]
       interval: 250ms


### PR DESCRIPTION
## Summary
- Adds `etc/docker/Dockerfile.zk-prover-postgres` baking `crates/proof/zk/db/migrations` into `postgres:17-alpine`.
- Publishes via existing l3 Docker CI as `ghcr.io/base/node-reth-dev:zk-prover-postgres-{sha,l3}`.
- Updates local compose files to build/use the image instead of bind-mounting migrations.

## Why
privacy-enclave (and other Odin/Codeflow deploys) cannot bind-mount migration files. Downstream repos should mirror this image rather than vendoring SQL.

## Test plan
- [x] `docker build -f etc/docker/Dockerfile.zk-prover-postgres .`
- [ ] After merge: confirm `docker-l3` workflow publishes `zk-prover-postgres-l3`
- [ ] Run `scripts/bump-docker-mirror-digests.sh` in privacy-enclave to pin digest


Made with [Cursor](https://cursor.com)