### PR TITLE
 chore(prover service): remove unused tracing subscriber dev dependency

### DIFF
--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -33,7 +33,6 @@ tracing.workspace = true
 rstest.workspace = true
 chrono.workspace = true
 jsonrpsee = { workspace = true, features = ["http-client"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 base-prover-service-protocol = { workspace = true, features = ["rpc-client"] }
 
 [lints]


### PR DESCRIPTION
`cargo-udeps` reported `tracing-subscriber` as an unused dev-dependency in `base-prover-service` (#3465). Verified: no source or test file in the crate references `tracing_subscriber`.

Closes #3465