### PR TITLE
feat(common): State Backed Activation Admin

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -178,6 +178,13 @@ impl ActionEngineClient {
                 "azul activation timestamp ({azul}) must be <= beryl activation timestamp ({beryl})",
             );
         }
+        if let Some(cobalt) = hf.base.cobalt {
+            let beryl = hf.base.beryl.expect("cobalt requires beryl to be configured");
+            assert!(
+                beryl <= cobalt,
+                "beryl activation timestamp ({beryl}) must be <= cobalt activation timestamp ({cobalt})",
+            );
+        }
 
         // Base Azul requires Osaka (the EL counterpart).
         genesis.config.osaka_time = hf.base.azul;
@@ -187,6 +194,9 @@ impl ActionEngineClient {
         }
         if let Some(ts) = hf.base.beryl {
             base.insert("beryl".to_string(), serde_json::json!(ts));
+        }
+        if let Some(ts) = hf.base.cobalt {
+            base.insert("cobalt".to_string(), serde_json::json!(ts));
         }
         if base.is_empty() {
             genesis.config.extra_fields.remove("base");

--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -169,6 +169,14 @@ impl TestRollupConfigBuilder {
         self
     }
 
+    /// Sets the Cobalt activation timestamp.
+    ///
+    /// Cobalt is a standalone Base-specific fork, independent of the inherited fork cascade.
+    pub const fn with_cobalt_at(mut self, t: u64) -> Self {
+        self.config.hardforks.base.cobalt = Some(t);
+        self
+    }
+
     /// Activates every scheduled fork from genesis for tests that need it.
     ///
     /// `base_mainnet` intentionally keeps the harness's existing "Canyon through

--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -173,7 +173,7 @@ impl TestRollupConfigBuilder {
     ///
     /// Cobalt is a standalone Base-specific fork, independent of the inherited fork cascade.
     pub const fn with_cobalt_at(mut self, t: u64) -> Self {
-        self.config.hardforks.base.cobalt = Some(t);
+        self.config.upgrades.base.cobalt = Some(t);
         self
     }
 

--- a/actions/harness/tests/beryl/activation.rs
+++ b/actions/harness/tests/beryl/activation.rs
@@ -112,17 +112,98 @@ async fn beryl_enables_activation_registry_admin_and_feature_lifecycle() {
     .await;
 }
 
+#[tokio::test]
+async fn cobalt_enables_state_backed_activation_admin_rotation() {
+    let mut env = BerylTestEnv::new_with_cobalt();
+    let (probe, deploy_probe) = env.deploy_staticcall_probe_tx(ActivationRegistryStorage::ADDRESS);
+
+    let pre_beryl = env.sequencer.build_next_block_with_transactions(vec![deploy_probe]).await;
+    assert!(env.user_tx_succeeded(&pre_beryl, 0), "activation-registry probe must deploy");
+
+    let beryl_boundary = env.sequencer.build_empty_block().await;
+
+    let pre_cobalt_set_admin = env.set_activation_admin_tx(BerylTestEnv::bob());
+    let pre_cobalt =
+        env.sequencer.build_next_block_with_transactions(vec![pre_cobalt_set_admin]).await;
+    assert!(
+        !env.user_tx_succeeded(&pre_cobalt, 0),
+        "setAdmin(newAdmin) must revert after Beryl but before Cobalt"
+    );
+
+    let cobalt_boundary = env.sequencer.build_empty_block().await;
+
+    let set_admin = env.set_activation_admin_tx(BerylTestEnv::bob());
+    let set_admin_block = env.sequencer.build_next_block_with_transactions(vec![set_admin]).await;
+    assert!(
+        env.user_tx_succeeded(&set_admin_block, 0),
+        "setAdmin(newAdmin) must succeed at Cobalt"
+    );
+    assert_admin_changed_log(&env, &set_admin_block);
+
+    let admin_call = Bytes::from(IActivationRegistry::adminCall {}.abi_encode());
+    let admin_probe =
+        env.call_staticcall_probe_tx(probe, admin_call, BerylTestEnv::B20_PROBE_GAS_LIMIT);
+    let admin_probe_block =
+        env.sequencer.build_next_block_with_transactions(vec![admin_probe]).await;
+    assert!(env.probe_call_succeeded(probe), "admin() staticcall must succeed after rotation");
+    assert_eq!(
+        env.probe_return_word(probe),
+        word_from_address(BerylTestEnv::bob()),
+        "admin() must return the state-backed activation admin"
+    );
+
+    let old_admin_activate = env.activate_feature_tx(FEATURE);
+    let old_admin_block =
+        env.sequencer.build_next_block_with_transactions(vec![old_admin_activate]).await;
+    assert!(
+        !env.user_tx_succeeded(&old_admin_block, 0),
+        "previous admin must not activate features after rotation"
+    );
+
+    let new_admin_activate = env.create_bob_tx(
+        TxKind::Call(ActivationRegistryStorage::ADDRESS),
+        Bytes::from(IActivationRegistry::activateCall { feature: FEATURE }.abi_encode()),
+        GAS_LIMIT,
+    );
+    let new_admin_block =
+        env.sequencer.build_next_block_with_transactions(vec![new_admin_activate]).await;
+    assert!(env.user_tx_succeeded(&new_admin_block, 0), "new admin must activate features");
+    assert_activation_log_from(&env, &new_admin_block, true, BerylTestEnv::bob());
+
+    env.derive_blocks(
+        [
+            (pre_beryl, 1),
+            (beryl_boundary, 2),
+            (pre_cobalt, 3),
+            (cobalt_boundary, 4),
+            (set_admin_block, 5),
+            (admin_probe_block, 6),
+            (old_admin_block, 7),
+            (new_admin_block, 8),
+        ],
+        8,
+    )
+    .await;
+}
+
 fn assert_activation_log(
     env: &BerylTestEnv,
     block: &base_common_consensus::BaseBlock,
     active: bool,
 ) {
+    assert_activation_log_from(env, block, active, BerylTestEnv::alice());
+}
+
+fn assert_activation_log_from(
+    env: &BerylTestEnv,
+    block: &base_common_consensus::BaseBlock,
+    active: bool,
+    caller: Address,
+) {
     let expected = if active {
-        IActivationRegistry::FeatureActivated { feature: FEATURE, caller: BerylTestEnv::alice() }
-            .encode_log_data()
+        IActivationRegistry::FeatureActivated { feature: FEATURE, caller }.encode_log_data()
     } else {
-        IActivationRegistry::FeatureDeactivated { feature: FEATURE, caller: BerylTestEnv::alice() }
-            .encode_log_data()
+        IActivationRegistry::FeatureDeactivated { feature: FEATURE, caller }.encode_log_data()
     };
     assert!(
         env.user_tx_receipt(block, 0)
@@ -130,6 +211,22 @@ fn assert_activation_log(
             .iter()
             .any(|log| log.address == ActivationRegistryStorage::ADDRESS && log.data == expected),
         "activation transition must emit the expected event"
+    );
+}
+
+fn assert_admin_changed_log(env: &BerylTestEnv, block: &base_common_consensus::BaseBlock) {
+    let expected = IActivationRegistry::AdminChanged {
+        previousAdmin: BerylTestEnv::alice(),
+        newAdmin: BerylTestEnv::bob(),
+        caller: BerylTestEnv::alice(),
+    }
+    .encode_log_data();
+    assert!(
+        env.user_tx_receipt(block, 0)
+            .logs()
+            .iter()
+            .any(|log| log.address == ActivationRegistryStorage::ADDRESS && log.data == expected),
+        "admin rotation must emit the expected event"
     );
 }
 

--- a/actions/harness/tests/beryl/env.rs
+++ b/actions/harness/tests/beryl/env.rs
@@ -20,6 +20,9 @@ use base_test_utils::Account;
 /// L2 timestamp where the Beryl fork activates in these tests.
 pub(crate) const BERYL_ACTIVATION_TIMESTAMP: u64 = 4;
 
+/// L2 timestamp where the Cobalt fork activates in tests that opt into it.
+pub(crate) const COBALT_ACTIVATION_TIMESTAMP: u64 = 8;
+
 /// B-20 token storage slot for `total_supply`.
 const B20_TOTAL_SUPPLY_SLOT: U256 =
     uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434003_U256);
@@ -111,17 +114,29 @@ impl BerylTestEnv {
     /// Creates an environment with all forks through Azul active at genesis
     /// and Base Beryl active at timestamp 4.
     pub(crate) fn new() -> Self {
+        Self::with_cobalt_activation(None)
+    }
+
+    /// Creates an environment with Base Beryl and Cobalt scheduled.
+    pub(crate) fn new_with_cobalt() -> Self {
+        Self::with_cobalt_activation(Some(COBALT_ACTIVATION_TIMESTAMP))
+    }
+
+    fn with_cobalt_activation(cobalt_activation: Option<u64>) -> Self {
         let batcher_cfg = BatcherConfig {
             encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
             ..Default::default()
         };
 
-        let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        let mut rollup_cfg_builder = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
             .through_isthmus()
             .with_jovian_at(0)
             .with_azul_at(0)
-            .with_beryl_at(BERYL_ACTIVATION_TIMESTAMP)
-            .build();
+            .with_beryl_at(BERYL_ACTIVATION_TIMESTAMP);
+        if let Some(cobalt_activation) = cobalt_activation {
+            rollup_cfg_builder = rollup_cfg_builder.with_cobalt_at(cobalt_activation);
+        }
+        let rollup_cfg = rollup_cfg_builder.build();
         let chain_id = rollup_cfg.l2_chain_id.id();
         let harness = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
@@ -378,6 +393,13 @@ impl BerylTestEnv {
     /// Creates an activation registry `deactivate(feature)` transaction signed by the admin.
     pub(crate) fn deactivate_feature_tx(&self, feature: B256) -> BaseTxEnvelope {
         let input = Bytes::from(IActivationRegistry::deactivateCall { feature }.abi_encode());
+        self.create_tx(TxKind::Call(ActivationRegistryStorage::ADDRESS), input, Self::B20_GAS_LIMIT)
+    }
+
+    /// Creates an activation registry `setAdmin(newAdmin)` transaction signed by the admin.
+    pub(crate) fn set_activation_admin_tx(&self, new_admin: Address) -> BaseTxEnvelope {
+        let input =
+            Bytes::from(IActivationRegistry::setAdminCall { newAdmin: new_admin }.abi_encode());
         self.create_tx(TxKind::Call(ActivationRegistryStorage::ADDRESS), input, Self::B20_GAS_LIMIT)
     }
 

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -97,13 +97,6 @@ pub struct ChainConfig {
     // Roles
     /// Unsafe block signer address.
     pub unsafe_block_signer: Option<Address>,
-    /// Activation registry admin address.
-    ///
-    /// Required and non-zero for all Base chains: every Base chain has Beryl scheduled, and
-    /// Beryl's activation registry precompile needs an admin at genesis. `Address::ZERO` is
-    /// rejected by chainspec validation.
-    pub activation_admin_address: Address,
-
     // Gas limits
     /// Maximum gas limit for L2 blocks.
     pub max_gas_limit: u64,
@@ -143,6 +136,18 @@ impl Bootnodes {
         self.execution.len() + self.consensus.len()
     }
 }
+
+/// Base Mainnet activation registry admin used by Beryl before Cobalt state-backed admin storage.
+pub const MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9");
+
+/// Base Sepolia activation registry admin used by Beryl before Cobalt state-backed admin storage.
+pub const SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("5F43072722f59964d886CBb507F6a85ca0759D42");
+
+/// Base Zeronet activation registry admin used by Beryl before Cobalt state-backed admin storage.
+pub const ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("F5969A85a555671EeD766C4ff0C61426AA626b11");
 
 impl ChainConfig {
     /// CLI chain name for Base Mainnet.
@@ -218,6 +223,21 @@ impl ChainConfig {
             763360 => Some(&ZERONET),
             _ => None,
         }
+    }
+
+    /// Returns the Beryl activation registry admin address for built-in chains that need one.
+    pub const fn beryl_activation_admin_address_by_chain_id(id: u64) -> Option<Address> {
+        match id {
+            8453 => Some(MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS),
+            84532 => Some(SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS),
+            763360 => Some(ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS),
+            _ => None,
+        }
+    }
+
+    /// Returns the Beryl activation registry admin address for this chain, if configured.
+    pub const fn beryl_activation_admin_address(&self) -> Option<Address> {
+        Self::beryl_activation_admin_address_by_chain_id(self.chain_id)
     }
 
     /// Returns the full [`RollupConfig`] for the given L2 chain ID.
@@ -373,7 +393,6 @@ const MAINNET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("8062abc286f5e7d9428a0ccb9abd71e50d93b935"),
 
     unsafe_block_signer: Some(address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a")),
-    activation_admin_address: address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"),
 
     max_gas_limit: 105_000_000,
     prune_delete_limit: 20_000,
@@ -447,7 +466,6 @@ const SEPOLIA: ChainConfig = ChainConfig {
     protocol_versions_address: address!("79add5713b383daa0a138d3c4780c7a1804a8090"),
 
     unsafe_block_signer: Some(address!("b830b99c95Ea32300039624Cb567d324D4b1D83C")),
-    activation_admin_address: address!("5F43072722f59964d886CBb507F6a85ca0759D42"),
 
     max_gas_limit: 45_000_000,
     prune_delete_limit: 10_000,
@@ -512,7 +530,6 @@ const DEVNET: ChainConfig = ChainConfig {
     protocol_versions_address: Address::ZERO,
 
     unsafe_block_signer: None,
-    activation_admin_address: address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc"),
 
     max_gas_limit: 30_000_000,
     prune_delete_limit: 20_000,
@@ -566,7 +583,6 @@ const ZERONET: ChainConfig = ChainConfig {
     protocol_versions_address: address!("646c8604cf62b23e0cf094f2e790c6c75547ff85"),
 
     unsafe_block_signer: Some(address!("cf17274338d3128f6C96d9af54511a17e8b38a08")),
-    activation_admin_address: address!("F5969A85a555671EeD766C4ff0C61426AA626b11"),
 
     max_gas_limit: 25_000_000,
     prune_delete_limit: 10_000,

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -6,7 +6,10 @@
 extern crate alloc;
 
 mod config;
-pub use config::{Bootnodes, ChainConfig};
+pub use config::{
+    Bootnodes, ChainConfig, MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS, ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+};
 
 mod upgrade;
 pub use upgrade::{BaseUpgrade, BaseUpgradeExt};

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -135,8 +135,8 @@ mod tests {
     use alloy_primitives::{Address, B256};
     use alloy_sol_types::SolCall;
     use base_common_precompiles::{
-        ActivationRegistryStorage, B20FactoryStorage, B20Variant, IActivationRegistry,
-        PolicyRegistryStorage,
+        ActivationFeature, ActivationRegistryStorage, B20FactoryStorage, B20Variant,
+        IActivationRegistry, PolicyRegistryStorage,
     };
     use revm::{
         Context, DatabaseRef, ExecuteEvm,
@@ -216,6 +216,90 @@ mod tests {
 
         assert_eq!(actual, admin);
         assert!(BerylPrecompileMetricsObserver::recorded_calls_for_test() > 0);
+    }
+
+    #[test]
+    fn cobalt_activation_admin_rotates_through_registry_state() {
+        let admin = Address::repeat_byte(0xaa);
+        let new_admin = Address::repeat_byte(0xbb);
+        let ctx =
+            Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Cobalt)));
+        let mut evm = ctx.build_base_with_activation_admin_address(Some(admin));
+
+        let set_admin = activation_registry_tx(
+            admin,
+            0,
+            Bytes::from(IActivationRegistry::setAdminCall { newAdmin: new_admin }.abi_encode()),
+        );
+        assert!(evm.transact_one(set_admin).unwrap().is_success());
+
+        let admin_result = evm
+            .transact_one(activation_registry_tx(
+                new_admin,
+                0,
+                Bytes::from(IActivationRegistry::adminCall {}.abi_encode()),
+            ))
+            .unwrap();
+        let actual_admin =
+            IActivationRegistry::adminCall::abi_decode_returns(admin_result.output().unwrap())
+                .unwrap();
+        assert_eq!(actual_admin, new_admin);
+
+        let feature = ActivationFeature::B20Asset.id();
+        let old_admin_activate = activation_registry_tx(
+            admin,
+            1,
+            Bytes::from(IActivationRegistry::activateCall { feature }.abi_encode()),
+        );
+        assert!(!evm.transact_one(old_admin_activate).unwrap().is_success());
+
+        let new_admin_activate = activation_registry_tx(
+            new_admin,
+            1,
+            Bytes::from(IActivationRegistry::activateCall { feature }.abi_encode()),
+        );
+        assert!(evm.transact_one(new_admin_activate).unwrap().is_success());
+    }
+
+    #[test]
+    fn beryl_activation_admin_rejects_state_rotation() {
+        let admin = Address::repeat_byte(0xaa);
+        let new_admin = Address::repeat_byte(0xbb);
+        let ctx =
+            Context::base().with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)));
+        let mut evm = ctx.build_base_with_activation_admin_address(Some(admin));
+
+        let set_admin = activation_registry_tx(
+            admin,
+            0,
+            Bytes::from(IActivationRegistry::setAdminCall { newAdmin: new_admin }.abi_encode()),
+        );
+        assert!(!evm.transact_one(set_admin).unwrap().is_success());
+
+        let admin_result = evm
+            .transact_one(activation_registry_tx(
+                admin,
+                1,
+                Bytes::from(IActivationRegistry::adminCall {}.abi_encode()),
+            ))
+            .unwrap();
+        let actual_admin =
+            IActivationRegistry::adminCall::abi_decode_returns(admin_result.output().unwrap())
+                .unwrap();
+        assert_eq!(actual_admin, admin);
+    }
+
+    fn activation_registry_tx(caller: Address, nonce: u64, data: Bytes) -> BaseTransaction<TxEnv> {
+        BaseTransaction::builder()
+            .base(
+                TxEnv::builder()
+                    .caller(caller)
+                    .nonce(nonce)
+                    .kind(TxKind::Call(ActivationRegistryStorage::ADDRESS))
+                    .data(data)
+                    .gas_limit(500_000),
+            )
+            .build_fill()
     }
 
     struct ReadOnlyDbAdapter;

--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -11,6 +11,13 @@ sol! {
         /// Emitted when a feature is deactivated.
         event FeatureDeactivated(bytes32 indexed feature, address indexed caller);
 
+        /// Emitted when the activation admin changes.
+        event AdminChanged(
+            address indexed previousAdmin,
+            address indexed newAdmin,
+            address indexed caller
+        );
+
         /// Caller is not authorized to activate features.
         error Unauthorized(address caller);
 
@@ -26,6 +33,12 @@ sol! {
         /// State-mutating call was attempted in a static context.
         error StaticCallNotAllowed();
 
+        /// State-backed admin storage is not active for this fork.
+        error AdminStorageNotEnabled();
+
+        /// The new admin address is zero.
+        error ZeroAdminAddress();
+
         /// Returns true when `feature` is activated.
         function isActivated(bytes32 feature) external view returns (bool);
 
@@ -34,6 +47,9 @@ sol! {
 
         /// Returns the activation admin.
         function admin() external view returns (address);
+
+        /// Sets the activation admin.
+        function setAdmin(address newAdmin) external;
 
         /// Activates `feature`.
         function activate(bytes32 feature) external;
@@ -50,6 +66,7 @@ impl IActivationRegistry::IActivationRegistryCalls {
             Self::isActivated(_) => "activation.isActivated",
             Self::checkActivated(_) => "activation.checkActivated",
             Self::admin(_) => "activation.admin",
+            Self::setAdmin(_) => "activation.setAdmin",
             Self::activate(_) => "activation.activate",
             Self::deactivate(_) => "activation.deactivate",
         }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -1,12 +1,12 @@
 //! ABI dispatch for the activation registry.
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
 use base_precompile_storage::StorageCtx;
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    ActivationRegistryStorage, BerylCallRecorder, BerylMetricLabels,
+    ActivationAdminConfig, ActivationRegistryStorage, BerylCallRecorder, BerylMetricLabels,
     IActivationRegistry::{self, IActivationRegistryCalls as C},
     NoopPrecompileCallObserver, PrecompileCallObserver,
     macros::decode_precompile_call,
@@ -18,14 +18,9 @@ impl ActivationRegistryStorage<'_> {
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
-        activation_admin_address: Option<Address>,
+        admin_config: ActivationAdminConfig,
     ) -> PrecompileResult {
-        self.dispatch_with_observer(
-            ctx,
-            calldata,
-            activation_admin_address,
-            NoopPrecompileCallObserver,
-        )
+        self.dispatch_with_observer(ctx, calldata, admin_config, NoopPrecompileCallObserver)
     }
 
     /// ABI-dispatches activation registry calldata with an observer.
@@ -33,7 +28,7 @@ impl ActivationRegistryStorage<'_> {
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
-        activation_admin_address: Option<Address>,
+        admin_config: ActivationAdminConfig,
         observer: O,
     ) -> PrecompileResult
     where
@@ -44,15 +39,13 @@ impl ActivationRegistryStorage<'_> {
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
-        recorder.record_base_result(ctx, self.inner(calldata, activation_admin_address), |output| {
-            output
-        })
+        recorder.record_base_result(ctx, self.inner(calldata, admin_config), |output| output)
     }
 
     fn inner(
         &mut self,
         calldata: &[u8],
-        activation_admin_address: Option<Address>,
+        admin_config: ActivationAdminConfig,
     ) -> base_precompile_storage::Result<Bytes> {
         match decode_precompile_call!(calldata, IActivationRegistry::IActivationRegistryCalls) {
             C::isActivated(call) => {
@@ -64,17 +57,21 @@ impl ActivationRegistryStorage<'_> {
                 Ok(Bytes::new())
             }
             C::activate(call) => {
-                self.activate(call.feature, activation_admin_address)?;
+                self.activate(call.feature, admin_config)?;
                 Ok(Bytes::new())
             }
             C::deactivate(call) => {
-                self.deactivate(call.feature, activation_admin_address)?;
+                self.deactivate(call.feature, admin_config)?;
                 Ok(Bytes::new())
             }
-            C::admin(_) => Ok(IActivationRegistry::adminCall::abi_encode_returns(
-                &self.admin(activation_admin_address),
-            )
-            .into()),
+            C::setAdmin(call) => {
+                self.set_admin(call.newAdmin, admin_config)?;
+                Ok(Bytes::new())
+            }
+            C::admin(_) => {
+                Ok(IActivationRegistry::adminCall::abi_encode_returns(&self.admin(admin_config)?)
+                    .into())
+            }
         }
     }
 }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::StorageCtx;
+use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
@@ -47,6 +47,11 @@ impl ActivationRegistryStorage<'_> {
         calldata: &[u8],
         admin_config: ActivationAdminConfig,
     ) -> base_precompile_storage::Result<Bytes> {
+        let set_admin_selector = IActivationRegistry::setAdminCall::SELECTOR;
+        if !admin_config.state_enabled && calldata.get(..4) == Some(set_admin_selector.as_slice()) {
+            return Err(BasePrecompileError::UnknownFunctionSelector(set_admin_selector));
+        }
+
         match decode_precompile_call!(calldata, IActivationRegistry::IActivationRegistryCalls) {
             C::isActivated(call) => {
                 let activated = self.is_activated(call.feature)?;
@@ -73,5 +78,61 @@ impl ActivationRegistryStorage<'_> {
                     .into())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, Bytes, address};
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{ActivationAdminConfig, ActivationRegistryStorage, IActivationRegistry};
+
+    const ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+    const NEW_ADMIN: Address = address!("0xcd00000000000000000000000000000000000000");
+    const STATIC_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::static_fallback(Some(ADMIN));
+    const STATE_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::state_backed(Some(ADMIN));
+
+    #[test]
+    fn dispatch_treats_set_admin_as_unknown_before_state_backed_admin() {
+        let malformed = Bytes::copy_from_slice(&IActivationRegistry::setAdminCall::SELECTOR);
+        let valid =
+            Bytes::from(IActivationRegistry::setAdminCall { newAdmin: NEW_ADMIN }.abi_encode());
+
+        for calldata in [malformed, valid] {
+            let mut storage = HashMapStorageProvider::new(1);
+            storage.set_caller(ADMIN);
+
+            let output = StorageCtx::enter(&mut storage, |ctx| {
+                ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATIC_ADMIN_CONFIG)
+            })
+            .expect("unknown selector must be returned as a revert");
+
+            assert!(output.is_revert(), "setAdmin must revert before Cobalt");
+            assert_eq!(
+                output.bytes,
+                Bytes::copy_from_slice(&IActivationRegistry::setAdminCall::SELECTOR),
+                "pre-Cobalt setAdmin must preserve the legacy unknown-selector output"
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_accepts_set_admin_when_state_backed_admin_is_enabled() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        let calldata =
+            Bytes::from(IActivationRegistry::setAdminCall { newAdmin: NEW_ADMIN }.abi_encode());
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATE_ADMIN_CONFIG)
+        })
+        .expect("setAdmin must not fatally error");
+
+        assert!(output.is_success(), "setAdmin must succeed once state-backed admin is enabled");
     }
 }

--- a/crates/common/precompiles/src/activation/mod.rs
+++ b/crates/common/precompiles/src/activation/mod.rs
@@ -4,7 +4,7 @@ mod abi;
 pub use abi::IActivationRegistry;
 
 mod storage;
-pub use storage::{ActivationFeature, ActivationRegistryStorage};
+pub use storage::{ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage};
 
 mod dispatch;
 

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,6 +1,7 @@
 //! Precompile entry point for the activation registry.
 
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_primitives::Address;
 use base_precompile_macros::precompile;
 
 use crate::{
@@ -9,11 +10,30 @@ use crate::{
 };
 
 /// Entry point for the activation registry precompile.
-#[precompile(install, args(admin_config: ActivationAdminConfig))]
+#[precompile(args(admin_config: ActivationAdminConfig))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
 
 impl ActivationRegistry {
+    /// Installs the activation registry precompile using a static fallback admin.
+    pub fn install(precompiles: &mut PrecompilesMap, activation_admin_address: Option<Address>) {
+        Self::install_with_config(
+            precompiles,
+            ActivationAdminConfig::static_fallback(activation_admin_address),
+        );
+    }
+
+    /// Installs the activation registry precompile with an explicit admin configuration.
+    pub fn install_with_config(
+        precompiles: &mut PrecompilesMap,
+        admin_config: ActivationAdminConfig,
+    ) {
+        precompiles.extend_precompiles(core::iter::once((
+            ActivationRegistryStorage::ADDRESS,
+            Self::precompile(admin_config),
+        )));
+    }
+
     /// Installs the activation registry precompile with an observer.
     pub fn install_with_observer<O>(
         precompiles: &mut PrecompilesMap,
@@ -45,5 +65,23 @@ impl ActivationRegistry {
                 observer,
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::precompiles::PrecompilesMap;
+    use alloy_primitives::Address;
+    use revm::precompile::Precompiles;
+
+    use crate::{ActivationRegistry, ActivationRegistryStorage};
+
+    #[test]
+    fn install_accepts_static_fallback_admin() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+
+        ActivationRegistry::install(&mut precompiles, Some(Address::repeat_byte(0x11)));
+
+        assert!(precompiles.get(&ActivationRegistryStorage::ADDRESS).is_some());
     }
 }

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -1,13 +1,15 @@
 //! Precompile entry point for the activation registry.
 
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
-use alloy_primitives::Address;
 use base_precompile_macros::precompile;
 
-use crate::{ActivationRegistryStorage, PrecompileCallObserver, macros::base_precompile};
+use crate::{
+    ActivationAdminConfig, ActivationRegistryStorage, PrecompileCallObserver,
+    macros::base_precompile,
+};
 
 /// Entry point for the activation registry precompile.
-#[precompile(install, args(activation_admin_address: Option<Address>))]
+#[precompile(install, args(admin_config: ActivationAdminConfig))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
 
@@ -15,20 +17,20 @@ impl ActivationRegistry {
     /// Installs the activation registry precompile with an observer.
     pub fn install_with_observer<O>(
         precompiles: &mut PrecompilesMap,
-        activation_admin_address: Option<Address>,
+        admin_config: ActivationAdminConfig,
         observer: O,
     ) where
         O: PrecompileCallObserver,
     {
         precompiles.extend_precompiles(core::iter::once((
             ActivationRegistryStorage::ADDRESS,
-            Self::precompile_with_observer(activation_admin_address, observer),
+            Self::precompile_with_observer(admin_config, observer),
         )));
     }
 
     /// Creates the EVM precompile wrapper for the activation registry with an observer.
     pub fn precompile_with_observer<O>(
-        activation_admin_address: Option<Address>,
+        admin_config: ActivationAdminConfig,
         observer: O,
     ) -> DynPrecompile
     where
@@ -39,7 +41,7 @@ impl ActivationRegistry {
             ActivationRegistryStorage::new(ctx).dispatch_with_observer(
                 ctx,
                 &calldata,
-                activation_admin_address,
+                admin_config,
                 observer,
             )
         })

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -195,9 +195,6 @@ impl ActivationRegistryStorage<'_> {
         }
 
         let caller = self.storage.caller();
-        if caller.is_zero() {
-            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
-        }
         let admin = self.authorized_admin(admin_config)?;
         if caller != admin {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -164,16 +164,12 @@ impl ActivationRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IActivationRegistry::ZeroAdminAddress {}));
         }
 
-        let caller = self.storage.caller();
-        let current_admin = self.authorized_admin(admin_config)?;
-        if caller != current_admin {
-            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
-        }
+        let caller = self.require_admin_caller(admin_config)?;
 
         self.__initialize()?;
         self.admin.write(new_admin)?;
         self.emit_event(IActivationRegistry::AdminChanged {
-            previousAdmin: current_admin,
+            previousAdmin: caller,
             newAdmin: new_admin,
             caller,
         })?;
@@ -194,11 +190,7 @@ impl ActivationRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IActivationRegistry::StaticCallNotAllowed {}));
         }
 
-        let caller = self.storage.caller();
-        let admin = self.authorized_admin(admin_config)?;
-        if caller != admin {
-            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
-        }
+        let caller = self.require_admin_caller(admin_config)?;
 
         let current_activated_state = self.features.at(&feature).read()?;
 
@@ -240,6 +232,16 @@ impl ActivationRegistryStorage<'_> {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         }
         Ok(admin)
+    }
+
+    /// Reverts unless the current caller is the effective activation admin.
+    pub fn require_admin_caller(&self, admin_config: ActivationAdminConfig) -> Result<Address> {
+        let caller = self.storage.caller();
+        let admin = self.authorized_admin(admin_config)?;
+        if caller != admin {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
+        Ok(caller)
     }
 }
 

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -13,6 +13,37 @@ use crate::IActivationRegistry;
 pub struct ActivationRegistryStorage {
     /// Runtime activation flags keyed by feature id.
     pub features: Mapping<B256, bool>,
+    /// Mutable activation registry admin address.
+    ///
+    /// Zero means "unset" and falls back to the static chain-config admin while the Cobalt
+    /// state-backed admin path is active.
+    pub admin: Address,
+}
+
+/// Activation admin source configured for one installed activation registry precompile.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ActivationAdminConfig {
+    /// Static chain-config activation admin used for Beryl replay and as the Cobalt fallback.
+    pub fallback: Option<Address>,
+    /// Whether the activation registry should consult its admin storage slot.
+    pub state_enabled: bool,
+}
+
+impl ActivationAdminConfig {
+    /// Creates a new activation admin configuration.
+    pub const fn new(fallback: Option<Address>, state_enabled: bool) -> Self {
+        Self { fallback, state_enabled }
+    }
+
+    /// Creates a static-only activation admin configuration.
+    pub const fn static_fallback(fallback: Option<Address>) -> Self {
+        Self::new(fallback, false)
+    }
+
+    /// Creates a state-backed activation admin configuration.
+    pub const fn state_backed(fallback: Option<Address>) -> Self {
+        Self::new(fallback, true)
+    }
 }
 
 /// Identifies a Base-native precompile feature in the activation registry.
@@ -56,17 +87,30 @@ impl ActivationRegistryStorage<'_> {
     /// Activation registry precompile address.
     pub const ADDRESS: Address = address!("8453000000000000000000000000000000000001");
 
-    /// Returns the activation admin address, or [`Address::ZERO`] if no admin is configured.
+    /// Returns the stored activation admin address.
+    pub fn stored_admin(&self) -> Result<Address> {
+        self.admin.read()
+    }
+
+    /// Returns the effective activation admin address.
+    ///
+    /// When state-backed admin storage is disabled, this always returns the static fallback. When
+    /// state-backed admin storage is enabled, a non-zero storage value wins; a zero storage value
+    /// falls back to the static chain-config admin so Cobalt can replay historical Beryl activation
+    /// transactions before the first admin rotation.
     ///
     /// [`Address::ZERO`] here means "no admin is set": it is not a valid admin address.
     /// Configuration-time validation rejects `Some(Address::ZERO)`, so in a correctly
     /// constructed chain spec the zero return always means `activation_admin_address` was
     /// `None`. Callers must not treat the zero return as a meaningful admin address.
-    pub const fn admin(&self, activation_admin_address: Option<Address>) -> Address {
-        match activation_admin_address {
-            Some(address) => address,
-            None => Address::ZERO,
+    pub fn admin(&self, admin_config: ActivationAdminConfig) -> Result<Address> {
+        if admin_config.state_enabled {
+            let stored_admin = self.stored_admin()?;
+            if !stored_admin.is_zero() {
+                return Ok(stored_admin);
+            }
         }
+        Ok(admin_config.fallback.unwrap_or(Address::ZERO))
     }
 
     /// Returns true when the feature is activated.
@@ -93,21 +137,48 @@ impl ActivationRegistryStorage<'_> {
     }
 
     /// Activates the feature.
-    pub fn activate(
-        &mut self,
-        feature: B256,
-        activation_admin_address: Option<Address>,
-    ) -> Result<()> {
-        self.set_activated(feature, true, activation_admin_address)
+    pub fn activate(&mut self, feature: B256, admin_config: ActivationAdminConfig) -> Result<()> {
+        self.set_activated(feature, true, admin_config)
     }
 
     /// Deactivates the feature.
-    pub fn deactivate(
+    pub fn deactivate(&mut self, feature: B256, admin_config: ActivationAdminConfig) -> Result<()> {
+        self.set_activated(feature, false, admin_config)
+    }
+
+    /// Sets the activation registry admin address.
+    pub fn set_admin(
         &mut self,
-        feature: B256,
-        activation_admin_address: Option<Address>,
+        new_admin: Address,
+        admin_config: ActivationAdminConfig,
     ) -> Result<()> {
-        self.set_activated(feature, false, activation_admin_address)
+        if self.storage.is_static() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::StaticCallNotAllowed {}));
+        }
+        if !admin_config.state_enabled {
+            return Err(BasePrecompileError::revert(
+                IActivationRegistry::AdminStorageNotEnabled {},
+            ));
+        }
+        if new_admin.is_zero() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::ZeroAdminAddress {}));
+        }
+
+        let caller = self.storage.caller();
+        let current_admin = self.authorized_admin(admin_config)?;
+        if caller != current_admin {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
+
+        self.__initialize()?;
+        self.admin.write(new_admin)?;
+        self.emit_event(IActivationRegistry::AdminChanged {
+            previousAdmin: current_admin,
+            newAdmin: new_admin,
+            caller,
+        })?;
+
+        Ok(())
     }
 
     /// Sets the feature activation state.
@@ -115,7 +186,7 @@ impl ActivationRegistryStorage<'_> {
         &mut self,
         feature: B256,
         to_activated_state: bool,
-        activation_admin_address: Option<Address>,
+        admin_config: ActivationAdminConfig,
     ) -> Result<()> {
         // Keep this guard at the shared mutation boundary so `activate`, `deactivate`, and direct
         // `set_activated` callers all get the same static-call behavior after calldata validation.
@@ -127,9 +198,7 @@ impl ActivationRegistryStorage<'_> {
         if caller.is_zero() {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         }
-        let Some(admin) = activation_admin_address else {
-            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
-        };
+        let admin = self.authorized_admin(admin_config)?;
         if caller != admin {
             return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
         }
@@ -162,11 +231,25 @@ impl ActivationRegistryStorage<'_> {
 
         Ok(())
     }
+
+    /// Returns the effective admin if one is configured and the caller address can be authorized.
+    pub fn authorized_admin(&self, admin_config: ActivationAdminConfig) -> Result<Address> {
+        let caller = self.storage.caller();
+        if caller.is_zero() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
+        let admin = self.admin(admin_config)?;
+        if admin.is_zero() {
+            return Err(BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller }));
+        }
+        Ok(admin)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256, U256, address, keccak256, uint};
+    use alloy_sol_types::{SolCall, SolEvent};
     use base_precompile_storage::{
         BasePrecompileError, HashMapStorageProvider, Result, StorageCtx, StorageKey,
     };
@@ -174,12 +257,17 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, IActivationRegistry,
+        ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, IActivationRegistry,
         activation::storage::slots,
     };
 
     const FEATURE: B256 = ActivationFeature::B20Asset.id();
     const ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+    const NEW_ADMIN: Address = address!("0xcd00000000000000000000000000000000000000");
+    const STATIC_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::static_fallback(Some(ADMIN));
+    const STATE_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::state_backed(Some(ADMIN));
     const ACTIVATION_REGISTRY_ROOT: U256 =
         uint!(0x43ee1bbe25e988521cccd8b2c8fbd38c8287ebff8e074e825a70dfd3885cce00_U256);
 
@@ -212,8 +300,8 @@ mod tests {
         StorageCtx::enter(storage, |ctx| {
             let mut registry = ActivationRegistryStorage::new(ctx);
             match transition {
-                Transition::Activate => registry.activate(FEATURE, Some(ADMIN)),
-                Transition::Deactivate => registry.deactivate(FEATURE, Some(ADMIN)),
+                Transition::Activate => registry.activate(FEATURE, STATIC_ADMIN_CONFIG),
+                Transition::Deactivate => registry.deactivate(FEATURE, STATIC_ADMIN_CONFIG),
             }
         })
     }
@@ -239,14 +327,14 @@ mod tests {
     fn activate_feature(storage: &mut HashMapStorageProvider) -> Result<()> {
         storage.set_caller(ADMIN);
         StorageCtx::enter(storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(ADMIN))
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, STATIC_ADMIN_CONFIG)
         })
     }
 
     fn deactivate_feature(storage: &mut HashMapStorageProvider) -> Result<()> {
         storage.set_caller(ADMIN);
         StorageCtx::enter(storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).deactivate(FEATURE, Some(ADMIN))
+            ActivationRegistryStorage::new(ctx).deactivate(FEATURE, STATIC_ADMIN_CONFIG)
         })
     }
 
@@ -287,6 +375,7 @@ mod tests {
         assert_eq!(slots::NAMESPACE_ID, "base.activation_registry");
         assert_eq!(slots::NAMESPACE_ROOT, ACTIVATION_REGISTRY_ROOT);
         assert_eq!(slots::FEATURES, ACTIVATION_REGISTRY_ROOT);
+        assert_eq!(slots::ADMIN, ACTIVATION_REGISTRY_ROOT + U256::ONE);
     }
 
     #[test]
@@ -336,7 +425,8 @@ mod tests {
 
         storage.set_caller(ADMIN);
         let err = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(configured_admin))
+            ActivationRegistryStorage::new(ctx)
+                .activate(FEATURE, ActivationAdminConfig::static_fallback(Some(configured_admin)))
         })
         .unwrap_err();
         assert!(matches!(err, BasePrecompileError::Revert(_)));
@@ -344,10 +434,122 @@ mod tests {
 
         storage.set_caller(configured_admin);
         StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(configured_admin))
+            ActivationRegistryStorage::new(ctx)
+                .activate(FEATURE, ActivationAdminConfig::static_fallback(Some(configured_admin)))
         })
         .unwrap();
         assert_activated(&mut storage, true);
+    }
+
+    #[test]
+    fn state_backed_admin_falls_back_until_storage_slot_is_set() {
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let registry = ActivationRegistryStorage::new(ctx);
+            assert_eq!(registry.stored_admin().unwrap(), Address::ZERO);
+            assert_eq!(registry.admin(STATE_ADMIN_CONFIG).unwrap(), ADMIN);
+            assert_eq!(registry.admin(STATIC_ADMIN_CONFIG).unwrap(), ADMIN);
+        });
+    }
+
+    #[test]
+    fn set_admin_updates_storage_and_authorization() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).set_admin(NEW_ADMIN, STATE_ADMIN_CONFIG).unwrap()
+        });
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let registry = ActivationRegistryStorage::new(ctx);
+            assert_eq!(registry.stored_admin().unwrap(), NEW_ADMIN);
+            assert_eq!(registry.admin(STATE_ADMIN_CONFIG).unwrap(), NEW_ADMIN);
+            assert_eq!(registry.admin(STATIC_ADMIN_CONFIG).unwrap(), ADMIN);
+        });
+
+        let events = storage.get_events(ActivationRegistryStorage::ADDRESS);
+        let event = IActivationRegistry::AdminChanged::decode_log_data(events.last().unwrap())
+            .expect("admin change event decodes");
+        assert_eq!(event.previousAdmin, ADMIN);
+        assert_eq!(event.newAdmin, NEW_ADMIN);
+        assert_eq!(event.caller, ADMIN);
+
+        let old_admin_err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, STATE_ADMIN_CONFIG)
+        })
+        .unwrap_err();
+        assert_eq!(
+            old_admin_err,
+            BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller: ADMIN })
+        );
+
+        storage.set_caller(NEW_ADMIN);
+        StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).activate(FEATURE, STATE_ADMIN_CONFIG)
+        })
+        .unwrap();
+        assert_activated(&mut storage, true);
+    }
+
+    #[test]
+    fn set_admin_reverts_when_state_backed_admin_is_disabled() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).set_admin(NEW_ADMIN, STATIC_ADMIN_CONFIG)
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IActivationRegistry::AdminStorageNotEnabled {})
+        );
+    }
+
+    #[test]
+    fn set_admin_reverts_for_zero_address() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).set_admin(Address::ZERO, STATE_ADMIN_CONFIG)
+        })
+        .unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::revert(IActivationRegistry::ZeroAdminAddress {}));
+    }
+
+    #[test]
+    fn set_admin_reverts_for_unauthorized_caller() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(NEW_ADMIN);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).set_admin(NEW_ADMIN, STATE_ADMIN_CONFIG)
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IActivationRegistry::Unauthorized { caller: NEW_ADMIN })
+        );
+    }
+
+    #[test]
+    fn set_admin_reverts_in_static_context() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+        storage.set_static(true);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).set_admin(NEW_ADMIN, STATE_ADMIN_CONFIG)
+        })
+        .unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::revert(IActivationRegistry::StaticCallNotAllowed {}));
     }
 
     #[test]
@@ -357,8 +559,11 @@ mod tests {
         storage.set_caller(ADMIN);
         let err = StorageCtx::enter(&mut storage, |ctx| {
             let mut registry = ActivationRegistryStorage::new(ctx);
-            assert_eq!(registry.admin(None), Address::ZERO);
-            registry.activate(FEATURE, None)
+            assert_eq!(
+                registry.admin(ActivationAdminConfig::static_fallback(None)).unwrap(),
+                Address::ZERO
+            );
+            registry.activate(FEATURE, ActivationAdminConfig::static_fallback(None))
         })
         .unwrap_err();
 
@@ -496,7 +701,8 @@ mod tests {
         storage.set_caller(Address::ZERO);
 
         let err = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).activate(FEATURE, Some(Address::ZERO))
+            ActivationRegistryStorage::new(ctx)
+                .activate(FEATURE, ActivationAdminConfig::static_fallback(Some(Address::ZERO)))
         })
         .unwrap_err();
 
@@ -509,8 +715,6 @@ mod tests {
     /// that must appear in `PrecompileOutput::gas_refunded`.
     #[test]
     fn dispatch_deactivate_propagates_sstore_refund() {
-        use alloy_sol_types::SolCall;
-
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(ADMIN);
 
@@ -520,7 +724,7 @@ mod tests {
         let calldata = IActivationRegistry::deactivateCall { feature: FEATURE }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, Some(ADMIN))
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATIC_ADMIN_CONFIG)
         })
         .expect("dispatch must not fatally error");
 
@@ -535,15 +739,13 @@ mod tests {
     /// zero-to-nonzero writes), so `gas_refunded` must be zero on the activate path.
     #[test]
     fn dispatch_activate_has_no_sstore_refund() {
-        use alloy_sol_types::SolCall;
-
         let mut storage = HashMapStorageProvider::new(1);
         storage.set_caller(ADMIN);
 
         let calldata = IActivationRegistry::activateCall { feature: FEATURE }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, Some(ADMIN))
+            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATIC_ADMIN_CONFIG)
         })
         .expect("dispatch must not fatally error");
 

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -487,9 +487,9 @@ mod tests {
     };
 
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20AssetStorage,
-        B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset, InMemoryPolicy,
-        InMemoryTokenAccounting, NoopPrecompileCallObserver, PrecompileCallMetric,
+        ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, AssetAccounting,
+        B20AssetStorage, B20AssetToken, B20TokenRole, BerylErrorKind, IB20, IB20Asset,
+        InMemoryPolicy, InMemoryTokenAccounting, NoopPrecompileCallObserver, PrecompileCallMetric,
         PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus, Token,
         TokenAccounting,
     };
@@ -517,6 +517,8 @@ mod tests {
     const BOB: Address = Address::repeat_byte(0xbb);
     const TOKEN: Address = Address::repeat_byte(0x01);
     const ACTIVATION_ADMIN: Address = Address::repeat_byte(0xcb);
+    const ACTIVATION_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::static_fallback(Some(ACTIVATION_ADMIN));
     fn make_token() -> TestAssetToken {
         let mut accounting = InMemoryTokenAccounting::new(TOKEN);
         accounting.multiplier = B20AssetStorage::WAD; // 1:1 multiplier
@@ -527,7 +529,7 @@ mod tests {
         storage.set_caller(ACTIVATION_ADMIN);
         StorageCtx::enter(storage, |ctx| {
             ActivationRegistryStorage::new(ctx)
-                .activate(ActivationFeature::B20Asset.id(), Some(ACTIVATION_ADMIN))
+                .activate(ActivationFeature::B20Asset.id(), ACTIVATION_ADMIN_CONFIG)
         })
         .unwrap();
     }

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -378,13 +378,15 @@ mod tests {
 
     use super::FACTORY_MARKER_CODE_HASH;
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, AssetAccounting, B20_MAX_SUPPLY_CAP,
-        B20AssetStorage, B20AssetToken, B20FactoryStorage, B20StablecoinStorage, B20TokenRole,
-        B20Variant, IB20, IB20Factory, Mintable, Permittable, PolicyHandle, RoleManaged, Token,
-        TokenAccounting, Transferable,
+        ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, AssetAccounting,
+        B20_MAX_SUPPLY_CAP, B20AssetStorage, B20AssetToken, B20FactoryStorage,
+        B20StablecoinStorage, B20TokenRole, B20Variant, IB20, IB20Factory, Mintable, Permittable,
+        PolicyHandle, RoleManaged, Token, TokenAccounting, Transferable,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+    const ACTIVATION_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::static_fallback(Some(ACTIVATION_ADMIN));
 
     #[test]
     fn factory_address_matches_canonical_precompile_address() {
@@ -398,7 +400,7 @@ mod tests {
         storage.set_caller(ACTIVATION_ADMIN);
         for key in [ActivationFeature::B20Stablecoin.id(), ActivationFeature::B20Asset.id()] {
             StorageCtx::enter(storage, |ctx| {
-                ActivationRegistryStorage::new(ctx).activate(key, Some(ACTIVATION_ADMIN)).unwrap()
+                ActivationRegistryStorage::new(ctx).activate(key, ACTIVATION_ADMIN_CONFIG).unwrap()
             });
         }
     }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -18,7 +18,8 @@ pub use spec::BasePrecompileSpec;
 
 mod activation;
 pub use activation::{
-    ActivationFeature, ActivationRegistry, ActivationRegistryStorage, IActivationRegistry,
+    ActivationAdminConfig, ActivationFeature, ActivationRegistry, ActivationRegistryStorage,
+    IActivationRegistry,
 };
 
 mod bn254_pair;

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -421,6 +421,7 @@ impl BerylMetricLabels {
                 Cow::Borrowed("checkActivated")
             }
             Some(IActivationRegistry::adminCall::SELECTOR) => Cow::Borrowed("admin"),
+            Some(IActivationRegistry::setAdminCall::SELECTOR) => Cow::Borrowed("setAdmin"),
             Some(IActivationRegistry::activateCall::SELECTOR) => Cow::Borrowed("activate"),
             Some(IActivationRegistry::deactivateCall::SELECTOR) => Cow::Borrowed("deactivate"),
             _ => Self::unknown(),

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -292,6 +292,12 @@ impl BerylErrorKind {
             return Self::InternalCallFailed;
         }
         if BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidVariant>(selector)
+            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::AdminStorageNotEnabled>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::ZeroAdminAddress>(
+                selector,
+            )
             || BerylErrorClassifier::is_error_selector::<IB20Factory::UnsupportedVersion>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20Factory::MissingRequiredField>(
                 selector,
@@ -655,7 +661,8 @@ mod tests {
 
     use crate::{
         BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
-        CALLDATA_WORD_GAS, IB20, IB20Factory, IPolicyRegistry, NoopPrecompileCallObserver,
+        CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
+        NoopPrecompileCallObserver,
     };
 
     #[test]
@@ -700,6 +707,16 @@ mod tests {
             BerylErrorKind::from_revert_bytes(&policy_not_found),
             BerylErrorKind::PolicyMissing
         );
+
+        let admin_storage_disabled =
+            IActivationRegistry::AdminStorageNotEnabled {}.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&admin_storage_disabled),
+            BerylErrorKind::InvalidInput
+        );
+
+        let zero_admin = IActivationRegistry::ZeroAdminAddress {}.abi_encode().into();
+        assert_eq!(BerylErrorKind::from_revert_bytes(&zero_admin), BerylErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -147,12 +147,14 @@ mod tests {
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use crate::{
-        ActivationFeature, ActivationRegistryStorage, BerylErrorKind, IPolicyRegistry,
-        PolicyRegistryStorage, PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome,
-        PrecompileCallStatus,
+        ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, BerylErrorKind,
+        IPolicyRegistry, PolicyRegistryStorage, PrecompileCallMetric, PrecompileCallObserver,
+        PrecompileCallOutcome, PrecompileCallStatus,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+    const ACTIVATION_ADMIN_CONFIG: ActivationAdminConfig =
+        ActivationAdminConfig::static_fallback(Some(ACTIVATION_ADMIN));
     const ADMIN: Address = address!("0x1000000000000000000000000000000000000001");
     const ALICE: Address = address!("0xA000000000000000000000000000000000000001");
 
@@ -177,7 +179,7 @@ mod tests {
         storage.set_caller(ACTIVATION_ADMIN);
         StorageCtx::enter(storage, |ctx| {
             ActivationRegistryStorage::new(ctx)
-                .activate(ActivationFeature::PolicyRegistry.id(), Some(ACTIVATION_ADMIN))
+                .activate(ActivationFeature::PolicyRegistry.id(), ACTIVATION_ADMIN_CONFIG)
                 .unwrap()
         });
     }
@@ -198,7 +200,7 @@ mod tests {
         storage.set_caller(ACTIVATION_ADMIN);
         StorageCtx::enter(storage, |ctx| {
             ActivationRegistryStorage::new(ctx)
-                .deactivate(ActivationFeature::PolicyRegistry.id(), Some(ACTIVATION_ADMIN))
+                .deactivate(ActivationFeature::PolicyRegistry.id(), ACTIVATION_ADMIN_CONFIG)
                 .unwrap()
         });
     }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -14,9 +14,9 @@ use revm::{
 };
 
 use crate::{
-    ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup, NonceManager,
-    NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver, TxContext,
-    bls12_381, bn254_pair,
+    ActivationAdminConfig, ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup,
+    NonceManager, NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver,
+    TxContext, bls12_381, bn254_pair,
 };
 
 /// Base precompile provider.
@@ -207,7 +207,10 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             PolicyRegistryPrecompile::install_with_observer(&mut precompiles, observer.clone());
             ActivationRegistry::install_with_observer(
                 &mut precompiles,
-                self.activation_admin_address,
+                ActivationAdminConfig::new(
+                    self.activation_admin_address,
+                    self.spec.upgrade() >= BaseUpgrade::Cobalt,
+                ),
                 observer,
             );
         }

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -486,11 +486,8 @@ impl TryFrom<&ChainConfig> for BaseChainSpec {
         let genesis = serde_json::from_str(cfg.genesis_json)?;
         let upgrades =
             base_common_chains::ChainUpgrades::new(BaseUpgrade::forks_for(cfg)).to_chain_upgrades();
-        Self::validate_beryl_activation_admin(
-            &upgrades,
-            Some(cfg.activation_admin_address),
-            cfg.chain_id,
-        )?;
+        let activation_admin_address = cfg.beryl_activation_admin_address();
+        Self::validate_beryl_activation_admin(&upgrades, activation_admin_address, cfg.chain_id)?;
         let genesis_header = match cfg.genesis_l2_hash {
             B256::ZERO => SealedHeader::seal_slow(Self::make_genesis_header(&genesis, &upgrades)),
             hash => SealedHeader::new(Self::make_genesis_header(&genesis, &upgrades), hash),
@@ -527,7 +524,7 @@ impl TryFrom<&ChainConfig> for BaseChainSpec {
                 prune_delete_limit: cfg.prune_delete_limit,
                 ..Default::default()
             },
-            activation_admin_address: Some(cfg.activation_admin_address),
+            activation_admin_address,
         })
     }
 }
@@ -929,6 +926,8 @@ mod tests {
         RuntimeUpgradeRegistry::clear_chain(chain_id);
         let mut config = ChainConfig::mainnet().clone();
         config.chain_id = chain_id;
+        config.beryl_timestamp = None;
+        config.cobalt_timestamp = None;
         let spec = BaseChainSpec::try_from(&config).unwrap();
         let timestamp = 42;
         let parent = spec.genesis_header();
@@ -973,14 +972,18 @@ mod tests {
     }
 
     #[test]
-    fn activation_admin_matches_chain_config() {
+    fn activation_admin_matches_beryl_constants() {
         assert_eq!(
             BaseChainSpec::mainnet().activation_admin_address(),
-            Some(address!("cE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"))
+            Some(base_common_chains::MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS)
         );
         assert_eq!(
             BaseChainSpec::sepolia().activation_admin_address(),
-            Some(address!("5F43072722f59964d886CBb507F6a85ca0759D42"))
+            Some(base_common_chains::SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS)
+        );
+        assert_eq!(
+            BaseChainSpec::zeronet().activation_admin_address(),
+            Some(base_common_chains::ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS)
         );
     }
 
@@ -1051,15 +1054,15 @@ mod tests {
     }
 
     #[test]
-    fn beryl_chain_config_with_zero_activation_admin_is_rejected() {
+    fn beryl_chain_config_without_known_activation_admin_is_rejected() {
         let mut config = ChainConfig::devnet().clone();
+        config.chain_id = 987_654;
         config.beryl_timestamp = Some(0);
-        config.activation_admin_address = Address::ZERO;
 
         let err = BaseChainSpec::try_from(&config)
-            .expect_err("Beryl chain config with zero activation admin should be rejected");
+            .expect_err("Beryl chain config without activation admin should be rejected");
         assert!(
-            matches!(err, BaseChainSpecError::ZeroActivationAdminAddress { chain_id } if chain_id == config.chain_id)
+            matches!(err, BaseChainSpecError::MissingActivationAdminAddress { chain_id } if chain_id == config.chain_id)
         );
     }
 

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -246,7 +246,7 @@ impl BootInfo {
 
         let built_in_chain_config = base_common_chains::ChainConfig::by_chain_id(chain_id);
         let activation_admin_address =
-            built_in_chain_config.map(|config| config.activation_admin_address);
+            base_common_chains::ChainConfig::beryl_activation_admin_address_by_chain_id(chain_id);
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
@@ -423,7 +423,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn loads_activation_admin_address_from_builtin_chain_config() {
+    async fn loads_activation_admin_address_from_builtin_chain_id() {
         let chain_config = BaseChainConfig::ZERONET;
 
         let mut oracle = MockOracle::new();
@@ -435,7 +435,10 @@ mod tests {
 
         let boot_info = BootInfo::load(&oracle).await.expect("boot info should load");
 
-        assert_eq!(boot_info.activation_admin_address, Some(chain_config.activation_admin_address));
+        assert_eq!(
+            boot_info.activation_admin_address,
+            Some(base_common_chains::ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS)
+        );
     }
 
     #[tokio::test]

--- a/crates/proof/succinct/utils/client/src/boot.rs
+++ b/crates/proof/succinct/utils/client/src/boot.rs
@@ -85,7 +85,9 @@ mod tests {
             claimed_l2_output_root: B256::repeat_byte(0x33),
             claimed_l2_block_number,
             chain_id: rollup_config.l2_chain_id.id(),
-            activation_admin_address: Some(ChainConfig::MAINNET.activation_admin_address),
+            activation_admin_address: Some(
+                base_common_chains::MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+            ),
             rollup_config,
             l1_config,
             proposer: Address::ZERO,

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -10,6 +10,7 @@ TEMPLATE_DIR="${TEMPLATE_DIR:-/templates}"
 L2_BASE_AZUL_BLOCK="${L2_BASE_AZUL_BLOCK:-}"
 L2_BASE_BERYL_BLOCK="${L2_BASE_BERYL_BLOCK:-}"
 L2_ISTHMUS_BLOCK="${L2_ISTHMUS_BLOCK:-}"
+L2_BASE_COBALT_BLOCK="${L2_BASE_COBALT_BLOCK:-}"
 L2_ACTIVATION_ADMIN_ADDR="${L2_ACTIVATION_ADMIN_ADDR:-$SEQUENCER_ADDR}"
 L2_EL_BOOTNODE_P2P_KEY="${L2_EL_BOOTNODE_P2P_KEY:-1111111111111111111111111111111111111111111111111111111111111111}"
 L2_EL_BOOTNODE_ENODE_ID="${L2_EL_BOOTNODE_ENODE_ID:-4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1}"
@@ -33,6 +34,10 @@ if [ -n "$L2_BASE_BERYL_BLOCK" ] && ! [[ "$L2_BASE_BERYL_BLOCK" =~ ^[0-9]+$ ]]; 
   echo "ERROR: L2_BASE_BERYL_BLOCK must be a non-negative integer when set, got: $L2_BASE_BERYL_BLOCK"
   exit 1
 fi
+if [ -n "$L2_BASE_COBALT_BLOCK" ] && ! [[ "$L2_BASE_COBALT_BLOCK" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: L2_BASE_COBALT_BLOCK must be a non-negative integer when set, got: $L2_BASE_COBALT_BLOCK"
+  exit 1
+fi
 if [ -n "$L2_ISTHMUS_BLOCK" ] && ! [[ "$L2_ISTHMUS_BLOCK" =~ ^[0-9]+$ ]]; then
   echo "ERROR: L2_ISTHMUS_BLOCK must be a non-negative integer when set, got: $L2_ISTHMUS_BLOCK"
   exit 1
@@ -52,6 +57,11 @@ if [ -n "$L2_BASE_BERYL_BLOCK" ]; then
   echo "Base Beryl activation block: $L2_BASE_BERYL_BLOCK"
 else
   echo "Base Beryl activation block: <unset>"
+fi
+if [ -n "$L2_BASE_COBALT_BLOCK" ]; then
+  echo "Base Cobalt activation block: $L2_BASE_COBALT_BLOCK"
+else
+  echo "Base Cobalt activation block: <unset>"
 fi
 if [ -n "$L2_ISTHMUS_BLOCK" ]; then
   echo "Isthmus activation block: $L2_ISTHMUS_BLOCK"
@@ -279,6 +289,41 @@ else
   echo "L2 genesis time: $L2_GENESIS_TIME"
   echo "L2 block time: $L2_BLOCK_TIME"
   echo "Base Beryl activation block is unset; leaving base.beryl unchanged"
+fi
+
+if [ -n "$L2_BASE_COBALT_BLOCK" ]; then
+  L2_BASE_COBALT_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_COBALT_BLOCK))
+
+  echo ""
+  echo "=== Configuring Base Cobalt Activation ==="
+  echo "L2 genesis time: $L2_GENESIS_TIME"
+  echo "L2 block time: $L2_BLOCK_TIME"
+  echo "Base Cobalt activation block: $L2_BASE_COBALT_BLOCK"
+  echo "Derived Base Cobalt activation timestamp: $L2_BASE_COBALT_TIME"
+
+  TMP_ROLLUP=$(mktemp)
+  jq \
+    --argjson cobalt_time "$L2_BASE_COBALT_TIME" \
+    '.base = ((.base // {}) + {cobalt: $cobalt_time})' \
+    "$OUTPUT_DIR/rollup.json" \
+    >"$TMP_ROLLUP"
+  replace_output_file "$TMP_ROLLUP" "$OUTPUT_DIR/rollup.json"
+
+  TMP_GENESIS=$(mktemp)
+  jq \
+    --argjson cobalt_time "$L2_BASE_COBALT_TIME" \
+    '.config.base = ((.config.base // {}) + {cobalt: $cobalt_time})' \
+    "$OUTPUT_DIR/genesis.json" \
+    >"$TMP_GENESIS"
+  replace_output_file "$TMP_GENESIS" "$OUTPUT_DIR/genesis.json"
+
+  echo "Patched Base Cobalt activation into rollup and genesis configs"
+else
+  echo ""
+  echo "=== Configuring Base Cobalt Activation ==="
+  echo "L2 genesis time: $L2_GENESIS_TIME"
+  echo "L2 block time: $L2_BLOCK_TIME"
+  echo "Base Cobalt activation block is unset; leaving base.cobalt unchanged"
 fi
 
 echo "Writing rollup-conductor.json (base fields stripped for op-conductor compatibility)..."

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -229,6 +229,7 @@ pub struct SetupContainer {
     isthmus_activation_block: Option<u64>,
     base_azul_activation_block: Option<u64>,
     base_beryl_activation_block: Option<u64>,
+    base_cobalt_activation_block: Option<u64>,
     network_name: Option<String>,
 }
 
@@ -243,6 +244,7 @@ impl SetupContainer {
             isthmus_activation_block: None,
             base_azul_activation_block: None,
             base_beryl_activation_block: None,
+            base_cobalt_activation_block: None,
             network_name: None,
         }
     }
@@ -280,6 +282,12 @@ impl SetupContainer {
     /// Sets the L2 block number at which Base Beryl activates.
     pub const fn with_base_beryl_activation_block(mut self, block: u64) -> Self {
         self.base_beryl_activation_block = Some(block);
+        self
+    }
+
+    /// Sets the L2 block number at which Base Cobalt activates.
+    pub const fn with_base_cobalt_activation_block(mut self, block: u64) -> Self {
+        self.base_cobalt_activation_block = Some(block);
         self
     }
 
@@ -378,6 +386,10 @@ impl SetupContainer {
 
         if let Some(block) = self.base_beryl_activation_block {
             container = container.with_env_var("L2_BASE_BERYL_BLOCK", block.to_string());
+        }
+
+        if let Some(block) = self.base_cobalt_activation_block {
+            container = container.with_env_var("L2_BASE_COBALT_BLOCK", block.to_string());
         }
 
         let _container = container

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -130,6 +130,7 @@ pub struct SystemTestStackBuilder {
     isthmus_activation_block: Option<u64>,
     base_azul_activation_block: Option<u64>,
     base_beryl_activation_block: Option<u64>,
+    base_cobalt_activation_block: Option<u64>,
     output_dir: Option<PathBuf>,
     stable_config: Option<StableSystemTestConfig>,
     tx_forwarding_config: Option<TxForwardingConfig>,
@@ -176,6 +177,12 @@ impl SystemTestStackBuilder {
     /// Sets the L2 block number at which Base Beryl activates.
     pub const fn with_base_beryl_activation_block(mut self, block: u64) -> Self {
         self.base_beryl_activation_block = Some(block);
+        self
+    }
+
+    /// Sets the L2 block number at which Base Cobalt activates.
+    pub const fn with_base_cobalt_activation_block(mut self, block: u64) -> Self {
+        self.base_cobalt_activation_block = Some(block);
         self
     }
 
@@ -236,6 +243,10 @@ impl SystemTestStackBuilder {
 
         if let Some(block) = self.base_beryl_activation_block {
             setup = setup.with_base_beryl_activation_block(block);
+        }
+
+        if let Some(block) = self.base_cobalt_activation_block {
+            setup = setup.with_base_cobalt_activation_block(block);
         }
 
         if let Some(ref config) = self.stable_config {

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -3,12 +3,18 @@
 mod common;
 
 use alloy_primitives::{Address, B256, LogData};
+use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent};
+use base_common_network::Base;
 use base_common_precompiles::{ActivationFeature, ActivationRegistryStorage, IActivationRegistry};
 use base_common_rpc_types::BaseTransactionReceipt;
-use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient};
+use base_system_tests::{
+    ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient, SystemTestStack, SystemTestStackBuilder,
+};
 use eyre::{Result, WrapErr};
+
+const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 
 /// `isActivated` returns `false` for every feature id by default.
 #[tokio::test]
@@ -52,6 +58,87 @@ async fn test_activation_registry_admin() -> Result<()> {
         .wrap_err("Failed to decode admin")?;
 
     assert_eq!(admin_addr, ANVIL_ACCOUNT_5.address);
+
+    Ok(())
+}
+
+/// `setAdmin` stays disabled while Beryl is active but Cobalt is not.
+#[tokio::test]
+async fn test_activation_registry_set_admin_reverts_before_cobalt() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse system test private key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    let succeeded = client
+        .try_send_call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::setAdminCall { newAdmin: ANVIL_ACCOUNT_6.address },
+            "set activation admin before Cobalt",
+        )
+        .await?;
+
+    assert!(!succeeded, "setAdmin should revert before Cobalt");
+    assert_eq!(admin_address(&client).await?, ANVIL_ACCOUNT_5.address);
+
+    Ok(())
+}
+
+/// At Cobalt, `setAdmin` updates the stored admin and future activation authority.
+#[tokio::test]
+async fn test_activation_registry_cobalt_admin_rotation() -> Result<()> {
+    let (_system, provider) = start_cobalt_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse system test admin private key")?;
+    let new_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
+        .wrap_err("Failed to parse system test new admin private key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+    common::wait_for_balance(&provider, new_admin.address()).await?;
+
+    let admin_client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    let new_admin_client = B20PrecompileClient::new(&provider, &new_admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+
+    assert_eq!(admin_address(&admin_client).await?, admin.address());
+
+    let set_admin_receipt = admin_client
+        .send_call_receipt(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::setAdminCall { newAdmin: new_admin.address() },
+            "set activation admin",
+        )
+        .await?;
+    assert_admin_changed_log(
+        &set_admin_receipt,
+        admin.address(),
+        new_admin.address(),
+        admin.address(),
+    );
+    assert_eq!(admin_address(&admin_client).await?, new_admin.address());
+
+    let feature = ActivationFeature::B20Stablecoin.id();
+    let old_admin_activate = admin_client
+        .try_send_call(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::activateCall { feature },
+            "activate feature with old admin",
+        )
+        .await?;
+    assert!(!old_admin_activate, "previous admin should not activate after rotation");
+
+    let new_admin_activate = new_admin_client
+        .send_call_receipt(
+            ActivationRegistryStorage::ADDRESS,
+            IActivationRegistry::activateCall { feature },
+            "activate feature with new admin",
+        )
+        .await?;
+    assert_activation_log(&new_admin_activate, feature, new_admin.address(), true);
+    assert!(is_activated(&new_admin_client, feature).await?, "new admin activation should persist");
 
     Ok(())
 }
@@ -205,6 +292,27 @@ async fn is_activated(client: &B20PrecompileClient<'_>, feature: B256) -> Result
         .wrap_err("Failed to decode isActivated")
 }
 
+async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(common::L1_CHAIN_ID)
+        .with_l2_chain_id(common::L2_CHAIN_ID)
+        .with_base_azul_activation_block(common::BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(common::BASE_BERYL_ACTIVATION_BLOCK)
+        .with_base_cobalt_activation_block(BASE_COBALT_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = system.l2_builder_provider()?;
+    common::wait_for_block(&provider, BASE_COBALT_ACTIVATION_BLOCK + 1).await?;
+    Ok((system, provider))
+}
+
+async fn admin_address(client: &B20PrecompileClient<'_>) -> Result<Address> {
+    let output =
+        client.call(ActivationRegistryStorage::ADDRESS, IActivationRegistry::adminCall {}).await?;
+    IActivationRegistry::adminCall::abi_decode_returns(output.as_ref())
+        .wrap_err("Failed to decode admin")
+}
+
 fn assert_activation_log(
     receipt: &BaseTransactionReceipt,
     feature: B256,
@@ -216,6 +324,21 @@ fn assert_activation_log(
     } else {
         IActivationRegistry::FeatureDeactivated { feature, caller }.encode_log_data()
     };
+    assert_receipt_log(receipt, ActivationRegistryStorage::ADDRESS, expected);
+}
+
+fn assert_admin_changed_log(
+    receipt: &BaseTransactionReceipt,
+    previous_admin: Address,
+    new_admin: Address,
+    caller: Address,
+) {
+    let expected = IActivationRegistry::AdminChanged {
+        previousAdmin: previous_admin,
+        newAdmin: new_admin,
+        caller,
+    }
+    .encode_log_data();
     assert_receipt_log(receipt, ActivationRegistryStorage::ADDRESS, expected);
 }
 


### PR DESCRIPTION
## Summary

This adds a Cobalt-gated state-backed admin slot to the activation registry while preserving the static chain-config admin as the Beryl replay fallback. The activation registry now supports setAdmin(address) once state-backed admin storage is enabled, and Cobalt execution reads the stored admin when present. The tests cover fallback behavior, admin rotation, Beryl rejection of state rotation, and the installed EVM precompile path.