### PR TITLE
fix(ci): Update Base Std Fork Runner

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -176,6 +176,21 @@ jobs:
 
           echo "BASE_STD_DIR=$base_std_dir" >> "$GITHUB_ENV"
 
+      - name: Set up Python 3.13
+        if: matrix.settings.smoke_test
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up base-std fork-test runner
+        if: matrix.settings.smoke_test
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cd "$BASE_STD_DIR"
+          make smoke-setup PYTHON=python3
+
       - name: Run base-std fork tests
         if: matrix.settings.smoke_test
         shell: bash
@@ -186,7 +201,7 @@ jobs:
           ANVIL_BIN="$BASE_ANVIL_DIR/target/release/anvil" \
             FORGE_BIN="$BASE_ANVIL_DIR/target/release/forge" \
             ANVIL_LOG="$RUNNER_TEMP/base-std-anvil.log" \
-            ./script/run-fork-tests.sh
+            make fork-tests
 
       - name: Upload anvil log
         if: always() && matrix.settings.smoke_test

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -130,6 +130,19 @@ jobs:
           "$BASE_ANVIL_DIR/target/release/anvil" --version
           "$BASE_ANVIL_DIR/target/release/forge" --version
 
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up base-std fork-test runner
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cd "$BASE_STD_DIR"
+          make smoke-setup PYTHON=python3
+
       - name: Run base-std fork tests
         shell: bash
         run: |
@@ -139,7 +152,7 @@ jobs:
           ANVIL_BIN="$BASE_ANVIL_DIR/target/release/anvil" \
             FORGE_BIN="$BASE_ANVIL_DIR/target/release/forge" \
             ANVIL_LOG="$RUNNER_TEMP/base-std-anvil.log" \
-            ./script/run-fork-tests.sh 2>&1 | tee "$RUNNER_TEMP/fork-test-output.txt"
+            make fork-tests 2>&1 | tee "$RUNNER_TEMP/fork-test-output.txt"
 
       - name: Comment fork test results on PR
         if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
## Summary

The base-std fork test workflow was still calling the removed script/run-fork-tests.sh entrypoint, which caused the job to fail before any tests ran. This updates the CI to provision Python 3.13, create the base-std fork-test venv, and run the current make fork-tests target with the patched base-anvil binaries. The related base-anvil package smoke test path now uses the same runner setup so it does not hit the same stale entrypoint.