### PR TITLE
[backport] straggler precompile fixes for releases/v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,7 @@ dependencies = [
  "revm",
  "rstest",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/precompile-macros/src/contract.rs
+++ b/crates/common/precompile-macros/src/contract.rs
@@ -23,8 +23,13 @@ impl syn::parse::Parse for ContractConfig {
         }
 
         let ident: Ident = input.parse()?;
-        if ident != "addr" && ident != "address" {
-            return Err(syn::Error::new(ident.span(), "only `addr` attribute is supported"));
+        if ident != "addr" {
+            return Err(syn::Error::new(
+                ident.span(),
+                format!(
+                    "unrecognized argument `{ident}`; supported arguments are: addr = \"0x...\""
+                ),
+            ));
         }
 
         input.parse::<Token![=]>()?;

--- a/crates/common/precompile-storage/Cargo.toml
+++ b/crates/common/precompile-storage/Cargo.toml
@@ -26,6 +26,7 @@ base-precompile-macros.workspace = true
 
 # misc
 thiserror.workspace = true
+tracing.workspace = true
 derive_more = { workspace = true, features = ["from", "try_into"] }
 
 [dev-dependencies]
@@ -46,5 +47,6 @@ std = [
 	"derive_more/std",
 	"revm/std",
 	"thiserror/std",
+	"tracing/std",
 ]
 test-utils = [ "std" ]

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -178,10 +178,8 @@ impl<'a> StorageCtx<'a> {
     /// Executes `f` with a temporary caller override, restoring the previous caller on exit.
     pub fn with_caller<R>(&self, caller: Address, f: impl FnOnce() -> R) -> R {
         let previous = self.with_storage(|s| s.replace_caller(caller));
-        let guard = CallerGuard { storage: *self, previous: Some(previous) };
-        let result = f();
-        drop(guard);
-        result
+        let _guard = CallerGuard { storage: *self, previous: Some(previous) };
+        f()
     }
 
     /// Deducts gas from the remaining gas, returning `OutOfGas` if insufficient.
@@ -264,9 +262,14 @@ struct CallerGuard<'a> {
 impl Drop for CallerGuard<'_> {
     fn drop(&mut self) {
         if let Some(previous) = self.previous.take() {
-            self.storage.with_storage(|s| {
-                s.replace_caller(previous);
-            });
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => {
+                    guard.replace_caller(previous);
+                }
+                Err(_) => tracing::warn!(
+                    "skipping caller restore: RefCell already borrowed (likely during unwind)"
+                ),
+            }
         }
     }
 }
@@ -283,6 +286,11 @@ pub struct CheckpointGuard<'a> {
 
 impl CheckpointGuard<'_> {
     /// Commits all state changes since the checkpoint.
+    ///
+    /// Uses `borrow_mut` (panicking) intentionally: `commit` is an explicit
+    /// caller action, so a conflicting borrow here is a logic bug that should
+    /// surface loudly. Contrast with `drop` below, which uses `try_borrow_mut`
+    /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
         if self.checkpoint.take().is_some() {
             self.storage.with_storage(|s| s.checkpoint_commit());
@@ -293,7 +301,12 @@ impl CheckpointGuard<'_> {
 impl Drop for CheckpointGuard<'_> {
     fn drop(&mut self) {
         if let Some(cp) = self.checkpoint.take() {
-            self.storage.with_storage(|s| s.checkpoint_revert(cp));
+            match self.storage.storage.try_borrow_mut() {
+                Ok(mut guard) => guard.checkpoint_revert(cp),
+                Err(_) => tracing::warn!(
+                    "skipping checkpoint revert: RefCell already borrowed (likely during unwind)"
+                ),
+            }
         }
     }
 }

--- a/crates/common/precompile-storage/src/types/set.rs
+++ b/crates/common/precompile-storage/src/types/set.rs
@@ -401,7 +401,7 @@ mod tests {
         });
     }
 
-    /// (`initial_size`, `final_size`) -- covers grow, shrink, and equal-size rewrite.
+    /// (`initial_size`, `final_size`) — covers grow, shrink, and equal-size rewrite.
     #[rstest]
     #[case(3, 7)] // grow
     #[case(7, 3)] // shrink

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -630,4 +630,144 @@ mod tests {
             assert_eq!(handler.len(), Err(BasePrecompileError::under_overflow()));
         });
     }
+
+    #[test]
+    fn test_vec_truncate_unpacked() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(400u64);
+            let handler = VecHandler::<U256>::new(len_slot, address, ctx);
+
+            let vals: Vec<U256> = (0..5).map(U256::from).collect();
+            for &v in &vals {
+                handler.push(v).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 5);
+
+            // truncate to 3 — elements 3 and 4 should be cleared.
+            handler.truncate(3).unwrap();
+            assert_eq!(handler.len().unwrap(), 3);
+
+            let data_start = calc_data_slot(len_slot);
+            let slot3 = U256::handle(data_start + U256::from(3), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            let slot4 = U256::handle(data_start + U256::from(4), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            assert_eq!(slot3, U256::ZERO, "vacated slot 3 must be cleared");
+            assert_eq!(slot4, U256::ZERO, "vacated slot 4 must be cleared");
+
+            // remaining elements are intact.
+            for i in 0..3 {
+                assert_eq!(handler.at(i).unwrap().unwrap().read().unwrap(), U256::from(i));
+            }
+
+            // truncate past current length is a no-op.
+            handler.truncate(10).unwrap();
+            assert_eq!(handler.len().unwrap(), 3);
+        });
+    }
+
+    #[test]
+    fn test_vec_truncate_packed_boundary_slot() {
+        // Vec<u8>: 32 elements per slot.  Push 35 elements; truncate to 33.
+        // Slot 0 (indices 0-31): fully kept.
+        // Slot 1 (indices 32-34): index 32 kept, indices 33-34 cleared individually.
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(500u64);
+            let handler = VecHandler::<u8>::new(len_slot, address, ctx);
+
+            for i in 0u8..35 {
+                handler.push(i).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 35);
+
+            handler.truncate(33).unwrap();
+            assert_eq!(handler.len().unwrap(), 33);
+
+            // Slot 1 must still contain element 32 (offset 0) and have bytes 1-2 cleared.
+            let data_start = calc_data_slot(len_slot);
+            let slot1 = U256::handle(data_start + U256::from(1), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            // Only byte 0 (element 32 = 0x20) should survive.
+            let expected = gen_word_from(&["0x20"]);
+            assert_eq!(slot1, expected, "boundary slot must retain element 32 only");
+        });
+    }
+
+    #[test]
+    fn test_vec_truncate_packed_full_tail_slots() {
+        // Vec<u8>: 32 elements per slot.  Push 65 elements; truncate to 32.
+        // Slot 0 (indices 0-31): fully kept.
+        // Slot 1 (indices 32-63): fully removed — zeroed in one store.
+        // Slot 2 (index 64): fully removed — zeroed in one store.
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(600u64);
+            let handler = VecHandler::<u8>::new(len_slot, address, ctx);
+
+            for i in 0u8..65 {
+                handler.push(i).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 65);
+
+            handler.truncate(32).unwrap();
+            assert_eq!(handler.len().unwrap(), 32);
+
+            let data_start = calc_data_slot(len_slot);
+            let slot1 = U256::handle(data_start + U256::from(1), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            let slot2 = U256::handle(data_start + U256::from(2), LayoutCtx::FULL, address, ctx)
+                .read()
+                .unwrap();
+            assert_eq!(slot1, U256::ZERO, "fully-removed slot 1 must be zeroed");
+            assert_eq!(slot2, U256::ZERO, "fully-removed slot 2 must be zeroed");
+
+            // slot 0 must be fully intact.
+            let slot0 = U256::handle(data_start, LayoutCtx::FULL, address, ctx).read().unwrap();
+            let expected = gen_word_from(&[
+                "0x1f", "0x1e", "0x1d", "0x1c", "0x1b", "0x1a", "0x19", "0x18", "0x17", "0x16",
+                "0x15", "0x14", "0x13", "0x12", "0x11", "0x10", "0x0f", "0x0e", "0x0d", "0x0c",
+                "0x0b", "0x0a", "0x09", "0x08", "0x07", "0x06", "0x05", "0x04", "0x03", "0x02",
+                "0x01", "0x00",
+            ]);
+            assert_eq!(slot0, expected, "slot 0 must be fully intact after truncate");
+        });
+    }
+
+    #[test]
+    fn test_vec_clear() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let len_slot = U256::from(700u64);
+            let handler = VecHandler::<U256>::new(len_slot, address, ctx);
+
+            for i in 0u64..4 {
+                handler.push(U256::from(i)).unwrap();
+            }
+            assert_eq!(handler.len().unwrap(), 4);
+
+            handler.clear().unwrap();
+            assert_eq!(handler.len().unwrap(), 0);
+            assert!(handler.is_empty().unwrap());
+
+            let data_start = calc_data_slot(len_slot);
+            for i in 0u64..4 {
+                let slot_val =
+                    U256::handle(data_start + U256::from(i), LayoutCtx::FULL, address, ctx)
+                        .read()
+                        .unwrap();
+                assert_eq!(slot_val, U256::ZERO, "slot {i} must be cleared after clear()");
+            }
+
+            // push-after-clear must work correctly.
+            handler.push(U256::from(42u64)).unwrap();
+            assert_eq!(handler.len().unwrap(), 1);
+            assert_eq!(handler.at(0).unwrap().unwrap().read().unwrap(), U256::from(42u64));
+        });
+    }
 }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -487,6 +487,23 @@ mod tests {
         );
     }
 
+    /// A zero-address caller must be rejected even when the admin is also configured as
+    /// `Address::ZERO`. This prevents deposit transactions with `msg.sender == Address::ZERO` from
+    /// toggling activation state on a misconfigured chain.
+    #[test]
+    fn zero_address_caller_with_zero_admin_is_rejected() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(Address::ZERO);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, BasePrecompileError::Revert(_)));
+        assert_activated(&mut storage, false);
+    }
+
     /// End-to-end test: activate a feature, then deactivate it through `dispatch`. Deactivation
     /// clears the feature storage slot (nonzero to zero SSTORE), which earns an EIP-3529 refund
     /// that must appear in `PrecompileOutput::gas_refunded`.

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -550,21 +550,4 @@ mod tests {
         assert!(output.is_success());
         assert_eq!(output.gas_refunded, 0, "writing to a zero slot earns no refund");
     }
-
-    /// A zero-address caller must be rejected even when the admin is also configured as
-    /// `Address::ZERO`. This prevents deposit transactions with `msg.sender == Address::ZERO` from
-    /// toggling activation state on a misconfigured chain.
-    #[test]
-    fn zero_address_caller_with_zero_admin_is_rejected() {
-        let mut storage = HashMapStorageProvider::new(1);
-        storage.set_caller(Address::ZERO);
-
-        let err = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
-        })
-        .unwrap_err();
-
-        assert!(matches!(err, BasePrecompileError::Revert(_)));
-        assert_activated(&mut storage, false);
-    }
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -405,7 +405,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Posts an announcement and atomically executes `internal_calls` via self-dispatch.
     ///
-    /// The `in_announcement` flag and selector check prevent recursive invocation.
+    /// The selector check in the inner loop prevents recursive invocation.
     fn announce<O>(
         &mut self,
         ctx: StorageCtx<'_>,
@@ -426,9 +426,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             internal_call_bytes,
         );
         self.ensure_operator_role(caller, privileged)?;
-        if self.is_announcement_active() {
-            return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
-        }
 
         let id = call.id;
         if self.accounting().is_announcement_id_used(id.as_str())? {
@@ -445,8 +442,6 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             }
             .encode_log_data(),
         )?;
-
-        self.begin_announcement();
 
         // Each internal call is dispatched via `inner_with_privilege`, a direct Rust function
         // call. Unlike the base-std Solidity reference which routes each `internalCalls` entry

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -17,13 +17,11 @@ use crate::{
 ///
 /// Mirrors the structure of [`crate::B20Token`] but requires `S: AssetAccounting`
 /// so the dispatch layer can read and write asset-specific storage (multiplier,
-/// extra metadata, announcement IDs). The `in_announcement` flag guards against
-/// recursive `announce` calls within a single precompile invocation.
+/// extra metadata, announcement IDs).
 #[derive(Debug, Clone)]
 pub struct B20AssetToken<S: AssetAccounting, P: Policy> {
     accounting: S,
     policy: P,
-    in_announcement: bool,
 }
 
 impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
@@ -37,17 +35,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Creates a `B20AssetToken` backed by the provided storage and policy adapters.
     pub const fn with_storage_and_policy(accounting: S, policy: P) -> Self {
-        Self { accounting, policy, in_announcement: false }
-    }
-
-    /// Returns whether this token is currently executing an announcement.
-    pub const fn is_announcement_active(&self) -> bool {
-        self.in_announcement
-    }
-
-    /// Marks this token as executing an announcement.
-    pub const fn begin_announcement(&mut self) {
-        self.in_announcement = true;
+        Self { accounting, policy }
     }
 }
 

--- a/crates/common/precompiles/src/b20_asset/token.rs
+++ b/crates/common/precompiles/src/b20_asset/token.rs
@@ -234,7 +234,19 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
 
     /// Mints tokens to multiple recipients. All-or-nothing.
     ///
-    /// Check order: PAUSE → ROLE → INPUT → BUSINESS
+    /// # Authorization boundary
+    ///
+    /// The `ensure_not_paused` and `ensure_token_role` calls below are the **sole**
+    /// authorization gate for all batch-mint operations. The inner [`Mintable::mint`]
+    /// calls pass `privileged = true` only to avoid re-running the same checks once
+    /// per recipient, which is safe because the outer guards have already fired.
+    ///
+    /// **Do not remove or conditionalize the outer guards.** Doing so would leave a
+    /// fully open privileged path, since the inner mints unconditionally bypass
+    /// their own checks. The tests `batch_mint_check_order` in this module pin this
+    /// invariant and will fail if either guard is dropped.
+    ///
+    /// Check order: PAUSE -> ROLE -> INPUT -> BUSINESS
     pub fn batch_mint(
         &mut self,
         caller: Address,

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -129,7 +129,8 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
                 C::name(_) => self.accounting().name()?.abi_encode().into(),
                 C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
                 // Stablecoin precision is fixed at 6 by the protocol spec; never read from
-                // storage to avoid the zero-return window during the factory bootstrap.
+                // storage to avoid the zero-return window during the factory bootstrap
+                // (BOP-349/PSRC-27).
                 C::decimals(_) => U256::from(
                     B20Variant::Stablecoin
                         .decimals()
@@ -340,6 +341,7 @@ impl<S: StablecoinAccounting, P: Policy> B20StablecoinToken<S, P> {
         Ok(encoded)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, Bytes, U256};

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, Result, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
 use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 
 use crate::{IActivationRegistry, IB20, IB20Asset, IB20Factory, IB20Stablecoin, IPolicyRegistry};
@@ -612,12 +612,7 @@ where
         if let Err(error) = &result {
             self.record_base_error(error);
         }
-        let result = result.into_precompile_result(
-            ctx.gas_used(),
-            ctx.state_gas_used(),
-            ctx.gas_refunded(),
-            encode_ok,
-        );
+        let result = ctx.result_output(result, encode_ok);
         self.record_result(&result);
         result
     }


### PR DESCRIPTION
Backports the remaining precompile fixes from main that were missing from \`releases/v1.1.0\` after the batch backport PRs (#3395, #3396, #3416, #3423, #3426, #3447). Excludes #3121 (EIP-8130 nonce/tx-context feature — intentionally deferred).

## Commits included

| Original PR | Description |
|---|---|
| #3388 | fix(precompile-macros): improve `#[contract]` macro diagnostic for unrecognized arguments |
| #3253 | refactor(b20-asset, activation): remove unreachable announcement guard and redundant `AlreadyDeactivated` error |
| #3344 | fix(chainspec,activation): reject zero activation admin address |
| #3404 | fix(precompile-storage): remove redundant drop in `with_caller` and harden `CallerGuard` |
| stragglers | `set.rs` em-dash, `vec.rs` truncate tests, `activation` test ordering, `token.rs` batch-mint auth boundary doc, `b20_stablecoin` comment, `metrics.rs` `ctx.result_output()` |

## What's intentionally NOT included

- #3121 (feat: EIP-8130 tx-context + nonce manager precompiles) — deferred from v1.1.0
- The `storage_ctx.rs` `origin()` method stub (part of #3121's `tx.origin` support)

## Test plan
- [ ] CI passes
- [ ] `git diff origin/releases/v1.1.0 origin/main -- crates/common/precompile-macros/ crates/common/precompile-storage/ crates/common/precompiles/` shows only #3121-related files after merge