### PR TITLE
fix(builder): reject zero flashblocks block time

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -254,7 +254,18 @@ mod tests {
         assert_eq!(config.block_time, Duration::from_millis(1000));
         assert!(config.max_gas_per_txn.is_none());
     }
+#[test]
+fn zero_flashblocks_block_time_is_rejected() {
+    use clap::Parser;
 
+    let result = Args::try_parse_from([
+        "builder",
+        "--flashblocks.block-time",
+        "0",
+    ]);
+
+    assert!(result.is_err());
+}
     #[rstest]
     #[case::block_time_1s(1000, 1000)]
     #[case::block_time_2s(2000, 2000)]

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -25,8 +25,13 @@ pub struct FlashblocksArgs {
     pub flashblocks_addr: String,
 
     /// flashblock block time in milliseconds
-    #[arg(long = "flashblocks.block-time", default_value = "250", env = "FLASHBLOCK_BLOCK_TIME")]
-    pub flashblocks_block_time: u64,
+#[arg(
+    long = "flashblocks.block-time",
+    default_value = "250",
+    env = "FLASHBLOCK_BLOCK_TIME",
+    value_parser = clap::value_parser!(u64).range(1..)
+)]
+pub flashblocks_block_time: u64,
 
     /// Time by which blocks would be completed earlier in milliseconds.
     ///


### PR DESCRIPTION
## Summary

Reject `--flashblocks.block-time=0` at CLI parsing time.

A zero flashblocks interval can currently reach `BuilderConfig.flashblocks_interval`, where it is later used in division/remainder operations and can panic at runtime.

## Changes

- Add a clap value parser requiring `flashblocks.block-time >= 1`
- Add a regression test for the zero-value case

## Testing

- `cargo test -p builder cli`