### PR TITLE
feat(eip8130): enshrined authenticator dispatch (Authenticate step)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-execution-eip8130"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "base-common-consensus",
+ "base64 0.22.1",
+ "k256",
+ "p256",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "base-execution-evm"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,6 +480,7 @@ sp1-cluster-artifact = { git = "https://github.com/succinctlabs/sp1-cluster", ta
 # crypto
 sha3 = "0.10"
 k256 = "0.13"
+p256 = "0.13"
 p384 = "0.13"
 ciborium = "0.2"
 rustls = "0.23.35"

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -81,19 +81,10 @@ impl Eip8130Contracts {
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
     // ─────────────────────────────────────────────────────────────────────────
 
-    /// secp256k1 (ECDSA) authenticator contract.
-    ///
-    /// Pinned for drift tracking, but **not** on the enshrined allowlist
-    /// ([`Self::CANONICAL_AUTHENTICATORS`]): on EIP-8130 chains secp256k1 is the
-    /// protocol-reserved native ecrecover sentinel
-    /// [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`](super::Eip8130Constants::ECRECOVER_AUTHENTICATOR)
-    /// (`address(1)`). This deployed `IAuthenticator` contract form exists for
-    /// non-8130 chains and is intentionally not accepted on the enshrined path.
-    pub const K1_AUTHENTICATOR: Address = address!("0x39221FB37Df105B22316328e88632C9684861466");
-
-    /// keccak256 of the `K1_AUTHENTICATOR` deployment init code.
-    pub const K1_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0x07a31dfd4ba2e2a529d9642b98430ea299bac428fe83312c54d16f519568d7d5");
+    // Note: secp256k1 has no contract entry. It is the protocol-reserved native
+    // ecrecover sentinel
+    // [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`](super::Eip8130Constants::ECRECOVER_AUTHENTICATOR)
+    // (`address(1)`), handled directly by the protocol, not a deployed contract.
 
     /// secp256r1 / P-256 (raw) authenticator contract.
     pub const P256_AUTHENTICATOR: Address = address!("0x3AE129D846CD1CAf0369b4Caa56c188E18E11B15");
@@ -124,8 +115,7 @@ impl Eip8130Contracts {
     ///
     /// secp256k1 is **not** a contract entry here: on EIP-8130 chains it is the
     /// protocol-reserved native ecrecover sentinel (`address(1)`), handled
-    /// directly by the protocol. The deployed [`Self::K1_AUTHENTICATOR`] contract
-    /// is therefore intentionally excluded; see its docs.
+    /// directly by the protocol rather than via a deployed authenticator contract.
     pub const CANONICAL_AUTHENTICATORS: [Address; 3] =
         [Self::P256_AUTHENTICATOR, Self::WEBAUTHN_AUTHENTICATOR, Self::DELEGATE_AUTHENTICATOR];
 
@@ -133,8 +123,7 @@ impl Eip8130Contracts {
     /// allowlist ([`Self::CANONICAL_AUTHENTICATORS`]).
     ///
     /// This intentionally does not account for the native ecrecover sentinel
-    /// (`address(1)`), which is handled separately by the protocol; see the
-    /// allowlist docs for the TBD around final membership.
+    /// (`address(1)`), which is handled separately by the protocol.
     #[must_use]
     pub fn is_canonical_authenticator(authenticator: &Address) -> bool {
         Self::CANONICAL_AUTHENTICATORS.contains(authenticator)
@@ -158,7 +147,6 @@ mod tests {
                 Eip8130Contracts::DEFAULT_HIGH_RATE_ACCOUNT,
                 Eip8130Contracts::DEFAULT_HIGH_RATE_ACCOUNT_INIT_CODE_HASH,
             ),
-            (Eip8130Contracts::K1_AUTHENTICATOR, Eip8130Contracts::K1_AUTHENTICATOR_INIT_CODE_HASH),
             (
                 Eip8130Contracts::P256_AUTHENTICATOR,
                 Eip8130Contracts::P256_AUTHENTICATOR_INIT_CODE_HASH,
@@ -185,8 +173,6 @@ mod tests {
         for auth in Eip8130Contracts::CANONICAL_AUTHENTICATORS {
             assert!(Eip8130Contracts::is_canonical_authenticator(&auth));
         }
-        // secp256k1 is the native ecrecover sentinel, not the deployed K1 contract.
-        assert!(!Eip8130Contracts::is_canonical_authenticator(&Eip8130Contracts::K1_AUTHENTICATOR));
         assert!(!Eip8130Contracts::is_canonical_authenticator(&Address::ZERO));
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -83,9 +83,12 @@ impl Eip8130Contracts {
 
     /// secp256k1 (ECDSA) authenticator contract.
     ///
-    /// Note: native EOA ecrecover is the separate protocol-reserved sentinel
+    /// Pinned for drift tracking, but **not** on the enshrined allowlist
+    /// ([`Self::CANONICAL_AUTHENTICATORS`]): on EIP-8130 chains secp256k1 is the
+    /// protocol-reserved native ecrecover sentinel
     /// [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`](super::Eip8130Constants::ECRECOVER_AUTHENTICATOR)
-    /// (`address(1)`); this is the deployed `IAuthenticator` contract form.
+    /// (`address(1)`). This deployed `IAuthenticator` contract form exists for
+    /// non-8130 chains and is intentionally not accepted on the enshrined path.
     pub const K1_AUTHENTICATOR: Address = address!("0x39221FB37Df105B22316328e88632C9684861466");
 
     /// keccak256 of the `K1_AUTHENTICATOR` deployment init code.
@@ -119,18 +122,12 @@ impl Eip8130Contracts {
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.
     ///
-    /// Native EOA ecrecover (`address(1)`) is a separate protocol-reserved path
-    /// and is not a deployed contract, so it is not listed here.
-    ///
-    /// The exact membership (including whether the native ecrecover sentinel and
-    /// the `K1_AUTHENTICATOR` contract are both accepted, and how enshrinement is
-    /// metered) is TBD pending the spec's companion ERC and contract finalization.
-    pub const CANONICAL_AUTHENTICATORS: [Address; 4] = [
-        Self::K1_AUTHENTICATOR,
-        Self::P256_AUTHENTICATOR,
-        Self::WEBAUTHN_AUTHENTICATOR,
-        Self::DELEGATE_AUTHENTICATOR,
-    ];
+    /// secp256k1 is **not** a contract entry here: on EIP-8130 chains it is the
+    /// protocol-reserved native ecrecover sentinel (`address(1)`), handled
+    /// directly by the protocol. The deployed [`Self::K1_AUTHENTICATOR`] contract
+    /// is therefore intentionally excluded; see its docs.
+    pub const CANONICAL_AUTHENTICATORS: [Address; 3] =
+        [Self::P256_AUTHENTICATOR, Self::WEBAUTHN_AUTHENTICATOR, Self::DELEGATE_AUTHENTICATOR];
 
     /// Returns `true` if `authenticator` is in the canonical deployed-contract
     /// allowlist ([`Self::CANONICAL_AUTHENTICATORS`]).
@@ -184,10 +181,12 @@ mod tests {
 
     #[test]
     fn canonical_authenticator_membership() {
-        assert_eq!(Eip8130Contracts::CANONICAL_AUTHENTICATORS.len(), 4);
+        assert_eq!(Eip8130Contracts::CANONICAL_AUTHENTICATORS.len(), 3);
         for auth in Eip8130Contracts::CANONICAL_AUTHENTICATORS {
             assert!(Eip8130Contracts::is_canonical_authenticator(&auth));
         }
+        // secp256k1 is the native ecrecover sentinel, not the deployed K1 contract.
+        assert!(!Eip8130Contracts::is_canonical_authenticator(&Eip8130Contracts::K1_AUTHENTICATOR));
         assert!(!Eip8130Contracts::is_canonical_authenticator(&Address::ZERO));
     }
 }

--- a/crates/execution/eip8130/Cargo.toml
+++ b/crates/execution/eip8130/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "base-execution-eip8130"
+description = "EIP-8130 account-abstraction authenticator dispatch (enshrined canonical set)"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# crypto
+k256.workspace = true
+p256.workspace = true
+sha2.workspace = true
+base64.workspace = true
+
+# alloy
+alloy-primitives = { workspace = true, features = ["k256"] }
+alloy-sol-types.workspace = true
+
+# base
+base-common-consensus = { workspace = true, default-features = false }
+
+# misc
+thiserror.workspace = true
+
+[dev-dependencies]
+p256 = { workspace = true, features = ["ecdsa"] }
+k256 = { workspace = true, features = ["ecdsa"] }

--- a/crates/execution/eip8130/Cargo.toml
+++ b/crates/execution/eip8130/Cargo.toml
@@ -15,13 +15,13 @@ workspace = true
 
 [dependencies]
 # crypto
-k256.workspace = true
-p256.workspace = true
 sha2.workspace = true
 base64.workspace = true
+k256 = { workspace = true, features = ["ecdsa"] }
+p256 = { workspace = true, features = ["ecdsa"] }
 
 # alloy
-alloy-primitives = { workspace = true, features = ["k256"] }
+alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 
 # base
@@ -29,7 +29,3 @@ base-common-consensus = { workspace = true, default-features = false }
 
 # misc
 thiserror.workspace = true
-
-[dev-dependencies]
-p256 = { workspace = true, features = ["ecdsa"] }
-k256 = { workspace = true, features = ["ecdsa"] }

--- a/crates/execution/eip8130/README.md
+++ b/crates/execution/eip8130/README.md
@@ -1,0 +1,40 @@
+# base-execution-eip8130
+
+EIP-8130 (Account Abstraction by Account Configuration) authenticator **dispatch**.
+
+This crate implements step 2 ("Authenticate") of the EIP-8130 validation flow: given a
+signing `hash` and an authentication blob (`authenticator || data`), it routes to the
+named authenticator, verifies the signature, and returns the resolved `actorId`.
+
+## Enshrined, not a precompile
+
+The canonical authenticators (P-256, `WebAuthn`, Delegate; native secp256k1 ecrecover for
+k1) are **enshrined** here as native Rust implementations keyed by their canonical
+CREATE2 addresses (from `base-common-consensus::Eip8130Contracts`). This is the
+protocol's own fast-path for authenticating AA transactions during validation and block
+execution; the EIP explicitly permits enshrining canonical authenticators at a fixed gas
+cost provided results are identical to the deployed contract.
+
+This is **not** an EVM precompile and does **not** shadow the authenticator addresses:
+ordinary EVM `CALL`/`STATICCALL` to those addresses still hits the real deployed
+contract bytecode (e.g. `AccountConfiguration.verifySignature()`, `applySignedActorChanges()`
+on non-8130 chains, wallet code). The native code here is invoked only by the protocol.
+
+## Parity is required
+
+Because the enshrined path and the EVM path can authenticate the same actor, the native
+implementation MUST produce byte-identical `actorId` results to the deployed authenticator
+contracts. The enshrined logic is pinned to a specific contract version via the
+`init_code_hash` constants in `Eip8130Contracts`; a contract bytecode change shifts the
+canonical address (caught by the registry drift test) and requires re-pinning the address
+and re-validating parity here. A differential test against the deployed contracts (via the
+EVM) is a planned follow-up.
+
+## Scope
+
+This crate is **stateless / pure**: it performs no storage reads and runs no EVM. The
+stateful "Authorize" step (reading `actor_config`, the implicit-EOA rule, scope/expiry,
+and the delegate authenticator's nested-actor authorization in the delegated account's
+SIGNATURE context) is layered on top in a later stage. For the delegate authenticator,
+dispatch verifies the nested signature and surfaces the nested actor as a
+[`DispatchOutcome::Delegated`] obligation for that authorize stage to discharge.

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -74,17 +74,12 @@ impl AuthenticatorDispatch {
         if authenticator == Eip8130Constants::REVOKED_AUTHENTICATOR {
             return Err(AuthError::Revoked);
         }
-        // Native secp256k1: the EOA path and the `ECRECOVER_AUTHENTICATOR`
-        // sentinel use raw ecrecover semantics (no malleability rejection).
+        // secp256k1 is the native ecrecover sentinel only. The deployed
+        // `K1_AUTHENTICATOR` contract is intentionally not accepted on the
+        // enshrined path (see `Eip8130Contracts::K1_AUTHENTICATOR`); it falls
+        // through to the non-canonical rejection below.
         if authenticator == Eip8130Constants::ECRECOVER_AUTHENTICATOR {
-            let actor_id = Self::ecrecover(hash, data, false)?;
-            return Ok(DispatchOutcome::Authenticated { actor_id });
-        }
-        // The deployed K1 authenticator contract uses OpenZeppelin `ECDSA.recover`,
-        // which requires `v in {27, 28}` and rejects high-`s`. Mirror it exactly.
-        if authenticator == Eip8130Contracts::K1_AUTHENTICATOR {
-            let actor_id = Self::ecrecover(hash, data, true)?;
-            return Ok(DispatchOutcome::Authenticated { actor_id });
+            return Ok(DispatchOutcome::Authenticated { actor_id: Self::ecrecover(hash, data)? });
         }
         if authenticator == Eip8130Contracts::P256_AUTHENTICATOR {
             return Ok(DispatchOutcome::Authenticated { actor_id: Self::p256(hash, data)? });
@@ -109,22 +104,29 @@ impl AuthenticatorDispatch {
         B256::from(id)
     }
 
-    /// Native secp256k1 recovery. `oz_strict` mirrors `OpenZeppelin` `ECDSA.recover`
-    /// (require `v in {27, 28}`, reject high-`s`); when `false`, raw ecrecover
-    /// semantics apply (accept `v in {0, 1, 27, 28}`, any `s`).
-    fn ecrecover(hash: B256, data: &[u8], oz_strict: bool) -> Result<B256, AuthError> {
+    /// Native secp256k1 ecrecover for the `ECRECOVER_AUTHENTICATOR` sentinel,
+    /// matching the on-chain reference (`AccountConfiguration._recoverSigner`,
+    /// i.e. the EVM `ecrecover` precompile): requires `v in {27, 28}` and accepts
+    /// any `s` (the precompile does not reject malleable high-`s`).
+    /// `actorId = bytes32(bytes20(recovered))`.
+    ///
+    /// `k256`'s recovery rejects high-`s`, so a high-`s` input is canonicalized to
+    /// its low-`s` malleable equivalent with the recovery parity flipped — this
+    /// recovers the identical key, since `ecrecover(h, v, r, s)` equals
+    /// `ecrecover(h, v ^ 1, r, n - s)`.
+    fn ecrecover(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
         if data.len() != 65 {
             return Err(AuthError::MalformedAuth);
         }
-        let recovery = match data[64] {
+        let mut recovery = match data[64] {
             27 | 28 => data[64] - 27,
-            v @ (0 | 1) if !oz_strict => v,
             _ => return Err(AuthError::InvalidSignature),
         };
-        let signature =
+        let mut signature =
             K256Signature::from_slice(&data[..64]).map_err(|_| AuthError::InvalidSignature)?;
-        if oz_strict && signature.normalize_s().is_some() {
-            return Err(AuthError::InvalidSignature);
+        if let Some(low_s) = signature.normalize_s() {
+            signature = low_s;
+            recovery ^= 1;
         }
         let recovery_id = RecoveryId::from_byte(recovery).ok_or(AuthError::InvalidSignature)?;
         let key = K256VerifyingKey::recover_from_prehash(hash.as_slice(), &signature, recovery_id)
@@ -349,54 +351,54 @@ mod tests {
     }
 
     #[test]
-    fn ecrecover_native_accepts_v_0_or_1_but_k1_contract_requires_27_or_28() {
+    fn ecrecover_requires_v_27_or_28() {
         let key = k1_key();
         let mut sig = k1_sig(&key, HASH);
-        sig[64] -= 27; // 0 or 1
-
-        // Native ecrecover accepts raw v in {0, 1}.
-        assert!(
+        sig[64] -= 27; // 0 or 1: invalid for the EVM ecrecover sentinel.
+        assert_eq!(
             AuthenticatorDispatch::authenticate(
                 HASH,
                 Eip8130Constants::ECRECOVER_AUTHENTICATOR,
                 &sig,
-            )
-            .is_ok()
-        );
-        // The K1 contract mirrors OZ ECDSA.recover, which requires v in {27, 28}.
-        assert_eq!(
-            AuthenticatorDispatch::authenticate(HASH, Eip8130Contracts::K1_AUTHENTICATOR, &sig),
+            ),
             Err(AuthError::InvalidSignature),
         );
     }
 
     #[test]
-    fn k1_contract_resolves_with_v_27_or_28() {
-        let key = k1_key();
-        let out = AuthenticatorDispatch::authenticate(
-            HASH,
-            Eip8130Contracts::K1_AUTHENTICATOR,
-            &k1_sig(&key, HASH),
-        )
-        .unwrap();
-        let expected = AuthenticatorDispatch::address_actor_id(k1_address(&key));
-        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
+    fn k1_authenticator_contract_is_not_canonical() {
+        // secp256k1 is the native ecrecover sentinel; the deployed K1 contract is
+        // intentionally not accepted on the enshrined path.
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Contracts::K1_AUTHENTICATOR,
+                &k1_sig(&k1_key(), HASH),
+            ),
+            Err(AuthError::NotCanonical(Eip8130Contracts::K1_AUTHENTICATOR)),
+        );
     }
 
     #[test]
-    fn k1_contract_rejects_high_s() {
+    fn ecrecover_accepts_high_s() {
+        // The EVM ecrecover precompile does not reject malleable high-s; the
+        // native sentinel must match. Negating s yields the high-s counterpart,
+        // and flipping the recovery parity recovers the same signer.
         let key = k1_key();
         let (sig, recid) = key.sign_prehash_recoverable(HASH.as_slice()).unwrap();
-        // Negate s to obtain the malleable high-s counterpart.
         let s_high = -*sig.s();
         let high = K256Signature::from_scalars(sig.r().to_bytes(), s_high.to_bytes()).unwrap();
         let mut bytes = [0u8; 65];
         bytes[..64].copy_from_slice(&high.to_bytes());
-        bytes[64] = recid.to_byte() + 27;
-        assert_eq!(
-            AuthenticatorDispatch::authenticate(HASH, Eip8130Contracts::K1_AUTHENTICATOR, &bytes),
-            Err(AuthError::InvalidSignature),
-        );
+        bytes[64] = (recid.to_byte() ^ 1) + 27;
+        let out = AuthenticatorDispatch::authenticate(
+            HASH,
+            Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+            &bytes,
+        )
+        .unwrap();
+        let expected = AuthenticatorDispatch::address_actor_id(k1_address(&key));
+        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
     }
 
     #[test]

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -74,10 +74,8 @@ impl AuthenticatorDispatch {
         if authenticator == Eip8130Constants::REVOKED_AUTHENTICATOR {
             return Err(AuthError::Revoked);
         }
-        // secp256k1 is the native ecrecover sentinel only. The deployed
-        // `K1_AUTHENTICATOR` contract is intentionally not accepted on the
-        // enshrined path (see `Eip8130Contracts::K1_AUTHENTICATOR`); it falls
-        // through to the non-canonical rejection below.
+        // secp256k1 is the protocol-reserved native ecrecover sentinel
+        // (`address(1)`); there is no deployed secp256k1 authenticator contract.
         if authenticator == Eip8130Constants::ECRECOVER_AUTHENTICATOR {
             return Ok(DispatchOutcome::Authenticated { actor_id: Self::ecrecover(hash, data)? });
         }
@@ -362,20 +360,6 @@ mod tests {
                 &sig,
             ),
             Err(AuthError::InvalidSignature),
-        );
-    }
-
-    #[test]
-    fn k1_authenticator_contract_is_not_canonical() {
-        // secp256k1 is the native ecrecover sentinel; the deployed K1 contract is
-        // intentionally not accepted on the enshrined path.
-        assert_eq!(
-            AuthenticatorDispatch::authenticate(
-                HASH,
-                Eip8130Contracts::K1_AUTHENTICATOR,
-                &k1_sig(&k1_key(), HASH),
-            ),
-            Err(AuthError::NotCanonical(Eip8130Contracts::K1_AUTHENTICATOR)),
         );
     }
 

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -135,8 +135,15 @@ impl AuthenticatorDispatch {
         Ok(Self::address_actor_id(address))
     }
 
-    /// P-256 raw authenticator. `data = r(32) || s(32) || x(32) || y(32) || pre_hash(1)`.
-    /// `actorId = keccak256(x || y)`.
+    /// P-256 raw authenticator. `data = r(32) || s(32) || x(32) || y(32) || pre_hash(1)`
+    /// (exactly 129 bytes). `actorId = keccak256(x || y)`.
+    ///
+    /// The trailing `pre_hash` byte (`data[128]`) is **reserved**: the deployed
+    /// `P256Authenticator` requires it to be present (it enforces `length == 129`)
+    /// but never reads it — it exists only so the contract wire format matches the
+    /// native-authenticator form. We mirror that exactly: require the byte, ignore
+    /// its value, and verify directly over `hash`. If the contract ever begins
+    /// interpreting `pre_hash`, this must change in lockstep to preserve parity.
     fn p256(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
         if data.len() != 129 {
             return Err(AuthError::MalformedAuth);
@@ -231,13 +238,11 @@ impl AuthenticatorDispatch {
         Ok(())
     }
 
-    /// Narrows a `clientDataJSON` index from `uint256` to `usize`, rejecting
-    /// implausibly large values.
+    /// Narrows a `clientDataJSON` index from `uint256` to `usize`, rejecting any
+    /// value that does not fit the platform pointer width (it cannot be a valid
+    /// offset into the blob anyway). Correct on 32- and 64-bit targets.
     fn index(value: &U256) -> Result<usize, AuthError> {
-        if *value > U256::from(u32::MAX) {
-            return Err(AuthError::MalformedAuth);
-        }
-        Ok(value.as_limbs()[0] as usize)
+        usize::try_from(*value).map_err(|_| AuthError::MalformedAuth)
     }
 
     /// Delegate authenticator. `data = delegate_account(20) || nested_auth`, where

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -1,0 +1,589 @@
+//! Stateless EIP-8130 authenticator dispatch: route a signing hash + auth blob
+//! to the enshrined canonical authenticator and return the resolved `actorId`.
+
+use alloy_primitives::{Address, B256, U256, keccak256};
+use alloy_sol_types::{SolValue, sol};
+use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
+use p256::ecdsa::{
+    Signature as P256Signature, VerifyingKey as P256VerifyingKey,
+    signature::hazmat::PrehashVerifier,
+};
+use sha2::{Digest, Sha256};
+
+use crate::{AuthError, DispatchOutcome};
+
+sol! {
+    /// Mirror of `OpenZeppelin` `WebAuthn.WebAuthnAuth`, used to ABI-decode the
+    /// `WebAuthn` authenticator's `data` blob (`abi.encode(WebAuthnAuth, x, y)`).
+    struct WebAuthnAuth {
+        bytes32 r;
+        bytes32 s;
+        uint256 challengeIndex;
+        uint256 typeIndex;
+        bytes authenticatorData;
+        string clientDataJSON;
+    }
+}
+
+/// The expected `"type"` member of a `WebAuthn` `clientDataJSON` (21 bytes).
+const WEBAUTHN_TYPE: &[u8] = b"\"type\":\"webauthn.get\"";
+/// Prefix of the `"challenge"` member of a `WebAuthn` `clientDataJSON`.
+const WEBAUTHN_CHALLENGE_PREFIX: &[u8] = b"\"challenge\":\"";
+/// `WebAuthn` authenticator-data flag bits.
+const FLAG_USER_PRESENT: u8 = 0x01;
+const FLAG_BACKUP_ELIGIBLE: u8 = 0x08;
+const FLAG_BACKUP_STATE: u8 = 0x10;
+
+/// Enshrined dispatch over the EIP-8130 canonical authenticator set.
+///
+/// Stateless: performs no storage reads and runs no EVM. See the crate docs for
+/// the enshrine-vs-precompile distinction and the parity requirement against the
+/// deployed authenticator contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AuthenticatorDispatch;
+
+impl AuthenticatorDispatch {
+    /// Authenticate `data` for `authenticator` against `hash`, returning the
+    /// resolved actor (or a [`DispatchOutcome::Delegated`] obligation for the
+    /// delegate authenticator).
+    ///
+    /// `hash` is the context-appropriate signing hash (sender, payer, or config
+    /// change digest); the caller computes it. For the EOA path (`sender` empty
+    /// in the wire format), the caller passes
+    /// [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`] as `authenticator` with the
+    /// raw 65-byte signature as `data`.
+    pub fn authenticate(
+        hash: B256,
+        authenticator: Address,
+        data: &[u8],
+    ) -> Result<DispatchOutcome, AuthError> {
+        Self::authenticate_inner(hash, authenticator, data, true)
+    }
+
+    /// Routes by authenticator address. `allow_delegate` is `false` for the
+    /// nested authentication inside a delegate blob (depth-1 only).
+    fn authenticate_inner(
+        hash: B256,
+        authenticator: Address,
+        data: &[u8],
+        allow_delegate: bool,
+    ) -> Result<DispatchOutcome, AuthError> {
+        if authenticator == Eip8130Constants::REVOKED_AUTHENTICATOR {
+            return Err(AuthError::Revoked);
+        }
+        // Native secp256k1: the EOA path and the `ECRECOVER_AUTHENTICATOR`
+        // sentinel use raw ecrecover semantics (no malleability rejection).
+        if authenticator == Eip8130Constants::ECRECOVER_AUTHENTICATOR {
+            let actor_id = Self::ecrecover(hash, data, false)?;
+            return Ok(DispatchOutcome::Authenticated { actor_id });
+        }
+        // The deployed K1 authenticator contract uses OpenZeppelin `ECDSA.recover`,
+        // which requires `v in {27, 28}` and rejects high-`s`. Mirror it exactly.
+        if authenticator == Eip8130Contracts::K1_AUTHENTICATOR {
+            let actor_id = Self::ecrecover(hash, data, true)?;
+            return Ok(DispatchOutcome::Authenticated { actor_id });
+        }
+        if authenticator == Eip8130Contracts::P256_AUTHENTICATOR {
+            return Ok(DispatchOutcome::Authenticated { actor_id: Self::p256(hash, data)? });
+        }
+        if authenticator == Eip8130Contracts::WEBAUTHN_AUTHENTICATOR {
+            return Ok(DispatchOutcome::Authenticated { actor_id: Self::webauthn(hash, data)? });
+        }
+        if authenticator == Eip8130Contracts::DELEGATE_AUTHENTICATOR {
+            if !allow_delegate {
+                return Err(AuthError::NestedDelegate);
+            }
+            return Self::delegate(hash, data);
+        }
+        Err(AuthError::NotCanonical(authenticator))
+    }
+
+    /// `actorId = bytes32(bytes20(address))`: the 20 address bytes left-aligned,
+    /// right-padded with zeros.
+    fn address_actor_id(address: Address) -> B256 {
+        let mut id = [0u8; 32];
+        id[..20].copy_from_slice(address.as_slice());
+        B256::from(id)
+    }
+
+    /// Native secp256k1 recovery. `oz_strict` mirrors `OpenZeppelin` `ECDSA.recover`
+    /// (require `v in {27, 28}`, reject high-`s`); when `false`, raw ecrecover
+    /// semantics apply (accept `v in {0, 1, 27, 28}`, any `s`).
+    fn ecrecover(hash: B256, data: &[u8], oz_strict: bool) -> Result<B256, AuthError> {
+        if data.len() != 65 {
+            return Err(AuthError::MalformedAuth);
+        }
+        let recovery = match data[64] {
+            27 | 28 => data[64] - 27,
+            v @ (0 | 1) if !oz_strict => v,
+            _ => return Err(AuthError::InvalidSignature),
+        };
+        let signature =
+            K256Signature::from_slice(&data[..64]).map_err(|_| AuthError::InvalidSignature)?;
+        if oz_strict && signature.normalize_s().is_some() {
+            return Err(AuthError::InvalidSignature);
+        }
+        let recovery_id = RecoveryId::from_byte(recovery).ok_or(AuthError::InvalidSignature)?;
+        let key = K256VerifyingKey::recover_from_prehash(hash.as_slice(), &signature, recovery_id)
+            .map_err(|_| AuthError::InvalidSignature)?;
+        let encoded = key.to_encoded_point(false);
+        // encoded = 0x04 || x(32) || y(32); address = keccak256(x || y)[12..].
+        let address = Address::from_slice(&keccak256(&encoded.as_bytes()[1..])[12..]);
+        Ok(Self::address_actor_id(address))
+    }
+
+    /// P-256 raw authenticator. `data = r(32) || s(32) || x(32) || y(32) || pre_hash(1)`.
+    /// `actorId = keccak256(x || y)`.
+    fn p256(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
+        if data.len() != 129 {
+            return Err(AuthError::MalformedAuth);
+        }
+        let (r, s, x, y) = (&data[0..32], &data[32..64], &data[64..96], &data[96..128]);
+        Self::p256_verify(hash.as_slice(), r, s, x, y)?;
+        Ok(keccak256([x, y].concat()))
+    }
+
+    /// Verify a P-256 signature `(r, s)` over `prehash` for public key `(x, y)`.
+    /// Enforces low-`s` to match `OpenZeppelin` `P256.verify` (malleability check).
+    fn p256_verify(
+        prehash: &[u8],
+        r: &[u8],
+        s: &[u8],
+        x: &[u8],
+        y: &[u8],
+    ) -> Result<(), AuthError> {
+        let mut sec1 = [0u8; 65];
+        sec1[0] = 0x04;
+        sec1[1..33].copy_from_slice(x);
+        sec1[33..65].copy_from_slice(y);
+        let key =
+            P256VerifyingKey::from_sec1_bytes(&sec1).map_err(|_| AuthError::InvalidPublicKey)?;
+
+        let mut rs = [0u8; 64];
+        rs[..32].copy_from_slice(r);
+        rs[32..].copy_from_slice(s);
+        let signature = P256Signature::from_slice(&rs).map_err(|_| AuthError::InvalidSignature)?;
+        if signature.normalize_s().is_some() {
+            return Err(AuthError::InvalidSignature);
+        }
+        key.verify_prehash(prehash, &signature).map_err(|_| AuthError::InvalidSignature)
+    }
+
+    /// `WebAuthn` authenticator. `data = abi.encode(WebAuthnAuth, x, y)`.
+    /// `actorId = keccak256(x || y)`. Mirrors `OpenZeppelin` `WebAuthn.verify`
+    /// with `requireUV = false` (as the deployed `WebAuthnAuthenticator`).
+    fn webauthn(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
+        let (auth, x, y) = <(WebAuthnAuth, B256, B256)>::abi_decode_params(data)
+            .map_err(|_| AuthError::MalformedAuth)?;
+
+        let auth_data = auth.authenticatorData.as_ref();
+        let client_json = auth.clientDataJSON.as_bytes();
+
+        // 37-byte minimum authenticator data (32 rpIdHash + 1 flags + 4 counter).
+        if auth_data.len() <= 36 {
+            return Err(AuthError::InvalidSignature);
+        }
+        // Step 11: `"type":"webauthn.get"` at typeIndex.
+        Self::contains_at(client_json, &auth.typeIndex, WEBAUTHN_TYPE)?;
+        // Step 12: `"challenge":"<base64url(hash)>"` at challengeIndex.
+        let mut expected = Vec::with_capacity(WEBAUTHN_CHALLENGE_PREFIX.len() + 44);
+        expected.extend_from_slice(WEBAUTHN_CHALLENGE_PREFIX);
+        expected.extend_from_slice(URL_SAFE_NO_PAD.encode(hash.as_slice()).as_bytes());
+        expected.push(b'"');
+        Self::contains_at(client_json, &auth.challengeIndex, &expected)?;
+        // Step 16: User Present bit must be set. Step 17 (UV) skipped (requireUV = false).
+        let flags = auth_data[32];
+        if flags & FLAG_USER_PRESENT != FLAG_USER_PRESENT {
+            return Err(AuthError::InvalidSignature);
+        }
+        // Backup state consistency: BS=1 requires BE=1.
+        if flags & FLAG_BACKUP_ELIGIBLE != FLAG_BACKUP_ELIGIBLE && flags & FLAG_BACKUP_STATE != 0 {
+            return Err(AuthError::InvalidSignature);
+        }
+        // Step 19-20: P-256 verify over sha256(authenticatorData || sha256(clientDataJSON)).
+        let client_hash = Sha256::digest(client_json);
+        let mut signed = Sha256::new();
+        signed.update(auth_data);
+        signed.update(client_hash);
+        let signed = signed.finalize();
+
+        Self::p256_verify(
+            signed.as_slice(),
+            auth.r.as_slice(),
+            auth.s.as_slice(),
+            x.as_slice(),
+            y.as_slice(),
+        )?;
+        Ok(keccak256([x.as_slice(), y.as_slice()].concat()))
+    }
+
+    /// Asserts `haystack[index..index + needle.len()] == needle`, rejecting an
+    /// out-of-range index or mismatch.
+    fn contains_at(haystack: &[u8], index: &U256, needle: &[u8]) -> Result<(), AuthError> {
+        let index = Self::index(index)?;
+        let end = index.checked_add(needle.len()).ok_or(AuthError::MalformedAuth)?;
+        if haystack.len() < end || &haystack[index..end] != needle {
+            return Err(AuthError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    /// Narrows a `clientDataJSON` index from `uint256` to `usize`, rejecting
+    /// implausibly large values.
+    fn index(value: &U256) -> Result<usize, AuthError> {
+        if *value > U256::from(u32::MAX) {
+            return Err(AuthError::MalformedAuth);
+        }
+        Ok(value.as_limbs()[0] as usize)
+    }
+
+    /// Delegate authenticator. `data = delegate_account(20) || nested_auth`, where
+    /// `nested_auth = nested_authenticator(20) || nested_data`. Verifies the nested
+    /// signature (canonical, non-delegate) and surfaces the nested actor as a
+    /// [`DispatchOutcome::Delegated`] obligation.
+    fn delegate(hash: B256, data: &[u8]) -> Result<DispatchOutcome, AuthError> {
+        if data.len() < 40 {
+            return Err(AuthError::MalformedAuth);
+        }
+        let delegate_account = Address::from_slice(&data[..20]);
+        let nested = &data[20..];
+        let nested_authenticator = Address::from_slice(&nested[..20]);
+        let nested_data = &nested[20..];
+
+        if nested_authenticator == Eip8130Contracts::DELEGATE_AUTHENTICATOR {
+            return Err(AuthError::NestedDelegate);
+        }
+        let nested_actor_id =
+            match Self::authenticate_inner(hash, nested_authenticator, nested_data, false)? {
+                DispatchOutcome::Authenticated { actor_id } => actor_id,
+                DispatchOutcome::Delegated { .. } => return Err(AuthError::NestedDelegate),
+            };
+
+        Ok(DispatchOutcome::Delegated {
+            actor_id: Self::address_actor_id(delegate_account),
+            delegate_account,
+            nested_authenticator,
+            nested_actor_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
+    use alloy_sol_types::SolValue;
+    use k256::ecdsa::SigningKey as K256SigningKey;
+    use p256::ecdsa::{
+        Signature as P256Sig, SigningKey as P256SigningKey, signature::hazmat::PrehashSigner,
+    };
+    use sha2::{Digest, Sha256};
+
+    use super::*;
+
+    const HASH: B256 = B256::repeat_byte(0x42);
+
+    fn k1_key() -> K256SigningKey {
+        K256SigningKey::from_slice(&[0x11u8; 32]).unwrap()
+    }
+
+    fn k1_address(key: &K256SigningKey) -> Address {
+        let point = key.verifying_key().to_encoded_point(false);
+        Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+    }
+
+    /// 65-byte `r || s || v` signature over `HASH`, `v` in `{27, 28}` (low-s).
+    fn k1_sig(key: &K256SigningKey, hash: B256) -> [u8; 65] {
+        let (sig, recid) = key.sign_prehash_recoverable(hash.as_slice()).unwrap();
+        let mut out = [0u8; 65];
+        out[..64].copy_from_slice(&sig.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    fn p256_key() -> P256SigningKey {
+        P256SigningKey::from_slice(&[0x22u8; 32]).unwrap()
+    }
+
+    fn p256_xy(key: &P256SigningKey) -> ([u8; 32], [u8; 32]) {
+        let point = key.verifying_key().to_encoded_point(false);
+        let bytes = point.as_bytes();
+        (bytes[1..33].try_into().unwrap(), bytes[33..65].try_into().unwrap())
+    }
+
+    fn p256_sign(key: &P256SigningKey, prehash: &[u8]) -> P256Sig {
+        let sig: P256Sig = key.sign_prehash(prehash).unwrap();
+        sig.normalize_s().unwrap_or(sig)
+    }
+
+    /// `data = r || s || x || y || pre_hash` for the P-256 authenticator.
+    fn p256_blob(key: &P256SigningKey, hash: B256) -> (Vec<u8>, B256) {
+        let (x, y) = p256_xy(key);
+        let sig = p256_sign(key, hash.as_slice());
+        let mut data = Vec::with_capacity(129);
+        data.extend_from_slice(&sig.to_bytes());
+        data.extend_from_slice(&x);
+        data.extend_from_slice(&y);
+        data.push(0);
+        (data, keccak256([x.as_slice(), y.as_slice()].concat()))
+    }
+
+    #[test]
+    fn ecrecover_native_resolves_eoa_actor_id() {
+        let key = k1_key();
+        let out = AuthenticatorDispatch::authenticate(
+            HASH,
+            Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+            &k1_sig(&key, HASH),
+        )
+        .unwrap();
+        let expected = AuthenticatorDispatch::address_actor_id(k1_address(&key));
+        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
+    }
+
+    #[test]
+    fn ecrecover_native_accepts_v_0_or_1_but_k1_contract_requires_27_or_28() {
+        let key = k1_key();
+        let mut sig = k1_sig(&key, HASH);
+        sig[64] -= 27; // 0 or 1
+
+        // Native ecrecover accepts raw v in {0, 1}.
+        assert!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                &sig,
+            )
+            .is_ok()
+        );
+        // The K1 contract mirrors OZ ECDSA.recover, which requires v in {27, 28}.
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(HASH, Eip8130Contracts::K1_AUTHENTICATOR, &sig),
+            Err(AuthError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn k1_contract_resolves_with_v_27_or_28() {
+        let key = k1_key();
+        let out = AuthenticatorDispatch::authenticate(
+            HASH,
+            Eip8130Contracts::K1_AUTHENTICATOR,
+            &k1_sig(&key, HASH),
+        )
+        .unwrap();
+        let expected = AuthenticatorDispatch::address_actor_id(k1_address(&key));
+        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
+    }
+
+    #[test]
+    fn k1_contract_rejects_high_s() {
+        let key = k1_key();
+        let (sig, recid) = key.sign_prehash_recoverable(HASH.as_slice()).unwrap();
+        // Negate s to obtain the malleable high-s counterpart.
+        let s_high = -*sig.s();
+        let high = K256Signature::from_scalars(sig.r().to_bytes(), s_high.to_bytes()).unwrap();
+        let mut bytes = [0u8; 65];
+        bytes[..64].copy_from_slice(&high.to_bytes());
+        bytes[64] = recid.to_byte() + 27;
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(HASH, Eip8130Contracts::K1_AUTHENTICATOR, &bytes),
+            Err(AuthError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn ecrecover_rejects_wrong_length() {
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                &[0u8; 64],
+            ),
+            Err(AuthError::MalformedAuth),
+        );
+    }
+
+    #[test]
+    fn p256_resolves_keccak_xy_actor_id() {
+        let key = p256_key();
+        let (data, expected) = p256_blob(&key, HASH);
+        let out =
+            AuthenticatorDispatch::authenticate(HASH, Eip8130Contracts::P256_AUTHENTICATOR, &data)
+                .unwrap();
+        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
+    }
+
+    #[test]
+    fn p256_rejects_tampered_hash() {
+        let key = p256_key();
+        let (data, _) = p256_blob(&key, HASH);
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                B256::repeat_byte(0x99),
+                Eip8130Contracts::P256_AUTHENTICATOR,
+                &data,
+            ),
+            Err(AuthError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn p256_rejects_wrong_length() {
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Contracts::P256_AUTHENTICATOR,
+                &[0u8; 128],
+            ),
+            Err(AuthError::MalformedAuth),
+        );
+    }
+
+    /// Builds an OZ-compatible `WebAuthn` blob (`abi.encode(WebAuthnAuth, x, y)`)
+    /// that authenticates `hash`.
+    fn webauthn_blob(key: &P256SigningKey, hash: B256) -> (Vec<u8>, B256) {
+        let (x, y) = p256_xy(key);
+        let challenge = URL_SAFE_NO_PAD.encode(hash.as_slice());
+        let client_json = format!(
+            "{{\"type\":\"webauthn.get\",\"challenge\":\"{challenge}\",\"origin\":\"https://base.org\"}}"
+        );
+        let type_index = client_json.find("\"type\":\"webauthn.get\"").unwrap();
+        let challenge_index = client_json.find("\"challenge\":\"").unwrap();
+
+        // 37 bytes: 32 rpIdHash + flags (UP set) + 4-byte counter.
+        let mut auth_data = vec![0xAAu8; 32];
+        auth_data.push(FLAG_USER_PRESENT);
+        auth_data.extend_from_slice(&[0, 0, 0, 1]);
+
+        let mut signed = Sha256::new();
+        signed.update(&auth_data);
+        signed.update(Sha256::digest(client_json.as_bytes()));
+        let sig = p256_sign(key, &signed.finalize());
+
+        let auth = WebAuthnAuth {
+            r: B256::from_slice(&sig.to_bytes()[..32]),
+            s: B256::from_slice(&sig.to_bytes()[32..]),
+            challengeIndex: U256::from(challenge_index),
+            typeIndex: U256::from(type_index),
+            authenticatorData: Bytes::from(auth_data),
+            clientDataJSON: client_json,
+        };
+        let data = (auth, B256::from(x), B256::from(y)).abi_encode_params();
+        (data, keccak256([x.as_slice(), y.as_slice()].concat()))
+    }
+
+    #[test]
+    fn webauthn_resolves_keccak_xy_actor_id() {
+        let key = p256_key();
+        let (data, expected) = webauthn_blob(&key, HASH);
+        let out = AuthenticatorDispatch::authenticate(
+            HASH,
+            Eip8130Contracts::WEBAUTHN_AUTHENTICATOR,
+            &data,
+        )
+        .unwrap();
+        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
+    }
+
+    #[test]
+    fn webauthn_rejects_wrong_challenge() {
+        let key = p256_key();
+        // Blob authenticates HASH, but we dispatch against a different hash, so the
+        // embedded challenge no longer matches the expected base64url(hash).
+        let (data, _) = webauthn_blob(&key, HASH);
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                B256::repeat_byte(0x01),
+                Eip8130Contracts::WEBAUTHN_AUTHENTICATOR,
+                &data,
+            ),
+            Err(AuthError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn delegate_surfaces_nested_obligation() {
+        let nested_key = k1_key();
+        let delegate_account = address!("0x00000000000000000000000000000000000000bb");
+
+        let mut data = Vec::new();
+        data.extend_from_slice(delegate_account.as_slice());
+        data.extend_from_slice(Eip8130Constants::ECRECOVER_AUTHENTICATOR.as_slice());
+        data.extend_from_slice(&k1_sig(&nested_key, HASH));
+
+        let out = AuthenticatorDispatch::authenticate(
+            HASH,
+            Eip8130Contracts::DELEGATE_AUTHENTICATOR,
+            &data,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            DispatchOutcome::Delegated {
+                actor_id: AuthenticatorDispatch::address_actor_id(delegate_account),
+                delegate_account,
+                nested_authenticator: Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                nested_actor_id: AuthenticatorDispatch::address_actor_id(k1_address(&nested_key)),
+            }
+        );
+    }
+
+    #[test]
+    fn delegate_rejects_nested_delegate() {
+        let delegate_account = address!("0x00000000000000000000000000000000000000bb");
+        let mut data = Vec::new();
+        data.extend_from_slice(delegate_account.as_slice());
+        // Nested authenticator is the delegate authenticator itself (depth-2).
+        data.extend_from_slice(Eip8130Contracts::DELEGATE_AUTHENTICATOR.as_slice());
+        data.extend_from_slice(&[0u8; 65]);
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Contracts::DELEGATE_AUTHENTICATOR,
+                &data,
+            ),
+            Err(AuthError::NestedDelegate),
+        );
+    }
+
+    #[test]
+    fn delegate_rejects_non_canonical_nested() {
+        let delegate_account = address!("0x00000000000000000000000000000000000000bb");
+        let mut data = Vec::new();
+        data.extend_from_slice(delegate_account.as_slice());
+        data.extend_from_slice(address!("0x00000000000000000000000000000000deadbeef").as_slice());
+        data.extend_from_slice(&[0u8; 65]);
+        assert!(matches!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Contracts::DELEGATE_AUTHENTICATOR,
+                &data,
+            ),
+            Err(AuthError::NotCanonical(_)),
+        ));
+    }
+
+    #[test]
+    fn rejects_revoked_authenticator() {
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Constants::REVOKED_AUTHENTICATOR,
+                &[0u8; 65],
+            ),
+            Err(AuthError::Revoked),
+        );
+    }
+
+    #[test]
+    fn rejects_non_canonical_authenticator() {
+        let authenticator = address!("0x00000000000000000000000000000000deadbeef");
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(HASH, authenticator, &[0u8; 65]),
+            Err(AuthError::NotCanonical(authenticator)),
+        );
+    }
+}

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -15,8 +15,15 @@ use sha2::{Digest, Sha256};
 use crate::{AuthError, DispatchOutcome};
 
 sol! {
-    /// Mirror of `OpenZeppelin` `WebAuthn.WebAuthnAuth`, used to ABI-decode the
-    /// `WebAuthn` authenticator's `data` blob (`abi.encode(WebAuthnAuth, x, y)`).
+    /// Mirror of `OpenZeppelin` `WebAuthn.WebAuthnAuth` (verified against
+    /// `openzeppelin-contracts/utils/cryptography/WebAuthn.sol`), used to
+    /// ABI-decode the deployed `WebAuthnAuthenticator`'s `data` blob, which is
+    /// `abi.encode(WebAuthn.WebAuthnAuth, bytes32 x, bytes32 y)`.
+    ///
+    /// Field order and types must match positionally — ABI decoding is positional.
+    /// Note this is OZ's layout (`r, s` first, as `bytes32`), which deliberately
+    /// differs from Coinbase/Daimo `webauthn-sol` (`authenticatorData,
+    /// clientDataJSON, ..., uint256 r, s`); the deployed contract imports OZ.
     struct WebAuthnAuth {
         bytes32 r;
         bytes32 s;

--- a/crates/execution/eip8130/src/error.rs
+++ b/crates/execution/eip8130/src/error.rs
@@ -1,0 +1,39 @@
+//! Errors returned by EIP-8130 authenticator dispatch.
+
+use alloy_primitives::Address;
+
+/// Reason an authentication blob was rejected during dispatch.
+///
+/// Every variant is a hard rejection: the transaction MUST NOT be admitted or
+/// included on the strength of this authentication blob.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AuthError {
+    /// The blob was empty, too short, or otherwise structurally malformed for
+    /// the routed authenticator (e.g. wrong fixed length, undecodable `WebAuthn`).
+    #[error("authentication data is malformed")]
+    MalformedAuth,
+
+    /// The authenticator address is not in the canonical allowlist (and is not
+    /// the native `ECRECOVER_AUTHENTICATOR` sentinel). Non-canonical
+    /// authenticators are not accepted on the EIP-8130 block-validation path.
+    #[error("authenticator {0} is not canonical")]
+    NotCanonical(Address),
+
+    /// The authenticator address is the `REVOKED_AUTHENTICATOR` sentinel.
+    #[error("authenticator is the revoked sentinel")]
+    Revoked,
+
+    /// The signature did not verify against the supplied hash / public key, or
+    /// the verifying authenticator returned no actor (`bytes32(0)`).
+    #[error("signature verification failed")]
+    InvalidSignature,
+
+    /// A delegate authentication tried to nest another delegate authenticator.
+    /// Delegation is depth-1 only.
+    #[error("delegate authentication cannot nest a delegate authenticator")]
+    NestedDelegate,
+
+    /// The supplied P-256 public-key coordinates do not lie on the curve.
+    #[error("invalid public key")]
+    InvalidPublicKey,
+}

--- a/crates/execution/eip8130/src/lib.rs
+++ b/crates/execution/eip8130/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod error;
+pub use error::AuthError;
+
+mod outcome;
+pub use outcome::DispatchOutcome;
+
+mod dispatch;
+pub use dispatch::AuthenticatorDispatch;

--- a/crates/execution/eip8130/src/outcome.rs
+++ b/crates/execution/eip8130/src/outcome.rs
@@ -9,8 +9,8 @@ use alloy_primitives::{Address, B256};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DispatchOutcome {
     /// Authentication fully resolved to an `actorId` by a verifying authenticator
-    /// (native secp256k1 ecrecover, the K1 contract, P-256, or `WebAuthn`). The
-    /// signature has been cryptographically verified against `hash`.
+    /// (native secp256k1 ecrecover sentinel, P-256, or `WebAuthn`). The signature
+    /// has been cryptographically verified against `hash`.
     Authenticated {
         /// The resolved actor id.
         actor_id: B256,

--- a/crates/execution/eip8130/src/outcome.rs
+++ b/crates/execution/eip8130/src/outcome.rs
@@ -1,0 +1,38 @@
+//! Successful outcome of EIP-8130 authenticator dispatch.
+
+use alloy_primitives::{Address, B256};
+
+/// The result of running an authenticator over a signing `hash` and auth blob.
+///
+/// Dispatch is the stateless "Authenticate" step; the stateful "Authorize" step
+/// (`actor_config` lookup, scope, expiry, implicit-EOA rule) consumes this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// Authentication fully resolved to an `actorId` by a verifying authenticator
+    /// (native secp256k1 ecrecover, the K1 contract, P-256, or `WebAuthn`). The
+    /// signature has been cryptographically verified against `hash`.
+    Authenticated {
+        /// The resolved actor id.
+        actor_id: B256,
+    },
+
+    /// The delegate authenticator: the nested signature has been cryptographically
+    /// verified, but the protocol must still **authorize** the nested actor against
+    /// the delegated account's `actor_config` in SIGNATURE context. That stateful
+    /// check is performed by the authorize stage; dispatch only proves the nested
+    /// signature is valid and surfaces the obligation here.
+    Delegated {
+        /// Outer actor id registered on the originating account:
+        /// `bytes32(bytes20(delegate_account))`.
+        actor_id: B256,
+        /// The delegated account (B) whose config the nested actor must be
+        /// authorized against, in SIGNATURE context.
+        delegate_account: Address,
+        /// The nested (canonical, non-delegate) authenticator that verified the
+        /// nested signature. The authorize stage must check this matches the
+        /// nested actor's stored authenticator on `delegate_account`.
+        nested_authenticator: Address,
+        /// The nested actor id resolved by the nested authenticator.
+        nested_actor_id: B256,
+    },
+}


### PR DESCRIPTION
## Summary

Adds `base-execution-eip8130`, the first piece of the EIP-8130 stateful validation pipeline that works for both **mempool admission** and **block inclusion**. It implements step 2 of the validation flow — **Authenticate** — as a stateless, pure function:

> given a signing `hash` and an authentication blob (`authenticator || data`), route to the named authenticator, verify the signature, and return the resolved `actorId`.

The canonical authenticator set is **enshrined** as native Rust, keyed by the canonical CREATE2 addresses from `Eip8130Contracts` (the registry added in #3440, which this stacks on):

| Authenticator | actorId | Notes |
| --- | --- | --- |
| native secp256k1 (`ECRECOVER` sentinel, EOA path) | `bytes20(recovered)` | matches `AccountConfiguration._recoverSigner` / EVM `ecrecover`: requires `v ∈ {27,28}`, accepts any `s` (high-`s` canonicalized to low-`s` with recovery parity flipped) |
| `P256_AUTHENTICATOR` | `keccak256(x‖y)` | low-`s` enforced (OZ `P256.verify`) |
| `WEBAUTHN_AUTHENTICATOR` | `keccak256(x‖y)` | mirrors OZ `WebAuthn.verify`, `requireUV = false` |
| `DELEGATE_AUTHENTICATOR` | `bytes20(delegate)` | depth-1; see below |

`REVOKED_AUTHENTICATOR` and any non-canonical address are hard-rejected.

## ⚠️ Enshrined ≠ precompile (design note)

This is a **protocol fast-path**, not an EVM precompile. It does **not** shadow the authenticator addresses: ordinary EVM `CALL`/`STATICCALL` to those addresses still execute the real deployed contract bytecode (e.g. `AccountConfiguration.verifySignature()` / wallet code / non-8130 chains). The native code here is invoked **only** by the protocol's own AA validation path.

Consequence: the native implementation MUST produce **byte-identical** `actorId` results to the deployed contracts. The enshrined logic is pinned to a contract version via the `*_INIT_CODE_HASH` constants in `Eip8130Contracts` — a bytecode change shifts the canonical address (caught by the registry drift test) and requires re-validating parity here. **A differential parity test against the deployed contracts (via the EVM) is a planned follow-up.**

## Scope (what this PR is *not*)

This crate is stateless: no storage reads, no EVM. The stateful **Authorize** step is layered on top in the next PR — `actor_config` lookup, the implicit-EOA rule, scope/expiry, and (for delegate) authorizing the nested actor against the delegated account's config in SIGNATURE context.

For the delegate authenticator, dispatch verifies the nested signature and returns a `DispatchOutcome::Delegated { delegate_account, nested_authenticator, nested_actor_id, .. }` obligation for the authorize stage to discharge against state.

## secp256k1: single native path (resolves prior open question)

There is **one** secp256k1 behavior: the protocol-reserved native `ECRECOVER` sentinel (`address(1)`), matching `AccountConfiguration._recoverSigner` (the EVM `ecrecover` precompile — `v ∈ {27,28}`, any `s`). This mirrors the contract, which special-cases `address(0)` (implicit EOA) and `address(1)` (explicit ecrecover) inline rather than as deployed `IAuthenticator`s. There is no secp256k1 authenticator contract in the registry at all — the sentinel is the single secp256k1 path, both as the implicit-EOA owner and as any explicitly-added K1 key.

Since `k256` recovery rejects high-`s`, a high-`s` input is canonicalized to its low-`s` malleable equivalent with the recovery parity flipped, which recovers the identical key (`ecrecover(h, v, r, s) == ecrecover(h, v ^ 1, r, n - s)`) — preserving byte-for-byte parity with the EVM precompile.

## Test plan

- [x] `cargo test -p base-execution-eip8130` — 14 self-consistent crypto + reject-path tests (ecrecover `v ∈ {27,28}` requirement, high-`s` acceptance/parity, P-256, WebAuthn challenge-binding, delegate obligation + depth-1/non-canonical rejection, revoked/non-canonical/malformed-length rejects)
- [x] `cargo clippy -p base-execution-eip8130 --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] (follow-up) differential parity test vs deployed authenticator contracts via EVM


