### PR TITLE
[SPIKE] feat(genesis): Plumb Activation Admin Address

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -508,6 +508,7 @@ impl ActionEngineClient {
             // The spec notes: "as long as MinBaseFee is not explicitly set, the
             // default value (0) will be systematically applied."
             min_base_fee: Some(0),
+            activation_admin_address: None,
         };
 
         let built = Self::build_payload(inner, payload.parent_hash, attrs)?;

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1173,6 +1173,7 @@ impl BasePayloadBuilderCtx {
             gas_limit: parent.gas_limit,
             parent_beacon_block_root: Some(B256::ZERO),
             extra_data: Default::default(),
+            activation_admin_address: None,
         };
 
         let evm_env = evm_config

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -175,6 +175,7 @@ where
             gas_limit: config.attributes.gas_limit.unwrap_or(config.parent_header.gas_limit),
             parent_beacon_block_root: config.attributes.payload_attributes.parent_beacon_block_root,
             extra_data,
+            activation_admin_address: config.attributes.activation_admin_address,
         };
 
         let evm_config = self.evm_config.clone();

--- a/crates/builder/core/src/test_utils/driver.rs
+++ b/crates/builder/core/src/test_utils/driver.rs
@@ -186,6 +186,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
                 no_tx_pool,
                 min_base_fee,
                 eip_1559_params: Some(B64::from(eip_1559_params)),
+                activation_admin_address: None,
             })
             .await?;
 

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -279,6 +279,7 @@ impl ChainConfig {
                 operator_fee_constant: None,
                 min_base_fee: None,
                 da_footprint_gas_scalar: None,
+                activation_admin_address: Some(self.activation_admin_address),
             }),
         }
     }
@@ -373,7 +374,7 @@ const MAINNET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
 
     unsafe_block_signer: Some(address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a")),
-    activation_admin_address: address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"),
+    activation_admin_address: address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"),
 
     max_gas_limit: 105_000_000,
     prune_delete_limit: 20_000,
@@ -447,7 +448,7 @@ const SEPOLIA: ChainConfig = ChainConfig {
     protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
 
     unsafe_block_signer: Some(address!("b830b99c95Ea32300039624Cb567d324D4b1D83C")),
-    activation_admin_address: address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"),
+    activation_admin_address: address!("5F43072722f59964d886CBb507F6a85ca0759D42"),
 
     max_gas_limit: 45_000_000,
     prune_delete_limit: 10_000,

--- a/crates/common/evm/src/executor/block_executor.rs
+++ b/crates/common/evm/src/executor/block_executor.rs
@@ -24,8 +24,8 @@ use revm::{
 };
 
 use crate::{
-    BaseBlockExecutionCtx, BaseBlockExecutionError, BaseReceiptBuilder, BaseTxEnv, BaseTxResult,
-    DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, canyon,
+    ActivationAdminPrecompiles, BaseBlockExecutionCtx, BaseBlockExecutionError, BaseReceiptBuilder,
+    BaseSpecId, BaseTxEnv, BaseTxResult, DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, canyon,
 };
 
 /// Block executor for Base.
@@ -56,12 +56,19 @@ pub struct BaseBlockExecutor<Evm, R: BaseReceiptBuilder, Spec> {
 
 impl<E, R, Spec> BaseBlockExecutor<E, R, Spec>
 where
-    E: Evm,
+    E: Evm<Spec = BaseSpecId>,
+    E::Precompiles: ActivationAdminPrecompiles,
     R: BaseReceiptBuilder,
     Spec: Upgrades + Clone,
 {
     /// Creates a new [`BaseBlockExecutor`].
-    pub fn new(evm: E, ctx: BaseBlockExecutionCtx, spec: Spec, receipt_builder: R) -> Self {
+    pub fn new(mut evm: E, ctx: BaseBlockExecutionCtx, spec: Spec, receipt_builder: R) -> Self {
+        if let Some(activation_admin_address) = ctx.activation_admin_address {
+            let spec_id = evm.cfg_env().spec;
+            evm.components_mut()
+                .2
+                .set_activation_admin_address(spec_id, Some(activation_admin_address));
+        }
         Self {
             is_regolith: spec
                 .is_regolith_active_at_timestamp(evm.block().timestamp().saturating_to()),

--- a/crates/common/evm/src/executor/context.rs
+++ b/crates/common/evm/src/executor/context.rs
@@ -1,6 +1,6 @@
 //! Contains the context for base block execution.
 
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 
 /// Context for base block execution.
 #[derive(Debug, Default, Clone)]
@@ -11,4 +11,6 @@ pub struct BaseBlockExecutionCtx {
     pub parent_beacon_block_root: Option<B256>,
     /// The block's extra data.
     pub extra_data: Bytes,
+    /// Activation registry admin address for this block.
+    pub activation_admin_address: Option<Address>,
 }

--- a/crates/common/evm/src/executor/factory.rs
+++ b/crates/common/evm/src/executor/factory.rs
@@ -10,8 +10,8 @@ use base_common_chains::{ChainUpgrades, Upgrades};
 use revm::Inspector;
 
 use crate::{
-    AlloyReceiptBuilder, BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmFactory,
-    BaseReceiptBuilder, BaseTxEnv, BaseTxResult,
+    ActivationAdminPrecompiles, AlloyReceiptBuilder, BaseBlockExecutionCtx, BaseBlockExecutor,
+    BaseEvmFactory, BaseReceiptBuilder, BaseSpecId, BaseTxEnv, BaseTxResult,
 };
 
 /// Ethereum block executor factory.
@@ -60,8 +60,10 @@ where
         > + Clone,
     Spec: Upgrades + Clone,
     EvmF: EvmFactory<
-        Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction> + BaseTxEnv,
-    >,
+            Spec = BaseSpecId,
+            Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction> + BaseTxEnv,
+        >,
+    EvmF::Precompiles: ActivationAdminPrecompiles,
     Self: 'static,
 {
     type EvmFactory = EvmF;

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -8,9 +8,31 @@ use revm::{
 };
 
 use crate::{
-    BaseContext, BaseEvm, BaseHaltReason, BaseSpecId, BaseTransaction, BaseTransactionError,
-    Builder, DefaultBase,
+    BaseContext, BaseEvm, BaseHaltReason, BasePrecompiles, BaseSpecId, BaseTransaction,
+    BaseTransactionError, BerylPrecompileMetricsObserver, Builder, DefaultBase,
 };
+
+/// Precompile providers that can rebuild their activation-registry admin binding.
+pub trait ActivationAdminPrecompiles {
+    /// Rebuilds the activation-registry precompile for `spec` and `activation_admin_address`.
+    fn set_activation_admin_address(
+        &mut self,
+        spec: BaseSpecId,
+        activation_admin_address: Option<Address>,
+    );
+}
+
+impl ActivationAdminPrecompiles for PrecompilesMap {
+    fn set_activation_admin_address(
+        &mut self,
+        spec: BaseSpecId,
+        activation_admin_address: Option<Address>,
+    ) {
+        *self = BasePrecompiles::new_with_spec(spec)
+            .with_activation_admin_address(activation_admin_address)
+            .install_with_observer(BerylPrecompileMetricsObserver);
+    }
+}
 
 /// Factory that produces [`BaseEvm`] instances backed by a [`PrecompilesMap`].
 ///

--- a/crates/common/evm/src/lib.rs
+++ b/crates/common/evm/src/lib.rs
@@ -38,7 +38,7 @@ mod evm;
 pub use evm::BaseEvm;
 
 mod factory;
-pub use factory::BaseEvmFactory;
+pub use factory::{ActivationAdminPrecompiles, BaseEvmFactory};
 
 mod tx_env;
 pub use tx_env::BaseTxEnv;

--- a/crates/common/genesis/src/genesis.rs
+++ b/crates/common/genesis/src/genesis.rs
@@ -66,6 +66,7 @@ mod tests {
                 operator_fee_constant: None,
                 min_base_fee: None,
                 da_footprint_gas_scalar: Some(10),
+                activation_admin_address: None,
             }),
         }
     }

--- a/crates/common/genesis/src/lib.rs
+++ b/crates/common/genesis/src/lib.rs
@@ -14,17 +14,18 @@ pub use params::FeeConfig;
 
 mod updates;
 pub use updates::{
-    BatcherUpdate, DaFootprintGasScalarUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate,
-    MinBaseFeeUpdate, OperatorFeeUpdate, UnsafeBlockSignerUpdate, UpdateDataValidator,
-    ValidatedUpdateData, ValidationError, Validator,
+    ActivationAdminUpdate, BatcherUpdate, DaFootprintGasScalarUpdate, Eip1559Update,
+    GasConfigUpdate, GasLimitUpdate, MinBaseFeeUpdate, OperatorFeeUpdate, UnsafeBlockSignerUpdate,
+    UpdateDataValidator, ValidatedUpdateData, ValidationError, Validator,
 };
 
 mod system;
 pub use system::{
-    BatcherUpdateError, DaFootprintGasScalarUpdateError, EIP1559UpdateError, GasConfigUpdateError,
-    GasLimitUpdateError, LogProcessingError, MinBaseFeeUpdateError, OperatorFeeUpdateError,
-    SystemConfig, SystemConfigLog, SystemConfigUpdate, SystemConfigUpdateError,
-    SystemConfigUpdateKind, UnsafeBlockSignerUpdateError,
+    ActivationAdminUpdateError, BatcherUpdateError, DaFootprintGasScalarUpdateError,
+    EIP1559UpdateError, GasConfigUpdateError, GasLimitUpdateError, LogProcessingError,
+    MinBaseFeeUpdateError, OperatorFeeUpdateError, SystemConfig, SystemConfigLog,
+    SystemConfigUpdate, SystemConfigUpdateError, SystemConfigUpdateKind,
+    UnsafeBlockSignerUpdateError,
 };
 
 mod chain;

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -591,6 +591,7 @@ mod tests {
                     operator_fee_constant: Some(40),
                     min_base_fee: Some(50),
                     da_footprint_gas_scalar: Some(10),
+                    activation_admin_address: None,
                 }),
             },
             block_time: 2,

--- a/crates/common/genesis/src/system/config.rs
+++ b/crates/common/genesis/src/system/config.rs
@@ -50,6 +50,8 @@ pub struct SystemConfig {
     /// Note: according to the [spec](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/system-config.md#initialization), as long as the `DAFootprintGasScalar` is not
     /// explicitly set, the default value (`400`) will be systematically applied.
     pub da_footprint_gas_scalar: Option<u16>,
+    /// Activation registry admin address.
+    pub activation_admin_address: Option<Address>,
 }
 
 /// Custom EIP-1559 parameter decoding is needed here for holocene encoding.
@@ -84,6 +86,7 @@ impl<'a> serde::Deserialize<'a> for SystemConfig {
             operator_fee_constant: Option<u64>,
             min_base_fee: Option<u64>,
             da_footprint_gas_scalar: Option<u16>,
+            activation_admin_address: Option<Address>,
         }
 
         let mut alias = SystemConfigAlias::deserialize(deserializer)?;
@@ -115,6 +118,7 @@ impl<'a> serde::Deserialize<'a> for SystemConfig {
             operator_fee_constant: alias.operator_fee_constant,
             min_base_fee: alias.min_base_fee,
             da_footprint_gas_scalar: alias.da_footprint_gas_scalar,
+            activation_admin_address: alias.activation_admin_address,
         })
     }
 }
@@ -241,6 +245,8 @@ mod tests {
         b256!("0000000000000000000000000000000000000000000000000000000000000004");
     const OPERATOR_FEE_UPDATE_TYPE: B256 =
         b256!("0000000000000000000000000000000000000000000000000000000000000005");
+    const ACTIVATION_ADMIN_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000008");
 
     #[test]
     #[cfg(feature = "serde")]
@@ -469,6 +475,30 @@ mod tests {
         assert_eq!(
             system_config.batcher_address,
             address!("000000000000000000000000000000000000bEEF")
+        );
+    }
+
+    #[test]
+    fn test_system_config_update_activation_admin_log() {
+        let mut system_config = SystemConfig::default();
+
+        let update_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
+                    ACTIVATION_ADMIN_UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        system_config.process_config_update_log(&update_log, false).unwrap();
+
+        assert_eq!(
+            system_config.activation_admin_address,
+            Some(address!("000000000000000000000000000000000000bEEF"))
         );
     }
 

--- a/crates/common/genesis/src/system/errors.rs
+++ b/crates/common/genesis/src/system/errors.rs
@@ -34,6 +34,9 @@ pub enum SystemConfigUpdateError {
     /// A da footprint gas scalar update error.
     #[error("DA footprint gas scalar update error: {0}")]
     DaFootprintGasScalar(DaFootprintGasScalarUpdateError),
+    /// An activation admin update error.
+    #[error("Activation admin update error: {0}")]
+    ActivationAdmin(ActivationAdminUpdateError),
 }
 
 /// An error occurred while processing the update log.
@@ -79,6 +82,30 @@ pub enum BatcherUpdateError {
     /// Failed to decode the batcher address argument from the batcher update log.
     #[error("Failed to decode batcher update log: batcher address")]
     BatcherAddressDecodingError,
+}
+
+/// An error for updating the activation admin address on the [`crate::SystemConfig`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ActivationAdminUpdateError {
+    /// Invalid data length.
+    #[error("Invalid config update log: invalid data length: {0}")]
+    InvalidDataLen(usize),
+    /// Failed to decode the data pointer argument from the activation admin update log.
+    #[error("Failed to decode activation admin update log: data pointer")]
+    PointerDecodingError,
+    /// The data pointer is invalid.
+    #[error("Invalid config update log: invalid data pointer: {0}")]
+    InvalidDataPointer(u64),
+    /// Failed to decode the data length argument from the activation admin update log.
+    #[error("Failed to decode activation admin update log: data length")]
+    LengthDecodingError,
+    /// The data length is invalid.
+    #[error("Invalid config update log: invalid data length: {0}")]
+    InvalidDataLength(u64),
+    /// Failed to decode the activation admin address argument from the activation admin update log.
+    #[error("Failed to decode activation admin update log: activation admin address")]
+    ActivationAdminAddressDecodingError,
 }
 
 /// An error for updating the unsafe block signer address on the [`crate::SystemConfig`].

--- a/crates/common/genesis/src/system/kind.rs
+++ b/crates/common/genesis/src/system/kind.rs
@@ -21,4 +21,6 @@ pub enum SystemConfigUpdateKind {
     MinBaseFee = 6,
     /// DA footprint gas scalar update type
     DaFootprintGasScalar = 7,
+    /// Activation registry admin update type
+    ActivationAdmin = 8,
 }

--- a/crates/common/genesis/src/system/log.rs
+++ b/crates/common/genesis/src/system/log.rs
@@ -3,9 +3,9 @@
 use alloy_primitives::Log;
 
 use crate::{
-    BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate, LogProcessingError,
-    OperatorFeeUpdate, SystemConfigUpdate, SystemConfigUpdateError, SystemConfigUpdateKind,
-    UnsafeBlockSignerUpdate,
+    ActivationAdminUpdate, BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate,
+    LogProcessingError, OperatorFeeUpdate, SystemConfigUpdate, SystemConfigUpdateError,
+    SystemConfigUpdateKind, UnsafeBlockSignerUpdate,
     updates::{DaFootprintGasScalarUpdate, MinBaseFeeUpdate},
 };
 
@@ -107,6 +107,10 @@ impl SystemConfigLog {
             SystemConfigUpdateKind::DaFootprintGasScalar => {
                 let update = DaFootprintGasScalarUpdate::try_from(self)?;
                 Ok(SystemConfigUpdate::DaFootprintGasScalar(update))
+            }
+            SystemConfigUpdateKind::ActivationAdmin => {
+                let update = ActivationAdminUpdate::try_from(self)?;
+                Ok(SystemConfigUpdate::ActivationAdmin(update))
             }
         }
     }

--- a/crates/common/genesis/src/system/mod.rs
+++ b/crates/common/genesis/src/system/mod.rs
@@ -14,7 +14,8 @@ pub use kind::SystemConfigUpdateKind;
 
 mod errors;
 pub use errors::{
-    BatcherUpdateError, DaFootprintGasScalarUpdateError, EIP1559UpdateError, GasConfigUpdateError,
-    GasLimitUpdateError, LogProcessingError, MinBaseFeeUpdateError, OperatorFeeUpdateError,
-    SystemConfigUpdateError, UnsafeBlockSignerUpdateError,
+    ActivationAdminUpdateError, BatcherUpdateError, DaFootprintGasScalarUpdateError,
+    EIP1559UpdateError, GasConfigUpdateError, GasLimitUpdateError, LogProcessingError,
+    MinBaseFeeUpdateError, OperatorFeeUpdateError, SystemConfigUpdateError,
+    UnsafeBlockSignerUpdateError,
 };

--- a/crates/common/genesis/src/system/update.rs
+++ b/crates/common/genesis/src/system/update.rs
@@ -3,8 +3,8 @@
 use alloy_primitives::{B256, b256};
 
 use crate::{
-    BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate, OperatorFeeUpdate, SystemConfig,
-    SystemConfigUpdateKind, UnsafeBlockSignerUpdate,
+    ActivationAdminUpdate, BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate,
+    OperatorFeeUpdate, SystemConfig, SystemConfigUpdateKind, UnsafeBlockSignerUpdate,
     updates::{DaFootprintGasScalarUpdate, MinBaseFeeUpdate},
 };
 
@@ -29,6 +29,8 @@ pub enum SystemConfigUpdate {
     MinBaseFee(MinBaseFeeUpdate),
     /// DA footprint gas scalar update.
     DaFootprintGasScalar(DaFootprintGasScalarUpdate),
+    /// Activation registry admin update.
+    ActivationAdmin(ActivationAdminUpdate),
 }
 
 impl SystemConfigUpdate {
@@ -50,6 +52,7 @@ impl SystemConfigUpdate {
             Self::OperatorFee(update) => update.apply(config),
             Self::MinBaseFee(update) => update.apply(config),
             Self::DaFootprintGasScalar(update) => update.apply(config),
+            Self::ActivationAdmin(update) => update.apply(config),
         }
     }
 
@@ -64,6 +67,7 @@ impl SystemConfigUpdate {
             Self::OperatorFee(_) => SystemConfigUpdateKind::OperatorFee,
             Self::MinBaseFee(_) => SystemConfigUpdateKind::MinBaseFee,
             Self::DaFootprintGasScalar(_) => SystemConfigUpdateKind::DaFootprintGasScalar,
+            Self::ActivationAdmin(_) => SystemConfigUpdateKind::ActivationAdmin,
         }
     }
 }

--- a/crates/common/genesis/src/updates/activation_admin.rs
+++ b/crates/common/genesis/src/updates/activation_admin.rs
@@ -1,0 +1,119 @@
+//! The activation admin update type.
+
+use alloy_primitives::{Address, LogData};
+use alloy_sol_types::{SolType, sol};
+
+use crate::{
+    ActivationAdminUpdateError, SystemConfig, SystemConfigLog, UpdateDataValidator, ValidationError,
+};
+
+/// The activation admin update type.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ActivationAdminUpdate {
+    /// The activation registry admin address.
+    pub activation_admin_address: Address,
+}
+
+impl ActivationAdminUpdate {
+    /// Applies the update to the [`SystemConfig`].
+    pub const fn apply(&self, config: &mut SystemConfig) {
+        config.activation_admin_address = Some(self.activation_admin_address);
+    }
+}
+
+impl TryFrom<&SystemConfigLog> for ActivationAdminUpdate {
+    type Error = ActivationAdminUpdateError;
+
+    fn try_from(log: &SystemConfigLog) -> Result<Self, Self::Error> {
+        let LogData { data, .. } = &log.log.data;
+
+        let validated = UpdateDataValidator::validate(data).map_err(|e| match e {
+            ValidationError::InvalidDataLen(_expected, actual) => {
+                ActivationAdminUpdateError::InvalidDataLen(actual)
+            }
+            ValidationError::PointerDecodingError => {
+                ActivationAdminUpdateError::PointerDecodingError
+            }
+            ValidationError::InvalidDataPointer(pointer) => {
+                ActivationAdminUpdateError::InvalidDataPointer(pointer)
+            }
+            ValidationError::LengthDecodingError => ActivationAdminUpdateError::LengthDecodingError,
+            ValidationError::InvalidDataLength(length) => {
+                ActivationAdminUpdateError::InvalidDataLength(length)
+            }
+        })?;
+
+        let Ok(activation_admin_address) =
+            <sol!(address)>::abi_decode_validate(validated.payload())
+        else {
+            return Err(ActivationAdminUpdateError::ActivationAdminAddressDecodingError);
+        };
+
+        Ok(Self { activation_admin_address })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use alloy_primitives::{B256, Bytes, Log, LogData, address, hex};
+    use rstest::rstest;
+
+    use super::*;
+    use crate::SystemConfigUpdate;
+
+    #[test]
+    fn test_activation_admin_update_try_from() {
+        let log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
+                    B256::ZERO,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into(),
+            ),
+        };
+        let system_log = SystemConfigLog::new(log, false);
+        let update = ActivationAdminUpdate::try_from(&system_log).unwrap();
+        assert_eq!(
+            update.activation_admin_address,
+            address!("000000000000000000000000000000000000bEEF")
+        );
+    }
+
+    #[test]
+    fn test_activation_admin_update_invalid_data_len() {
+        let log =
+            Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
+        let system_log = SystemConfigLog::new(log, false);
+        assert_eq!(
+            ActivationAdminUpdate::try_from(&system_log).unwrap_err(),
+            ActivationAdminUpdateError::InvalidDataLen(0)
+        );
+    }
+
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), ActivationAdminUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), ActivationAdminUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), ActivationAdminUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), ActivationAdminUpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), ActivationAdminUpdateError::ActivationAdminAddressDecodingError)]
+    fn test_activation_admin_update_errors(
+        #[case] data: [u8; 96],
+        #[case] expected: ActivationAdminUpdateError,
+    ) {
+        let log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
+        };
+        let system_log = SystemConfigLog::new(log, false);
+        assert_eq!(ActivationAdminUpdate::try_from(&system_log).unwrap_err(), expected);
+    }
+}

--- a/crates/common/genesis/src/updates/mod.rs
+++ b/crates/common/genesis/src/updates/mod.rs
@@ -26,3 +26,6 @@ pub use min_base_fee::MinBaseFeeUpdate;
 
 mod da_footprint_gas_scalar;
 pub use da_footprint_gas_scalar::DaFootprintGasScalarUpdate;
+
+mod activation_admin;
+pub use activation_admin::ActivationAdminUpdate;

--- a/crates/common/rpc-types-engine/src/attributes.rs
+++ b/crates/common/rpc-types-engine/src/attributes.rs
@@ -7,7 +7,7 @@ use alloy_eips::{
     eip1559::BaseFeeParams,
     eip2718::{Eip2718Result, WithEncoded},
 };
-use alloy_primitives::{B64, B256, Bytes, keccak256};
+use alloy_primitives::{Address, B64, B256, Bytes, keccak256};
 use alloy_rlp::{Encodable, Result};
 use alloy_rpc_types_engine::{PayloadAttributes, PayloadId};
 use base_common_consensus::{
@@ -50,6 +50,9 @@ pub struct BasePayloadAttributes {
     /// Prior to Jovian activation, this field should always be [None].
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub min_base_fee: Option<u64>,
+    /// If set, this selects the activation registry admin for the block.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub activation_admin_address: Option<Address>,
 }
 
 impl BasePayloadAttributes {
@@ -101,6 +104,10 @@ impl BasePayloadAttributes {
 
         if let Some(min_base_fee) = self.min_base_fee {
             hasher.update(min_base_fee.to_be_bytes());
+        }
+
+        if let Some(activation_admin_address) = self.activation_admin_address {
+            hasher.update(activation_admin_address.as_slice());
         }
 
         let mut out = hasher.finalize();
@@ -242,6 +249,7 @@ mod test {
             gas_limit: Some(30000000),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
 
         // Reth's `PayloadId` should match op-geth's `PayloadId`. This fails
@@ -276,6 +284,7 @@ mod test {
             gas_limit: Some(30000000),
             eip_1559_params: None,
             min_base_fee: Some(100),
+            activation_admin_address: None,
         };
 
         // Reth's `PayloadId` should match op-geth's `PayloadId`. This fails
@@ -305,6 +314,7 @@ mod test {
             gas_limit: Some(42),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -329,6 +339,7 @@ mod test {
             gas_limit: Some(42),
             eip_1559_params: Some(b64!("0000dead0000beef")),
             min_base_fee: None,
+            activation_admin_address: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -371,6 +382,7 @@ mod test {
             gas_limit: Some(42),
             eip_1559_params: Some(b64!("0000dead0000beef")),
             min_base_fee: None,
+            activation_admin_address: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -395,6 +407,7 @@ mod test {
             gas_limit: Some(42),
             eip_1559_params: None,
             min_base_fee: Some(1),
+            activation_admin_address: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -215,6 +215,7 @@ where
                 l2_parent.block_info.timestamp,
                 next_l2_time,
             ),
+            activation_admin_address: sys_config.activation_admin_address,
             min_base_fee: self
                 .rollup_cfg
                 .is_jovian_active(next_l2_time)
@@ -497,6 +498,7 @@ mod tests {
             )),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
         assert_eq!(payload, expected);
         assert_eq!(payload.transactions.unwrap().len(), 1);
@@ -550,6 +552,7 @@ mod tests {
             )),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
         assert_eq!(payload, expected);
         assert_eq!(payload.transactions.unwrap().len(), 1);
@@ -604,6 +607,7 @@ mod tests {
             )),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
         assert_eq!(payload, expected);
         assert_eq!(payload.transactions.unwrap().len(), 7);
@@ -657,6 +661,7 @@ mod tests {
             )),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
         assert_eq!(payload.transactions.as_ref().unwrap().len(), 10);
         assert_eq!(payload, expected);

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -290,6 +290,7 @@ mod tests {
                 gas_limit: None,
                 eip_1559_params: None,
                 min_base_fee: None,
+                activation_admin_address: None,
             },
             parent: Default::default(),
             derived_from: Default::default(),

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -240,6 +240,7 @@ mod tests {
             gas_limit: None,
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         }
     }
 

--- a/crates/consensus/engine/src/test_utils/attributes.rs
+++ b/crates/consensus/engine/src/test_utils/attributes.rs
@@ -94,6 +94,7 @@ impl TestAttributesBuilder {
             gas_limit: self.gas_limit,
             eip_1559_params: self.eip_1559_params,
             min_base_fee: self.min_base_fee,
+            activation_admin_address: None,
         };
 
         AttributesWithParent::new(attributes, self.parent, self.derived_from, self.is_last_in_span)

--- a/crates/consensus/protocol/src/utils.rs
+++ b/crates/consensus/protocol/src/utils.rs
@@ -57,6 +57,10 @@ pub fn to_system_config(
         overhead: l1_info.l1_fee_overhead(),
         scalar: l1_fee_scalar,
         gas_limit: block.header.gas_limit,
+        activation_admin_address: rollup_config
+            .genesis
+            .system_config
+            .and_then(|config| config.activation_admin_address),
         ..Default::default()
     };
 
@@ -314,6 +318,7 @@ mod tests {
             operator_fee_constant: None,
             min_base_fee: None,
             da_footprint_gas_scalar: None,
+            activation_admin_address: None,
         };
         assert_eq!(config, expected);
     }
@@ -363,6 +368,7 @@ mod tests {
             operator_fee_constant: None,
             min_base_fee: None,
             da_footprint_gas_scalar: None,
+            activation_admin_address: None,
         };
         assert_eq!(config, expected);
     }
@@ -416,6 +422,7 @@ mod tests {
             operator_fee_constant: Some(0xdcba),
             min_base_fee: None,
             da_footprint_gas_scalar: None,
+            activation_admin_address: None,
         };
         assert_eq!(config, expected);
     }

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -667,11 +667,11 @@ mod tests {
     fn activation_admin_matches_chain_config() {
         assert_eq!(
             BaseChainSpec::mainnet().activation_admin_address(),
-            Some(address!("331C9d37BbcebBC9dfAf98FBE3C5B8A39Dd6E771"))
+            Some(address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"))
         );
         assert_eq!(
             BaseChainSpec::sepolia().activation_admin_address(),
-            Some(address!("5Be7Dd3678e999D5F7bC508c413db239F7D4Ac59"))
+            Some(address!("5F43072722f59964d886CBb507F6a85ca0759D42"))
         );
     }
 

--- a/crates/execution/evm/src/config.rs
+++ b/crates/execution/evm/src/config.rs
@@ -51,6 +51,8 @@ pub struct BaseNextBlockEnvAttributes {
     pub parent_beacon_block_root: Option<B256>,
     /// Encoded EIP-1559 parameters to include into block's `extra_data` field.
     pub extra_data: RevmBytes,
+    /// Activation registry admin address for the next block.
+    pub activation_admin_address: Option<Address>,
 }
 
 #[cfg(feature = "rpc")]
@@ -65,6 +67,7 @@ impl<H: alloy_consensus::BlockHeader> reth_rpc_eth_api::helpers::pending_block::
             gas_limit: parent.gas_limit(),
             parent_beacon_block_root: parent.parent_beacon_block_root(),
             extra_data: parent.extra_data().clone(),
+            activation_admin_address: None,
         }
     }
 }
@@ -194,6 +197,7 @@ where
             parent_hash: block.header().parent_hash(),
             parent_beacon_block_root: block.header().parent_beacon_block_root(),
             extra_data: block.header().extra_data().clone(),
+            activation_admin_address: None,
         })
     }
 
@@ -206,6 +210,7 @@ where
             parent_hash: parent.hash(),
             parent_beacon_block_root: attributes.parent_beacon_block_root,
             extra_data: attributes.extra_data,
+            activation_admin_address: attributes.activation_admin_address,
         })
     }
 }
@@ -237,6 +242,7 @@ where
             parent_hash: payload.parent_hash(),
             parent_beacon_block_root: payload.sidecar.parent_beacon_block_root(),
             extra_data: payload.payload.as_v1().extra_data.clone(),
+            activation_admin_address: None,
         })
     }
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -585,6 +585,7 @@ where
             gas_limit: base.gas_limit,
             parent_beacon_block_root: Some(base.parent_beacon_block_root),
             extra_data: base.extra_data.clone(),
+            activation_admin_address: None,
         };
         let evm_env = evm_config
             .next_evm_env(&previous_header, &block_env_attributes)
@@ -725,6 +726,7 @@ where
                 gas_limit: assembled.base.gas_limit,
                 parent_beacon_block_root: Some(assembled.base.parent_beacon_block_root),
                 extra_data: assembled.base.extra_data.clone(),
+                activation_admin_address: None,
             };
 
             let evm_env = evm_config

--- a/crates/execution/metering/src/block.rs
+++ b/crates/execution/metering/src/block.rs
@@ -67,6 +67,7 @@ where
         gas_limit: block.header().gas_limit(),
         parent_beacon_block_root: block.header().parent_beacon_block_root(),
         extra_data: block.header().extra_data().clone(),
+        activation_admin_address: None,
     };
 
     // Recover signers first (this can be parallelized in production)

--- a/crates/execution/metering/src/meter.rs
+++ b/crates/execution/metering/src/meter.rs
@@ -400,6 +400,7 @@ where
         parent_beacon_block_root: parent_beacon_block_root
             .or_else(|| header.parent_beacon_block_root()),
         extra_data: header.extra_data().clone(),
+        activation_admin_address: None,
     };
 
     // Execute transactions with a MeteringInspector to collect per-opcode and

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -420,6 +420,7 @@ mod tests {
                     parent_beacon_block_root: Some(B256::ZERO),
                     slot_number: None,
                 },
+                activation_admin_address: None,
             },
             3,
         )

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -178,6 +178,7 @@ impl PayloadAttributesBuilder<BasePayloadBuilderAttributes<BaseTxEnvelope>>
             gas_limit,
             eip_1559_params,
             min_base_fee: Some(0),
+            activation_admin_address: None,
         };
 
         BasePayloadBuilderAttributes::try_new(parent.hash(), attributes, 3)

--- a/crates/execution/node/src/utils.rs
+++ b/crates/execution/node/src/utils.rs
@@ -84,5 +84,6 @@ pub fn payload_attributes<T>(timestamp: u64) -> BasePayloadBuilderAttributes<T> 
         gas_limit: Some(30_000_000),
         eip_1559_params: None,
         min_base_fee: None,
+        activation_admin_address: None,
     }
 }

--- a/crates/execution/node/tests/e2e-testsuite/testsuite.rs
+++ b/crates/execution/node/tests/e2e-testsuite/testsuite.rs
@@ -52,6 +52,7 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
                     eip_1559_params: None,
                     min_base_fee: None,
                     gas_limit: Some(30_000_000),
+                    activation_admin_address: None,
                 },
                 3,
             )
@@ -103,6 +104,7 @@ async fn test_testsuite_op_assert_mine_block_isthmus_activated() -> Result<()> {
                     eip_1559_params: Some(B64::ZERO),
                     min_base_fee: None,
                     gas_limit: Some(30_000_000),
+                    activation_admin_address: None,
                 },
                 3,
             )

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -69,6 +69,8 @@ pub struct BasePayloadBuilderAttributes<T> {
     pub eip_1559_params: Option<B64>,
     /// Min base fee for the generated payload (only available post-Jovian)
     pub min_base_fee: Option<u64>,
+    /// Activation registry admin address for the generated payload.
+    pub activation_admin_address: Option<Address>,
 }
 
 impl<T> Default for BasePayloadBuilderAttributes<T> {
@@ -80,6 +82,7 @@ impl<T> Default for BasePayloadBuilderAttributes<T> {
             eip_1559_params: Default::default(),
             transactions: Default::default(),
             min_base_fee: Default::default(),
+            activation_admin_address: Default::default(),
         }
     }
 }
@@ -105,6 +108,7 @@ impl<T> BasePayloadBuilderAttributes<T> {
             gas_limit: self.gas_limit,
             eip_1559_params: self.eip_1559_params,
             min_base_fee: self.min_base_fee,
+            activation_admin_address: self.activation_admin_address,
         }
     }
 
@@ -176,6 +180,7 @@ impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> BasePayloadBuilde
             gas_limit: attributes.gas_limit,
             eip_1559_params: attributes.eip_1559_params,
             min_base_fee: attributes.min_base_fee,
+            activation_admin_address: attributes.activation_admin_address,
         })
     }
 }
@@ -518,6 +523,10 @@ pub fn payload_id(
         hasher.update(min_base_fee.to_be_bytes());
     }
 
+    if let Some(activation_admin_address) = attributes.activation_admin_address {
+        hasher.update(activation_admin_address.as_slice());
+    }
+
     let mut out = hasher.finalize();
     out[0] = payload_version;
 
@@ -565,6 +574,7 @@ where
             gas_limit: attributes.gas_limit.unwrap_or_else(|| parent.gas_limit()),
             parent_beacon_block_root: attributes.payload_attributes.parent_beacon_block_root,
             extra_data,
+            activation_admin_address: attributes.activation_admin_address,
         })
     }
 }
@@ -599,6 +609,7 @@ mod tests {
             gas_limit: Some(30000000),
             eip_1559_params: None,
             min_base_fee: None,
+            activation_admin_address: None,
         };
 
         // Reth's `PayloadId` should match op-geth's `PayloadId`. This fails
@@ -631,6 +642,7 @@ mod tests {
             gas_limit: Some(30000000),
             eip_1559_params: None,
             min_base_fee: Some(100),
+            activation_admin_address: None,
         };
 
         // Reth's `PayloadId` should match op-geth's `PayloadId`. This fails

--- a/crates/execution/runner/src/test_utils/harness.rs
+++ b/crates/execution/runner/src/test_utils/harness.rs
@@ -196,6 +196,7 @@ impl TestHarness {
                 no_tx_pool: Some(true),
                 min_base_fee: Some(min_base_fee),
                 eip_1559_params: Some(B64::from(eip_1559_params)),
+                activation_admin_address: None,
             },
             3,
         )?;

--- a/crates/proof/executor/src/builder/core.rs
+++ b/crates/proof/executor/src/builder/core.rs
@@ -14,7 +14,8 @@ use alloy_evm::{
 };
 use base_common_consensus::{BaseReceiptEnvelope, BaseTxEnvelope};
 use base_common_evm::{
-    AlloyReceiptBuilder, BaseBlockExecutionCtx, BaseBlockExecutorFactory, BaseSpecId, BaseTxEnv,
+    ActivationAdminPrecompiles, AlloyReceiptBuilder, BaseBlockExecutionCtx,
+    BaseBlockExecutorFactory, BaseSpecId, BaseTxEnv,
 };
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
@@ -57,6 +58,7 @@ where
     P: TrieDBProvider + Debug,
     H: TrieHinter + Debug,
     Evm: EvmFactory<Spec = BaseSpecId, BlockEnv = BlockEnv> + 'static,
+    <Evm as EvmFactory>::Precompiles: ActivationAdminPrecompiles,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<BaseTxEnvelope> + FromRecoveredTx<BaseTxEnvelope> + BaseTxEnv,
 {
@@ -146,6 +148,7 @@ where
             parent_beacon_block_root: attrs.payload_attributes.parent_beacon_block_root,
             // This field is unused for individual block building jobs.
             extra_data: Default::default(),
+            activation_admin_address: attrs.activation_admin_address,
         };
         let executor = self.factory.create_executor(evm, ctx);
 

--- a/crates/proof/executor/src/test_utils.rs
+++ b/crates/proof/executor/src/test_utils.rs
@@ -172,6 +172,7 @@ impl ExecutorTestFixtureCreator {
                     .map(u64::from_be_bytes)
                     .expect("Invalid header format for Jovian")
             }),
+            activation_admin_address: None,
         };
 
         let fixture_path = self.data_dir.join("fixture.json");

--- a/crates/proof/executor/src/util.rs
+++ b/crates/proof/executor/src/util.rs
@@ -125,6 +125,7 @@ mod test {
             gas_limit: None,
             eip_1559_params,
             min_base_fee: None,
+            activation_admin_address: None,
         }
     }
 

--- a/crates/proof/primitives/src/per_chain_config.rs
+++ b/crates/proof/primitives/src/per_chain_config.rs
@@ -262,6 +262,7 @@ impl PerChainConfig {
                 operator_fee_constant: None,
                 da_footprint_gas_scalar: None,
                 min_base_fee: None,
+                activation_admin_address: None,
             }),
         }
     }

--- a/crates/proof/proof/src/executor.rs
+++ b/crates/proof/proof/src/executor.rs
@@ -8,7 +8,7 @@ use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded, revm::context::B
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_common_consensus::BaseTxEnvelope;
-use base_common_evm::{BaseSpecId, BaseTxEnv};
+use base_common_evm::{ActivationAdminPrecompiles, BaseSpecId, BaseTxEnv};
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_proof_driver::Executor;
@@ -59,6 +59,7 @@ where
     P: TrieDBProvider + Debug + Send + Sync + Clone,
     H: TrieHinter + Debug + Send + Sync + Clone,
     Evm: EvmFactory<Spec = BaseSpecId, BlockEnv = BlockEnv> + Send + Sync + Clone + 'static,
+    <Evm as EvmFactory>::Precompiles: ActivationAdminPrecompiles,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<BaseTxEnvelope> + FromRecoveredTx<BaseTxEnvelope> + BaseTxEnv,
 {

--- a/crates/proof/succinct/utils/client/src/precompiles/mod.rs
+++ b/crates/proof/succinct/utils/client/src/precompiles/mod.rs
@@ -6,7 +6,7 @@ use alloy_evm::precompiles::PrecompilesMap;
 #[cfg(target_os = "zkvm")]
 use alloy_evm::precompiles::{DynPrecompile, Precompile};
 use alloy_primitives::Address;
-use base_common_evm::{BasePrecompiles, BaseSpecId};
+use base_common_evm::{ActivationAdminPrecompiles, BasePrecompiles, BaseSpecId};
 use base_common_precompiles::PrecompileCallObserver;
 #[cfg(any(test, target_os = "zkvm"))]
 use revm::precompile::PrecompileId;
@@ -167,6 +167,16 @@ impl BaseZkvmPrecompiles {
 
     #[cfg(not(target_os = "zkvm"))]
     const fn install_cycle_trackers(_precompiles: &mut PrecompilesMap) {}
+}
+
+impl ActivationAdminPrecompiles for BaseZkvmPrecompiles {
+    fn set_activation_admin_address(
+        &mut self,
+        spec: BaseSpecId,
+        activation_admin_address: Option<Address>,
+    ) {
+        *self = Self::new_with_spec_and_activation_admin_address(spec, activation_admin_address);
+    }
 }
 
 impl<CTX> PrecompileProvider<CTX> for BaseZkvmPrecompiles


### PR DESCRIPTION
## Summary

This PR adds activation admin updates to the system config path and propagates the selected admin address through payload attributes, block execution context, and proof execution. It also updates the configured mainnet and Sepolia activation admin addresses and keeps tests and helpers explicit about the new optional field.