### PR TITLE
test(system): harden flaky system tests

### DIFF
--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -551,7 +551,7 @@ impl<'a> B20PrecompileClient<'a> {
         input: Bytes,
         label: &'static str,
     ) -> Result<BaseTransactionReceipt> {
-        let nonce = self.provider.get_transaction_count(self.signer.address()).await?;
+        let nonce = self.provider.get_transaction_count(self.signer.address()).pending().await?;
         let (raw_tx, expected_tx_hash) = self.create_signed_tx(to, nonce, input).wrap_err(label)?;
 
         let pending_tx = self

--- a/etc/systems/tests/bundles.rs
+++ b/etc/systems/tests/bundles.rs
@@ -22,7 +22,9 @@ const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
 const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(120);
+const BUNDLE_TARGET_BLOCK_LEAD: u64 = 5;
+const BUNDLE_PRE_TARGET_CHECK_OFFSET: u64 = 2;
 
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -125,9 +127,7 @@ async fn test_send_bundle_accepts_valid_bundle() -> Result<()> {
         create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
 
     let current_block = builder_provider.get_block_number().await?;
-    // Use +3 to give enough lead time for the bundle to propagate from client
-    // to builder before the target block is built.
-    let target_block = current_block + 3;
+    let target_block = current_block + BUNDLE_TARGET_BLOCK_LEAD;
 
     let request = BundleRequest {
         txs: vec![raw_tx],
@@ -192,7 +192,7 @@ async fn test_send_bundle_included_only_in_target_block() -> Result<()> {
         create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
 
     let current_block = builder_provider.get_block_number().await?;
-    let target_block = current_block + 2;
+    let target_block = current_block + BUNDLE_TARGET_BLOCK_LEAD;
 
     let request = BundleRequest {
         txs: vec![raw_tx],
@@ -208,9 +208,12 @@ async fn test_send_bundle_included_only_in_target_block() -> Result<()> {
     let bundle_hash: B256 = rpc_client.request("eth_sendBundle", (request,)).await?;
     assert_eq!(bundle_hash, expected_tx_hash, "Bundle returned unexpected hash");
 
-    wait_for_block(&builder_provider, target_block - 1).await?;
-    let early_receipt = builder_provider.get_transaction_receipt(expected_tx_hash).await?;
-    assert!(early_receipt.is_none(), "Bundle tx should not be included before target block");
+    let pre_target_block =
+        wait_for_block(&builder_provider, target_block - BUNDLE_PRE_TARGET_CHECK_OFFSET).await?;
+    if pre_target_block < target_block {
+        let early_receipt = builder_provider.get_transaction_receipt(expected_tx_hash).await?;
+        assert!(early_receipt.is_none(), "Bundle tx should not be included before target block");
+    }
 
     let receipt = timeout(TX_RECEIPT_TIMEOUT, async {
         loop {

--- a/etc/systems/tests/policy_transfer.rs
+++ b/etc/systems/tests/policy_transfer.rs
@@ -9,7 +9,7 @@
 mod common;
 
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::RootProvider;
+use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
 use base_common_network::Base;
@@ -181,6 +181,9 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
             "updateAllowlist add non-member",
         )
         .await?;
+
+    let current_block = provider.get_block_number().await?;
+    common::wait_for_block(&provider, current_block + 1).await?;
 
     // Non-member is now authorized.
     assert!(


### PR DESCRIPTION
## Summary
- use pending nonces for B-20 system-test helper transactions so back-to-back sends do not reuse a nonce while txpool state is pending
- give bundle target blocks more lead time and extend bundle receipt polling for slow system-test runs
- avoid a false pre-target bundle assertion when polling has already reached the target block
- wait one block after allowlist mutation before asserting transfer authorization

## CI context
- Linked merge-queue system-test job was canceled after runner shutdown, not by a deterministic test assertion
- Nearby failed system-test runs showed bundle receipt timeouts / early target-block race and B-20 allowlist transfer visibility flakes

## Validation
- cargo +nightly fmt --check
- cargo check -p base-system-tests --tests --locked
- git diff --check