### PR TITLE
fix(prover-service-db): preserve terminal worker sessions

### DIFF
--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1120,6 +1120,8 @@ pub struct WorkerSessionUpsert {
 pub enum RecordSessionOutcome {
     /// The session was inserted or updated and the active row is returned.
     Recorded(ProofSession),
+    /// A row for the requested backend session already reached a terminal state.
+    TerminalBackendSession(ProofSession),
     /// No proof job exists for the supplied `session_id`.
     NotFound,
     /// The job exists but is not currently claimed.

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1154,8 +1154,34 @@ impl ProofRequestRepo {
             ClaimAuth::Expired => return Ok(RecordSessionOutcome::Expired),
         }
 
-        // `FOR UPDATE` above serializes the find-then-write: only the lock holder
-        // reaches here, so at most one active row exists per session type.
+        let existing_backend_sessions = sqlx::query(
+            r#"
+            SELECT id, proof_request_id, session_type, backend_session_id,
+                   status, error_message, metadata, created_at, completed_at
+            FROM proof_sessions
+            WHERE proof_request_id = $1
+              AND session_type = $2
+              AND backend_session_id = $3
+            ORDER BY id DESC
+            FOR UPDATE
+            "#,
+        )
+        .bind(proof_request_id)
+        .bind(req.session_type.as_str())
+        .bind(&req.backend_session_id)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        for row in existing_backend_sessions {
+            let session = row_to_proof_session(&row)?;
+            if session.status.is_terminal() {
+                return Ok(RecordSessionOutcome::TerminalBackendSession(session));
+            }
+        }
+
+        // The proof request row lock serializes worker writers, while this
+        // session row lock prevents pollers from terminalizing the selected row
+        // before the update below.
         let active_id: Option<i64> = sqlx::query(
             r#"
             SELECT id
@@ -1163,6 +1189,7 @@ impl ProofRequestRepo {
             WHERE proof_request_id = $1
               AND session_type = $2
               AND status IN ('SUBMITTING', 'RUNNING')
+            FOR UPDATE
             "#,
         )
         .bind(proof_request_id)
@@ -1179,6 +1206,7 @@ impl ProofRequestRepo {
                     status = $2,
                     error_message = $4
                 WHERE id = $3
+                  AND status IN ('SUBMITTING', 'RUNNING')
                 RETURNING id, proof_request_id, session_type, backend_session_id,
                           status, error_message, metadata, created_at, completed_at
                 "#,
@@ -1187,8 +1215,14 @@ impl ProofRequestRepo {
             .bind(req.status.as_str())
             .bind(active_id)
             .bind(&req.error_message)
-            .fetch_one(&mut *tx)
+            .fetch_optional(&mut *tx)
             .await?
+            .ok_or_else(|| {
+                sqlx::Error::Protocol(
+                    "active proof session status changed between SELECT FOR UPDATE and UPDATE"
+                        .into(),
+                )
+            })?
         } else {
             sqlx::query(
                 r#"

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1903,6 +1903,110 @@ async fn test_record_worker_proof_session_records_resumes_and_updates() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_record_worker_proof_session_preserves_terminal_backend_sessions() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("session-terminal-backend-worker", 3))
+        .await
+        .unwrap()
+        .expect("compressed job should be claimed");
+    assert_eq!(claimed.id, id);
+    let session_id = claimed.session_id.clone();
+    let lock_id = claimed.lock_id.expect("claimed job has lock");
+    let terminal_backend_id = format!("cluster-proof-{}", Uuid::new_v4());
+    let active_backend_id = format!("cluster-proof-{}", Uuid::new_v4());
+
+    let recorded = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id,
+            worker_id: "session-terminal-backend-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: terminal_backend_id.clone(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(recorded, RecordSessionOutcome::Recorded(_)));
+
+    repo.update_proof_session(UpdateProofSession {
+        backend_session_id: terminal_backend_id.clone(),
+        status: SessionStatus::Completed,
+        error_message: None,
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let retry = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id,
+            worker_id: "session-terminal-backend-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: terminal_backend_id.clone(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    let RecordSessionOutcome::TerminalBackendSession(terminal) = retry else {
+        panic!("terminal backend session retry should be idempotent");
+    };
+    assert_eq!(terminal.backend_session_id, terminal_backend_id);
+    assert_eq!(terminal.status, SessionStatus::Completed);
+    assert!(repo.get_active_session(&session_id, SessionType::Stark).await.unwrap().is_none());
+
+    let recorded = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id,
+            worker_id: "session-terminal-backend-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: active_backend_id.clone(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(recorded, RecordSessionOutcome::Recorded(_)));
+
+    let retry = repo
+        .record_worker_proof_session(WorkerSessionUpsert {
+            session_id: session_id.clone(),
+            lock_id,
+            worker_id: "session-terminal-backend-worker".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: terminal_backend_id.clone(),
+            status: SessionStatus::Running,
+            error_message: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(retry, RecordSessionOutcome::TerminalBackendSession(_)));
+
+    let active = repo
+        .get_active_session(&session_id, SessionType::Stark)
+        .await
+        .unwrap()
+        .expect("active backend session should not be overwritten");
+    assert_eq!(active.backend_session_id, active_backend_id);
+
+    let sessions = repo.get_sessions_for_request(id).await.unwrap();
+    let terminal_rows =
+        sessions.iter().filter(|session| session.backend_session_id == terminal_backend_id).count();
+    assert_eq!(terminal_rows, 1);
+    assert!(sessions.iter().any(|session| session.backend_session_id == terminal_backend_id
+        && session.status == SessionStatus::Completed));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
 async fn test_record_worker_proof_session_guards_ownership() {
     let pool = test_pool().await;
     let repo = test_repo(pool.clone());


### PR DESCRIPTION
## Summary
- prevent worker session record retries from reopening terminal backend sessions
- lock matching backend session rows before recording active worker sessions
- add ignored Postgres integration coverage for terminal backend-session retries

Follow up: https://github.com/base/base/pull/3379#discussion_r3391299810