### PR TITLE
fix(precompiles): Cap B20 Token Supply

### DIFF
--- a/actions/harness/tests/beryl/b20.rs
+++ b/actions/harness/tests/beryl/b20.rs
@@ -7,7 +7,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_action_harness::TEST_ACCOUNT_KEY;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
-use base_common_precompiles::{B20TokenRole, IB20};
+use base_common_precompiles::{B20_MAX_SUPPLY_CAP, B20TokenRole, IB20};
 
 use crate::env::BerylTestEnv;
 
@@ -297,7 +297,11 @@ async fn b20_staticcall_abi_covers_all_read_methods() {
                 IB20::isPausedCall { feature: IB20::PausableFeature::TRANSFER }.abi_encode(),
                 U256::ZERO,
             ),
-            StaticcallCase::word("supplyCap", IB20::supplyCapCall {}.abi_encode(), U256::MAX),
+            StaticcallCase::word(
+                "supplyCap",
+                IB20::supplyCapCall {}.abi_encode(),
+                B20_MAX_SUPPLY_CAP,
+            ),
             StaticcallCase::word(
                 "DOMAIN_SEPARATOR",
                 IB20::DOMAIN_SEPARATORCall {}.abi_encode(),
@@ -583,7 +587,7 @@ async fn b20_extended_mutations_update_state_and_emit_events() {
         3,
         IB20::SupplyCapUpdated {
             updater: BerylTestEnv::alice(),
-            oldSupplyCap: U256::MAX,
+            oldSupplyCap: B20_MAX_SUPPLY_CAP,
             newSupplyCap: new_cap,
         }
         .encode_log_data(),

--- a/actions/harness/tests/beryl/stablecoin.rs
+++ b/actions/harness/tests/beryl/stablecoin.rs
@@ -5,7 +5,8 @@ use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_precompiles::{
-    B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory, IB20Stablecoin,
+    B20_MAX_SUPPLY_CAP, B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory,
+    IB20Stablecoin,
 };
 
 use crate::{
@@ -88,7 +89,11 @@ async fn stablecoin_creation_initializes_currency_and_factory_views() {
                     .abi_encode(),
                     U256::ZERO,
                 ),
-                StaticcallCase::word("supplyCap", IB20::supplyCapCall {}.abi_encode(), U256::MAX),
+                StaticcallCase::word(
+                    "supplyCap",
+                    IB20::supplyCapCall {}.abi_encode(),
+                    B20_MAX_SUPPLY_CAP,
+                ),
                 StaticcallCase::string("contractURI", IB20::contractURICall {}.abi_encode(), ""),
                 StaticcallCase::word(
                     "nonces(alice)",

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -7,10 +7,10 @@ use base_precompile_storage::{BasePrecompileError, Result};
 use revm::state::Bytecode;
 
 use crate::{
-    ActivationRegistryStorage, B20AssetInit, B20AssetStorage, B20AssetToken, B20StablecoinInit,
-    B20StablecoinStorage, B20StablecoinToken, B20TokenRole, B20Variant, BerylAuxiliaryMetrics,
-    IB20Factory, NoopPrecompileCallObserver, PolicyHandle, PrecompileCallObserver, RoleManaged,
-    Token,
+    ActivationRegistryStorage, B20_MAX_SUPPLY_CAP, B20AssetInit, B20AssetStorage, B20AssetToken,
+    B20StablecoinInit, B20StablecoinStorage, B20StablecoinToken, B20TokenRole, B20Variant,
+    BerylAuxiliaryMetrics, IB20Factory, NoopPrecompileCallObserver, PolicyHandle,
+    PrecompileCallObserver, RoleManaged, Token,
 };
 
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
@@ -28,7 +28,7 @@ fn encode_stablecoin_variant_params(currency: &str) -> Bytes {
 }
 
 /// Maximum total supply for all newly-created B-20 tokens.
-const DEFAULT_SUPPLY_CAP: U256 = U256::MAX;
+const DEFAULT_SUPPLY_CAP: U256 = B20_MAX_SUPPLY_CAP;
 
 /// Initial multiplier storage value. Reads treat zero as WAD precision (1:1).
 const INITIAL_MULTIPLIER: U256 = U256::ZERO;
@@ -378,10 +378,10 @@ mod tests {
 
     use super::FACTORY_MARKER_CODE_HASH;
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
-        B20AssetToken, B20FactoryStorage, B20StablecoinStorage, B20TokenRole, B20Variant, IB20,
-        IB20Factory, Mintable, Permittable, PolicyHandle, RoleManaged, Token, TokenAccounting,
-        Transferable,
+        ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20_MAX_SUPPLY_CAP,
+        B20AssetStorage, B20AssetToken, B20FactoryStorage, B20StablecoinStorage, B20TokenRole,
+        B20Variant, IB20, IB20Factory, Mintable, Permittable, PolicyHandle, RoleManaged, Token,
+        TokenAccounting, Transferable,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
@@ -546,7 +546,8 @@ mod tests {
             assert_eq!(token.b20.name.read().unwrap(), "My Token");
             assert_eq!(token.b20.symbol.read().unwrap(), "MYT");
             assert_eq!(AssetAccounting::decimals(&token).unwrap(), B20AssetStorage::MIN_DECIMALS);
-            assert_eq!(token.supply_cap().unwrap(), B20FactoryStorage::DEFAULT_SUPPLY_CAP);
+            assert_eq!(B20FactoryStorage::DEFAULT_SUPPLY_CAP, B20_MAX_SUPPLY_CAP);
+            assert_eq!(token.supply_cap().unwrap(), B20_MAX_SUPPLY_CAP);
         });
     }
 

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -30,4 +30,4 @@ mod token;
 pub use token::Token;
 
 mod token_accounting;
-pub use token_accounting::TokenAccounting;
+pub use token_accounting::{B20_MAX_SUPPLY_CAP, TokenAccounting};

--- a/crates/common/precompiles/src/common/ops/configurable.rs
+++ b/crates/common/precompiles/src/common/ops/configurable.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolEvent;
 use base_precompile_storage::{BasePrecompileError, Result};
 
-use crate::{B20Guards, B20TokenRole, IB20, Token, TokenAccounting};
+use crate::{B20_MAX_SUPPLY_CAP, B20Guards, B20TokenRole, IB20, Token, TokenAccounting};
 
 /// Mutable configuration operations: supply cap, metadata, and contract URI updates.
 ///
@@ -22,7 +22,7 @@ pub trait Configurable: Token {
             B20Guards::ensure_token_role::<Self>(self, caller, B20TokenRole::DefaultAdmin)?;
         }
         let supply = self.accounting().total_supply()?;
-        if new_cap < supply {
+        if new_cap < supply || new_cap > B20_MAX_SUPPLY_CAP {
             return Err(BasePrecompileError::revert(IB20::InvalidSupplyCap {
                 currentSupply: supply,
                 proposedCap: new_cap,
@@ -79,8 +79,8 @@ mod tests {
     use base_precompile_storage::BasePrecompileError;
 
     use crate::{
-        B20TokenRole, Configurable, IB20, InMemoryPolicy, InMemoryTokenAccounting, TestToken,
-        Token, TokenAccounting,
+        B20_MAX_SUPPLY_CAP, B20TokenRole, Configurable, IB20, InMemoryPolicy,
+        InMemoryTokenAccounting, TestToken, Token, TokenAccounting,
     };
 
     const CALLER: Address = Address::repeat_byte(0xaa);
@@ -119,6 +119,20 @@ mod tests {
             BasePrecompileError::revert(IB20::InvalidSupplyCap {
                 currentSupply: U256::from(100u64),
                 proposedCap: U256::from(99u64),
+            })
+        );
+    }
+
+    #[test]
+    fn update_supply_cap_above_max_supply_cap_reverts() {
+        let mut token = make_token();
+        let proposed_cap = B20_MAX_SUPPLY_CAP + U256::ONE;
+
+        assert_eq!(
+            token.update_supply_cap(CALLER, proposed_cap, true).unwrap_err(),
+            BasePrecompileError::revert(IB20::InvalidSupplyCap {
+                currentSupply: U256::ZERO,
+                proposedCap: proposed_cap,
             })
         );
     }

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -12,7 +12,7 @@ use crate::{
     IPolicyRegistry, PolicyRegistry, PolicyRegistryStorage,
     b20_asset::{AssetAccounting, B20AssetStorage, B20AssetToken},
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
-    common::{Policy, TokenAccounting},
+    common::{B20_MAX_SUPPLY_CAP, Policy, TokenAccounting},
 };
 
 /// Convenience alias: [`B20AssetToken`] wired with both in-memory fakes.
@@ -37,7 +37,7 @@ pub struct InMemoryTokenAccounting {
     pub allowances: HashMap<(Address, Address), U256>,
     /// Current total token supply.
     pub total_supply: U256,
-    /// Defaults to `U256::MAX` so mint tests don't need to set a cap explicitly.
+    /// Defaults to [`B20_MAX_SUPPLY_CAP`] so mint tests don't need to set a cap explicitly.
     pub supply_cap: U256,
     /// Token name.
     pub name: String,
@@ -80,7 +80,7 @@ impl InMemoryTokenAccounting {
             balances: HashMap::new(),
             allowances: HashMap::new(),
             total_supply: U256::ZERO,
-            supply_cap: U256::MAX,
+            supply_cap: B20_MAX_SUPPLY_CAP,
             name: String::new(),
             symbol: String::new(),
             decimals: 18,

--- a/crates/common/precompiles/src/common/token_accounting.rs
+++ b/crates/common/precompiles/src/common/token_accounting.rs
@@ -4,6 +4,9 @@ use alloc::string::String;
 use alloy_primitives::{Address, B256, LogData, U256};
 use base_precompile_storage::Result;
 
+/// Maximum total supply for a B-20 token.
+pub const B20_MAX_SUPPLY_CAP: U256 = U256::from_limbs([u64::MAX, u64::MAX, 0, 0]);
+
 /// Outbound port: all data reads and writes the core business logic requires.
 ///
 /// Each token variant's `#[contract]` storage struct implements this trait.
@@ -101,4 +104,18 @@ pub trait TokenAccounting {
 
     /// Publishes a pre-encoded EVM event log from this token's address.
     fn emit_event(&mut self, log: LogData) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::U256;
+
+    use super::B20_MAX_SUPPLY_CAP;
+
+    #[test]
+    fn max_supply_cap_equals_two_to_128_minus_one() {
+        let expected = U256::from(2u64).pow(U256::from(128u64)) - U256::ONE;
+
+        assert_eq!(B20_MAX_SUPPLY_CAP, expected);
+    }
 }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -38,9 +38,9 @@ pub use bls12_381::{
 
 mod common;
 pub use common::{
-    B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType, B20TokenRole, Burnable,
-    Configurable, Eip712Domain, IB20, Mintable, Pausable, PermitArgs, Permittable, Policy,
-    PolicyRegistry, RoleManaged, Token, TokenAccounting, Transferable,
+    B20_MAX_SUPPLY_CAP, B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType, B20TokenRole,
+    Burnable, Configurable, Eip712Domain, IB20, Mintable, Pausable, PermitArgs, Permittable,
+    Policy, PolicyRegistry, RoleManaged, Token, TokenAccounting, Transferable,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use common::{InMemoryPolicy, InMemoryTokenAccounting, TestStablecoinToken, TestToken};


### PR DESCRIPTION
## Summary

- add a shared B20 max supply cap of 2^128 - 1
- enforce that max in mint even if a stored/configured cap is higher
- reject updateSupplyCap values above the max using the existing InvalidSupplyCap error
- use the same max as the factory default supply cap
- verify the limb-encoded max equals 2^128 - 1

## Tests

- cargo test -p base-common-precompiles common::token_accounting::tests::max_supply_cap_equals_two_to_128_minus_one
- cargo test -p base-common-precompiles common::ops
- cargo test -p base-common-precompiles b20_factory::storage
- git diff --check