### PR TITLE
[backport] fix(precompile-storage): remove redundant drop in with_caller and harden CallerGuard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,7 @@ dependencies = [
  "revm",
  "rstest",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -26,6 +26,7 @@ base-precompile-macros.workspace = true
 
 # misc
 thiserror.workspace = true
+tracing.workspace = true
 derive_more = { workspace = true, features = ["from", "try_into"] }
 
 [dev-dependencies]
@@ -46,5 +47,6 @@ std = [
 	"derive_more/std",
 	"revm/std",
 	"thiserror/std",
+	"tracing/std",
 ]
 test-utils = [ "std" ]

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -178,10 +178,8 @@ impl<'a> StorageCtx<'a> {
     /// Executes `f` with a temporary caller override, restoring the previous caller on exit.
     pub fn with_caller<R>(&self, caller: Address, f: impl FnOnce() -> R) -> R {
         let previous = self.with_storage(|s| s.replace_caller(caller));
-        let guard = CallerGuard { storage: *self, previous: Some(previous) };
-        let result = f();
-        drop(guard);
-        result
+        let _guard = CallerGuard { storage: *self, previous: Some(previous) };
+        f()
     }
 
     /// Deducts gas from the remaining gas, returning `OutOfGas` if insufficient.
@@ -264,9 +262,14 @@ struct CallerGuard<'a> {
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
         if let Some(previous) = self.previous.take() {
-            self.storage.with_storage(|s| {
-                s.replace_caller(previous);
-            });
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => {
+                    guard.replace_caller(previous);
+                }
+                Err(_) => tracing::warn!(
+                    "skipping caller restore: RefCell already borrowed (likely during unwind)"
+                ),
+            }
         }
     }
 }
@@ -283,6 +286,11 @@ pub struct CheckpointGuard<'a> {
 
 impl CheckpointGuard<'_> {
     /// Commits all state changes since the checkpoint.
+    ///
+    /// Uses `borrow_mut` (panicking) intentionally: `commit` is an explicit
+    /// caller action, so a conflicting borrow here is a logic bug that should
+    /// surface loudly. Contrast with `drop` below, which uses `try_borrow_mut`
+    /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
         if self.checkpoint.take().is_some() {
             self.storage.with_storage(|s| s.checkpoint_commit());
@@ -293,7 +301,12 @@ impl CheckpointGuard<'_> {
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
         if let Some(cp) = self.checkpoint.take() {
-            self.storage.with_storage(|s| s.checkpoint_revert(cp));
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => guard.checkpoint_revert(cp),
+                Err(_) => tracing::warn!(
+                    "skipping checkpoint revert: RefCell already borrowed (likely during unwind)"
+                ),
+            }
         }
     }
 }


### PR DESCRIPTION
Backport of #3404 to `releases/v1.1.0`.

Hardens `CallerGuard::drop` and `CheckpointGuard::drop` to use `try_borrow_mut` with a tracing warn instead of panicking during unwind. Also adds the required `tracing` dependency.