### PR TITLE
[backport] BOP precompile fixes batch 5 for v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,7 @@ dependencies = [
  "revm",
  "rstest",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -23,8 +23,13 @@ impl syn::parse::Parse for ContractConfig {
         }
 
         let ident: Ident = input.parse()?;
-        if ident != "addr" && ident != "address" {
-            return Err(syn::Error::new(ident.span(), "only `addr` attribute is supported"));
+        if ident != "addr" {
+            return Err(syn::Error::new(
+                ident.span(),
+                format!(
+                    "unrecognized argument `{ident}`; supported arguments are: addr = \"0x...\""
+                ),
+            ));
         }
 
         input.parse::<Token![=]>()?;

--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -66,15 +66,16 @@ pub(crate) fn generate(input: DeriveInput, address: Option<&Expr>) -> proc_macro
 fn gen_output(input: DeriveInput, address: Option<&Expr>) -> syn::Result<TokenStream> {
     let (ident, vis) = (input.ident.clone(), input.vis.clone());
     let namespace = extract_namespace(&input.attrs)?;
-    let derives = input
+    let passthrough_attrs = input
         .attrs
         .iter()
-        .filter(|attr| attr.path().is_ident("derive"))
+        .filter(|attr| !attr.path().is_ident("namespace"))
         .cloned()
         .collect::<Vec<_>>();
     let fields = parse_fields(input, namespace.is_some())?;
 
-    let storage_output = gen_storage(&ident, &vis, &derives, &fields, address, namespace.as_ref())?;
+    let storage_output =
+        gen_storage(&ident, &vis, &passthrough_attrs, &fields, address, namespace.as_ref())?;
     Ok(quote! { #storage_output })
 }
 

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -124,11 +124,15 @@ pub(crate) fn gen_struct(
     allocated_fields: &[LayoutField<'_>],
 ) -> proc_macro2::TokenStream {
     let handler_fields = allocated_fields.iter().map(gen_handler_field_decl);
-    let doc_str = format!("Storage layout for the [`{name}`] precompile.");
+    let has_user_doc = attrs.iter().any(|attr| attr.path().is_ident("doc"));
+    let fallback_doc = (!has_user_doc).then(|| {
+        let doc_str = format!("Storage layout for the [`{name}`] precompile.");
+        quote! { #[doc = #doc_str] }
+    });
 
     quote! {
         #(#attrs)*
-        #[doc = #doc_str]
+        #fallback_doc
         #vis struct #name<'a> {
             #(#handler_fields,)*
             address: ::alloy_primitives::Address,

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -92,6 +92,7 @@ impl Parse for PrecompileConfig {
         let mut storage = None;
         let mut macro_path = None;
         let mut args = Vec::new();
+        let mut args_seen = false;
         let mut install = None;
 
         while !input.is_empty() {
@@ -113,9 +114,10 @@ impl Parse for PrecompileConfig {
                     macro_path = Some(input.parse()?);
                 }
                 "args" => {
-                    if !args.is_empty() {
+                    if args_seen {
                         return Err(syn::Error::new_spanned(key, "duplicate `args` option"));
                     }
+                    args_seen = true;
                     let content;
                     parenthesized!(content in input);
                     args = content
@@ -293,5 +295,19 @@ mod tests {
         let err = parse_config(quote! { install(addr = X, extra) }).err().unwrap();
 
         assert!(err.to_string().contains("unexpected `install` option"));
+    }
+
+    #[test]
+    fn config_rejects_duplicate_empty_args() {
+        let err = parse_config(quote! { args(), args() }).err().unwrap();
+
+        assert!(err.to_string().contains("duplicate `args` option"));
+    }
+
+    #[test]
+    fn config_rejects_duplicate_args_where_first_is_empty() {
+        let err = parse_config(quote! { args(), args(x: u8) }).err().unwrap();
+
+        assert!(err.to_string().contains("duplicate `args` option"));
     }
 }

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -26,6 +26,7 @@ base-precompile-macros.workspace = true
 
 # misc
 thiserror.workspace = true
+tracing.workspace = true
 derive_more = { workspace = true, features = ["from", "try_into"] }
 
 [dev-dependencies]
@@ -46,5 +47,6 @@ std = [
 	"derive_more/std",
 	"revm/std",
 	"thiserror/std",
+	"tracing/std",
 ]
 test-utils = [ "std" ]

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -98,31 +98,24 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         // Yellow Paper G_codedeposit: 200 gas per byte of deployed bytecode.
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
-        let (is_new_account, has_empty_code) = {
+        // Charge CREATE equivalent costs whenever code is written to an account that had no code,
+        // regardless of its balance. A prefunded account (balance > 0, no code) passes the
+        // factory's collision check (which only rejects accounts that already have code), but
+        // must still pay G_create and the keccak hash cost.
+        let is_new_code = {
             let state_load = self
                 .internals
                 .load_account(address)
                 .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-            let info = &state_load.data.info;
-            (info.is_empty(), info.is_empty_code_hash())
+            state_load.data.info.is_empty_code_hash()
         };
 
-        if has_empty_code {
+        if is_new_code {
             // Yellow Paper G_create: base cost for creating a new contract account.
             self.deduct_gas(self.gas_params.create_cost())?;
             // Yellow Paper G_sha3 + G_sha3word: cost of computing the stored code hash.
             let num_words = code_len.div_ceil(32) as u64;
             self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
-        }
-        if is_new_account {
-            // EIP-8037: charge for the new account entry in the state trie.
-            self.deduct_state_gas(self.gas_params.create_state_gas())?;
-        }
-        if has_empty_code {
-            // EIP-8037: charge for depositing code into an account whose code slot is
-            // currently empty. Applies to both new accounts and existent accounts that
-            // have only a nonzero balance or nonce (no prior code).
-            self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }
 
         self.internals

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -156,19 +156,30 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
-        let s = self
-            .internals
-            .sload(address, key)
-            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+        let checkpoint = self.internals.checkpoint();
+        let result = (|| {
+            let s = self
+                .internals
+                .sload(address, key)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
 
-        // EIP-2929: warm base cost always charged
-        self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-        // dynamic cold penalty
-        if s.is_cold {
-            self.deduct_gas(self.gas_params.cold_storage_additional_cost())?;
+            // EIP-2929: warm base cost always charged
+            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+            // dynamic cold penalty
+            if s.is_cold {
+                self.deduct_gas(self.gas_params.cold_storage_additional_cost())?;
+            }
+
+            Ok(s.data)
+        })();
+
+        if result.is_ok() {
+            self.internals.checkpoint_commit();
+        } else {
+            self.internals.checkpoint_revert(checkpoint);
         }
 
-        Ok(s.data)
+        result
     }
 
     fn tload(&mut self, address: Address, key: U256) -> Result<U256> {
@@ -409,8 +420,65 @@ mod tests {
         }
     }
 
-    /// `set_code` on a brand-new account must charge both `create_state_gas` and
-    /// `code_deposit_state_gas` against the state-gas counter.
+    /// An OOG `sload` must not leave the slot warmed in the journal.
+    ///
+    /// We give the provider exactly `warm_storage_read_cost - 1` gas so that the
+    /// cold read fails (it cannot even afford the warm base cost). A second provider
+    /// with unlimited gas then reads the same slot: if the journal still carries the
+    /// spurious warm entry the second read would be charged only `warm_storage_read_cost`,
+    /// but the slot was never successfully accessed so it must still be cold.
+    #[test]
+    fn sload_oog_does_not_warm_slot() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let address = Address::repeat_byte(0x77);
+        let key = U256::from(5);
+
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+
+        // First provider: gas just below warm_storage_read_cost → OOG on sload.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: gas_params.warm_storage_read_cost() - 1,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(provider.sload(address, key), Err(BasePrecompileError::OutOfGas));
+        }
+
+        // Second provider: unlimited gas. The slot must still be cold, so the full
+        // cold read cost (warm_base + cold_additional) must be charged.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(provider.sload(address, key).unwrap(), U256::ZERO);
+            assert_eq!(
+                provider.gas_used(),
+                gas_params
+                    .warm_storage_read_cost()
+                    .saturating_add(gas_params.cold_storage_additional_cost()),
+                "slot must still be cold after a failed OOG read"
+            );
+        }
+    }
+
+    /// `set_code` in a static context returns `StaticCallViolation` before any gas is charged.
     #[test]
     fn set_code_new_account_charges_create_and_deposit_state_gas() {
         let mut provider = amsterdam_provider();

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -332,7 +332,8 @@ mod tests {
     };
 
     use crate::{
-        BasePrecompileError, hashmap::HashMapStorageProvider, provider::PrecompileStorageProvider,
+        error::BasePrecompileError, hashmap::HashMapStorageProvider,
+        provider::PrecompileStorageProvider,
     };
 
     fn amsterdam_provider() -> HashMapStorageProvider {
@@ -341,21 +342,51 @@ mod tests {
         provider
     }
 
-    /// The EIP-2200 stipend guard in [`super::EvmPrecompileStorageProvider::sstore`] compares
-    /// `gas.remaining()` against `gas_params.call_stipend()`. This test verifies that the
-    /// call stipend constant returned by `GasParams` is exactly 2300, as required by EIP-2200.
-    ///
-    /// Unit tests cannot directly instantiate [`super::EvmPrecompileStorageProvider`] because
-    /// it requires a live EVM journal via `PrecompileInput`. The stipend guard is therefore not
-    /// exercisable in isolation here. Full coverage of the guard at runtime is provided by the
-    /// B20 fork tests that forward exactly 2300 gas into a stateful precompile call.
+    fn make_evm_provider<'a>(
+        ctx: &'a mut EthEvmContext<EmptyDB>,
+        gas_params: GasParams,
+        gas: u64,
+        is_static: bool,
+    ) -> super::EvmPrecompileStorageProvider<'a> {
+        let input = PrecompileInput {
+            data: &[],
+            gas,
+            reservoir: 0,
+            caller: Address::ZERO,
+            value: U256::ZERO,
+            target_address: Address::ZERO,
+            is_static,
+            bytecode_address: Address::ZERO,
+            internals: EvmInternals::from_context(ctx),
+        };
+        super::EvmPrecompileStorageProvider::new(input, gas_params)
+    }
+
+    /// EIP-2200 stipend boundary: `remaining == call_stipend` (2300) must block.
     #[test]
-    fn eip_2200_stipend_guard_constant_is_2300() {
-        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+    fn sstore_oog_at_call_stipend_boundary() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            make_evm_provider(&mut ctx, gas_params.clone(), gas_params.call_stipend(), false);
+
         assert_eq!(
-            gas_params.call_stipend(),
-            2300,
-            "call_stipend must equal 2300 as required by EIP-2200"
+            provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)),
+            Err(BasePrecompileError::OutOfGas),
+        );
+    }
+
+    /// Below the stipend (2299): also blocked.
+    #[test]
+    fn sstore_oog_below_call_stipend() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            make_evm_provider(&mut ctx, gas_params.clone(), gas_params.call_stipend() - 1, false);
+
+        assert_eq!(
+            provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)),
+            Err(BasePrecompileError::OutOfGas),
         );
     }
 
@@ -430,36 +461,20 @@ mod tests {
 
         // First provider: gas just below warm_storage_read_cost → OOG on sload.
         {
-            let input = PrecompileInput {
-                data: &[],
-                gas: gas_params.warm_storage_read_cost() - 1,
-                reservoir: 0,
-                caller: Address::ZERO,
-                value: U256::ZERO,
-                target_address: address,
-                is_static: false,
-                bytecode_address: address,
-                internals: EvmInternals::from_context(&mut ctx),
-            };
-            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            let mut provider = make_evm_provider(
+                &mut ctx,
+                gas_params.clone(),
+                gas_params.warm_storage_read_cost() - 1,
+                false,
+            );
             assert_eq!(provider.sload(address, key), Err(BasePrecompileError::OutOfGas));
         }
 
         // Second provider: unlimited gas. The slot must still be cold, so the full
         // cold read cost (warm_base + cold_additional) must be charged.
         {
-            let input = PrecompileInput {
-                data: &[],
-                gas: u64::MAX,
-                reservoir: 0,
-                caller: Address::ZERO,
-                value: U256::ZERO,
-                target_address: address,
-                is_static: false,
-                bytecode_address: address,
-                internals: EvmInternals::from_context(&mut ctx),
-            };
-            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            let mut provider =
+                make_evm_provider(&mut ctx, gas_params.clone(), u64::MAX, false);
             assert_eq!(provider.sload(address, key).unwrap(), U256::ZERO);
             assert_eq!(
                 provider.gas_used(),

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -390,6 +390,33 @@ mod tests {
         );
     }
 
+    /// Strictly above the stipend: guard passes, sstore completes.
+    #[test]
+    fn sstore_allowed_above_call_stipend() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        // Large margin covers the stipend guard + cold sstore costs (~2600 gas).
+        let gas = gas_params.call_stipend() + 1_000_000;
+        let mut provider = make_evm_provider(&mut ctx, gas_params, gas, false);
+
+        assert!(provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)).is_ok());
+    }
+
+    /// Static-call violation is checked before the stipend guard.
+    #[test]
+    fn sstore_static_violation_checked_before_stipend_guard() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        // Gas at stipend boundary — both guards would fire, static takes priority.
+        let mut provider =
+            make_evm_provider(&mut ctx, gas_params.clone(), gas_params.call_stipend(), true);
+
+        assert_eq!(
+            provider.sstore(Address::ZERO, U256::ZERO, U256::from(1u64)),
+            Err(BasePrecompileError::StaticCallViolation),
+        );
+    }
+
     #[test]
     fn sstore_oog_reverts_local_journal_mutation() {
         let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
@@ -461,20 +488,36 @@ mod tests {
 
         // First provider: gas just below warm_storage_read_cost → OOG on sload.
         {
-            let mut provider = make_evm_provider(
-                &mut ctx,
-                gas_params.clone(),
-                gas_params.warm_storage_read_cost() - 1,
-                false,
-            );
+            let input = PrecompileInput {
+                data: &[],
+                gas: gas_params.warm_storage_read_cost() - 1,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
             assert_eq!(provider.sload(address, key), Err(BasePrecompileError::OutOfGas));
         }
 
         // Second provider: unlimited gas. The slot must still be cold, so the full
         // cold read cost (warm_base + cold_additional) must be charged.
         {
-            let mut provider =
-                make_evm_provider(&mut ctx, gas_params.clone(), u64::MAX, false);
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
             assert_eq!(provider.sload(address, key).unwrap(), U256::ZERO);
             assert_eq!(
                 provider.gas_used(),
@@ -488,46 +531,23 @@ mod tests {
 
     /// `set_code` in a static context returns `StaticCallViolation` before any gas is charged.
     #[test]
-    fn set_code_new_account_charges_create_and_deposit_state_gas() {
-        let mut provider = amsterdam_provider();
-        let addr = Address::from([0x42u8; 20]);
-        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
-        let code_len = code.len();
-        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+    fn set_code_static_violation_before_gas_charge() {
+        let gas_params = GasParams::default();
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let gas = 1_000_000;
+        let mut provider = make_evm_provider(&mut ctx, gas_params, gas, true);
 
-        provider.set_code(addr, code).unwrap();
-
-        let expected = gas_params.create_state_gas() + gas_params.code_deposit_state_gas(code_len);
-        assert!(expected > 0, "AMSTERDAM state gas must be non-zero");
-        assert_eq!(provider.state_gas_used(), expected);
-    }
-
-    /// `set_code` on a balance-only account (nonzero balance, no code) must charge
-    /// `code_deposit_state_gas` but not `create_state_gas`. This covers the attack where
-    /// a caller prefunds a future token address before calling the factory.
-    #[test]
-    fn set_code_balance_only_account_charges_code_deposit_state_gas_only() {
-        let mut provider = amsterdam_provider();
-        let addr = Address::from([0x42u8; 20]);
-        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
-        let code_len = code.len();
-        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
-
-        // Simulate a prefunded account: has balance but no code.
-        provider.set_balance(addr, U256::from(1u64));
-
-        provider.set_code(addr, code).unwrap();
-
-        let expected = gas_params.code_deposit_state_gas(code_len);
         assert_eq!(
-            provider.state_gas_used(),
-            expected,
-            "balance-only account must pay code_deposit_state_gas but not create_state_gas"
+            provider.set_code(Address::ZERO, Bytecode::new_raw([0x60u8, 0x00].as_ref().into())),
+            Err(BasePrecompileError::StaticCallViolation),
         );
+        // No gas must have been consumed.
+        assert_eq!(provider.gas_used(), 0);
     }
 
-    /// `set_code` on a prefunded account (balance > 0, no code) must charge the same regular gas
-    /// as a fully empty account.
+    /// `set_code` on a prefunded account (balance > 0, no code) must charge the same gas
+    /// as a fully empty account. Before the fix, `is_empty()` returned false for prefunded
+    /// accounts, silently skipping `G_create` and the keccak hash cost (~32 036 gas).
     #[test]
     fn set_code_prefunded_account_charges_same_gas_as_empty_account() {
         let addr = Address::from([0x43u8; 20]);
@@ -545,34 +565,31 @@ mod tests {
         assert!(gas_for_empty > 0, "set_code must charge non-zero gas");
         assert_eq!(
             gas_for_empty, gas_for_prefunded,
-            "prefunded account must pay identical regular gas to an empty account"
+            "prefunded account must pay identical gas to an empty account"
         );
     }
 
-    /// `set_code` on an already-initialised account must NOT charge any additional
-    /// state gas (the account and its metadata already exist in the trie).
+    /// `set_code` on an account that already has code must replace it without error.
     #[test]
-    fn set_code_existing_account_skips_state_gas() {
+    fn set_code_existing_account_replaces_code() {
         let mut provider = amsterdam_provider();
         let addr = Address::from([0x42u8; 20]);
-        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        let code1 = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        let code2 = Bytecode::new_raw([0x60u8, 0x01].as_ref().into());
+        let expected_hash = code2.hash_slow();
 
-        // First call creates the account and charges state gas.
-        provider.set_code(addr, code.clone()).unwrap();
-        let after_first = provider.state_gas_used();
-        assert!(after_first > 0);
+        provider.set_code(addr, code1).unwrap();
+        provider.set_code(addr, code2).unwrap();
 
-        // Second call updates an existing account; state gas must not increase.
-        provider.set_code(addr, code).unwrap();
         assert_eq!(
-            provider.state_gas_used(),
-            after_first,
-            "state_gas_used must not increase for an existing account"
+            provider.get_account_info(addr).map(|i| i.code_hash),
+            Some(expected_hash),
+            "second set_code must replace the stored code hash"
         );
     }
 
     #[test]
-    fn set_code_static_context_reverts_before_state_gas_or_code_mutation() {
+    fn set_code_static_context_reverts_before_code_mutation() {
         let mut provider = amsterdam_provider();
         provider.set_static(true);
         let addr = Address::from([0x42u8; 20]);
@@ -581,7 +598,6 @@ mod tests {
         let err = provider.set_code(addr, code).unwrap_err();
 
         assert_eq!(err, BasePrecompileError::StaticCallViolation);
-        assert_eq!(provider.state_gas_used(), 0);
         assert!(provider.get_account_info(addr).is_none());
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -105,8 +105,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
 
         let code_len = code.len();
-        let is_new_code =
-            self.accounts.get(&address).is_none_or(|info| info.is_empty_code_hash());
+        let is_new_code = self.accounts.get(&address).is_none_or(|info| info.is_empty_code_hash());
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
         if is_new_code {
@@ -533,9 +532,9 @@ mod tests {
     #[test]
     fn checkpoint_commit_does_not_revert_mutations() {
         let mut p = HashMapStorageProvider::new(1);
-        let cp = p.checkpoint();
+        p.checkpoint();
         p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
-        p.checkpoint_commit(cp);
+        p.checkpoint_commit();
         assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -105,21 +105,14 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
 
         let code_len = code.len();
-        let is_new_account = self.accounts.get(&address).is_none_or(AccountInfo::is_empty);
-        let has_empty_code =
+        let is_new_code =
             self.accounts.get(&address).is_none_or(|info| info.is_empty_code_hash());
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
-        if has_empty_code {
+        if is_new_code {
             self.deduct_gas(self.gas_params.create_cost())?;
             let num_words = code_len.div_ceil(32) as u64;
             self.deduct_gas(KECCAK256.saturating_add(KECCAK256WORD.saturating_mul(num_words)))?;
-        }
-        if is_new_account {
-            self.deduct_state_gas(self.gas_params.create_state_gas())?;
-        }
-        if has_empty_code {
-            self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
         }
 
         let account = self.accounts.entry(address).or_default();

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -41,7 +41,11 @@ pub struct HashMapStorageProvider {
 #[derive(Debug)]
 struct Snapshot {
     internals: HashMap<(Address, U256), U256>,
+    transient: HashMap<(Address, U256), U256>,
+    accounts: HashMap<Address, AccountInfo>,
     events: HashMap<Address, Vec<LogData>>,
+    gas_refunded: i64,
+    state_gas_used: u64,
 }
 
 impl HashMapStorageProvider {
@@ -249,8 +253,14 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn checkpoint(&mut self) -> JournalCheckpoint {
         let idx = self.snapshots.len();
-        self.snapshots
-            .push(Snapshot { internals: self.internals.clone(), events: self.events.clone() });
+        self.snapshots.push(Snapshot {
+            internals: self.internals.clone(),
+            transient: self.transient.clone(),
+            accounts: self.accounts.clone(),
+            events: self.events.clone(),
+            gas_refunded: self.gas_refunded,
+            state_gas_used: self.state_gas_used,
+        });
         JournalCheckpoint { log_i: 0, journal_i: idx, selfdestructed_i: 0 }
     }
 
@@ -267,7 +277,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         );
         if let Some(snapshot) = self.snapshots.drain(checkpoint.journal_i..).next() {
             self.internals = snapshot.internals;
+            self.transient = snapshot.transient;
+            self.accounts = snapshot.accounts;
             self.events = snapshot.events;
+            self.gas_refunded = snapshot.gas_refunded;
+            self.state_gas_used = snapshot.state_gas_used;
         }
     }
 }
@@ -447,5 +461,88 @@ mod tests {
         let mut p = HashMapStorageProvider::new(1);
         p.sstore(ADDR, KEY, U256::from(99u64)).unwrap();
         assert_eq!(p.gas_refunded(), 0);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_internals() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.sstore(ADDR, KEY, U256::from(1u64)).unwrap();
+        let cp = p.checkpoint();
+        p.sstore(ADDR, KEY, U256::from(2u64)).unwrap();
+        p.checkpoint_revert(cp);
+        assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(1u64));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_transient() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.tstore(ADDR, KEY, U256::from(10u64)).unwrap();
+        let cp = p.checkpoint();
+        p.tstore(ADDR, KEY, U256::from(99u64)).unwrap();
+        p.checkpoint_revert(cp);
+        assert_eq!(p.tload(ADDR, KEY).unwrap(), U256::from(10u64));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_accounts() {
+        let mut p = HashMapStorageProvider::new(1);
+        let code_before = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        p.set_code(ADDR, code_before.clone()).unwrap();
+        let cp = p.checkpoint();
+        let code_after = Bytecode::new_raw([0x60u8, 0x01].as_ref().into());
+        p.set_code(ADDR, code_after).unwrap();
+        p.checkpoint_revert(cp);
+        let mut seen_hash = None;
+        p.with_account_info(ADDR, &mut |info| {
+            seen_hash = Some(info.code_hash);
+        })
+        .unwrap();
+        assert_eq!(seen_hash.unwrap(), code_before.hash_slow());
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_events() {
+        use alloy_primitives::Bytes;
+        let mut p = HashMapStorageProvider::new(1);
+        let event_before = LogData::new_unchecked(vec![], Bytes::from_static(b"before"));
+        p.emit_event(ADDR, event_before).unwrap();
+        let cp = p.checkpoint();
+        let event_after = LogData::new_unchecked(vec![], Bytes::from_static(b"after"));
+        p.emit_event(ADDR, event_after).unwrap();
+        p.checkpoint_revert(cp);
+        let events = p.get_events(ADDR);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, Bytes::from_static(b"before"));
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_gas_refunded() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.refund_gas(1_000);
+        let cp = p.checkpoint();
+        p.refund_gas(500);
+        assert_eq!(p.gas_refunded(), 1_500);
+        p.checkpoint_revert(cp);
+        assert_eq!(p.gas_refunded(), 1_000);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_state_gas_used() {
+        let mut p = HashMapStorageProvider::new(1);
+        p.deduct_state_gas(100).unwrap();
+        let cp = p.checkpoint();
+        p.deduct_state_gas(50).unwrap();
+        assert_eq!(p.state_gas_used(), 150);
+        p.checkpoint_revert(cp);
+        assert_eq!(p.state_gas_used(), 100);
+    }
+
+    #[test]
+    fn checkpoint_commit_does_not_revert_mutations() {
+        let mut p = HashMapStorageProvider::new(1);
+        let cp = p.checkpoint();
+        p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
+        p.checkpoint_commit(cp);
+        assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -178,10 +178,8 @@ impl<'a> StorageCtx<'a> {
     /// Executes `f` with a temporary caller override, restoring the previous caller on exit.
     pub fn with_caller<R>(&self, caller: Address, f: impl FnOnce() -> R) -> R {
         let previous = self.with_storage(|s| s.replace_caller(caller));
-        let guard = CallerGuard { storage: *self, previous: Some(previous) };
-        let result = f();
-        drop(guard);
-        result
+        let _guard = CallerGuard { storage: *self, previous: Some(previous) };
+        f()
     }
 
     /// Deducts gas from the remaining gas, returning `OutOfGas` if insufficient.
@@ -264,9 +262,14 @@ struct CallerGuard<'a> {
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
         if let Some(previous) = self.previous.take() {
-            self.storage.with_storage(|s| {
-                s.replace_caller(previous);
-            });
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => {
+                    guard.replace_caller(previous);
+                }
+                Err(_) => tracing::warn!(
+                    "skipping caller restore: RefCell already borrowed (likely during unwind)"
+                ),
+            }
         }
     }
 }
@@ -283,6 +286,11 @@ pub struct CheckpointGuard<'a> {
 
 impl CheckpointGuard<'_> {
     /// Commits all state changes since the checkpoint.
+    ///
+    /// Uses `borrow_mut` (panicking) intentionally: `commit` is an explicit
+    /// caller action, so a conflicting borrow here is a logic bug that should
+    /// surface loudly. Contrast with `drop` below, which uses `try_borrow_mut`
+    /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
         if self.checkpoint.take().is_some() {
             self.storage.with_storage(|s| s.checkpoint_commit());
@@ -293,7 +301,12 @@ impl CheckpointGuard<'_> {
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
         if let Some(cp) = self.checkpoint.take() {
-            self.storage.with_storage(|s| s.checkpoint_revert(cp));
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => guard.checkpoint_revert(cp),
+                Err(_) => tracing::warn!(
+                    "skipping checkpoint revert: RefCell already borrowed (likely during unwind)"
+                ),
+            }
         }
     }
 }

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -83,11 +83,14 @@ impl<'a, T: StorableType, const N: usize> ArrayHandler<'a, T, N> {
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = packing::calc_element_loc(index, T::BYTES);
             (
-                base_slot + U256::from(location.offset_slots),
+                base_slot.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
-            (base_slot + U256::from(index * T::SLOTS), LayoutCtx::FULL)
+            (
+                base_slot.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                LayoutCtx::FULL,
+            )
         };
         T::handle(slot, layout_ctx, address, storage)
     }

--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -194,7 +194,8 @@ where
         let mut data = Vec::new();
 
         for i in 0..chunks {
-            let slot = slot_start + U256::from(i);
+            let slot =
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_value = storage.load(slot)?;
             let chunk_bytes = chunk_value.to_be_bytes::<32>();
             let bytes_to_take = if i == chunks - 1 { length - (i * 32) } else { 32 };
@@ -219,7 +220,8 @@ fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U25
         let chunks = calc_chunks(length);
 
         for i in 0..chunks {
-            let slot = slot_start + U256::from(i);
+            let slot =
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_start = i * 32;
             let chunk_end = (chunk_start + 32).min(length);
             let chunk = &bytes[chunk_start..chunk_end];
@@ -242,7 +244,10 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
         let slot_start = calc_data_slot(base_slot);
         let chunks = calc_chunks(length);
         for i in 0..chunks {
-            storage.store(slot_start + U256::from(i), U256::ZERO)?;
+            storage.store(
+                slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?,
+                U256::ZERO,
+            )?;
         }
     }
 

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -134,7 +134,9 @@ where
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         let values: Vec<T> = Vec::load(storage, slot, LayoutCtx::FULL)?;
         for value in values {
-            let pos_slot = value.mapping_slot(slot + U256::ONE);
+            let pos_slot = value.mapping_slot(
+                slot.checked_add(U256::ONE).ok_or(BasePrecompileError::SlotOverflow)?,
+            );
             <U256 as Storable>::delete(storage, pos_slot, LayoutCtx::FULL)?;
         }
         <Vec<T> as Storable>::delete(storage, slot, ctx)
@@ -154,10 +156,14 @@ where
     T: Storable + StorageKey + Eq + Clone + Ord,
 {
     /// Creates a new handler for the set at the given base slot.
-    pub fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
+    pub const fn new(base_slot: U256, address: Address, storage: crate::StorageCtx<'a>) -> Self {
         Self {
             values: VecHandler::new(base_slot, address, storage),
-            positions: MappingHandler::new(base_slot + U256::ONE, address, storage),
+            positions: MappingHandler::new(
+                base_slot.checked_add(U256::ONE).expect("slot overflow"),
+                address,
+                storage,
+            ),
             base_slot,
             address,
             storage,

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -386,7 +386,20 @@ mod tests {
             }
         });
     }
-    /// (`initial_size`, `final_size`) - covers grow, shrink, and equal-size rewrite.
+    #[test]
+    fn test_set_transient_methods_return_err() {
+        let (mut storage, contract_addr) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let base = U256::from(800u64);
+            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
+
+            assert!(handler.t_read().is_err());
+            assert!(handler.t_write(Set::default()).is_err());
+            assert!(handler.t_delete().is_err());
+        });
+    }
+
+    /// (`initial_size`, `final_size`) — covers grow, shrink, and equal-size rewrite.
     #[rstest]
     #[case(3, 7)] // grow
     #[case(7, 3)] // shrink
@@ -418,16 +431,4 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_set_transient_methods_return_err() {
-        let (mut storage, contract_addr) = setup_storage();
-        StorageCtx::enter(&mut storage, |ctx| {
-            let base = U256::from(800u64);
-            let mut handler = SetHandler::<Address>::new(base, contract_addr, ctx);
-
-            assert!(handler.t_read().is_err());
-            assert!(handler.t_write(Set::default()).is_err());
-            assert!(handler.t_delete().is_err());
-        });
-    }
 }

--- a/crates/common/precompile-storage/src/types/slot.rs
+++ b/crates/common/precompile-storage/src/types/slot.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use alloy_primitives::{Address, U256};
 
 use crate::{
-    error::Result,
+    error::{BasePrecompileError, Result},
     packing::FieldLocation,
     provider::{Handler, LayoutCtx, Storable, StorableType, StorageOps},
     storage_ctx::StorageCtx,
@@ -41,19 +41,21 @@ impl<'a, T> Slot<'a, T> {
 
     /// Creates a full-slot accessor at `base_slot + offset_slots`.
     #[inline]
-    pub const fn new_at_offset(
+    pub fn new_at_offset(
         base_slot: U256,
         offset_slots: usize,
         address: Address,
         storage: StorageCtx<'a>,
-    ) -> Self {
-        Self {
-            slot: base_slot.saturating_add(U256::from_limbs([offset_slots as u64, 0, 0, 0])),
+    ) -> Result<Self> {
+        Ok(Self {
+            slot: base_slot
+                .checked_add(U256::from_limbs([offset_slots as u64, 0, 0, 0]))
+                .ok_or(BasePrecompileError::SlotOverflow)?,
             ctx: LayoutCtx::FULL,
             address,
             storage,
             _ty: PhantomData,
-        }
+        })
     }
 
     /// Creates a packed-field accessor using a [`FieldLocation`] from `#[derive(Storable)]`.
@@ -63,18 +65,20 @@ impl<'a, T> Slot<'a, T> {
         loc: FieldLocation,
         address: Address,
         storage: StorageCtx<'a>,
-    ) -> Self
+    ) -> Result<Self>
     where
         T: StorableType,
     {
         debug_assert!(T::IS_PACKABLE, "`fn new_at_loc` can only be used with packable types");
-        Self {
-            slot: base_slot.saturating_add(U256::from_limbs([loc.offset_slots as u64, 0, 0, 0])),
+        Ok(Self {
+            slot: base_slot
+                .checked_add(U256::from_limbs([loc.offset_slots as u64, 0, 0, 0]))
+                .ok_or(BasePrecompileError::SlotOverflow)?,
             ctx: LayoutCtx::packed(loc.offset_bytes),
             address,
             storage,
             _ty: PhantomData,
-        }
+        })
     }
 
     /// Returns the storage slot number.
@@ -249,7 +253,7 @@ mod tests {
             let base = pair_key.mapping_slot(U256::ZERO);
             let test_addr = Address::from([0x22; 20]);
 
-            let mut slot = Slot::<Address>::new_at_offset(base, 0, address, ctx);
+            let mut slot = Slot::<Address>::new_at_offset(base, 0, address, ctx)?;
             slot.write(test_addr)?;
             assert_eq!(slot.read()?, test_addr);
             slot.delete()?;

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, U256, keccak256};
 
 use crate::{
     error::{BasePrecompileError, Result},
-    packing::{PackedSlot, calc_element_loc, calc_packed_slot_count},
+    packing::{PackedSlot, calc_element_loc, calc_packed_slot_count, create_element_mask},
     provider::{Handler, Layout, LayoutCtx, Storable, StorableType, StorageOps},
     types::{HandlerCache, Slot},
 };
@@ -250,6 +250,82 @@ where
         let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
         length_slot.write(U256::from(last_index))?;
         Ok(Some(element))
+    }
+
+    /// Shortens the vector to `new_len` elements, clearing all vacated storage slots.
+    ///
+    /// If `new_len` is greater than or equal to the current length, this has no effect.
+    /// Each element slot is explicitly zeroed before the length counter is decremented,
+    /// preventing stale tail data from being exposed by a future length-slot corruption.
+    ///
+    /// For packed element types (`T::BYTES <= 16`), elements in the "boundary" slot (the
+    /// last slot that contains both kept and removed elements) are cleared individually
+    /// using read-modify-write. Slots that are fully removed are zeroed in a single store.
+    pub fn truncate(&self, new_len: usize) -> Result<()>
+    where
+        T: Storable,
+        T::Handler<'a>: Handler<T>,
+    {
+        let old_len = self.len()?;
+        if new_len >= old_len {
+            return Ok(());
+        }
+        let data_start = self.data_slot();
+        if T::BYTES <= 16 {
+            let elems_per_slot = 32 / T::BYTES;
+            // `first_full_tail_slot` is the index of the first slot that contains only
+            // elements being removed (no kept elements). Slots before it may contain a
+            // mix of kept and removed elements and require element-by-element clearing.
+            let first_full_tail_slot = new_len.div_ceil(elems_per_slot);
+
+            // Clear elements in the partial boundary slot (if any) with a single
+            // SLOAD + mask + SSTORE. These elements share the slot with kept elements,
+            // so we compute one combined clear-mask for all removed positions and apply
+            // it in one read-modify-write rather than one per element.
+            let boundary_slot_end = (first_full_tail_slot * elems_per_slot).min(old_len);
+            if boundary_slot_end > new_len {
+                let boundary_slot_addr = data_start + U256::from(new_len / elems_per_slot);
+                let current = self.storage.sload(self.address, boundary_slot_addr)?;
+                let mut combined_clear_mask = U256::ZERO;
+                for index in new_len..boundary_slot_end {
+                    let byte_offset = (index % elems_per_slot) * T::BYTES;
+                    combined_clear_mask |= create_element_mask(T::BYTES) << (byte_offset * 8);
+                }
+                self.storage.sstore(
+                    self.address,
+                    boundary_slot_addr,
+                    current & !combined_clear_mask,
+                )?;
+            }
+
+            // Zero all fully-removed tail slots in a single store each.
+            let last_slot = calc_packed_slot_count(old_len, T::BYTES);
+            for slot_idx in first_full_tail_slot..last_slot {
+                let slot_addr = data_start + U256::from(slot_idx);
+                self.storage.sstore(self.address, slot_addr, U256::ZERO)?;
+            }
+        } else {
+            // Unpacked types: each element occupies one or more full slots;
+            // delegate to the element handler's delete to zero every occupied slot.
+            for index in new_len..old_len {
+                let mut elem = Self::compute_handler(data_start, self.address, self.storage, index);
+                elem.delete()?;
+            }
+        }
+        // Update the length counter only after all vacated slots are cleared.
+        let mut length_slot = Slot::<U256>::new(self.len_slot, self.address, self.storage);
+        length_slot.write(U256::from(new_len))
+    }
+
+    /// Clears the vector, removing all elements and zeroing all data slots.
+    ///
+    /// Equivalent to `truncate(0)`. Matches Solidity's `delete arr` semantics.
+    pub fn clear(&self) -> Result<()>
+    where
+        T: Storable,
+        T::Handler<'a>: Handler<T>,
+    {
+        self.truncate(0)
     }
 }
 
@@ -527,6 +603,146 @@ mod tests {
 
             len_slot.write(U256::from(u32::MAX as u64 + 1)).unwrap();
             assert_eq!(handler.len(), Err(BasePrecompileError::under_overflow()));
+        });
+    }
+
+    #[test]
+    fn test_vec_truncate_unpacked() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(400u64);
+            let handler = VecHandler::<U256>::new(len_slot, address, ctx);
+
+            let vals: Vec<U256> = (0..5).map(U256::from).collect();
+            for &v in &vals {
+                handler.push(v).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 5);
+
+            // truncate to 3 — elements 3 and 4 should be cleared.
+            handler.truncate(3).unwrap();
+            assert_eq!(handler.len().unwrap(), 3);
+
+            let data_start = calc_data_slot(len_slot);
+            let slot3 = U256::handle(data_start + U256::from(3), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            let slot4 = U256::handle(data_start + U256::from(4), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            assert_eq!(slot3, U256::ZERO, "vacated slot 3 must be cleared");
+            assert_eq!(slot4, U256::ZERO, "vacated slot 4 must be cleared");
+
+            // remaining elements are intact.
+            for i in 0..3 {
+                assert_eq!(handler.at(i).unwrap().unwrap().read().unwrap(), U256::from(i));
+            }
+
+            // truncate past current length is a no-op.
+            handler.truncate(10).unwrap();
+            assert_eq!(handler.len().unwrap(), 3);
+        });
+    }
+
+    #[test]
+    fn test_vec_truncate_packed_boundary_slot() {
+        // Vec<u8>: 32 elements per slot.  Push 35 elements; truncate to 33.
+        // Slot 0 (indices 0-31): fully kept.
+        // Slot 1 (indices 32-34): index 32 kept, indices 33-34 cleared individually.
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(500u64);
+            let handler = VecHandler::<u8>::new(len_slot, address, ctx);
+
+            for i in 0u8..35 {
+                handler.push(i).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 35);
+
+            handler.truncate(33).unwrap();
+            assert_eq!(handler.len().unwrap(), 33);
+
+            // Slot 1 must still contain element 32 (offset 0) and have bytes 1-2 cleared.
+            let data_start = calc_data_slot(len_slot);
+            let slot1 = U256::handle(data_start + U256::from(1), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            // Only byte 0 (element 32 = 0x20) should survive.
+            let expected = gen_word_from(&["0x20"]);
+            assert_eq!(slot1, expected, "boundary slot must retain element 32 only");
+        });
+    }
+
+    #[test]
+    fn test_vec_truncate_packed_full_tail_slots() {
+        // Vec<u8>: 32 elements per slot.  Push 65 elements; truncate to 32.
+        // Slot 0 (indices 0-31): fully kept.
+        // Slot 1 (indices 32-63): fully removed — zeroed in one store.
+        // Slot 2 (index 64): fully removed — zeroed in one store.
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(600u64);
+            let handler = VecHandler::<u8>::new(len_slot, address, ctx);
+
+            for i in 0u8..65 {
+                handler.push(i).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 65);
+
+            handler.truncate(32).unwrap();
+            assert_eq!(handler.len().unwrap(), 32);
+
+            let data_start = calc_data_slot(len_slot);
+            let slot1 = U256::handle(data_start + U256::from(1), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            let slot2 = U256::handle(data_start + U256::from(2), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            assert_eq!(slot1, U256::ZERO, "fully-removed slot 1 must be zeroed");
+            assert_eq!(slot2, U256::ZERO, "fully-removed slot 2 must be zeroed");
+
+            // slot 0 must be fully intact.
+            let slot0 = U256::handle(data_start, LayoutCtx::FULL, address, ctx).read().unwrap();
+            let expected = gen_word_from(&[
+                "0x1f", "0x1e", "0x1d", "0x1c", "0x1b", "0x1a", "0x19", "0x18", "0x17", "0x16",
+                "0x15", "0x14", "0x13", "0x12", "0x11", "0x10", "0x0f", "0x0e", "0x0d", "0x0c",
+                "0x0b", "0x0a", "0x09", "0x08", "0x07", "0x06", "0x05", "0x04", "0x03", "0x02",
+                "0x01", "0x00",
+            ]);
+            assert_eq!(slot0, expected, "slot 0 must be fully intact after truncate");
+        });
+    }
+
+    #[test]
+    fn test_vec_clear() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(700u64);
+            let handler = VecHandler::<U256>::new(len_slot, address, ctx);
+
+            for i in 0u64..4 {
+                handler.push(U256::from(i)).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 4);
+
+            handler.clear().unwrap();
+            assert_eq!(handler.len().unwrap(), 0);
+            assert!(handler.is_empty().unwrap());
+
+            let data_start = calc_data_slot(len_slot);
+            for i in 0u64..4 {
+                let slot_val =
+                    U256::handle(data_start + U256::from(i), LayoutCtx::FULL, address, ctx)
+                        .read()
+                        .unwrap();
+                assert_eq!(slot_val, U256::ZERO, "slot {i} must be cleared after clear()");
+            }
+
+            // push-after-clear must work correctly.
+            handler.push(U256::from(42u64)).unwrap();
+            assert_eq!(handler.len().unwrap(), 1);
+            assert_eq!(handler.at(0).unwrap().unwrap().read().unwrap(), U256::from(42u64));
         });
     }
 }

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -85,11 +85,18 @@ where
         if T::BYTES <= 16 {
             let slot_count = calc_packed_slot_count(length, T::BYTES);
             for slot_idx in 0..slot_count {
-                storage.store(data_start + U256::from(slot_idx), U256::ZERO)?;
+                storage.store(
+                    data_start
+                        .checked_add(U256::from(slot_idx))
+                        .ok_or(BasePrecompileError::SlotOverflow)?,
+                    U256::ZERO,
+                )?;
             }
         } else {
             for elem_idx in 0..length {
-                let elem_slot = data_start + U256::from(elem_idx * T::SLOTS);
+                let elem_slot = data_start
+                    .checked_add(U256::from(elem_idx * T::SLOTS))
+                    .ok_or(BasePrecompileError::SlotOverflow)?;
                 T::delete(storage, elem_slot, LayoutCtx::FULL)?;
             }
         }
@@ -191,11 +198,14 @@ where
         let (slot, layout_ctx) = if T::BYTES <= 16 {
             let location = calc_element_loc(index, T::BYTES);
             (
-                data_start + U256::from(location.offset_slots),
+                data_start.checked_add(U256::from(location.offset_slots)).expect("slot overflow"),
                 LayoutCtx::packed(location.offset_bytes),
             )
         } else {
-            (data_start + U256::from(index * T::SLOTS), LayoutCtx::FULL)
+            (
+                data_start.checked_add(U256::from(index * T::SLOTS)).expect("slot overflow"),
+                LayoutCtx::FULL,
+            )
         };
         T::handle(slot, layout_ctx, address, storage)
     }
@@ -400,7 +410,9 @@ where
     let mut current_offset = 0;
 
     for slot_idx in 0..slot_count {
-        let slot_addr = data_start + U256::from(slot_idx);
+        let slot_addr = data_start
+            .checked_add(U256::from(slot_idx))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         let slot_value = storage.load(slot_addr)?;
         let slot_packed = PackedSlot(slot_value);
 
@@ -439,7 +451,9 @@ where
     let slot_count = calc_packed_slot_count(elements.len(), byte_count);
 
     for slot_idx in 0..slot_count {
-        let slot_addr = data_start + U256::from(slot_idx);
+        let slot_addr = data_start
+            .checked_add(U256::from(slot_idx))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         let start_elem = slot_idx * elements_per_slot;
         let end_elem = (start_elem + elements_per_slot).min(elements.len());
         let slot_value = build_packed_slot(&elements[start_elem..end_elem], byte_count)?;
@@ -469,7 +483,9 @@ where
 {
     let mut result = Vec::new();
     for index in 0..length {
-        let elem_slot = data_start + U256::from(index * T::SLOTS);
+        let elem_slot = data_start
+            .checked_add(U256::from(index * T::SLOTS))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         result.push(T::load(storage, elem_slot, LayoutCtx::FULL)?);
     }
     Ok(result)
@@ -481,7 +497,9 @@ where
     S: StorageOps,
 {
     for (idx, elem) in elements.iter().enumerate() {
-        let elem_slot = data_start + U256::from(idx * T::SLOTS);
+        let elem_slot = data_start
+            .checked_add(U256::from(idx * T::SLOTS))
+            .ok_or(BasePrecompileError::SlotOverflow)?;
         elem.store(storage, elem_slot, LayoutCtx::FULL)?;
     }
     Ok(())

--- a/crates/common/precompile-storage/tests/contract.rs
+++ b/crates/common/precompile-storage/tests/contract.rs
@@ -517,6 +517,65 @@ mod namespaced_fields {
     }
 }
 
+mod struct_level_attribute_passthrough {
+    //! Verifies that `#[contract]` forwards all struct-level attributes except its own
+    //! `#[namespace]` to the generated layout struct — doc comments, `#[allow]`, `#[cfg_attr]`.
+
+    mod allow_and_doc {
+        use alloy_primitives::{Address, U256, address};
+        use base_precompile_macros::contract;
+        use base_precompile_storage::{Handler, StorageCtx, setup_storage};
+
+        const ATTR_ADDR: Address = address!("0000000000000000000000000000000000007777");
+
+        /// User-supplied doc comment on the contract struct.
+        ///
+        /// The macro must forward this rather than replace it with the generic fallback.
+        #[allow(dead_code)]
+        #[contract(addr = ATTR_ADDR)]
+        pub struct AttrForwardStorage {
+            pub value: U256,
+            pub flag: bool,
+        }
+
+        #[test]
+        fn allow_and_doc_attrs_are_forwarded_to_generated_struct() {
+            let (mut storage, _) = setup_storage();
+            StorageCtx::enter(&mut storage, |ctx| {
+                let mut layout = AttrForwardStorage::new(ctx);
+                layout.value.write(U256::from(42u64)).unwrap();
+                layout.flag.write(true).unwrap();
+                assert_eq!(layout.value.read().unwrap(), U256::from(42u64));
+                assert!(layout.flag.read().unwrap());
+            });
+        }
+    }
+
+    mod cfg_attr {
+        use alloy_primitives::{Address, address};
+        use base_precompile_macros::contract;
+        use base_precompile_storage::{Handler, StorageCtx, setup_storage};
+
+        const CFG_ATTR_ADDR: Address = address!("0000000000000000000000000000000000007778");
+
+        #[cfg_attr(test, allow(dead_code))]
+        #[contract(addr = CFG_ATTR_ADDR)]
+        pub struct CfgAttrForwardStorage {
+            pub x: Address,
+        }
+
+        #[test]
+        fn cfg_attr_is_forwarded_to_generated_struct() {
+            let (mut storage, _) = setup_storage();
+            StorageCtx::enter(&mut storage, |ctx| {
+                let mut layout = CfgAttrForwardStorage::new(ctx);
+                layout.x.write(Address::from([0xab; 20])).unwrap();
+                assert_eq!(layout.x.read().unwrap(), Address::from([0xab; 20]));
+            });
+        }
+    }
+}
+
 mod packed_slot_layout {
     //! End-to-end bit-level verification of multi-field packed storage slots.
     //!
@@ -533,10 +592,10 @@ mod packed_slot_layout {
     /// A layout where four sub-word primitives share a single storage slot.
     ///
     /// Packing order (low-to-high bytes within the slot):
-    /// - `low_byte`  : u8  → offset_bytes 0, bits  [0..7]
-    /// - `mid_short` : u16 → offset_bytes 1, bits  [8..23]
-    /// - `mid_int`   : u32 → offset_bytes 3, bits  [24..55]
-    /// - `high_long` : u64 → offset_bytes 7, bits  [56..119]
+    /// - `low_byte`  : u8  → `offset_bytes` 0, bits  [0..7]
+    /// - `mid_short` : u16 → `offset_bytes` 1, bits  [8..23]
+    /// - `mid_int`   : u32 → `offset_bytes` 3, bits  [24..55]
+    /// - `high_long` : u64 → `offset_bytes` 7, bits  [56..119]
     ///
     /// Total: 15 bytes → all packed into slot 0.
     /// `big_val` (U256, full slot) goes to slot 1.

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -487,6 +487,23 @@ mod tests {
         );
     }
 
+    /// A zero-address caller must be rejected even when the admin is also configured as
+    /// `Address::ZERO`. This prevents deposit transactions with `msg.sender == Address::ZERO` from
+    /// toggling activation state on a misconfigured chain.
+    #[test]
+    fn zero_address_caller_with_zero_admin_is_rejected() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(Address::ZERO);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+        assert_activated(&mut storage, false);
+    }
+
     /// End-to-end test: activate a feature, then deactivate it through `dispatch`. Deactivation
     /// clears the feature storage slot (nonzero to zero SSTORE), which earns an EIP-3529 refund
     /// that must appear in `PrecompileOutput::gas_refunded`.
@@ -532,22 +549,5 @@ mod tests {
 
         assert!(output.is_success());
         assert_eq!(output.gas_refunded, 0, "writing to a zero slot earns no refund");
-    }
-
-    /// A zero-address caller must be rejected even when the admin is also configured as
-    /// `Address::ZERO`. This prevents deposit transactions with `msg.sender == Address::ZERO` from
-    /// toggling activation state on a misconfigured chain.
-    #[test]
-    fn zero_address_caller_with_zero_admin_is_rejected() {
-        let mut storage = HashMapStorageProvider::new(1);
-        storage.set_caller(Address::ZERO);
-
-        let err = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
-        })
-        .unwrap_err();
-
-        assert!(matches!(err, BasePrecompileError::Revert(_)));
-        assert_activated(&mut storage, false);
     }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -405,7 +405,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Posts an announcement and atomically executes `internal_calls` via self-dispatch.
     ///
-    /// The `in_announcement` flag and selector check prevent recursive invocation.
+    /// The selector check in the inner loop prevents recursive invocation.
     fn announce<O>(
         &mut self,
         ctx: StorageCtx<'_>,
@@ -426,9 +426,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             internal_call_bytes,
         );
         self.ensure_operator_role(caller, privileged)?;
-        if self.is_announcement_active() {
-            return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
-        }
 
         let id = call.id;
         if self.accounting().is_announcement_id_used(id.as_str())? {
@@ -445,8 +442,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             }
             .encode_log_data(),
         )?;
-
-        self.begin_announcement();
 
         // Each internal call is dispatched via `inner_with_privilege`, a direct Rust function
         // call. Unlike the base-std Solidity reference which routes each `internalCalls` entry

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -17,13 +17,11 @@ use crate::{
 ///
 /// Mirrors the structure of [`crate::B20Token`] but requires `S: AssetAccounting`
 /// so the dispatch layer can read and write asset-specific storage (multiplier,
-/// extra metadata, announcement IDs). The `in_announcement` flag guards against
-/// recursive `announce` calls within a single precompile invocation.
+/// extra metadata, announcement IDs).
 #[derive(Debug, Clone)]
 pub struct B20AssetToken<S: AssetAccounting, P: Policy> {
     accounting: S,
     policy: P,
-    in_announcement: bool,
 }
 
 impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
@@ -37,17 +35,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Creates a `B20AssetToken` backed by the provided storage and policy adapters.
     pub const fn with_storage_and_policy(accounting: S, policy: P) -> Self {
-        Self { accounting, policy, in_announcement: false }
-    }
-
-    /// Returns whether this token is currently executing an announcement.
-    pub const fn is_announcement_active(&self) -> bool {
-        self.in_announcement
-    }
-
-    /// Marks this token as executing an announcement.
-    pub const fn begin_announcement(&mut self) {
-        self.in_announcement = true;
+        Self { accounting, policy }
     }
 }
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -234,7 +234,19 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Mints tokens to multiple recipients. All-or-nothing.
     ///
-    /// Check order: PAUSE → ROLE → INPUT → BUSINESS
+    /// # Authorization boundary
+    ///
+    /// The `ensure_not_paused` and `ensure_token_role` calls below are the **sole**
+    /// authorization gate for all batch-mint operations. The inner [`Mintable::mint`]
+    /// calls pass `privileged = true` only to avoid re-running the same checks once
+    /// per recipient, which is safe because the outer guards have already fired.
+    ///
+    /// **Do not remove or conditionalize the outer guards.** Doing so would leave a
+    /// fully open privileged path, since the inner mints unconditionally bypass
+    /// their own checks. The tests `batch_mint_check_order` in this module pin this
+    /// invariant and will fail if either guard is dropped.
+    ///
+    /// Check order: PAUSE -> ROLE -> INPUT -> BUSINESS
     pub fn batch_mint(
         &mut self,
         caller: Address,

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -129,7 +129,9 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
                 C::name(_) => self.accounting().name()?.abi_encode().into(),
                 C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
                 // Stablecoin precision is fixed at 6 by the protocol spec; never read from
-                // storage to avoid the zero-return window during the factory bootstrap.
+<<<<<<< HEAD
+                // storage to avoid the zero-return window during the factory bootstrap
+                // (BOP-349/PSRC-27).
                 C::decimals(_) => U256::from(
                     B20Variant::Stablecoin
                         .decimals()
@@ -340,16 +342,14 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         Ok(encoded)
     }
 }
+
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, Bytes, U256};
-    use alloy_sol_types::{SolCall, SolError, SolValue};
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolCall, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
-    use crate::{
-        B20StablecoinToken, IB20, InMemoryPolicy, InMemoryTokenAccounting,
-        NoopPrecompileCallObserver, TestStablecoinToken,
-    };
+    use crate::{IB20, InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken};
 
     const TOKEN: Address = Address::repeat_byte(0x01);
 
@@ -363,13 +363,6 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(TOKEN);
         StorageCtx::enter(&mut storage, |ctx| token.inner(ctx, calldata)).unwrap().to_vec()
-    }
-
-    fn make_token() -> B20StablecoinToken<InMemoryTokenAccounting, InMemoryPolicy> {
-        B20StablecoinToken::with_storage_and_policy(
-            InMemoryTokenAccounting::new(TOKEN),
-            InMemoryPolicy::new(),
-        )
     }
 
     /// Decimals always returns 6 regardless of what the underlying accounting stores.
@@ -388,21 +381,5 @@ mod tests {
         let mut default = make_stablecoin_token_with_decimals(18);
         let result = call_inner(&mut default, &calldata);
         assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
-    }
-
-    #[test]
-    fn dispatch_rejects_call_with_nonzero_value() {
-        let mut token = make_token();
-        let calldata = IB20::balanceOfCall { account: Address::ZERO }.abi_encode();
-        let mut storage = HashMapStorageProvider::new(1);
-        storage.set_call_value(U256::from(1u64));
-
-        let out = StorageCtx::enter(&mut storage, |ctx| {
-            token.dispatch_with_observer(ctx, &calldata, NoopPrecompileCallObserver)
-        })
-        .expect("dispatch must not fatally error");
-
-        assert!(out.is_revert());
-        assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -129,7 +129,6 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
                 C::name(_) => self.accounting().name()?.abi_encode().into(),
                 C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
                 // Stablecoin precision is fixed at 6 by the protocol spec; never read from
-<<<<<<< HEAD
                 // storage to avoid the zero-return window during the factory bootstrap
                 // (BOP-349/PSRC-27).
                 C::decimals(_) => U256::from(
@@ -345,11 +344,14 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256};
-    use alloy_sol_types::{SolCall, SolValue};
+    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
-    use crate::{IB20, InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken};
+    use crate::{
+        B20StablecoinToken, IB20, InMemoryPolicy, InMemoryTokenAccounting,
+        NoopPrecompileCallObserver, TestStablecoinToken,
+    };
 
     const TOKEN: Address = Address::repeat_byte(0x01);
 
@@ -363,6 +365,13 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(TOKEN);
         StorageCtx::enter(&mut storage, |ctx| token.inner(ctx, calldata)).unwrap().to_vec()
+    }
+
+    fn make_token() -> B20StablecoinToken<InMemoryTokenAccounting, InMemoryPolicy> {
+        B20StablecoinToken::with_storage_and_policy(
+            InMemoryTokenAccounting::new(TOKEN),
+            InMemoryPolicy::new(),
+        )
     }
 
     /// Decimals always returns 6 regardless of what the underlying accounting stores.
@@ -381,5 +390,21 @@ mod tests {
         let mut default = make_stablecoin_token_with_decimals(18);
         let result = call_inner(&mut default, &calldata);
         assert_eq!(U256::abi_decode(&result).unwrap(), U256::from(6u8));
+    }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value() {
+        let mut token = make_token();
+        let calldata = IB20::balanceOfCall { account: Address::ZERO }.abi_encode();
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_call_value(U256::from(1u64));
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            token.dispatch_with_observer(ctx, &calldata, NoopPrecompileCallObserver)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
     }
 }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Result, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
 use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 
 use crate::{IActivationRegistry, IB20, IB20Asset, IB20Factory, IB20Stablecoin, IPolicyRegistry};
@@ -612,12 +612,7 @@ where
         if let Err(error) = &result {
             self.record_base_error(error);
         }
-        let result = result.into_precompile_result(
-            ctx.gas_used(),
-            ctx.state_gas_used(),
-            ctx.gas_refunded(),
-            encode_ok,
-        );
+        let result = ctx.result_output(result, encode_ok);
         self.record_result(&result);
         result
     }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,5 +1,7 @@
+use alloc::string::ToString;
+
 use alloy_primitives::Bytes;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{SolCall, SolInterface};
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
@@ -41,29 +43,33 @@ impl PolicyRegistryStorage<'_> {
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
-        let result = if Self::is_view_selector(calldata) {
-            self.inner(calldata, &observer)
-        } else {
-            ActivationRegistryStorage::new(ctx)
-                .ensure_activated(ActivationFeature::PolicyRegistry.id())
-                .and_then(|()| self.inner(calldata, &observer))
+        let result = match calldata.first_chunk::<4>().copied() {
+            None => Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4])),
+            Some(sel)
+                if sel == IPolicyRegistry::isAuthorizedCall::SELECTOR
+                    || sel == IPolicyRegistry::policyExistsCall::SELECTOR
+                    || sel == IPolicyRegistry::policyAdminCall::SELECTOR
+                    || sel == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR =>
+            {
+                self.inner(calldata, &observer)
+            }
+            Some(sel) if IPolicyRegistry::IPolicyRegistryCalls::valid_selector(sel) => {
+                // Validate ABI encoding before the activation gate so that malformed
+                // arguments return AbiDecodeFailed regardless of activation state.
+                IPolicyRegistry::IPolicyRegistryCalls::abi_decode_validate(calldata)
+                    .map_err(|e| BasePrecompileError::AbiDecodeFailed {
+                        selector: sel,
+                        error: e.to_string(),
+                    })
+                    .and_then(|_| {
+                        ActivationRegistryStorage::new(ctx)
+                            .ensure_activated(ActivationFeature::PolicyRegistry.id())
+                            .and_then(|()| self.inner(calldata, &observer))
+                    })
+            }
+            Some(sel) => Err(BasePrecompileError::UnknownFunctionSelector(sel)),
         };
         recorder.record_base_result(ctx, result, |b| b)
-    }
-
-    /// Returns `true` when the calldata selector belongs to a view (read-only) function.
-    ///
-    /// View functions are accessible regardless of whether the feature is activated, so that
-    /// callers can still query policy state (e.g. check blocklist membership) even if the
-    /// precompile feature is administratively disabled.
-    fn is_view_selector(calldata: &[u8]) -> bool {
-        let Some(selector) = calldata.first_chunk::<4>().copied() else {
-            return false;
-        };
-        selector == IPolicyRegistry::isAuthorizedCall::SELECTOR
-            || selector == IPolicyRegistry::policyExistsCall::SELECTOR
-            || selector == IPolicyRegistry::policyAdminCall::SELECTOR
-            || selector == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR
     }
 
     fn inner<O>(&mut self, calldata: &[u8], observer: &O) -> base_precompile_storage::Result<Bytes>
@@ -614,6 +620,66 @@ mod tests {
             .unwrap();
             assert!(out.is_revert(), "createPolicy must revert when feature is deactivated");
         }
+    }
+
+    #[test]
+    fn inactive_unknown_selector_returns_unknown_function_selector() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // Unknown selector; feature never activated.
+        let calldata = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00];
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        // UnknownFunctionSelector encodes as the raw 4-byte selector.
+        assert_eq!(out.bytes, Bytes::from([0xde, 0xad, 0xbe, 0xef].as_ref()));
+    }
+
+    #[test]
+    fn inactive_malformed_view_selector_returns_abi_decode_error() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // policyExists selector with no arguments (truncated); feature inactive.
+        let calldata = IPolicyRegistry::policyExistsCall::SELECTOR.to_vec();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        // AbiDecodeFailed encodes as selector || error_string. The first 4 bytes of the
+        // revert data are the matched function selector, which differs from the 4-byte
+        // ABI error selector that FeatureNotActivated would produce.
+        assert_eq!(
+            out.bytes.get(..4),
+            Some(IPolicyRegistry::policyExistsCall::SELECTOR.as_ref()),
+            "revert must be AbiDecodeFailed, not FeatureNotActivated"
+        );
+    }
+
+    #[test]
+    fn inactive_malformed_write_selector_returns_abi_decode_error() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // createPolicy selector with no arguments (truncated); feature inactive.
+        let calldata = IPolicyRegistry::createPolicyCall::SELECTOR.to_vec();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        // AbiDecodeFailed encodes as selector || error_string. The first 4 bytes of the
+        // revert data are the matched function selector, which differs from the 4-byte
+        // ABI error selector that FeatureNotActivated would produce.
+        assert_eq!(
+            out.bytes.get(..4),
+            Some(IPolicyRegistry::createPolicyCall::SELECTOR.as_ref()),
+            "revert must be AbiDecodeFailed, not FeatureNotActivated"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of #3384, #3385, #3387, #3388, #3404, #3405, #3407, #3415, #3421, and #3438 into \`releases/v1.1.0\`.

## Source PRs

- #3384 / BOP-339: add VecHandler::truncate and clear, zeroing vacated slots on shrink.
- #3385 / BOP-342 / PSRC-27: hard-code stablecoin decimals to 6 to eliminate zero-return window.
- #3387 / BOP-359: restore all mutable fields in checkpoint_revert.
- #3388 / BOP-340: improve #[contract] macro diagnostic for unrecognized arguments.
- #3404: remove redundant drop in with_caller and harden CallerGuard.
- #3405: reject duplicate args() option regardless of argument count.
- #3407 / BOP-360: forward all struct-level attrs through #[contract].
- #3415 / BOP-356: replace saturating/unchecked slot arithmetic with checked_add.
- #3421 / BOP-378 / PSRC-26: classify calldata before activation gate in policy-registry.
- #3438 / BOP-380: deduct gas before sload warms slot in journal.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p base-precompile-storage --lib`
- `cargo test -p base-common-precompiles --lib`
- `cargo test -p base-precompile-macros`
- `cargo check -p base-precompile-storage --no-default-features`
- `cargo check -p base-common-precompiles --no-default-features`