### PR TITLE
fix(precompiles): return halt for oversized crypto precompile inputs

### DIFF
--- a/crates/common/evm/src/evm.rs
+++ b/crates/common/evm/src/evm.rs
@@ -493,8 +493,8 @@ mod tests {
             internals: EvmInternals::from_context(ctx),
         });
         assert!(
-            result.is_err(),
-            "precompile {address} should fail over max input size, got {result:?}"
+            matches!(&result, Ok(output) if output.halt_reason().is_some()),
+            "precompile {address} should halt over max input size, got {result:?}"
         );
     }
 }

--- a/crates/common/evm/src/precompiles/mod.rs
+++ b/crates/common/evm/src/precompiles/mod.rs
@@ -38,7 +38,10 @@ mod tests {
 
         let input = vec![0u8; 81_984 + bn254::PAIR_ELEMENT_LEN];
         let result = bn254_pair.execute(&input, u64::MAX, 0);
-        assert!(result.is_err(), "expected error for oversized bn254 pair input, got {result:?}");
+        assert!(
+            matches!(&result, Ok(output) if output.halt_reason().is_some()),
+            "expected halt for oversized bn254 pair input, got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/bls12_381.rs
+++ b/crates/common/precompiles/src/bls12_381.rs
@@ -1,7 +1,6 @@
-use alloc::string::ToString;
-
 use revm::precompile::{
-    self as precompile, Precompile, PrecompileError, PrecompileId, PrecompileResult,
+    self as precompile, Precompile, PrecompileHalt, PrecompileId, PrecompileOutput,
+    PrecompileResult,
     bls12_381_const::{G1_MSM_ADDRESS, G2_MSM_ADDRESS, PAIRING_ADDRESS},
     call_eth_precompile,
 };
@@ -28,10 +27,7 @@ pub const ISTHMUS_G1_MSM: Precompile =
 /// Run the BLS12-381 G1 MSM precompile with Isthmus input limits.
 pub fn run_isthmus_g1_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > ISTHMUS_G1_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G1MSM input length too long for Base input size limitation after the Isthmus Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G1MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g1_msm::g1_msm, input, gas_limit, reservoir))
 }
@@ -43,9 +39,7 @@ pub const ISTHMUS_G2_MSM: Precompile =
 /// Run the BLS12-381 G2 MSM precompile with Isthmus input limits.
 pub fn run_isthmus_g2_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > ISTHMUS_G2_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G2MSM input length too long for Base input size limitation".to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G2MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g2_msm::g2_msm, input, gas_limit, reservoir))
 }
@@ -57,9 +51,7 @@ pub const ISTHMUS_PAIRING: Precompile =
 /// Run the BLS12-381 pairing precompile with Isthmus input limits.
 pub fn run_isthmus_pairing(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > ISTHMUS_PAIRING_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "Pairing input length too long for Base input size limitation".to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381PairingInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::pairing::pairing, input, gas_limit, reservoir))
 }
@@ -71,10 +63,7 @@ pub const JOVIAN_G1_MSM: Precompile =
 /// Run the BLS12-381 G1 MSM precompile with Jovian input limits.
 pub fn run_jovian_g1_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_G1_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G1MSM input length too long for Base input size limitation after the Jovian Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G1MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g1_msm::g1_msm, input, gas_limit, reservoir))
 }
@@ -86,10 +75,7 @@ pub const JOVIAN_G2_MSM: Precompile =
 /// Run the BLS12-381 G2 MSM precompile with Jovian input limits.
 pub fn run_jovian_g2_msm(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_G2_MSM_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "G2MSM input length too long for Base input size limitation after the Jovian Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381G2MsmInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::g2_msm::g2_msm, input, gas_limit, reservoir))
 }
@@ -101,20 +87,14 @@ pub const JOVIAN_PAIRING: Precompile =
 /// Run the BLS12-381 pairing precompile with Jovian input limits.
 pub fn run_jovian_pairing(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_PAIRING_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal(
-            "Pairing input length too long for Base input size limitation after the Jovian Hardfork"
-                .to_string(),
-        ));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bls12381PairingInputLength, reservoir));
     }
     Ok(call_eth_precompile(precompile::bls12_381::pairing::pairing, input, gas_limit, reservoir))
 }
 
 #[cfg(test)]
 mod tests {
-    use revm::{
-        precompile::{Precompile, PrecompileError},
-        primitives::Bytes,
-    };
+    use revm::{precompile::Precompile, primitives::Bytes};
     use rstest::rstest;
 
     use crate::{
@@ -139,8 +119,8 @@ mod tests {
         let input = Bytes::from(vec![0u8; max_input_size + 1]);
         let result = precompile.execute(&input, gas_limit, 0);
         assert!(
-            matches!(&result, Err(PrecompileError::Fatal(msg)) if msg.contains("input length too long")),
-            "expected Fatal error for oversized input, got {result:?}"
+            matches!(&result, Ok(o) if o.halt_reason().is_some()),
+            "expected halt for oversized input, got {result:?}"
         );
     }
 }

--- a/crates/common/precompiles/src/bn254_pair.rs
+++ b/crates/common/precompiles/src/bn254_pair.rs
@@ -1,7 +1,6 @@
-use alloc::string::ToString;
-
 use revm::precompile::{
-    Precompile, PrecompileError, PrecompileId, PrecompileResult, bn254, call_eth_precompile,
+    Precompile, PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult, bn254,
+    call_eth_precompile,
 };
 
 /// Max input size for the bn254 pair precompile after the Granite hardfork.
@@ -13,7 +12,7 @@ pub const GRANITE: Precompile =
 /// Run the bn254 pair precompile with Granite input limit.
 pub fn run_pair_granite(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > GRANITE_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal("Bn254PairLength".to_string()));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bn254PairLength, reservoir));
     }
     Ok(call_eth_precompile(
         |i, g| {
@@ -39,7 +38,7 @@ pub const JOVIAN: Precompile =
 /// Run the bn254 pair precompile with Jovian input limit.
 pub fn run_pair_jovian(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     if input.len() > JOVIAN_MAX_INPUT_SIZE {
-        return Err(PrecompileError::Fatal("Bn254PairLength".to_string()));
+        return Ok(PrecompileOutput::halt(PrecompileHalt::Bn254PairLength, reservoir));
     }
     Ok(call_eth_precompile(
         |i, g| {
@@ -58,10 +57,7 @@ pub fn run_pair_jovian(input: &[u8], gas_limit: u64, reservoir: u64) -> Precompi
 
 #[cfg(test)]
 mod tests {
-    use revm::{
-        precompile::{PrecompileError, bn254},
-        primitives::hex,
-    };
+    use revm::{precompile::bn254, primitives::hex};
 
     use crate::{JOVIAN_MAX_INPUT_SIZE, run_pair_granite, run_pair_jovian};
 
@@ -111,7 +107,7 @@ mod tests {
         let over_limit = vec![1u8; 587 * bn254::PAIR_ELEMENT_LEN];
         assert!(matches!(
             run_pair_granite(&over_limit, 260_000, 0),
-            Err(PrecompileError::Fatal(_))
+            Ok(o) if o.halt_reason().is_some()
         ));
     }
 
@@ -130,6 +126,6 @@ mod tests {
     #[test]
     fn test_bn254_pair_jovian_bad_input_len() {
         let input = [0u8; JOVIAN_MAX_INPUT_SIZE + 1];
-        assert!(matches!(run_pair_jovian(&input, u64::MAX, 0), Err(PrecompileError::Fatal(_))));
+        assert!(matches!(run_pair_jovian(&input, u64::MAX, 0), Ok(o) if o.halt_reason().is_some()));
     }
 }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -345,25 +345,37 @@ mod tests {
         let mut bad_input_len = bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bn254_pair::GRANITE_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        assert!(bn254_pair_precompile.execute(&input, u64::MAX, 0).is_err());
+        assert!(matches!(
+            bn254_pair_precompile.execute(&input, u64::MAX, 0),
+            Ok(output) if output.halt_reason().is_some()
+        ));
 
         let g1_msm = precompiles.precompiles().get(&bls12_381_const::G1_MSM_ADDRESS).unwrap();
         bad_input_len = bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_G1_MSM_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        assert!(g1_msm.execute(&input, u64::MAX, 0).is_err());
+        assert!(matches!(
+            g1_msm.execute(&input, u64::MAX, 0),
+            Ok(output) if output.halt_reason().is_some()
+        ));
 
         let g2_msm = precompiles.precompiles().get(&bls12_381_const::G2_MSM_ADDRESS).unwrap();
         bad_input_len = bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_G2_MSM_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        assert!(g2_msm.execute(&input, u64::MAX, 0).is_err());
+        assert!(matches!(
+            g2_msm.execute(&input, u64::MAX, 0),
+            Ok(output) if output.halt_reason().is_some()
+        ));
 
         let pairing = precompiles.precompiles().get(&bls12_381_const::PAIRING_ADDRESS).unwrap();
         bad_input_len = bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_PAIRING_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        assert!(pairing.execute(&input, u64::MAX, 0).is_err());
+        assert!(matches!(
+            pairing.execute(&input, u64::MAX, 0),
+            Ok(output) if output.halt_reason().is_some()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- return `PrecompileOutput::halt(...)` instead of `PrecompileError::Fatal` for oversized BN254 pairing and BLS12-381 MSM/pairing inputs
- align provider-level precompile tests with the new halt behavior
- align EVM-level Jovian oversized-input tests with the new halt behavior

## Testing
- cargo test -p base-common-precompiles
- cargo test -p base-common-evm