### PR TITLE
[backport] BOP Batch 6 fixes for releases/v1.1.0

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -156,19 +156,34 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
-        let s = self
-            .internals
-            .sload(address, key)
-            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+        // Checkpoint before the read so that an OOG failure reverts the slot warming.
+        // Without this, `internals.sload` would mark the slot warm in the revm journal
+        // before gas is deducted; a subsequent OOG would leave the spurious warm entry
+        // behind, breaking EIP-2929 cold-slot accounting for any later access.
+        let checkpoint = self.internals.checkpoint();
+        let result = (|| {
+            let s = self
+                .internals
+                .sload(address, key)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
 
-        // EIP-2929: warm base cost always charged
-        self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-        // dynamic cold penalty
-        if s.is_cold {
-            self.deduct_gas(self.gas_params.cold_storage_additional_cost())?;
+            // EIP-2929: warm base cost always charged
+            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+            // dynamic cold penalty
+            if s.is_cold {
+                self.deduct_gas(self.gas_params.cold_storage_additional_cost())?;
+            }
+
+            Ok(s.data)
+        })();
+
+        if result.is_ok() {
+            self.internals.checkpoint_commit();
+        } else {
+            self.internals.checkpoint_revert(checkpoint);
         }
 
-        Ok(s.data)
+        result
     }
 
     fn tload(&mut self, address: Address, key: U256) -> Result<U256> {
@@ -405,6 +420,64 @@ mod tests {
                 gas_params
                     .warm_storage_read_cost()
                     .saturating_add(gas_params.cold_storage_additional_cost())
+            );
+        }
+    }
+
+    /// An OOG `sload` must not leave the slot warmed in the journal.
+    ///
+    /// We give the provider exactly `warm_storage_read_cost - 1` gas so that the
+    /// cold read fails (it cannot even afford the warm base cost). A second provider
+    /// with unlimited gas then reads the same slot: if the journal still carries the
+    /// spurious warm entry the second read would be charged only `warm_storage_read_cost`,
+    /// but the slot was never successfully accessed so it must still be cold.
+    #[test]
+    fn sload_oog_does_not_warm_slot() {
+        let gas_params = GasParams::new_spec(SpecId::AMSTERDAM);
+        let address = Address::repeat_byte(0x77);
+        let key = U256::from(5);
+
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+
+        // First provider: gas just below warm_storage_read_cost → OOG on sload.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: gas_params.warm_storage_read_cost() - 1,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(provider.sload(address, key), Err(BasePrecompileError::OutOfGas));
+        }
+
+        // Second provider: unlimited gas. The slot must still be cold, so the full
+        // cold read cost (warm_base + cold_additional) must be charged.
+        {
+            let input = PrecompileInput {
+                data: &[],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: address,
+                is_static: false,
+                bytecode_address: address,
+                internals: EvmInternals::from_context(&mut ctx),
+            };
+            let mut provider = super::EvmPrecompileStorageProvider::new(input, gas_params.clone());
+            assert_eq!(provider.sload(address, key).unwrap(), U256::ZERO);
+            assert_eq!(
+                provider.gas_used(),
+                gas_params
+                    .warm_storage_read_cost()
+                    .saturating_add(gas_params.cold_storage_additional_cost()),
+                "slot must still be cold after a failed OOG read"
             );
         }
     }

--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -156,10 +156,6 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
-        // Checkpoint before the read so that an OOG failure reverts the slot warming.
-        // Without this, `internals.sload` would mark the slot warm in the revm journal
-        // before gas is deducted; a subsequent OOG would leave the spurious warm entry
-        // behind, breaking EIP-2929 cold-slot accounting for any later access.
         let checkpoint = self.internals.checkpoint();
         let result = (|| {
             let s = self

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,5 +1,7 @@
+use alloc::string::ToString;
+
 use alloy_primitives::Bytes;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{SolCall, SolInterface};
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
@@ -41,29 +43,33 @@ impl PolicyRegistryStorage<'_> {
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
-        let result = if Self::is_view_selector(calldata) {
-            self.inner(calldata, &observer)
-        } else {
-            ActivationRegistryStorage::new(ctx)
-                .ensure_activated(ActivationFeature::PolicyRegistry.id())
-                .and_then(|()| self.inner(calldata, &observer))
+        let result = match calldata.first_chunk::<4>().copied() {
+            None => Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4])),
+            Some(sel)
+                if sel == IPolicyRegistry::isAuthorizedCall::SELECTOR
+                    || sel == IPolicyRegistry::policyExistsCall::SELECTOR
+                    || sel == IPolicyRegistry::policyAdminCall::SELECTOR
+                    || sel == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR =>
+            {
+                self.inner(calldata, &observer)
+            }
+            Some(sel) if IPolicyRegistry::IPolicyRegistryCalls::valid_selector(sel) => {
+                // Validate ABI encoding before the activation gate so that malformed
+                // arguments return AbiDecodeFailed regardless of activation state.
+                IPolicyRegistry::IPolicyRegistryCalls::abi_decode_validate(calldata)
+                    .map_err(|e| BasePrecompileError::AbiDecodeFailed {
+                        selector: sel,
+                        error: e.to_string(),
+                    })
+                    .and_then(|_| {
+                        ActivationRegistryStorage::new(ctx)
+                            .ensure_activated(ActivationFeature::PolicyRegistry.id())
+                            .and_then(|()| self.inner(calldata, &observer))
+                    })
+            }
+            Some(sel) => Err(BasePrecompileError::UnknownFunctionSelector(sel)),
         };
         recorder.record_base_result(ctx, result, |b| b)
-    }
-
-    /// Returns `true` when the calldata selector belongs to a view (read-only) function.
-    ///
-    /// View functions are accessible regardless of whether the feature is activated, so that
-    /// callers can still query policy state (e.g. check blocklist membership) even if the
-    /// precompile feature is administratively disabled.
-    fn is_view_selector(calldata: &[u8]) -> bool {
-        let Some(selector) = calldata.first_chunk::<4>().copied() else {
-            return false;
-        };
-        selector == IPolicyRegistry::isAuthorizedCall::SELECTOR
-            || selector == IPolicyRegistry::policyExistsCall::SELECTOR
-            || selector == IPolicyRegistry::policyAdminCall::SELECTOR
-            || selector == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR
     }
 
     fn inner<O>(&mut self, calldata: &[u8], observer: &O) -> base_precompile_storage::Result<Bytes>
@@ -614,6 +620,66 @@ mod tests {
             .unwrap();
             assert!(out.is_revert(), "createPolicy must revert when feature is deactivated");
         }
+    }
+
+    #[test]
+    fn inactive_unknown_selector_returns_unknown_function_selector() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // Unknown selector; feature never activated.
+        let calldata = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00];
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        // UnknownFunctionSelector encodes as the raw 4-byte selector.
+        assert_eq!(out.bytes, Bytes::from([0xde, 0xad, 0xbe, 0xef].as_ref()));
+    }
+
+    #[test]
+    fn inactive_malformed_view_selector_returns_abi_decode_error() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // policyExists selector with no arguments (truncated); feature inactive.
+        let calldata = IPolicyRegistry::policyExistsCall::SELECTOR.to_vec();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        // AbiDecodeFailed encodes as selector || error_string. The first 4 bytes of the
+        // revert data are the matched function selector, which differs from the 4-byte
+        // ABI error selector that FeatureNotActivated would produce.
+        assert_eq!(
+            out.bytes.get(..4),
+            Some(IPolicyRegistry::policyExistsCall::SELECTOR.as_ref()),
+            "revert must be AbiDecodeFailed, not FeatureNotActivated"
+        );
+    }
+
+    #[test]
+    fn inactive_malformed_write_selector_returns_abi_decode_error() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // createPolicy selector with no arguments (truncated); feature inactive.
+        let calldata = IPolicyRegistry::createPolicyCall::SELECTOR.to_vec();
+
+        let out = StorageCtx::enter(&mut storage, |ctx| {
+            PolicyRegistryStorage::new(ctx).dispatch(ctx, &calldata)
+        })
+        .expect("dispatch must not fatally error");
+
+        assert!(out.is_revert());
+        // AbiDecodeFailed encodes as selector || error_string. The first 4 bytes of the
+        // revert data are the matched function selector, which differs from the 4-byte
+        // ABI error selector that FeatureNotActivated would produce.
+        assert_eq!(
+            out.bytes.get(..4),
+            Some(IPolicyRegistry::createPolicyCall::SELECTOR.as_ref()),
+            "revert must be AbiDecodeFailed, not FeatureNotActivated"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> [!NOTE]
> This is a combined backport of BOP Batch 6 audit fixes into `releases/v1.1.0`.

## Source PRs

- #3421 / BOP-378 / PSRC-26: fix(policy-registry): classify calldata before activation gate.
- #3438 / BOP-380: fix(precompile-storage): deduct gas before sload warms slot in journal.

## Changes

**#3421 (BOP-378/PSRC-26):** `dispatch_with_observer` was calling `ensure_activated` before ABI-decoding write calldata. Unknown selectors and malformed write arguments returned `FeatureNotActivated` instead of `UnknownFunctionSelector` / `AbiDecodeFailed` when the policy registry was inactive. Fix classifies calldata before touching the activation gate so error behavior is activation-state-independent.

**#3438 (BOP-380):** `internals.sload` marked the slot warm in the revm journal before gas was deducted. A subsequent OOG would leave the spurious warm entry behind, breaking EIP-2929 cold-slot accounting. Applied the same checkpoint/revert pattern already used by `sstore`. Includes regression test `sload_oog_does_not_warm_slot`.

## Conflict resolution

One conflict in `evm.rs`: the sload commit referenced `set_code_static_violation_before_gas_charge` as context (a test that only exists on `main`). Resolved by inserting `sload_oog_does_not_warm_slot` at the correct position and preserving the release branch doc comment for `set_code_new_account_charges_create_and_deposit_state_gas`.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p base-precompile-storage --features test-utils`
- `cargo test -p base-common-precompiles`
- `cargo test -p base-precompile-storage sload_oog_does_not_warm_slot`