### PR TITLE
feat(prover-service): add worker backend session APIs

### DIFF
--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -3,8 +3,9 @@
 use async_trait::async_trait;
 use backon::Retryable;
 use base_prover_service_protocol::{
-    GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
-    ProverWorkerApiClient, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
+    GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ProverWorkerApiClient, RecordProofSessionRequest,
+    RecordProofSessionResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 use base_retry::RetryConfig;
 use jsonrpsee::http_client::HttpClient;
@@ -36,6 +37,18 @@ pub trait ProverWorkerProvider: Send + Sync {
         &self,
         request: WorkerSubmitProofRequest,
     ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError>;
+
+    /// Look up the active backend session recorded for a claimed proof job.
+    async fn get_proof_session(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProverServiceClientError>;
+
+    /// Record (insert or update) the backend session for a claimed proof job.
+    async fn record_proof_session(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProverServiceClientError>;
 }
 
 /// JSON-RPC client for prover worker methods.
@@ -163,6 +176,70 @@ impl ProverWorkerClient {
         })
         .await
     }
+
+    /// Look up the active backend session recorded for a claimed proof job.
+    pub async fn get_proof_session(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProverServiceClientError> {
+        debug!(
+            session_id = %request.session_id,
+            session_type = ?request.session_type,
+            "looking up backend session"
+        );
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.get_proof_session(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                session_type = ?request.session_type,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "get proof session failed; retrying"
+            );
+        })
+        .await
+    }
+
+    /// Record (insert or update) the backend session for a claimed proof job.
+    pub async fn record_proof_session(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProverServiceClientError> {
+        debug!(
+            session_id = %request.session_id,
+            lock_id = %request.lock_id,
+            worker_id = %request.worker_id,
+            session_type = ?request.session_type,
+            backend_session_id = %request.backend_session_id,
+            "recording backend session"
+        );
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.record_proof_session(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                lock_id = %request.lock_id,
+                worker_id = %request.worker_id,
+                session_type = ?request.session_type,
+                backend_session_id = %request.backend_session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "record proof session failed; retrying"
+            );
+        })
+        .await
+    }
 }
 
 #[async_trait]
@@ -187,6 +264,20 @@ impl ProverWorkerProvider for ProverWorkerClient {
     ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError> {
         Self::submit_proof(self, request).await
     }
+
+    async fn get_proof_session(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProverServiceClientError> {
+        Self::get_proof_session(self, request).await
+    }
+
+    async fn record_proof_session(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProverServiceClientError> {
+        Self::record_proof_session(self, request).await
+    }
 }
 
 #[cfg(test)]
@@ -202,8 +293,10 @@ mod tests {
     };
 
     use base_prover_service_protocol::{
+        BackendSession, BackendSessionState, GetProofSessionRequest, GetProofSessionResponse,
         ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind, ProofResult, ProofType,
-        ProverWorkerApiServer, ZkProofRequest, ZkProofResult, ZkVm,
+        ProverWorkerApiServer, RecordProofSessionRequest, RecordProofSessionResponse, SessionType,
+        ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -235,9 +328,13 @@ mod tests {
         get_next_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
         heartbeat_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
         submit_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        get_session_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        record_session_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
         get_next_calls: Arc<AtomicU32>,
         heartbeat_calls: Arc<AtomicU32>,
         submit_calls: Arc<AtomicU32>,
+        get_session_calls: Arc<AtomicU32>,
+        record_session_calls: Arc<AtomicU32>,
     }
 
     #[derive(Debug, Default)]
@@ -261,9 +358,13 @@ mod tests {
                 get_next_script: Arc::new(Mutex::new(VecDeque::new())),
                 heartbeat_script: Arc::new(Mutex::new(VecDeque::new())),
                 submit_script: Arc::new(Mutex::new(VecDeque::new())),
+                get_session_script: Arc::new(Mutex::new(VecDeque::new())),
+                record_session_script: Arc::new(Mutex::new(VecDeque::new())),
                 get_next_calls: Arc::new(AtomicU32::new(0)),
                 heartbeat_calls: Arc::new(AtomicU32::new(0)),
                 submit_calls: Arc::new(AtomicU32::new(0)),
+                get_session_calls: Arc::new(AtomicU32::new(0)),
+                record_session_calls: Arc::new(AtomicU32::new(0)),
             }
         }
 
@@ -285,6 +386,17 @@ mod tests {
             self.submit_script.lock().expect("script lock").extend(outcomes);
         }
 
+        fn queue_get_session_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.get_session_script.lock().expect("script lock").extend(outcomes);
+        }
+
+        fn queue_record_session_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(
+            &self,
+            outcomes: I,
+        ) {
+            self.record_session_script.lock().expect("script lock").extend(outcomes);
+        }
+
         fn get_next_calls(&self) -> u32 {
             self.get_next_calls.load(Ordering::SeqCst)
         }
@@ -295,6 +407,14 @@ mod tests {
 
         fn submit_calls(&self) -> u32 {
             self.submit_calls.load(Ordering::SeqCst)
+        }
+
+        fn get_session_calls(&self) -> u32 {
+            self.get_session_calls.load(Ordering::SeqCst)
+        }
+
+        fn record_session_calls(&self) -> u32 {
+            self.record_session_calls.load(Ordering::SeqCst)
         }
     }
 
@@ -396,6 +516,58 @@ mod tests {
                 ),
             })
         }
+
+        async fn get_proof_session(
+            &self,
+            request: GetProofSessionRequest,
+        ) -> RpcResult<GetProofSessionResponse> {
+            self.get_session_calls.fetch_add(1, Ordering::SeqCst);
+
+            match self.get_session_script.lock().expect("script lock").pop_front() {
+                Some(ScriptedOutcome::Retryable) => {
+                    return Err(unavailable_error("scripted get_proof_session retryable failure"));
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    return Err(invalid_params_error("scripted get_proof_session fatal failure"));
+                }
+                None | Some(ScriptedOutcome::Success) => {}
+            }
+
+            Ok(GetProofSessionResponse {
+                session: Some(BackendSession {
+                    backend_session_id: format!("backend-for-{}", request.session_id),
+                    state: BackendSessionState::Running,
+                }),
+            })
+        }
+
+        async fn record_proof_session(
+            &self,
+            request: RecordProofSessionRequest,
+        ) -> RpcResult<RecordProofSessionResponse> {
+            self.record_session_calls.fetch_add(1, Ordering::SeqCst);
+
+            match self.record_session_script.lock().expect("script lock").pop_front() {
+                Some(ScriptedOutcome::Retryable) => {
+                    return Err(unavailable_error(
+                        "scripted record_proof_session retryable failure",
+                    ));
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    return Err(invalid_params_error(
+                        "scripted record_proof_session fatal failure",
+                    ));
+                }
+                None | Some(ScriptedOutcome::Success) => {}
+            }
+
+            Ok(RecordProofSessionResponse {
+                session: BackendSession {
+                    backend_session_id: request.backend_session_id,
+                    state: request.state,
+                },
+            })
+        }
     }
 
     impl RunningWorkerServer {
@@ -461,6 +633,24 @@ mod tests {
             lock_id: "lock-submit".to_owned(),
             worker_id: "worker-submit".to_owned(),
             result: proof_result(),
+        }
+    }
+
+    fn sample_get_session_request(session_id: &str) -> GetProofSessionRequest {
+        GetProofSessionRequest {
+            session_id: session_id.to_owned(),
+            session_type: SessionType::Stark,
+        }
+    }
+
+    fn sample_record_session_request(session_id: &str) -> RecordProofSessionRequest {
+        RecordProofSessionRequest {
+            session_id: session_id.to_owned(),
+            lock_id: "lock-record".to_owned(),
+            worker_id: "worker-record".to_owned(),
+            session_type: SessionType::Stark,
+            backend_session_id: "backend-record".to_owned(),
+            state: BackendSessionState::Running,
         }
     }
 
@@ -653,6 +843,47 @@ mod tests {
 
         assert_eq!(response.job.session_id, "session-submit-retry");
         assert_eq!(api_clone.submit_calls(), 2);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_retries_retryable_get_proof_session_until_success() {
+        let api = MockWorkerApi::new();
+        api.queue_get_session_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let response = server
+            .client
+            .get_proof_session(sample_get_session_request("session-get-session-retry"))
+            .await
+            .expect("get_proof_session should succeed after retry");
+
+        let session = response.session.expect("backend session should be returned");
+        assert_eq!(session.backend_session_id, "backend-for-session-get-session-retry");
+        assert_eq!(session.state, BackendSessionState::Running);
+        assert_eq!(api_clone.get_session_calls(), 2);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn worker_retries_retryable_record_proof_session_until_success() {
+        let api = MockWorkerApi::new();
+        api.queue_record_session_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
+        let api_clone = api.clone();
+        let server = RunningWorkerServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let response = server
+            .client
+            .record_proof_session(sample_record_session_request("session-record-retry"))
+            .await
+            .expect("record_proof_session should succeed after retry");
+
+        assert_eq!(response.session.backend_session_id, "backend-record");
+        assert_eq!(response.session.state, BackendSessionState::Running);
+        assert_eq!(api_clone.record_session_calls(), 2);
 
         server.shutdown().await;
     }

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -4,15 +4,17 @@
 //! responses through ad hoc field access.
 
 use base_prover_service_protocol::{
+    BackendSession as ProtocolBackendSession, BackendSessionState as ProtocolBackendSessionState,
     ProofJob as ProtocolProofJob, ProofJobStatus as ProtocolProofJobStatus,
     ProofResult as ProtocolProofResult, ProofStatus as ProtocolProofStatus,
-    ProofSummary as ProtocolProofSummary, ProofType as ProtocolProofType, SnarkGroth16ProofResult,
-    TeeKind as ProtocolTeeKind, ZkProofResult, ZkVm as ProtocolZkVm,
+    ProofSummary as ProtocolProofSummary, ProofType as ProtocolProofType,
+    SessionType as ProtocolSessionType, SnarkGroth16ProofResult, TeeKind as ProtocolTeeKind,
+    ZkProofResult, ZkVm as ProtocolZkVm,
 };
 
 use crate::{
-    ApiProofType, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem, ProofStatus,
-    ProofType, TeeKind, ZkVmKind,
+    ApiProofType, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem, ProofSession,
+    ProofStatus, ProofType, SessionStatus, SessionType, TeeKind, ZkVmKind,
 };
 
 /// Errors raised while converting stored database state into protocol types.
@@ -133,6 +135,52 @@ impl ProofStatus {
             ProtocolProofStatus::Succeeded => vec![Self::Succeeded],
             ProtocolProofStatus::Failed => vec![Self::Failed],
         }
+    }
+}
+
+impl From<ProtocolSessionType> for SessionType {
+    fn from(session_type: ProtocolSessionType) -> Self {
+        match session_type {
+            ProtocolSessionType::Stark => Self::Stark,
+            ProtocolSessionType::Snark => Self::Snark,
+        }
+    }
+}
+
+impl From<SessionType> for ProtocolSessionType {
+    fn from(session_type: SessionType) -> Self {
+        match session_type {
+            SessionType::Stark => Self::Stark,
+            SessionType::Snark => Self::Snark,
+        }
+    }
+}
+
+impl From<ProtocolBackendSessionState> for SessionStatus {
+    fn from(state: ProtocolBackendSessionState) -> Self {
+        match state {
+            ProtocolBackendSessionState::Submitting => Self::Submitting,
+            ProtocolBackendSessionState::Running => Self::Running,
+            ProtocolBackendSessionState::Completed => Self::Completed,
+            ProtocolBackendSessionState::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<SessionStatus> for ProtocolBackendSessionState {
+    fn from(status: SessionStatus) -> Self {
+        match status {
+            SessionStatus::Submitting => Self::Submitting,
+            SessionStatus::Running => Self::Running,
+            SessionStatus::Completed => Self::Completed,
+            SessionStatus::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<ProofSession> for ProtocolBackendSession {
+    fn from(session: ProofSession) -> Self {
+        Self { backend_session_id: session.backend_session_id, state: session.status.into() }
     }
 }
 

--- a/crates/proof/prover-service/protocol/src/api.rs
+++ b/crates/proof/prover-service/protocol/src/api.rs
@@ -3,9 +3,11 @@
 use jsonrpsee::proc_macros::rpc;
 
 use crate::{
-    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse, HeartbeatRequest,
-    HeartbeatResponse, ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest,
-    ProveBlockRangeResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
+    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse,
+    GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse,
+    ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
+    WorkerSubmitProofResponse,
 };
 
 #[cfg_attr(
@@ -78,4 +80,18 @@ pub trait ProverWorkerApi {
         &self,
         request: WorkerSubmitProofRequest,
     ) -> jsonrpsee::core::RpcResult<WorkerSubmitProofResponse>;
+
+    /// Look up the active backend session recorded for a claimed proof job.
+    #[method(name = "getProofSession")]
+    async fn get_proof_session(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> jsonrpsee::core::RpcResult<GetProofSessionResponse>;
+
+    /// Record (insert or update) the backend session for a claimed proof job.
+    #[method(name = "recordProofSession")]
+    async fn record_proof_session(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> jsonrpsee::core::RpcResult<RecordProofSessionResponse>;
 }

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -12,10 +12,12 @@ pub use session::ProofSessionId;
 
 mod types;
 pub use types::{
-    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse, HeartbeatRequest,
-    HeartbeatResponse, ListProofsRequest, ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE,
-    ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind, ProofResult, ProofStatus,
-    ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    BackendSession, BackendSessionState, GetNextProofRequest, GetNextProofResponse,
+    GetProofRequest, GetProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ListProofsRequest, ListProofsResponse,
+    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind,
+    ProofResult, ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest,
+    ProveBlockRangeResponse, RecordProofSessionRequest, RecordProofSessionResponse, SessionType,
     SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult,
     WorkerSubmitProofRequest, WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -341,6 +341,84 @@ pub struct WorkerSubmitProofResponse {
     pub job: ProofJob,
 }
 
+/// Kind of backend session tracked for a proof job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionType {
+    /// STARK proving session.
+    Stark,
+    /// SNARK proving session.
+    Snark,
+}
+
+/// Lifecycle state of a tracked backend session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendSessionState {
+    /// Reservation placeholder before the backend job has been submitted.
+    Submitting,
+    /// Backend session is actively running.
+    Running,
+    /// Backend session completed successfully.
+    Completed,
+    /// Backend session failed.
+    Failed,
+}
+
+/// A backend session tracked in the prover service for a proof job.
+///
+/// Workers record the backend-issued identifier (for example an SP1 cluster or
+/// network proof id) so a restart or reclaim resumes the in-flight backend job
+/// rather than re-running it. The worker itself holds no local state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackendSession {
+    /// Backend-specific session identifier used to resume polling.
+    pub backend_session_id: String,
+    /// Current backend session lifecycle state.
+    pub state: BackendSessionState,
+}
+
+/// Request to look up the active backend session for a proof job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetProofSessionRequest {
+    /// Proof session identifier.
+    pub session_id: String,
+    /// Backend session type to look up.
+    pub session_type: SessionType,
+}
+
+/// Response carrying the active backend session, if one exists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetProofSessionResponse {
+    /// Active backend session, if one is recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<BackendSession>,
+}
+
+/// Request to record (insert or update) the backend session for a proof job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordProofSessionRequest {
+    /// Proof session identifier.
+    pub session_id: String,
+    /// Server-issued lock identifier for this worker claim.
+    pub lock_id: String,
+    /// Worker identifier.
+    pub worker_id: String,
+    /// Backend session type being recorded.
+    pub session_type: SessionType,
+    /// Backend-specific session identifier to persist.
+    pub backend_session_id: String,
+    /// Backend session lifecycle state to persist.
+    pub state: BackendSessionState,
+}
+
+/// Response returned after recording a backend session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordProofSessionResponse {
+    /// The recorded backend session.
+    pub session: BackendSession,
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Bytes, address};

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -2,11 +2,12 @@
 
 use base_prover_service_db::{
     ClaimProofJob, CompleteClaimedProofJob, HeartbeatOutcome, HeartbeatProofJob,
-    SubmitProofOutcome, canonical_session_id,
+    RecordSessionOutcome, SubmitProofOutcome, WorkerSessionUpsert, canonical_session_id,
 };
 use base_prover_service_protocol::{
-    GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
-    ProofJob as ProtocolProofJob, ProverWorkerApiServer, WorkerSubmitProofRequest,
+    GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ProofJob as ProtocolProofJob, ProverWorkerApiServer,
+    RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
     WorkerSubmitProofResponse,
 };
 use jsonrpsee::{
@@ -39,6 +40,20 @@ impl ProverWorkerApiServer for ProverServiceServer {
         request: WorkerSubmitProofRequest,
     ) -> RpcResult<WorkerSubmitProofResponse> {
         self.submit_proof_impl(request).await
+    }
+
+    async fn get_proof_session(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> RpcResult<GetProofSessionResponse> {
+        self.get_proof_session_impl(request).await
+    }
+
+    async fn record_proof_session(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> RpcResult<RecordProofSessionResponse> {
+        self.record_proof_session_impl(request).await
     }
 }
 
@@ -239,6 +254,118 @@ impl ProverServiceServer {
                 "submit_proof",
                 &request.session_id,
                 "lock is no longer valid",
+            )),
+        }
+    }
+
+    /// Returns the active backend session recorded for a claimed proof job.
+    pub async fn get_proof_session_impl(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> RpcResult<GetProofSessionResponse> {
+        let start = std::time::Instant::now();
+        let result = self.get_proof_session_inner(request).await;
+        record_rpc_result("GetProofSession", start, &result);
+
+        result
+    }
+
+    async fn get_proof_session_inner(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> RpcResult<GetProofSessionResponse> {
+        let session_id = canonical_session_id(&request.session_id)
+            .map_err(|e| invalid_argument(format!("{e}")))?;
+
+        let session = self
+            .repo
+            .get_active_session(&session_id, request.session_type.into())
+            .await
+            .map_err(|e| internal(format!("Database error: {e}")))?;
+
+        Ok(GetProofSessionResponse { session: session.map(Into::into) })
+    }
+
+    /// Records (inserts or updates) the backend session for a claimed proof job.
+    pub async fn record_proof_session_impl(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> RpcResult<RecordProofSessionResponse> {
+        let start = std::time::Instant::now();
+        let result = self.record_proof_session_inner(request).await;
+        record_rpc_result("RecordProofSession", start, &result);
+
+        result
+    }
+
+    async fn record_proof_session_inner(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> RpcResult<RecordProofSessionResponse> {
+        let session_id = canonical_session_id(&request.session_id)
+            .map_err(|e| invalid_argument(format!("{e}")))?;
+        let lock_id = parse_lock_id(&request.lock_id)?;
+
+        let outcome = self
+            .repo
+            .record_worker_proof_session(WorkerSessionUpsert {
+                session_id,
+                lock_id,
+                worker_id: request.worker_id.clone(),
+                session_type: request.session_type.into(),
+                backend_session_id: request.backend_session_id,
+                status: request.state.into(),
+                error_message: None,
+            })
+            .await
+            .map_err(|e| internal(format!("Database error: {e}")))?;
+
+        match outcome {
+            RecordSessionOutcome::Recorded(session) => {
+                info!(
+                    worker_id = %request.worker_id,
+                    session_id = %request.session_id,
+                    backend_session_id = %session.backend_session_id,
+                    "recorded backend session for worker"
+                );
+                Ok(RecordProofSessionResponse { session: session.into() })
+            }
+            RecordSessionOutcome::TerminalBackendSession(session) => {
+                info!(
+                    worker_id = %request.worker_id,
+                    session_id = %request.session_id,
+                    backend_session_id = %session.backend_session_id,
+                    "backend session was already terminal"
+                );
+                Ok(RecordProofSessionResponse { session: session.into() })
+            }
+            RecordSessionOutcome::NotFound => {
+                Err(not_found(format!("proof job not found for session_id {}", request.session_id)))
+            }
+            RecordSessionOutcome::NotClaimed => Err(reject_ownership(
+                "record_proof_session",
+                &request.session_id,
+                "job is not currently claimed",
+            )),
+            RecordSessionOutcome::StaleLock => Err(reject_ownership(
+                "record_proof_session",
+                &request.session_id,
+                "lock is held by another worker or has been rotated",
+            )),
+            RecordSessionOutcome::Expired => Err(reject_ownership(
+                "record_proof_session",
+                &request.session_id,
+                "lock has expired",
+            )),
+            RecordSessionOutcome::Terminal => Err(reject_ownership(
+                "record_proof_session",
+                &request.session_id,
+                "job has already reached a terminal state",
+            )),
+            RecordSessionOutcome::TerminalSessionStatus => Err(reject_ownership(
+                "record_proof_session",
+                &request.session_id,
+                "backend session status is terminal",
             )),
         }
     }

--- a/crates/proof/tee/nitro-host/src/job_discovery.rs
+++ b/crates/proof/tee/nitro-host/src/job_discovery.rs
@@ -330,9 +330,10 @@ mod tests {
     use base_proof_host::ProverConfig;
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
     use base_prover_service_protocol::{
-        GetNextProofResponse, HeartbeatRequest, HeartbeatResponse, ProofJob, ProofJobStatus,
-        ProofRequest, ProofRequestKind, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
-        ZkProofRequest, ZkVm,
+        GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
+        HeartbeatResponse, ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind,
+        RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
+        WorkerSubmitProofResponse, ZkProofRequest, ZkVm,
     };
     use chrono::Utc;
     use tokio::time::timeout;
@@ -398,6 +399,20 @@ mod tests {
             _request: WorkerSubmitProofRequest,
         ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError> {
             panic!("submit_proof is not used by job discovery tests")
+        }
+
+        async fn get_proof_session(
+            &self,
+            _request: GetProofSessionRequest,
+        ) -> Result<GetProofSessionResponse, ProverServiceClientError> {
+            panic!("get_proof_session is not used by job discovery tests")
+        }
+
+        async fn record_proof_session(
+            &self,
+            _request: RecordProofSessionRequest,
+        ) -> Result<RecordProofSessionResponse, ProverServiceClientError> {
+            panic!("record_proof_session is not used by job discovery tests")
         }
     }
 

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -389,8 +389,10 @@ mod tests {
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
     use base_prover_service_client::ProverServiceClientError;
     use base_prover_service_protocol::{
-        GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse,
-        ProofJobStatus, ProofRequest, TeeKind, TeeProofRequest, WorkerSubmitProofRequest,
+        GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+        HeartbeatRequest, HeartbeatResponse, ProofJobStatus, ProofRequest,
+        RecordProofSessionRequest, RecordProofSessionResponse, TeeKind, TeeProofRequest,
+        WorkerSubmitProofRequest,
     };
     use chrono::Utc;
     use tokio::time::sleep;
@@ -499,6 +501,20 @@ mod tests {
                     PrimitiveRequestKind::Tee,
                 ),
             })
+        }
+
+        async fn get_proof_session(
+            &self,
+            _request: GetProofSessionRequest,
+        ) -> Result<GetProofSessionResponse, ProverServiceClientError> {
+            panic!("get_proof_session is not used by proof generator tests")
+        }
+
+        async fn record_proof_session(
+            &self,
+            _request: RecordProofSessionRequest,
+        ) -> Result<RecordProofSessionResponse, ProverServiceClientError> {
+            panic!("record_proof_session is not used by proof generator tests")
         }
     }
 

--- a/crates/proof/tee/nitro-host/src/proof_submitter.rs
+++ b/crates/proof/tee/nitro-host/src/proof_submitter.rs
@@ -152,8 +152,9 @@ mod tests {
     use async_trait::async_trait;
     use base_proof_primitives::{ProofRequest as PrimitiveProofRequest, Proposal};
     use base_prover_service_protocol::{
-        GetNextProofRequest, GetNextProofResponse, HeartbeatRequest, HeartbeatResponse, ProofJob,
-        ProofJobStatus, ProofRequest, ProofRequestKind, TeeProofRequest,
+        GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+        HeartbeatRequest, HeartbeatResponse, ProofJob, ProofJobStatus, ProofRequest,
+        ProofRequestKind, RecordProofSessionRequest, RecordProofSessionResponse, TeeProofRequest,
     };
     use chrono::Utc;
     use tokio::time::{sleep, timeout};
@@ -227,6 +228,20 @@ mod tests {
             }
 
             Ok(WorkerSubmitProofResponse { job: proof_job_for_submission(&request) })
+        }
+
+        async fn get_proof_session(
+            &self,
+            _request: GetProofSessionRequest,
+        ) -> Result<GetProofSessionResponse, ProverServiceClientError> {
+            panic!("get_proof_session is not used by proof submitter tests")
+        }
+
+        async fn record_proof_session(
+            &self,
+            _request: RecordProofSessionRequest,
+        ) -> Result<RecordProofSessionResponse, ProverServiceClientError> {
+            panic!("record_proof_session is not used by proof submitter tests")
         }
     }
 


### PR DESCRIPTION
## Summary
Adds worker-facing RPC, client, and server support for recording and fetching backend proof sessions, so ZK workers can persist backend session IDs and resume in-flight work while preserving worker lock ownership checks.