### PR TITLE
fix(precompile-storage): deduct gas before sload warms slot in journal (BOP-380)

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -638,7 +638,7 @@ mod tests {
             };
             let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
             assert_eq!(
-                provider.set_code(address, code.clone()),
+                provider.set_code(address, code),
                 Err(BasePrecompileError::OutOfGas)
             );
         }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -124,9 +124,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
                 self.deduct_gas(self.gas_params.create_cost())?;
                 // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
                 let num_words = code_len.div_ceil(32) as u64;
-                self.deduct_gas(
-                    KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)),
-                )?;
+                self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
             }
 
             self.internals
@@ -637,10 +635,7 @@ mod tests {
                 internals: EvmInternals::from_context(&mut ctx),
             };
             let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
-            assert_eq!(
-                provider.set_code(address, code),
-                Err(BasePrecompileError::OutOfGas)
-            );
+            assert_eq!(provider.set_code(address, code), Err(BasePrecompileError::OutOfGas));
         }
 
         // Second provider: unlimited gas. Account must still be cold.

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -105,40 +105,29 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         // Yellow Paper G_codedeposit: 200 gas per byte of deployed bytecode.
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
-        let checkpoint = self.internals.checkpoint();
-        let result = (|| {
-            // Charge CREATE equivalent costs whenever code is written to an account that had no
-            // code, regardless of its balance. A prefunded account (balance > 0, no code) passes
-            // the factory's collision check (which only rejects accounts that already have code),
-            // but must still pay G_create and the keccak hash cost.
-            let is_new_code = {
-                let state_load = self
-                    .internals
-                    .load_account(address)
-                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-                state_load.data.info.is_empty_code_hash()
-            };
+        // Charge CREATE equivalent costs whenever code is written to an account that had no code,
+        // regardless of its balance. A prefunded account (balance > 0, no code) passes the
+        // factory's collision check (which only rejects accounts that already have code), but
+        // must still pay G_create and the keccak hash cost.
+        let is_new_code = {
+            let state_load = self
+                .internals
+                .load_account(address)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+            state_load.data.info.is_empty_code_hash()
+        };
 
-            if is_new_code {
-                // Yellow Paper G_create: base cost for creating a new contract account.
-                self.deduct_gas(self.gas_params.create_cost())?;
-                // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
-                let num_words = code_len.div_ceil(32) as u64;
-                self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
-            }
-
-            self.internals
-                .set_code(address, code)
-                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
-        })();
-
-        if result.is_ok() {
-            self.internals.checkpoint_commit();
-        } else {
-            self.internals.checkpoint_revert(checkpoint);
+        if is_new_code {
+            // Yellow Paper G_create: base cost for creating a new contract account.
+            self.deduct_gas(self.gas_params.create_cost())?;
+            // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
+            let num_words = code_len.div_ceil(32) as u64;
+            self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
         }
 
-        result
+        self.internals
+            .set_code(address, code)
+            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
     }
 
     fn with_account_info(
@@ -146,35 +135,24 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         address: Address,
         f: &mut dyn FnMut(&AccountInfo),
     ) -> Result<()> {
-        let checkpoint = self.internals.checkpoint();
-        let result = (|| {
-            // Extract is_cold and clone AccountInfo before releasing the internals borrow.
-            let (info, is_cold) = {
-                let state_load = self
-                    .internals
-                    .load_account(address)
-                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-                (state_load.data.info.clone(), state_load.is_cold)
-            };
+        // Extract is_cold and clone AccountInfo before releasing the internals borrow.
+        let (info, is_cold) = {
+            let state_load = self
+                .internals
+                .load_account(address)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+            (state_load.data.info.clone(), state_load.is_cold)
+        };
 
-            // EIP-2929: warm base cost always charged (100)
-            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-            // dynamic cold penalty — total 2600 for a cold account access
-            if is_cold {
-                self.deduct_gas(self.gas_params.cold_account_additional_cost())?;
-            }
-
-            f(&info);
-            Ok(())
-        })();
-
-        if result.is_ok() {
-            self.internals.checkpoint_commit();
-        } else {
-            self.internals.checkpoint_revert(checkpoint);
+        // EIP-2929: warm base cost always charged (100)
+        self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+        // dynamic cold penalty — total 2600 for a cold account access
+        if is_cold {
+            self.deduct_gas(self.gas_params.cold_account_additional_cost())?;
         }
 
-        result
+        f(&info);
+        Ok(())
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
@@ -554,111 +532,6 @@ mod tests {
                     .warm_storage_read_cost()
                     .saturating_add(gas_params.cold_storage_additional_cost()),
                 "slot must still be cold after a failed OOG read"
-            );
-        }
-    }
-
-    /// An OOG `with_account_info` must not leave the account warmed in the journal.
-    #[test]
-    fn with_account_info_oog_does_not_warm_account() {
-        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
-        let address = Address::repeat_byte(0x88);
-
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-
-        // First provider: gas just below warm_storage_read_cost → OOG on account load.
-        {
-            let input = PrecompileInput {
-                data: &[],
-                gas: gas_params.warm_storage_read_cost() - 1,
-                reservoir: 0,
-                caller: Address::ZERO,
-                value: U256::ZERO,
-                target_address: address,
-                is_static: false,
-                bytecode_address: address,
-                internals: EvmInternals::from_context(&mut ctx),
-            };
-            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
-            assert_eq!(
-                provider.with_account_info(address, &mut |_| {}),
-                Err(BasePrecompileError::OutOfGas)
-            );
-        }
-
-        // Second provider: unlimited gas. Account must still be cold.
-        {
-            let input = PrecompileInput {
-                data: &[],
-                gas: u64::MAX,
-                reservoir: 0,
-                caller: Address::ZERO,
-                value: U256::ZERO,
-                target_address: address,
-                is_static: false,
-                bytecode_address: address,
-                internals: EvmInternals::from_context(&mut ctx),
-            };
-            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
-            provider.with_account_info(address, &mut |_| {}).unwrap();
-            assert_eq!(
-                provider.gas_used(),
-                gas_params
-                    .warm_storage_read_cost()
-                    .saturating_add(gas_params.cold_account_additional_cost()),
-                "account must still be cold after a failed OOG access"
-            );
-        }
-    }
-
-    /// An OOG `set_code` (failing after `load_account`) must not leave the account warmed.
-    #[test]
-    fn set_code_oog_after_load_does_not_warm_account() {
-        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
-        let address = Address::repeat_byte(0x99);
-        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
-
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-
-        // Gas covers code_deposit_cost but not the subsequent create_cost → OOG after load_account.
-        let tight_gas = gas_params.code_deposit_cost(code.len());
-        {
-            let input = PrecompileInput {
-                data: &[],
-                gas: tight_gas,
-                reservoir: 0,
-                caller: Address::ZERO,
-                value: U256::ZERO,
-                target_address: address,
-                is_static: false,
-                bytecode_address: address,
-                internals: EvmInternals::from_context(&mut ctx),
-            };
-            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
-            assert_eq!(provider.set_code(address, code), Err(BasePrecompileError::OutOfGas));
-        }
-
-        // Second provider: unlimited gas. Account must still be cold.
-        {
-            let input = PrecompileInput {
-                data: &[],
-                gas: u64::MAX,
-                reservoir: 0,
-                caller: Address::ZERO,
-                value: U256::ZERO,
-                target_address: address,
-                is_static: false,
-                bytecode_address: address,
-                internals: EvmInternals::from_context(&mut ctx),
-            };
-            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
-            provider.with_account_info(address, &mut |_| {}).unwrap();
-            assert_eq!(
-                provider.gas_used(),
-                gas_params
-                    .warm_storage_read_cost()
-                    .saturating_add(gas_params.cold_account_additional_cost()),
-                "account must still be cold after a failed OOG set_code"
             );
         }
     }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -156,10 +156,6 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
-        // Checkpoint before the read so that an OOG failure reverts the slot warming.
-        // Without this, `internals.sload` would mark the slot warm in the revm journal
-        // before gas is deducted; a subsequent OOG would leave the spurious warm entry
-        // behind, breaking EIP-2929 cold-slot accounting for any later access.
         let checkpoint = self.internals.checkpoint();
         let result = (|| {
             let s = self

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -156,19 +156,34 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
-        let s = self
-            .internals
-            .sload(address, key)
-            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+        // Checkpoint before the read so that an OOG failure reverts the slot warming.
+        // Without this, `internals.sload` would mark the slot warm in the revm journal
+        // before gas is deducted; a subsequent OOG would leave the spurious warm entry
+        // behind, breaking EIP-2929 cold-slot accounting for any later access.
+        let checkpoint = self.internals.checkpoint();
+        let result = (|| {
+            let s = self
+                .internals
+                .sload(address, key)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
 
-        // EIP-2929: warm base cost always charged
-        self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-        // dynamic cold penalty
-        if s.is_cold {
-            self.deduct_gas(self.gas_params.cold_storage_additional_cost())?;
+            // EIP-2929: warm base cost always charged
+            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+            // dynamic cold penalty
+            if s.is_cold {
+                self.deduct_gas(self.gas_params.cold_storage_additional_cost())?;
+            }
+
+            Ok(s.data)
+        })();
+
+        if result.is_ok() {
+            self.internals.checkpoint_commit();
+        } else {
+            self.internals.checkpoint_revert(checkpoint);
         }
 
-        Ok(s.data)
+        result
     }
 
     fn tload(&mut self, address: Address, key: U256) -> Result<U256> {
@@ -463,6 +478,64 @@ mod tests {
                 gas_params
                     .warm_storage_read_cost()
                     .saturating_add(gas_params.cold_storage_additional_cost())
+            );
+        }
+    }
+
+    /// An OOG `sload` must not leave the slot warmed in the journal.
+    ///
+    /// We give the provider exactly `warm_storage_read_cost - 1` gas so that the
+    /// cold read fails (it cannot even afford the warm base cost). A second provider
+    /// with unlimited gas then reads the same slot: if the journal still carries the
+    /// spurious warm entry the second read would be charged only `warm_storage_read_cost`,
+    /// but the slot was never successfully accessed so it must still be cold.
+    #[test]
+    fn sload_oog_does_not_warm_slot() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let address = Address::repeat_byte(0x77);
+        let key = U256::from(5);
+
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+
+        // First provider: gas just below warm_storage_read_cost → OOG on sload.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: gas_params.warm_storage_read_cost() - 1,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(provider.sload(address, key), Err(BasePrecompileError::OutOfGas));
+        }
+
+        // Second provider: unlimited gas. The slot must still be cold, so the full
+        // cold read cost (warm_base + cold_additional) must be charged.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(provider.sload(address, key).unwrap(), U256::ZERO);
+            assert_eq!(
+                provider.gas_used(),
+                gas_params
+                    .warm_storage_read_cost()
+                    .saturating_add(gas_params.cold_storage_additional_cost()),
+                "slot must still be cold after a failed OOG read"
             );
         }
     }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -105,29 +105,42 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         // Yellow Paper G_codedeposit: 200 gas per byte of deployed bytecode.
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
-        // Charge CREATE equivalent costs whenever code is written to an account that had no code,
-        // regardless of its balance. A prefunded account (balance > 0, no code) passes the
-        // factory's collision check (which only rejects accounts that already have code), but
-        // must still pay G_create and the keccak hash cost.
-        let is_new_code = {
-            let state_load = self
-                .internals
-                .load_account(address)
-                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-            state_load.data.info.is_empty_code_hash()
-        };
+        let checkpoint = self.internals.checkpoint();
+        let result = (|| {
+            // Charge CREATE equivalent costs whenever code is written to an account that had no
+            // code, regardless of its balance. A prefunded account (balance > 0, no code) passes
+            // the factory's collision check (which only rejects accounts that already have code),
+            // but must still pay G_create and the keccak hash cost.
+            let is_new_code = {
+                let state_load = self
+                    .internals
+                    .load_account(address)
+                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+                state_load.data.info.is_empty_code_hash()
+            };
 
-        if is_new_code {
-            // Yellow Paper G_create: base cost for creating a new contract account.
-            self.deduct_gas(self.gas_params.create_cost())?;
-            // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
-            let num_words = code_len.div_ceil(32) as u64;
-            self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
+            if is_new_code {
+                // Yellow Paper G_create: base cost for creating a new contract account.
+                self.deduct_gas(self.gas_params.create_cost())?;
+                // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
+                let num_words = code_len.div_ceil(32) as u64;
+                self.deduct_gas(
+                    KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)),
+                )?;
+            }
+
+            self.internals
+                .set_code(address, code)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
+        })();
+
+        if result.is_ok() {
+            self.internals.checkpoint_commit();
+        } else {
+            self.internals.checkpoint_revert(checkpoint);
         }
 
-        self.internals
-            .set_code(address, code)
-            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
+        result
     }
 
     fn with_account_info(
@@ -135,24 +148,35 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         address: Address,
         f: &mut dyn FnMut(&AccountInfo),
     ) -> Result<()> {
-        // Extract is_cold and clone AccountInfo before releasing the internals borrow.
-        let (info, is_cold) = {
-            let state_load = self
-                .internals
-                .load_account(address)
-                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-            (state_load.data.info.clone(), state_load.is_cold)
-        };
+        let checkpoint = self.internals.checkpoint();
+        let result = (|| {
+            // Extract is_cold and clone AccountInfo before releasing the internals borrow.
+            let (info, is_cold) = {
+                let state_load = self
+                    .internals
+                    .load_account(address)
+                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+                (state_load.data.info.clone(), state_load.is_cold)
+            };
 
-        // EIP-2929: warm base cost always charged (100)
-        self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-        // dynamic cold penalty — total 2600 for a cold account access
-        if is_cold {
-            self.deduct_gas(self.gas_params.cold_account_additional_cost())?;
+            // EIP-2929: warm base cost always charged (100)
+            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+            // dynamic cold penalty — total 2600 for a cold account access
+            if is_cold {
+                self.deduct_gas(self.gas_params.cold_account_additional_cost())?;
+            }
+
+            f(&info);
+            Ok(())
+        })();
+
+        if result.is_ok() {
+            self.internals.checkpoint_commit();
+        } else {
+            self.internals.checkpoint_revert(checkpoint);
         }
 
-        f(&info);
-        Ok(())
+        result
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
@@ -532,6 +556,114 @@ mod tests {
                     .warm_storage_read_cost()
                     .saturating_add(gas_params.cold_storage_additional_cost()),
                 "slot must still be cold after a failed OOG read"
+            );
+        }
+    }
+
+    /// An OOG `with_account_info` must not leave the account warmed in the journal.
+    #[test]
+    fn with_account_info_oog_does_not_warm_account() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let address = Address::repeat_byte(0x88);
+
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+
+        // First provider: gas just below warm_storage_read_cost → OOG on account load.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: gas_params.warm_storage_read_cost() - 1,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(
+                provider.with_account_info(address, &mut |_| {}),
+                Err(BasePrecompileError::OutOfGas)
+            );
+        }
+
+        // Second provider: unlimited gas. Account must still be cold.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            provider.with_account_info(address, &mut |_| {}).unwrap();
+            assert_eq!(
+                provider.gas_used(),
+                gas_params
+                    .warm_storage_read_cost()
+                    .saturating_add(gas_params.cold_account_additional_cost()),
+                "account must still be cold after a failed OOG access"
+            );
+        }
+    }
+
+    /// An OOG `set_code` (failing after `load_account`) must not leave the account warmed.
+    #[test]
+    fn set_code_oog_after_load_does_not_warm_account() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let address = Address::repeat_byte(0x99);
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+
+        // Gas covers code_deposit_cost but not the subsequent create_cost → OOG after load_account.
+        let tight_gas = gas_params.code_deposit_cost(code.len());
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: tight_gas,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(
+                provider.set_code(address, code.clone()),
+                Err(BasePrecompileError::OutOfGas)
+            );
+        }
+
+        // Second provider: unlimited gas. Account must still be cold.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            provider.with_account_info(address, &mut |_| {}).unwrap();
+            assert_eq!(
+                provider.gas_used(),
+                gas_params
+                    .warm_storage_read_cost()
+                    .saturating_add(gas_params.cold_account_additional_cost()),
+                "account must still be cold after a failed OOG set_code"
             );
         }
     }


### PR DESCRIPTION
## Summary

- `internals.sload` marks the slot warm in the revm journal **before** gas is deducted. If either `deduct_gas` call returns `OutOfGas`, the spurious warm entry persists — a subsequent cold read of the same slot is then billed at warm cost instead of cold cost, breaking EIP-2929 accounting.
- Apply the same checkpoint/revert pattern already used by `sstore`: take a journal checkpoint before the read and revert on any error, so a failed OOG sload leaves the slot's cold/warm state unchanged.
- Add a regression test that verifies an OOG sload does not warm the slot.

Today the bug is masked because precompiles run inside a revm frame that reverts on `OutOfGas`, rolling back the journal. The protection is incidental and undocumented; any direct `StorageProvider` use without a surrounding frame would observe the spurious warming.

Closes BOP-380.

## Test plan

- [ ] `cargo test -p base-precompile-storage sload_oog_does_not_warm_slot` — new regression test passes
- [ ] `cargo test -p base-precompile-storage` — full suite (176 tests) passes