### PR TITLE
fix(challenger): submit bond transactions asynchronously

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -937,16 +937,16 @@ impl<C: Clock> BondManager<C> {
                     return Ok(None);
                 }
             }
-        } else {
-            ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
-                .increment(1);
-            info!(game = %game_address, status = ?status, "game already resolved");
-            // Status is immutable after resolution — cache it so that
-            // try_anchor_update (called later this tick) can skip the
-            // redundant RPC round-trip.
-            if let Some(g) = self.tracked.get_mut(&game_address) {
-                g.cached_status = Some(status);
-            }
+        }
+
+        ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
+            .increment(1);
+        info!(game = %game_address, status = ?status, "game already resolved");
+        // Status is immutable after resolution — cache it so that
+        // try_anchor_update (called later this tick) can skip the
+        // redundant RPC round-trip.
+        if let Some(g) = self.tracked.get_mut(&game_address) {
+            g.cached_status = Some(status);
         }
 
         // Re-read the onchain bondRecipient — resolve may have changed it
@@ -1123,12 +1123,12 @@ impl<C: Clock> BondManager<C> {
     }
 
     /// Constructs the pending unlock phase.
-    pub fn awaiting_unlock(handle: BondTxHandle) -> BondPhase {
+    pub const fn awaiting_unlock(handle: BondTxHandle) -> BondPhase {
         BondPhase::AwaitingUnlock { handle }
     }
 
     /// Constructs the pending withdraw phase.
-    pub fn awaiting_withdraw(handle: BondTxHandle) -> BondPhase {
+    pub const fn awaiting_withdraw(handle: BondTxHandle) -> BondPhase {
         BondPhase::AwaitingWithdraw { handle }
     }
 
@@ -1385,17 +1385,14 @@ impl<C: Clock> BondManager<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) {
-        let should_skip = match self.tracked.get(&game_address) {
-            Some(game) => {
-                game.anchor_update_complete
-                    || (game.cached_status.is_none()
-                        && matches!(
-                            game.phase,
-                            BondPhase::NeedsResolve | BondPhase::AwaitingResolve { .. }
-                        ))
-            }
-            None => true,
-        };
+        let should_skip = self.tracked.get(&game_address).is_none_or(|game| {
+            game.anchor_update_complete
+                || (game.cached_status.is_none()
+                    && matches!(
+                        game.phase,
+                        BondPhase::NeedsResolve | BondPhase::AwaitingResolve { .. }
+                    ))
+        });
         if should_skip {
             return;
         }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -43,8 +43,7 @@ use base_proof_contracts::{
 use base_runtime::Clock;
 use base_tx_manager::TxManagerError;
 use futures::stream::{self, StreamExt};
-use tokio::sync::oneshot;
-use tokio::sync::oneshot::error::TryRecvError;
+use tokio::sync::{oneshot, oneshot::error::TryRecvError};
 use tracing::{debug, info, warn};
 
 use crate::{ChallengeSubmitError, ChallengerMetrics, GameScanner};
@@ -1672,16 +1671,6 @@ pub trait BondTransactionSubmitter: Send + Sync {
         to: Address,
         calldata: alloy_primitives::Bytes,
     ) -> Result<BondTxHandle, crate::ChallengeSubmitError>;
-
-    /// Sends a transaction and waits for confirmation.
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: alloy_primitives::Bytes,
-    ) -> Result<alloy_primitives::B256, crate::ChallengeSubmitError> {
-        self.send_bond_tx_async(game_address, to, calldata).await?.await
-    }
 }
 
 #[cfg(test)]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -27,7 +27,10 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
     sync::Arc,
+    task::{Context, Poll},
     time::Duration,
 };
 
@@ -38,10 +41,57 @@ use base_proof_contracts::{
     encode_set_anchor_state_calldata,
 };
 use base_runtime::Clock;
+use base_tx_manager::TxManagerError;
 use futures::stream::{self, StreamExt};
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::TryRecvError;
 use tracing::{debug, info, warn};
 
-use crate::{ChallengerMetrics, GameScanner};
+use crate::{ChallengeSubmitError, ChallengerMetrics, GameScanner};
+
+/// Result returned by an asynchronous bond lifecycle transaction.
+pub type BondTxResult = Result<alloy_primitives::B256, ChallengeSubmitError>;
+
+/// Handle for a bond lifecycle transaction submitted asynchronously.
+#[derive(Debug)]
+pub struct BondTxHandle {
+    rx: oneshot::Receiver<BondTxResult>,
+}
+
+impl BondTxHandle {
+    /// Creates a new handle from a oneshot receiver.
+    pub const fn new(rx: oneshot::Receiver<BondTxResult>) -> Self {
+        Self { rx }
+    }
+
+    /// Creates a handle that is immediately ready with `result`.
+    pub fn ready(result: BondTxResult) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(result);
+        Self::new(rx)
+    }
+
+    /// Checks whether the transaction has completed without blocking.
+    pub fn try_recv(&mut self) -> Option<BondTxResult> {
+        match self.rx.try_recv() {
+            Ok(result) => Some(result),
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Closed) => {
+                Some(Err(ChallengeSubmitError::TxManager(TxManagerError::ChannelClosed)))
+            }
+        }
+    }
+}
+
+impl Future for BondTxHandle {
+    type Output = BondTxResult;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.get_mut().rx).poll(cx).map(|res| {
+            res.unwrap_or(Err(ChallengeSubmitError::TxManager(TxManagerError::ChannelClosed)))
+        })
+    }
+}
 
 /// Reason a game was removed from tracking after `BondManager::advance_game`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,13 +103,23 @@ pub enum RemovalReason {
 }
 
 /// Phase of the bond claim lifecycle for a single tracked game.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum BondPhase {
     /// The game's dispute period is over; needs a `resolve()` call.
     NeedsResolve,
+    /// A `resolve()` transaction has been submitted and is awaiting confirmation.
+    AwaitingResolve {
+        /// Pending transaction handle.
+        handle: BondTxHandle,
+    },
     /// The game has been resolved; needs the first `claimCredit()` call
     /// to trigger `DelayedWETH.unlock()`.
     NeedsUnlock,
+    /// An unlock `claimCredit()` transaction has been submitted and is awaiting confirmation.
+    AwaitingUnlock {
+        /// Pending transaction handle.
+        handle: BondTxHandle,
+    },
     /// The unlock has been submitted; waiting for the `DelayedWETH` delay
     /// to elapse before the second `claimCredit()` call.
     AwaitingDelay {
@@ -71,12 +131,17 @@ pub enum BondPhase {
     /// The delay has elapsed; needs the second `claimCredit()` call to
     /// complete the withdrawal.
     NeedsWithdraw,
+    /// A withdraw `claimCredit()` transaction has been submitted and is awaiting confirmation.
+    AwaitingWithdraw {
+        /// Pending transaction handle.
+        handle: BondTxHandle,
+    },
     /// Bond fully claimed. The entry will be removed from tracking.
     Completed,
 }
 
 /// A game being tracked for bond lifecycle management.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TrackedGame {
     /// Current lifecycle phase.
     pub phase: BondPhase,
@@ -97,6 +162,8 @@ pub struct TrackedGame {
     /// Cached L2 block number for this game. Read from immutable game info
     /// once the game is finalized and reused for retries.
     pub cached_l2_block_number: Option<u64>,
+    /// Pending `setAnchorState()` transaction, if one has been submitted.
+    pub pending_anchor_update: Option<BondTxHandle>,
     /// Monotonic timestamp for games whose bond lifecycle is complete but
     /// which remain tracked until the anchor update completes.
     pub anchor_update_retained_since: Option<Duration>,
@@ -115,6 +182,7 @@ impl TrackedGame {
             cached_status: None,
             cached_asr_address: None,
             cached_l2_block_number: None,
+            pending_anchor_update: None,
             anchor_update_retained_since: None,
             anchor_update_retention_reason: None,
         }
@@ -747,17 +815,86 @@ impl<C: Clock> BondManager<C> {
             BondPhase::NeedsResolve => {
                 self.try_resolve(game_address, verifier_client, submitter).await
             }
+            BondPhase::AwaitingResolve { .. } => {
+                self.poll_resolve_tx(game_address, verifier_client).await
+            }
             BondPhase::NeedsUnlock => {
                 self.try_unlock(game_address, verifier_client, submitter).await
             }
+            BondPhase::AwaitingUnlock { .. } => self.poll_unlock_tx(game_address),
             BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs } => {
                 self.check_delay(game_address, *unlocked_at, *unlocked_at_unix_secs)
             }
             BondPhase::NeedsWithdraw => {
                 self.try_withdraw(game_address, verifier_client, submitter).await
             }
+            BondPhase::AwaitingWithdraw { .. } => self.poll_withdraw_tx(game_address),
             BondPhase::Completed => Ok(Some(RemovalReason::Completed)),
         }
+    }
+
+    /// Polls a pending `resolve()` transaction and advances the lifecycle once confirmed.
+    async fn poll_resolve_tx(
+        &mut self,
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+    ) -> eyre::Result<Option<RemovalReason>> {
+        let Some(result) = self.pending_resolve_result(game_address) else {
+            return Ok(None);
+        };
+
+        match result {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    tx_hash = %tx_hash,
+                    "resolve transaction confirmed"
+                );
+                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+                match verifier_client.status(game_address).await {
+                    Ok(resolved_status) => {
+                        if let Some(g) = self.tracked.get_mut(&game_address) {
+                            g.cached_status = Some(resolved_status);
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            game = %game_address,
+                            error = %e,
+                            "failed to cache status after resolve, will re-read later"
+                        );
+                    }
+                }
+
+                if !self.is_bond_claimable(verifier_client, game_address).await? {
+                    return Ok(Some(RemovalReason::NotClaimable));
+                }
+
+                self.set_phase(game_address, BondPhase::NeedsUnlock);
+                Ok(None)
+            }
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    "resolve transaction failed, will retry"
+                );
+                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+                self.set_phase(game_address, BondPhase::NeedsResolve);
+                Ok(None)
+            }
+        }
+    }
+
+    /// Returns a pending resolve transaction result if it is ready.
+    fn pending_resolve_result(&mut self, game_address: Address) -> Option<BondTxResult> {
+        let game = self.tracked.get_mut(&game_address)?;
+        let BondPhase::AwaitingResolve { handle } = &mut game.phase else {
+            return None;
+        };
+        handle.try_recv()
     }
 
     /// Attempts to resolve the game by calling `resolve()`.
@@ -784,38 +921,16 @@ impl<C: Clock> BondManager<C> {
 
             let calldata = encode_resolve_calldata();
             info!(game = %game_address, "submitting resolve transaction");
-            match submitter.send_bond_tx(game_address, game_address, calldata).await {
-                Ok(tx_hash) => {
-                    info!(
-                        game = %game_address,
-                        tx_hash = %tx_hash,
-                        "resolve transaction confirmed"
-                    );
-                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
-                        .increment(1);
-                    // Re-read and cache the now-immutable status so that
-                    // try_anchor_update (called later this tick) can use
-                    // it without a redundant RPC call.
-                    match verifier_client.status(game_address).await {
-                        Ok(resolved_status) => {
-                            if let Some(g) = self.tracked.get_mut(&game_address) {
-                                g.cached_status = Some(resolved_status);
-                            }
-                        }
-                        Err(e) => {
-                            debug!(
-                                game = %game_address,
-                                error = %e,
-                                "failed to cache status after resolve, will re-read later"
-                            );
-                        }
-                    }
+            match submitter.send_bond_tx_async(game_address, game_address, calldata).await {
+                Ok(handle) => {
+                    self.set_phase(game_address, BondPhase::AwaitingResolve { handle });
+                    return Ok(None);
                 }
                 Err(e) => {
                     warn!(
                         game = %game_address,
                         error = %e,
-                        "resolve transaction failed, will retry"
+                        "resolve transaction submission failed, will retry"
                     );
                     ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                         .increment(1);
@@ -910,14 +1025,7 @@ impl<C: Clock> BondManager<C> {
             return Ok(None);
         }
 
-        self.submit_claim_credit(
-            game_address,
-            submitter,
-            "unlock",
-            BondPhase::AwaitingDelay { unlocked_at: self.clock.now(), unlocked_at_unix_secs: None },
-            None,
-        )
-        .await
+        self.submit_claim_credit(game_address, submitter, "unlock", Self::awaiting_unlock).await
     }
 
     /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
@@ -979,59 +1087,123 @@ impl<C: Clock> BondManager<C> {
             return Ok(Some(RemovalReason::Completed));
         }
 
-        self.submit_claim_credit(
-            game_address,
-            submitter,
-            "withdraw",
-            BondPhase::Completed,
-            Some(Self::WITHDRAW_REVERT_RETRY_DELAY),
-        )
-        .await
+        self.submit_claim_credit(game_address, submitter, "withdraw", Self::awaiting_withdraw).await
     }
 
     /// Submits a `claimCredit()` transaction and transitions to the given
-    /// phase on success. If `revert_retry_delay` is set, a reverted
-    /// transaction backs off by that duration before retrying. Returns
-    /// `Ok(Some(Completed))` when the success phase is [`BondPhase::Completed`].
+    /// awaiting phase until the asynchronous transaction confirms.
     async fn submit_claim_credit(
         &mut self,
         game_address: Address,
         submitter: &dyn BondTransactionSubmitter,
         step: &str,
-        success_phase: BondPhase,
-        revert_retry_delay: Option<Duration>,
+        awaiting_phase: fn(BondTxHandle) -> BondPhase,
     ) -> eyre::Result<Option<RemovalReason>> {
         let calldata = encode_claim_credit_calldata();
         ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
         info!(game = %game_address, step, "submitting claimCredit transaction");
-        match submitter.send_bond_tx(game_address, game_address, calldata).await {
-            Ok(tx_hash) => {
-                info!(
-                    game = %game_address,
-                    tx_hash = %tx_hash,
-                    step,
-                    "claimCredit transaction confirmed"
-                );
-                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
-                    .increment(1);
-                let completed = matches!(success_phase, BondPhase::Completed);
-                self.set_phase(game_address, success_phase);
-                Ok(completed.then_some(RemovalReason::Completed))
+        match submitter.send_bond_tx_async(game_address, game_address, calldata).await {
+            Ok(handle) => {
+                self.set_phase(game_address, awaiting_phase(handle));
+                Ok(None)
             }
             Err(e) => {
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
-                if let Some(retry_delay) = revert_retry_delay
-                    && matches!(&e, crate::ChallengeSubmitError::TxReverted { .. })
-                {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    step,
+                    retry = "immediate",
+                    "claimCredit transaction submission failed, will retry"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Constructs the pending unlock phase.
+    pub fn awaiting_unlock(handle: BondTxHandle) -> BondPhase {
+        BondPhase::AwaitingUnlock { handle }
+    }
+
+    /// Constructs the pending withdraw phase.
+    pub fn awaiting_withdraw(handle: BondTxHandle) -> BondPhase {
+        BondPhase::AwaitingWithdraw { handle }
+    }
+
+    /// Polls a pending unlock `claimCredit()` transaction.
+    fn poll_unlock_tx(&mut self, game_address: Address) -> eyre::Result<Option<RemovalReason>> {
+        let Some(result) = self.pending_unlock_result(game_address) else {
+            return Ok(None);
+        };
+
+        match result {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    tx_hash = %tx_hash,
+                    step = "unlock",
+                    "claimCredit transaction confirmed"
+                );
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+                self.set_phase(
+                    game_address,
+                    BondPhase::AwaitingDelay {
+                        unlocked_at: self.clock.now(),
+                        unlocked_at_unix_secs: None,
+                    },
+                );
+            }
+            Err(e) => {
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    step = "unlock",
+                    retry = "immediate",
+                    "claimCredit transaction failed, will retry"
+                );
+                self.set_phase(game_address, BondPhase::NeedsUnlock);
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Polls a pending withdraw `claimCredit()` transaction.
+    fn poll_withdraw_tx(&mut self, game_address: Address) -> eyre::Result<Option<RemovalReason>> {
+        let Some(result) = self.pending_withdraw_result(game_address) else {
+            return Ok(None);
+        };
+
+        match result {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    tx_hash = %tx_hash,
+                    step = "withdraw",
+                    "claimCredit transaction confirmed"
+                );
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+                self.set_phase(game_address, BondPhase::Completed);
+                Ok(Some(RemovalReason::Completed))
+            }
+            Err(e) => {
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+                if matches!(&e, ChallengeSubmitError::TxReverted { .. }) {
                     let delay = self.effective_weth_delay(game_address);
-                    let retry_delay = retry_delay.min(delay);
+                    let retry_delay = Self::WITHDRAW_REVERT_RETRY_DELAY.min(delay);
                     let elapsed_before_retry = delay.saturating_sub(retry_delay);
                     let unlocked_at = self.clock.now().saturating_sub(elapsed_before_retry);
                     warn!(
                         game = %game_address,
                         error = %e,
-                        step,
+                        step = "withdraw",
                         retry = "after_backoff",
                         retry_delay_secs = retry_delay.as_secs(),
                         "claimCredit transaction failed, will retry after backoff"
@@ -1044,14 +1216,33 @@ impl<C: Clock> BondManager<C> {
                     warn!(
                         game = %game_address,
                         error = %e,
-                        step,
+                        step = "withdraw",
                         retry = "immediate",
                         "claimCredit transaction failed, will retry"
                     );
+                    self.set_phase(game_address, BondPhase::NeedsWithdraw);
                 }
                 Ok(None)
             }
         }
+    }
+
+    /// Returns a pending unlock transaction result if it is ready.
+    fn pending_unlock_result(&mut self, game_address: Address) -> Option<BondTxResult> {
+        let game = self.tracked.get_mut(&game_address)?;
+        let BondPhase::AwaitingUnlock { handle } = &mut game.phase else {
+            return None;
+        };
+        handle.try_recv()
+    }
+
+    /// Returns a pending withdraw transaction result if it is ready.
+    fn pending_withdraw_result(&mut self, game_address: Address) -> Option<BondTxResult> {
+        let game = self.tracked.get_mut(&game_address)?;
+        let BondPhase::AwaitingWithdraw { handle } = &mut game.phase else {
+            return None;
+        };
+        handle.try_recv()
     }
 
     /// Converts a Unix timestamp (seconds) to a monotonic [`Duration`]
@@ -1194,21 +1385,30 @@ impl<C: Clock> BondManager<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) {
-        let game = match self.tracked.get(&game_address) {
-            Some(g) => g,
-            None => return,
+        let should_skip = match self.tracked.get(&game_address) {
+            Some(game) => {
+                game.anchor_update_complete
+                    || (game.cached_status.is_none()
+                        && matches!(
+                            game.phase,
+                            BondPhase::NeedsResolve | BondPhase::AwaitingResolve { .. }
+                        ))
+            }
+            None => true,
         };
+        if should_skip {
+            return;
+        }
 
-        if game.anchor_update_complete
-            || (game.cached_status.is_none() && matches!(game.phase, BondPhase::NeedsResolve))
-        {
+        if self.poll_anchor_update_tx(game_address) {
             return;
         }
 
         // Only DEFENDER_WINS games can update the anchor state.
         // The status is immutable after resolution, so we cache it
         // after the first successful RPC read to avoid redundant calls.
-        let status = if let Some(cached) = game.cached_status {
+        let cached_status = self.tracked.get(&game_address).and_then(|g| g.cached_status);
+        let status = if let Some(cached) = cached_status {
             cached
         } else {
             match verifier_client.status(game_address).await {
@@ -1364,20 +1564,16 @@ impl<C: Clock> BondManager<C> {
         }
 
         let calldata = encode_set_anchor_state_calldata(game_address);
-        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
-            Ok(tx_hash) => {
+        match submitter.send_bond_tx_async(game_address, asr_address, calldata).await {
+            Ok(handle) => {
                 info!(
                     game = %game_address,
                     asr = %asr_address,
-                    tx_hash = %tx_hash,
-                    "anchor state registry updated"
+                    "anchor state registry update submitted"
                 );
-                self.mark_anchor_update_complete(game_address);
-                ChallengerMetrics::anchor_update_tx_outcome_total(
-                    ChallengerMetrics::STATUS_SUCCESS,
-                )
-                .increment(1);
-                ChallengerMetrics::anchor_l2_block_number().set(game_l2_block_number as f64);
+                if let Some(game) = self.tracked.get_mut(&game_address) {
+                    game.pending_anchor_update = Some(handle);
+                }
             }
             Err(e) => {
                 debug!(
@@ -1390,6 +1586,62 @@ impl<C: Clock> BondManager<C> {
                     .increment(1);
             }
         }
+    }
+
+    /// Polls a pending anchor update transaction.
+    ///
+    /// Returns `true` if a pending transaction existed and was handled (or is
+    /// still pending), signalling that callers should not submit another anchor
+    /// update during the same tick.
+    fn poll_anchor_update_tx(&mut self, game_address: Address) -> bool {
+        let result = {
+            let Some(game) = self.tracked.get_mut(&game_address) else {
+                return true;
+            };
+            let Some(handle) = game.pending_anchor_update.as_mut() else {
+                return false;
+            };
+            handle.try_recv()
+        };
+
+        let Some(result) = result else {
+            return true;
+        };
+
+        if let Some(game) = self.tracked.get_mut(&game_address) {
+            game.pending_anchor_update = None;
+        }
+
+        match result {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    tx_hash = %tx_hash,
+                    "anchor state registry updated"
+                );
+                self.mark_anchor_update_complete(game_address);
+                ChallengerMetrics::anchor_update_tx_outcome_total(
+                    ChallengerMetrics::STATUS_SUCCESS,
+                )
+                .increment(1);
+                if let Some(l2_block_number) =
+                    self.tracked.get(&game_address).and_then(|g| g.cached_l2_block_number)
+                {
+                    ChallengerMetrics::anchor_l2_block_number().set(l2_block_number as f64);
+                }
+            }
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    error = %e,
+                    "anchor state update failed, will retry"
+                );
+                ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+            }
+        }
+
+        true
     }
 
     /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
@@ -1413,15 +1665,26 @@ impl<C: Clock> BondManager<C> {
 /// can be tested with mock submitters.
 #[async_trait::async_trait]
 pub trait BondTransactionSubmitter: Send + Sync {
-    /// Sends a transaction with the given calldata to `to`. `game_address`
-    /// is the dispute game this transaction is associated with, used for
-    /// log/metric correlation.
+    /// Sends a transaction asynchronously with the given calldata to `to`.
+    ///
+    /// `game_address` is the dispute game this transaction is associated with,
+    /// used for log/metric correlation.
+    async fn send_bond_tx_async(
+        &self,
+        game_address: Address,
+        to: Address,
+        calldata: alloy_primitives::Bytes,
+    ) -> Result<BondTxHandle, crate::ChallengeSubmitError>;
+
+    /// Sends a transaction and waits for confirmation.
     async fn send_bond_tx(
         &self,
         game_address: Address,
         to: Address,
         calldata: alloy_primitives::Bytes,
-    ) -> Result<alloy_primitives::B256, crate::ChallengeSubmitError>;
+    ) -> Result<alloy_primitives::B256, crate::ChallengeSubmitError> {
+        self.send_bond_tx_async(game_address, to, calldata).await?.await
+    }
 }
 
 #[cfg(test)]
@@ -1652,6 +1915,13 @@ mod tests {
         let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
         assert!(result.is_none());
         assert_eq!(submitter.recorded_calls().len(), 1);
+        assert!(matches!(
+            mgr.tracked.get(&game).unwrap().phase,
+            BondPhase::AwaitingWithdraw { .. }
+        ));
+
+        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
+        assert!(result.is_none());
         let expected_unlocked_at = Duration::from_secs(monotonic_secs).saturating_sub(
             delay.saturating_sub(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY),
         );
@@ -1737,18 +2007,26 @@ mod tests {
         assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
         assert!(submitter.recorded_calls().is_empty());
 
-        // Second poll: NeedsWithdraw → submit_claim_credit → non-revert
-        // failure. The phase must remain `NeedsWithdraw`; the back-off
-        // path is gated on `TxReverted` only.
+        // Second poll: NeedsWithdraw → submit claimCredit asynchronously.
         let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
         assert!(result.is_none());
         assert_eq!(submitter.recorded_calls().len(), 1);
+        assert!(
+            matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::AwaitingWithdraw { .. }),
+            "withdraw submission should transition to AwaitingWithdraw"
+        );
+
+        // Third poll: AwaitingWithdraw → non-revert failure. The phase must
+        // return to `NeedsWithdraw`; the back-off path is gated on
+        // `TxReverted` only.
+        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
+        assert!(result.is_none());
         assert!(
             matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw),
             "non-revert withdraw failure must not transition back to AwaitingDelay"
         );
 
-        // Third poll: still `NeedsWithdraw` → resubmits immediately,
+        // Fourth poll: still `NeedsWithdraw` → resubmits immediately,
         // without waiting on a back-off window.
         let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
         assert!(result.is_none());
@@ -1757,7 +2035,10 @@ mod tests {
             2,
             "non-revert failures must not introduce a back-off delay before retry"
         );
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
+        assert!(matches!(
+            mgr.tracked.get(&game).unwrap().phase,
+            BondPhase::AwaitingWithdraw { .. }
+        ));
     }
 
     #[test]
@@ -2181,6 +2462,10 @@ mod tests {
         let submitter = MockBondTransactionSubmitter::success(tx_hash);
         let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
         assert!(result.is_none(), "try_unlock should not remove the game");
+        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::AwaitingUnlock { .. }));
+
+        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
+        assert!(result.is_none(), "confirmed unlock should not remove the game");
 
         let tracked = mgr.tracked.get(&game).expect("game should still be tracked");
         assert!(
@@ -2373,6 +2658,9 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].0, game, "tx should carry game address as context");
         assert_eq!(calls[0].1, asr, "tx should be sent to ASR address");
+        assert!(!mgr.tracked.get(&game).unwrap().anchor_update_complete);
+
+        mgr.try_anchor_update(game, &*verifier, &submitter).await;
         assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
     }
 
@@ -2425,6 +2713,8 @@ mod tests {
         // First call succeeds.
         let tx_hash = B256::repeat_byte(0xDD);
         let submitter = MockBondTransactionSubmitter::success(tx_hash);
+        mgr.try_anchor_update(game, &*verifier, &submitter).await;
+        assert!(!mgr.tracked.get(&game).unwrap().anchor_update_complete);
         mgr.try_anchor_update(game, &*verifier, &submitter).await;
         assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
 

--- a/crates/proof/challenge/src/error.rs
+++ b/crates/proof/challenge/src/error.rs
@@ -13,6 +13,12 @@ pub enum ChallengeSubmitError {
         /// Hash of the reverted transaction.
         tx_hash: B256,
     },
+    /// An internal asynchronous transaction task panicked.
+    #[error("bond transaction task panicked: {message}")]
+    BondTaskPanicked {
+        /// Panic message captured from the asynchronous task.
+        message: String,
+    },
     /// Transaction manager error (nonce, fees, RPC, signing, etc.).
     #[error(transparent)]
     TxManager(#[from] TxManagerError),

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -48,7 +48,10 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, RemovalReason, TrackedGame};
+pub use bond::{
+    BondManager, BondPhase, BondTransactionSubmitter, BondTxHandle, BondTxResult, RemovalReason,
+    TrackedGame,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -163,13 +163,15 @@ impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
             .catch_unwind()
             .await
             .unwrap_or_else(|payload| {
-                let message = if let Some(message) = payload.downcast_ref::<&str>() {
-                    (*message).to_owned()
-                } else if let Some(message) = payload.downcast_ref::<String>() {
-                    message.clone()
-                } else {
-                    "non-string panic payload".to_owned()
-                };
+                let message = payload.downcast_ref::<&str>().map_or_else(
+                    || {
+                        payload.downcast_ref::<String>().map_or_else(
+                            || "non-string panic payload".to_owned(),
+                            |message| message.clone(),
+                        )
+                    },
+                    |message| (*message).to_owned(),
+                );
                 error!(panic = %message, "bond transaction task panicked");
                 Err(ChallengeSubmitError::BondTaskPanicked { message })
             });

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -15,7 +15,9 @@ use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::{debug, info};
 
-use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
+use crate::{
+    BondTransactionSubmitter, BondTxHandle, ChallengeSubmitError, ChallengerMetrics, DisputeIntent,
+};
 
 /// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
@@ -117,12 +119,12 @@ impl<T: TxManager> ChallengeSubmitter<T> {
 
 #[async_trait::async_trait]
 impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
-    async fn send_bond_tx(
+    async fn send_bond_tx_async(
         &self,
         game_address: Address,
         to: Address,
         calldata: Bytes,
-    ) -> Result<B256, ChallengeSubmitError> {
+    ) -> Result<BondTxHandle, ChallengeSubmitError> {
         let candidate = TxCandidate {
             tx_data: calldata,
             to: Some(to),
@@ -138,16 +140,27 @@ impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
         );
 
         let start = Instant::now();
-        let receipt = self.tx_manager.send(candidate).await?;
-        let latency = start.elapsed();
-        ChallengerMetrics::bond_tx_latency_seconds().record(latency.as_secs_f64());
-        let tx_hash = receipt.transaction_hash;
+        let send_handle = self.tx_manager.send_async(candidate).await;
+        let (tx, rx) = tokio::sync::oneshot::channel();
 
-        if !receipt.inner.status() {
-            return Err(ChallengeSubmitError::TxReverted { tx_hash });
-        }
+        tokio::spawn(async move {
+            let result = match send_handle.await {
+                Ok(receipt) => {
+                    let latency = start.elapsed();
+                    ChallengerMetrics::bond_tx_latency_seconds().record(latency.as_secs_f64());
+                    let tx_hash = receipt.transaction_hash;
+                    if receipt.inner.status() {
+                        Ok(tx_hash)
+                    } else {
+                        Err(ChallengeSubmitError::TxReverted { tx_hash })
+                    }
+                }
+                Err(e) => Err(ChallengeSubmitError::TxManager(e)),
+            };
+            let _ = tx.send(result);
+        });
 
-        Ok(tx_hash)
+        Ok(BondTxHandle::new(rx))
     }
 }
 

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -8,12 +8,13 @@
 //!    with a ZK proof to refute the fraudulent challenge.
 //! 3. **Wrong ZK proposal** — `nullify()` with a ZK proof.
 
-use std::time::Instant;
+use std::{panic::AssertUnwindSafe, time::Instant};
 
 use alloy_primitives::{Address, B256, Bytes, U256};
 use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
-use tracing::{debug, info};
+use futures::FutureExt;
+use tracing::{debug, error, info};
 
 use crate::{
     BondTransactionSubmitter, BondTxHandle, ChallengeSubmitError, ChallengerMetrics, DisputeIntent,
@@ -144,19 +145,34 @@ impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
-            let result = match send_handle.await {
-                Ok(receipt) => {
-                    let latency = start.elapsed();
-                    ChallengerMetrics::bond_tx_latency_seconds().record(latency.as_secs_f64());
-                    let tx_hash = receipt.transaction_hash;
-                    if receipt.inner.status() {
-                        Ok(tx_hash)
-                    } else {
-                        Err(ChallengeSubmitError::TxReverted { tx_hash })
+            let result = AssertUnwindSafe(async move {
+                match send_handle.await {
+                    Ok(receipt) => {
+                        let latency = start.elapsed();
+                        ChallengerMetrics::bond_tx_latency_seconds().record(latency.as_secs_f64());
+                        let tx_hash = receipt.transaction_hash;
+                        if receipt.inner.status() {
+                            Ok(tx_hash)
+                        } else {
+                            Err(ChallengeSubmitError::TxReverted { tx_hash })
+                        }
                     }
+                    Err(e) => Err(ChallengeSubmitError::TxManager(e)),
                 }
-                Err(e) => Err(ChallengeSubmitError::TxManager(e)),
-            };
+            })
+            .catch_unwind()
+            .await
+            .unwrap_or_else(|payload| {
+                let message = if let Some(message) = payload.downcast_ref::<&str>() {
+                    (*message).to_owned()
+                } else if let Some(message) = payload.downcast_ref::<String>() {
+                    message.clone()
+                } else {
+                    "non-string panic payload".to_owned()
+                };
+                error!(panic = %message, "bond transaction task panicked");
+                Err(ChallengeSubmitError::BondTaskPanicked { message })
+            });
             let _ = tx.send(result);
         });
 
@@ -288,5 +304,45 @@ mod tests {
             .await;
 
         assert_eq!(result.unwrap(), tx_hash);
+    }
+
+    #[tokio::test]
+    async fn send_bond_tx_async_success_returns_tx_hash() {
+        let tx_hash = B256::repeat_byte(0xDD);
+        let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+        let submitter = ChallengeSubmitter::new(mock);
+
+        let handle = submitter
+            .send_bond_tx_async(
+                Address::repeat_byte(0x01),
+                Address::repeat_byte(0x02),
+                Bytes::from(vec![0xBA, 0x5E]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(handle.await.unwrap(), tx_hash);
+    }
+
+    #[tokio::test]
+    async fn send_bond_tx_async_reverted_returns_error() {
+        let tx_hash = B256::repeat_byte(0xEE);
+        let mock = MockTxManager::new(Ok(receipt_with_status(false, tx_hash)));
+        let submitter = ChallengeSubmitter::new(mock);
+
+        let handle = submitter
+            .send_bond_tx_async(
+                Address::repeat_byte(0x01),
+                Address::repeat_byte(0x02),
+                Bytes::from(vec![0xBA, 0x5E]),
+            )
+            .await
+            .unwrap();
+
+        let err = handle.await.unwrap_err();
+        assert!(
+            matches!(err, ChallengeSubmitError::TxReverted { tx_hash: h } if h == tx_hash),
+            "expected TxReverted, got {err:?}",
+        );
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -836,7 +836,15 @@ impl TxManager for MockTxManager {
     }
 
     async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-        unimplemented!("not needed for these tests")
+        let response = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("MockTxManager has no more responses");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let _ = tx.send(response);
+        SendHandle::new(rx)
     }
 
     fn sender_address(&self) -> Address {

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -924,10 +924,11 @@ pub fn build_test_header_and_account_for_address(
 
 /// Mock bond transaction submitter for testing the [`BondManager`](crate::BondManager).
 ///
-/// Records all submitted transactions and returns pre-configured responses.
+/// Records all submitted transactions and returns pre-configured asynchronous responses.
 #[derive(Debug)]
 pub struct MockBondTransactionSubmitter {
-    /// Queue of results returned by [`send_bond_tx`](crate::BondTransactionSubmitter::send_bond_tx).
+    /// Queue of results returned by
+    /// [`send_bond_tx_async`](crate::BondTransactionSubmitter::send_bond_tx_async).
     pub responses: Mutex<VecDeque<Result<B256, crate::ChallengeSubmitError>>>,
     /// Recorded `(game_address, to, calldata)` tuples for each submitted transaction.
     pub calls: Mutex<Vec<(Address, Address, Bytes)>>,
@@ -952,18 +953,20 @@ impl MockBondTransactionSubmitter {
 
 #[async_trait]
 impl crate::BondTransactionSubmitter for MockBondTransactionSubmitter {
-    async fn send_bond_tx(
+    async fn send_bond_tx_async(
         &self,
         game_address: Address,
         to: Address,
         calldata: Bytes,
-    ) -> Result<B256, crate::ChallengeSubmitError> {
+    ) -> Result<crate::BondTxHandle, crate::ChallengeSubmitError> {
         self.calls.lock().unwrap().push((game_address, to, calldata));
-        self.responses
+        let result = self
+            .responses
             .lock()
             .unwrap()
             .pop_front()
-            .expect("MockBondTransactionSubmitter has no more responses")
+            .expect("MockBondTransactionSubmitter has no more responses");
+        Ok(crate::BondTxHandle::ready(result))
     }
 }
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,9 +8,10 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
-    BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
-    DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofPhase, ProofUpdate, TeeConfig,
+    BondManager, BondTransactionSubmitter, BondTxHandle, BondTxResult, ChallengeSubmitter,
+    ChallengerProofAdapter, DisputeIntent, Driver, DriverComponents, DriverConfig, GameScanner,
+    L1HeadProvider, OutputValidator, PendingProof, PendingProofs, ProofPhase, ProofUpdate,
+    TeeConfig,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
         MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager,
@@ -28,6 +29,7 @@ use base_prover_service_protocol::{
 };
 use base_runtime::TokioRuntime;
 use base_tx_manager::TxManagerError;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
 const STORAGE_HASH: B256 = B256::repeat_byte(0xBB);
@@ -1403,6 +1405,34 @@ fn default_bond_manager(claim_addr: Address) -> BondManager<TokioRuntime> {
     mgr
 }
 
+/// Bond submitter whose returned handles never complete until the test drops it.
+#[derive(Debug, Default)]
+struct PendingBondSubmitter {
+    calls: Mutex<Vec<(Address, Address, Bytes)>>,
+    senders: Mutex<Vec<oneshot::Sender<BondTxResult>>>,
+}
+
+impl PendingBondSubmitter {
+    fn recorded_calls(&self) -> Vec<(Address, Address, Bytes)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl BondTransactionSubmitter for PendingBondSubmitter {
+    async fn send_bond_tx_async(
+        &self,
+        game_address: Address,
+        to: Address,
+        calldata: Bytes,
+    ) -> Result<BondTxHandle, base_challenger::ChallengeSubmitError> {
+        self.calls.lock().unwrap().push((game_address, to, calldata));
+        let (tx, rx) = oneshot::channel();
+        self.senders.lock().unwrap().push(tx);
+        Ok(BondTxHandle::new(rx))
+    }
+}
+
 #[tokio::test]
 async fn test_bond_manager_full_lifecycle() {
     // Verify the full bond lifecycle: NeedsResolve → NeedsUnlock →
@@ -1431,17 +1461,25 @@ async fn test_bond_manager_full_lifecycle() {
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
 
-    // Poll 2: NeedsUnlock → claimCredit (unlock) tx → AwaitingDelay.
+    // Poll 2: NeedsUnlock → submit claimCredit (unlock) tx.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked while unlock confirms");
+
+    // Poll 3: unlock tx confirmed → AwaitingDelay.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked during delay");
 
-    // Poll 3: AwaitingDelay (delay=0s, already elapsed) → NeedsWithdraw.
+    // Poll 4: AwaitingDelay (delay=0s, already elapsed) → NeedsWithdraw.
     // check_delay transitions to NeedsWithdraw, but advance_game returns
     // Ok(false), so the game is still tracked. Need one more poll.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after delay");
 
-    // Poll 4: NeedsWithdraw → claimCredit (withdraw) tx → Completed → removed.
+    // Poll 5: NeedsWithdraw → submit claimCredit (withdraw) tx.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked while withdraw confirms");
+
+    // Poll 6: withdraw tx confirmed → Completed → removed.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 0, "game should be removed after completion");
 
@@ -1452,6 +1490,35 @@ async fn test_bond_manager_full_lifecycle() {
         assert_eq!(*game, game_addr, "all transactions should reference the game address");
         assert_eq!(*target, game_addr, "all transactions should target the game address");
     }
+}
+
+#[tokio::test]
+async fn test_bond_manager_submits_all_ready_resolves_without_waiting_for_confirmations() {
+    let claim_addr = ZK_PROVER_ADDR;
+    let game_addresses = [addr(0), addr(1), addr(2)];
+
+    let mut verifier_games = HashMap::new();
+    for (i, game_address) in game_addresses.iter().copied().enumerate() {
+        let mut state = mock_state(GameStatus::InProgress, claim_addr, 100 + i as u64);
+        state.game_over = true;
+        state.bond_recipient = claim_addr;
+        verifier_games.insert(game_address, state);
+    }
+    let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+    let submitter = PendingBondSubmitter::default();
+
+    let mut mgr = default_bond_manager(claim_addr);
+    for game_address in game_addresses {
+        assert!(mgr.track_game(game_address, claim_addr));
+    }
+
+    tokio::time::timeout(Duration::from_millis(100), mgr.poll(&*verifier, &submitter))
+        .await
+        .expect("poll should not wait for resolve confirmations");
+
+    let calls = submitter.recorded_calls();
+    assert_eq!(calls.len(), game_addresses.len(), "all ready resolves should be submitted");
+    assert_eq!(mgr.tracked_count(), game_addresses.len());
 }
 
 #[tokio::test]
@@ -1480,7 +1547,11 @@ async fn test_bond_manager_skips_already_unlocked_game() {
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1);
 
-    // Poll 3: NeedsWithdraw -> submit withdraw -> Completed -> removed.
+    // Poll 3: NeedsWithdraw -> submit withdraw.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 4: withdraw tx confirmed -> Completed -> removed.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 0);
 
@@ -1537,11 +1608,15 @@ async fn test_bond_manager_tx_failure_retries() {
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
 
-    // Poll 2: NeedsUnlock → claimCredit tx fails → stays NeedsUnlock.
+    // Poll 2: NeedsUnlock → submit claimCredit tx.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked while tx confirms");
+
+    // Poll 3: tx fails → stays NeedsUnlock.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after tx failure");
 
-    // Poll 3: NeedsUnlock → retry → claimCredit tx succeeds → AwaitingDelay.
+    // Poll 4: NeedsUnlock → retry submit.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after unlock");
 
@@ -1607,7 +1682,12 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
     mgr.track_game(game_addr, claim_addr);
     assert_eq!(mgr.tracked_count(), 1);
 
-    // Poll 1: NeedsResolve → resolved, bondRecipient not in claim set → removed.
+    // Poll 1: NeedsResolve → resolved, bondRecipient not in claim set,
+    // anchor update submitted before removal.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should be retained while anchor update confirms");
+
+    // Poll 2: anchor update confirmed → removed.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(
         mgr.tracked_count(),


### PR DESCRIPTION
### What changed? Why?

Migrates challenger bond lifecycle transaction submission to use `send_async()` instead of waiting for each transaction receipt inline.

Previously, the bond manager processed tracked games serially and awaited confirmation for each `resolve()`, `claimCredit()`, and anchor update transaction before advancing to the next game. This could delay ready game resolutions by hours when there was a backlog.

The bond lifecycle now records pending transaction handles and checks them on later polls, allowing one poll to submit all currently ready transactions without waiting for confirmations.

### Notes to reviewers

`resolve()`, unlock `claimCredit()`, withdraw `claimCredit()`, and `setAnchorState()` now follow a submit-now/check-later state-machine pattern.

The new regression test `test_bond_manager_submits_all_ready_resolves_without_waiting_for_confirmations` uses never-confirming handles to verify that multiple ready resolves are submitted in a single poll.

### How has it been tested?

- `cargo fmt -p base-challenger`
- `cargo test -p base-challenger`