### PR TITLE
fix(chains): update B20 activation admin addresses for Base Sepolia and Mainnet

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -373,7 +373,7 @@ const MAINNET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
 
     unsafe_block_signer: Some(address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a")),
-    activation_admin_address: address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"),
+    activation_admin_address: address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"),
 
     max_gas_limit: 105_000_000,
     prune_delete_limit: 20_000,
@@ -447,7 +447,7 @@ const SEPOLIA: ChainConfig = ChainConfig {
     protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
 
     unsafe_block_signer: Some(address!("b830b99c95Ea32300039624Cb567d324D4b1D83C")),
-    activation_admin_address: address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"),
+    activation_admin_address: address!("5F43072722f59964d886CBb507F6a85ca0759D42"),
 
     max_gas_limit: 45_000_000,
     prune_delete_limit: 10_000,

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -667,11 +667,11 @@ mod tests {
     fn activation_admin_matches_chain_config() {
         assert_eq!(
             BaseChainSpec::mainnet().activation_admin_address(),
-            Some(address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"))
+            Some(address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"))
         );
         assert_eq!(
             BaseChainSpec::sepolia().activation_admin_address(),
-            Some(address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"))
+            Some(address!("5F43072722f59964d886CBb507F6a85ca0759D42"))
         );
     }
 


### PR DESCRIPTION
## Summary

- Updates `activation_admin_address` for Base Mainnet to `0xcE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9`
- Updates `activation_admin_address` for Base Sepolia to `0x5F43072722f59964d886CBb507F6a85ca0759D42`

These are the newly provisioned coreKMS keys for activation testing and smoke tests (BOP-382).

## Test plan

- [ ] Confirm addresses match the provisioned coreKMS keys in the ticket
- [ ] Verify `cargo check -p base-common-chains` passes (done locally)