### PR TITLE
feat(consensus): EIP-8130 canonical contract registry

### DIFF
--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -30,8 +30,8 @@ pub use transaction::{
     AccountChange, ActorChange, ActorChangeType, BasePooledTransaction, BaseTransaction,
     BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ConfigChange, CreateEntry,
     DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, EIP8130_REJECTION_MSG,
-    EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Signed, InitialActor, OpTxType, Scope, TxDeposit,
-    TxEip8130,
+    EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Contracts, Eip8130Signed, InitialActor, OpTxType,
+    Scope, TxDeposit, TxEip8130,
 };
 
 mod extra;

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -60,35 +60,21 @@ impl Eip8130Contracts {
     // Account implementations (init code embeds `ACCOUNT_CONFIG`)
     // ─────────────────────────────────────────────────────────────────────────
 
-    /// Default wallet implementation auto-delegated to EOAs (`DEFAULT_ACCOUNT_ADDRESS`).
+    /// Default wallet implementation, used as the target of default EOA delegation.
     pub const DEFAULT_ACCOUNT: Address = address!("0x124b52d5D57a76ed064c414975beA11Beffe0251");
 
     /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
     pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
         b256!("0xcabcfd4783f18c6b043f02dbea18dc611fb9fec737477884620a83e2de25c898");
 
-    /// Wallet variant that blocks ETH transfers when locked (higher mempool rate limits).
+    /// Wallet variant that blocks ETH transfers when locked, granting higher
+    /// EIP-8130 mempool access (rate limits).
     pub const DEFAULT_HIGH_RATE_ACCOUNT: Address =
         address!("0x13dD0F222cCF60B7C08a95C2d1FcC85A38DD675D");
 
     /// keccak256 of the `DEFAULT_HIGH_RATE_ACCOUNT` deployment init code.
     pub const DEFAULT_HIGH_RATE_ACCOUNT_INIT_CODE_HASH: B256 =
         b256!("0x9496825d45d5185c429df2ee447c2a47b0b3240ef91bfbfe82a2e55a71815bd3");
-
-    /// Backward-compatible ERC-4337 account implementation.
-    pub const ERC4337_ACCOUNT: Address = address!("0x9748aeA1e1762E50a4d8927777FeDB63A2Ef06C0");
-
-    /// keccak256 of the `ERC4337_ACCOUNT` deployment init code (embeds the
-    /// ERC-4337 v0.7 EntryPoint in addition to `ACCOUNT_CONFIG`).
-    pub const ERC4337_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xdaf67d73c20c5e9cbd989cc443a9a056cf7d74f27d8dd9f14404adf9558b0287");
-
-    /// UUPS-upgradeable account implementation.
-    pub const UPGRADEABLE_ACCOUNT: Address = address!("0xD9C5aA253332D71Ab471f122307Bc528E861646f");
-
-    /// keccak256 of the `UPGRADEABLE_ACCOUNT` deployment init code.
-    pub const UPGRADEABLE_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0x1669129014aa72a7db02721804318d93b2da8c13427a0b927791ccb4f5f1a91e");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
@@ -112,7 +98,7 @@ impl Eip8130Contracts {
     pub const P256_AUTHENTICATOR_INIT_CODE_HASH: B256 =
         b256!("0x87b9a0dbffce118797e1d133f563f99697396c9b447becb900157f60197adea0");
 
-    /// secp256r1 / P-256 (WebAuthn) authenticator contract.
+    /// secp256r1 / P-256 (`WebAuthn`) authenticator contract.
     pub const WEBAUTHN_AUTHENTICATOR: Address =
         address!("0x1CB75BE39Fb950202BF4239010534B86EdA66c31");
 
@@ -129,30 +115,11 @@ impl Eip8130Contracts {
     pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
         b256!("0xa1980fff3bbb86a0d4ea4593ae921c8292f4b33254851db8406b098eb5db49ec");
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // Non-canonical (deployed, but MUST NOT be allowlisted)
-    // ─────────────────────────────────────────────────────────────────────────
-
-    /// Always-valid authenticator — a keyless-relay example/test helper.
-    ///
-    /// **Not canonical.** It authenticates any signature, so allowlisting it on
-    /// the EIP-8130 path would let anyone spend any account that registers it. It
-    /// is deliberately excluded from [`Self::CANONICAL_AUTHENTICATORS`]; the
-    /// constant exists only so the address is documented and explicitly recognized
-    /// as non-canonical.
-    pub const ALWAYS_VALID_AUTHENTICATOR: Address =
-        address!("0x520fBA4840729CB57b3Dc7B40D548AcF354DBA25");
-
-    /// keccak256 of the `ALWAYS_VALID_AUTHENTICATOR` deployment init code.
-    pub const ALWAYS_VALID_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0x7d0e1321e0ef97b569f703a36a202121eb13e3fc50f026a006f016260361da0f");
-
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.
     ///
-    /// Deliberately excludes [`Self::ALWAYS_VALID_AUTHENTICATOR`]. Native EOA
-    /// ecrecover (`address(1)`) is a separate protocol-reserved path and is not a
-    /// deployed contract, so it is not listed here.
+    /// Native EOA ecrecover (`address(1)`) is a separate protocol-reserved path
+    /// and is not a deployed contract, so it is not listed here.
     ///
     /// The exact membership (including whether the native ecrecover sentinel and
     /// the `K1_AUTHENTICATOR` contract are both accepted, and how enshrinement is
@@ -192,11 +159,6 @@ mod tests {
                 Eip8130Contracts::DEFAULT_HIGH_RATE_ACCOUNT,
                 Eip8130Contracts::DEFAULT_HIGH_RATE_ACCOUNT_INIT_CODE_HASH,
             ),
-            (Eip8130Contracts::ERC4337_ACCOUNT, Eip8130Contracts::ERC4337_ACCOUNT_INIT_CODE_HASH),
-            (
-                Eip8130Contracts::UPGRADEABLE_ACCOUNT,
-                Eip8130Contracts::UPGRADEABLE_ACCOUNT_INIT_CODE_HASH,
-            ),
             (Eip8130Contracts::K1_AUTHENTICATOR, Eip8130Contracts::K1_AUTHENTICATOR_INIT_CODE_HASH),
             (
                 Eip8130Contracts::P256_AUTHENTICATOR,
@@ -210,10 +172,6 @@ mod tests {
                 Eip8130Contracts::DELEGATE_AUTHENTICATOR,
                 Eip8130Contracts::DELEGATE_AUTHENTICATOR_INIT_CODE_HASH,
             ),
-            (
-                Eip8130Contracts::ALWAYS_VALID_AUTHENTICATOR,
-                Eip8130Contracts::ALWAYS_VALID_AUTHENTICATOR_INIT_CODE_HASH,
-            ),
         ];
         for (expected, init_code_hash) in cases {
             let derived =
@@ -223,16 +181,11 @@ mod tests {
     }
 
     #[test]
-    fn always_valid_is_not_canonical() {
-        assert!(
-            !Eip8130Contracts::is_canonical_authenticator(
-                &Eip8130Contracts::ALWAYS_VALID_AUTHENTICATOR
-            ),
-            "AlwaysValidAuthenticator must never be in the canonical allowlist"
-        );
+    fn canonical_authenticator_membership() {
         assert_eq!(Eip8130Contracts::CANONICAL_AUTHENTICATORS.len(), 4);
         for auth in Eip8130Contracts::CANONICAL_AUTHENTICATORS {
             assert!(Eip8130Contracts::is_canonical_authenticator(&auth));
         }
+        assert!(!Eip8130Contracts::is_canonical_authenticator(&Address::ZERO));
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -1,0 +1,238 @@
+//! Canonical [EIP-8130] system-contract addresses and the node authenticator allowlist.
+//!
+//! These are the deterministic CREATE2 addresses of the EIP-8130 contracts (the
+//! Account Configuration system contract, the account implementations, and the
+//! canonical authenticators). Every contract is deployed through Nick's
+//! deterministic-deployment proxy ([`Eip8130Contracts::CREATE2_FACTORY`]) with a
+//! zero salt, so the address is a pure function of the contract init code and is
+//! identical on every chain that deploys the same bytecode.
+//!
+//! # ⚠️ These values are NOT final
+//!
+//! EIP-8130 is in Draft and the reference contracts (`base/eip-8130`) are still
+//! churning. Because each address is derived from the contract init code, **any
+//! change to the contract bytecode changes its address**, and the account-
+//! implementation and delegate-authenticator addresses additionally cascade off
+//! the Account Configuration address (it is passed as a constructor argument).
+//!
+//! The values below are the current Base Sepolia deployment. They are expected to
+//! change as the contracts evolve and finalize. On each redeploy, re-pin both the
+//! address and its `*_INIT_CODE_HASH` together (the [`tests`] module asserts they
+//! stay consistent under CREATE2) and, once the bytecode is frozen for the Cobalt
+//! upgrade, freeze these as the canonical mainnet values.
+//!
+//! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+
+use alloy_primitives::{Address, B256, address, b256};
+
+/// Canonical [EIP-8130] contract addresses and the node authenticator allowlist.
+///
+/// See the [module docs](self) for the (important) caveat that these are
+/// provisional Base Sepolia values that change with the contract bytecode.
+#[derive(Debug)]
+pub struct Eip8130Contracts;
+
+impl Eip8130Contracts {
+    /// Nick's deterministic-deployment proxy (the "Arachnid" CREATE2 factory),
+    /// deployed at the same address on every EVM chain. Every EIP-8130 contract is
+    /// deployed by sending `SALT || init_code` to this factory.
+    ///
+    /// <https://github.com/Arachnid/deterministic-deployment-proxy>
+    pub const CREATE2_FACTORY: Address = address!("0x4e59b44847b379578588920cA78FbF26c0B4956C");
+
+    /// The CREATE2 salt used for every EIP-8130 deployment (zero).
+    pub const SALT: B256 = B256::ZERO;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // System contract
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Account Configuration system contract (`ACCOUNT_CONFIG_ADDRESS`). The
+    /// protocol reads actor/account state directly from this contract's storage.
+    pub const ACCOUNT_CONFIG: Address = address!("0xb0198a714872EE5bfDF829e7986DB5C5899a6b50");
+
+    /// keccak256 of the `ACCOUNT_CONFIG` deployment init code (for CREATE2
+    /// derivation and bytecode-drift detection).
+    pub const ACCOUNT_CONFIG_INIT_CODE_HASH: B256 =
+        b256!("0x6c3a49f4636ff758e77f9213fd57c8e5a55677545e31d99441ec173f44a6f518");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Account implementations (init code embeds `ACCOUNT_CONFIG`)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Default wallet implementation auto-delegated to EOAs (`DEFAULT_ACCOUNT_ADDRESS`).
+    pub const DEFAULT_ACCOUNT: Address = address!("0x124b52d5D57a76ed064c414975beA11Beffe0251");
+
+    /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
+    pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
+        b256!("0xcabcfd4783f18c6b043f02dbea18dc611fb9fec737477884620a83e2de25c898");
+
+    /// Wallet variant that blocks ETH transfers when locked (higher mempool rate limits).
+    pub const DEFAULT_HIGH_RATE_ACCOUNT: Address =
+        address!("0x13dD0F222cCF60B7C08a95C2d1FcC85A38DD675D");
+
+    /// keccak256 of the `DEFAULT_HIGH_RATE_ACCOUNT` deployment init code.
+    pub const DEFAULT_HIGH_RATE_ACCOUNT_INIT_CODE_HASH: B256 =
+        b256!("0x9496825d45d5185c429df2ee447c2a47b0b3240ef91bfbfe82a2e55a71815bd3");
+
+    /// Backward-compatible ERC-4337 account implementation.
+    pub const ERC4337_ACCOUNT: Address = address!("0x9748aeA1e1762E50a4d8927777FeDB63A2Ef06C0");
+
+    /// keccak256 of the `ERC4337_ACCOUNT` deployment init code (embeds the
+    /// ERC-4337 v0.7 EntryPoint in addition to `ACCOUNT_CONFIG`).
+    pub const ERC4337_ACCOUNT_INIT_CODE_HASH: B256 =
+        b256!("0xdaf67d73c20c5e9cbd989cc443a9a056cf7d74f27d8dd9f14404adf9558b0287");
+
+    /// UUPS-upgradeable account implementation.
+    pub const UPGRADEABLE_ACCOUNT: Address = address!("0xD9C5aA253332D71Ab471f122307Bc528E861646f");
+
+    /// keccak256 of the `UPGRADEABLE_ACCOUNT` deployment init code.
+    pub const UPGRADEABLE_ACCOUNT_INIT_CODE_HASH: B256 =
+        b256!("0x1669129014aa72a7db02721804318d93b2da8c13427a0b927791ccb4f5f1a91e");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Canonical authenticators (accepted on the EIP-8130 block-validation path)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// secp256k1 (ECDSA) authenticator contract.
+    ///
+    /// Note: native EOA ecrecover is the separate protocol-reserved sentinel
+    /// [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`](super::Eip8130Constants::ECRECOVER_AUTHENTICATOR)
+    /// (`address(1)`); this is the deployed `IAuthenticator` contract form.
+    pub const K1_AUTHENTICATOR: Address = address!("0x39221FB37Df105B22316328e88632C9684861466");
+
+    /// keccak256 of the `K1_AUTHENTICATOR` deployment init code.
+    pub const K1_AUTHENTICATOR_INIT_CODE_HASH: B256 =
+        b256!("0x07a31dfd4ba2e2a529d9642b98430ea299bac428fe83312c54d16f519568d7d5");
+
+    /// secp256r1 / P-256 (raw) authenticator contract.
+    pub const P256_AUTHENTICATOR: Address = address!("0x3AE129D846CD1CAf0369b4Caa56c188E18E11B15");
+
+    /// keccak256 of the `P256_AUTHENTICATOR` deployment init code.
+    pub const P256_AUTHENTICATOR_INIT_CODE_HASH: B256 =
+        b256!("0x87b9a0dbffce118797e1d133f563f99697396c9b447becb900157f60197adea0");
+
+    /// secp256r1 / P-256 (WebAuthn) authenticator contract.
+    pub const WEBAUTHN_AUTHENTICATOR: Address =
+        address!("0x1CB75BE39Fb950202BF4239010534B86EdA66c31");
+
+    /// keccak256 of the `WEBAUTHN_AUTHENTICATOR` deployment init code.
+    pub const WEBAUTHN_AUTHENTICATOR_INIT_CODE_HASH: B256 =
+        b256!("0xbaeb605566ca94a5d7af1bb61996e409d457ac3d21a2cda682f08ee46a356ef5");
+
+    /// Delegated-validation (1-hop) authenticator contract (init code embeds
+    /// `ACCOUNT_CONFIG`).
+    pub const DELEGATE_AUTHENTICATOR: Address =
+        address!("0xE67D299Ff3F0a185398B6C5a28998696969265d7");
+
+    /// keccak256 of the `DELEGATE_AUTHENTICATOR` deployment init code.
+    pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
+        b256!("0xa1980fff3bbb86a0d4ea4593ae921c8292f4b33254851db8406b098eb5db49ec");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Non-canonical (deployed, but MUST NOT be allowlisted)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Always-valid authenticator — a keyless-relay example/test helper.
+    ///
+    /// **Not canonical.** It authenticates any signature, so allowlisting it on
+    /// the EIP-8130 path would let anyone spend any account that registers it. It
+    /// is deliberately excluded from [`Self::CANONICAL_AUTHENTICATORS`]; the
+    /// constant exists only so the address is documented and explicitly recognized
+    /// as non-canonical.
+    pub const ALWAYS_VALID_AUTHENTICATOR: Address =
+        address!("0x520fBA4840729CB57b3Dc7B40D548AcF354DBA25");
+
+    /// keccak256 of the `ALWAYS_VALID_AUTHENTICATOR` deployment init code.
+    pub const ALWAYS_VALID_AUTHENTICATOR_INIT_CODE_HASH: B256 =
+        b256!("0x7d0e1321e0ef97b569f703a36a202121eb13e3fc50f026a006f016260361da0f");
+
+    /// The canonical authenticator allowlist: the deployed `IAuthenticator`
+    /// contracts a compliant node accepts on the EIP-8130 block-validation path.
+    ///
+    /// Deliberately excludes [`Self::ALWAYS_VALID_AUTHENTICATOR`]. Native EOA
+    /// ecrecover (`address(1)`) is a separate protocol-reserved path and is not a
+    /// deployed contract, so it is not listed here.
+    ///
+    /// The exact membership (including whether the native ecrecover sentinel and
+    /// the `K1_AUTHENTICATOR` contract are both accepted, and how enshrinement is
+    /// metered) is TBD pending the spec's companion ERC and contract finalization.
+    pub const CANONICAL_AUTHENTICATORS: [Address; 4] = [
+        Self::K1_AUTHENTICATOR,
+        Self::P256_AUTHENTICATOR,
+        Self::WEBAUTHN_AUTHENTICATOR,
+        Self::DELEGATE_AUTHENTICATOR,
+    ];
+
+    /// Returns `true` if `authenticator` is in the canonical deployed-contract
+    /// allowlist ([`Self::CANONICAL_AUTHENTICATORS`]).
+    ///
+    /// This intentionally does not account for the native ecrecover sentinel
+    /// (`address(1)`), which is handled separately by the protocol; see the
+    /// allowlist docs for the TBD around final membership.
+    pub fn is_canonical_authenticator(authenticator: &Address) -> bool {
+        Self::CANONICAL_AUTHENTICATORS.contains(authenticator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each `(address, init_code_hash)` pair must be self-consistent under
+    /// CREATE2 with the canonical factory + zero salt. If the contract bytecode
+    /// changes, both values must be re-pinned together or this fails — the drift
+    /// guard for the provisional addresses.
+    #[test]
+    fn addresses_match_create2_derivation() {
+        let cases = [
+            (Eip8130Contracts::ACCOUNT_CONFIG, Eip8130Contracts::ACCOUNT_CONFIG_INIT_CODE_HASH),
+            (Eip8130Contracts::DEFAULT_ACCOUNT, Eip8130Contracts::DEFAULT_ACCOUNT_INIT_CODE_HASH),
+            (
+                Eip8130Contracts::DEFAULT_HIGH_RATE_ACCOUNT,
+                Eip8130Contracts::DEFAULT_HIGH_RATE_ACCOUNT_INIT_CODE_HASH,
+            ),
+            (Eip8130Contracts::ERC4337_ACCOUNT, Eip8130Contracts::ERC4337_ACCOUNT_INIT_CODE_HASH),
+            (
+                Eip8130Contracts::UPGRADEABLE_ACCOUNT,
+                Eip8130Contracts::UPGRADEABLE_ACCOUNT_INIT_CODE_HASH,
+            ),
+            (Eip8130Contracts::K1_AUTHENTICATOR, Eip8130Contracts::K1_AUTHENTICATOR_INIT_CODE_HASH),
+            (
+                Eip8130Contracts::P256_AUTHENTICATOR,
+                Eip8130Contracts::P256_AUTHENTICATOR_INIT_CODE_HASH,
+            ),
+            (
+                Eip8130Contracts::WEBAUTHN_AUTHENTICATOR,
+                Eip8130Contracts::WEBAUTHN_AUTHENTICATOR_INIT_CODE_HASH,
+            ),
+            (
+                Eip8130Contracts::DELEGATE_AUTHENTICATOR,
+                Eip8130Contracts::DELEGATE_AUTHENTICATOR_INIT_CODE_HASH,
+            ),
+            (
+                Eip8130Contracts::ALWAYS_VALID_AUTHENTICATOR,
+                Eip8130Contracts::ALWAYS_VALID_AUTHENTICATOR_INIT_CODE_HASH,
+            ),
+        ];
+        for (expected, init_code_hash) in cases {
+            let derived =
+                Eip8130Contracts::CREATE2_FACTORY.create2(Eip8130Contracts::SALT, init_code_hash);
+            assert_eq!(derived, expected, "CREATE2 derivation mismatch for {expected}");
+        }
+    }
+
+    #[test]
+    fn always_valid_is_not_canonical() {
+        assert!(
+            !Eip8130Contracts::is_canonical_authenticator(
+                &Eip8130Contracts::ALWAYS_VALID_AUTHENTICATOR
+            ),
+            "AlwaysValidAuthenticator must never be in the canonical allowlist"
+        );
+        assert_eq!(Eip8130Contracts::CANONICAL_AUTHENTICATORS.len(), 4);
+        for auth in Eip8130Contracts::CANONICAL_AUTHENTICATORS {
+            assert!(Eip8130Contracts::is_canonical_authenticator(&auth));
+        }
+    }
+}

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -29,7 +29,8 @@ use alloy_primitives::{Address, B256, address, b256};
 ///
 /// See the [module docs](self) for the (important) caveat that these are
 /// provisional Base Sepolia values that change with the contract bytecode.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Eip8130Contracts;
 
 impl Eip8130Contracts {
@@ -137,6 +138,7 @@ impl Eip8130Contracts {
     /// This intentionally does not account for the native ecrecover sentinel
     /// (`address(1)`), which is handled separately by the protocol; see the
     /// allowlist docs for the TBD around final membership.
+    #[must_use]
     pub fn is_canonical_authenticator(authenticator: &Address) -> bool {
         Self::CANONICAL_AUTHENTICATORS.contains(authenticator)
     }

--- a/crates/common/consensus/src/transaction/eip8130/mod.rs
+++ b/crates/common/consensus/src/transaction/eip8130/mod.rs
@@ -9,6 +9,9 @@
 mod constants;
 pub use constants::Eip8130Constants;
 
+mod addresses;
+pub use addresses::Eip8130Contracts;
+
 mod call;
 pub use call::Call;
 

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -6,7 +6,7 @@ pub use deposit::{DepositTransaction, TxDeposit};
 mod eip8130;
 pub use eip8130::{
     AccountChange, ActorChange, ActorChangeType, Call, ConfigChange, CreateEntry, Delegation,
-    Eip8130Constants, Eip8130Signed, InitialActor, Scope, TxEip8130,
+    Eip8130Constants, Eip8130Contracts, Eip8130Signed, InitialActor, Scope, TxEip8130,
 };
 
 mod tx_type;


### PR DESCRIPTION
## Summary
First piece of the EIP-8130 **contract integration** epic, stacked on the realignment PR #3311 (it references the renamed `ECRECOVER_AUTHENTICATOR`).

Adds a node-side canonical registry, `Eip8130Contracts`, in `base-common-consensus`, pinning the deterministic CREATE2 addresses for the **7 contracts the node needs**:
- **System contract**: `ACCOUNT_CONFIG` (Account Configuration).
- **Account implementations**: `DEFAULT_ACCOUNT` (default EOA delegation target) and `DEFAULT_HIGH_RATE_ACCOUNT` (grants higher EIP-8130 mempool access).
- **Canonical authenticators**: `K1`, `P256`, `WebAuthn`, `Delegate` — exposed as the `CANONICAL_AUTHENTICATORS` allowlist + `is_canonical_authenticator()`.
- `CREATE2_FACTORY` (Nick's factory) + zero `SALT`, with each address paired to its init-code hash.

## Drift detection
`addresses_match_create2_derivation` asserts every `(address, init_code_hash)` pair is self-consistent under `CREATE2(factory, salt=0, hash)`. Verified against the live Base Sepolia deployment for all pinned contracts. A bytecode change forces both the address and hash to be re-pinned together or the test fails. `canonical_authenticator_membership` guards the allowlist contents.

## ⚠️ Provisional
EIP-8130 is Draft and `base/eip-8130` is still churning. These are the current Base Sepolia values and **are expected to change as the contracts finalize** (account-impl and delegate addresses also cascade off the Account Configuration address, which is a constructor arg). On each redeploy, re-pin address + hash together; freeze for Cobalt once bytecode is final.

Open question called out in code: exact allowlist membership (native ecrecover `address(1)` sentinel vs the `K1Authenticator` contract; enshrinement metering) is TBD pending spec/contract finalization.

## Test plan
- [x] `cargo test -p base-common-consensus --lib addresses` (2 passed)
- [x] `cargo clippy -p base-common-consensus --lib` (clean)
- [x] `cargo fmt` clean