### PR TITLE
[backport] fix(precompiles): Cap B20 Account Balances

### DIFF
--- a/crates/common/precompiles/src/common/abi.rs
+++ b/crates/common/precompiles/src/common/abi.rs
@@ -29,6 +29,7 @@ sol! {
         error InvalidApprover(address approver);
         error InvalidSpender(address spender);
         error InvalidAmount();
+        error MaxBalanceExceeded(address account, uint256 maxBalance, uint256 attemptedBalance);
         error EmptyFeatureSet();
         error InvalidSupplyCap(uint256 currentSupply, uint256 proposedCap);
         error SupplyCapExceeded(uint256 cap, uint256 attempted);

--- a/crates/common/precompiles/src/common/balance.rs
+++ b/crates/common/precompiles/src/common/balance.rs
@@ -1,0 +1,31 @@
+//! B-20 balance constraints.
+
+use alloy_primitives::{Address, U256};
+use base_precompile_storage::{BasePrecompileError, Result};
+
+use crate::IB20;
+
+/// Balance constraints for B-20 token accounts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct B20Balance;
+
+impl B20Balance {
+    /// Maximum balance for a single account.
+    ///
+    /// The upper 128 bits of the storage slot are reserved for future per-account
+    /// accounting extensions such as locked and unlocked balances.
+    pub const MAX: U256 = U256::from_limbs([u64::MAX, u64::MAX, 0, 0]);
+
+    /// Adds `amount` to `balance`, rejecting values that exceed [`Self::MAX`].
+    pub fn checked_add(account: Address, balance: U256, amount: U256) -> Result<U256> {
+        let attempted = balance.saturating_add(amount);
+        if attempted > Self::MAX {
+            return Err(BasePrecompileError::revert(IB20::MaxBalanceExceeded {
+                account,
+                maxBalance: Self::MAX,
+                attemptedBalance: attempted,
+            }));
+        }
+        Ok(attempted)
+    }
+}

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -3,6 +3,9 @@
 mod abi;
 pub use abi::IB20;
 
+mod balance;
+pub use balance::B20Balance;
+
 mod core_storage;
 pub use core_storage::B20CoreStorage;
 

--- a/crates/common/precompiles/src/common/ops/mintable.rs
+++ b/crates/common/precompiles/src/common/ops/mintable.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
-use crate::{B20Guards, B20PolicyType, B20TokenRole, IB20, Token, TokenAccounting};
+use crate::{B20Balance, B20Guards, B20PolicyType, B20TokenRole, IB20, Token, TokenAccounting};
 
 /// Token minting operations.
 ///
@@ -29,10 +29,9 @@ pub trait Mintable: Token {
                 attempted: new_supply,
             }));
         }
-        self.accounting_mut().set_total_supply(new_supply)?;
         let to_balance = self.accounting().balance_of(to)?;
-        let new_balance =
-            to_balance.checked_add(amount).ok_or_else(BasePrecompileError::under_overflow)?;
+        let new_balance = B20Balance::checked_add(to, to_balance, amount)?;
+        self.accounting_mut().set_total_supply(new_supply)?;
         self.accounting_mut().set_balance(to, new_balance)?;
         self.accounting_mut()
             .emit_event(IB20::Transfer { from: Address::ZERO, to, amount }.encode_log_data())
@@ -59,7 +58,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        B20PausableFeature, B20PolicyType, B20TokenRole, IB20, InMemoryPolicy,
+        B20Balance, B20PausableFeature, B20PolicyType, B20TokenRole, IB20, InMemoryPolicy,
         InMemoryTokenAccounting, Mintable, PolicyRegistryStorage, TestToken, Token,
         TokenAccounting,
     };
@@ -110,6 +109,35 @@ mod tests {
         token.mint(CALLER, ALICE, U256::from(100u64), true).unwrap();
 
         assert_eq!(token.accounting().total_supply().unwrap(), U256::from(100u64));
+    }
+
+    #[test]
+    fn mint_allows_max_account_balance_boundary() {
+        let mut token = make_token();
+
+        token.mint(CALLER, ALICE, B20Balance::MAX, true).unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), B20Balance::MAX);
+        assert_eq!(token.accounting().total_supply().unwrap(), B20Balance::MAX);
+    }
+
+    #[test]
+    fn mint_reverts_when_account_balance_exceeds_max() {
+        let mut token = make_token();
+        token.accounting_mut().balances.insert(ALICE, B20Balance::MAX);
+        token.accounting_mut().total_supply = B20Balance::MAX;
+
+        assert_eq!(
+            token.mint(CALLER, ALICE, U256::ONE, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::MaxBalanceExceeded {
+                account: ALICE,
+                maxBalance: B20Balance::MAX,
+                attemptedBalance: B20Balance::MAX + U256::ONE,
+            })
+        );
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), B20Balance::MAX);
+        assert_eq!(token.accounting().total_supply().unwrap(), B20Balance::MAX);
+        assert!(token.accounting().events.is_empty());
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/ops/transferable.rs
+++ b/crates/common/precompiles/src/common/ops/transferable.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
-use crate::{B20Guards, B20PolicyType, IB20, Token, TokenAccounting};
+use crate::{B20Balance, B20Guards, B20PolicyType, IB20, Token, TokenAccounting};
 
 /// ERC-20 transfer, approval, and memo-decorated transfer operations.
 ///
@@ -54,12 +54,16 @@ pub trait Transferable: Token {
                 needed: amount,
             }));
         }
+        if from == to {
+            return self
+                .accounting_mut()
+                .emit_event(IB20::Transfer { from, to, amount }.encode_log_data());
+        }
         let new_from_balance =
             from_balance.checked_sub(amount).ok_or_else(BasePrecompileError::under_overflow)?;
-        self.accounting_mut().set_balance(from, new_from_balance)?;
         let to_balance = self.accounting().balance_of(to)?;
-        let new_to_balance =
-            to_balance.checked_add(amount).ok_or_else(BasePrecompileError::under_overflow)?;
+        let new_to_balance = B20Balance::checked_add(to, to_balance, amount)?;
+        self.accounting_mut().set_balance(from, new_from_balance)?;
         self.accounting_mut().set_balance(to, new_to_balance)?;
         self.accounting_mut().emit_event(IB20::Transfer { from, to, amount }.encode_log_data())
     }
@@ -155,8 +159,9 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        B20PausableFeature, B20PolicyType, IB20, InMemoryPolicy, InMemoryTokenAccounting,
-        PolicyRegistryStorage, TestToken, Token, TokenAccounting, Transferable,
+        B20Balance, B20PausableFeature, B20PolicyType, IB20, InMemoryPolicy,
+        InMemoryTokenAccounting, PolicyRegistryStorage, TestToken, Token, TokenAccounting,
+        Transferable,
     };
 
     const ALICE: Address = Address::repeat_byte(0xaa);
@@ -480,6 +485,39 @@ mod tests {
 
         assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::ZERO);
         assert_eq!(token.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn transfer_allows_max_receiver_balance_boundary() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::ONE);
+        accounting.balances.insert(BOB, B20Balance::MAX - U256::ONE);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        token.transfer(ALICE, BOB, U256::ONE, true).unwrap();
+
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::ZERO);
+        assert_eq!(token.accounting().balance_of(BOB).unwrap(), B20Balance::MAX);
+    }
+
+    #[test]
+    fn transfer_reverts_when_receiver_balance_exceeds_max() {
+        let mut accounting = InMemoryTokenAccounting::new(TOKEN_ADDR);
+        accounting.balances.insert(ALICE, U256::ONE);
+        accounting.balances.insert(BOB, B20Balance::MAX);
+        let mut token = TestToken::with_storage_and_policy(accounting, InMemoryPolicy::new());
+
+        assert_eq!(
+            token.transfer(ALICE, BOB, U256::ONE, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::MaxBalanceExceeded {
+                account: BOB,
+                maxBalance: B20Balance::MAX,
+                attemptedBalance: B20Balance::MAX + U256::ONE,
+            })
+        );
+        assert_eq!(token.accounting().balance_of(ALICE).unwrap(), U256::ONE);
+        assert_eq!(token.accounting().balance_of(BOB).unwrap(), B20Balance::MAX);
+        assert!(token.accounting().events.is_empty());
     }
 
     #[test]

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -38,9 +38,9 @@ pub use bls12_381::{
 
 mod common;
 pub use common::{
-    B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType, B20TokenRole, Burnable,
-    Configurable, Eip712Domain, IB20, Mintable, Pausable, PermitArgs, Permittable, Policy,
-    PolicyRegistry, RoleManaged, Token, TokenAccounting, Transferable,
+    B20Balance, B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType, B20TokenRole,
+    Burnable, Configurable, Eip712Domain, IB20, Mintable, Pausable, PermitArgs, Permittable,
+    Policy, PolicyRegistry, RoleManaged, Token, TokenAccounting, Transferable,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, TestToken};

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -317,6 +317,7 @@ impl BerylErrorKind {
             || BerylErrorClassifier::is_error_selector::<IB20::InvalidApprover>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::InvalidSpender>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::InvalidAmount>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::MaxBalanceExceeded>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::EmptyFeatureSet>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::InvalidSupplyCap>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::SupplyCapExceeded>(selector)


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #3457 into `releases/v1.1.0`.

## Summary

This reserves the upper 128 bits of each B20 account balance slot by capping balances at 2^128 - 1. Mint and transfer paths now validate the recipient's resulting balance before writing state and return a dedicated MaxBalanceExceeded error when the cap would be crossed. The focused unit tests cover the exact boundary and the revert path without changing burn or allowance behavior.