### PR TITLE
feat(proposer): add collector orchestration

### DIFF
--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -24,7 +24,11 @@ mod proof_adapter;
 pub use proof_adapter::{DispatchedProof, ProofRequesterDispatcher, ProposerProofAdapter};
 
 mod proof_collector;
-pub use proof_collector::{CollectedProof, ProofCollector, TargetPoll};
+pub use proof_collector::{
+    CollectedProof, ProofCollector, ProofCollectorOrchestrator, ProofCollectorRecoveryProvider,
+    ProofCollectorRuntimeConfig, ProofCollectorState, ProofCollectorTickResult, ProofRecoveryCache,
+    ProofSubmitEffect, TargetPoll,
+};
 
 mod proof_dispatcher;
 pub use proof_dispatcher::{

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -70,6 +70,9 @@ base_metrics::define_metrics! {
     #[describe("Total output root mismatches detected at submit time")]
     root_mismatch_total: counter,
 
+    #[describe("Total inline submit attempts that exceeded the submit timeout")]
+    submit_timeouts_total: counter,
+
     #[describe("Time to generate a single proof (seconds)")]
     proof_duration_seconds: histogram,
 

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1,4 +1,4 @@
-//! Polls the prover service for the proof of a single derived target block.
+//! Polls and orchestrates prover-service collection for proposer TEE proofs.
 //!
 //! The [`ProofCollector`] does not care about the proof dispatcher. It assumes that
 //! the eligible block range either has, or will have, a `prove_block_range` request
@@ -14,20 +14,107 @@
 //! dispatch state, the collector can rediscover and complete sessions across
 //! proposer restarts.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
+use async_trait::async_trait;
 use base_proof_primitives::ProofResult;
-use base_proof_rpc::RollupProvider;
+use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{GetProofRequest, GetProofResponse, ProofStatus, TeeKind};
 use futures::{StreamExt, stream};
-use tracing::debug;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
 
 use crate::{
-    driver::RecoveredState, error::ProposerError, metrics::Metrics,
+    driver::RecoveredState,
+    error::ProposerError,
+    metrics::Metrics,
     proof_adapter::ProposerProofAdapter,
+    proof_dispatcher::{ProofDispatchAttempt, ProofDispatcher},
+    proof_submitter::{ProofSubmitter, SubmitAction},
 };
+
+/// Cached result from the last successful recovery walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofRecoveryCache {
+    /// Factory `game_count` at the time of the walk.
+    pub game_count: u64,
+    /// Recovered on-chain state from the walk.
+    pub state: RecoveredState,
+}
+
+/// Recovery hook used by collector orchestration after successful submissions.
+#[async_trait]
+pub trait ProofCollectorRecoveryProvider: Send + Sync {
+    /// Refreshes the recovery cache and returns the latest on-chain state.
+    async fn recover_latest_state(
+        &self,
+        cache: &mut Option<ProofRecoveryCache>,
+    ) -> Result<RecoveredState, ProposerError>;
+}
+
+/// Runtime settings for collector orchestration.
+#[derive(Debug, Clone, Copy)]
+pub struct ProofCollectorRuntimeConfig {
+    /// Number of L2 blocks between output proposals.
+    pub block_interval: u64,
+    /// Maximum proof failures or discard retries before dropping recovery state.
+    pub max_retries: u32,
+    /// Maximum duration for a single inline submit attempt.
+    pub submit_timeout: Duration,
+}
+
+/// Mutable collector-side orchestration state.
+#[derive(Debug, Default)]
+pub struct ProofCollectorState {
+    /// Latest block the collector has submitted through.
+    pub cursor: Option<RecoveredState>,
+    /// Per-target proof/dispatch retry counts.
+    pub retry_counts: HashMap<u64, u32>,
+    /// Per-target discard retry counts.
+    pub discard_retry_counts: HashMap<u64, u32>,
+    /// Active retry-specific prover-service sessions by target block.
+    pub retry_sessions: HashMap<u64, String>,
+}
+
+/// Result of one collector tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofCollectorTickResult {
+    /// The collector made progress or reached a natural wait point.
+    Continue,
+    /// The owning pipeline session should restart from recovered chain state.
+    Restart,
+}
+
+/// Result of an inline submit attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofSubmitEffect {
+    /// The proof was submitted or the game already existed.
+    Submitted,
+    /// The pipeline should restart before collecting more proofs.
+    Restart,
+    /// The submitted proof should be replaced by a retry-specific session.
+    Redispatch {
+        /// Claimed L2 output root for the discarded proof.
+        claimed_l2_output_root: B256,
+    },
+}
+
+/// Owns collector-side polling, sequential submit, and retry-session orchestration.
+pub struct ProofCollectorOrchestrator<L1, L2, R, Recovery>
+where
+    L1: L1Provider,
+    L2: L2Provider,
+    R: RollupProvider,
+    Recovery: ProofCollectorRecoveryProvider,
+{
+    collector: ProofCollector<R>,
+    dispatcher: ProofDispatcher<L1, L2, R>,
+    submitter: ProofSubmitter<L1, R>,
+    recovery: Arc<Recovery>,
+    runtime: ProofCollectorRuntimeConfig,
+}
 
 /// Outcome of polling the prover service for a single target block.
 ///
@@ -567,6 +654,513 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             ProofStatus::Succeeded => Metrics::PROOF_STATUS_SUCCEEDED,
             ProofStatus::Failed => Metrics::PROOF_STATUS_FAILED,
         }
+    }
+}
+
+impl ProofCollectorState {
+    /// Creates empty collector state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Removes state for targets already recovered on-chain.
+    pub fn prune_recovered(&mut self, recovered_block: u64) {
+        self.retry_counts.retain(|&target, _| target > recovered_block);
+        self.discard_retry_counts.retain(|&target, _| target > recovered_block);
+        self.retry_sessions.retain(|&target, _| target > recovered_block);
+    }
+
+    /// Records a proof failure and returns whether retrying is still allowed.
+    pub fn handle_proof_failure(
+        &mut self,
+        target: u64,
+        error: ProposerError,
+        max_retries: u32,
+        cache: &mut Option<ProofRecoveryCache>,
+    ) -> bool {
+        Metrics::errors_total(error.metric_label()).increment(1);
+        Metrics::proof_retries_total().increment(1);
+
+        let count = self.retry_counts.entry(target).or_insert(0);
+        *count += 1;
+        if *count >= max_retries {
+            error!(
+                target_block = target,
+                attempts = *count,
+                error = %error,
+                "Proof failed after max retries, dropping cached recovery"
+            );
+            self.retry_counts.remove(&target);
+            *cache = None;
+            false
+        } else {
+            warn!(
+                target_block = target,
+                attempt = *count,
+                error = %error,
+                "Proof failed, re-dispatching"
+            );
+            true
+        }
+    }
+}
+
+impl<L1, L2, R, Recovery> Clone for ProofCollectorOrchestrator<L1, L2, R, Recovery>
+where
+    L1: L1Provider,
+    L2: L2Provider,
+    R: RollupProvider,
+    Recovery: ProofCollectorRecoveryProvider,
+{
+    fn clone(&self) -> Self {
+        Self {
+            collector: self.collector.clone(),
+            dispatcher: self.dispatcher.clone(),
+            submitter: self.submitter.clone(),
+            recovery: Arc::clone(&self.recovery),
+            runtime: self.runtime,
+        }
+    }
+}
+
+impl<L1, L2, R, Recovery> std::fmt::Debug for ProofCollectorOrchestrator<L1, L2, R, Recovery>
+where
+    L1: L1Provider,
+    L2: L2Provider,
+    R: RollupProvider,
+    Recovery: ProofCollectorRecoveryProvider,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProofCollectorOrchestrator")
+            .field("collector", &self.collector)
+            .field("dispatcher", &self.dispatcher)
+            .field("runtime", &self.runtime)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<L1, L2, R, Recovery> ProofCollectorOrchestrator<L1, L2, R, Recovery>
+where
+    L1: L1Provider + 'static,
+    L2: L2Provider + 'static,
+    R: RollupProvider + 'static,
+    Recovery: ProofCollectorRecoveryProvider + 'static,
+{
+    /// Creates a collector orchestrator from low-level proof components.
+    pub const fn new(
+        collector: ProofCollector<R>,
+        dispatcher: ProofDispatcher<L1, L2, R>,
+        submitter: ProofSubmitter<L1, R>,
+        recovery: Arc<Recovery>,
+        runtime: ProofCollectorRuntimeConfig,
+    ) -> Self {
+        Self { collector, dispatcher, submitter, recovery, runtime }
+    }
+
+    /// Runs one collector tick from the supplied recovered state and safe head.
+    pub async fn tick(
+        &self,
+        state: &mut ProofCollectorState,
+        cache: &mut Option<ProofRecoveryCache>,
+        recovered: RecoveredState,
+        safe_head: u64,
+        cancel: &CancellationToken,
+    ) -> ProofCollectorTickResult {
+        state.prune_recovered(recovered.l2_block_number);
+
+        if state.cursor.is_none_or(|cursor| cursor.l2_block_number < recovered.l2_block_number) {
+            state.cursor = Some(recovered);
+        }
+
+        while let Some(current) = state.cursor {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            let Some(target_block) = self.next_target_block(current.l2_block_number) else {
+                break;
+            };
+
+            if target_block > safe_head {
+                debug!(
+                    current_block = current.l2_block_number,
+                    target_block,
+                    safe_head,
+                    "Safe head below collection target, waiting for L2 head to advance"
+                );
+                break;
+            }
+
+            let poll = if let Some(session_id) = state.retry_sessions.get(&target_block).cloned() {
+                self.collector.poll_session(target_block, session_id).await
+            } else {
+                self.collector.poll(target_block).await
+            };
+
+            match poll {
+                TargetPoll::Ready { session_id, proof } => {
+                    info!(target_block, session_id = %session_id, "Proof ready, submitting inline");
+                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_READY).increment(1);
+                    Metrics::last_collected_block().set(target_block as f64);
+                    match self
+                        .submit_inline(target_block, &current, proof, state, cache, cancel)
+                        .await
+                    {
+                        ProofSubmitEffect::Submitted => {
+                            state.retry_sessions.remove(&target_block);
+                            state.discard_retry_counts.remove(&target_block);
+                            if let Some(cached) = cache.as_ref() {
+                                state.cursor = Some(cached.state);
+                                if cached.state.l2_block_number > current.l2_block_number {
+                                    continue;
+                                }
+                            }
+                            break;
+                        }
+                        ProofSubmitEffect::Restart => {
+                            Metrics::pipeline_retries()
+                                .set(state.retry_counts.values().sum::<u32>() as f64);
+                            return ProofCollectorTickResult::Restart;
+                        }
+                        ProofSubmitEffect::Redispatch { claimed_l2_output_root } => {
+                            self.dispatch_discard_retry(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                state,
+                                cache,
+                                true,
+                            )
+                            .await;
+                            break;
+                        }
+                    }
+                }
+                TargetPoll::Pending { session_id, status } => {
+                    debug!(
+                        target_block,
+                        session_id = %session_id,
+                        ?status,
+                        "Proof pending, waiting for prover service"
+                    );
+                    break;
+                }
+                TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
+                    if state.retry_sessions.get(&target_block).is_some_and(|id| id == &session_id) {
+                        warn!(
+                            target_block,
+                            session_id = %session_id,
+                            "Discard retry session missing, dispatching a fresh retry"
+                        );
+                        self.dispatch_discard_retry(
+                            target_block,
+                            &current,
+                            claimed_l2_output_root,
+                            state,
+                            cache,
+                            true,
+                        )
+                        .await;
+                    } else {
+                        debug!(
+                            target_block,
+                            session_id = %session_id,
+                            claimed_l2_output_root = %claimed_l2_output_root,
+                            "No prover-service session for target, waiting for dispatcher"
+                        );
+                    }
+                    break;
+                }
+                TargetPoll::Failed { session_id, claimed_l2_output_root, error } => {
+                    warn!(
+                        target_block,
+                        session_id = %session_id,
+                        error = %error,
+                        "Prover service reported failed session, re-dispatching"
+                    );
+                    Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED)
+                        .increment(1);
+                    if state.handle_proof_failure(
+                        target_block,
+                        error,
+                        self.runtime.max_retries,
+                        cache,
+                    ) {
+                        if state
+                            .retry_sessions
+                            .get(&target_block)
+                            .is_some_and(|id| id == &session_id)
+                        {
+                            self.dispatch_discard_retry(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                state,
+                                cache,
+                                false,
+                            )
+                            .await;
+                        } else {
+                            self.dispatch_root_retry(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                state,
+                                cache,
+                                false,
+                            )
+                            .await;
+                        }
+                    }
+                    break;
+                }
+                TargetPoll::Unknown { session_id, error } => {
+                    debug!(
+                        target_block,
+                        session_id = ?session_id,
+                        error = %error,
+                        "Transient poll failure, will retry next iteration"
+                    );
+                    break;
+                }
+            }
+        }
+
+        Metrics::pipeline_retries().set(state.retry_counts.values().sum::<u32>() as f64);
+        ProofCollectorTickResult::Continue
+    }
+
+    /// Validates and submits a ready proof inline.
+    pub async fn submit_inline(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        proof: ProofResult,
+        state: &mut ProofCollectorState,
+        cache: &mut Option<ProofRecoveryCache>,
+        cancel: &CancellationToken,
+    ) -> ProofSubmitEffect {
+        let claimed_l2_output_root = match &proof {
+            ProofResult::Tee { aggregate_proposal, .. } => aggregate_proposal.output_root,
+            ProofResult::Zk { .. } => {
+                warn!(target_block, "Unexpected ZK proof result in TEE proposer path");
+                return ProofSubmitEffect::Restart;
+            }
+        };
+        let parent_address = recovered.parent_address;
+        info!(target_block, parent_address = %parent_address, "Submitting proof inline");
+
+        let mut submit_timer = base_metrics::timed!(Metrics::proposal_total_duration_seconds());
+        let result = tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                submit_timer.disarm();
+                warn!(target_block, "Inline submit cancelled, restarting pipeline session");
+                return ProofSubmitEffect::Restart;
+            }
+            result = tokio::time::timeout(
+                self.runtime.submit_timeout,
+                self.submitter.submit(&proof, target_block, parent_address),
+            ) => result,
+        };
+
+        match result {
+            Err(_) => {
+                submit_timer.disarm();
+                Metrics::submit_timeouts_total().increment(1);
+                warn!(
+                    target_block,
+                    timeout_secs = self.runtime.submit_timeout.as_secs(),
+                    "Inline submit timed out, restarting pipeline session"
+                );
+                ProofSubmitEffect::Restart
+            }
+            Ok(Ok(())) => {
+                drop(submit_timer);
+                info!(target_block, "Submission successful");
+                Metrics::last_proposed_block().set(target_block as f64);
+                state.retry_counts.remove(&target_block);
+                if let Err(e) = self.recovery.recover_latest_state(cache).await {
+                    warn!(error = %e, "Failed to recover state after submission");
+                }
+                ProofSubmitEffect::Submitted
+            }
+            Ok(Err(SubmitAction::RootMismatch)) => {
+                submit_timer.disarm();
+                warn!(target_block, "Output root mismatch at submit time, restarting pipeline");
+                Metrics::root_mismatch_total().increment(1);
+                *cache = None;
+                ProofSubmitEffect::Restart
+            }
+            Ok(Err(SubmitAction::GameAlreadyExists)) => {
+                submit_timer.disarm();
+                info!(target_block, "Game already exists on chain");
+                Metrics::last_proposed_block().set(target_block as f64);
+                state.retry_counts.remove(&target_block);
+                if let Some(cached) = cache.as_mut() {
+                    cached.game_count = cached.game_count.saturating_sub(1);
+                }
+                if let Err(e) = self.recovery.recover_latest_state(cache).await {
+                    warn!(error = %e, "Failed to recover state after GameAlreadyExists");
+                }
+                ProofSubmitEffect::Submitted
+            }
+            Ok(Err(SubmitAction::Failed(error))) => {
+                submit_timer.disarm();
+                Metrics::errors_total(error.metric_label()).increment(1);
+                if error.is_invalid_parent_game() {
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Submission rejected: parent game invalid, restarting pipeline"
+                    );
+                    *cache = None;
+                } else {
+                    warn!(target_block, error = %error, "Submission failed, restarting pipeline");
+                }
+                ProofSubmitEffect::Restart
+            }
+            Ok(Err(SubmitAction::Discard(error))) => {
+                submit_timer.disarm();
+                Metrics::errors_total(error.metric_label()).increment(1);
+                warn!(
+                    target_block,
+                    error = %error,
+                    "Proof discarded by submitter, dispatching fresh retry proof"
+                );
+                ProofSubmitEffect::Redispatch { claimed_l2_output_root }
+            }
+        }
+    }
+
+    /// Dispatches a root-derived retry after a failed prover-service session.
+    pub async fn dispatch_root_retry(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        claimed_l2_output_root: B256,
+        state: &mut ProofCollectorState,
+        cache: &mut Option<ProofRecoveryCache>,
+        count_dispatch_failure: bool,
+    ) {
+        match self.dispatcher.dispatch_for(target_block, recovered, claimed_l2_output_root).await {
+            ProofDispatchAttempt::Accepted(dispatched) => {
+                info!(
+                    target_block,
+                    session_id = %dispatched.session_id,
+                    from_block = recovered.l2_block_number,
+                    "Proof request accepted by prover service"
+                );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+            }
+            ProofDispatchAttempt::BuildFailed(error) => {
+                warn!(target_block, error = %error, "Failed to build proof request");
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+            }
+            ProofDispatchAttempt::DispatchFailed(error) => {
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+                if count_dispatch_failure {
+                    state.handle_proof_failure(
+                        target_block,
+                        error,
+                        self.runtime.max_retries,
+                        cache,
+                    );
+                } else {
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Immediate re-dispatch failed after failed proof session"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Dispatches a retry-specific proof request after a discarded proof.
+    pub async fn dispatch_discard_retry(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        claimed_l2_output_root: B256,
+        state: &mut ProofCollectorState,
+        cache: &mut Option<ProofRecoveryCache>,
+        count_dispatch_failure: bool,
+    ) {
+        let current_attempt = state.discard_retry_counts.get(&target_block).copied().unwrap_or(0);
+        if current_attempt >= self.runtime.max_retries {
+            error!(
+                target_block,
+                attempts = current_attempt,
+                max_retries = self.runtime.max_retries,
+                "Discard retry budget exhausted, dropping recovery cache"
+            );
+            state.discard_retry_counts.remove(&target_block);
+            state.retry_sessions.remove(&target_block);
+            *cache = None;
+            return;
+        }
+
+        let attempt = current_attempt + 1;
+        match self
+            .dispatcher
+            .dispatch_discard_retry(
+                target_block,
+                recovered,
+                claimed_l2_output_root,
+                self.collector.tee_kind(),
+                attempt,
+            )
+            .await
+        {
+            ProofDispatchAttempt::Accepted(dispatched) => {
+                info!(
+                    target_block,
+                    session_id = %dispatched.session_id,
+                    attempt,
+                    "Discard retry proof request accepted by prover service"
+                );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                state.discard_retry_counts.insert(target_block, attempt);
+                state.retry_sessions.insert(target_block, dispatched.session_id);
+            }
+            ProofDispatchAttempt::BuildFailed(error) => {
+                warn!(target_block, error = %error, "Failed to build discard retry proof request");
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+            }
+            ProofDispatchAttempt::DispatchFailed(error) => {
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+                if count_dispatch_failure {
+                    state.handle_proof_failure(
+                        target_block,
+                        error,
+                        self.runtime.max_retries,
+                        cache,
+                    );
+                } else {
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Immediate discard retry dispatch failed after failed proof session"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Computes the next collector target from a current block.
+    pub fn next_target_block(&self, current_block: u64) -> Option<u64> {
+        current_block.checked_add(self.runtime.block_interval).map_or_else(
+            || {
+                error!(
+                    current_block,
+                    block_interval = self.runtime.block_interval,
+                    "Overflow computing next target block"
+                );
+                None
+            },
+            Some,
+        )
     }
 }
 

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -671,6 +671,7 @@ impl ProofCollectorState {
     }
 
     /// Records a proof failure and returns whether retrying is still allowed.
+    #[must_use]
     pub fn handle_proof_failure(
         &mut self,
         target: u64,
@@ -919,15 +920,21 @@ where
                                 return ProofCollectorTickResult::Restart;
                             }
                         } else {
-                            self.dispatch_root_retry(
-                                target_block,
-                                &current,
-                                claimed_l2_output_root,
-                                state,
-                                cache,
-                                false,
-                            )
-                            .await;
+                            if !self
+                                .dispatch_root_retry(
+                                    target_block,
+                                    &current,
+                                    claimed_l2_output_root,
+                                    state,
+                                    cache,
+                                    false,
+                                )
+                                .await
+                            {
+                                Metrics::pipeline_retries()
+                                    .set(state.retry_counts.values().sum::<u32>() as f64);
+                                return ProofCollectorTickResult::Restart;
+                            }
                         }
                     } else {
                         Metrics::pipeline_retries()
@@ -1056,6 +1063,8 @@ where
     }
 
     /// Dispatches a root-derived retry after a failed prover-service session.
+    ///
+    /// Returns `false` when retry accounting is exhausted and the caller should restart.
     pub async fn dispatch_root_retry(
         &self,
         target_block: u64,
@@ -1064,7 +1073,7 @@ where
         state: &mut ProofCollectorState,
         cache: &mut Option<ProofRecoveryCache>,
         count_dispatch_failure: bool,
-    ) {
+    ) -> bool {
         match self.dispatcher.dispatch_for(target_block, recovered, claimed_l2_output_root).await {
             ProofDispatchAttempt::Accepted(dispatched) => {
                 info!(
@@ -1086,12 +1095,14 @@ where
             ProofDispatchAttempt::DispatchFailed(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
                 if count_dispatch_failure {
-                    state.handle_proof_failure(
+                    if !state.handle_proof_failure(
                         target_block,
                         error,
                         self.runtime.max_retries,
                         cache,
-                    );
+                    ) {
+                        return false;
+                    }
                 } else {
                     warn!(
                         target_block,
@@ -1101,6 +1112,8 @@ where
                 }
             }
         }
+
+        true
     }
 
     /// Dispatches a retry-specific proof request after a discarded proof.
@@ -1160,12 +1173,14 @@ where
             ProofDispatchAttempt::DispatchFailed(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
                 if count_dispatch_failure {
-                    state.handle_proof_failure(
+                    if !state.handle_proof_failure(
                         target_block,
                         error,
                         self.runtime.max_retries,
                         cache,
-                    );
+                    ) {
+                        return false;
+                    }
                 } else {
                     warn!(
                         target_block,
@@ -1228,6 +1243,9 @@ mod tests {
     #[derive(Debug)]
     struct DiscardingOutputProposer;
 
+    #[derive(Debug)]
+    struct RejectingProofRequester;
+
     #[async_trait]
     impl ProofCollectorRecoveryProvider for NoopRecovery {
         async fn recover_latest_state(
@@ -1247,6 +1265,33 @@ mod tests {
             _intermediate_roots: &[B256],
         ) -> Result<(), ProposerError> {
             Err(ProposerError::L1OriginTooOld)
+        }
+    }
+
+    #[async_trait]
+    impl ProofRequesterProvider for RejectingProofRequester {
+        async fn prove_block_range(
+            &self,
+            _request: base_prover_service_protocol::ProveBlockRangeRequest,
+        ) -> Result<base_prover_service_protocol::ProveBlockRangeResponse, ProverServiceClientError>
+        {
+            Err(ProverServiceClientError::Timeout("simulated dispatch failure".into()))
+        }
+
+        async fn get_proof(
+            &self,
+            _request: base_prover_service_protocol::GetProofRequest,
+        ) -> Result<base_prover_service_protocol::GetProofResponse, ProverServiceClientError>
+        {
+            unimplemented!("tests do not poll proofs")
+        }
+
+        async fn list_proofs(
+            &self,
+            _request: base_prover_service_protocol::ListProofsRequest,
+        ) -> Result<base_prover_service_protocol::ListProofsResponse, ProverServiceClientError>
+        {
+            unimplemented!("tests do not list proofs")
         }
     }
 
@@ -1463,6 +1508,75 @@ mod tests {
         assert_eq!(state.discard_retry_counts.get(&target_block).copied(), Some(1));
         assert!(state.retry_counts.is_empty());
         assert!(cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn discard_retry_dispatch_failure_returns_false_on_retry_exhaustion() {
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(200, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&requester),
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            requester,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 1,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let target_block = 200;
+        let mut state = ProofCollectorState::new();
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+
+        let should_continue = orchestrator
+            .dispatch_discard_retry(
+                target_block,
+                &recovered(100),
+                B256::repeat_byte(0xaa),
+                &mut state,
+                &mut cache,
+                true,
+            )
+            .await;
+
+        assert!(!should_continue);
+        assert!(cache.is_none());
+        assert!(state.retry_counts.is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1188,17 +1188,43 @@ where
 
         let attempt = current_attempt + 1;
         state.pending_discard_roots.insert(target_block, claimed_l2_output_root);
-        match self
+        let request = match self
             .dispatcher
-            .dispatch_discard_retry(
-                target_block,
-                recovered,
-                claimed_l2_output_root,
-                self.collector.tee_kind(),
-                attempt,
-            )
+            .build_request(target_block, recovered, claimed_l2_output_root)
             .await
         {
+            Ok(request) => request,
+            Err(error) => {
+                warn!(target_block, error = %error, "Failed to build discard retry proof request");
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+                state.retry_sessions.remove(&target_block);
+                return true;
+            }
+        };
+        let session_id = ProposerProofAdapter::tee_discard_retry_session_id(
+            &request,
+            self.collector.tee_kind(),
+            attempt,
+        );
+        state.retry_sessions.insert(target_block, session_id.clone());
+
+        let dispatch = match self
+            .dispatcher
+            .requester_dispatcher()
+            .dispatch_tee_with_session_id(request, session_id.clone())
+            .await
+        {
+            Ok(dispatched) if dispatched.session_id == session_id => {
+                ProofDispatchAttempt::Accepted(dispatched)
+            }
+            Ok(dispatched) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
+                "prover service returned mismatched session_id: expected {}, got {}",
+                session_id, dispatched.session_id
+            ))),
+            Err(error) => ProofDispatchAttempt::DispatchFailed(error),
+        };
+
+        match dispatch {
             ProofDispatchAttempt::Accepted(dispatched) => {
                 info!(
                     target_block,
@@ -1213,7 +1239,11 @@ where
                 state.counted_failed_sessions.remove(&target_block);
             }
             ProofDispatchAttempt::BuildFailed(error) => {
-                warn!(target_block, error = %error, "Failed to build discard retry proof request");
+                warn!(
+                    target_block,
+                    error = %error,
+                    "Failed to build discard retry proof request"
+                );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
                 state.retry_sessions.remove(&target_block);
             }
@@ -1226,6 +1256,10 @@ where
                         self.runtime.max_retries,
                         cache,
                     ) {
+                        state.discard_retry_counts.remove(&target_block);
+                        state.retry_sessions.remove(&target_block);
+                        state.pending_discard_roots.remove(&target_block);
+                        state.counted_failed_sessions.remove(&target_block);
                         return false;
                     }
                 } else {
@@ -1578,6 +1612,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn discard_retry_dispatch_failure_preserves_intended_retry_session() {
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(200, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&requester),
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            requester,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 2,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let target_block = 200;
+        let claimed_root = B256::repeat_byte(0xaa);
+        let request = orchestrator
+            .dispatcher
+            .build_request(target_block, &recovered(100), claimed_root)
+            .await
+            .expect("test setup should build request");
+        let expected_session_id =
+            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 1);
+        let mut state = ProofCollectorState::new();
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+
+        let should_continue = orchestrator
+            .dispatch_discard_retry(
+                target_block,
+                &recovered(100),
+                claimed_root,
+                &mut state,
+                &mut cache,
+                false,
+            )
+            .await;
+
+        assert!(should_continue);
+        assert_eq!(state.retry_sessions.get(&target_block), Some(&expected_session_id));
+        assert_eq!(state.pending_discard_roots.get(&target_block).copied(), Some(claimed_root));
+        assert!(cache.is_some());
+    }
+
+    #[tokio::test]
     async fn root_retry_build_failure_restarts_without_exhausting_retry_budget() {
         let proof_requester = Arc::new(MockProofRequester::default());
         let l1 = Arc::new(FailingL1);
@@ -1715,6 +1827,10 @@ mod tests {
         assert!(!should_continue);
         assert!(cache.is_none());
         assert!(state.retry_counts.is_empty());
+        assert!(state.discard_retry_counts.is_empty());
+        assert!(state.retry_sessions.is_empty());
+        assert!(state.pending_discard_roots.is_empty());
+        assert!(state.counted_failed_sessions.is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1054,7 +1054,11 @@ where
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
             }
             ProofDispatchAttempt::BuildFailed(error) => {
-                warn!(target_block, error = %error, "Failed to build proof request");
+                error!(
+                    target_block,
+                    error = %error,
+                    "Failed to build proof request for root retry"
+                );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
             }
             ProofDispatchAttempt::DispatchFailed(error) => {
@@ -1127,6 +1131,7 @@ where
             ProofDispatchAttempt::BuildFailed(error) => {
                 warn!(target_block, error = %error, "Failed to build discard retry proof request");
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+                state.retry_sessions.remove(&target_block);
             }
             ProofDispatchAttempt::DispatchFailed(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
@@ -1189,6 +1194,9 @@ mod tests {
     #[derive(Debug)]
     struct NoopRecovery;
 
+    #[derive(Debug)]
+    struct FailingL1;
+
     #[async_trait]
     impl ProofCollectorRecoveryProvider for NoopRecovery {
         async fn recover_latest_state(
@@ -1196,6 +1204,58 @@ mod tests {
             _cache: &mut Option<ProofRecoveryCache>,
         ) -> Result<RecoveredState, ProposerError> {
             Ok(recovered(0))
+        }
+    }
+
+    #[async_trait]
+    impl L1Provider for FailingL1 {
+        async fn block_number(&self) -> base_proof_rpc::RpcResult<u64> {
+            Ok(1000)
+        }
+
+        async fn header_by_number(
+            &self,
+            _: Option<u64>,
+        ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
+            Err(base_proof_rpc::RpcError::Transport("simulated L1 outage".into()))
+        }
+
+        async fn header_by_hash(
+            &self,
+            _: B256,
+        ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
+            unimplemented!("tests do not fetch L1 headers by hash")
+        }
+
+        async fn block_receipts(
+            &self,
+            _: B256,
+        ) -> base_proof_rpc::RpcResult<Vec<alloy_rpc_types_eth::TransactionReceipt>> {
+            unimplemented!("tests do not fetch receipts")
+        }
+
+        async fn code_at(
+            &self,
+            _: Address,
+            _: Option<u64>,
+        ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
+            unimplemented!("tests do not fetch code")
+        }
+
+        async fn call_contract(
+            &self,
+            _: Address,
+            _: alloy_primitives::Bytes,
+            _: Option<u64>,
+        ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
+            unimplemented!("tests do not call contracts")
+        }
+
+        async fn get_balance(
+            &self,
+            _: Address,
+        ) -> base_proof_rpc::RpcResult<alloy_primitives::U256> {
+            Ok(alloy_primitives::U256::ZERO)
         }
     }
 
@@ -1221,9 +1281,18 @@ mod tests {
     fn make_orchestrator(
         block_interval: u64,
     ) -> ProofCollectorOrchestrator<MockL1, MockL2, MockRollupClient, NoopRecovery> {
+        make_orchestrator_with_l1(Arc::new(MockL1 { latest_block_number: 1000 }), block_interval)
+    }
+
+    fn make_orchestrator_with_l1<L1>(
+        l1: Arc<L1>,
+        block_interval: u64,
+    ) -> ProofCollectorOrchestrator<L1, MockL2, MockRollupClient, NoopRecovery>
+    where
+        L1: L1Provider + 'static,
+    {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::new(MockProofRequester::default());
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(0, B256::ZERO),
@@ -1325,6 +1394,32 @@ mod tests {
         let orchestrator = make_orchestrator(0);
 
         assert_eq!(orchestrator.next_target_block(100), None);
+    }
+
+    #[tokio::test]
+    async fn discard_retry_build_failure_removes_stale_retry_session() {
+        let orchestrator = make_orchestrator_with_l1(Arc::new(FailingL1), 100);
+        let target_block = 200;
+        let mut state = ProofCollectorState::new();
+        state.retry_sessions.insert(target_block, "stale-failed-session".to_owned());
+        state.discard_retry_counts.insert(target_block, 1);
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+
+        orchestrator
+            .dispatch_discard_retry(
+                target_block,
+                &recovered(100),
+                B256::repeat_byte(0xaa),
+                &mut state,
+                &mut cache,
+                true,
+            )
+            .await;
+
+        assert!(!state.retry_sessions.contains_key(&target_block));
+        assert_eq!(state.discard_retry_counts.get(&target_block).copied(), Some(1));
+        assert!(state.retry_counts.is_empty());
+        assert!(cache.is_some());
     }
 
     /// Restart/recovery: the collector derives the prover-service session id

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1150,6 +1150,11 @@ where
 
     /// Computes the next collector target from a current block.
     pub fn next_target_block(&self, current_block: u64) -> Option<u64> {
+        if self.runtime.block_interval == 0 {
+            error!("Block interval must be non-zero");
+            return None;
+        }
+
         current_block.checked_add(self.runtime.block_interval).map_or_else(
             || {
                 error!(
@@ -1173,8 +1178,26 @@ mod tests {
     use super::*;
     use crate::{
         proof_adapter::ProofRequesterDispatcher,
-        test_utils::{MockProofRequester, MockRollupClient, test_sync_status},
+        proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
+        proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
+        test_utils::{
+            MockL1, MockL2, MockOutputProposer, MockProofRequester, MockRollupClient,
+            test_sync_status,
+        },
     };
+
+    #[derive(Debug)]
+    struct NoopRecovery;
+
+    #[async_trait]
+    impl ProofCollectorRecoveryProvider for NoopRecovery {
+        async fn recover_latest_state(
+            &self,
+            _cache: &mut Option<ProofRecoveryCache>,
+        ) -> Result<RecoveredState, ProposerError> {
+            Ok(recovered(0))
+        }
+    }
 
     fn recovered(block: u64) -> RecoveredState {
         RecoveredState {
@@ -1193,6 +1216,60 @@ mod tests {
             max_safe_block: None,
         });
         ProofCollector::aws_nitro(proof_requester, rollup_client, block_interval, 4)
+    }
+
+    fn make_orchestrator(
+        block_interval: u64,
+    ) -> ProofCollectorOrchestrator<MockL1, MockL2, MockRollupClient, NoopRecovery> {
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(0, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&proof_requester),
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            proof_requester,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 300,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval,
+                intermediate_block_interval: 300,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+
+        ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval,
+                max_retries: 3,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        )
     }
 
     #[test]
@@ -1241,6 +1318,13 @@ mod tests {
         let targets = collector.collectable_targets(&recovered(0), 100, |_| false);
 
         assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn orchestrator_next_target_block_returns_none_for_zero_interval() {
+        let orchestrator = make_orchestrator(0);
+
+        assert_eq!(orchestrator.next_target_block(100), None);
     }
 
     /// Restart/recovery: the collector derives the prover-service session id

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1150,6 +1150,7 @@ where
                         error = %error,
                         "Immediate re-dispatch failed after failed proof session"
                     );
+                    return false;
                 }
             }
         }
@@ -1714,6 +1715,78 @@ mod tests {
         assert!(!should_continue);
         assert!(cache.is_none());
         assert!(state.retry_counts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn root_retry_dispatch_failure_returns_false_after_failed_session_was_counted() {
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(200, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&requester),
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            requester,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 2,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let target_block = 200;
+        let session_id = "failed-session".to_owned();
+        let mut state = ProofCollectorState::new();
+        state.retry_counts.insert(target_block, 1);
+        state.counted_failed_sessions.insert(target_block, session_id);
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+
+        let should_continue = orchestrator
+            .dispatch_root_retry(
+                target_block,
+                &recovered(100),
+                B256::repeat_byte(0xaa),
+                &mut state,
+                &mut cache,
+                false,
+            )
+            .await;
+
+        assert!(!should_continue);
+        assert_eq!(state.retry_counts.get(&target_block).copied(), Some(1));
+        assert!(cache.is_some());
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1198,7 +1198,7 @@ where
                 warn!(target_block, error = %error, "Failed to build discard retry proof request");
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
                 state.retry_sessions.remove(&target_block);
-                return true;
+                return false;
             }
         };
         let session_id = ProposerProofAdapter::tee_discard_retry_session_id(
@@ -1208,24 +1208,13 @@ where
         );
         state.retry_sessions.insert(target_block, session_id.clone());
 
-        let dispatch = match self
+        let dispatch_error = match self
             .dispatcher
             .requester_dispatcher()
             .dispatch_tee_with_session_id(request, session_id.clone())
             .await
         {
             Ok(dispatched) if dispatched.session_id == session_id => {
-                ProofDispatchAttempt::Accepted(dispatched)
-            }
-            Ok(dispatched) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {}, got {}",
-                session_id, dispatched.session_id
-            ))),
-            Err(error) => ProofDispatchAttempt::DispatchFailed(error),
-        };
-
-        match dispatch {
-            ProofDispatchAttempt::Accepted(dispatched) => {
                 info!(
                     target_block,
                     session_id = %dispatched.session_id,
@@ -1237,38 +1226,32 @@ where
                 state.retry_sessions.insert(target_block, dispatched.session_id);
                 state.pending_discard_roots.remove(&target_block);
                 state.counted_failed_sessions.remove(&target_block);
+                None
             }
-            ProofDispatchAttempt::BuildFailed(error) => {
+            Ok(dispatched) => Some(ProposerError::Prover(format!(
+                "prover service returned mismatched session_id: expected {}, got {}",
+                session_id, dispatched.session_id
+            ))),
+            Err(error) => Some(error),
+        };
+
+        if let Some(error) = dispatch_error {
+            Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+            if count_dispatch_failure {
+                if !state.handle_proof_failure(target_block, error, self.runtime.max_retries, cache)
+                {
+                    state.discard_retry_counts.remove(&target_block);
+                    state.retry_sessions.remove(&target_block);
+                    state.pending_discard_roots.remove(&target_block);
+                    state.counted_failed_sessions.remove(&target_block);
+                    return false;
+                }
+            } else {
                 warn!(
                     target_block,
                     error = %error,
-                    "Failed to build discard retry proof request"
+                    "Immediate discard retry dispatch failed after failed proof session"
                 );
-                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
-                state.retry_sessions.remove(&target_block);
-            }
-            ProofDispatchAttempt::DispatchFailed(error) => {
-                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
-                if count_dispatch_failure {
-                    if !state.handle_proof_failure(
-                        target_block,
-                        error,
-                        self.runtime.max_retries,
-                        cache,
-                    ) {
-                        state.discard_retry_counts.remove(&target_block);
-                        state.retry_sessions.remove(&target_block);
-                        state.pending_discard_roots.remove(&target_block);
-                        state.counted_failed_sessions.remove(&target_block);
-                        return false;
-                    }
-                } else {
-                    warn!(
-                        target_block,
-                        error = %error,
-                        "Immediate discard retry dispatch failed after failed proof session"
-                    );
-                }
             }
         }
 
@@ -1590,7 +1573,7 @@ mod tests {
         state.discard_retry_counts.insert(target_block, 1);
         let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
 
-        orchestrator
+        let should_continue = orchestrator
             .dispatch_discard_retry(
                 target_block,
                 &recovered(100),
@@ -1601,6 +1584,7 @@ mod tests {
             )
             .await;
 
+        assert!(!should_continue);
         assert!(!state.retry_sessions.contains_key(&target_block));
         assert_eq!(
             state.pending_discard_roots.get(&target_block).copied(),

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -68,6 +68,8 @@ pub struct ProofCollectorRuntimeConfig {
 /// Mutable collector-side orchestration state.
 #[derive(Debug, Default)]
 pub struct ProofCollectorState {
+    /// Recovered chain state that the current cursor was derived from.
+    pub recovered: Option<RecoveredState>,
     /// Latest block the collector has submitted through.
     pub cursor: Option<RecoveredState>,
     /// Per-target proof/dispatch retry counts.
@@ -76,6 +78,10 @@ pub struct ProofCollectorState {
     pub discard_retry_counts: HashMap<u64, u32>,
     /// Active retry-specific prover-service sessions by target block.
     pub retry_sessions: HashMap<u64, String>,
+    /// Targets whose root-derived proof was discarded and need a retry-specific session.
+    pub pending_discard_roots: HashMap<u64, B256>,
+    /// Terminal failed sessions already counted while waiting for replacement dispatch.
+    pub counted_failed_sessions: HashMap<u64, String>,
 }
 
 /// Result of one collector tick.
@@ -668,6 +674,8 @@ impl ProofCollectorState {
         self.retry_counts.retain(|&target, _| target > recovered_block);
         self.discard_retry_counts.retain(|&target, _| target > recovered_block);
         self.retry_sessions.retain(|&target, _| target > recovered_block);
+        self.pending_discard_roots.retain(|&target, _| target > recovered_block);
+        self.counted_failed_sessions.retain(|&target, _| target > recovered_block);
     }
 
     /// Records a proof failure and returns whether retrying is still allowed.
@@ -769,7 +777,8 @@ where
     ) -> ProofCollectorTickResult {
         state.prune_recovered(recovered.l2_block_number);
 
-        if state.cursor.is_none_or(|cursor| cursor.l2_block_number < recovered.l2_block_number) {
+        if state.recovered != Some(recovered) || state.cursor.is_none() {
+            state.recovered = Some(recovered);
             state.cursor = Some(recovered);
         }
 
@@ -792,6 +801,27 @@ where
                 break;
             }
 
+            if let Some(claimed_l2_output_root) =
+                state.pending_discard_roots.get(&target_block).copied()
+            {
+                if !self
+                    .dispatch_discard_retry(
+                        target_block,
+                        &current,
+                        claimed_l2_output_root,
+                        state,
+                        cache,
+                        true,
+                    )
+                    .await
+                {
+                    Metrics::pipeline_retries()
+                        .set(state.retry_counts.values().sum::<u32>() as f64);
+                    return ProofCollectorTickResult::Restart;
+                }
+                break;
+            }
+
             let poll = if let Some(session_id) = state.retry_sessions.get(&target_block).cloned() {
                 self.collector.poll_session(target_block, session_id).await
             } else {
@@ -810,6 +840,8 @@ where
                         ProofSubmitEffect::Submitted => {
                             state.retry_sessions.remove(&target_block);
                             state.discard_retry_counts.remove(&target_block);
+                            state.pending_discard_roots.remove(&target_block);
+                            state.counted_failed_sessions.remove(&target_block);
                             if let Some(cached) = cache.as_ref() {
                                 state.cursor = Some(cached.state);
                                 if cached.state.l2_block_number > current.l2_block_number {
@@ -893,12 +925,19 @@ where
                     );
                     Metrics::proof_collection_total(Metrics::COLLECTION_OUTCOME_FAILED)
                         .increment(1);
-                    if state.handle_proof_failure(
-                        target_block,
-                        error,
-                        self.runtime.max_retries,
-                        cache,
-                    ) {
+                    let already_counted = state
+                        .counted_failed_sessions
+                        .get(&target_block)
+                        .is_some_and(|id| id == &session_id);
+                    if already_counted
+                        || state.handle_proof_failure(
+                            target_block,
+                            error,
+                            self.runtime.max_retries,
+                            cache,
+                        )
+                    {
+                        state.counted_failed_sessions.insert(target_block, session_id.clone());
                         if state
                             .retry_sessions
                             .get(&target_block)
@@ -1083,6 +1122,7 @@ where
                     "Proof request accepted by prover service"
                 );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                state.counted_failed_sessions.remove(&target_block);
             }
             ProofDispatchAttempt::BuildFailed(error) => {
                 error!(
@@ -1138,11 +1178,14 @@ where
             );
             state.discard_retry_counts.remove(&target_block);
             state.retry_sessions.remove(&target_block);
+            state.pending_discard_roots.remove(&target_block);
+            state.counted_failed_sessions.remove(&target_block);
             *cache = None;
             return false;
         }
 
         let attempt = current_attempt + 1;
+        state.pending_discard_roots.insert(target_block, claimed_l2_output_root);
         match self
             .dispatcher
             .dispatch_discard_retry(
@@ -1164,6 +1207,8 @@ where
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
                 state.discard_retry_counts.insert(target_block, attempt);
                 state.retry_sessions.insert(target_block, dispatched.session_id);
+                state.pending_discard_roots.remove(&target_block);
+                state.counted_failed_sessions.remove(&target_block);
             }
             ProofDispatchAttempt::BuildFailed(error) => {
                 warn!(target_block, error = %error, "Failed to build discard retry proof request");
@@ -1485,6 +1530,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tick_resets_cursor_when_recovery_rewinds() {
+        let orchestrator = make_orchestrator(100);
+        let mut state = ProofCollectorState::new();
+        state.recovered = Some(recovered(300));
+        state.cursor = Some(recovered(500));
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+        let cancel = CancellationToken::new();
+
+        let result = orchestrator.tick(&mut state, &mut cache, recovered(100), 200, &cancel).await;
+
+        assert_eq!(result, ProofCollectorTickResult::Continue);
+        assert_eq!(state.recovered, Some(recovered(100)));
+        assert_eq!(state.cursor, Some(recovered(100)));
+    }
+
+    #[tokio::test]
     async fn discard_retry_build_failure_removes_stale_retry_session() {
         let orchestrator = make_orchestrator_with_l1(Arc::new(FailingL1), 100);
         let target_block = 200;
@@ -1505,8 +1566,86 @@ mod tests {
             .await;
 
         assert!(!state.retry_sessions.contains_key(&target_block));
+        assert_eq!(
+            state.pending_discard_roots.get(&target_block).copied(),
+            Some(B256::repeat_byte(0xaa))
+        );
         assert_eq!(state.discard_retry_counts.get(&target_block).copied(), Some(1));
         assert!(state.retry_counts.is_empty());
+        assert!(cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn failed_session_is_counted_once_until_replacement_is_accepted() {
+        let proof_requester = Arc::new(MockProofRequester::default());
+        let l1 = Arc::new(FailingL1);
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let target_block = 200;
+        let claimed_root = B256::repeat_byte(target_block as u8);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(claimed_root, TeeKind::AwsNitro);
+        proof_requester
+            .failed_sessions
+            .lock()
+            .unwrap()
+            .insert(session_id.clone(), "simulated proof failure".to_owned());
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(target_block, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            l1,
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            Arc::new(FailingL1),
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 2,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let mut state = ProofCollectorState::new();
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+        let cancel = CancellationToken::new();
+
+        let first =
+            orchestrator.tick(&mut state, &mut cache, recovered(100), target_block, &cancel).await;
+        let second =
+            orchestrator.tick(&mut state, &mut cache, recovered(100), target_block, &cancel).await;
+
+        assert_eq!(first, ProofCollectorTickResult::Continue);
+        assert_eq!(second, ProofCollectorTickResult::Continue);
+        assert_eq!(state.retry_counts.get(&target_block).copied(), Some(1));
+        assert_eq!(state.counted_failed_sessions.get(&target_block), Some(&session_id));
         assert!(cache.is_some());
     }
 

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1213,7 +1213,6 @@ where
             self.collector.tee_kind(),
             attempt,
         );
-        state.retry_sessions.insert(target_block, session_id.clone());
 
         let dispatch_error = match self
             .dispatcher
@@ -1235,15 +1234,24 @@ where
                 state.counted_failed_sessions.remove(&target_block);
                 None
             }
-            Ok(dispatched) => Some(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {}, got {}",
-                session_id, dispatched.session_id
-            ))),
+            Ok(dispatched) => {
+                error!(
+                    target_block,
+                    expected_session_id = %session_id,
+                    actual_session_id = %dispatched.session_id,
+                    "Prover service returned mismatched discard retry session id"
+                );
+                Some(ProposerError::Prover(format!(
+                    "prover service returned mismatched session_id: expected {}, got {}",
+                    session_id, dispatched.session_id
+                )))
+            }
             Err(error) => Some(error),
         };
 
         if let Some(error) = dispatch_error {
             Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+            state.retry_sessions.remove(&target_block);
             if count_dispatch_failure {
                 if !state.handle_proof_failure(target_block, error, self.runtime.max_retries, cache)
                 {
@@ -1321,6 +1329,9 @@ mod tests {
     #[derive(Debug)]
     struct RejectingProofRequester;
 
+    #[derive(Debug)]
+    struct MismatchedProofRequester;
+
     #[async_trait]
     impl ProofCollectorRecoveryProvider for NoopRecovery {
         async fn recover_latest_state(
@@ -1361,6 +1372,35 @@ mod tests {
         ) -> Result<base_prover_service_protocol::ProveBlockRangeResponse, ProverServiceClientError>
         {
             Err(ProverServiceClientError::Timeout("simulated dispatch failure".into()))
+        }
+
+        async fn get_proof(
+            &self,
+            _request: base_prover_service_protocol::GetProofRequest,
+        ) -> Result<base_prover_service_protocol::GetProofResponse, ProverServiceClientError>
+        {
+            unimplemented!("tests do not poll proofs")
+        }
+
+        async fn list_proofs(
+            &self,
+            _request: base_prover_service_protocol::ListProofsRequest,
+        ) -> Result<base_prover_service_protocol::ListProofsResponse, ProverServiceClientError>
+        {
+            unimplemented!("tests do not list proofs")
+        }
+    }
+
+    #[async_trait]
+    impl ProofRequesterProvider for MismatchedProofRequester {
+        async fn prove_block_range(
+            &self,
+            _request: base_prover_service_protocol::ProveBlockRangeRequest,
+        ) -> Result<base_prover_service_protocol::ProveBlockRangeResponse, ProverServiceClientError>
+        {
+            Ok(base_prover_service_protocol::ProveBlockRangeResponse {
+                session_id: "unexpected-session".to_owned(),
+            })
         }
 
         async fn get_proof(
@@ -1681,7 +1721,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discard_retry_dispatch_failure_preserves_intended_retry_session() {
+    async fn discard_retry_dispatch_failure_does_not_store_unaccepted_session() {
         let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
@@ -1731,13 +1771,6 @@ mod tests {
         );
         let target_block = 200;
         let claimed_root = B256::repeat_byte(0xaa);
-        let request = orchestrator
-            .dispatcher
-            .build_request(target_block, &recovered(100), claimed_root)
-            .await
-            .expect("test setup should build request");
-        let expected_session_id =
-            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 1);
         let mut state = ProofCollectorState::new();
         let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
 
@@ -1753,8 +1786,81 @@ mod tests {
             .await;
 
         assert!(!should_continue);
-        assert_eq!(state.retry_sessions.get(&target_block), Some(&expected_session_id));
+        assert!(state.retry_sessions.is_empty());
         assert_eq!(state.pending_discard_roots.get(&target_block).copied(), Some(claimed_root));
+        assert!(cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn discard_retry_session_mismatch_does_not_store_unaccepted_session() {
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(200, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MismatchedProofRequester);
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&requester),
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            requester,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 2,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let target_block = 200;
+        let claimed_root = B256::repeat_byte(0xaa);
+        let mut state = ProofCollectorState::new();
+        state.retry_sessions.insert(target_block, "stale-session".to_owned());
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+
+        let should_continue = orchestrator
+            .dispatch_discard_retry(
+                target_block,
+                &recovered(100),
+                claimed_root,
+                &mut state,
+                &mut cache,
+                true,
+            )
+            .await;
+
+        assert!(should_continue);
+        assert!(state.retry_sessions.is_empty());
+        assert_eq!(state.pending_discard_roots.get(&target_block).copied(), Some(claimed_root));
+        assert_eq!(state.retry_counts.get(&target_block).copied(), Some(1));
         assert!(cache.is_some());
     }
 

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -97,7 +97,10 @@ pub enum ProofCollectorTickResult {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProofSubmitEffect {
     /// The proof was submitted or the game already existed.
-    Submitted,
+    Submitted {
+        /// Latest recovered chain state after the submit was observed.
+        recovered: RecoveredState,
+    },
     /// The pipeline should restart before collecting more proofs.
     Restart,
     /// The submitted proof should be replaced by a retry-specific session.
@@ -837,16 +840,14 @@ where
                         .submit_inline(target_block, &current, proof, state, cache, cancel)
                         .await
                     {
-                        ProofSubmitEffect::Submitted => {
+                        ProofSubmitEffect::Submitted { recovered } => {
                             state.retry_sessions.remove(&target_block);
                             state.discard_retry_counts.remove(&target_block);
                             state.pending_discard_roots.remove(&target_block);
                             state.counted_failed_sessions.remove(&target_block);
-                            if let Some(cached) = cache.as_ref() {
-                                state.cursor = Some(cached.state);
-                                if cached.state.l2_block_number > current.l2_block_number {
-                                    continue;
-                                }
+                            state.cursor = Some(recovered);
+                            if recovered.l2_block_number > current.l2_block_number {
+                                continue;
                             }
                             break;
                         }
@@ -1048,10 +1049,13 @@ where
                 info!(target_block, "Submission successful");
                 Metrics::last_proposed_block().set(target_block as f64);
                 state.retry_counts.remove(&target_block);
-                if let Err(e) = self.recovery.recover_latest_state(cache).await {
-                    warn!(error = %e, "Failed to recover state after submission");
+                match self.recovery.recover_latest_state(cache).await {
+                    Ok(recovered) => ProofSubmitEffect::Submitted { recovered },
+                    Err(e) => {
+                        warn!(error = %e, "Failed to recover state after submission");
+                        ProofSubmitEffect::Restart
+                    }
                 }
-                ProofSubmitEffect::Submitted
             }
             Ok(Err(SubmitAction::RootMismatch)) => {
                 submit_timer.disarm();
@@ -1068,10 +1072,13 @@ where
                 if let Some(cached) = cache.as_mut() {
                     cached.game_count = cached.game_count.saturating_sub(1);
                 }
-                if let Err(e) = self.recovery.recover_latest_state(cache).await {
-                    warn!(error = %e, "Failed to recover state after GameAlreadyExists");
+                match self.recovery.recover_latest_state(cache).await {
+                    Ok(recovered) => ProofSubmitEffect::Submitted { recovered },
+                    Err(e) => {
+                        warn!(error = %e, "Failed to recover state after GameAlreadyExists");
+                        ProofSubmitEffect::Restart
+                    }
                 }
-                ProofSubmitEffect::Submitted
             }
             Ok(Err(SubmitAction::Failed(error))) => {
                 submit_timer.disarm();
@@ -1295,12 +1302,15 @@ mod tests {
         proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
         test_utils::{
             MockL1, MockL2, MockOutputProposer, MockProofRequester, MockRollupClient,
-            test_sync_status,
+            test_proposal, test_sync_status,
         },
     };
 
     #[derive(Debug)]
     struct NoopRecovery;
+
+    #[derive(Debug)]
+    struct FailingRecovery;
 
     #[derive(Debug)]
     struct FailingL1;
@@ -1318,6 +1328,16 @@ mod tests {
             _cache: &mut Option<ProofRecoveryCache>,
         ) -> Result<RecoveredState, ProposerError> {
             Ok(recovered(0))
+        }
+    }
+
+    #[async_trait]
+    impl ProofCollectorRecoveryProvider for FailingRecovery {
+        async fn recover_latest_state(
+            &self,
+            _cache: &mut Option<ProofRecoveryCache>,
+        ) -> Result<RecoveredState, ProposerError> {
+            Err(ProposerError::Internal("simulated recovery failure".to_owned()))
         }
     }
 
@@ -1563,6 +1583,70 @@ mod tests {
         assert_eq!(result, ProofCollectorTickResult::Continue);
         assert_eq!(state.recovered, Some(recovered(100)));
         assert_eq!(state.cursor, Some(recovered(100)));
+    }
+
+    #[tokio::test]
+    async fn submit_inline_restarts_when_post_submit_recovery_fails() {
+        let proof_requester: Arc<dyn ProofRequesterProvider> =
+            Arc::new(MockProofRequester::default());
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(200, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&proof_requester),
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            proof_requester,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(FailingRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 2,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let proposal = test_proposal(200);
+        let proof =
+            ProofResult::Tee { aggregate_proposal: proposal.clone(), proposals: vec![proposal] };
+        let mut state = ProofCollectorState::new();
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+        let cancel = CancellationToken::new();
+
+        let effect = orchestrator
+            .submit_inline(200, &recovered(100), proof, &mut state, &mut cache, &cancel)
+            .await;
+
+        assert_eq!(effect, ProofSubmitEffect::Restart);
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -911,6 +911,10 @@ where
                             )
                             .await;
                         }
+                    } else {
+                        Metrics::pipeline_retries()
+                            .set(state.retry_counts.values().sum::<u32>() as f64);
+                        return ProofCollectorTickResult::Restart;
                     }
                     break;
                 }
@@ -1182,7 +1186,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        proof_adapter::ProofRequesterDispatcher,
+        proof_adapter::{ProofRequesterDispatcher, ProposerProofAdapter},
         proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
         proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
         test_utils::{
@@ -1420,6 +1424,76 @@ mod tests {
         assert_eq!(state.discard_retry_counts.get(&target_block).copied(), Some(1));
         assert!(state.retry_counts.is_empty());
         assert!(cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn tick_returns_restart_when_failed_session_exhausts_retries() {
+        let proof_requester = Arc::new(MockProofRequester::default());
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let target_block = 200;
+        let claimed_root = B256::repeat_byte(target_block as u8);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(claimed_root, TeeKind::AwsNitro);
+        proof_requester
+            .failed_sessions
+            .lock()
+            .unwrap()
+            .insert(session_id, "simulated proof failure".to_owned());
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(target_block, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(MockOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 1,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let mut state = ProofCollectorState::new();
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+        let cancel = CancellationToken::new();
+
+        let result =
+            orchestrator.tick(&mut state, &mut cache, recovered(100), target_block, &cancel).await;
+
+        assert_eq!(result, ProofCollectorTickResult::Restart);
+        assert!(cache.is_none());
+        assert!(state.retry_counts.is_empty());
     }
 
     /// Restart/recovery: the collector derives the prover-service session id

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1160,7 +1160,7 @@ where
 
     /// Dispatches a retry-specific proof request after a discarded proof.
     ///
-    /// Returns `false` when the discard retry budget is exhausted and the caller should restart.
+    /// Returns `false` when the caller should restart before collecting more proofs.
     pub async fn dispatch_discard_retry(
         &self,
         target_block: u64,
@@ -1252,6 +1252,7 @@ where
                     error = %error,
                     "Immediate discard retry dispatch failed after failed proof session"
                 );
+                return false;
             }
         }
 
@@ -1667,7 +1668,7 @@ mod tests {
             )
             .await;
 
-        assert!(should_continue);
+        assert!(!should_continue);
         assert_eq!(state.retry_sessions.get(&target_block), Some(&expected_session_id));
         assert_eq!(state.pending_discard_roots.get(&target_block).copied(), Some(claimed_root));
         assert!(cache.is_some());

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1103,7 +1103,7 @@ where
 
     /// Dispatches a root-derived retry after a failed prover-service session.
     ///
-    /// Returns `false` when retry accounting is exhausted and the caller should restart.
+    /// Returns `false` when the caller should restart before collecting more proofs.
     pub async fn dispatch_root_retry(
         &self,
         target_block: u64,
@@ -1131,6 +1131,7 @@ where
                     "Failed to build proof request for root retry"
                 );
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+                return false;
             }
             ProofDispatchAttempt::DispatchFailed(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
@@ -1576,7 +1577,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_session_is_counted_once_until_replacement_is_accepted() {
+    async fn root_retry_build_failure_restarts_without_exhausting_retry_budget() {
         let proof_requester = Arc::new(MockProofRequester::default());
         let l1 = Arc::new(FailingL1);
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
@@ -1637,13 +1638,10 @@ mod tests {
         let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
         let cancel = CancellationToken::new();
 
-        let first =
-            orchestrator.tick(&mut state, &mut cache, recovered(100), target_block, &cancel).await;
-        let second =
+        let result =
             orchestrator.tick(&mut state, &mut cache, recovered(100), target_block, &cancel).await;
 
-        assert_eq!(first, ProofCollectorTickResult::Continue);
-        assert_eq!(second, ProofCollectorTickResult::Continue);
+        assert_eq!(result, ProofCollectorTickResult::Restart);
         assert_eq!(state.retry_counts.get(&target_block).copied(), Some(1));
         assert_eq!(state.counted_failed_sessions.get(&target_block), Some(&session_id));
         assert!(cache.is_some());

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -823,15 +823,21 @@ where
                             return ProofCollectorTickResult::Restart;
                         }
                         ProofSubmitEffect::Redispatch { claimed_l2_output_root } => {
-                            self.dispatch_discard_retry(
-                                target_block,
-                                &current,
-                                claimed_l2_output_root,
-                                state,
-                                cache,
-                                true,
-                            )
-                            .await;
+                            if !self
+                                .dispatch_discard_retry(
+                                    target_block,
+                                    &current,
+                                    claimed_l2_output_root,
+                                    state,
+                                    cache,
+                                    true,
+                                )
+                                .await
+                            {
+                                Metrics::pipeline_retries()
+                                    .set(state.retry_counts.values().sum::<u32>() as f64);
+                                return ProofCollectorTickResult::Restart;
+                            }
                             break;
                         }
                     }
@@ -852,15 +858,21 @@ where
                             session_id = %session_id,
                             "Discard retry session missing, dispatching a fresh retry"
                         );
-                        self.dispatch_discard_retry(
-                            target_block,
-                            &current,
-                            claimed_l2_output_root,
-                            state,
-                            cache,
-                            true,
-                        )
-                        .await;
+                        if !self
+                            .dispatch_discard_retry(
+                                target_block,
+                                &current,
+                                claimed_l2_output_root,
+                                state,
+                                cache,
+                                true,
+                            )
+                            .await
+                        {
+                            Metrics::pipeline_retries()
+                                .set(state.retry_counts.values().sum::<u32>() as f64);
+                            return ProofCollectorTickResult::Restart;
+                        }
                     } else {
                         debug!(
                             target_block,
@@ -891,15 +903,21 @@ where
                             .get(&target_block)
                             .is_some_and(|id| id == &session_id)
                         {
-                            self.dispatch_discard_retry(
-                                target_block,
-                                &current,
-                                claimed_l2_output_root,
-                                state,
-                                cache,
-                                false,
-                            )
-                            .await;
+                            if !self
+                                .dispatch_discard_retry(
+                                    target_block,
+                                    &current,
+                                    claimed_l2_output_root,
+                                    state,
+                                    cache,
+                                    false,
+                                )
+                                .await
+                            {
+                                Metrics::pipeline_retries()
+                                    .set(state.retry_counts.values().sum::<u32>() as f64);
+                                return ProofCollectorTickResult::Restart;
+                            }
                         } else {
                             self.dispatch_root_retry(
                                 target_block,
@@ -1086,6 +1104,8 @@ where
     }
 
     /// Dispatches a retry-specific proof request after a discarded proof.
+    ///
+    /// Returns `false` when the discard retry budget is exhausted and the caller should restart.
     pub async fn dispatch_discard_retry(
         &self,
         target_block: u64,
@@ -1094,7 +1114,7 @@ where
         state: &mut ProofCollectorState,
         cache: &mut Option<ProofRecoveryCache>,
         count_dispatch_failure: bool,
-    ) {
+    ) -> bool {
         let current_attempt = state.discard_retry_counts.get(&target_block).copied().unwrap_or(0);
         if current_attempt >= self.runtime.max_retries {
             error!(
@@ -1106,7 +1126,7 @@ where
             state.discard_retry_counts.remove(&target_block);
             state.retry_sessions.remove(&target_block);
             *cache = None;
-            return;
+            return false;
         }
 
         let attempt = current_attempt + 1;
@@ -1155,6 +1175,8 @@ where
                 }
             }
         }
+
+        true
     }
 
     /// Computes the next collector target from a current block.
@@ -1183,9 +1205,11 @@ mod tests {
     use std::collections::{BTreeSet, HashMap};
 
     use alloy_primitives::{Address, B256};
+    use base_proof_primitives::Proposal;
 
     use super::*;
     use crate::{
+        output_proposer::OutputProposer,
         proof_adapter::{ProofRequesterDispatcher, ProposerProofAdapter},
         proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
         proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
@@ -1201,6 +1225,9 @@ mod tests {
     #[derive(Debug)]
     struct FailingL1;
 
+    #[derive(Debug)]
+    struct DiscardingOutputProposer;
+
     #[async_trait]
     impl ProofCollectorRecoveryProvider for NoopRecovery {
         async fn recover_latest_state(
@@ -1208,6 +1235,18 @@ mod tests {
             _cache: &mut Option<ProofRecoveryCache>,
         ) -> Result<RecoveredState, ProposerError> {
             Ok(recovered(0))
+        }
+    }
+
+    #[async_trait]
+    impl OutputProposer for DiscardingOutputProposer {
+        async fn propose_output(
+            &self,
+            _proposal: &Proposal,
+            _parent_address: Address,
+            _intermediate_roots: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::L1OriginTooOld)
         }
     }
 
@@ -1424,6 +1463,87 @@ mod tests {
         assert_eq!(state.discard_retry_counts.get(&target_block).copied(), Some(1));
         assert!(state.retry_counts.is_empty());
         assert!(cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn tick_returns_restart_when_discard_retry_budget_exhausts() {
+        let proof_requester = Arc::new(MockProofRequester::default());
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let target_block = 200;
+        let claimed_root = B256::repeat_byte(target_block as u8);
+        let rollup_client = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(target_block, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let request = base_proof_primitives::ProofRequest {
+            l1_head: B256::repeat_byte(0x01),
+            agreed_l2_head_hash: B256::repeat_byte(0x02),
+            agreed_l2_output_root: B256::ZERO,
+            claimed_l2_output_root: claimed_root,
+            claimed_l2_block_number: target_block,
+            proposer: Address::repeat_byte(0x04),
+            intermediate_block_interval: 100,
+            l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x05),
+        };
+        ProofRequesterDispatcher::aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>
+        )
+        .dispatch_tee(request)
+        .await
+        .expect("test setup should dispatch root session");
+        let collector = ProofCollector::target_poller_aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            Arc::clone(&rollup_client),
+        );
+        let dispatcher = ProofDispatcher::aws_nitro(
+            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
+            Arc::clone(&l1),
+            l2,
+            Arc::clone(&rollup_client),
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let submitter = ProofSubmitter::new(
+            Arc::new(DiscardingOutputProposer),
+            rollup_client,
+            l1,
+            ProofSubmitterConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                tee_image_hash: B256::repeat_byte(0x05),
+                tee_prover_registry_address: None,
+                output_fetch_concurrency: 1,
+            },
+        );
+        let orchestrator = ProofCollectorOrchestrator::new(
+            collector,
+            dispatcher,
+            submitter,
+            Arc::new(NoopRecovery),
+            ProofCollectorRuntimeConfig {
+                block_interval: 100,
+                max_retries: 0,
+                submit_timeout: std::time::Duration::from_secs(60),
+            },
+        );
+        let mut state = ProofCollectorState::new();
+        let mut cache = Some(ProofRecoveryCache { game_count: 0, state: recovered(100) });
+        let cancel = CancellationToken::new();
+
+        let result =
+            orchestrator.tick(&mut state, &mut cache, recovered(100), target_block, &cancel).await;
+
+        assert_eq!(result, ProofCollectorTickResult::Restart);
+        assert!(cache.is_none());
+        assert!(state.discard_retry_counts.is_empty());
+        assert!(state.retry_sessions.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds collector-side orchestration on top of the deterministic polling support and dispatcher abstraction.

The collector orchestrator owns polling, sequential inline submit, ready-backlog draining, retry-specific sessions, and restart decisions so final pipeline wiring can remain a thin lifecycle coordinator.

## Changes

- Add `ProofCollectorOrchestrator` for collector-side polling and submit orchestration.
- Add collector runtime/state types for cursor tracking, retry accounting, discard retry state, and retry sessions.
- Move inline submit behavior into collector orchestration, including submit timeout handling and restart/drop-cache decisions.
- Re-dispatch terminal failed sessions through the dispatcher abstraction.
- Dispatch retry-specific sessions for discarded proofs and cap discard retries.
- Replace missing retry-specific sessions with fresh retry sessions.
- Add a recovery-provider hook used after successful submits and `GameAlreadyExists` recovery.

## Verification

- `cargo +nightly fmt -p base-proposer`
- `cargo test -p base-proposer --lib`
- `cargo test -p base-proposer --lib --features metrics`
- `cargo clippy -p base-proposer --all-targets -- -D warnings`
- `cargo clippy -p base-proposer --all-targets --features metrics -- -D warnings`