### PR TITLE
[backport] fix(precompile-storage): remove unused token arg from checkpoint_commit (BOP-350)

### DIFF
--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -540,9 +540,9 @@ mod tests {
     #[test]
     fn checkpoint_commit_does_not_revert_mutations() {
         let mut p = HashMapStorageProvider::new(1);
-        let cp = p.checkpoint();
+        p.checkpoint();
         p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
-        p.checkpoint_commit(cp);
+        p.checkpoint_commit();
         assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }


### PR DESCRIPTION
Backport of #3406 to `releases/v1.1.0`.

The batch backport updated the `checkpoint_commit` trait signature to take no arguments, but the test in `hashmap.rs` was left calling `p.checkpoint_commit(cp)` with the old `JournalCheckpoint` argument — causing a compile error.

This fixes the test to match the already-backported signature:
```rust
- let cp = p.checkpoint();
+ p.checkpoint();
  p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
- p.checkpoint_commit(cp);
+ p.checkpoint_commit();
```

## Test plan
- [ ] CI passes (compile error resolved)