### PR TITLE
refactor(proof): extract SignerManager from registration driver

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -23,7 +23,7 @@ use base_proof_tee_registrar::{
     DEFAULT_MAX_RECOVERY_ATTEMPTS, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, NitroVerifierClient,
     NitroVerifierContractClient, ProverClient, ProvingConfig, RegistrarConfig, RegistrarError,
-    RegistrarMetrics, RegistrationDriver, RegistryContractClient,
+    RegistrarMetrics, RegistrationDriver, RegistryContractClient, SignerManagerConfig,
 };
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use boundless_market::{
@@ -685,12 +685,14 @@ impl Cli {
         // ── 8. Build and run driver ──────────────────────────────────────────
         let signer_client = ProverClient::new(config.prover_timeout);
         let driver_config = DriverConfig {
-            registry_address: config.tee_prover_registry_address,
             poll_interval: config.poll_interval,
-            cancel: cancel.clone(),
-            max_concurrency: config.max_concurrency,
-            max_tx_retries: config.max_tx_retries,
-            tx_retry_delay: config.tx_retry_delay,
+            signer_manager: SignerManagerConfig {
+                registry_address: config.tee_prover_registry_address,
+                cancel: cancel.clone(),
+                max_concurrency: config.max_concurrency,
+                max_tx_retries: config.max_tx_retries,
+                tx_retry_delay: config.tx_retry_delay,
+            },
             unhealthy_registration_window: config.unhealthy_registration_window,
             crl: config.crl,
         };

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -23,7 +23,8 @@ use base_proof_tee_registrar::{
     DEFAULT_MAX_RECOVERY_ATTEMPTS, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, NitroVerifierClient,
     NitroVerifierContractClient, ProverClient, ProvingConfig, RegistrarConfig, RegistrarError,
-    RegistrarMetrics, RegistrationDriver, RegistryContractClient, SignerManagerConfig,
+    RegistrarMetrics, RegistrationDriver, RegistryContractClient, SignerManager,
+    SignerManagerConfig,
 };
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use boundless_market::{
@@ -703,15 +704,19 @@ impl Cli {
         // would add complexity without benefit.
         ready.store(true, Ordering::SeqCst);
 
-        let cancel_guard = cancel.clone().drop_guard();
-        let driver = RegistrationDriver::new(
-            discovery,
+        let signer_manager = Arc::new(SignerManager::new(
             proof_provider,
             registry,
             tx_manager,
+            driver_config.signer_manager.clone(),
+        ));
+        let cancel_guard = cancel.clone().drop_guard();
+        let driver = RegistrationDriver::new(
+            discovery,
             signer_client,
             driver_config,
             nitro_verifier,
+            signer_manager,
         )?;
         let driver_result = driver.run().await;
         drop(cancel_guard);

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -15,7 +15,8 @@ to detect new Nitro enclave instances, fetches their attestation documents via
   and [`SigningConfig`] for L1 transaction signing.
 - **`error`** — [`RegistrarError`] enum covering all failure modes.
 - **`prover`** — [`ProverClient`] JSON-RPC client for polling prover signer endpoints.
-- **`registration_manager`** — [`RegistrationManager`] orchestration for signer proof requests.
+- **`signer_manager`** — [`SignerManager`] lifecycle management for signer proof tasks.
+- **`registration_manager`** — [`RegistrationManager`] execution path for a single signer registration.
 - **`proof_handler`** — [`ProofHandler`] handling for completed proofs and registration txs.
 - **`traits`** — [`InstanceDiscovery`] and [`AttestationProofProvider`] trait definitions.
 - **`types`** — Core domain types: [`ProverInstance`], [`RegisteredSigner`].

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -10,7 +10,6 @@ use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::ITEEProverRegistry;
 use base_tx_manager::{TxCandidate, TxManager};
-use futures::stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -22,7 +21,6 @@ pub struct DeregistrationManager<'a, R: ?Sized, T: ?Sized> {
     registry: &'a R,
     tx_manager: &'a T,
     signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
-    max_concurrency: usize,
 }
 
 impl<R: ?Sized, T: ?Sized> fmt::Debug for DeregistrationManager<'_, R, T> {
@@ -41,13 +39,7 @@ impl<'a, R: ?Sized, T: ?Sized> DeregistrationManager<'a, R, T> {
         tx_manager: &'a T,
         signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
     ) -> Self {
-        Self { registry_address, registry, tx_manager, signer_history, max_concurrency: 1 }
-    }
-
-    /// Sets the maximum number of orphan deregistration tasks to run at once.
-    pub const fn with_max_concurrency(mut self, max_concurrency: usize) -> Self {
-        self.max_concurrency = max_concurrency;
-        self
+        Self { registry_address, registry, tx_manager, signer_history }
     }
 }
 
@@ -193,15 +185,14 @@ where
 
         info!(count = orphans.len(), "deregistering orphan signers");
 
-        let concurrency = self.max_concurrency.max(1).min(orphans.len());
-        let mut deregistrations = futures::stream::iter(
-            orphans.into_iter().map(|signer| self.deregister_orphan(signer, cancel)),
-        )
-        .buffer_unordered(concurrency);
-
         let mut deregistered = 0usize;
-        while let Some(deregistered_orphan) = deregistrations.next().await {
-            if deregistered_orphan {
+        for signer in orphans {
+            if cancel.is_cancelled() {
+                debug!("shutdown requested, stopping orphan deregistration");
+                break;
+            }
+
+            if self.deregister_orphan(signer, cancel).await {
                 RegistrarMetrics::deregistrations_total().increment(1);
                 deregistered += 1;
             }
@@ -218,10 +209,7 @@ where
 mod tests {
     use std::{
         future,
-        sync::{
-            Arc, Mutex,
-            atomic::{AtomicUsize, Ordering},
-        },
+        sync::{Arc, Mutex},
         time::Duration,
     };
 
@@ -377,30 +365,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deregister_orphans_respects_configured_concurrency() {
-        let registered_signers = vec![SIGNER_A, SIGNER_B, SIGNER_C];
-        let registry =
-            ConcurrencyTrackingRegistry::new(registered_signers.clone(), Duration::from_millis(25));
-        let peak = registry.peak();
-        let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history)
-                .with_max_concurrency(2);
-
-        manager
-            .deregister_orphans(&HashSet::new(), &registered_signers, &CancellationToken::new())
-            .await
-            .unwrap();
-
-        assert!(
-            peak.load(Ordering::SeqCst) <= 2,
-            "orphan deregistration exceeded configured concurrency"
-        );
-        assert_eq!(tx_manager.take_candidates().len(), registered_signers.len());
-    }
-
-    #[tokio::test]
     async fn run_orphan_dereg_respects_cancellation_while_loading_signers() {
         let registry = MockRegistry::stalling_get_registered_signers();
         let get_registered_signers_started = registry.get_registered_signers_started();
@@ -491,51 +455,6 @@ mod tests {
             if self.stall_get_registered_signers {
                 future::pending::<()>().await;
             }
-            Ok(self.signers.clone())
-        }
-    }
-
-    #[derive(Debug)]
-    struct ConcurrencyTrackingRegistry {
-        signers: Vec<Address>,
-        active: Arc<AtomicUsize>,
-        peak: Arc<AtomicUsize>,
-        delay: Duration,
-    }
-
-    impl ConcurrencyTrackingRegistry {
-        fn new(signers: Vec<Address>, delay: Duration) -> Self {
-            Self {
-                signers,
-                active: Arc::new(AtomicUsize::new(0)),
-                peak: Arc::new(AtomicUsize::new(0)),
-                delay,
-            }
-        }
-
-        fn peak(&self) -> Arc<AtomicUsize> {
-            Arc::clone(&self.peak)
-        }
-    }
-
-    #[async_trait]
-    impl RegistryClient for ConcurrencyTrackingRegistry {
-        async fn is_registered(&self, _signer: Address) -> Result<bool> {
-            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
-            let mut peak = self.peak.load(Ordering::SeqCst);
-            while active > peak {
-                match self.peak.compare_exchange(peak, active, Ordering::SeqCst, Ordering::SeqCst) {
-                    Ok(_) => break,
-                    Err(current) => peak = current,
-                }
-            }
-
-            tokio::time::sleep(self.delay).await;
-            self.active.fetch_sub(1, Ordering::SeqCst);
-            Ok(true)
-        }
-
-        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
             Ok(self.signers.clone())
         }
     }

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -131,21 +131,17 @@ where
     ///
     /// Checks `isRegisteredSigner` before submitting a transaction so stale
     /// `getRegisteredSigners()` entries do not loop forever.
-    pub async fn deregister_orphan(
-        &self,
-        signer: Address,
-        cancel: &CancellationToken,
-    ) -> Result<bool> {
+    pub async fn deregister_orphan(&self, signer: Address, cancel: &CancellationToken) -> bool {
         if cancel.is_cancelled() {
             debug!("shutdown requested, stopping orphan deregistration");
-            return Ok(false);
+            return false;
         }
 
         let registered = tokio::select! {
             biased;
             () = cancel.cancelled() => {
                 debug!("shutdown requested while verifying orphan signer");
-                return Ok(false);
+                return false;
             }
             res = self.registry.is_registered(signer) => res,
         };
@@ -157,7 +153,7 @@ where
                     "signer appears in getRegisteredSigners but isRegisteredSigner is false, \
                      skipping (possible EnumerableSet ghost entry)"
                 );
-                Ok(false)
+                false
             }
             Err(e) => {
                 warn!(
@@ -165,16 +161,16 @@ where
                     signer = %signer,
                     "failed to verify signer registration status, skipping deregistration"
                 );
-                Ok(false)
+                false
             }
             Ok(true) if cancel.is_cancelled() => {
                 debug!(
                     signer = %signer,
                     "shutdown requested before submitting orphan deregistration"
                 );
-                Ok(false)
+                false
             }
-            Ok(true) => Ok(self.submit_deregistration(signer).await),
+            Ok(true) => self.submit_deregistration(signer).await,
         }
     }
 
@@ -204,8 +200,8 @@ where
         .buffer_unordered(concurrency);
 
         let mut deregistered = 0usize;
-        while let Some(result) = deregistrations.next().await {
-            if result? {
+        while let Some(deregistered_orphan) = deregistrations.next().await {
+            if deregistered_orphan {
                 RegistrarMetrics::deregistrations_total().increment(1);
                 deregistered += 1;
             }
@@ -373,7 +369,7 @@ mod tests {
         let manager =
             DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
 
-        manager.deregister_orphan(SIGNER_A, &cancel).await.unwrap();
+        manager.deregister_orphan(SIGNER_A, &cancel).await;
 
         assert!(tx_manager.take_candidates().is_empty());
     }

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt,
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
 
 use alloy_primitives::{Address, Bytes};
@@ -20,7 +20,7 @@ pub struct DeregistrationManager<'a, R: ?Sized, T: ?Sized> {
     registry_address: Address,
     registry: &'a R,
     tx_manager: &'a T,
-    signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
+    signer_history: &'a Mutex<HashMap<Address, String>>,
 }
 
 impl<R: ?Sized, T: ?Sized> fmt::Debug for DeregistrationManager<'_, R, T> {
@@ -37,7 +37,7 @@ impl<'a, R: ?Sized, T: ?Sized> DeregistrationManager<'a, R, T> {
         registry_address: Address,
         registry: &'a R,
         tx_manager: &'a T,
-        signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
+        signer_history: &'a Mutex<HashMap<Address, String>>,
     ) -> Self {
         Self { registry_address, registry, tx_manager, signer_history }
     }

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -1,10 +1,6 @@
 //! Signer deregistration management for orphaned prover signers.
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    sync::Mutex,
-};
+use std::{collections::HashSet, fmt};
 
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
@@ -20,7 +16,6 @@ pub struct DeregistrationManager<'a, R: ?Sized, T: ?Sized> {
     registry_address: Address,
     registry: &'a R,
     tx_manager: &'a T,
-    signer_history: &'a Mutex<HashMap<Address, String>>,
 }
 
 impl<R: ?Sized, T: ?Sized> fmt::Debug for DeregistrationManager<'_, R, T> {
@@ -33,13 +28,8 @@ impl<R: ?Sized, T: ?Sized> fmt::Debug for DeregistrationManager<'_, R, T> {
 
 impl<'a, R: ?Sized, T: ?Sized> DeregistrationManager<'a, R, T> {
     /// Creates a manager for orphan signer cleanup.
-    pub const fn new(
-        registry_address: Address,
-        registry: &'a R,
-        tx_manager: &'a T,
-        signer_history: &'a Mutex<HashMap<Address, String>>,
-    ) -> Self {
-        Self { registry_address, registry, tx_manager, signer_history }
+    pub const fn new(registry_address: Address, registry: &'a R, tx_manager: &'a T) -> Self {
+        Self { registry_address, registry, tx_manager }
     }
 }
 
@@ -76,13 +66,8 @@ where
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
     pub async fn submit_deregistration(&self, signer: Address) -> bool {
         let candidate = self.candidate(signer);
-        let last_known_instance = {
-            let history = self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
-            history.get(&signer).cloned()
-        };
         info!(
             signer = %signer,
-            last_known_instance = ?last_known_instance,
             registry = %self.registry_address,
             calldata_len = candidate.tx_data.len(),
             "Deregistering signer"
@@ -232,9 +217,7 @@ mod tests {
     fn candidate_targets_registry_with_deregister_signer_calldata() {
         let registry = MockRegistry::with_signers(vec![SIGNER_A]);
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
 
         let candidate = manager.candidate(SIGNER_A);
 
@@ -259,9 +242,7 @@ mod tests {
     ) {
         let registry = MockRegistry::with_signers(registered_signers.clone());
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
         let protected_signers: HashSet<Address> = protected_signers.into_iter().collect();
 
         manager
@@ -276,9 +257,7 @@ mod tests {
     async fn deregister_orphans_submits_only_unprotected_signers() {
         let registry = MockRegistry::with_signers(vec![SIGNER_A, SIGNER_B]);
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
 
         manager
             .deregister_orphans(
@@ -304,9 +283,7 @@ mod tests {
             vec![SIGNER_B],
         );
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
 
         manager.run_orphan_dereg(&HashSet::new(), &CancellationToken::new()).await.unwrap();
 
@@ -325,9 +302,7 @@ mod tests {
             vec![],
         );
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
 
         manager.run_orphan_dereg(&HashSet::new(), &CancellationToken::new()).await.unwrap();
 
@@ -338,9 +313,7 @@ mod tests {
     async fn deregister_orphans_respects_cancellation() {
         let registry = MockRegistry::with_signers(vec![SIGNER_A]);
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
         let cancel = CancellationToken::new();
         cancel.cancel();
 
@@ -355,9 +328,7 @@ mod tests {
         let registry =
             MockRegistry::with_signers(vec![SIGNER_A]).cancel_on_is_registered(cancel.clone());
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
 
         manager.deregister_orphan(SIGNER_A, &cancel).await;
 
@@ -369,9 +340,7 @@ mod tests {
         let registry = MockRegistry::stalling_get_registered_signers();
         let get_registered_signers_started = registry.get_registered_signers_started();
         let tx_manager = MockTxManager::default();
-        let history = Arc::new(Mutex::new(HashMap::new()));
-        let manager =
-            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+        let manager = DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager);
         let cancel = CancellationToken::new();
         let protected_signers = HashSet::new();
 

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -218,8 +218,10 @@ where
 mod tests {
     use std::{
         future,
-        sync::atomic::{AtomicUsize, Ordering},
-        sync::{Arc, Mutex},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::Duration,
     };
 

--- a/crates/proof/tee/registrar/src/deregistration_manager.rs
+++ b/crates/proof/tee/registrar/src/deregistration_manager.rs
@@ -10,6 +10,7 @@ use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::ITEEProverRegistry;
 use base_tx_manager::{TxCandidate, TxManager};
+use futures::stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -21,6 +22,7 @@ pub struct DeregistrationManager<'a, R: ?Sized, T: ?Sized> {
     registry: &'a R,
     tx_manager: &'a T,
     signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
+    max_concurrency: usize,
 }
 
 impl<R: ?Sized, T: ?Sized> fmt::Debug for DeregistrationManager<'_, R, T> {
@@ -39,7 +41,13 @@ impl<'a, R: ?Sized, T: ?Sized> DeregistrationManager<'a, R, T> {
         tx_manager: &'a T,
         signer_history: &'a Arc<Mutex<HashMap<Address, String>>>,
     ) -> Self {
-        Self { registry_address, registry, tx_manager, signer_history }
+        Self { registry_address, registry, tx_manager, signer_history, max_concurrency: 1 }
+    }
+
+    /// Sets the maximum number of orphan deregistration tasks to run at once.
+    pub const fn with_max_concurrency(mut self, max_concurrency: usize) -> Self {
+        self.max_concurrency = max_concurrency;
+        self
     }
 }
 
@@ -119,10 +127,58 @@ where
         }
     }
 
-    /// Deregisters registered signers that are not currently protected.
+    /// Deregisters one orphan signer if it is still registered onchain.
     ///
-    /// Each candidate is checked against `isRegisteredSigner` before submitting a
-    /// transaction so stale `getRegisteredSigners()` entries do not loop forever.
+    /// Checks `isRegisteredSigner` before submitting a transaction so stale
+    /// `getRegisteredSigners()` entries do not loop forever.
+    pub async fn deregister_orphan(
+        &self,
+        signer: Address,
+        cancel: &CancellationToken,
+    ) -> Result<bool> {
+        if cancel.is_cancelled() {
+            debug!("shutdown requested, stopping orphan deregistration");
+            return Ok(false);
+        }
+
+        let registered = tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                debug!("shutdown requested while verifying orphan signer");
+                return Ok(false);
+            }
+            res = self.registry.is_registered(signer) => res,
+        };
+
+        match registered {
+            Ok(false) => {
+                warn!(
+                    signer = %signer,
+                    "signer appears in getRegisteredSigners but isRegisteredSigner is false, \
+                     skipping (possible EnumerableSet ghost entry)"
+                );
+                Ok(false)
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    signer = %signer,
+                    "failed to verify signer registration status, skipping deregistration"
+                );
+                Ok(false)
+            }
+            Ok(true) if cancel.is_cancelled() => {
+                debug!(
+                    signer = %signer,
+                    "shutdown requested before submitting orphan deregistration"
+                );
+                Ok(false)
+            }
+            Ok(true) => Ok(self.submit_deregistration(signer).await),
+        }
+    }
+
+    /// Deregisters registered signers that are not currently protected.
     pub async fn deregister_orphans(
         &self,
         protected_signers: &HashSet<Address>,
@@ -141,35 +197,15 @@ where
 
         info!(count = orphans.len(), "deregistering orphan signers");
 
+        let concurrency = self.max_concurrency.max(1).min(orphans.len());
+        let mut deregistrations = futures::stream::iter(
+            orphans.into_iter().map(|signer| self.deregister_orphan(signer, cancel)),
+        )
+        .buffer_unordered(concurrency);
+
         let mut deregistered = 0usize;
-
-        for signer in orphans {
-            if cancel.is_cancelled() {
-                debug!("shutdown requested, stopping orphan deregistration");
-                break;
-            }
-
-            match self.registry.is_registered(signer).await {
-                Ok(false) => {
-                    warn!(
-                        signer = %signer,
-                        "signer appears in getRegisteredSigners but isRegisteredSigner is false, \
-                         skipping (possible EnumerableSet ghost entry)"
-                    );
-                    continue;
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        signer = %signer,
-                        "failed to verify signer registration status, skipping deregistration"
-                    );
-                    continue;
-                }
-                Ok(true) => {}
-            }
-
-            if self.submit_deregistration(signer).await {
+        while let Some(result) = deregistrations.next().await {
+            if result? {
                 RegistrarMetrics::deregistrations_total().increment(1);
                 deregistered += 1;
             }
@@ -186,6 +222,7 @@ where
 mod tests {
     use std::{
         future,
+        sync::atomic::{AtomicUsize, Ordering},
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -327,6 +364,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn deregister_orphan_rechecks_cancellation_before_submission() {
+        let cancel = CancellationToken::new();
+        let registry =
+            MockRegistry::with_signers(vec![SIGNER_A]).cancel_on_is_registered(cancel.clone());
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history);
+
+        manager.deregister_orphan(SIGNER_A, &cancel).await.unwrap();
+
+        assert!(tx_manager.take_candidates().is_empty());
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_respects_configured_concurrency() {
+        let registered_signers = vec![SIGNER_A, SIGNER_B, SIGNER_C];
+        let registry =
+            ConcurrencyTrackingRegistry::new(registered_signers.clone(), Duration::from_millis(25));
+        let peak = registry.peak();
+        let tx_manager = MockTxManager::default();
+        let history = Arc::new(Mutex::new(HashMap::new()));
+        let manager =
+            DeregistrationManager::new(REGISTRY_ADDRESS, &registry, &tx_manager, &history)
+                .with_max_concurrency(2);
+
+        manager
+            .deregister_orphans(&HashSet::new(), &registered_signers, &CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert!(
+            peak.load(Ordering::SeqCst) <= 2,
+            "orphan deregistration exceeded configured concurrency"
+        );
+        assert_eq!(tx_manager.take_candidates().len(), registered_signers.len());
+    }
+
+    #[tokio::test]
     async fn run_orphan_dereg_respects_cancellation_while_loading_signers() {
         let registry = MockRegistry::stalling_get_registered_signers();
         let get_registered_signers_started = registry.get_registered_signers_started();
@@ -362,6 +438,7 @@ mod tests {
         true_signers: HashSet<Address>,
         get_registered_signers_started: Arc<Notify>,
         stall_get_registered_signers: bool,
+        cancel_on_is_registered: Option<CancellationToken>,
     }
 
     impl MockRegistry {
@@ -378,6 +455,7 @@ mod tests {
                 true_signers: true_signers.into_iter().collect(),
                 get_registered_signers_started: Arc::new(Notify::new()),
                 stall_get_registered_signers: false,
+                cancel_on_is_registered: None,
             }
         }
 
@@ -387,17 +465,26 @@ mod tests {
                 true_signers: HashSet::new(),
                 get_registered_signers_started: Arc::new(Notify::new()),
                 stall_get_registered_signers: true,
+                cancel_on_is_registered: None,
             }
         }
 
         fn get_registered_signers_started(&self) -> Arc<Notify> {
             Arc::clone(&self.get_registered_signers_started)
         }
+
+        fn cancel_on_is_registered(mut self, cancel: CancellationToken) -> Self {
+            self.cancel_on_is_registered = Some(cancel);
+            self
+        }
     }
 
     #[async_trait]
     impl RegistryClient for MockRegistry {
         async fn is_registered(&self, signer: Address) -> Result<bool> {
+            if let Some(cancel) = &self.cancel_on_is_registered {
+                cancel.cancel();
+            }
             Ok(self.true_signers.contains(&signer))
         }
 
@@ -406,6 +493,51 @@ mod tests {
             if self.stall_get_registered_signers {
                 future::pending::<()>().await;
             }
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct ConcurrencyTrackingRegistry {
+        signers: Vec<Address>,
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        delay: Duration,
+    }
+
+    impl ConcurrencyTrackingRegistry {
+        fn new(signers: Vec<Address>, delay: Duration) -> Self {
+            Self {
+                signers,
+                active: Arc::new(AtomicUsize::new(0)),
+                peak: Arc::new(AtomicUsize::new(0)),
+                delay,
+            }
+        }
+
+        fn peak(&self) -> Arc<AtomicUsize> {
+            Arc::clone(&self.peak)
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for ConcurrencyTrackingRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            let mut peak = self.peak.load(Ordering::SeqCst);
+            while active > peak {
+                match self.peak.compare_exchange(peak, active, Ordering::SeqCst, Ordering::SeqCst) {
+                    Ok(_) => break,
+                    Err(current) => peak = current,
+                }
+            }
+
+            tokio::time::sleep(self.delay).await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(true)
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
             Ok(self.signers.clone())
         }
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1537,16 +1537,12 @@ mod tests {
         }
     }
 
-    fn proof_task_success_for_test(signer: Address, instance_id: &str) -> ProofTaskOutcome {
-        ProofTaskOutcome { signer, instance_id: instance_id.to_string(), result: Ok(()) }
+    fn proof_task_success_for_test(signer: Address) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, result: Ok(()) }
     }
 
-    fn proof_task_failure_for_test(
-        signer: Address,
-        instance_id: &str,
-        error: RegistrarError,
-    ) -> ProofTaskOutcome {
-        ProofTaskOutcome { signer, instance_id: instance_id.to_string(), result: Err(error) }
+    fn proof_task_failure_for_test(signer: Address, error: RegistrarError) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, result: Err(error) }
     }
 
     /// Builds a synthetic [`DiscoveryResolution`] from a list of
@@ -2455,7 +2451,7 @@ mod tests {
             let task_cancel_inner = task_cancel.clone();
             let handle = proof_tasks.tasks_mut().spawn(async move {
                 task_cancel_inner.cancelled().await;
-                proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+                proof_task_success_for_test(signer)
             });
             proof_tasks.pending_mut().insert(
                 signer,
@@ -2539,7 +2535,7 @@ mod tests {
         let stale_cancel_inner = stale_cancel.clone();
         let stale_handle = proof_tasks.tasks_mut().spawn(async move {
             stale_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+            proof_task_success_for_test(signer)
         });
         let stale_task_id = stale_handle.id();
         proof_tasks.pending_mut().insert(
@@ -2615,7 +2611,7 @@ mod tests {
         let task_cancel_inner = task_cancel.clone();
         let handle = proof_tasks.tasks_mut().spawn(async move {
             task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+            proof_task_success_for_test(signer)
         });
         proof_tasks.pending_mut().insert(
             signer,
@@ -2709,7 +2705,7 @@ mod tests {
         let task_cancel_inner = task_cancel.clone();
         let handle = proof_tasks.tasks_mut().spawn(async move {
             task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+            proof_task_success_for_test(signer)
         });
         proof_tasks.pending_mut().insert(
             signer,
@@ -2839,7 +2835,7 @@ mod tests {
                         let cancel_inner = cancel.clone();
                         let handle = proof_tasks.tasks_mut().spawn(async move {
                             cancel_inner.cancelled().await;
-                            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+                            proof_task_success_for_test(signer)
                         });
                         proof_tasks.pending_mut().insert(
                             signer,
@@ -3049,11 +3045,10 @@ mod tests {
 
         let handle = proof_tasks.tasks_mut().spawn(async move {
             if succeed {
-                proof_task_success_for_test(HARDHAT_ACCOUNT, TEST_PENDING_INSTANCE_ID)
+                proof_task_success_for_test(HARDHAT_ACCOUNT)
             } else {
                 proof_task_failure_for_test(
                     HARDHAT_ACCOUNT,
-                    TEST_PENDING_INSTANCE_ID,
                     RegistrarError::Transaction("synthetic".into()),
                 )
             }
@@ -3079,7 +3074,7 @@ mod tests {
         let cancel_inner = cancel.clone();
         let handle = proof_tasks.tasks_mut().spawn(async move {
             cancel_inner.cancelled().await;
-            proof_task_success_for_test(HARDHAT_ACCOUNT, TEST_PENDING_INSTANCE_ID)
+            proof_task_success_for_test(HARDHAT_ACCOUNT)
         });
         proof_tasks.pending_mut().insert(
             HARDHAT_ACCOUNT,
@@ -3434,9 +3429,8 @@ mod tests {
         // instead simulate the post-overwrite state where the stale
         // entry is gone but its outcome is still in-flight on the
         // JoinSet.
-        let stale_handle = proof_tasks
-            .tasks_mut()
-            .spawn(async move { proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID) });
+        let stale_handle =
+            proof_tasks.tasks_mut().spawn(async move { proof_task_success_for_test(signer) });
         let stale_task_id = stale_handle.id();
 
         // Fresh task: spawn another, register it under `signer` in
@@ -3446,7 +3440,7 @@ mod tests {
         let fresh_cancel_inner = fresh_cancel.clone();
         let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
             fresh_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+            proof_task_success_for_test(signer)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
@@ -3507,7 +3501,6 @@ mod tests {
         let stale_handle = proof_tasks.tasks_mut().spawn(async move {
             proof_task_failure_for_test(
                 signer,
-                TEST_PENDING_INSTANCE_ID,
                 RegistrarError::Config("synthetic stale proof failure".to_string()),
             )
         });
@@ -3519,7 +3512,7 @@ mod tests {
         let fresh_cancel_inner = fresh_cancel.clone();
         let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
             fresh_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
+            proof_task_success_for_test(signer)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -8,16 +8,14 @@
 use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, hex};
-use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
-use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    ProofTaskSet, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient,
-    Result, SignerClient, SignerManager, SignerManagerConfig,
+    ProofTaskSet, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, Result,
+    SignerClient, SignerLifecycle, SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -160,13 +158,12 @@ pub struct ResolveOutcome {
     pub unresolved: bool,
 }
 
-/// Core registration loop tying together discovery, attestation polling,
-/// ZK proof generation, and onchain submission.
+/// Core registration loop tying together discovery, attestation polling, signer
+/// lifecycle reconciliation, and orphan cleanup.
 ///
-/// Generic over the discovery, proof generation, registry, transaction
-/// manager, and signer client backends so each can be mocked independently
-/// in tests.
-pub struct RegistrationDriver<D, P, R, T, S> {
+/// Generic over discovery, signer client, and signer lifecycle backends so each
+/// can be mocked independently in tests.
+pub struct RegistrationDriver<D, S, M> {
     discovery: D,
     signer_client: S,
     config: DriverConfig,
@@ -174,22 +171,20 @@ pub struct RegistrationDriver<D, P, R, T, S> {
     /// time when CRL checking is enabled. `None` when CRL checking is disabled.
     cert_manager: Option<CertManager>,
     /// Signer lifecycle manager for registration tasks and orphan cleanup.
-    signer_manager: Arc<SignerManager<P, R, T>>,
+    signer_manager: M,
 }
 
-impl<D, P, R, T, S> fmt::Debug for RegistrationDriver<D, P, R, T, S> {
+impl<D, S, M> fmt::Debug for RegistrationDriver<D, S, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RegistrationDriver").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
-impl<D, P, R, T, S> RegistrationDriver<D, P, R, T, S>
+impl<D, S, M> RegistrationDriver<D, S, M>
 where
     D: InstanceDiscovery + 'static,
-    P: AttestationProofProvider + 'static,
-    R: RegistryClient + 'static,
-    T: TxManager + 'static,
     S: SignerClient + 'static,
+    M: SignerLifecycle + 'static,
 {
     /// Creates a new registration driver.
     ///
@@ -207,12 +202,10 @@ where
     /// misconfigured driver from silently bypassing CRL protection at runtime.
     pub fn new(
         discovery: D,
-        proof_provider: P,
-        registry: R,
-        tx_manager: T,
         signer_client: S,
         config: DriverConfig,
         nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
+        signer_manager: M,
     ) -> Result<Self> {
         let cert_manager = if config.crl.enabled {
             let Some(nitro_verifier) = nitro_verifier else {
@@ -227,12 +220,6 @@ where
         } else {
             None
         };
-        let signer_manager = Arc::new(SignerManager::new(
-            proof_provider,
-            registry,
-            tx_manager,
-            config.signer_manager.clone(),
-        ));
         Ok(Self { discovery, signer_client, config, cert_manager, signer_manager })
     }
 
@@ -691,20 +678,16 @@ mod tests {
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
     use base_proof_contracts::ITEEProverRegistry;
-    use base_proof_tee_nitro_attestation_prover::AttestationProof;
+    use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
     use hex_literal::hex;
     use k256::ecdsa::SigningKey;
     use rstest::rstest;
-    use tokio::task;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
-    use crate::{
-        InstanceHealthStatus, PendingRegistration, ProofTaskOutcome, RegistryClient, Result,
-        SignerClient,
-    };
+    use crate::{InstanceHealthStatus, RegistryClient, Result, SignerClient, SignerManager};
 
     // ── Shared constants ────────────────────────────────────────────────
 
@@ -1017,23 +1000,56 @@ mod tests {
         }
     }
 
-    /// Stub signer client that is unused by `deregister_orphans` tests.
-    #[derive(Debug)]
-    struct StubSignerClient;
+    /// Driver-level signer lifecycle mock. It records calls without running
+    /// proof generation or registry cleanup, keeping run-loop tests focused on
+    /// driver orchestration.
+    #[derive(Debug, Clone)]
+    struct MockSignerManager {
+        tx: SharedTxManager,
+        reconcile_calls: Arc<AtomicUsize>,
+        orphan_calls: Arc<Mutex<Vec<HashSet<Address>>>>,
+        cancel_after_orphan: CancellationToken,
+    }
 
-    #[async_trait]
-    impl SignerClient for StubSignerClient {
-        async fn signer_public_key(&self, _endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            unimplemented!("not used in deregister_orphans tests")
+    impl MockSignerManager {
+        fn new(tx: SharedTxManager, cancel_after_orphan: CancellationToken) -> Self {
+            Self {
+                tx,
+                reconcile_calls: Arc::new(AtomicUsize::new(0)),
+                orphan_calls: Arc::new(Mutex::new(Vec::new())),
+                cancel_after_orphan,
+            }
         }
 
-        async fn signer_attestation(
+        fn reconcile_count(&self) -> usize {
+            self.reconcile_calls.load(Ordering::SeqCst)
+        }
+
+        fn orphan_inputs(&self) -> Vec<HashSet<Address>> {
+            self.orphan_calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl SignerLifecycle for MockSignerManager {
+        type TransactionManager = SharedTxManager;
+
+        fn tx_manager(&self) -> &Self::TransactionManager {
+            &self.tx
+        }
+
+        fn reconcile_proof_tasks(
             &self,
-            _endpoint: &Url,
-            _user_data: Option<Vec<u8>>,
-            _nonce: Option<Vec<u8>>,
-        ) -> Result<Vec<Vec<u8>>> {
-            unimplemented!("not used in deregister_orphans tests")
+            _resolution: &DiscoveryResolution,
+            _proof_tasks: &mut ProofTaskSet,
+        ) {
+            self.reconcile_calls.fetch_add(1, Ordering::SeqCst);
+        }
+
+        async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
+            self.orphan_calls.lock().unwrap().push(protected_signers.clone());
+            self.cancel_after_orphan.cancel();
+            Ok(())
         }
     }
 
@@ -1060,6 +1076,12 @@ mod tests {
         }
     }
 
+    type CycleDriver = RegistrationDriver<
+        MockDiscovery,
+        MockSignerClient,
+        Arc<SignerManager<StubProofProvider, MockRegistry, SharedTxManager>>,
+    >;
+
     /// Builds a fully-configured driver for primitive-level tests that
     /// invoke `discover_and_resolve` and `run_orphan_dereg` directly
     /// (rather than the spawn pipeline in `run`). Returns an `Arc` so tests
@@ -1070,86 +1092,32 @@ mod tests {
         registry: MockRegistry,
         tx: SharedTxManager,
         cancel: CancellationToken,
-    ) -> Arc<
-        RegistrationDriver<
-            MockDiscovery,
+    ) -> Arc<CycleDriver> {
+        let config = default_config(cancel);
+        let signer_manager = Arc::new(SignerManager::new(
             StubProofProvider,
-            MockRegistry,
-            SharedTxManager,
-            MockSignerClient,
-        >,
-    > {
+            registry,
+            tx,
+            config.signer_manager.clone(),
+        ));
         Arc::new(
             RegistrationDriver::new(
                 MockDiscovery { instances },
-                StubProofProvider,
-                registry,
-                tx,
                 signer_client,
-                default_config(cancel),
+                config,
                 None,
+                signer_manager,
             )
             .expect("test driver construction succeeds"),
         )
     }
 
-    // ── Proof-task mock types ─────────────────────────────────────────
-
-    /// Proof provider that records the `(signer, attestation_bytes)` pair
-    /// passed to every `generate_proof_for_signer` invocation, then
-    /// returns `Err` so the spawned registration task exits without
-    /// reaching the tx-manager send path.
-    ///
-    /// Used by the spawn-pass indexing tests to assert that
-    /// [`SignerManager::reconcile_proof_tasks`] pairs each signer
-    /// with `attestations[idx]` and never with a sibling's blob.
-    #[derive(Debug, Clone, Default)]
-    struct RecordingProofProvider {
-        recorded: Arc<Mutex<HashMap<Address, Vec<u8>>>>,
-    }
-
-    impl RecordingProofProvider {
-        fn snapshot(&self) -> HashMap<Address, Vec<u8>> {
-            self.recorded.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl AttestationProofProvider for RecordingProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            unreachable!(
-                "RecordingProofProvider is only invoked via generate_proof_for_signer; \
-                 reaching generate_proof would mean the driver bypassed signer routing"
-            )
-        }
-
-        async fn generate_proof_for_signer(
-            &self,
-            attestation_bytes: &[u8],
-            signer_address: Address,
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            self.recorded.lock().unwrap().insert(signer_address, attestation_bytes.to_vec());
-            // Returning `Err` short-circuits the spawned task before it reaches
-            // `tx_manager.send()`, which we do not wire for the indexing tests.
-            Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
-                "RecordingProofProvider exits after capturing attestation".into(),
-            ))
-        }
-    }
-
     // ── Pipeline test infrastructure ────────────────────────────────────
     //
-    // Used by the `reconcile_proof_tasks`, `reap_finished_tasks`, and
-    // top-level `run` test suites added in this commit. Designed so the
-    // entire run loop can be driven from a `tokio::test` without real
-    // sleeps: the gated proof provider parks every spawned proof on a
-    // `CancellationToken` that the test releases when it has observed
-    // the behaviour it cares about.
+    // Used by top-level `run` tests. Designed so the entire run loop can be
+    // driven from a `tokio::test` without real sleeps: the gated proof provider
+    // parks every spawned proof on a `CancellationToken` that the test releases
+    // when it has observed the behaviour it cares about.
 
     /// Tightened poll interval for spawn-pipeline tests so we observe
     /// multiple cycles without burning real wall-time.
@@ -1319,10 +1287,8 @@ mod tests {
     /// the pipeline tests.
     type RunDriver = RegistrationDriver<
         MutableDiscovery,
-        GatedProofProvider,
-        MockRegistry,
-        SharedTxManager,
         MockSignerClient,
+        Arc<SignerManager<GatedProofProvider, MockRegistry, SharedTxManager>>,
     >;
 
     /// Bundles every handle a pipeline test needs to drive the loop.
@@ -1351,16 +1317,20 @@ mod tests {
 
             let mut config = default_config(cancel.clone());
             config.poll_interval = GATED_POLL_INTERVAL;
+            let signer_manager = Arc::new(SignerManager::new(
+                proof_provider,
+                registry,
+                tx.clone(),
+                config.signer_manager.clone(),
+            ));
 
             let driver = Arc::new(
                 RegistrationDriver::new(
                     discovery.clone(),
-                    proof_provider,
-                    registry,
-                    tx.clone(),
                     signer_client,
                     config,
                     None,
+                    signer_manager,
                 )
                 .expect("test driver construction succeeds"),
             );
@@ -1415,52 +1385,6 @@ mod tests {
         sent.iter().filter(|c| c.len() >= 4 && c[..4] == sel).count()
     }
 
-    /// Instance ID used by every `PendingRegistration` constructed for
-    /// the reconcile / reap unit tests. The string is opaque — only the
-    /// `Address` keying matters for cancel/spawn logic — but pinning it
-    /// to a single named const keeps test output readable and avoids
-    /// per-test magic strings.
-    const TEST_PENDING_INSTANCE_ID: &str = "i-pending-test";
-
-    /// Cooperative shutdown for any [`JoinSet`] / `pending` pair built
-    /// by a unit test (i.e. without spawning the full `run()` loop).
-    ///
-    /// Fires every per-task cancel token, then `abort_all`s as a
-    /// backstop and drains the `JoinSet` so test teardown doesn't leak
-    /// futures that are forever parked on their tokens. Mirrors the
-    /// production shutdown sequence in [`RegistrationDriver::run`].
-    async fn drain_test_tasks(proof_tasks: &mut ProofTaskSet) {
-        for task in proof_tasks.pending().values() {
-            task.cancel.cancel();
-        }
-        let tasks = proof_tasks.tasks_mut();
-        tasks.abort_all();
-        while tasks.join_next().await.is_some() {}
-        proof_tasks.pending_mut().clear();
-    }
-
-    /// Polling fixed point used by the reap-loop helper below — small
-    /// enough that even on a loaded runner the test still terminates
-    /// well inside [`GATED_WAIT_TIMEOUT`].
-    const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
-
-    /// Repeatedly invokes [`ProofTaskSet::reap_finished_tasks`] until
-    /// `pending` is empty or [`GATED_WAIT_TIMEOUT`] elapses. The
-    /// production loop calls `reap_finished_tasks` exactly once per
-    /// cycle, so unit tests that drive it directly need to give the
-    /// runtime time to schedule the spawned task that they are waiting
-    /// to observe complete.
-    async fn reap_until_pending_empty(proof_tasks: &mut ProofTaskSet) {
-        let started = std::time::Instant::now();
-        while !proof_tasks.is_pending_empty() {
-            if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("timed out reaping {} pending task(s)", proof_tasks.pending_len());
-            }
-            proof_tasks.reap_finished_tasks();
-            tokio::time::sleep(REAP_POLL_INTERVAL).await;
-        }
-    }
-
     /// Builds a [`MockRegistry`] that reports zero registered signers.
     /// Used by every pipeline test that wants the onchain state to
     /// start empty.
@@ -1501,56 +1425,40 @@ mod tests {
         GatedRunHarness::new(initial, &all_keys, empty_registry())
     }
 
-    /// Builds a minimal [`PendingRegistration`] for unit-testing
-    /// reap/apply-outcome flows without spawning a real future. The
-    /// `task_id` is taken from the spawned placeholder's
-    /// `JoinHandle::id()` so join-error handling in
-    /// [`ProofTaskSet::apply_join_outcome`] can recover the
-    /// signer just as it does in production when the pending entry
-    /// is still current.
-    fn pending_registration_for_test(task_id: task::Id, instance_id: &str) -> PendingRegistration {
-        PendingRegistration {
-            instance_id: instance_id.to_string(),
-            task_id,
-            cancel: CancellationToken::new(),
-            cancelled_by_reconcile: false,
-        }
-    }
+    #[tokio::test]
+    async fn run_loop_uses_injected_signer_manager_boundary() {
+        let cancel = CancellationToken::new();
+        let mut config = default_config(cancel.clone());
+        config.poll_interval = GATED_POLL_INTERVAL;
 
-    fn proof_task_success_for_test(signer: Address) -> ProofTaskOutcome {
-        ProofTaskOutcome { signer, result: Ok(()) }
-    }
+        let tx = SharedTxManager::new();
+        let signer_manager = MockSignerManager::new(tx, cancel.clone());
+        let signer_manager_handle = signer_manager.clone();
+        let signer = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0))
+            .expect("test key derives");
 
-    fn proof_task_failure_for_test(signer: Address, error: RegistrarError) -> ProofTaskOutcome {
-        ProofTaskOutcome { signer, result: Err(error) }
-    }
+        let driver = RegistrationDriver::<MockDiscovery, MockSignerClient, MockSignerManager>::new(
+            MockDiscovery { instances: vec![instance(EP1, InstanceHealthStatus::Healthy)] },
+            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
+            config,
+            None,
+            signer_manager,
+        )
+        .expect("test driver construction succeeds");
 
-    /// Builds a synthetic [`DiscoveryResolution`] from a list of
-    /// `(endpoint, key)` pairs we want kept as registerable this
-    /// cycle.
-    fn dr_from_kept(kept: &[(&str, &[u8; 32])]) -> DiscoveryResolution {
-        let mut registerable = Vec::new();
-        let mut active_signers = HashSet::new();
-        for (ep, key) in kept {
-            let inst = instance(ep, InstanceHealthStatus::Healthy);
-            let addr = ProverClient::derive_address(&public_key_from_private(key)).unwrap();
-            active_signers.insert(addr);
-            registerable.push(RegisterableSigner {
-                instance: inst,
-                signer: addr,
-                attestation: b"gated-attestation".to_vec(),
-                enclave_index: 0,
-            });
-        }
-        let total = kept.len();
-        DiscoveryResolution {
-            registerable,
-            active_signers,
-            reachable_count: total,
-            total_count: total,
-            ok_to_dereg: true,
-            unresolved_instance_ids: HashSet::new(),
-        }
+        driver.run_loop().await.expect("driver exits after mock orphan pass cancels");
+
+        assert_eq!(
+            signer_manager_handle.reconcile_count(),
+            1,
+            "driver should delegate registerable reconciliation to signer manager",
+        );
+        let orphan_inputs = signer_manager_handle.orphan_inputs();
+        assert_eq!(orphan_inputs.len(), 1, "driver should delegate one orphan pass");
+        assert!(
+            orphan_inputs[0].contains(&signer),
+            "driver passes active signer set into orphan protection",
+        );
     }
 
     #[tokio::test]
@@ -1602,25 +1510,13 @@ mod tests {
 
     // ── discover_and_resolve + run_orphan_dereg tests ──────────────────
 
-    /// When discovery returns zero instances the active set is empty, so
-    /// every onchain signer is an orphan and must be deregistered.
-    /// Verifies both that `discover_and_resolve` flips `ok_to_dereg` to
-    /// `true` for the legitimate zero-instance case and that
-    /// `run_orphan_dereg` emits a deregistration tx per onchain signer.
-    #[rstest]
-    #[case::single_orphan(vec![ORPHAN_A])]
-    #[case::multiple_orphans(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C])]
     #[tokio::test]
-    async fn run_orphan_dereg_deregisters_all_onchain_signers_when_discovery_is_empty(
-        #[case] orphans: Vec<Address>,
-    ) {
-        let expected_count = orphans.len();
-        let tx = SharedTxManager::new();
+    async fn discover_and_resolve_allows_orphan_pass_when_discovery_is_empty() {
         let driver = cycle_driver(
-            vec![], // no discovered instances
+            vec![],
             MockSignerClient::from_keys(&[]),
-            MockRegistry::with_signers(orphans.clone()),
-            tx.clone(),
+            MockRegistry::with_signers(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C]),
+            SharedTxManager::new(),
             CancellationToken::new(),
         );
 
@@ -1630,20 +1526,6 @@ mod tests {
             resolution.ok_to_dereg,
             "zero-instance fleet drain is a legitimate empty active set",
         );
-
-        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
-
-        let sent = tx.sent_calldata();
-        assert_eq!(sent.len(), expected_count, "all onchain signers should be deregistered");
-
-        // Verify each deregistration targets the correct signer.
-        for orphan in orphans {
-            let expected = ITEEProverRegistry::deregisterSignerCall { signer: orphan }.abi_encode();
-            assert!(
-                sent.iter().any(|s| s[..] == expected[..]),
-                "expected deregistration of {orphan}"
-            );
-        }
     }
 
     #[tokio::test]
@@ -1937,16 +1819,21 @@ mod tests {
             inner: MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
             cancel: cancel.clone(),
         };
+        let config = default_config(cancel);
+        let signer_manager = Arc::new(SignerManager::new(
+            StubProofProvider,
+            MockRegistry::all_registered(vec![ORPHAN_E]),
+            tx.clone(),
+            config.signer_manager.clone(),
+        ));
 
         let driver = Arc::new(
             RegistrationDriver::new(
                 MockDiscovery { instances },
-                StubProofProvider,
-                MockRegistry::all_registered(vec![ORPHAN_E]),
-                tx.clone(),
                 signer_client,
-                default_config(cancel),
+                config,
                 None,
+                signer_manager,
             )
             .expect("test driver construction succeeds"),
         );
@@ -2167,15 +2054,20 @@ mod tests {
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
 
         let tx = SharedTxManager::new();
+        let config = default_config(CancellationToken::new());
+        let signer_manager = Arc::new(SignerManager::new(
+            FailingProofProvider,
+            MockRegistry::with_signers(vec![signer_addr]),
+            tx.clone(),
+            config.signer_manager.clone(),
+        ));
         let driver = Arc::new(
             RegistrationDriver::new(
                 MockDiscovery { instances },
-                FailingProofProvider,
-                MockRegistry::with_signers(vec![signer_addr]),
-                tx.clone(),
                 signer_client,
-                default_config(CancellationToken::new()),
+                config,
                 None,
+                signer_manager,
             )
             .expect("test driver construction succeeds"),
         );
@@ -2266,16 +2158,20 @@ mod tests {
         let tx = SharedTxManager::new();
         let mut config = default_config(cancel);
         config.signer_manager.max_concurrency = max_concurrency;
+        let signer_manager = Arc::new(SignerManager::new(
+            StubProofProvider,
+            MockRegistry::with_signers(vec![]),
+            tx.clone(),
+            config.signer_manager.clone(),
+        ));
 
         let driver = Arc::new(
             RegistrationDriver::new(
                 MockDiscovery { instances },
-                StubProofProvider,
-                MockRegistry::with_signers(vec![]),
-                tx.clone(),
                 signer_client,
                 config,
                 None,
+                signer_manager,
             )
             .expect("test driver construction succeeds"),
         );
@@ -2294,796 +2190,6 @@ mod tests {
         );
         // Resolution itself emits no onchain tx — the spawn pass owns registration.
         assert!(tx.sent_calldata().is_empty(), "discover_and_resolve must not send txs");
-    }
-
-    // ── cancel-aware registry await tests ──────────────────────────────
-    //
-    // `get_registered_signers` in `run_orphan_dereg` is wrapped in
-    // `select!` against the driver cancel token so a shutdown during the
-    // RPC drops the call immediately. Proof-handler-owned registry awaits
-    // are covered in `proof_handler::tests`.
-
-    /// Per-call stall registry: parks the configured method on a
-    /// never-completing future. Used to assert that the `select!`
-    /// wrapper in `run_orphan_dereg` short-circuits on cancel instead of
-    /// blocking on the RPC.
-    struct StallingRegistry {
-        signers: Vec<Address>,
-    }
-
-    impl StallingRegistry {
-        fn stalling_get_registered_signers(signers: Vec<Address>) -> Self {
-            Self { signers }
-        }
-    }
-
-    #[async_trait]
-    impl RegistryClient for StallingRegistry {
-        async fn is_registered(&self, _signer: Address) -> Result<bool> {
-            Ok(false)
-        }
-
-        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            std::future::pending::<()>().await;
-            Ok(self.signers.clone())
-        }
-    }
-
-    /// Upper bound on how long a cancel must take to abort an in-flight
-    /// registry RPC. Generous enough to absorb CI jitter while still
-    /// failing fast on a regression (without the `select!` wrapper the
-    /// test would hang until the [`tokio::time::timeout`] backstop
-    /// fires, far above this bound).
-    const CANCEL_ABORT_BUDGET: Duration = Duration::from_secs(1);
-
-    /// Soft window the test sleeps between spawning the call-under-test
-    /// and firing the cancel token. Long enough that the spawned future
-    /// reaches its `is_registered` await point, short enough that the
-    /// total test time stays well under [`CANCEL_ABORT_BUDGET`].
-    const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
-
-    /// `run_orphan_dereg` MUST abort promptly when the configured cancel
-    /// token fires during the `get_registered_signers` RPC. Without the
-    /// `select!` wrap a stalled RPC here would extend drain latency by one
-    /// round-trip even though the function never reaches the per-orphan loop
-    /// that has its own cancel check.
-    #[tokio::test]
-    async fn run_orphan_dereg_aborts_promptly_when_cancel_fires_during_registry_stall() {
-        let cancel = CancellationToken::new();
-        let driver = Arc::new(
-            RegistrationDriver::new(
-                MockDiscovery { instances: vec![] },
-                StubProofProvider,
-                StallingRegistry::stalling_get_registered_signers(vec![]),
-                SharedTxManager::new(),
-                StubSignerClient,
-                default_config(cancel.clone()),
-                None,
-            )
-            .expect("driver constructs"),
-        );
-
-        let driver_clone = Arc::clone(&driver);
-        let cancel_clone = cancel.clone();
-        let handle = tokio::spawn(async move {
-            let active: HashSet<Address> = HashSet::new();
-            let start = tokio::time::Instant::now();
-            let res = driver_clone.signer_manager.run_orphan_dereg(&active).await;
-            (res, start.elapsed(), cancel_clone)
-        });
-
-        tokio::time::sleep(PRE_CANCEL_WARMUP).await;
-        cancel.cancel();
-
-        let (result, elapsed, _alive) = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
-            .await
-            .expect("run_orphan_dereg must not hang past the timeout")
-            .expect("spawned task must not panic");
-
-        assert!(result.is_ok(), "cancel-induced exit must be Ok(()): {result:?}");
-        assert!(
-            elapsed < CANCEL_ABORT_BUDGET,
-            "cancel must abort the registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
-        );
-    }
-
-    // ── reconcile_proof_tasks tests ─────────────────────────────────────
-    //
-    // These unit-tests exercise the spawn / cancel decisions without
-    // spinning up the run loop. They build a synthetic
-    // `DiscoveryResolution` via `dr_from_kept` and a hand-rolled
-    // `pending` map, then assert exactly which tasks get cancelled
-    // and which get spawned.
-
-    #[rstest]
-    #[case::no_pending_spawns_all(&[], &[(EP1, &HARDHAT_KEY_0)], 1, 0)]
-    #[case::pending_for_kept_spawns_nothing(&[(EP1, &HARDHAT_KEY_0)], &[(EP1, &HARDHAT_KEY_0)], 0, 0)]
-    #[case::pending_for_dropped_cancels_one(&[(EP1, &HARDHAT_KEY_0)], &[], 0, 1)]
-    #[case::pending_one_kept_one_dropped(
-        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
-        &[(EP1, &HARDHAT_KEY_0)],
-        0,
-        1,
-    )]
-    #[case::two_new_signers_two_spawns(
-        &[],
-        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
-        2,
-        0,
-    )]
-    #[tokio::test]
-    async fn reconcile_proof_tasks_cancel_and_spawn_passes(
-        #[case] pre_existing: &[(&'static str, &'static [u8; 32])],
-        #[case] kept: &[(&'static str, &'static [u8; 32])],
-        #[case] expected_new_spawns: usize,
-        #[case] expected_cancels: usize,
-    ) {
-        let harness = single_healthy_harness();
-        let mut proof_tasks = ProofTaskSet::new();
-
-        // Seed the pending map by spawning placeholder tasks for the
-        // pre-existing signers. These futures park on their per-task
-        // cancel token so cooperative cancellation is observable.
-        let mut seeded_cancels: Vec<CancellationToken> = Vec::new();
-        for (_, key) in pre_existing {
-            let signer = ProverClient::derive_address(&public_key_from_private(key)).unwrap();
-            let task_cancel = CancellationToken::new();
-            let task_cancel_inner = task_cancel.clone();
-            let handle = proof_tasks.tasks_mut().spawn(async move {
-                task_cancel_inner.cancelled().await;
-                proof_task_success_for_test(signer)
-            });
-            proof_tasks.pending_mut().insert(
-                signer,
-                PendingRegistration {
-                    instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                    task_id: handle.id(),
-                    cancel: task_cancel.clone(),
-                    cancelled_by_reconcile: false,
-                },
-            );
-            seeded_cancels.push(task_cancel);
-        }
-
-        let resolution = dr_from_kept(kept);
-        let pre_spawn_count = proof_tasks.pending_len();
-        let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
-
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
-
-        let post_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
-        let new_spawns = proof_tasks.pending_len().saturating_sub(pre_spawn_count);
-
-        assert_eq!(new_spawns, expected_new_spawns, "spawn-pass count");
-        assert_eq!(post_cancelled - pre_cancelled, expected_cancels, "cancel-pass count");
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    #[tokio::test]
-    async fn reconcile_proof_tasks_idempotent_when_resolution_unchanged() {
-        // Running reconcile twice with the same resolution must not
-        // spawn duplicate tasks or cancel an already-pending one.
-        let harness = single_healthy_harness();
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
-
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
-        let after_first = proof_tasks.pending_len();
-        let snapshot_ids: HashSet<_> = proof_tasks.pending().keys().copied().collect();
-
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
-
-        assert_eq!(proof_tasks.pending_len(), after_first, "idempotent: no extra spawns");
-        let after_second: HashSet<_> = proof_tasks.pending().keys().copied().collect();
-        assert_eq!(snapshot_ids, after_second, "pending signer keys unchanged across reconciles");
-        for task in proof_tasks.pending().values() {
-            assert!(!task.cancel.is_cancelled(), "kept task must not be cancelled");
-        }
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    /// Vanish-then-reappear: a signer cancelled in cycle N (because it
-    /// dropped from `registerable`) and then re-added in cycle N+1 must
-    /// spawn a fresh task in N+1 — the cancelled `pending` entry must
-    /// not block the respawn. Exercises the
-    /// `filter(|t| !t.cancel.is_cancelled())` on the `in_flight` build,
-    /// which is what enables single-cycle rolling-deploy convergence
-    /// instead of a 2-cycle (~60s at 30s poll) latency.
-    ///
-    /// With the address-keyed `pending` map (one entry per signer at
-    /// most), the fresh spawn-pass entry OVERWRITES the stale entry in
-    /// place. The stale task itself stays in the `JoinSet` until it
-    /// observes its cancel and exits; `apply_join_outcome`'s
-    /// `task_id`-match guard then prevents the stale task's terminal
-    /// outcome from evicting the fresh entry — that guard is exercised
-    /// indirectly via the `task_id` assertion below.
-    #[tokio::test]
-    async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
-        let harness = single_healthy_harness();
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-
-        // Cycle N: seed pending with a placeholder task for the signer.
-        // The placeholder parks on its cancel token so cooperative
-        // cancellation is observable without the task self-resolving.
-        let stale_cancel = CancellationToken::new();
-        let stale_cancel_inner = stale_cancel.clone();
-        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
-            stale_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        let stale_task_id = stale_handle.id();
-        proof_tasks.pending_mut().insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: stale_task_id,
-                cancel: stale_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        // Cycle N+1: signer absent from resolution → cancel-pass fires
-        // but does not reap, so the (now cancelled) entry persists in
-        // `pending` keyed by `signer`.
-        let empty = dr_from_kept(&[]);
-        harness.driver.signer_manager.reconcile_proof_tasks(&empty, &mut proof_tasks);
-        assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
-        assert_eq!(
-            proof_tasks.pending().get(&signer).map(|p| p.task_id),
-            Some(stale_task_id),
-            "cancelled entry still keyed by signer until reaped",
-        );
-        assert_eq!(
-            proof_tasks.pending_len(),
-            1,
-            "no fresh spawn yet (signer not registerable this cycle)"
-        );
-
-        // Cycle N+2 (BEFORE the stale entry is reaped): signer reappears
-        // → fresh spawn must happen this cycle, not deferred to N+3. The
-        // fresh entry overwrites the stale one in the address-keyed map;
-        // the stale task lives on in the JoinSet (parked on its cancel
-        // until drain).
-        let resurrected = dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]);
-        harness.driver.signer_manager.reconcile_proof_tasks(&resurrected, &mut proof_tasks);
-
-        assert_eq!(
-            proof_tasks.pending_len(),
-            1,
-            "still exactly one entry per signer after respawn"
-        );
-        let fresh = proof_tasks
-            .pending()
-            .get(&signer)
-            .expect("fresh entry keyed by the resurrected signer");
-        assert_ne!(fresh.task_id, stale_task_id, "fresh task_id replaces the stale one");
-        assert!(!fresh.cancel.is_cancelled(), "fresh task carries a live cancel token");
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    /// Inconclusive-snapshot guard: when a signer's source instance
-    /// failed to resolve this cycle (its `instance_id` is recorded in
-    /// `DiscoveryResolution::unresolved_instance_ids`), reconcile MUST
-    /// NOT cancel that signer's in-flight proof task — the signer is
-    /// absent from `registerable` only because we couldn't tell this
-    /// cycle, not because we proved it's gone or ineligible. Without
-    /// this guard a single transient `signer_public_key` /
-    /// `signer_attestation` / CRL hiccup during a long (~70 min)
-    /// Boundless proof would abandon the in-flight work.
-    #[tokio::test]
-    async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
-        let harness = single_healthy_harness();
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-
-        // Seed pending with a placeholder task for the signer, tagged
-        // with the instance_id we'll later mark as unresolved.
-        let task_cancel = CancellationToken::new();
-        let task_cancel_inner = task_cancel.clone();
-        let handle = proof_tasks.tasks_mut().spawn(async move {
-            task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        proof_tasks.pending_mut().insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: handle.id(),
-                cancel: task_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        // Build a resolution where the signer is absent from
-        // `registerable` (so `wanted` is empty) BUT the source
-        // instance is flagged as unresolved this cycle.
-        let mut unresolved = HashSet::new();
-        unresolved.insert(TEST_PENDING_INSTANCE_ID.to_string());
-        let resolution = DiscoveryResolution {
-            registerable: Vec::new(),
-            active_signers: HashSet::new(),
-            reachable_count: 0,
-            total_count: 1,
-            ok_to_dereg: false,
-            unresolved_instance_ids: unresolved,
-        };
-
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
-
-        assert!(
-            !task_cancel.is_cancelled(),
-            "task tied to an unresolved instance must be preserved across the cancel-pass",
-        );
-        assert_eq!(proof_tasks.pending_len(), 1, "no spurious spawn or eviction this cycle");
-
-        // Sanity contrast: same setup, but the instance is NOT
-        // unresolved → cancel-pass MUST fire. Asserts the previous
-        // arm's success was due to the guard, not unrelated logic.
-        let resolution_conclusive = DiscoveryResolution {
-            registerable: Vec::new(),
-            active_signers: HashSet::new(),
-            reachable_count: 1,
-            total_count: 1,
-            ok_to_dereg: true,
-            unresolved_instance_ids: HashSet::new(),
-        };
-        harness
-            .driver
-            .signer_manager
-            .reconcile_proof_tasks(&resolution_conclusive, &mut proof_tasks);
-        assert!(
-            task_cancel.is_cancelled(),
-            "with no inconclusive guard, the cancel-pass MUST fire on the same setup",
-        );
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    /// Orphan-dereg companion to
-    /// [`reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve`].
-    ///
-    /// When `resolve_instance` fails transiently for an instance whose
-    /// proof task is still in-flight, the signer is **absent from**
-    /// `resolution.active_signers` (no fresh evidence this cycle) but
-    /// is **present in** `pending` (reconcile preserves the task via
-    /// `unresolved_instance_ids`). If the preserved task succeeds and
-    /// registers the signer onchain right as the orphan-dereg pass
-    /// runs, the protected set assembled by
-    /// [`ProofTaskSet::protected_signers`] MUST union the two, otherwise
-    /// the very next call to `deregister_orphans` would deregister the
-    /// freshly-registered signer (TOCTOU race).
-    #[tokio::test]
-    async fn protected_signers_union_blocks_dereg_of_freshly_registered_signer() {
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-
-        // Registry reports the signer as already registered onchain —
-        // the state that exists immediately after the preserved task's
-        // `registerSigner` tx confirms.
-        let harness = GatedRunHarness::new(
-            vec![instance(EP1, InstanceHealthStatus::Healthy)],
-            &[(EP1, &HARDHAT_KEY_0)],
-            MockRegistry::with_signers(vec![signer]),
-        );
-
-        // Seed `pending` with an entry for the signer tied to an
-        // instance that is "unresolved" this cycle. Address-keying
-        // alone is what `protected_signers` consumes; the placeholder
-        // task is just there so cleanup runs through the same path the
-        // production loop does.
-        let mut proof_tasks = ProofTaskSet::new();
-        let task_cancel = CancellationToken::new();
-        let task_cancel_inner = task_cancel.clone();
-        let handle = proof_tasks.tasks_mut().spawn(async move {
-            task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        proof_tasks.pending_mut().insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: handle.id(),
-                cancel: task_cancel,
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        // `active_signers` is empty (the signer's source instance
-        // failed to resolve this cycle) but `ok_to_dereg` is true so
-        // the orphan pass would otherwise run unimpeded.
-        let mut unresolved = HashSet::new();
-        unresolved.insert(TEST_PENDING_INSTANCE_ID.to_string());
-        let resolution = DiscoveryResolution {
-            registerable: Vec::new(),
-            active_signers: HashSet::new(),
-            reachable_count: 1,
-            total_count: 1,
-            ok_to_dereg: true,
-            unresolved_instance_ids: unresolved,
-        };
-
-        let protected = proof_tasks.protected_signers(&resolution);
-        assert!(
-            protected.contains(&signer),
-            "protected set must include in-flight signer even when absent from active_signers",
-        );
-
-        harness.driver.signer_manager.run_orphan_dereg(&protected).await.unwrap();
-
-        let sent = harness.tx.sent_calldata();
-        assert_eq!(
-            count_deregister_calls(&sent),
-            0,
-            "orphan pass must NOT deregister a signer with an in-flight proof task",
-        );
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    /// Sanity contrast for
-    /// [`protected_signers_union_blocks_dereg_of_freshly_registered_signer`]:
-    /// with `pending` empty and the same onchain state, the orphan
-    /// pass MUST deregister the signer. Proves the previous test's
-    /// success was due to the union, not unrelated logic.
-    #[tokio::test]
-    async fn protected_signers_union_does_not_shield_when_pending_empty() {
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let harness = GatedRunHarness::new(
-            vec![instance(EP1, InstanceHealthStatus::Healthy)],
-            &[(EP1, &HARDHAT_KEY_0)],
-            MockRegistry::with_signers(vec![signer]),
-        );
-
-        let proof_tasks = ProofTaskSet::new();
-        let resolution = DiscoveryResolution {
-            registerable: Vec::new(),
-            active_signers: HashSet::new(),
-            reachable_count: 1,
-            total_count: 1,
-            ok_to_dereg: true,
-            unresolved_instance_ids: HashSet::new(),
-        };
-
-        let protected = proof_tasks.protected_signers(&resolution);
-        assert!(protected.is_empty(), "no pending → protected set is empty");
-
-        harness.driver.signer_manager.run_orphan_dereg(&protected).await.unwrap();
-
-        let sent = harness.tx.sent_calldata();
-        assert_eq!(
-            count_deregister_calls(&sent),
-            1,
-            "with no in-flight task and no active signer, orphan pass MUST deregister",
-        );
-    }
-
-    // ── drain_proof_tasks metric-gating test ────────────────────────────
-
-    /// At shutdown, [`ProofTaskSet::drain_proof_tasks`] MUST count
-    /// only the tasks whose cancellation it actually drives — tasks
-    /// already cancelled by a prior
-    /// [`SignerManager::reconcile_proof_tasks`] cancel-pass were
-    /// counted at intent time and double-counting them in the drain pass
-    /// would inflate the `proof_tasks_cancelled` counter. The gate uses
-    /// the `cancelled_by_reconcile` flag (not
-    /// `cancel.is_cancelled()`) because every per-task `signer_cancel`
-    /// is a child of `DriverConfig::cancel`, so by the time drain runs
-    /// the parent has already auto-cancelled every child token and
-    /// `is_cancelled()` no longer distinguishes the two cases.
-    ///
-    /// This test wires a real prometheus recorder via
-    /// [`metrics::with_local_recorder`], seeds three pending tasks (one
-    /// pre-flagged as `cancelled_by_reconcile = true`, two not), drains,
-    /// and asserts the counter increment equals exactly the unflagged
-    /// count.
-    #[cfg(feature = "metrics")]
-    mod drain_metric_tests {
-        use metrics_exporter_prometheus::PrometheusBuilder;
-
-        use super::*;
-
-        #[test]
-        fn drain_counts_only_tasks_not_already_cancelled_by_reconcile() {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-            let recorder = PrometheusBuilder::new().build_recorder();
-            let handle = recorder.handle();
-
-            metrics::with_local_recorder(&recorder, || {
-                rt.block_on(async {
-                    let mut proof_tasks = ProofTaskSet::new();
-
-                    // Seed: (key, was_flagged_by_reconcile). The flagged
-                    // task must NOT re-count at drain; the two unflagged
-                    // ones must count exactly once each.
-                    let seed: &[(&[u8; 32], bool)] =
-                        &[(&HARDHAT_KEY_0, true), (&HARDHAT_KEY_1, false), (&HARDHAT_KEY_2, false)];
-
-                    for (key, flagged) in seed {
-                        let signer =
-                            ProverClient::derive_address(&public_key_from_private(key)).unwrap();
-                        let cancel = CancellationToken::new();
-                        let cancel_inner = cancel.clone();
-                        let handle = proof_tasks.tasks_mut().spawn(async move {
-                            cancel_inner.cancelled().await;
-                            proof_task_success_for_test(signer)
-                        });
-                        proof_tasks.pending_mut().insert(
-                            signer,
-                            PendingRegistration {
-                                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                                task_id: handle.id(),
-                                cancel: cancel.clone(),
-                                cancelled_by_reconcile: *flagged,
-                            },
-                        );
-                        // Simulate the reconcile cancel-pass having
-                        // already fired for the flagged entry — this is
-                        // the precise state drain encounters at
-                        // shutdown for tasks reconcile already counted.
-                        if *flagged {
-                            cancel.cancel();
-                        }
-                    }
-
-                    proof_tasks.drain_proof_tasks().await;
-                });
-            });
-
-            let rendered = handle.render();
-            assert!(
-                rendered.contains("base_registrar_proof_tasks_cancelled 2"),
-                "drain must count only the unflagged tasks once each (expected 2); \
-                 double-count would render `3`, miscount `1`. Got:\n{rendered}",
-            );
-        }
-    }
-
-    // ── reconcile_proof_tasks: dedupe + indexing tests ─────────────────
-
-    /// Driver specialisation used by the spawn-pass indexing tests so a
-    /// [`RecordingProofProvider`] can capture the `(signer, attestation)`
-    /// pairs handed to each spawned task.
-    type RecordingDriver = RegistrationDriver<
-        MockDiscovery,
-        RecordingProofProvider,
-        MockRegistry,
-        SharedTxManager,
-        MockSignerClient,
-    >;
-
-    /// Builds a driver suitable for direct `reconcile_proof_tasks`
-    /// invocation: the registry reports no signers as registered (so
-    /// each task reaches the proof step), and the proof provider
-    /// records and exits.
-    fn recording_driver(
-        keys: &[(&str, &[u8; 32])],
-        proof_provider: RecordingProofProvider,
-    ) -> Arc<RecordingDriver> {
-        Arc::new(
-            RegistrationDriver::new(
-                MockDiscovery { instances: vec![] },
-                proof_provider,
-                MockRegistry::with_signers(vec![]),
-                SharedTxManager::new(),
-                MockSignerClient::from_keys(keys),
-                default_config(CancellationToken::new()),
-                None,
-            )
-            .expect("recording driver constructs cleanly"),
-        )
-    }
-
-    #[tokio::test]
-    async fn reconcile_proof_tasks_dedupes_signer_across_registerable_entries() {
-        // Two `RegisterableSigner` entries report the SAME signer
-        // address (misconfig: two prover instances were provisioned
-        // with identical enclave keys). The spawn pass must only
-        // spawn one task — duplicating would later trigger two
-        // `tx_manager.send()` calls for the same signer and waste
-        // nonces.
-        let proof_provider = RecordingProofProvider::default();
-        let driver = recording_driver(
-            &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_0)],
-            proof_provider.clone(),
-        );
-
-        // Both entries carry the same derived address but different
-        // attestation bytes so an accidental second spawn would be
-        // visible as a stale-attestation race in `recorded`.
-        let signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let entry_a = RegisterableSigner {
-            instance: instance(EP1, InstanceHealthStatus::Healthy),
-            signer,
-            attestation: b"attestation-from-instance-a".to_vec(),
-            enclave_index: 0,
-        };
-        let entry_b = RegisterableSigner {
-            instance: instance(EP2, InstanceHealthStatus::Healthy),
-            signer,
-            attestation: b"attestation-from-instance-b".to_vec(),
-            enclave_index: 0,
-        };
-        let resolution = DiscoveryResolution {
-            registerable: vec![entry_a, entry_b],
-            active_signers: HashSet::from([signer]),
-            reachable_count: 2,
-            total_count: 2,
-            ok_to_dereg: false,
-            unresolved_instance_ids: HashSet::new(),
-        };
-
-        let mut proof_tasks = ProofTaskSet::new();
-
-        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
-
-        assert_eq!(
-            proof_tasks.pending_len(),
-            1,
-            "exactly one task should spawn for a duplicate signer"
-        );
-        let (&only_signer, _entry) = proof_tasks.pending().iter().next().unwrap();
-        assert_eq!(only_signer, signer, "the spawned task is keyed by the deduplicated signer");
-
-        // Let the single task run, record its attestation, and exit.
-        wait_for("the lone spawned task recorded its attestation", || {
-            !proof_provider.snapshot().is_empty()
-        })
-        .await;
-        drain_test_tasks(&mut proof_tasks).await;
-
-        let snap = proof_provider.snapshot();
-        assert_eq!(snap.len(), 1, "exactly one signer recorded across both entries");
-    }
-
-    #[rstest]
-    #[case::forward_order(false)]
-    #[case::reversed_order(true)]
-    #[tokio::test]
-    async fn reconcile_proof_tasks_pairs_attestation_with_signer(#[case] reverse: bool) {
-        // After the flatten in `discover_and_resolve`, each
-        // `RegisterableSigner` carries its own `(signer, attestation)`
-        // pair, so mispairing via the old `attestations[idx]` indexing
-        // bug class is structurally impossible. This test asserts the
-        // spawn pass forwards each entry's `signer` and `attestation`
-        // consistently — regardless of the order entries appear in the
-        // registerable vector — by recording the attestation the
-        // provider received per signer.
-        let signer_a =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let signer_b =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_1)).unwrap();
-        assert_ne!(signer_a, signer_b, "test setup: distinct signer addresses");
-
-        let att_a: Vec<u8> = b"attestation-aligned-to-A".to_vec();
-        let att_b: Vec<u8> = b"attestation-aligned-to-B".to_vec();
-
-        let entry_a = RegisterableSigner {
-            instance: instance(EP1, InstanceHealthStatus::Healthy),
-            signer: signer_a,
-            attestation: att_a.clone(),
-            enclave_index: 0,
-        };
-        let entry_b = RegisterableSigner {
-            instance: instance(EP2, InstanceHealthStatus::Healthy),
-            signer: signer_b,
-            attestation: att_b.clone(),
-            enclave_index: 0,
-        };
-        let registerable = if reverse { vec![entry_b, entry_a] } else { vec![entry_a, entry_b] };
-
-        let proof_provider = RecordingProofProvider::default();
-        let driver = recording_driver(
-            &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
-            proof_provider.clone(),
-        );
-
-        let resolution = DiscoveryResolution {
-            registerable,
-            active_signers: HashSet::from([signer_a, signer_b]),
-            reachable_count: 2,
-            total_count: 2,
-            ok_to_dereg: false,
-            unresolved_instance_ids: HashSet::new(),
-        };
-
-        let mut proof_tasks = ProofTaskSet::new();
-
-        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
-
-        wait_for("both signers recorded their attestations", || {
-            proof_provider.snapshot().len() == 2
-        })
-        .await;
-        drain_test_tasks(&mut proof_tasks).await;
-
-        let snap = proof_provider.snapshot();
-        assert_eq!(snap.get(&signer_a), Some(&att_a), "signer A got the A-aligned attestation");
-        assert_eq!(snap.get(&signer_b), Some(&att_b), "signer B got the B-aligned attestation");
-    }
-
-    // ── reap_finished_tasks + apply_join_outcome tests ─────────────────
-
-    #[rstest]
-    #[case::ok_outcome(true)]
-    #[case::err_outcome(false)]
-    #[tokio::test]
-    async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
-        // Spawn one task that completes immediately; reap_finished_tasks
-        // must remove it from `pending` regardless of inner success.
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let handle = proof_tasks.tasks_mut().spawn(async move {
-            if succeed {
-                proof_task_success_for_test(HARDHAT_ACCOUNT)
-            } else {
-                proof_task_failure_for_test(
-                    HARDHAT_ACCOUNT,
-                    RegistrarError::Transaction("synthetic".into()),
-                )
-            }
-        });
-        proof_tasks.pending_mut().insert(
-            HARDHAT_ACCOUNT,
-            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
-        );
-
-        reap_until_pending_empty(&mut proof_tasks).await;
-
-        assert!(proof_tasks.is_pending_empty(), "completed task must be evicted from pending");
-        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
-    }
-
-    #[tokio::test]
-    async fn reap_finished_tasks_leaves_in_flight_alone() {
-        // A task that never completes must remain in `pending` after
-        // `reap_finished_tasks` is called (it is non-blocking).
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let cancel = CancellationToken::new();
-        let cancel_inner = cancel.clone();
-        let handle = proof_tasks.tasks_mut().spawn(async move {
-            cancel_inner.cancelled().await;
-            proof_task_success_for_test(HARDHAT_ACCOUNT)
-        });
-        proof_tasks.pending_mut().insert(
-            HARDHAT_ACCOUNT,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: handle.id(),
-                cancel,
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        proof_tasks.reap_finished_tasks();
-
-        assert_eq!(proof_tasks.pending_len(), 1, "live task must remain in pending");
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    #[tokio::test]
-    async fn reap_finished_tasks_is_noop_when_pending_is_empty() {
-        // Sanity: the production loop calls `reap_finished_tasks` every
-        // cycle, including cycles with no pending work. It must not
-        // panic in that case.
-        let mut proof_tasks = ProofTaskSet::new();
-
-        proof_tasks.reap_finished_tasks();
-
-        assert!(proof_tasks.is_pending_empty(), "pending stays empty");
-        assert!(proof_tasks.is_join_set_empty(), "JoinSet stays empty");
     }
 
     // ── run() spawn-and-reap pipeline tests ─────────────────────────────
@@ -3356,178 +2462,7 @@ mod tests {
         assert_eq!(count_register_calls(&sent), 0, "no registration submitted at shutdown");
     }
 
-    // ── apply_join_outcome + run() additional coverage ──────────────────
-    //
-    // These cover three gaps left after the initial spawn-and-reap test
-    // suite: the panic arm of [`apply_join_outcome`], the proof-failure
-    // path through the registration manager, and a single cycle that
-    // fires both the registration and orphan-dereg passes.
-
-    #[tokio::test]
-    async fn apply_join_outcome_drops_pending_entry_when_task_panics() {
-        // The `Err(JoinError)` arm of `apply_join_outcome` must still
-        // remove the panicked task from `pending`. With the address-
-        // keyed map and the panic path losing the task's return value,
-        // the recovery routes through the task-id scan over `pending`
-        // to map `JoinError::id()` back to the signer address. The
-        // per-task cancel handle is dropped and the proof-task-completed
-        // metric still fires. The full reap path is exercised so this
-        // is also a coverage test for `reap_finished_tasks` routing the
-        // `JoinError` correctly.
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let handle = proof_tasks.tasks_mut().spawn(async {
-            panic!("synthetic proof-task panic for apply_join_outcome test");
-        });
-        proof_tasks.pending_mut().insert(
-            HARDHAT_ACCOUNT,
-            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
-        );
-
-        reap_until_pending_empty(&mut proof_tasks).await;
-
-        assert!(proof_tasks.is_pending_empty(), "panicked task must be evicted from pending");
-        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
-    }
-
-    /// Address-keyed cleanup safety: a stale task whose `pending` entry
-    /// was overwritten by a same-cycle respawn for the same signer
-    /// must NOT evict the fresh entry when its terminal success outcome
-    /// flows through [`ProofTaskSet::apply_join_outcome`]. The
-    /// `task_id`-match guard in the success arm is the protection — a
-    /// stale completion without the guard would leak the fresh task
-    /// from `pending` (orphaning its cancel handle) and corrupt
-    /// shutdown bookkeeping.
-    #[tokio::test]
-    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_completes_for_same_signer() {
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let signer = HARDHAT_ACCOUNT;
-
-        // Stale task: spawn one that returns immediately. Capture its
-        // task_id but DO NOT insert it into `pending` keyed by signer —
-        // instead simulate the post-overwrite state where the stale
-        // entry is gone but its outcome is still in-flight on the
-        // JoinSet.
-        let stale_handle =
-            proof_tasks.tasks_mut().spawn(async move { proof_task_success_for_test(signer) });
-        let stale_task_id = stale_handle.id();
-
-        // Fresh task: spawn another, register it under `signer` in
-        // `pending`. This entry must survive the stale task's
-        // terminal outcome.
-        let fresh_cancel = CancellationToken::new();
-        let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
-            fresh_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        let fresh_task_id = fresh_handle.id();
-        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
-
-        proof_tasks.pending_mut().insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: fresh_task_id,
-                cancel: fresh_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        // Drain just the stale task; the fresh one parks on its
-        // cancel token so reap only sees the stale outcome.
-        let started = std::time::Instant::now();
-        loop {
-            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
-                proof_tasks.apply_join_outcome(joined);
-                break;
-            }
-            if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("stale task never resolved");
-            }
-            tokio::time::sleep(REAP_POLL_INTERVAL).await;
-        }
-
-        assert_eq!(
-            proof_tasks.pending_len(),
-            1,
-            "fresh entry must NOT be evicted by stale completion"
-        );
-        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
-        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
-        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
-
-        // Tear down: cancel the fresh task and drain.
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    /// Mirror of the success-arm fresh/stale test for the
-    /// [`ProofTaskSet::apply_join_outcome`] inner-`Err` arm: a
-    /// stale task failing must NOT evict the fresh entry that
-    /// reconcile dropped into the slot for the same signer. The
-    /// task-id guard in the error arms is what enforces this — without
-    /// it, a stale failure could evict a fresh entry for the same
-    /// signer.
-    #[tokio::test]
-    async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
-     {
-        let mut proof_tasks = ProofTaskSet::new();
-
-        let signer = HARDHAT_ACCOUNT;
-
-        // Stale task returns an immediate `Err`. Its task_id is NOT in
-        // `pending` — simulating the post-overwrite state.
-        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
-            proof_task_failure_for_test(
-                signer,
-                RegistrarError::Config("synthetic stale proof failure".to_string()),
-            )
-        });
-        let stale_task_id = stale_handle.id();
-
-        // Fresh task parked on its cancel token; pending keys it under
-        // `signer`. This entry must survive the stale `Err` outcome.
-        let fresh_cancel = CancellationToken::new();
-        let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
-            fresh_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        let fresh_task_id = fresh_handle.id();
-        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
-
-        proof_tasks.pending_mut().insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: fresh_task_id,
-                cancel: fresh_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        // Drain just the stale task; the fresh one parks on its
-        // cancel token so reap only sees the stale outcome.
-        let started = std::time::Instant::now();
-        loop {
-            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
-                proof_tasks.apply_join_outcome(joined);
-                break;
-            }
-            if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("stale task never resolved");
-            }
-            tokio::time::sleep(REAP_POLL_INTERVAL).await;
-        }
-
-        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must NOT be evicted by stale Err");
-        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
-        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
-        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
+    // ── run() additional coverage ─────────────────────────────────────
 
     #[tokio::test]
     async fn run_isolates_proof_failure_and_continues_pipeline_for_other_signers() {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -17,8 +17,6 @@ use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
-#[cfg(test)]
-use tokio::task;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
@@ -328,7 +326,7 @@ where
             // `pending` for an entire cycle and (incorrectly) cause
             // reconcile to skip spawning a replacement on transient
             // failure (audit finding #9).
-            Self::reap_finished_tasks(&mut tasks, &mut pending);
+            SignerManager::<P, R, T>::reap_finished_tasks(&mut tasks, &mut pending);
 
             match self.discover_and_resolve().await {
                 Ok(resolution) => {
@@ -336,21 +334,26 @@ where
                     // (potentially slow) discovery RPCs would otherwise
                     // look in-flight to reconcile and get spuriously
                     // re-cancelled or have its respawn deferred a cycle.
-                    Self::reap_finished_tasks(&mut tasks, &mut pending);
+                    SignerManager::<P, R, T>::reap_finished_tasks(&mut tasks, &mut pending);
 
                     // Spawning new proof tasks during a shutdown would
                     // acquire L1 nonces we have no intention of
                     // broadcasting. Skip reconcile (and the orphan
                     // dereg pass) entirely when cancellation is set.
                     if !self.config.cancel.is_cancelled() {
-                        self.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+                        self.signer_manager.reconcile_proof_tasks(
+                            &resolution,
+                            &mut tasks,
+                            &mut pending,
+                        );
                     }
 
                     if resolution.ok_to_dereg && !self.config.cancel.is_cancelled() {
                         // Pending proof tasks can register while orphan cleanup
                         // is running, so protect those signers too.
-                        let protected = Self::protected_signers(&resolution, &pending);
-                        if let Err(e) = self.run_orphan_dereg(&protected).await {
+                        let protected =
+                            SignerManager::<P, R, T>::protected_signers(&resolution, &pending);
+                        if let Err(e) = self.signer_manager.run_orphan_dereg(&protected).await {
                             warn!(error = %e, "orphan deregistration pass failed");
                             RegistrarMetrics::processing_errors_total().increment(1);
                         }
@@ -385,7 +388,7 @@ where
             }
         }
 
-        Self::drain_proof_tasks(&mut tasks, &mut pending).await;
+        SignerManager::<P, R, T>::drain_proof_tasks(&mut tasks, &mut pending).await;
 
         info!("registration driver stopped");
         Ok(())
@@ -714,134 +717,6 @@ where
             unresolved_instance_ids,
         })
     }
-
-    /// Runs orphan deregistration through [`DeregistrationManager`].
-    async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
-        self.signer_manager.run_orphan_dereg(protected_signers).await
-    }
-
-    /// Builds the protected-signer set for orphan deregistration.
-    ///
-    /// Includes both active signers and pending proof tasks so a signer that
-    /// registers mid-pass is not immediately deregistered.
-    fn protected_signers(
-        resolution: &DiscoveryResolution,
-        pending: &HashMap<Address, PendingRegistration>,
-    ) -> HashSet<Address> {
-        SignerManager::<P, R, T>::protected_signers(resolution, pending)
-    }
-
-    /// Reconciles the in-flight `pending` set against this cycle's
-    /// `resolution`.
-    ///
-    /// Two passes:
-    ///
-    /// 1. **Cancel pass** — any task whose `signer` is no longer in the
-    ///    current registerable set is cooperatively cancelled, **except**
-    ///    when the task's `instance_id` is in
-    ///    [`DiscoveryResolution::unresolved_instance_ids`]. That
-    ///    inconclusive-snapshot guard prevents a single transient
-    ///    `resolve_instance` failure (e.g. signer-service RPC blip, CRL
-    ///    endpoint hiccup) from abandoning an in-flight ~70 min Boundless
-    ///    proof: the signer is missing from `registerable` only because
-    ///    we couldn't tell this cycle, not because we proved it's gone.
-    ///    The `PendingRegistration::cancel` token fires; the task itself observes
-    ///    it at its next checkpoint (proof generation, retry sleep,
-    ///    pre-send) and exits with `Ok(())`. The entry stays in `pending`
-    ///    until the join arrives (handled by [`Self::reap_finished_tasks`]).
-    /// 2. **Spawn pass** — any registerable `(instance, signer)` not
-    ///    currently in-flight (excluding already-cancelled tasks awaiting
-    ///    reap) is spawned into the `JoinSet`. Each spawn creates a fresh
-    ///    child token from [`DriverConfig::cancel`] so the parent
-    ///    shutdown still propagates.
-    ///
-    /// Treating cancelled-but-not-reaped tasks as "not in-flight" enables
-    /// single-cycle convergence for the vanish-then-reappear case (e.g.
-    /// rolling deployments) where a signer drops out of `registerable`
-    /// one cycle and returns the next: without this filter the fresh
-    /// task would be deferred for an extra cycle until reap clears the
-    /// stale entry. Safety relies on
-    /// [`SignerManager`] (the registration-manager-layer
-    /// process-wide `Mutex<HashSet<Address>>` dedupe) catching any
-    /// brief overlap between the old task winding down and the new task
-    /// entering registration. The second arrival short-circuits with a
-    /// debug log and exits `Ok(())`.
-    ///
-    /// Transient task failures (non-cancel `Err`) are not re-spawned this
-    /// cycle: the entry remains until reaped, after which the next cycle
-    /// observes the empty in-flight set and respawns naturally if the
-    /// signer is still registerable.
-    fn reconcile_proof_tasks(
-        self: &Arc<Self>,
-        resolution: &DiscoveryResolution,
-        tasks: &mut JoinSet<Result<Address>>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        self.signer_manager.reconcile_proof_tasks(resolution, tasks, pending);
-    }
-
-    /// Drains every task that has already finished from `tasks`,
-    /// removing the matching entry from `pending` and updating metrics
-    /// via [`SignerManager::apply_join_outcome`].
-    ///
-    /// Non-blocking: returns once `try_join_next_with_id` yields
-    /// `None`. Called at the top of each [`Self::run`] cycle so the
-    /// in-flight gauge tracks reality before the next reconcile.
-    fn reap_finished_tasks(
-        tasks: &mut JoinSet<Result<Address>>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        SignerManager::<P, R, T>::reap_finished_tasks(tasks, pending);
-    }
-
-    /// Consumes one `JoinSet` outcome and updates `pending` + metrics.
-    ///
-    /// Handles all three termination paths:
-    /// - successful completion (`Ok((id, Ok(signer)))`) — the task
-    ///   reported its signer directly, so cleanup is an O(1) lookup
-    ///   guarded by a `task_id` match (a stale-but-still-running task
-    ///   whose entry was already overwritten by a same-cycle respawn
-    ///   must NOT evict the fresh entry).
-    /// - inner error (`Ok((id, Err(_)))`) — no signer in hand, so the
-    ///   address is recovered from the pending task id.
-    /// - join error (panic or external abort) — same recovery path,
-    ///   keyed off [`tokio::task::JoinError::id`].
-    ///
-    /// Returns silently when `joined` is `None` so the caller's
-    /// `try_join_next_with_id` loop can use it unconditionally.
-    #[cfg(test)]
-    fn apply_join_outcome(
-        joined: Option<std::result::Result<(task::Id, Result<Address>), tokio::task::JoinError>>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        SignerManager::<P, R, T>::apply_join_outcome(joined, pending);
-    }
-
-    /// Cancels every pending task cooperatively, awaits them to natural
-    /// completion, and updates `pending` via [`SignerManager::apply_join_outcome`].
-    /// Used only at shutdown — see [`Self::run`].
-    ///
-    /// **No `JoinSet::abort_all`.** Aborting would drop futures at arbitrary
-    /// await points, including inside [`base_tx_manager::TxManager::send`]
-    /// after a `NonceGuard` has been acquired but before the transaction is
-    /// broadcast — leaving a permanent nonce gap (`NonceGuard::Drop` does not
-    /// roll back). Cooperative cancellation is the only safe option: each
-    /// task observes its `signer_cancel` token at its own checkpoints and
-    /// exits with `Ok(())`. All registry RPCs in the spawned-task path
-    /// (`is_registered`, `get_registered_signers`) are wrapped in
-    /// `select!` against `signer_cancel` (or `DriverConfig::cancel` for
-    /// non-spawned paths) so they drop immediately on cancel — the only
-    /// remaining non-cancel-aware operation is
-    /// [`base_tx_manager::TxManager::send`], which is intentionally
-    /// kept that way to prevent the nonce-gap class of bugs. Shutdown
-    /// latency is therefore bounded by a single in-flight `send()` per
-    /// task, not by additional registry round-trips.
-    async fn drain_proof_tasks(
-        tasks: &mut JoinSet<Result<Address>>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        SignerManager::<P, R, T>::drain_proof_tasks(tasks, pending).await;
-    }
 }
 
 #[cfg(test)]
@@ -866,6 +741,7 @@ mod tests {
     use hex_literal::hex;
     use k256::ecdsa::SigningKey;
     use rstest::rstest;
+    use tokio::task;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
@@ -1266,7 +1142,7 @@ mod tests {
     /// reaching the tx-manager send path.
     ///
     /// Used by the spawn-pass indexing tests to assert that
-    /// [`RegistrationDriver::reconcile_proof_tasks`] pairs each signer
+    /// [`SignerManager::reconcile_proof_tasks`] pairs each signer
     /// with `attestations[idx]` and never with a sibling's blob.
     #[derive(Debug, Clone, Default)]
     struct RecordingProofProvider {
@@ -1490,6 +1366,9 @@ mod tests {
         MockSignerClient,
     >;
 
+    /// Type alias for the [`SignerManager`] owned by [`RunDriver`].
+    type RunSignerManager = SignerManager<GatedProofProvider, MockRegistry, SharedTxManager>;
+
     /// Bundles every handle a pipeline test needs to drive the loop.
     struct GatedRunHarness {
         driver: Arc<RunDriver>,
@@ -1614,7 +1493,7 @@ mod tests {
     /// well inside [`GATED_WAIT_TIMEOUT`].
     const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
-    /// Repeatedly invokes [`RunDriver::reap_finished_tasks`] until
+    /// Repeatedly invokes [`RunSignerManager::reap_finished_tasks`] until
     /// `pending` is empty or [`GATED_WAIT_TIMEOUT`] elapses. The
     /// production loop calls `reap_finished_tasks` exactly once per
     /// cycle, so unit tests that drive it directly need to give the
@@ -1629,7 +1508,7 @@ mod tests {
             if started.elapsed() > GATED_WAIT_TIMEOUT {
                 panic!("timed out reaping {} pending task(s)", pending.len());
             }
-            RunDriver::reap_finished_tasks(tasks, pending);
+            RunSignerManager::reap_finished_tasks(tasks, pending);
             tokio::time::sleep(REAP_POLL_INTERVAL).await;
         }
     }
@@ -1678,7 +1557,7 @@ mod tests {
     /// reap/apply-outcome flows without spawning a real future. The
     /// `task_id` is taken from the spawned placeholder's
     /// `JoinHandle::id()` so the failure-path O(n) scan in
-    /// [`RegistrationDriver::apply_join_outcome`] can recover the
+    /// [`SignerManager::apply_join_outcome`] can recover the
     /// signer just as it does in production.
     fn pending_registration_for_test(task_id: task::Id, instance_id: &str) -> PendingRegistration {
         PendingRegistration {
@@ -1756,7 +1635,7 @@ mod tests {
         assert!(resolution.ok_to_dereg, "single reachable instance clears the majority guard");
 
         // Orphan-dereg pass must not deregister the signer (it's in active_signers).
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         assert!(
             tx.sent_calldata().is_empty(),
@@ -1795,7 +1674,7 @@ mod tests {
             "zero-instance fleet drain is a legitimate empty active set",
         );
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         let sent = tx.sent_calldata();
         assert_eq!(sent.len(), expected_count, "all onchain signers should be deregistered");
@@ -1879,7 +1758,7 @@ mod tests {
         );
         // And `run_orphan_dereg` itself is cancel-aware — call it
         // directly to confirm it bails out without loading the registry.
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
         assert!(tx.sent_calldata().is_empty(), "no txs should be sent after cancellation");
     }
 
@@ -1914,7 +1793,7 @@ mod tests {
         );
         assert!(resolution.ok_to_dereg, "single reachable instance clears the majority guard");
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         // No registration (draining) and no deregistration (signer is active).
         assert!(tx.sent_calldata().is_empty());
@@ -1984,7 +1863,7 @@ mod tests {
         );
 
         if resolution.ok_to_dereg {
-            driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+            driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
             let sent = tx.sent_calldata();
             assert_eq!(sent.len(), 1, "{reachable_count}/4 reachable: should deregister orphan");
             let expected =
@@ -2122,7 +2001,7 @@ mod tests {
         );
         // run_orphan_dereg is cancel-aware — call it to confirm it bails
         // out without loading the registry or sending any tx.
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
         assert!(
             tx.sent_calldata().is_empty(),
             "mid-cycle cancellation should prevent any orphan deregistration",
@@ -2162,7 +2041,7 @@ mod tests {
         assert!(resolution.active_signers.contains(&addr1));
         assert!(resolution.ok_to_dereg);
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         // No registration (draining) and no deregistration (both signers
         // are in active_signers).
@@ -2221,7 +2100,7 @@ mod tests {
         );
         assert!(resolution.ok_to_dereg);
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         assert!(
             tx.sent_calldata().is_empty(),
@@ -2268,7 +2147,7 @@ mod tests {
         );
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         assert!(
             tx.sent_calldata().is_empty(),
@@ -2303,7 +2182,7 @@ mod tests {
         assert!(resolution.unresolved_instance_ids.contains(&inst.instance_id));
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         assert!(
             tx.sent_calldata().is_empty(),
@@ -2355,7 +2234,7 @@ mod tests {
             "registerable list is computed without invoking the proof provider",
         );
 
-        driver.run_orphan_dereg(&resolution.active_signers).await.unwrap();
+        driver.signer_manager.run_orphan_dereg(&resolution.active_signers).await.unwrap();
 
         // No deregistration tx (signer is in active_signers despite the
         // proof failure path being possible downstream).
@@ -2532,7 +2411,7 @@ mod tests {
         let handle = tokio::spawn(async move {
             let active: HashSet<Address> = HashSet::new();
             let start = tokio::time::Instant::now();
-            let res = driver_clone.run_orphan_dereg(&active).await;
+            let res = driver_clone.signer_manager.run_orphan_dereg(&active).await;
             (res, start.elapsed(), cancel_clone)
         });
 
@@ -2614,7 +2493,7 @@ mod tests {
         let pre_spawn_count = pending.len();
         let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
 
-        harness.driver.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
 
         let post_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
         let new_spawns = pending.len().saturating_sub(pre_spawn_count);
@@ -2635,11 +2514,11 @@ mod tests {
 
         let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
 
-        harness.driver.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
         let after_first = pending.len();
         let snapshot_ids: HashSet<_> = pending.keys().copied().collect();
 
-        harness.driver.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
 
         assert_eq!(pending.len(), after_first, "idempotent: no extra spawns");
         let after_second: HashSet<_> = pending.keys().copied().collect();
@@ -2699,7 +2578,7 @@ mod tests {
         // but does not reap, so the (now cancelled) entry persists in
         // `pending` keyed by `signer`.
         let empty = dr_from_kept(&[]);
-        harness.driver.reconcile_proof_tasks(&empty, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&empty, &mut tasks, &mut pending);
         assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
         assert_eq!(
             pending.get(&signer).map(|p| p.task_id),
@@ -2714,7 +2593,7 @@ mod tests {
         // the stale task lives on in the JoinSet (parked on its cancel
         // until drain).
         let resurrected = dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]);
-        harness.driver.reconcile_proof_tasks(&resurrected, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resurrected, &mut tasks, &mut pending);
 
         assert_eq!(pending.len(), 1, "still exactly one entry per signer after respawn");
         let fresh = pending.get(&signer).expect("fresh entry keyed by the resurrected signer");
@@ -2774,7 +2653,7 @@ mod tests {
             unresolved_instance_ids: unresolved,
         };
 
-        harness.driver.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
 
         assert!(
             !task_cancel.is_cancelled(),
@@ -2793,7 +2672,11 @@ mod tests {
             ok_to_dereg: true,
             unresolved_instance_ids: HashSet::new(),
         };
-        harness.driver.reconcile_proof_tasks(&resolution_conclusive, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(
+            &resolution_conclusive,
+            &mut tasks,
+            &mut pending,
+        );
         assert!(
             task_cancel.is_cancelled(),
             "with no inconclusive guard, the cancel-pass MUST fire on the same setup",
@@ -2812,7 +2695,7 @@ mod tests {
     /// `unresolved_instance_ids`). If the preserved task succeeds and
     /// registers the signer onchain right as the orphan-dereg pass
     /// runs, the protected set assembled by
-    /// [`RunDriver::protected_signers`] MUST union the two, otherwise
+    /// [`RunSignerManager::protected_signers`] MUST union the two, otherwise
     /// the very next call to `deregister_orphans` would deregister the
     /// freshly-registered signer (TOCTOU race).
     #[tokio::test]
@@ -2866,13 +2749,13 @@ mod tests {
             unresolved_instance_ids: unresolved,
         };
 
-        let protected = RunDriver::protected_signers(&resolution, &pending);
+        let protected = RunSignerManager::protected_signers(&resolution, &pending);
         assert!(
             protected.contains(&signer),
             "protected set must include in-flight signer even when absent from active_signers",
         );
 
-        harness.driver.run_orphan_dereg(&protected).await.unwrap();
+        harness.driver.signer_manager.run_orphan_dereg(&protected).await.unwrap();
 
         let sent = harness.tx.sent_calldata();
         assert_eq!(
@@ -2909,10 +2792,10 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let protected = RunDriver::protected_signers(&resolution, &pending);
+        let protected = RunSignerManager::protected_signers(&resolution, &pending);
         assert!(protected.is_empty(), "no pending → protected set is empty");
 
-        harness.driver.run_orphan_dereg(&protected).await.unwrap();
+        harness.driver.signer_manager.run_orphan_dereg(&protected).await.unwrap();
 
         let sent = harness.tx.sent_calldata();
         assert_eq!(
@@ -2924,10 +2807,10 @@ mod tests {
 
     // ── drain_proof_tasks metric-gating test ────────────────────────────
 
-    /// At shutdown, [`RegistrationDriver::drain_proof_tasks`] MUST count
+    /// At shutdown, [`SignerManager::drain_proof_tasks`] MUST count
     /// only the tasks whose cancellation it actually drives — tasks
     /// already cancelled by a prior
-    /// [`RegistrationDriver::reconcile_proof_tasks`] cancel-pass were
+    /// [`SignerManager::reconcile_proof_tasks`] cancel-pass were
     /// counted at intent time and double-counting them in the drain pass
     /// would inflate the `proof_tasks_cancelled` counter. The gate uses
     /// the `cancelled_by_reconcile` flag (not
@@ -2991,7 +2874,7 @@ mod tests {
                         }
                     }
 
-                    RunDriver::drain_proof_tasks(&mut tasks, &mut pending).await;
+                    RunSignerManager::drain_proof_tasks(&mut tasks, &mut pending).await;
                 });
             });
 
@@ -3082,7 +2965,7 @@ mod tests {
         let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
-        driver.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
 
         assert_eq!(pending.len(), 1, "exactly one task should spawn for a duplicate signer");
         let (&only_signer, _entry) = pending.iter().next().unwrap();
@@ -3153,7 +3036,7 @@ mod tests {
         let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
-        driver.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
 
         wait_for("both signers recorded their attestations", || {
             proof_provider.snapshot().len() == 2
@@ -3219,7 +3102,7 @@ mod tests {
             },
         );
 
-        RunDriver::reap_finished_tasks(&mut tasks, &mut pending);
+        RunSignerManager::reap_finished_tasks(&mut tasks, &mut pending);
 
         assert_eq!(pending.len(), 1, "live task must remain in pending");
 
@@ -3234,7 +3117,7 @@ mod tests {
         let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
-        RunDriver::reap_finished_tasks(&mut tasks, &mut pending);
+        RunSignerManager::reap_finished_tasks(&mut tasks, &mut pending);
 
         assert!(pending.is_empty(), "pending stays empty");
         assert!(tasks.is_empty(), "JoinSet stays empty");
@@ -3522,12 +3405,12 @@ mod tests {
         // The `Err(JoinError)` arm of `apply_join_outcome` must still
         // remove the panicked task from `pending`. With the address-
         // keyed map and the panic path losing the task's return value,
-        // the recovery routes through `find_signer_by_task_id` (the
-        // O(n) scan over `pending`) to map `JoinError::id()` back to
-        // the signer address. The per-task cancel handle is dropped
-        // and the proof-task-completed metric still fires. The full
-        // reap path is exercised so this is also a coverage test for
-        // `reap_finished_tasks` routing the `JoinError` correctly.
+        // the recovery routes through the task-id scan over `pending`
+        // to map `JoinError::id()` back to the signer address. The
+        // per-task cancel handle is dropped and the proof-task-completed
+        // metric still fires. The full reap path is exercised so this
+        // is also a coverage test for `reap_finished_tasks` routing the
+        // `JoinError` correctly.
         let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
@@ -3548,7 +3431,7 @@ mod tests {
     /// Address-keyed cleanup safety: a stale task whose `pending` entry
     /// was overwritten by a same-cycle respawn for the same signer
     /// must NOT evict the fresh entry when its terminal `Ok(signer)`
-    /// flows through [`RegistrationDriver::apply_join_outcome`]. The
+    /// flows through [`SignerManager::apply_join_outcome`]. The
     /// `task_id`-match guard in the success arm is the protection — a
     /// stale completion without the guard would leak the fresh task
     /// from `pending` (orphaning its cancel handle) and corrupt
@@ -3595,7 +3478,7 @@ mod tests {
         let started = std::time::Instant::now();
         loop {
             if let Some(joined) = tasks.try_join_next_with_id() {
-                RunDriver::apply_join_outcome(Some(joined), &mut pending);
+                RunSignerManager::apply_join_outcome(Some(joined), &mut pending);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {
@@ -3614,14 +3497,12 @@ mod tests {
     }
 
     /// Mirror of the success-arm fresh/stale test for the
-    /// [`RegistrationDriver::apply_join_outcome`] inner-`Err` arm: a
+    /// [`SignerManager::apply_join_outcome`] inner-`Err` arm: a
     /// stale task failing must NOT evict the fresh entry that
     /// reconcile dropped into the slot for the same signer. The
-    /// [`RegistrationDriver::remove_if_task_matches`] guard threaded
-    /// through all three arms is what enforces this — without it,
-    /// `find_signer_by_task_id` returning `None` for the stale id is
-    /// the only thing preventing fresh-entry eviction, which is a
-    /// fragile implicit invariant.
+    /// [`SignerManager::remove_by_task_id`] guard threaded through the
+    /// error arms is what enforces this — without it, a stale failure
+    /// could evict a fresh entry for the same signer.
     #[tokio::test]
     async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
      {
@@ -3663,7 +3544,7 @@ mod tests {
         let started = std::time::Instant::now();
         loop {
             if let Some(joined) = tasks.try_join_next_with_id() {
-                RunDriver::apply_join_outcome(Some(joined), &mut pending);
+                RunSignerManager::apply_join_outcome(Some(joined), &mut pending);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -8,7 +8,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 
@@ -17,17 +17,16 @@ use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
-use tokio::{
-    sync::Semaphore,
-    task::{self, JoinSet},
-};
+#[cfg(test)]
+use tokio::task;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CertManager, CrlConfig, DeregistrationManager, InstanceDiscovery, InstanceHealthStatus,
-    NitroVerifierClient, ProofHandlerConfig, ProverClient, ProverInstance, RegistrarError,
-    RegistrarMetrics, RegistrationManager, RegistryClient, Result, SignerClient,
+    CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
+    PendingRegistration, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics,
+    RegistryClient, Result, SignerClient, SignerManager, SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -85,49 +84,6 @@ pub struct DriverConfig {
     /// CRL checking configuration. When enabled, intermediate certificates
     /// are checked against CRL distribution points before registration.
     pub crl: CrlConfig,
-}
-
-/// State for a proof-generation task currently in-flight in the
-/// [`RegistrationDriver::run`] spawn-and-reap loop.
-///
-/// One entry per signer address — the `pending` map is keyed by
-/// [`Address`] (the signer this task owns) so reconcile's per-cycle
-/// match against the latest registerable set is an O(1) lookup and
-/// "at most one active proof task per signer" is a structural
-/// invariant of the map, not a runtime check.
-///
-/// `cancel` is a child of [`DriverConfig::cancel`]. Firing it asks the
-/// task to terminate cooperatively at the next checkpoint (proof-gen,
-/// retry sleep, before tx send) — the task always returns the signer
-/// address (`Ok(signer)`) when it observes the cancel, never an error,
-/// so the happy and cancelled paths route identically through
-/// [`RegistrationDriver::apply_join_outcome`].
-#[derive(Debug)]
-pub struct PendingRegistration {
-    /// Originating instance ID — recorded only for logging.
-    pub instance_id: String,
-    /// `JoinSet` task id for this proof task. Used by
-    /// [`RegistrationDriver::apply_join_outcome`] for two things: (1)
-    /// recovering the signer address on failure paths via an O(n) scan
-    /// over `pending` (bounded by [`DriverConfig::max_concurrency`]),
-    /// and (2) gating success-arm cleanup with a `task_id == id` check
-    /// so a stale task's terminal outcome cannot evict a same-signer
-    /// respawn that reconcile dropped into the slot mid-cycle.
-    pub task_id: task::Id,
-    /// Cooperative cancel handle for this single task.
-    pub cancel: CancellationToken,
-    /// `true` once [`RegistrationDriver::reconcile_proof_tasks`] has
-    /// fired this task's [`Self::cancel`] (signer dropped from the
-    /// registerable set mid-flight). Lets [`RegistrationDriver::
-    /// drain_proof_tasks`] distinguish reconcile-cancelled tasks
-    /// (already counted in `proof_tasks_cancelled` at intent time)
-    /// from shutdown-cancelled tasks so neither double-counts nor
-    /// silently misses the shutdown path — every cancellation increments
-    /// the metric exactly once. Necessary because [`Self::cancel`] is a
-    /// child of [`DriverConfig::cancel`]; on shutdown the parent's fire
-    /// auto-cancels every child, so an `is_cancelled()` gate alone
-    /// cannot tell the two cases apart.
-    pub cancelled_by_reconcile: bool,
 }
 
 /// A single (signer, attestation) pair from a prover instance that
@@ -229,43 +185,13 @@ pub struct ResolveOutcome {
 /// in tests.
 pub struct RegistrationDriver<D, P, R, T, S> {
     discovery: D,
-    proof_provider: P,
-    registry: R,
-    tx_manager: T,
     signer_client: S,
     config: DriverConfig,
     /// Optional certificate revocation manager. Built once at construction
     /// time when CRL checking is enabled. `None` when CRL checking is disabled.
     cert_manager: Option<CertManager>,
-    /// Bounds the number of proof-generation calls that may be in-flight
-    /// across the spawned task pool at once. Sized from
-    /// [`DriverConfig::max_concurrency`], matching the discovery/resolve
-    /// concurrency bound so an ASG scale-up cannot fan out an unbounded
-    /// number of concurrent Boundless proof requests. Permits are acquired
-    /// inside [`Self::run_proof_task`], not at spawn time, so the
-    /// reconcile pass remains synchronous.
-    proof_semaphore: Arc<Semaphore>,
-    /// Process-local set of signer addresses currently being registered.
-    ///
-    /// [`RegistrationManager::register_signer`] reserves an entry here before
-    /// its `is_registered` precheck and releases it when it returns. This closes
-    /// a TOCTOU race in which two concurrent registration attempts for the same
-    /// signer both read `is_registered == false`, both generate proofs, and both
-    /// submit duplicate registration transactions.
-    ///
-    /// This is a defence-in-depth backstop: the [`Self::run`] spawn loop's
-    /// `in_flight: HashSet<Address>` already dedupes at task-spawn time,
-    /// so the registration-manager layer only catches duplicates from callers
-    /// that bypass the spawn loop.
-    ///
-    /// The set is held across the entire registration lifecycle (including
-    /// the ~20 minute Boundless proof generation) so deduplication holds
-    /// across cycles as well as within one.
-    in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
-    /// Last-known EC2 instance ID for every signer observed during discovery.
-    /// Used to annotate orphan deregistration logs.
-    /// Entries are never evicted; bounded by historic fleet size.
-    signer_history: Arc<Mutex<HashMap<Address, String>>>,
+    /// Signer lifecycle manager for registration tasks and orphan cleanup.
+    signer_manager: Arc<SignerManager<P, R, T>>,
 }
 
 impl<D, P, R, T, S> fmt::Debug for RegistrationDriver<D, P, R, T, S> {
@@ -318,19 +244,19 @@ where
         } else {
             None
         };
-        let proof_semaphore = Arc::new(Semaphore::new(config.max_concurrency.max(1)));
-        Ok(Self {
-            discovery,
+        let signer_manager = Arc::new(SignerManager::new(
             proof_provider,
             registry,
             tx_manager,
-            signer_client,
-            config,
-            cert_manager,
-            proof_semaphore,
-            in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
-            signer_history: Arc::new(Mutex::new(HashMap::new())),
-        })
+            SignerManagerConfig {
+                registry_address: config.registry_address,
+                cancel: config.cancel.clone(),
+                max_concurrency: config.max_concurrency,
+                max_tx_retries: config.max_tx_retries,
+                tx_retry_delay: config.tx_retry_delay,
+            },
+        ));
+        Ok(Self { discovery, signer_client, config, cert_manager, signer_manager })
     }
 
     /// Runs the registration loop until cancelled.
@@ -364,9 +290,9 @@ where
     /// On shutdown every `PendingRegistration::cancel` is fired cooperatively;
     /// tasks are then awaited to natural completion via
     /// `join_next_with_id` so each terminal outcome flows through
-    /// `apply_join_outcome`, keeping the proof-task metrics consistent.
-    /// `JoinSet::abort_all` is deliberately **not** used — see
-    /// [`Self::drain_proof_tasks`] for the nonce-gap rationale.
+    /// the signer manager join-outcome path, keeping the proof-task metrics
+    /// consistent. `JoinSet::abort_all` is deliberately **not** used — see
+    /// [`SignerManager::drain_proof_tasks`] for the nonce-gap rationale.
     ///
     /// # Ownership
     ///
@@ -620,7 +546,11 @@ where
             let cert_manager =
                 self.cert_manager.as_ref().expect("cert_manager required when CRL enabled");
             match cert_manager
-                .check_and_revoke_crls(first_attestation, instance, &self.tx_manager)
+                .check_and_revoke_crls(
+                    first_attestation,
+                    instance,
+                    self.signer_manager.tx_manager(),
+                )
                 .await
             {
                 Ok(true) => {
@@ -721,13 +651,7 @@ where
                     }
                     // Record signer -> instance attribution before `instance`
                     // is moved into `RegisterableSigner` below.
-                    {
-                        let mut history =
-                            self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
-                        for addr in &outcome.addresses {
-                            history.insert(*addr, instance.instance_id.clone());
-                        }
-                    }
+                    self.signer_manager.record_signers(&outcome.addresses, &instance.instance_id);
                     if let Some(attestations) = outcome.attestations {
                         // `resolve_instance` already enforced the pairing
                         // invariants (non-empty addresses,
@@ -793,13 +717,7 @@ where
 
     /// Runs orphan deregistration through [`DeregistrationManager`].
     async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
-        let manager = DeregistrationManager::new(
-            self.config.registry_address,
-            &self.registry,
-            &self.tx_manager,
-            &self.signer_history,
-        );
-        manager.run_orphan_dereg(protected_signers, &self.config.cancel).await
+        self.signer_manager.run_orphan_dereg(protected_signers).await
     }
 
     /// Builds the protected-signer set for orphan deregistration.
@@ -810,9 +728,7 @@ where
         resolution: &DiscoveryResolution,
         pending: &HashMap<Address, PendingRegistration>,
     ) -> HashSet<Address> {
-        let mut protected = resolution.active_signers.clone();
-        protected.extend(pending.keys().copied());
-        protected
+        SignerManager::<P, R, T>::protected_signers(resolution, pending)
     }
 
     /// Reconciles the in-flight `pending` set against this cycle's
@@ -845,7 +761,7 @@ where
     /// one cycle and returns the next: without this filter the fresh
     /// task would be deferred for an extra cycle until reap clears the
     /// stale entry. Safety relies on
-    /// [`Self::in_flight_registrations`] (the registration-manager-layer
+    /// [`SignerManager`] (the registration-manager-layer
     /// process-wide `Mutex<HashSet<Address>>` dedupe) catching any
     /// brief overlap between the old task winding down and the new task
     /// entering registration. The second arrival short-circuits with a
@@ -861,138 +777,12 @@ where
         tasks: &mut JoinSet<Result<Address>>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
-        let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
-
-        // Cancel-pass: any in-flight task whose signer is no longer
-        // wanted AND whose source instance produced a conclusive
-        // verdict this cycle (i.e. NOT in `unresolved_instance_ids`).
-        // Tasks tied to instances that failed to resolve transiently
-        // are preserved — the absence from `wanted` is then a lack of
-        // evidence, not evidence of absence.
-        //
-        // `cancelled_by_reconcile = true` is set alongside the cancel
-        // intent so [`Self::drain_proof_tasks`] can tell shutdown-driven
-        // cancels (which it must count) apart from reconcile-driven
-        // cancels (already counted here).
-        for (signer, task) in pending.iter_mut() {
-            if !wanted.contains(signer)
-                && !task.cancel.is_cancelled()
-                && !resolution.unresolved_instance_ids.contains(&task.instance_id)
-            {
-                info!(
-                    signer = %signer,
-                    instance = %task.instance_id,
-                    "cancelling proof task: signer no longer registerable"
-                );
-                task.cancel.cancel();
-                task.cancelled_by_reconcile = true;
-                RegistrarMetrics::proof_tasks_cancelled().increment(1);
-            } else if !wanted.contains(signer)
-                && !task.cancel.is_cancelled()
-                && resolution.unresolved_instance_ids.contains(&task.instance_id)
-            {
-                debug!(
-                    signer = %signer,
-                    instance = %task.instance_id,
-                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
-                );
-            }
-        }
-
-        // Build `in_flight` from only the still-live entries so a signer
-        // that was cancelled in a previous cycle and has now reappeared
-        // in `registerable` can spawn a fresh task immediately rather
-        // than waiting two cycles (one to reap, one to respawn).
-        // The registration-manager in-flight mutex catches any brief
-        // overlap between the winding-down old task and the new task.
-        // Updated as we spawn so a signer that appears in two registerable
-        // entries within the same cycle (misconfig / discovery glitch —
-        // two instances briefly backing the same enclave key) cannot
-        // spawn duplicate proof tasks.
-        //
-        // A fresh spawn for a signer whose stale entry is still in
-        // `pending` (cancelled, not yet reaped) overwrites the stale
-        // entry below. The stale task continues running in the JoinSet
-        // and `apply_join_outcome`'s task_id-match guard prevents it
-        // from later evicting the fresh entry.
-        let mut in_flight: HashSet<Address> = pending
-            .iter()
-            .filter(|(_, t)| !t.cancel.is_cancelled())
-            .map(|(addr, _)| *addr)
-            .collect();
-
-        // Spawn-pass: any wanted signer not currently in-flight.
-        for entry in &resolution.registerable {
-            if !in_flight.insert(entry.signer) {
-                continue;
-            }
-            let signer_cancel = self.config.cancel.child_token();
-            let driver = Arc::clone(self);
-            let instance_owned = entry.instance.clone();
-            // Clone `instance_id` from `instance_owned` (rather than
-            // re-reaching into `entry.instance`) to make the origin
-            // explicit — the string is allocated twice either way
-            // because `instance_owned` is moved into the spawned future
-            // while `PendingRegistration` outlives the move.
-            let instance_id = instance_owned.instance_id.clone();
-            let attestation = entry.attestation.clone();
-            let task_cancel = signer_cancel.clone();
-            let signer = entry.signer;
-            let enclave_index = entry.enclave_index;
-
-            let handle = tasks.spawn(async move {
-                driver
-                    .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
-                    .await
-            });
-            pending.insert(
-                signer,
-                PendingRegistration {
-                    instance_id,
-                    task_id: handle.id(),
-                    cancel: signer_cancel,
-                    cancelled_by_reconcile: false,
-                },
-            );
-            RegistrarMetrics::proof_tasks_spawned().increment(1);
-        }
-    }
-
-    /// Spawned-task body: runs signer registration with task-scoped
-    /// cancellation. Always returns `Ok(signer)` on cooperative cancel
-    /// and on registration success; only genuine failures propagate as
-    /// `Err`. The success arm carries the signer address so
-    /// [`Self::apply_join_outcome`] can clean `pending` in O(1) without
-    /// a reverse `task::Id → Address` lookup.
-    async fn run_proof_task(
-        self: Arc<Self>,
-        instance: ProverInstance,
-        signer: Address,
-        enclave_index: usize,
-        attestation_bytes: Vec<u8>,
-        signer_cancel: CancellationToken,
-    ) -> Result<Address> {
-        let registration_manager = RegistrationManager::new(
-            &self.proof_provider,
-            &self.registry,
-            &self.tx_manager,
-            self.proof_semaphore.as_ref(),
-            &self.in_flight_registrations,
-            ProofHandlerConfig {
-                registry_address: self.config.registry_address,
-                max_tx_retries: self.config.max_tx_retries,
-                tx_retry_delay: self.config.tx_retry_delay,
-            },
-        );
-        registration_manager
-            .register_signer(&instance, signer, enclave_index, &attestation_bytes, &signer_cancel)
-            .await?;
-        Ok(signer)
+        self.signer_manager.reconcile_proof_tasks(resolution, tasks, pending);
     }
 
     /// Drains every task that has already finished from `tasks`,
     /// removing the matching entry from `pending` and updating metrics
-    /// via [`Self::apply_join_outcome`].
+    /// via [`SignerManager::apply_join_outcome`].
     ///
     /// Non-blocking: returns once `try_join_next_with_id` yields
     /// `None`. Called at the top of each [`Self::run`] cycle so the
@@ -1001,47 +791,7 @@ where
         tasks: &mut JoinSet<Result<Address>>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
-        while let Some(joined) = tasks.try_join_next_with_id() {
-            Self::apply_join_outcome(Some(joined), pending);
-        }
-    }
-
-    /// O(n) scan to find the signer address whose pending entry was
-    /// spawned with `task_id`. `pending` is bounded by
-    /// [`DriverConfig::max_concurrency`] (typically <20), so this
-    /// rare-path scan (only hit on `Err` or panic, never the happy
-    /// path) is cheaper than maintaining a second reverse `task::Id →
-    /// Address` index that would have to stay consistent with every
-    /// spawn/reap.
-    fn find_signer_by_task_id(
-        pending: &HashMap<Address, PendingRegistration>,
-        task_id: task::Id,
-    ) -> Option<Address> {
-        pending.iter().find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))
-    }
-
-    /// Removes the `pending` entry for `signer` only when its
-    /// `task_id` matches `id`. Returns the removed entry or `None` if
-    /// the slot was already overwritten by a same-signer respawn.
-    ///
-    /// Every [`Self::apply_join_outcome`] arm funnels through this
-    /// helper so the same stale-task / fresh-respawn invariant applies
-    /// uniformly: a terminal outcome from a stale task must never
-    /// evict the fresh entry reconcile dropped into the slot
-    /// mid-cycle. The check is technically redundant on the
-    /// [`Self::find_signer_by_task_id`] paths (the scan already filters
-    /// by `task_id`), but making the guard local rather than implicit
-    /// in another helper hardens the invariant against future
-    /// refactors of the recovery routine.
-    fn remove_if_task_matches(
-        pending: &mut HashMap<Address, PendingRegistration>,
-        signer: Address,
-        id: task::Id,
-    ) -> Option<PendingRegistration> {
-        match pending.get(&signer) {
-            Some(entry) if entry.task_id == id => pending.remove(&signer),
-            _ => None,
-        }
+        SignerManager::<P, R, T>::reap_finished_tasks(tasks, pending);
     }
 
     /// Consumes one `JoinSet` outcome and updates `pending` + metrics.
@@ -1053,61 +803,22 @@ where
     ///   whose entry was already overwritten by a same-cycle respawn
     ///   must NOT evict the fresh entry).
     /// - inner error (`Ok((id, Err(_)))`) — no signer in hand, so the
-    ///   address is recovered via [`Self::find_signer_by_task_id`].
+    ///   address is recovered from the pending task id.
     /// - join error (panic or external abort) — same recovery path,
     ///   keyed off [`tokio::task::JoinError::id`].
     ///
     /// Returns silently when `joined` is `None` so the caller's
     /// `try_join_next_with_id` loop can use it unconditionally.
+    #[cfg(test)]
     fn apply_join_outcome(
         joined: Option<std::result::Result<(task::Id, Result<Address>), tokio::task::JoinError>>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
-        let Some(result) = joined else { return };
-        RegistrarMetrics::proof_tasks_completed().increment(1);
-        match result {
-            Ok((id, Ok(signer))) => {
-                let removed = Self::remove_if_task_matches(pending, signer, id);
-                debug!(
-                    task_id = ?id,
-                    signer = %signer,
-                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
-                    superseded = removed.is_none(),
-                    "proof task completed",
-                );
-            }
-            Ok((id, Err(e))) => {
-                let signer = Self::find_signer_by_task_id(pending, id);
-                let removed = signer.and_then(|s| Self::remove_if_task_matches(pending, s, id));
-                warn!(
-                    task_id = ?id,
-                    error = %e,
-                    signer = ?signer,
-                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
-                    superseded = signer.is_some() && removed.is_none(),
-                    "proof task failed"
-                );
-                RegistrarMetrics::processing_errors_total().increment(1);
-            }
-            Err(join_err) => {
-                let id = join_err.id();
-                let signer = Self::find_signer_by_task_id(pending, id);
-                let removed = signer.and_then(|s| Self::remove_if_task_matches(pending, s, id));
-                warn!(
-                    task_id = ?id,
-                    error = %join_err,
-                    signer = ?signer,
-                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
-                    superseded = signer.is_some() && removed.is_none(),
-                    "proof task join error (panic or abort)"
-                );
-                RegistrarMetrics::processing_errors_total().increment(1);
-            }
-        }
+        SignerManager::<P, R, T>::apply_join_outcome(joined, pending);
     }
 
     /// Cancels every pending task cooperatively, awaits them to natural
-    /// completion, and updates `pending` via [`Self::apply_join_outcome`].
+    /// completion, and updates `pending` via [`SignerManager::apply_join_outcome`].
     /// Used only at shutdown — see [`Self::run`].
     ///
     /// **No `JoinSet::abort_all`.** Aborting would drop futures at arbitrary
@@ -1129,32 +840,7 @@ where
         tasks: &mut JoinSet<Result<Address>>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
-        for task in pending.values() {
-            // Gate on `cancelled_by_reconcile`, NOT on
-            // `task.cancel.is_cancelled()`. Each `signer_cancel` is a
-            // child of `DriverConfig::cancel`, so by the time drain
-            // runs the parent has already auto-cancelled every child —
-            // `is_cancelled()` is `true` for all tasks regardless of
-            // who triggered the cancel. Using the reconcile flag lets
-            // us count every shutdown-driven cancellation exactly once
-            // while preserving the "reconcile counted at intent time"
-            // contract. `task.cancel.cancel()` is still issued for
-            // belt-and-braces (it's a no-op when the parent fired) so
-            // the bookkeeping stays correct if anyone ever decouples
-            // `signer_cancel` from the parent in the future.
-            if !task.cancelled_by_reconcile {
-                task.cancel.cancel();
-                RegistrarMetrics::proof_tasks_cancelled().increment(1);
-            }
-        }
-        // NOTE: we drain through `join_next_with_id` (not
-        // `JoinSet::shutdown`) so each terminal outcome flows through
-        // `apply_join_outcome` — keeping the `pending` map and the
-        // proof-task metrics consistent at shutdown.
-        while let Some(joined) = tasks.join_next_with_id().await {
-            Self::apply_join_outcome(Some(joined), pending);
-        }
-        RegistrarMetrics::proof_tasks_pending().set(0.0);
+        SignerManager::<P, R, T>::drain_proof_tasks(tasks, pending).await;
     }
 }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -22,8 +22,9 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    PendingRegistration, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics,
-    RegistryClient, Result, SignerClient, SignerManager, SignerManagerConfig,
+    PendingRegistration, ProofTaskOutcome, ProofTaskSet, ProverClient, ProverInstance,
+    RegistrarError, RegistrarMetrics, RegistryClient, Result, SignerClient, SignerManager,
+    SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -275,7 +276,7 @@ where
     /// `join_next_with_id` so each terminal outcome flows through
     /// the signer manager join-outcome path, keeping the proof-task metrics
     /// consistent. `JoinSet::abort_all` is deliberately **not** used — see
-    /// [`SignerManager::drain_proof_tasks`] for the nonce-gap rationale.
+    /// [`ProofTaskSet::drain_proof_tasks`] for the nonce-gap rationale.
     ///
     /// # Ownership
     ///
@@ -299,11 +300,11 @@ where
     pub async fn run_arc(self: Arc<Self>) -> Result<()> {
         info!(
             poll_interval = ?self.config.poll_interval,
-            registry = %self.config.signer_manager.registry_address,
+            registry = %self.signer_manager.registry_address(),
             "starting registration driver"
         );
 
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         loop {
@@ -311,7 +312,7 @@ where
             // `pending` for an entire cycle and (incorrectly) cause
             // reconcile to skip spawning a replacement on transient
             // failure (audit finding #9).
-            SignerManager::<P, R, T>::reap_finished_tasks(&mut tasks, &mut pending);
+            ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
 
             match self.discover_and_resolve().await {
                 Ok(resolution) => {
@@ -319,13 +320,13 @@ where
                     // (potentially slow) discovery RPCs would otherwise
                     // look in-flight to reconcile and get spuriously
                     // re-cancelled or have its respawn deferred a cycle.
-                    SignerManager::<P, R, T>::reap_finished_tasks(&mut tasks, &mut pending);
+                    ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
 
                     // Spawning new proof tasks during a shutdown would
                     // acquire L1 nonces we have no intention of
                     // broadcasting. Skip reconcile (and the orphan
                     // dereg pass) entirely when cancellation is set.
-                    if !self.config.signer_manager.cancel.is_cancelled() {
+                    if !self.signer_manager.cancel().is_cancelled() {
                         self.signer_manager.reconcile_proof_tasks(
                             &resolution,
                             &mut tasks,
@@ -333,11 +334,10 @@ where
                         );
                     }
 
-                    if resolution.ok_to_dereg && !self.config.signer_manager.cancel.is_cancelled() {
+                    if resolution.ok_to_dereg && !self.signer_manager.cancel().is_cancelled() {
                         // Pending proof tasks can register while orphan cleanup
                         // is running, so protect those signers too.
-                        let protected =
-                            SignerManager::<P, R, T>::protected_signers(&resolution, &pending);
+                        let protected = ProofTaskSet::protected_signers(&resolution, &pending);
                         if let Err(e) = self.signer_manager.run_orphan_dereg(&protected).await {
                             warn!(error = %e, "orphan deregistration pass failed");
                             RegistrarMetrics::processing_errors_total().increment(1);
@@ -362,7 +362,7 @@ where
 
             tokio::select! {
                 biased;
-                () = self.config.signer_manager.cancel.cancelled() => {
+                () = self.signer_manager.cancel().cancelled() => {
                     info!(
                         pending = pending.len(),
                         "registration driver received shutdown signal"
@@ -373,7 +373,7 @@ where
             }
         }
 
-        SignerManager::<P, R, T>::drain_proof_tasks(&mut tasks, &mut pending).await;
+        ProofTaskSet::drain_proof_tasks(&mut tasks, &mut pending).await;
 
         info!("registration driver stopped");
         Ok(())
@@ -425,12 +425,12 @@ where
     /// spawned tasks instead of blocking the next discovery cycle.
     ///
     /// **Cancellation contract.** This future checks
-    /// `self.config.signer_manager.cancel.is_cancelled()` before starting new side effects.
+    /// `self.signer_manager.cancel().is_cancelled()` before starting new side effects.
     /// `check_and_revoke_crls` awaits any `revokeCert` transaction
     /// submissions it triggers, so revocation outcomes are logged before
     /// the resolution future returns.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
-        if self.config.signer_manager.cancel.is_cancelled() {
+        if self.signer_manager.cancel().is_cancelled() {
             return Ok(ResolveOutcome {
                 addresses: Vec::new(),
                 attestations: None,
@@ -465,7 +465,7 @@ where
             );
         }
 
-        if self.config.signer_manager.cancel.is_cancelled() {
+        if self.signer_manager.cancel().is_cancelled() {
             return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
         }
 
@@ -515,7 +515,7 @@ where
             // would still be discarded; keeping it `None` removes the
             // non-local dependence on that re-check and matches the
             // CRL-revoked branch below.
-            if self.config.signer_manager.cancel.is_cancelled() {
+            if self.signer_manager.cancel().is_cancelled() {
                 return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
             }
             // Use `.first()` rather than `[0]` so the non-empty
@@ -606,7 +606,7 @@ where
         let mut registerable: Vec<RegisterableSigner> = Vec::new();
         let mut unresolved_instance_ids: HashSet<String> = HashSet::new();
 
-        let concurrency = self.config.signer_manager.max_concurrency.max(1);
+        let concurrency = self.signer_manager.max_concurrency().max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
             let driver = Arc::clone(self);
             let span = info_span!(
@@ -677,19 +677,18 @@ where
             }
         }
 
-        let ok_to_dereg = if self.config.signer_manager.cancel.is_cancelled()
-            || !unresolved_instance_ids.is_empty()
-        {
-            false
-        } else if total_count == 0 {
-            true
-        } else {
-            // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
-            // is bounded above by `total_count = instances.len()`, so the
-            // doubling can only overflow on a list with `usize::MAX / 2`
-            // entries, which is physically impossible.
-            reachable_count * 2 > total_count
-        };
+        let ok_to_dereg =
+            if self.signer_manager.cancel().is_cancelled() || !unresolved_instance_ids.is_empty() {
+                false
+            } else if total_count == 0 {
+                true
+            } else {
+                // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
+                // is bounded above by `total_count = instances.len()`, so the
+                // doubling can only overflow on a list with `usize::MAX / 2`
+                // entries, which is physically impossible.
+                reachable_count * 2 > total_count
+            };
 
         Ok(DiscoveryResolution {
             registerable,
@@ -1351,9 +1350,6 @@ mod tests {
         MockSignerClient,
     >;
 
-    /// Type alias for the [`SignerManager`] owned by [`RunDriver`].
-    type RunSignerManager = SignerManager<GatedProofProvider, MockRegistry, SharedTxManager>;
-
     /// Bundles every handle a pipeline test needs to drive the loop.
     struct GatedRunHarness {
         driver: Arc<RunDriver>,
@@ -1462,7 +1458,7 @@ mod tests {
     /// futures that are forever parked on their tokens. Mirrors the
     /// production shutdown sequence in [`RegistrationDriver::run`].
     async fn drain_test_tasks(
-        tasks: &mut JoinSet<Result<Address>>,
+        tasks: &mut JoinSet<ProofTaskOutcome>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
         for task in pending.values() {
@@ -1478,14 +1474,14 @@ mod tests {
     /// well inside [`GATED_WAIT_TIMEOUT`].
     const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
-    /// Repeatedly invokes [`RunSignerManager::reap_finished_tasks`] until
+    /// Repeatedly invokes [`ProofTaskSet::reap_finished_tasks`] until
     /// `pending` is empty or [`GATED_WAIT_TIMEOUT`] elapses. The
     /// production loop calls `reap_finished_tasks` exactly once per
     /// cycle, so unit tests that drive it directly need to give the
     /// runtime time to schedule the spawned task that they are waiting
     /// to observe complete.
     async fn reap_until_pending_empty(
-        tasks: &mut JoinSet<Result<Address>>,
+        tasks: &mut JoinSet<ProofTaskOutcome>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
         let started = std::time::Instant::now();
@@ -1493,7 +1489,7 @@ mod tests {
             if started.elapsed() > GATED_WAIT_TIMEOUT {
                 panic!("timed out reaping {} pending task(s)", pending.len());
             }
-            RunSignerManager::reap_finished_tasks(tasks, pending);
+            ProofTaskSet::reap_finished_tasks(tasks, pending);
             tokio::time::sleep(REAP_POLL_INTERVAL).await;
         }
     }
@@ -1541,9 +1537,10 @@ mod tests {
     /// Builds a minimal [`PendingRegistration`] for unit-testing
     /// reap/apply-outcome flows without spawning a real future. The
     /// `task_id` is taken from the spawned placeholder's
-    /// `JoinHandle::id()` so the failure-path O(n) scan in
-    /// [`SignerManager::apply_join_outcome`] can recover the
-    /// signer just as it does in production.
+    /// `JoinHandle::id()` so join-error handling in
+    /// [`ProofTaskSet::apply_join_outcome`] can recover the
+    /// signer just as it does in production when the pending entry
+    /// is still current.
     fn pending_registration_for_test(task_id: task::Id, instance_id: &str) -> PendingRegistration {
         PendingRegistration {
             instance_id: instance_id.to_string(),
@@ -1551,6 +1548,18 @@ mod tests {
             cancel: CancellationToken::new(),
             cancelled_by_reconcile: false,
         }
+    }
+
+    fn proof_task_success_for_test(signer: Address, instance_id: &str) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, instance_id: instance_id.to_string(), result: Ok(()) }
+    }
+
+    fn proof_task_failure_for_test(
+        signer: Address,
+        instance_id: &str,
+        error: RegistrarError,
+    ) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, instance_id: instance_id.to_string(), result: Err(error) }
     }
 
     /// Builds a synthetic [`DiscoveryResolution`] from a list of
@@ -2447,7 +2456,7 @@ mod tests {
         #[case] expected_cancels: usize,
     ) {
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         // Seed the pending map by spawning placeholder tasks for the
@@ -2460,7 +2469,7 @@ mod tests {
             let task_cancel_inner = task_cancel.clone();
             let handle = tasks.spawn(async move {
                 task_cancel_inner.cancelled().await;
-                Ok(signer)
+                proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
             });
             pending.insert(
                 signer,
@@ -2494,7 +2503,7 @@ mod tests {
         // Running reconcile twice with the same resolution must not
         // spawn duplicate tasks or cancel an already-pending one.
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
@@ -2533,7 +2542,7 @@ mod tests {
     #[tokio::test]
     async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let signer =
@@ -2546,7 +2555,7 @@ mod tests {
         let stale_cancel_inner = stale_cancel.clone();
         let stale_handle = tasks.spawn(async move {
             stale_cancel_inner.cancelled().await;
-            Ok(signer)
+            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         let stale_task_id = stale_handle.id();
         pending.insert(
@@ -2600,7 +2609,7 @@ mod tests {
     #[tokio::test]
     async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let signer =
@@ -2612,7 +2621,7 @@ mod tests {
         let task_cancel_inner = task_cancel.clone();
         let handle = tasks.spawn(async move {
             task_cancel_inner.cancelled().await;
-            Ok(signer)
+            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         pending.insert(
             signer,
@@ -2680,7 +2689,7 @@ mod tests {
     /// `unresolved_instance_ids`). If the preserved task succeeds and
     /// registers the signer onchain right as the orphan-dereg pass
     /// runs, the protected set assembled by
-    /// [`RunSignerManager::protected_signers`] MUST union the two, otherwise
+    /// [`ProofTaskSet::protected_signers`] MUST union the two, otherwise
     /// the very next call to `deregister_orphans` would deregister the
     /// freshly-registered signer (TOCTOU race).
     #[tokio::test]
@@ -2702,13 +2711,13 @@ mod tests {
         // alone is what `protected_signers` consumes; the placeholder
         // task is just there so cleanup runs through the same path the
         // production loop does.
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
         let task_cancel = CancellationToken::new();
         let task_cancel_inner = task_cancel.clone();
         let handle = tasks.spawn(async move {
             task_cancel_inner.cancelled().await;
-            Ok(signer)
+            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         pending.insert(
             signer,
@@ -2734,7 +2743,7 @@ mod tests {
             unresolved_instance_ids: unresolved,
         };
 
-        let protected = RunSignerManager::protected_signers(&resolution, &pending);
+        let protected = ProofTaskSet::protected_signers(&resolution, &pending);
         assert!(
             protected.contains(&signer),
             "protected set must include in-flight signer even when absent from active_signers",
@@ -2777,7 +2786,7 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let protected = RunSignerManager::protected_signers(&resolution, &pending);
+        let protected = ProofTaskSet::protected_signers(&resolution, &pending);
         assert!(protected.is_empty(), "no pending → protected set is empty");
 
         harness.driver.signer_manager.run_orphan_dereg(&protected).await.unwrap();
@@ -2792,7 +2801,7 @@ mod tests {
 
     // ── drain_proof_tasks metric-gating test ────────────────────────────
 
-    /// At shutdown, [`SignerManager::drain_proof_tasks`] MUST count
+    /// At shutdown, [`ProofTaskSet::drain_proof_tasks`] MUST count
     /// only the tasks whose cancellation it actually drives — tasks
     /// already cancelled by a prior
     /// [`SignerManager::reconcile_proof_tasks`] cancel-pass were
@@ -2823,7 +2832,7 @@ mod tests {
 
             metrics::with_local_recorder(&recorder, || {
                 rt.block_on(async {
-                    let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+                    let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
                     let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
                     // Seed: (key, was_flagged_by_reconcile). The flagged
@@ -2839,7 +2848,7 @@ mod tests {
                         let cancel_inner = cancel.clone();
                         let handle = tasks.spawn(async move {
                             cancel_inner.cancelled().await;
-                            Ok(signer)
+                            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
                         });
                         pending.insert(
                             signer,
@@ -2859,7 +2868,7 @@ mod tests {
                         }
                     }
 
-                    RunSignerManager::drain_proof_tasks(&mut tasks, &mut pending).await;
+                    ProofTaskSet::drain_proof_tasks(&mut tasks, &mut pending).await;
                 });
             });
 
@@ -2947,7 +2956,7 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
@@ -3018,7 +3027,7 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
@@ -3043,14 +3052,18 @@ mod tests {
     async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
         // Spawn one task that completes immediately; reap_finished_tasks
         // must remove it from `pending` regardless of inner success.
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let handle = tasks.spawn(async move {
             if succeed {
-                Ok(HARDHAT_ACCOUNT)
+                proof_task_success_for_test(HARDHAT_ACCOUNT, TEST_PENDING_INSTANCE_ID)
             } else {
-                Err(RegistrarError::Transaction("synthetic".into()))
+                proof_task_failure_for_test(
+                    HARDHAT_ACCOUNT,
+                    TEST_PENDING_INSTANCE_ID,
+                    RegistrarError::Transaction("synthetic".into()),
+                )
             }
         });
         pending.insert(
@@ -3068,14 +3081,14 @@ mod tests {
     async fn reap_finished_tasks_leaves_in_flight_alone() {
         // A task that never completes must remain in `pending` after
         // `reap_finished_tasks` is called (it is non-blocking).
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let cancel = CancellationToken::new();
         let cancel_inner = cancel.clone();
         let handle = tasks.spawn(async move {
             cancel_inner.cancelled().await;
-            Ok(HARDHAT_ACCOUNT)
+            proof_task_success_for_test(HARDHAT_ACCOUNT, TEST_PENDING_INSTANCE_ID)
         });
         pending.insert(
             HARDHAT_ACCOUNT,
@@ -3087,7 +3100,7 @@ mod tests {
             },
         );
 
-        RunSignerManager::reap_finished_tasks(&mut tasks, &mut pending);
+        ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
 
         assert_eq!(pending.len(), 1, "live task must remain in pending");
 
@@ -3099,10 +3112,10 @@ mod tests {
         // Sanity: the production loop calls `reap_finished_tasks` every
         // cycle, including cycles with no pending work. It must not
         // panic in that case.
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
-        RunSignerManager::reap_finished_tasks(&mut tasks, &mut pending);
+        ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
 
         assert!(pending.is_empty(), "pending stays empty");
         assert!(tasks.is_empty(), "JoinSet stays empty");
@@ -3396,7 +3409,7 @@ mod tests {
         // metric still fires. The full reap path is exercised so this
         // is also a coverage test for `reap_finished_tasks` routing the
         // `JoinError` correctly.
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let handle = tasks.spawn(async {
@@ -3415,15 +3428,15 @@ mod tests {
 
     /// Address-keyed cleanup safety: a stale task whose `pending` entry
     /// was overwritten by a same-cycle respawn for the same signer
-    /// must NOT evict the fresh entry when its terminal `Ok(signer)`
-    /// flows through [`SignerManager::apply_join_outcome`]. The
+    /// must NOT evict the fresh entry when its terminal success outcome
+    /// flows through [`ProofTaskSet::apply_join_outcome`]. The
     /// `task_id`-match guard in the success arm is the protection — a
     /// stale completion without the guard would leak the fresh task
     /// from `pending` (orphaning its cancel handle) and corrupt
     /// shutdown bookkeeping.
     #[tokio::test]
     async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_completes_for_same_signer() {
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let signer = HARDHAT_ACCOUNT;
@@ -3433,7 +3446,8 @@ mod tests {
         // instead simulate the post-overwrite state where the stale
         // entry is gone but its outcome is still in-flight on the
         // JoinSet.
-        let stale_handle = tasks.spawn(async move { Ok(signer) });
+        let stale_handle = tasks
+            .spawn(async move { proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID) });
         let stale_task_id = stale_handle.id();
 
         // Fresh task: spawn another, register it under `signer` in
@@ -3443,7 +3457,7 @@ mod tests {
         let fresh_cancel_inner = fresh_cancel.clone();
         let fresh_handle = tasks.spawn(async move {
             fresh_cancel_inner.cancelled().await;
-            Ok(signer)
+            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
@@ -3463,7 +3477,7 @@ mod tests {
         let started = std::time::Instant::now();
         loop {
             if let Some(joined) = tasks.try_join_next_with_id() {
-                RunSignerManager::apply_join_outcome(joined, &mut pending);
+                ProofTaskSet::apply_join_outcome(joined, &mut pending);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {
@@ -3482,7 +3496,7 @@ mod tests {
     }
 
     /// Mirror of the success-arm fresh/stale test for the
-    /// [`SignerManager::apply_join_outcome`] inner-`Err` arm: a
+    /// [`ProofTaskSet::apply_join_outcome`] inner-`Err` arm: a
     /// stale task failing must NOT evict the fresh entry that
     /// reconcile dropped into the slot for the same signer. The
     /// task-id guard in the error arms is what enforces this — without
@@ -3491,7 +3505,7 @@ mod tests {
     #[tokio::test]
     async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
      {
-        let mut tasks: JoinSet<Result<Address>> = JoinSet::new();
+        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
         let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
 
         let signer = HARDHAT_ACCOUNT;
@@ -3499,7 +3513,11 @@ mod tests {
         // Stale task returns an immediate `Err`. Its task_id is NOT in
         // `pending` — simulating the post-overwrite state.
         let stale_handle = tasks.spawn(async move {
-            Err(RegistrarError::Config("synthetic stale proof failure".to_string()))
+            proof_task_failure_for_test(
+                signer,
+                TEST_PENDING_INSTANCE_ID,
+                RegistrarError::Config("synthetic stale proof failure".to_string()),
+            )
         });
         let stale_task_id = stale_handle.id();
 
@@ -3509,7 +3527,7 @@ mod tests {
         let fresh_cancel_inner = fresh_cancel.clone();
         let fresh_handle = tasks.spawn(async move {
             fresh_cancel_inner.cancelled().await;
-            Ok(signer)
+            proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
@@ -3529,7 +3547,7 @@ mod tests {
         let started = std::time::Instant::now();
         loop {
             if let Some(joined) = tasks.try_join_next_with_id() {
-                RunSignerManager::apply_join_outcome(joined, &mut pending);
+                ProofTaskSet::apply_join_outcome(joined, &mut pending);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -652,9 +652,6 @@ where
                     if outcome.unresolved {
                         unresolved_instance_ids.insert(instance.instance_id.clone());
                     }
-                    // Record signer -> instance attribution before `instance`
-                    // is moved into `RegisterableSigner` below.
-                    self.signer_manager.record_signers(&outcome.addresses, &instance.instance_id);
                     if let Some(attestations) = outcome.attestations {
                         // `resolve_instance` already enforced the pairing
                         // invariants (non-empty addresses,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -271,26 +271,11 @@ where
     /// consistent. `JoinSet::abort_all` is deliberately **not** used — see
     /// [`ProofTaskSet::drain_proof_tasks`] for the nonce-gap rationale.
     ///
-    /// # Ownership
-    ///
-    /// Consumes `self` by value so the API matches every other long-lived
-    /// `*_service::run` in the workspace. Internally the driver is wrapped
-    /// in an [`Arc`] and the spawned proof tasks each hold a clone — see
-    /// [`Self::run_arc`] for the underlying loop and the rationale for the
-    /// shared ownership.
     pub async fn run(self) -> Result<()> {
-        Arc::new(self).run_arc().await
+        self.run_loop().await
     }
 
-    /// Underlying registration loop that powers [`Self::run`].
-    ///
-    /// Takes `self: Arc<Self>` directly because each spawned proof task
-    /// owns an `Arc<Self>` clone so the cycle loop can continue to mutate
-    /// `proof_tasks` while proofs run for tens of minutes. Tests
-    /// that need to inspect driver state from outside the task can call
-    /// this method directly with their own `Arc` clone; production code
-    /// uses [`Self::run`].
-    pub async fn run_arc(self: Arc<Self>) -> Result<()> {
+    async fn run_loop(&self) -> Result<()> {
         info!(
             poll_interval = ?self.config.poll_interval,
             registry = %self.config.signer_manager.registry_address,
@@ -498,7 +483,7 @@ where
             // Return `attestations: None` so the safety invariant —
             // `Some(..)` ↔ "passed every eligibility + security gate,
             // including CRL" — is enforced locally. Today the outer
-            // `run_arc` loop re-checks `cancel.is_cancelled()` before
+            // run loop re-checks `cancel.is_cancelled()` before
             // calling `reconcile_proof_tasks`, so a `Some(..)` here
             // would still be discarded; keeping it `None` removes the
             // non-local dependence on that re-check and matches the
@@ -574,7 +559,7 @@ where
     /// `true` so legitimate fleet drains still let orphan cleanup proceed —
     /// except when the driver is cancelled, in which case the orphan dereg
     /// pass is skipped so we don't acquire nonces during shutdown.
-    async fn discover_and_resolve(self: &Arc<Self>) -> Result<DiscoveryResolution> {
+    async fn discover_and_resolve(&self) -> Result<DiscoveryResolution> {
         let instances = self.discovery.discover_instances().await?;
         RegistrarMetrics::discovery_success_total().increment(1);
 
@@ -596,7 +581,6 @@ where
 
         let concurrency = self.config.signer_manager.max_concurrency.max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
-            let driver = Arc::clone(self);
             let span = info_span!(
                 "resolve_instance",
                 instance_id = %instance.instance_id,
@@ -604,7 +588,7 @@ where
                 health = ?instance.health_status,
             );
             async move {
-                let result = driver.resolve_instance(&instance).await;
+                let result = self.resolve_instance(&instance).await;
                 (instance, result)
             }
             .instrument(span)
@@ -1078,9 +1062,8 @@ mod tests {
 
     /// Builds a fully-configured driver for primitive-level tests that
     /// invoke `discover_and_resolve` and `run_orphan_dereg` directly
-    /// (rather than the spawn pipeline in `run`). Returns an `Arc` so callers can invoke
-    /// `discover_and_resolve` (which takes `&Arc<Self>`) without
-    /// re-wrapping at every call site.
+    /// (rather than the spawn pipeline in `run`). Returns an `Arc` so tests
+    /// that spawn the run loop can keep handles for state inspection.
     fn cycle_driver(
         instances: Vec<ProverInstance>,
         signer_client: MockSignerClient,
@@ -1386,13 +1369,10 @@ mod tests {
         }
 
         /// Spawns the registration loop on the current runtime, returning
-        /// the `JoinHandle` so the test can await shutdown. Uses
-        /// [`RegistrationDriver::run_arc`] (rather than the value-API
-        /// `run`) so the harness can keep its own `Arc<RegistrationDriver>`
-        /// for state inspection.
+        /// the `JoinHandle` so the test can await shutdown.
         fn spawn_run(&self) -> tokio::task::JoinHandle<Result<()>> {
             let driver = Arc::clone(&self.driver);
-            tokio::spawn(driver.run_arc())
+            tokio::spawn(async move { driver.run_loop().await })
         }
 
         /// Cancels the harness, awaits its run handle inside

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -5,26 +5,19 @@
 //! to L1 via the [`TxManager`]. Also detects orphaned onchain signers (those
 //! no longer backed by a healthy instance) and deregisters them.
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, hex};
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
-use tokio::task::JoinSet;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, NitroVerifierClient,
-    PendingRegistration, ProofTaskOutcome, ProofTaskSet, ProverClient, ProverInstance,
-    RegistrarError, RegistrarMetrics, RegistryClient, Result, SignerClient, SignerManager,
-    SignerManagerConfig,
+    ProofTaskSet, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient,
+    Result, SignerClient, SignerManager, SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -263,7 +256,7 @@ where
     ///    run a single deregistration pass over signers no longer backed
     ///    by an active instance (`run_orphan_dereg`). The protected set
     ///    is the union of `resolution.active_signers` and the keys of
-    ///    `pending` (see [`Self::protected_signers`]) so a signer
+    ///    `pending` (see [`ProofTaskSet::protected_signers`]) so a signer
     ///    registered mid-cycle by a preserved task — whose source
     ///    instance failed `resolve_instance` transiently — cannot be
     ///    deregistered in the same pass.
@@ -293,26 +286,25 @@ where
     ///
     /// Takes `self: Arc<Self>` directly because each spawned proof task
     /// owns an `Arc<Self>` clone so the cycle loop can continue to mutate
-    /// `pending` and `tasks` while proofs run for tens of minutes. Tests
+    /// `proof_tasks` while proofs run for tens of minutes. Tests
     /// that need to inspect driver state from outside the task can call
     /// this method directly with their own `Arc` clone; production code
     /// uses [`Self::run`].
     pub async fn run_arc(self: Arc<Self>) -> Result<()> {
         info!(
             poll_interval = ?self.config.poll_interval,
-            registry = %self.signer_manager.registry_address(),
+            registry = %self.config.signer_manager.registry_address,
             "starting registration driver"
         );
 
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         loop {
             // Reap before discovery so finished tasks don't linger in
             // `pending` for an entire cycle and (incorrectly) cause
             // reconcile to skip spawning a replacement on transient
             // failure (audit finding #9).
-            ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
+            proof_tasks.reap_finished_tasks();
 
             match self.discover_and_resolve().await {
                 Ok(resolution) => {
@@ -320,24 +312,20 @@ where
                     // (potentially slow) discovery RPCs would otherwise
                     // look in-flight to reconcile and get spuriously
                     // re-cancelled or have its respawn deferred a cycle.
-                    ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
+                    proof_tasks.reap_finished_tasks();
 
                     // Spawning new proof tasks during a shutdown would
                     // acquire L1 nonces we have no intention of
                     // broadcasting. Skip reconcile (and the orphan
                     // dereg pass) entirely when cancellation is set.
-                    if !self.signer_manager.cancel().is_cancelled() {
-                        self.signer_manager.reconcile_proof_tasks(
-                            &resolution,
-                            &mut tasks,
-                            &mut pending,
-                        );
+                    if !self.config.signer_manager.cancel.is_cancelled() {
+                        self.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
                     }
 
-                    if resolution.ok_to_dereg && !self.signer_manager.cancel().is_cancelled() {
+                    if resolution.ok_to_dereg && !self.config.signer_manager.cancel.is_cancelled() {
                         // Pending proof tasks can register while orphan cleanup
                         // is running, so protect those signers too.
-                        let protected = ProofTaskSet::protected_signers(&resolution, &pending);
+                        let protected = proof_tasks.protected_signers(&resolution);
                         if let Err(e) = self.signer_manager.run_orphan_dereg(&protected).await {
                             warn!(error = %e, "orphan deregistration pass failed");
                             RegistrarMetrics::processing_errors_total().increment(1);
@@ -358,13 +346,13 @@ where
 
             // Publish gauge once per cycle, after every path that could
             // mutate `pending` (reconcile, reap) has run.
-            RegistrarMetrics::proof_tasks_pending().set(pending.len() as f64);
+            RegistrarMetrics::proof_tasks_pending().set(proof_tasks.pending_len() as f64);
 
             tokio::select! {
                 biased;
-                () = self.signer_manager.cancel().cancelled() => {
+                () = self.config.signer_manager.cancel.cancelled() => {
                     info!(
-                        pending = pending.len(),
+                        pending = proof_tasks.pending_len(),
                         "registration driver received shutdown signal"
                     );
                     break;
@@ -373,7 +361,7 @@ where
             }
         }
 
-        ProofTaskSet::drain_proof_tasks(&mut tasks, &mut pending).await;
+        proof_tasks.drain_proof_tasks().await;
 
         info!("registration driver stopped");
         Ok(())
@@ -425,12 +413,12 @@ where
     /// spawned tasks instead of blocking the next discovery cycle.
     ///
     /// **Cancellation contract.** This future checks
-    /// `self.signer_manager.cancel().is_cancelled()` before starting new side effects.
+    /// `self.config.signer_manager.cancel.is_cancelled()` before starting new side effects.
     /// `check_and_revoke_crls` awaits any `revokeCert` transaction
     /// submissions it triggers, so revocation outcomes are logged before
     /// the resolution future returns.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
-        if self.signer_manager.cancel().is_cancelled() {
+        if self.config.signer_manager.cancel.is_cancelled() {
             return Ok(ResolveOutcome {
                 addresses: Vec::new(),
                 attestations: None,
@@ -465,7 +453,7 @@ where
             );
         }
 
-        if self.signer_manager.cancel().is_cancelled() {
+        if self.config.signer_manager.cancel.is_cancelled() {
             return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
         }
 
@@ -515,7 +503,7 @@ where
             // would still be discarded; keeping it `None` removes the
             // non-local dependence on that re-check and matches the
             // CRL-revoked branch below.
-            if self.signer_manager.cancel().is_cancelled() {
+            if self.config.signer_manager.cancel.is_cancelled() {
                 return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
             }
             // Use `.first()` rather than `[0]` so the non-empty
@@ -606,7 +594,7 @@ where
         let mut registerable: Vec<RegisterableSigner> = Vec::new();
         let mut unresolved_instance_ids: HashSet<String> = HashSet::new();
 
-        let concurrency = self.signer_manager.max_concurrency().max(1);
+        let concurrency = self.config.signer_manager.max_concurrency.max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
             let driver = Arc::clone(self);
             let span = info_span!(
@@ -677,18 +665,19 @@ where
             }
         }
 
-        let ok_to_dereg =
-            if self.signer_manager.cancel().is_cancelled() || !unresolved_instance_ids.is_empty() {
-                false
-            } else if total_count == 0 {
-                true
-            } else {
-                // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
-                // is bounded above by `total_count = instances.len()`, so the
-                // doubling can only overflow on a list with `usize::MAX / 2`
-                // entries, which is physically impossible.
-                reachable_count * 2 > total_count
-            };
+        let ok_to_dereg = if self.config.signer_manager.cancel.is_cancelled()
+            || !unresolved_instance_ids.is_empty()
+        {
+            false
+        } else if total_count == 0 {
+            true
+        } else {
+            // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
+            // is bounded above by `total_count = instances.len()`, so the
+            // doubling can only overflow on a list with `usize::MAX / 2`
+            // entries, which is physically impossible.
+            reachable_count * 2 > total_count
+        };
 
         Ok(DiscoveryResolution {
             registerable,
@@ -728,7 +717,10 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::{InstanceHealthStatus, RegistryClient, Result, SignerClient};
+    use crate::{
+        InstanceHealthStatus, PendingRegistration, ProofTaskOutcome, RegistryClient, Result,
+        SignerClient,
+    };
 
     // ── Shared constants ────────────────────────────────────────────────
 
@@ -1457,16 +1449,14 @@ mod tests {
     /// backstop and drains the `JoinSet` so test teardown doesn't leak
     /// futures that are forever parked on their tokens. Mirrors the
     /// production shutdown sequence in [`RegistrationDriver::run`].
-    async fn drain_test_tasks(
-        tasks: &mut JoinSet<ProofTaskOutcome>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        for task in pending.values() {
+    async fn drain_test_tasks(proof_tasks: &mut ProofTaskSet) {
+        for task in proof_tasks.pending().values() {
             task.cancel.cancel();
         }
+        let tasks = proof_tasks.tasks_mut();
         tasks.abort_all();
         while tasks.join_next().await.is_some() {}
-        pending.clear();
+        proof_tasks.pending_mut().clear();
     }
 
     /// Polling fixed point used by the reap-loop helper below — small
@@ -1480,16 +1470,13 @@ mod tests {
     /// cycle, so unit tests that drive it directly need to give the
     /// runtime time to schedule the spawned task that they are waiting
     /// to observe complete.
-    async fn reap_until_pending_empty(
-        tasks: &mut JoinSet<ProofTaskOutcome>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
+    async fn reap_until_pending_empty(proof_tasks: &mut ProofTaskSet) {
         let started = std::time::Instant::now();
-        while !pending.is_empty() {
+        while !proof_tasks.is_pending_empty() {
             if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("timed out reaping {} pending task(s)", pending.len());
+                panic!("timed out reaping {} pending task(s)", proof_tasks.pending_len());
             }
-            ProofTaskSet::reap_finished_tasks(tasks, pending);
+            proof_tasks.reap_finished_tasks();
             tokio::time::sleep(REAP_POLL_INTERVAL).await;
         }
     }
@@ -2456,8 +2443,7 @@ mod tests {
         #[case] expected_cancels: usize,
     ) {
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         // Seed the pending map by spawning placeholder tasks for the
         // pre-existing signers. These futures park on their per-task
@@ -2467,11 +2453,11 @@ mod tests {
             let signer = ProverClient::derive_address(&public_key_from_private(key)).unwrap();
             let task_cancel = CancellationToken::new();
             let task_cancel_inner = task_cancel.clone();
-            let handle = tasks.spawn(async move {
+            let handle = proof_tasks.tasks_mut().spawn(async move {
                 task_cancel_inner.cancelled().await;
                 proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
             });
-            pending.insert(
+            proof_tasks.pending_mut().insert(
                 signer,
                 PendingRegistration {
                     instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -2484,18 +2470,18 @@ mod tests {
         }
 
         let resolution = dr_from_kept(kept);
-        let pre_spawn_count = pending.len();
+        let pre_spawn_count = proof_tasks.pending_len();
         let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
 
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
 
         let post_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
-        let new_spawns = pending.len().saturating_sub(pre_spawn_count);
+        let new_spawns = proof_tasks.pending_len().saturating_sub(pre_spawn_count);
 
         assert_eq!(new_spawns, expected_new_spawns, "spawn-pass count");
         assert_eq!(post_cancelled - pre_cancelled, expected_cancels, "cancel-pass count");
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     #[tokio::test]
@@ -2503,25 +2489,24 @@ mod tests {
         // Running reconcile twice with the same resolution must not
         // spawn duplicate tasks or cancel an already-pending one.
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
 
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
-        let after_first = pending.len();
-        let snapshot_ids: HashSet<_> = pending.keys().copied().collect();
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+        let after_first = proof_tasks.pending_len();
+        let snapshot_ids: HashSet<_> = proof_tasks.pending().keys().copied().collect();
 
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
 
-        assert_eq!(pending.len(), after_first, "idempotent: no extra spawns");
-        let after_second: HashSet<_> = pending.keys().copied().collect();
+        assert_eq!(proof_tasks.pending_len(), after_first, "idempotent: no extra spawns");
+        let after_second: HashSet<_> = proof_tasks.pending().keys().copied().collect();
         assert_eq!(snapshot_ids, after_second, "pending signer keys unchanged across reconciles");
-        for task in pending.values() {
+        for task in proof_tasks.pending().values() {
             assert!(!task.cancel.is_cancelled(), "kept task must not be cancelled");
         }
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     /// Vanish-then-reappear: a signer cancelled in cycle N (because it
@@ -2542,8 +2527,7 @@ mod tests {
     #[tokio::test]
     async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         let signer =
             ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
@@ -2553,12 +2537,12 @@ mod tests {
         // cancellation is observable without the task self-resolving.
         let stale_cancel = CancellationToken::new();
         let stale_cancel_inner = stale_cancel.clone();
-        let stale_handle = tasks.spawn(async move {
+        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
             stale_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         let stale_task_id = stale_handle.id();
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -2572,14 +2556,18 @@ mod tests {
         // but does not reap, so the (now cancelled) entry persists in
         // `pending` keyed by `signer`.
         let empty = dr_from_kept(&[]);
-        harness.driver.signer_manager.reconcile_proof_tasks(&empty, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&empty, &mut proof_tasks);
         assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
         assert_eq!(
-            pending.get(&signer).map(|p| p.task_id),
+            proof_tasks.pending().get(&signer).map(|p| p.task_id),
             Some(stale_task_id),
             "cancelled entry still keyed by signer until reaped",
         );
-        assert_eq!(pending.len(), 1, "no fresh spawn yet (signer not registerable this cycle)");
+        assert_eq!(
+            proof_tasks.pending_len(),
+            1,
+            "no fresh spawn yet (signer not registerable this cycle)"
+        );
 
         // Cycle N+2 (BEFORE the stale entry is reaped): signer reappears
         // → fresh spawn must happen this cycle, not deferred to N+3. The
@@ -2587,14 +2575,21 @@ mod tests {
         // the stale task lives on in the JoinSet (parked on its cancel
         // until drain).
         let resurrected = dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]);
-        harness.driver.signer_manager.reconcile_proof_tasks(&resurrected, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resurrected, &mut proof_tasks);
 
-        assert_eq!(pending.len(), 1, "still exactly one entry per signer after respawn");
-        let fresh = pending.get(&signer).expect("fresh entry keyed by the resurrected signer");
+        assert_eq!(
+            proof_tasks.pending_len(),
+            1,
+            "still exactly one entry per signer after respawn"
+        );
+        let fresh = proof_tasks
+            .pending()
+            .get(&signer)
+            .expect("fresh entry keyed by the resurrected signer");
         assert_ne!(fresh.task_id, stale_task_id, "fresh task_id replaces the stale one");
         assert!(!fresh.cancel.is_cancelled(), "fresh task carries a live cancel token");
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     /// Inconclusive-snapshot guard: when a signer's source instance
@@ -2609,8 +2604,7 @@ mod tests {
     #[tokio::test]
     async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
         let harness = single_healthy_harness();
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         let signer =
             ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
@@ -2619,11 +2613,11 @@ mod tests {
         // with the instance_id we'll later mark as unresolved.
         let task_cancel = CancellationToken::new();
         let task_cancel_inner = task_cancel.clone();
-        let handle = tasks.spawn(async move {
+        let handle = proof_tasks.tasks_mut().spawn(async move {
             task_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -2647,13 +2641,13 @@ mod tests {
             unresolved_instance_ids: unresolved,
         };
 
-        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        harness.driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
 
         assert!(
             !task_cancel.is_cancelled(),
             "task tied to an unresolved instance must be preserved across the cancel-pass",
         );
-        assert_eq!(pending.len(), 1, "no spurious spawn or eviction this cycle");
+        assert_eq!(proof_tasks.pending_len(), 1, "no spurious spawn or eviction this cycle");
 
         // Sanity contrast: same setup, but the instance is NOT
         // unresolved → cancel-pass MUST fire. Asserts the previous
@@ -2666,17 +2660,16 @@ mod tests {
             ok_to_dereg: true,
             unresolved_instance_ids: HashSet::new(),
         };
-        harness.driver.signer_manager.reconcile_proof_tasks(
-            &resolution_conclusive,
-            &mut tasks,
-            &mut pending,
-        );
+        harness
+            .driver
+            .signer_manager
+            .reconcile_proof_tasks(&resolution_conclusive, &mut proof_tasks);
         assert!(
             task_cancel.is_cancelled(),
             "with no inconclusive guard, the cancel-pass MUST fire on the same setup",
         );
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     /// Orphan-dereg companion to
@@ -2711,15 +2704,14 @@ mod tests {
         // alone is what `protected_signers` consumes; the placeholder
         // task is just there so cleanup runs through the same path the
         // production loop does.
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
         let task_cancel = CancellationToken::new();
         let task_cancel_inner = task_cancel.clone();
-        let handle = tasks.spawn(async move {
+        let handle = proof_tasks.tasks_mut().spawn(async move {
             task_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -2743,7 +2735,7 @@ mod tests {
             unresolved_instance_ids: unresolved,
         };
 
-        let protected = ProofTaskSet::protected_signers(&resolution, &pending);
+        let protected = proof_tasks.protected_signers(&resolution);
         assert!(
             protected.contains(&signer),
             "protected set must include in-flight signer even when absent from active_signers",
@@ -2758,7 +2750,7 @@ mod tests {
             "orphan pass must NOT deregister a signer with an in-flight proof task",
         );
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     /// Sanity contrast for
@@ -2776,7 +2768,7 @@ mod tests {
             MockRegistry::with_signers(vec![signer]),
         );
 
-        let pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let proof_tasks = ProofTaskSet::new();
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
@@ -2786,7 +2778,7 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let protected = ProofTaskSet::protected_signers(&resolution, &pending);
+        let protected = proof_tasks.protected_signers(&resolution);
         assert!(protected.is_empty(), "no pending → protected set is empty");
 
         harness.driver.signer_manager.run_orphan_dereg(&protected).await.unwrap();
@@ -2832,8 +2824,7 @@ mod tests {
 
             metrics::with_local_recorder(&recorder, || {
                 rt.block_on(async {
-                    let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-                    let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+                    let mut proof_tasks = ProofTaskSet::new();
 
                     // Seed: (key, was_flagged_by_reconcile). The flagged
                     // task must NOT re-count at drain; the two unflagged
@@ -2846,11 +2837,11 @@ mod tests {
                             ProverClient::derive_address(&public_key_from_private(key)).unwrap();
                         let cancel = CancellationToken::new();
                         let cancel_inner = cancel.clone();
-                        let handle = tasks.spawn(async move {
+                        let handle = proof_tasks.tasks_mut().spawn(async move {
                             cancel_inner.cancelled().await;
                             proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
                         });
-                        pending.insert(
+                        proof_tasks.pending_mut().insert(
                             signer,
                             PendingRegistration {
                                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -2868,7 +2859,7 @@ mod tests {
                         }
                     }
 
-                    ProofTaskSet::drain_proof_tasks(&mut tasks, &mut pending).await;
+                    proof_tasks.drain_proof_tasks().await;
                 });
             });
 
@@ -2956,13 +2947,16 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
-        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
 
-        assert_eq!(pending.len(), 1, "exactly one task should spawn for a duplicate signer");
-        let (&only_signer, _entry) = pending.iter().next().unwrap();
+        assert_eq!(
+            proof_tasks.pending_len(),
+            1,
+            "exactly one task should spawn for a duplicate signer"
+        );
+        let (&only_signer, _entry) = proof_tasks.pending().iter().next().unwrap();
         assert_eq!(only_signer, signer, "the spawned task is keyed by the deduplicated signer");
 
         // Let the single task run, record its attestation, and exit.
@@ -2970,7 +2964,7 @@ mod tests {
             !proof_provider.snapshot().is_empty()
         })
         .await;
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
 
         let snap = proof_provider.snapshot();
         assert_eq!(snap.len(), 1, "exactly one signer recorded across both entries");
@@ -3027,16 +3021,15 @@ mod tests {
             unresolved_instance_ids: HashSet::new(),
         };
 
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
-        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut tasks, &mut pending);
+        driver.signer_manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
 
         wait_for("both signers recorded their attestations", || {
             proof_provider.snapshot().len() == 2
         })
         .await;
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
 
         let snap = proof_provider.snapshot();
         assert_eq!(snap.get(&signer_a), Some(&att_a), "signer A got the A-aligned attestation");
@@ -3052,10 +3045,9 @@ mod tests {
     async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
         // Spawn one task that completes immediately; reap_finished_tasks
         // must remove it from `pending` regardless of inner success.
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
-        let handle = tasks.spawn(async move {
+        let handle = proof_tasks.tasks_mut().spawn(async move {
             if succeed {
                 proof_task_success_for_test(HARDHAT_ACCOUNT, TEST_PENDING_INSTANCE_ID)
             } else {
@@ -3066,31 +3058,30 @@ mod tests {
                 )
             }
         });
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             HARDHAT_ACCOUNT,
             pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
         );
 
-        reap_until_pending_empty(&mut tasks, &mut pending).await;
+        reap_until_pending_empty(&mut proof_tasks).await;
 
-        assert!(pending.is_empty(), "completed task must be evicted from pending");
-        assert!(tasks.is_empty(), "JoinSet must drain to empty");
+        assert!(proof_tasks.is_pending_empty(), "completed task must be evicted from pending");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
     }
 
     #[tokio::test]
     async fn reap_finished_tasks_leaves_in_flight_alone() {
         // A task that never completes must remain in `pending` after
         // `reap_finished_tasks` is called (it is non-blocking).
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         let cancel = CancellationToken::new();
         let cancel_inner = cancel.clone();
-        let handle = tasks.spawn(async move {
+        let handle = proof_tasks.tasks_mut().spawn(async move {
             cancel_inner.cancelled().await;
             proof_task_success_for_test(HARDHAT_ACCOUNT, TEST_PENDING_INSTANCE_ID)
         });
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             HARDHAT_ACCOUNT,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -3100,11 +3091,11 @@ mod tests {
             },
         );
 
-        ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
+        proof_tasks.reap_finished_tasks();
 
-        assert_eq!(pending.len(), 1, "live task must remain in pending");
+        assert_eq!(proof_tasks.pending_len(), 1, "live task must remain in pending");
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     #[tokio::test]
@@ -3112,13 +3103,12 @@ mod tests {
         // Sanity: the production loop calls `reap_finished_tasks` every
         // cycle, including cycles with no pending work. It must not
         // panic in that case.
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
-        ProofTaskSet::reap_finished_tasks(&mut tasks, &mut pending);
+        proof_tasks.reap_finished_tasks();
 
-        assert!(pending.is_empty(), "pending stays empty");
-        assert!(tasks.is_empty(), "JoinSet stays empty");
+        assert!(proof_tasks.is_pending_empty(), "pending stays empty");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet stays empty");
     }
 
     // ── run() spawn-and-reap pipeline tests ─────────────────────────────
@@ -3409,21 +3399,20 @@ mod tests {
         // metric still fires. The full reap path is exercised so this
         // is also a coverage test for `reap_finished_tasks` routing the
         // `JoinError` correctly.
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
-        let handle = tasks.spawn(async {
+        let handle = proof_tasks.tasks_mut().spawn(async {
             panic!("synthetic proof-task panic for apply_join_outcome test");
         });
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             HARDHAT_ACCOUNT,
             pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
         );
 
-        reap_until_pending_empty(&mut tasks, &mut pending).await;
+        reap_until_pending_empty(&mut proof_tasks).await;
 
-        assert!(pending.is_empty(), "panicked task must be evicted from pending");
-        assert!(tasks.is_empty(), "JoinSet must drain to empty");
+        assert!(proof_tasks.is_pending_empty(), "panicked task must be evicted from pending");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
     }
 
     /// Address-keyed cleanup safety: a stale task whose `pending` entry
@@ -3436,8 +3425,7 @@ mod tests {
     /// shutdown bookkeeping.
     #[tokio::test]
     async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_completes_for_same_signer() {
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         let signer = HARDHAT_ACCOUNT;
 
@@ -3446,7 +3434,8 @@ mod tests {
         // instead simulate the post-overwrite state where the stale
         // entry is gone but its outcome is still in-flight on the
         // JoinSet.
-        let stale_handle = tasks
+        let stale_handle = proof_tasks
+            .tasks_mut()
             .spawn(async move { proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID) });
         let stale_task_id = stale_handle.id();
 
@@ -3455,14 +3444,14 @@ mod tests {
         // terminal outcome.
         let fresh_cancel = CancellationToken::new();
         let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = tasks.spawn(async move {
+        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
             fresh_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
 
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -3476,8 +3465,8 @@ mod tests {
         // cancel token so reap only sees the stale outcome.
         let started = std::time::Instant::now();
         loop {
-            if let Some(joined) = tasks.try_join_next_with_id() {
-                ProofTaskSet::apply_join_outcome(joined, &mut pending);
+            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+                proof_tasks.apply_join_outcome(joined);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {
@@ -3486,13 +3475,17 @@ mod tests {
             tokio::time::sleep(REAP_POLL_INTERVAL).await;
         }
 
-        assert_eq!(pending.len(), 1, "fresh entry must NOT be evicted by stale completion");
-        let entry = pending.get(&signer).expect("fresh entry still keyed by signer");
+        assert_eq!(
+            proof_tasks.pending_len(),
+            1,
+            "fresh entry must NOT be evicted by stale completion"
+        );
+        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
         assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
         assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
 
         // Tear down: cancel the fresh task and drain.
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     /// Mirror of the success-arm fresh/stale test for the
@@ -3505,14 +3498,13 @@ mod tests {
     #[tokio::test]
     async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
      {
-        let mut tasks: JoinSet<ProofTaskOutcome> = JoinSet::new();
-        let mut pending: HashMap<Address, PendingRegistration> = HashMap::new();
+        let mut proof_tasks = ProofTaskSet::new();
 
         let signer = HARDHAT_ACCOUNT;
 
         // Stale task returns an immediate `Err`. Its task_id is NOT in
         // `pending` — simulating the post-overwrite state.
-        let stale_handle = tasks.spawn(async move {
+        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
             proof_task_failure_for_test(
                 signer,
                 TEST_PENDING_INSTANCE_ID,
@@ -3525,14 +3517,14 @@ mod tests {
         // `signer`. This entry must survive the stale `Err` outcome.
         let fresh_cancel = CancellationToken::new();
         let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = tasks.spawn(async move {
+        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
             fresh_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer, TEST_PENDING_INSTANCE_ID)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
 
-        pending.insert(
+        proof_tasks.pending_mut().insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -3546,8 +3538,8 @@ mod tests {
         // cancel token so reap only sees the stale outcome.
         let started = std::time::Instant::now();
         loop {
-            if let Some(joined) = tasks.try_join_next_with_id() {
-                ProofTaskSet::apply_join_outcome(joined, &mut pending);
+            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+                proof_tasks.apply_join_outcome(joined);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {
@@ -3556,12 +3548,12 @@ mod tests {
             tokio::time::sleep(REAP_POLL_INTERVAL).await;
         }
 
-        assert_eq!(pending.len(), 1, "fresh entry must NOT be evicted by stale Err");
-        let entry = pending.get(&signer).expect("fresh entry still keyed by signer");
+        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must NOT be evicted by stale Err");
+        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
         assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
         assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
 
-        drain_test_tasks(&mut tasks, &mut pending).await;
+        drain_test_tasks(&mut proof_tasks).await;
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -3475,7 +3475,7 @@ mod tests {
         let started = std::time::Instant::now();
         loop {
             if let Some(joined) = tasks.try_join_next_with_id() {
-                RunSignerManager::apply_join_outcome(Some(joined), &mut pending);
+                RunSignerManager::apply_join_outcome(joined, &mut pending);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {
@@ -3497,9 +3497,9 @@ mod tests {
     /// [`SignerManager::apply_join_outcome`] inner-`Err` arm: a
     /// stale task failing must NOT evict the fresh entry that
     /// reconcile dropped into the slot for the same signer. The
-    /// [`SignerManager::remove_by_task_id`] guard threaded through the
-    /// error arms is what enforces this — without it, a stale failure
-    /// could evict a fresh entry for the same signer.
+    /// task-id guard in the error arms is what enforces this — without
+    /// it, a stale failure could evict a fresh entry for the same
+    /// signer.
     #[tokio::test]
     async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
      {
@@ -3541,7 +3541,7 @@ mod tests {
         let started = std::time::Instant::now();
         loop {
             if let Some(joined) = tasks.try_join_next_with_id() {
-                RunSignerManager::apply_join_outcome(Some(joined), &mut pending);
+                RunSignerManager::apply_join_outcome(joined, &mut pending);
                 break;
             }
             if started.elapsed() > GATED_WAIT_TIMEOUT {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -18,7 +18,6 @@ use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
 use tokio::task::JoinSet;
-use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
@@ -58,22 +57,14 @@ pub const DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS: u64 = 5100;
 /// trait-based dependencies.
 #[derive(Debug, Clone)]
 pub struct DriverConfig {
-    /// `TEEProverRegistry` contract address on L1.
-    pub registry_address: Address,
     /// Interval between discovery and registration poll cycles.
     pub poll_interval: Duration,
-    /// Cancellation token for graceful shutdown.
-    pub cancel: CancellationToken,
-    /// Maximum number of instances to process concurrently. Each instance
-    /// may trigger proof generation, so this bounds concurrent proof work.
-    /// Defaults to [`DEFAULT_MAX_CONCURRENCY`].
-    pub max_concurrency: usize,
-    /// Maximum number of transaction submission retries for transient errors.
-    /// Defaults to [`DEFAULT_MAX_TX_RETRIES`].
-    pub max_tx_retries: u32,
-    /// Delay between transaction submission retries.
-    /// Defaults to [`DEFAULT_TX_RETRY_DELAY_SECS`] seconds.
-    pub tx_retry_delay: Duration,
+    /// Signer lifecycle settings.
+    ///
+    /// The registrar currently uses `signer_manager.max_concurrency` for both
+    /// per-cycle instance resolution and spawned proof task concurrency so one
+    /// CLI setting controls total signer lifecycle pressure.
+    pub signer_manager: SignerManagerConfig,
     /// Duration after launch during which unhealthy instances are still
     /// eligible for registration. New instances may fail ALB health checks
     /// while the application is still initializing. Set to zero to disable.
@@ -246,13 +237,7 @@ where
             proof_provider,
             registry,
             tx_manager,
-            SignerManagerConfig {
-                registry_address: config.registry_address,
-                cancel: config.cancel.clone(),
-                max_concurrency: config.max_concurrency,
-                max_tx_retries: config.max_tx_retries,
-                tx_retry_delay: config.tx_retry_delay,
-            },
+            config.signer_manager.clone(),
         ));
         Ok(Self { discovery, signer_client, config, cert_manager, signer_manager })
     }
@@ -314,7 +299,7 @@ where
     pub async fn run_arc(self: Arc<Self>) -> Result<()> {
         info!(
             poll_interval = ?self.config.poll_interval,
-            registry = %self.config.registry_address,
+            registry = %self.config.signer_manager.registry_address,
             "starting registration driver"
         );
 
@@ -340,7 +325,7 @@ where
                     // acquire L1 nonces we have no intention of
                     // broadcasting. Skip reconcile (and the orphan
                     // dereg pass) entirely when cancellation is set.
-                    if !self.config.cancel.is_cancelled() {
+                    if !self.config.signer_manager.cancel.is_cancelled() {
                         self.signer_manager.reconcile_proof_tasks(
                             &resolution,
                             &mut tasks,
@@ -348,7 +333,7 @@ where
                         );
                     }
 
-                    if resolution.ok_to_dereg && !self.config.cancel.is_cancelled() {
+                    if resolution.ok_to_dereg && !self.config.signer_manager.cancel.is_cancelled() {
                         // Pending proof tasks can register while orphan cleanup
                         // is running, so protect those signers too.
                         let protected =
@@ -377,7 +362,7 @@ where
 
             tokio::select! {
                 biased;
-                () = self.config.cancel.cancelled() => {
+                () = self.config.signer_manager.cancel.cancelled() => {
                     info!(
                         pending = pending.len(),
                         "registration driver received shutdown signal"
@@ -440,12 +425,12 @@ where
     /// spawned tasks instead of blocking the next discovery cycle.
     ///
     /// **Cancellation contract.** This future checks
-    /// `self.config.cancel.is_cancelled()` before starting new side effects.
+    /// `self.config.signer_manager.cancel.is_cancelled()` before starting new side effects.
     /// `check_and_revoke_crls` awaits any `revokeCert` transaction
     /// submissions it triggers, so revocation outcomes are logged before
     /// the resolution future returns.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
-        if self.config.cancel.is_cancelled() {
+        if self.config.signer_manager.cancel.is_cancelled() {
             return Ok(ResolveOutcome {
                 addresses: Vec::new(),
                 attestations: None,
@@ -480,7 +465,7 @@ where
             );
         }
 
-        if self.config.cancel.is_cancelled() {
+        if self.config.signer_manager.cancel.is_cancelled() {
             return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
         }
 
@@ -530,7 +515,7 @@ where
             // would still be discarded; keeping it `None` removes the
             // non-local dependence on that re-check and matches the
             // CRL-revoked branch below.
-            if self.config.cancel.is_cancelled() {
+            if self.config.signer_manager.cancel.is_cancelled() {
                 return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
             }
             // Use `.first()` rather than `[0]` so the non-empty
@@ -581,7 +566,7 @@ where
     /// [`DiscoveryResolution`] consumed by the spawn-and-reap loop.
     ///
     /// This fans out per-instance resolution work concurrently (bounded by
-    /// [`DriverConfig::max_concurrency`]). No registration transactions are
+    /// [`SignerManagerConfig::max_concurrency`]). No registration transactions are
     /// submitted here; the [`Self::run`] loop spawns a dedicated task per
     /// registerable signer instead, so long Boundless proofs do not block the
     /// next discovery cycle.
@@ -589,7 +574,7 @@ where
     /// **Why no outer cancel-select.** `resolve_instance` performs several
     /// side effects before deciding whether an instance is registerable. The
     /// buffered stream is therefore drained to natural completion; each
-    /// `resolve_instance` short-circuits on `self.config.cancel` between
+    /// `resolve_instance` short-circuits on the configured cancellation token between
     /// awaits. Shutdown latency is bounded by `max_concurrency` × the slowest
     /// signer-RPC / CRL-fetch timeout, not by long proof work (which lives in
     /// the spawned proof tasks).
@@ -621,7 +606,7 @@ where
         let mut registerable: Vec<RegisterableSigner> = Vec::new();
         let mut unresolved_instance_ids: HashSet<String> = HashSet::new();
 
-        let concurrency = self.config.max_concurrency.max(1);
+        let concurrency = self.config.signer_manager.max_concurrency.max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
             let driver = Arc::clone(self);
             let span = info_span!(
@@ -639,7 +624,7 @@ where
         .buffer_unordered(concurrency);
 
         // No cancel-select around `futs.next()`: each future checks
-        // `self.config.cancel` cooperatively between awaits, so new work is
+        // cancellation cooperatively between awaits, so new work is
         // short-circuited while already-started resolution work reaches a
         // natural boundary.
         while let Some((instance, result)) = futs.next().await {
@@ -692,18 +677,19 @@ where
             }
         }
 
-        let ok_to_dereg =
-            if self.config.cancel.is_cancelled() || !unresolved_instance_ids.is_empty() {
-                false
-            } else if total_count == 0 {
-                true
-            } else {
-                // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
-                // is bounded above by `total_count = instances.len()`, so the
-                // doubling can only overflow on a list with `usize::MAX / 2`
-                // entries, which is physically impossible.
-                reachable_count * 2 > total_count
-            };
+        let ok_to_dereg = if self.config.signer_manager.cancel.is_cancelled()
+            || !unresolved_instance_ids.is_empty()
+        {
+            false
+        } else if total_count == 0 {
+            true
+        } else {
+            // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
+            // is bounded above by `total_count = instances.len()`, so the
+            // doubling can only overflow on a list with `usize::MAX / 2`
+            // entries, which is physically impossible.
+            reachable_count * 2 > total_count
+        };
 
         Ok(DiscoveryResolution {
             registerable,
@@ -1080,12 +1066,14 @@ mod tests {
 
     fn default_config(cancel: CancellationToken) -> DriverConfig {
         DriverConfig {
-            registry_address: TEST_REGISTRY_ADDRESS,
             poll_interval: Duration::from_secs(1),
-            cancel,
-            max_concurrency: DEFAULT_MAX_CONCURRENCY,
-            max_tx_retries: DEFAULT_MAX_TX_RETRIES,
-            tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
+            signer_manager: SignerManagerConfig {
+                registry_address: TEST_REGISTRY_ADDRESS,
+                cancel,
+                max_concurrency: DEFAULT_MAX_CONCURRENCY,
+                max_tx_retries: DEFAULT_MAX_TX_RETRIES,
+                tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
+            },
             unhealthy_registration_window: Duration::from_secs(
                 DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
             ),
@@ -2305,7 +2293,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let tx = SharedTxManager::new();
         let mut config = default_config(cancel);
-        config.max_concurrency = max_concurrency;
+        config.signer_manager.max_concurrency = max_concurrency;
 
         let driver = Arc::new(
             RegistrationDriver::new(
@@ -2382,11 +2370,11 @@ mod tests {
     /// total test time stays well under [`CANCEL_ABORT_BUDGET`].
     const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
 
-    /// `run_orphan_dereg` MUST abort promptly when `config.cancel` fires
-    /// during the `get_registered_signers` RPC. Without the `select!`
-    /// wrap a stalled RPC here would extend drain latency by one
-    /// round-trip even though the function never reaches the
-    /// per-orphan loop that has its own cancel check.
+    /// `run_orphan_dereg` MUST abort promptly when the configured cancel
+    /// token fires during the `get_registered_signers` RPC. Without the
+    /// `select!` wrap a stalled RPC here would extend drain latency by one
+    /// round-trip even though the function never reaches the per-orphan loop
+    /// that has its own cancel check.
     #[tokio::test]
     async fn run_orphan_dereg_aborts_promptly_when_cancel_fires_during_registry_stall() {
         let cancel = CancellationToken::new();

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -45,7 +45,7 @@ mod proof_handler;
 pub use proof_handler::{ProofHandler, ProofHandlerConfig};
 
 mod registration_manager;
-pub use registration_manager::{InFlightRegistrationGuard, RegistrationManager};
+pub use registration_manager::RegistrationManager;
 
 mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -51,7 +51,9 @@ mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};
 
 mod signer_manager;
-pub use signer_manager::{PendingRegistration, SignerManager, SignerManagerConfig};
+pub use signer_manager::{
+    PendingRegistration, ProofTaskOutcome, ProofTaskSet, SignerManager, SignerManagerConfig,
+};
 
 mod traits;
 pub use traits::{InstanceDiscovery, SignerClient};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -52,7 +52,8 @@ pub use registry::{RegistryClient, RegistryContractClient};
 
 mod signer_manager;
 pub use signer_manager::{
-    PendingRegistration, ProofTaskOutcome, ProofTaskSet, SignerManager, SignerManagerConfig,
+    PendingRegistration, ProofTaskOutcome, ProofTaskSet, SignerLifecycle, SignerManager,
+    SignerManagerConfig,
 };
 
 mod traits;

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -29,7 +29,7 @@ mod driver;
 pub use driver::{
     DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DiscoveryResolution, DriverConfig,
-    PendingRegistration, RegisterableSigner, RegistrationDriver, ResolveOutcome,
+    RegisterableSigner, RegistrationDriver, ResolveOutcome,
 };
 
 mod error;
@@ -49,6 +49,9 @@ pub use registration_manager::{InFlightRegistrationGuard, RegistrationManager};
 
 mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};
+
+mod signer_manager;
+pub use signer_manager::{PendingRegistration, SignerManager, SignerManagerConfig};
 
 mod traits;
 pub use traits::{InstanceDiscovery, SignerClient};

--- a/crates/proof/tee/registrar/src/registration_manager.rs
+++ b/crates/proof/tee/registrar/src/registration_manager.rs
@@ -3,10 +3,10 @@
 //! Coordinates signer-level registration work before handing completed proof
 //! results to [`ProofHandler`]. This keeps the driver focused on discovery and
 //! task lifecycle management while centralizing the expensive path:
-//! deduplicate signer proof work, submit the proof request, then invoke the
-//! proof handler.
+//! confirm the signer still needs registration, submit the proof request,
+//! then invoke the proof handler.
 
-use std::{collections::HashSet, fmt, sync::Mutex};
+use std::fmt;
 
 use alloy_primitives::Address;
 use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
@@ -19,9 +19,10 @@ use crate::{ProofHandler, ProofHandlerConfig, ProverInstance, RegistryClient, Re
 
 /// Component responsible for signer-level registration orchestration.
 ///
-/// For each signer it checks whether proof work is already in progress,
-/// starts the attestation proof request when needed, and passes the completed
-/// proof to [`ProofHandler`] for onchain registration.
+/// For each signer it confirms the signer still needs registration, starts the
+/// attestation proof request when needed, and passes the completed proof to
+/// [`ProofHandler`] for onchain registration. The caller owns task-level
+/// deduplication; production calls flow through [`crate::SignerManager`].
 pub struct RegistrationManager<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
     /// Proof provider used to submit or recover attestation proof requests.
     proof_provider: &'a P,
@@ -31,8 +32,6 @@ pub struct RegistrationManager<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
     tx_manager: &'a T,
     /// Semaphore bounding concurrent proof work.
     proof_semaphore: &'a Semaphore,
-    /// Process-local signer set used to deduplicate concurrent attempts.
-    in_flight_registrations: &'a Mutex<HashSet<Address>>,
     /// Runtime settings for registration transaction handling.
     config: ProofHandlerConfig,
 }
@@ -54,45 +53,9 @@ impl<'a, P: ?Sized, R: ?Sized, T: ?Sized> RegistrationManager<'a, P, R, T> {
         registry: &'a R,
         tx_manager: &'a T,
         proof_semaphore: &'a Semaphore,
-        in_flight_registrations: &'a Mutex<HashSet<Address>>,
         config: ProofHandlerConfig,
     ) -> Self {
-        Self {
-            proof_provider,
-            registry,
-            tx_manager,
-            proof_semaphore,
-            in_flight_registrations,
-            config,
-        }
-    }
-}
-
-/// RAII guard that removes a signer address from the in-flight set when
-/// dropped.
-///
-/// Ensures cleanup on every exit path from [`RegistrationManager::register_signer`]:
-/// success, error, retry exhaustion, cancellation drop, and panic.
-#[doc(hidden)]
-#[derive(Debug)]
-pub struct InFlightRegistrationGuard<'a> {
-    in_flight: &'a Mutex<HashSet<Address>>,
-    signer: Address,
-}
-
-impl<'a> InFlightRegistrationGuard<'a> {
-    /// Reserves `signer` in `in_flight` until the returned guard is dropped.
-    pub fn try_acquire(in_flight: &'a Mutex<HashSet<Address>>, signer: Address) -> Option<Self> {
-        let mut set = in_flight.lock().unwrap_or_else(|e| e.into_inner());
-        set.insert(signer).then(|| Self { in_flight, signer })
-    }
-}
-
-impl Drop for InFlightRegistrationGuard<'_> {
-    fn drop(&mut self) {
-        // Recover from poisoning so guard cleanup still runs.
-        let mut set = self.in_flight.lock().unwrap_or_else(|e| e.into_inner());
-        set.remove(&self.signer);
+        Self { proof_provider, registry, tx_manager, proof_semaphore, config }
     }
 }
 
@@ -104,10 +67,9 @@ where
 {
     /// Attempts to register a signer onchain if it is not already registered.
     ///
-    /// This is the expensive path: checks whether proof work is already in
-    /// progress for the signer, confirms the signer still needs registration,
-    /// generates or recovers the proof, and invokes [`ProofHandler`] with the
-    /// completed proof.
+    /// This is the expensive path: confirms the signer still needs
+    /// registration, generates or recovers the proof, and invokes
+    /// [`ProofHandler`] with the completed proof.
     ///
     /// Registration is PCR0-agnostic: all legitimate enclaves are registered
     /// regardless of their PCR0 measurement. This enables pre-registration of
@@ -124,12 +86,12 @@ where
         attestation_bytes: &[u8],
         signer_cancel: &CancellationToken,
     ) -> Result<()> {
-        let Some(_in_flight) = self
-            .prepare_registration_attempt(instance, signer_address, enclave_index, signer_cancel)
+        if !self
+            .signer_needs_registration(instance, signer_address, enclave_index, signer_cancel)
             .await?
-        else {
+        {
             return Ok(());
-        };
+        }
 
         let Some(proof) = self
             .generate_registration_proof(
@@ -144,38 +106,24 @@ where
             return Ok(());
         };
 
-        self.invoke_proof_handler(instance, signer_address, proof, signer_cancel).await
+        let handler =
+            ProofHandler::new(self.proof_provider, self.registry, self.tx_manager, self.config);
+        handler.handle_registration_proof(instance, signer_address, proof, signer_cancel).await
     }
 
-    /// Reserves this signer and confirms it still needs registration.
-    pub async fn prepare_registration_attempt(
+    /// Confirms this signer still needs registration.
+    pub async fn signer_needs_registration(
         &self,
         instance: &ProverInstance,
         signer_address: Address,
         enclave_index: usize,
         signer_cancel: &CancellationToken,
-    ) -> Result<Option<InFlightRegistrationGuard<'_>>> {
+    ) -> Result<bool> {
         // Avoid taking locks or making registry RPCs after cancellation.
         if signer_cancel.is_cancelled() {
             debug!(signer = %signer_address, "task cancelled before registry probe");
-            return Ok(None);
+            return Ok(false);
         }
-
-        // Reserve this signer in the in-flight set before the `is_registered`
-        // precheck. If another concurrent task already owns it, short-circuit
-        // so we do not race past the precheck, regenerate the proof, and
-        // submit a duplicate registration transaction.
-        let Some(in_flight) =
-            InFlightRegistrationGuard::try_acquire(self.in_flight_registrations, signer_address)
-        else {
-            debug!(
-                signer = %signer_address,
-                enclave_index,
-                instance = %instance.instance_id,
-                "registration already in flight for this signer, skipping duplicate",
-            );
-            return Ok(None);
-        };
 
         // Safe to cancel because this is a side-effect-free registry read.
         let already_registered = tokio::select! {
@@ -183,18 +131,25 @@ where
             () = signer_cancel.cancelled() => {
                 debug!(
                     signer = %signer_address,
+                    enclave_index,
+                    instance = %instance.instance_id,
                     "cancelled while probing registry pre-proof-gen"
                 );
-                return Ok(None);
+                return Ok(false);
             }
             res = self.registry.is_registered(signer_address) => res?,
         };
         if already_registered {
-            debug!(signer = %signer_address, "already registered, skipping");
-            return Ok(None);
+            debug!(
+                signer = %signer_address,
+                enclave_index,
+                instance = %instance.instance_id,
+                "already registered, skipping"
+            );
+            return Ok(false);
         }
 
-        Ok(Some(in_flight))
+        Ok(true)
     }
 
     /// Generates or recovers an attestation proof for a signer.
@@ -285,29 +240,13 @@ where
             }
         }
     }
-
-    /// Invokes the proof handler with a completed registration proof.
-    pub async fn invoke_proof_handler(
-        &self,
-        instance: &ProverInstance,
-        signer_address: Address,
-        proof: AttestationProof,
-        signer_cancel: &CancellationToken,
-    ) -> Result<()> {
-        let handler =
-            ProofHandler::new(self.proof_provider, self.registry, self.tx_manager, self.config);
-        handler.handle_registration_proof(instance, signer_address, proof, signer_cancel).await
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::{HashSet, VecDeque},
-        sync::{
-            Arc, Mutex,
-            atomic::{AtomicU32, Ordering},
-        },
+        collections::VecDeque,
+        sync::{Arc, Mutex},
         time::Duration,
     };
 
@@ -317,7 +256,6 @@ mod tests {
     use async_trait::async_trait;
     use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
     use base_tx_manager::{SendHandle, TxCandidate, TxManager, TxManagerError};
-    use rstest::rstest;
     use tokio::sync::Semaphore;
     use tokio_util::sync::CancellationToken;
     use url::Url;
@@ -373,18 +311,11 @@ mod tests {
         registry: R,
         tx_manager: T,
         proof_semaphore: Semaphore,
-        in_flight_registrations: Mutex<HashSet<Address>>,
     }
 
     impl<P, R, T> ManagerHarness<P, R, T> {
         fn new(proof_provider: P, registry: R, tx_manager: T) -> Self {
-            Self {
-                proof_provider,
-                registry,
-                tx_manager,
-                proof_semaphore: Semaphore::new(4),
-                in_flight_registrations: Mutex::new(HashSet::new()),
-            }
+            Self { proof_provider, registry, tx_manager, proof_semaphore: Semaphore::new(4) }
         }
 
         fn manager(&self) -> RegistrationManager<'_, P, R, T> {
@@ -393,7 +324,6 @@ mod tests {
                 &self.registry,
                 &self.tx_manager,
                 &self.proof_semaphore,
-                &self.in_flight_registrations,
                 ProofHandlerConfig {
                     registry_address: TEST_REGISTRY_ADDRESS,
                     max_tx_retries: MAX_TX_RETRIES,
@@ -434,39 +364,6 @@ mod tests {
             Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
                 "simulated cancel race".into(),
             ))
-        }
-    }
-
-    #[derive(Debug)]
-    struct YieldingProofProvider {
-        call_count: Arc<AtomicU32>,
-    }
-
-    impl YieldingProofProvider {
-        fn new() -> Self {
-            Self { call_count: Arc::new(AtomicU32::new(0)) }
-        }
-
-        fn call_count(&self) -> u32 {
-            self.call_count.load(Ordering::Relaxed)
-        }
-    }
-
-    #[async_trait]
-    impl AttestationProofProvider for YieldingProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            self.call_count.fetch_add(1, Ordering::Relaxed);
-            for _ in 0..16 {
-                tokio::task::yield_now().await;
-            }
-            Ok(AttestationProof {
-                output: Bytes::from_static(b"stub-output"),
-                proof_bytes: Bytes::from_static(b"stub-proof"),
-            })
         }
     }
 
@@ -605,55 +502,5 @@ mod tests {
             elapsed < CANCEL_ABORT_BUDGET,
             "cancel must abort the registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
         );
-    }
-
-    #[tokio::test]
-    async fn register_signer_concurrent_same_signer_dedups() {
-        let tx = FailingTxManager::with_errors(vec![]);
-        let harness = ManagerHarness::new(
-            YieldingProofProvider::new(),
-            DynamicRegistry::never_registered(vec![]),
-            tx.clone(),
-        );
-        let cancel = CancellationToken::new();
-        let manager = harness.manager();
-        let inst = instance();
-
-        let (r1, r2) = tokio::join!(
-            manager.register_signer(&inst, TEST_SIGNER, 0, ATTESTATION, &cancel),
-            manager.register_signer(&inst, TEST_SIGNER, 0, ATTESTATION, &cancel),
-        );
-
-        assert!(r1.is_ok(), "first concurrent registration failed: {r1:?}");
-        assert!(r2.is_ok(), "second concurrent registration failed: {r2:?}");
-        assert_eq!(tx.send_count(), 1, "same signer must dedup to a single tx");
-        assert_eq!(harness.proof_provider.call_count(), 1, "proof should be generated once");
-    }
-
-    #[rstest]
-    #[case::completion(vec![], false)]
-    #[case::failure(vec![TxManagerError::InsufficientFunds], true)]
-    #[tokio::test]
-    async fn register_signer_in_flight_slot_released_after_attempt(
-        #[case] errors: Vec<TxManagerError>,
-        #[case] first_attempt_should_fail: bool,
-    ) {
-        let tx = FailingTxManager::with_errors(errors);
-        let harness = ManagerHarness::new(
-            StubProofProvider,
-            DynamicRegistry::never_registered(vec![]),
-            tx.clone(),
-        );
-        let cancel = CancellationToken::new();
-
-        let first_result = register(&harness, &cancel).await;
-        assert_eq!(
-            first_result.is_err(),
-            first_attempt_should_fail,
-            "unexpected first registration result: {first_result:?}",
-        );
-        register(&harness, &cancel).await.unwrap();
-
-        assert_eq!(tx.send_count(), 2, "registration must release in-flight slot");
     }
 }

--- a/crates/proof/tee/registrar/src/registration_manager.rs
+++ b/crates/proof/tee/registrar/src/registration_manager.rs
@@ -6,11 +6,7 @@
 //! deduplicate signer proof work, submit the proof request, then invoke the
 //! proof handler.
 
-use std::{
-    collections::HashSet,
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashSet, fmt, sync::Mutex};
 
 use alloy_primitives::Address;
 use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
@@ -36,7 +32,7 @@ pub struct RegistrationManager<'a, P: ?Sized, R: ?Sized, T: ?Sized> {
     /// Semaphore bounding concurrent proof work.
     proof_semaphore: &'a Semaphore,
     /// Process-local signer set used to deduplicate concurrent attempts.
-    in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
+    in_flight_registrations: &'a Mutex<HashSet<Address>>,
     /// Runtime settings for registration transaction handling.
     config: ProofHandlerConfig,
 }
@@ -58,7 +54,7 @@ impl<'a, P: ?Sized, R: ?Sized, T: ?Sized> RegistrationManager<'a, P, R, T> {
         registry: &'a R,
         tx_manager: &'a T,
         proof_semaphore: &'a Semaphore,
-        in_flight_registrations: &'a Arc<Mutex<HashSet<Address>>>,
+        in_flight_registrations: &'a Mutex<HashSet<Address>>,
         config: ProofHandlerConfig,
     ) -> Self {
         Self {
@@ -79,20 +75,20 @@ impl<'a, P: ?Sized, R: ?Sized, T: ?Sized> RegistrationManager<'a, P, R, T> {
 /// success, error, retry exhaustion, cancellation drop, and panic.
 #[doc(hidden)]
 #[derive(Debug)]
-pub struct InFlightRegistrationGuard {
-    in_flight: Arc<Mutex<HashSet<Address>>>,
+pub struct InFlightRegistrationGuard<'a> {
+    in_flight: &'a Mutex<HashSet<Address>>,
     signer: Address,
 }
 
-impl InFlightRegistrationGuard {
+impl<'a> InFlightRegistrationGuard<'a> {
     /// Reserves `signer` in `in_flight` until the returned guard is dropped.
-    pub fn try_acquire(in_flight: &Arc<Mutex<HashSet<Address>>>, signer: Address) -> Option<Self> {
+    pub fn try_acquire(in_flight: &'a Mutex<HashSet<Address>>, signer: Address) -> Option<Self> {
         let mut set = in_flight.lock().unwrap_or_else(|e| e.into_inner());
-        set.insert(signer).then(|| Self { in_flight: Arc::clone(in_flight), signer })
+        set.insert(signer).then(|| Self { in_flight, signer })
     }
 }
 
-impl Drop for InFlightRegistrationGuard {
+impl Drop for InFlightRegistrationGuard<'_> {
     fn drop(&mut self) {
         // Recover from poisoning so guard cleanup still runs.
         let mut set = self.in_flight.lock().unwrap_or_else(|e| e.into_inner());
@@ -158,7 +154,7 @@ where
         signer_address: Address,
         enclave_index: usize,
         signer_cancel: &CancellationToken,
-    ) -> Result<Option<InFlightRegistrationGuard>> {
+    ) -> Result<Option<InFlightRegistrationGuard<'_>>> {
         // Avoid taking locks or making registry RPCs after cancellation.
         if signer_cancel.is_cancelled() {
             debug!(signer = %signer_address, "task cancelled before registry probe");
@@ -377,7 +373,7 @@ mod tests {
         registry: R,
         tx_manager: T,
         proof_semaphore: Semaphore,
-        in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
+        in_flight_registrations: Mutex<HashSet<Address>>,
     }
 
     impl<P, R, T> ManagerHarness<P, R, T> {
@@ -387,7 +383,7 @@ mod tests {
                 registry,
                 tx_manager,
                 proof_semaphore: Semaphore::new(4),
-                in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
+                in_flight_registrations: Mutex::new(HashSet::new()),
             }
         }
 

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -124,14 +124,6 @@ impl<P, R, T> SignerManager<P, R, T> {
         }
     }
 
-    /// Finds the signer address whose pending entry was spawned with `task_id`.
-    pub fn find_signer_by_task_id(
-        pending: &HashMap<Address, PendingRegistration>,
-        task_id: task::Id,
-    ) -> Option<Address> {
-        pending.iter().find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))
-    }
-
     /// Removes the `pending` entry for `signer` only when its task id matches.
     pub fn remove_if_task_matches(
         pending: &mut HashMap<Address, PendingRegistration>,
@@ -142,6 +134,17 @@ impl<P, R, T> SignerManager<P, R, T> {
             Some(entry) if entry.task_id == id => pending.remove(&signer),
             _ => None,
         }
+    }
+
+    /// Removes the `pending` entry spawned with `task_id`.
+    pub fn remove_by_task_id(
+        pending: &mut HashMap<Address, PendingRegistration>,
+        task_id: task::Id,
+    ) -> Option<(Address, PendingRegistration)> {
+        let signer =
+            pending.iter().find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))?;
+        let registration = pending.remove(&signer)?;
+        Some((signer, registration))
     }
 
     /// Consumes one `JoinSet` outcome and updates `pending` plus metrics.
@@ -163,28 +166,28 @@ impl<P, R, T> SignerManager<P, R, T> {
                 );
             }
             Ok((id, Err(e))) => {
-                let signer = Self::find_signer_by_task_id(pending, id);
-                let removed = signer.and_then(|s| Self::remove_if_task_matches(pending, s, id));
+                let removed = Self::remove_by_task_id(pending, id);
+                let signer = removed.as_ref().map(|(signer, _)| *signer);
                 warn!(
                     task_id = ?id,
                     error = %e,
                     signer = ?signer,
-                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
-                    superseded = signer.is_some() && removed.is_none(),
+                    instance = ?removed.as_ref().map(|(_, t)| t.instance_id.as_str()),
+                    pending_entry_found = removed.is_some(),
                     "proof task failed"
                 );
                 RegistrarMetrics::processing_errors_total().increment(1);
             }
             Err(join_err) => {
                 let id = join_err.id();
-                let signer = Self::find_signer_by_task_id(pending, id);
-                let removed = signer.and_then(|s| Self::remove_if_task_matches(pending, s, id));
+                let removed = Self::remove_by_task_id(pending, id);
+                let signer = removed.as_ref().map(|(signer, _)| *signer);
                 warn!(
                     task_id = ?id,
                     error = %join_err,
                     signer = ?signer,
-                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
-                    superseded = signer.is_some() && removed.is_none(),
+                    instance = ?removed.as_ref().map(|(_, t)| t.instance_id.as_str()),
+                    pending_entry_found = removed.is_some(),
                     "proof task join error (panic or abort)"
                 );
                 RegistrarMetrics::processing_errors_total().increment(1);
@@ -226,10 +229,16 @@ where
         let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
 
         for (signer, task) in pending.iter_mut() {
-            if !wanted.contains(signer)
-                && !task.cancel.is_cancelled()
-                && !resolution.unresolved_instance_ids.contains(&task.instance_id)
-            {
+            if wanted.contains(signer) || task.cancel.is_cancelled() {
+                continue;
+            }
+            if resolution.unresolved_instance_ids.contains(&task.instance_id) {
+                debug!(
+                    signer = %signer,
+                    instance = %task.instance_id,
+                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
+                );
+            } else {
                 info!(
                     signer = %signer,
                     instance = %task.instance_id,
@@ -238,15 +247,6 @@ where
                 task.cancel.cancel();
                 task.cancelled_by_reconcile = true;
                 RegistrarMetrics::proof_tasks_cancelled().increment(1);
-            } else if !wanted.contains(signer)
-                && !task.cancel.is_cancelled()
-                && resolution.unresolved_instance_ids.contains(&task.instance_id)
-            {
-                debug!(
-                    signer = %signer,
-                    instance = %task.instance_id,
-                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
-                );
             }
         }
 

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -89,7 +89,7 @@ impl<P, R, T> SignerManager<P, R, T> {
     }
 
     /// Returns the transaction manager used by signer lifecycle operations.
-    pub fn tx_manager(&self) -> &T {
+    pub const fn tx_manager(&self) -> &T {
         &self.tx_manager
     }
 

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -290,8 +290,7 @@ where
             let handle = tasks.spawn(async move {
                 let result = manager
                     .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
-                    .await
-                    .map(|_| ());
+                    .await;
                 ProofTaskOutcome { signer, instance_id: outcome_instance_id, result }
             });
             pending.insert(
@@ -315,7 +314,7 @@ where
         enclave_index: usize,
         attestation_bytes: Vec<u8>,
         signer_cancel: CancellationToken,
-    ) -> Result<Address> {
+    ) -> Result<()> {
         let registration_manager = RegistrationManager::new(
             &self.proof_provider,
             &self.registry,
@@ -331,7 +330,7 @@ where
         registration_manager
             .register_signer(&instance, signer, enclave_index, &attestation_bytes, &signer_cancel)
             .await?;
-        Ok(signer)
+        Ok(())
     }
 
     /// Queries onchain signers and deregisters orphans.

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -6,7 +6,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 
@@ -73,7 +73,6 @@ pub struct SignerManager<P, R, T> {
     registry: R,
     tx_manager: T,
     proof_semaphore: Semaphore,
-    in_flight_registrations: Mutex<HashSet<Address>>,
     config: SignerManagerConfig,
 }
 
@@ -87,14 +86,7 @@ impl<P, R, T> SignerManager<P, R, T> {
     /// Creates a signer manager from the signer lifecycle dependencies.
     pub fn new(proof_provider: P, registry: R, tx_manager: T, config: SignerManagerConfig) -> Self {
         let proof_semaphore = Semaphore::new(config.max_concurrency.max(1));
-        Self {
-            proof_provider,
-            registry,
-            tx_manager,
-            proof_semaphore,
-            in_flight_registrations: Mutex::new(HashSet::new()),
-            config,
-        }
+        Self { proof_provider, registry, tx_manager, proof_semaphore, config }
     }
 
     /// Returns the transaction manager used by signer lifecycle operations.
@@ -351,7 +343,6 @@ where
             &self.registry,
             &self.tx_manager,
             &self.proof_semaphore,
-            &self.in_flight_registrations,
             ProofHandlerConfig {
                 registry_address: self.config.registry_address,
                 max_tx_retries: self.config.max_tx_retries,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -1,0 +1,329 @@
+//! Signer lifecycle orchestration for the registrar.
+//!
+//! Coordinates signer-level registration tasks and orphaned signer cleanup
+//! after the driver has resolved discovered prover instances.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use alloy_primitives::Address;
+use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
+use base_tx_manager::TxManager;
+use tokio::{
+    sync::Semaphore,
+    task::{self, JoinSet},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    DeregistrationManager, DiscoveryResolution, ProofHandlerConfig, ProverInstance,
+    RegistrarMetrics, RegistrationManager, RegistryClient, Result,
+};
+
+/// Runtime settings for signer lifecycle management.
+#[derive(Debug, Clone)]
+pub struct SignerManagerConfig {
+    /// `TEEProverRegistry` contract address on L1.
+    pub registry_address: Address,
+    /// Cancellation token for graceful shutdown.
+    pub cancel: CancellationToken,
+    /// Maximum number of signer registration proof tasks to run concurrently.
+    pub max_concurrency: usize,
+    /// Maximum number of transaction submission retries for transient errors.
+    pub max_tx_retries: u32,
+    /// Delay between transaction submission retries.
+    pub tx_retry_delay: Duration,
+}
+
+/// State for a proof-generation task currently in-flight.
+///
+/// One entry per signer address. The pending map is keyed by [`Address`] so
+/// each signer has at most one active registration task.
+#[derive(Debug)]
+pub struct PendingRegistration {
+    /// Originating instance ID, recorded only for logging.
+    pub instance_id: String,
+    /// `JoinSet` task id for this proof task.
+    pub task_id: task::Id,
+    /// Cooperative cancel handle for this single task.
+    pub cancel: CancellationToken,
+    /// Whether this task was already cancelled by the reconcile pass.
+    pub cancelled_by_reconcile: bool,
+}
+
+/// Coordinates signer registration and orphan signer deregistration.
+pub struct SignerManager<P, R, T> {
+    proof_provider: Arc<P>,
+    registry: Arc<R>,
+    tx_manager: Arc<T>,
+    proof_semaphore: Arc<Semaphore>,
+    in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
+    signer_history: Arc<Mutex<HashMap<Address, String>>>,
+    config: SignerManagerConfig,
+}
+
+impl<P, R, T> fmt::Debug for SignerManager<P, R, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignerManager").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+impl<P, R, T> SignerManager<P, R, T> {
+    /// Creates a signer manager from the signer lifecycle dependencies.
+    pub fn new(proof_provider: P, registry: R, tx_manager: T, config: SignerManagerConfig) -> Self {
+        let proof_semaphore = Arc::new(Semaphore::new(config.max_concurrency.max(1)));
+        Self {
+            proof_provider: Arc::new(proof_provider),
+            registry: Arc::new(registry),
+            tx_manager: Arc::new(tx_manager),
+            proof_semaphore,
+            in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
+            signer_history: Arc::new(Mutex::new(HashMap::new())),
+            config,
+        }
+    }
+
+    /// Returns the transaction manager used by signer lifecycle operations.
+    pub fn tx_manager(&self) -> &T {
+        self.tx_manager.as_ref()
+    }
+
+    /// Records last-known instance attribution for signer addresses.
+    pub fn record_signers(&self, addresses: &[Address], instance_id: &str) {
+        let mut history = self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
+        for addr in addresses {
+            history.insert(*addr, instance_id.to_string());
+        }
+    }
+
+    /// Builds the protected-signer set for orphan deregistration.
+    ///
+    /// Includes both fetched prover signers and pending proof tasks so a signer
+    /// that registers mid-pass is not immediately deregistered.
+    pub fn protected_signers(
+        resolution: &DiscoveryResolution,
+        pending: &HashMap<Address, PendingRegistration>,
+    ) -> HashSet<Address> {
+        let mut protected = resolution.active_signers.clone();
+        protected.extend(pending.keys().copied());
+        protected
+    }
+
+    /// Drains every task that has already finished from `tasks`.
+    pub fn reap_finished_tasks(
+        tasks: &mut JoinSet<Result<Address>>,
+        pending: &mut HashMap<Address, PendingRegistration>,
+    ) {
+        while let Some(joined) = tasks.try_join_next_with_id() {
+            Self::apply_join_outcome(Some(joined), pending);
+        }
+    }
+
+    /// Finds the signer address whose pending entry was spawned with `task_id`.
+    pub fn find_signer_by_task_id(
+        pending: &HashMap<Address, PendingRegistration>,
+        task_id: task::Id,
+    ) -> Option<Address> {
+        pending.iter().find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))
+    }
+
+    /// Removes the `pending` entry for `signer` only when its task id matches.
+    pub fn remove_if_task_matches(
+        pending: &mut HashMap<Address, PendingRegistration>,
+        signer: Address,
+        id: task::Id,
+    ) -> Option<PendingRegistration> {
+        match pending.get(&signer) {
+            Some(entry) if entry.task_id == id => pending.remove(&signer),
+            _ => None,
+        }
+    }
+
+    /// Consumes one `JoinSet` outcome and updates `pending` plus metrics.
+    pub fn apply_join_outcome(
+        joined: Option<std::result::Result<(task::Id, Result<Address>), tokio::task::JoinError>>,
+        pending: &mut HashMap<Address, PendingRegistration>,
+    ) {
+        let Some(result) = joined else { return };
+        RegistrarMetrics::proof_tasks_completed().increment(1);
+        match result {
+            Ok((id, Ok(signer))) => {
+                let removed = Self::remove_if_task_matches(pending, signer, id);
+                debug!(
+                    task_id = ?id,
+                    signer = %signer,
+                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
+                    superseded = removed.is_none(),
+                    "proof task completed",
+                );
+            }
+            Ok((id, Err(e))) => {
+                let signer = Self::find_signer_by_task_id(pending, id);
+                let removed = signer.and_then(|s| Self::remove_if_task_matches(pending, s, id));
+                warn!(
+                    task_id = ?id,
+                    error = %e,
+                    signer = ?signer,
+                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
+                    superseded = signer.is_some() && removed.is_none(),
+                    "proof task failed"
+                );
+                RegistrarMetrics::processing_errors_total().increment(1);
+            }
+            Err(join_err) => {
+                let id = join_err.id();
+                let signer = Self::find_signer_by_task_id(pending, id);
+                let removed = signer.and_then(|s| Self::remove_if_task_matches(pending, s, id));
+                warn!(
+                    task_id = ?id,
+                    error = %join_err,
+                    signer = ?signer,
+                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
+                    superseded = signer.is_some() && removed.is_none(),
+                    "proof task join error (panic or abort)"
+                );
+                RegistrarMetrics::processing_errors_total().increment(1);
+            }
+        }
+    }
+
+    /// Cancels every pending task cooperatively and awaits natural completion.
+    pub async fn drain_proof_tasks(
+        tasks: &mut JoinSet<Result<Address>>,
+        pending: &mut HashMap<Address, PendingRegistration>,
+    ) {
+        for task in pending.values() {
+            if !task.cancelled_by_reconcile {
+                task.cancel.cancel();
+                RegistrarMetrics::proof_tasks_cancelled().increment(1);
+            }
+        }
+        while let Some(joined) = tasks.join_next_with_id().await {
+            Self::apply_join_outcome(Some(joined), pending);
+        }
+        RegistrarMetrics::proof_tasks_pending().set(0.0);
+    }
+}
+
+impl<P, R, T> SignerManager<P, R, T>
+where
+    P: AttestationProofProvider + 'static,
+    R: RegistryClient + 'static,
+    T: TxManager + 'static,
+{
+    /// Reconciles in-flight registration tasks against fetched prover signers.
+    pub fn reconcile_proof_tasks(
+        self: &Arc<Self>,
+        resolution: &DiscoveryResolution,
+        tasks: &mut JoinSet<Result<Address>>,
+        pending: &mut HashMap<Address, PendingRegistration>,
+    ) {
+        let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
+
+        for (signer, task) in pending.iter_mut() {
+            if !wanted.contains(signer)
+                && !task.cancel.is_cancelled()
+                && !resolution.unresolved_instance_ids.contains(&task.instance_id)
+            {
+                info!(
+                    signer = %signer,
+                    instance = %task.instance_id,
+                    "cancelling proof task: signer no longer registerable"
+                );
+                task.cancel.cancel();
+                task.cancelled_by_reconcile = true;
+                RegistrarMetrics::proof_tasks_cancelled().increment(1);
+            } else if !wanted.contains(signer)
+                && !task.cancel.is_cancelled()
+                && resolution.unresolved_instance_ids.contains(&task.instance_id)
+            {
+                debug!(
+                    signer = %signer,
+                    instance = %task.instance_id,
+                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
+                );
+            }
+        }
+
+        let mut in_flight: HashSet<Address> = pending
+            .iter()
+            .filter(|(_, t)| !t.cancel.is_cancelled())
+            .map(|(addr, _)| *addr)
+            .collect();
+
+        for entry in &resolution.registerable {
+            if !in_flight.insert(entry.signer) {
+                continue;
+            }
+            let signer_cancel = self.config.cancel.child_token();
+            let manager = Arc::clone(self);
+            let instance_owned = entry.instance.clone();
+            let instance_id = instance_owned.instance_id.clone();
+            let attestation = entry.attestation.clone();
+            let task_cancel = signer_cancel.clone();
+            let signer = entry.signer;
+            let enclave_index = entry.enclave_index;
+
+            let handle = tasks.spawn(async move {
+                manager
+                    .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
+                    .await
+            });
+            pending.insert(
+                signer,
+                PendingRegistration {
+                    instance_id,
+                    task_id: handle.id(),
+                    cancel: signer_cancel,
+                    cancelled_by_reconcile: false,
+                },
+            );
+            RegistrarMetrics::proof_tasks_spawned().increment(1);
+        }
+    }
+
+    /// Runs a signer registration through [`RegistrationManager`].
+    pub async fn run_proof_task(
+        self: Arc<Self>,
+        instance: ProverInstance,
+        signer: Address,
+        enclave_index: usize,
+        attestation_bytes: Vec<u8>,
+        signer_cancel: CancellationToken,
+    ) -> Result<Address> {
+        let registration_manager = RegistrationManager::new(
+            self.proof_provider.as_ref(),
+            self.registry.as_ref(),
+            self.tx_manager.as_ref(),
+            self.proof_semaphore.as_ref(),
+            &self.in_flight_registrations,
+            ProofHandlerConfig {
+                registry_address: self.config.registry_address,
+                max_tx_retries: self.config.max_tx_retries,
+                tx_retry_delay: self.config.tx_retry_delay,
+            },
+        );
+        registration_manager
+            .register_signer(&instance, signer, enclave_index, &attestation_bytes, &signer_cancel)
+            .await?;
+        Ok(signer)
+    }
+
+    /// Queries onchain signers and deregisters orphans.
+    pub async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
+        let deregistration_manager = DeregistrationManager::new(
+            self.config.registry_address,
+            self.registry.as_ref(),
+            self.tx_manager.as_ref(),
+            &self.signer_history,
+        )
+        .with_max_concurrency(self.config.max_concurrency);
+
+        deregistration_manager.run_orphan_dereg(protected_signers, &self.config.cancel).await
+    }
+}

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -61,8 +61,6 @@ pub struct PendingRegistration {
 pub struct ProofTaskOutcome {
     /// Signer address the task attempted to register.
     pub signer: Address,
-    /// Source prover instance ID used for diagnostic logs.
-    pub instance_id: String,
     /// Result of the signer registration attempt.
     pub result: Result<()>,
 }
@@ -173,51 +171,48 @@ impl ProofTaskSet {
         &mut self,
         joined: std::result::Result<(task::Id, ProofTaskOutcome), JoinError>,
     ) {
-        let remove_current_task =
-            |tasks: &mut Self, signer: Address, task_id: task::Id| match tasks.pending.get(&signer)
-            {
-                Some(entry) if entry.task_id == task_id => tasks.pending.remove(&signer),
-                _ => None,
-            };
-        let remove_by_task_id = |tasks: &mut Self, task_id: task::Id| {
-            tasks
-                .pending
-                .iter()
-                .find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))
-                .and_then(|signer| tasks.pending.remove(&signer).map(|entry| (signer, entry)))
-        };
-
         RegistrarMetrics::proof_tasks_completed().increment(1);
         match joined {
-            Ok((id, outcome)) => match outcome.result {
-                Ok(()) => {
-                    let removed = remove_current_task(self, outcome.signer, id);
-                    debug!(
-                        task_id = ?id,
-                        signer = %outcome.signer,
-                        instance = %outcome.instance_id,
-                        pending_entry_found = removed.is_some(),
-                        superseded = removed.is_none(),
-                        "proof task completed",
-                    );
+            Ok((id, outcome)) => {
+                let removed = match self.pending.get(&outcome.signer) {
+                    Some(entry) if entry.task_id == id => self.pending.remove(&outcome.signer),
+                    _ => None,
+                };
+                let instance_id =
+                    removed.as_ref().map_or("superseded", |entry| entry.instance_id.as_str());
+
+                match outcome.result {
+                    Ok(()) => {
+                        debug!(
+                            task_id = ?id,
+                            signer = %outcome.signer,
+                            instance = %instance_id,
+                            pending_entry_found = removed.is_some(),
+                            superseded = removed.is_none(),
+                            "proof task completed",
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            task_id = ?id,
+                            error = %e,
+                            signer = %outcome.signer,
+                            instance = %instance_id,
+                            pending_entry_found = removed.is_some(),
+                            superseded = removed.is_none(),
+                            "proof task failed"
+                        );
+                        RegistrarMetrics::processing_errors_total().increment(1);
+                    }
                 }
-                Err(e) => {
-                    let removed = remove_current_task(self, outcome.signer, id);
-                    warn!(
-                        task_id = ?id,
-                        error = %e,
-                        signer = %outcome.signer,
-                        instance = %outcome.instance_id,
-                        pending_entry_found = removed.is_some(),
-                        superseded = removed.is_none(),
-                        "proof task failed"
-                    );
-                    RegistrarMetrics::processing_errors_total().increment(1);
-                }
-            },
+            }
             Err(join_err) => {
                 let id = join_err.id();
-                let removed = remove_by_task_id(self, id);
+                let removed = self
+                    .pending
+                    .iter()
+                    .find_map(|(addr, p)| (p.task_id == id).then_some(*addr))
+                    .and_then(|signer| self.pending.remove(&signer).map(|entry| (signer, entry)));
                 let signer = removed.as_ref().map(|(signer, _)| *signer);
                 warn!(
                     task_id = ?id,
@@ -266,12 +261,20 @@ where
         proof_tasks: &mut ProofTaskSet,
     ) {
         let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
+        let mut live_signers = HashSet::new();
 
         for (signer, task) in &mut proof_tasks.pending {
-            if wanted.contains(signer) || task.cancel.is_cancelled() {
+            if task.cancel.is_cancelled() {
                 continue;
             }
+
+            if wanted.contains(signer) {
+                live_signers.insert(*signer);
+                continue;
+            }
+
             if resolution.unresolved_instance_ids.contains(&task.instance_id) {
+                live_signers.insert(*signer);
                 debug!(
                     signer = %signer,
                     instance = %task.instance_id,
@@ -289,22 +292,14 @@ where
             }
         }
 
-        let mut in_flight: HashSet<Address> = proof_tasks
-            .pending
-            .iter()
-            .filter(|(_, t)| !t.cancel.is_cancelled())
-            .map(|(addr, _)| *addr)
-            .collect();
-
         for entry in &resolution.registerable {
-            if !in_flight.insert(entry.signer) {
+            if !live_signers.insert(entry.signer) {
                 continue;
             }
             let signer_cancel = self.config.cancel.child_token();
             let manager = Arc::clone(self);
             let instance_owned = entry.instance.clone();
             let instance_id = instance_owned.instance_id.clone();
-            let outcome_instance_id = instance_id.clone();
             let attestation = entry.attestation.clone();
             let task_cancel = signer_cancel.clone();
             let signer = entry.signer;
@@ -314,7 +309,7 @@ where
                 let result = manager
                     .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
                     .await;
-                ProofTaskOutcome { signer, instance_id: outcome_instance_id, result }
+                ProofTaskOutcome { signer, result }
             });
             proof_tasks.pending.insert(
                 signer,
@@ -351,8 +346,7 @@ where
         );
         registration_manager
             .register_signer(&instance, signer, enclave_index, &attestation_bytes, &signer_cancel)
-            .await?;
-        Ok(())
+            .await
     }
 
     /// Queries onchain signers and deregisters orphans.

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -110,43 +110,30 @@ impl<P, R, T> SignerManager<P, R, T> {
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
         while let Some(joined) = tasks.try_join_next_with_id() {
-            Self::apply_join_outcome(Some(joined), pending);
+            Self::apply_join_outcome(joined, pending);
         }
-    }
-
-    /// Removes the `pending` entry for `signer` only when its task id matches.
-    pub fn remove_if_task_matches(
-        pending: &mut HashMap<Address, PendingRegistration>,
-        signer: Address,
-        id: task::Id,
-    ) -> Option<PendingRegistration> {
-        match pending.get(&signer) {
-            Some(entry) if entry.task_id == id => pending.remove(&signer),
-            _ => None,
-        }
-    }
-
-    /// Removes the `pending` entry spawned with `task_id`.
-    pub fn remove_by_task_id(
-        pending: &mut HashMap<Address, PendingRegistration>,
-        task_id: task::Id,
-    ) -> Option<(Address, PendingRegistration)> {
-        let signer =
-            pending.iter().find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))?;
-        let registration = pending.remove(&signer)?;
-        Some((signer, registration))
     }
 
     /// Consumes one `JoinSet` outcome and updates `pending` plus metrics.
     pub fn apply_join_outcome(
-        joined: Option<std::result::Result<(task::Id, Result<Address>), tokio::task::JoinError>>,
+        joined: std::result::Result<(task::Id, Result<Address>), tokio::task::JoinError>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
-        let Some(result) = joined else { return };
+        let remove_by_task_id = |pending: &mut HashMap<Address, PendingRegistration>,
+                                 task_id: task::Id| {
+            pending
+                .iter()
+                .find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))
+                .and_then(|signer| pending.remove(&signer).map(|entry| (signer, entry)))
+        };
+
         RegistrarMetrics::proof_tasks_completed().increment(1);
-        match result {
+        match joined {
             Ok((id, Ok(signer))) => {
-                let removed = Self::remove_if_task_matches(pending, signer, id);
+                let removed = match pending.get(&signer) {
+                    Some(entry) if entry.task_id == id => pending.remove(&signer),
+                    _ => None,
+                };
                 debug!(
                     task_id = ?id,
                     signer = %signer,
@@ -156,7 +143,7 @@ impl<P, R, T> SignerManager<P, R, T> {
                 );
             }
             Ok((id, Err(e))) => {
-                let removed = Self::remove_by_task_id(pending, id);
+                let removed = remove_by_task_id(pending, id);
                 let signer = removed.as_ref().map(|(signer, _)| *signer);
                 warn!(
                     task_id = ?id,
@@ -170,7 +157,7 @@ impl<P, R, T> SignerManager<P, R, T> {
             }
             Err(join_err) => {
                 let id = join_err.id();
-                let removed = Self::remove_by_task_id(pending, id);
+                let removed = remove_by_task_id(pending, id);
                 let signer = removed.as_ref().map(|(signer, _)| *signer);
                 warn!(
                     task_id = ?id,
@@ -197,7 +184,7 @@ impl<P, R, T> SignerManager<P, R, T> {
             }
         }
         while let Some(joined) = tasks.join_next_with_id().await {
-            Self::apply_join_outcome(Some(joined), pending);
+            Self::apply_join_outcome(joined, pending);
         }
         RegistrarMetrics::proof_tasks_pending().set(0.0);
     }

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -61,9 +61,9 @@ pub struct SignerManager<P, R, T> {
     proof_provider: P,
     registry: R,
     tx_manager: T,
-    proof_semaphore: Arc<Semaphore>,
-    in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
-    signer_history: Arc<Mutex<HashMap<Address, String>>>,
+    proof_semaphore: Semaphore,
+    in_flight_registrations: Mutex<HashSet<Address>>,
+    signer_history: Mutex<HashMap<Address, String>>,
     config: SignerManagerConfig,
 }
 
@@ -76,14 +76,14 @@ impl<P, R, T> fmt::Debug for SignerManager<P, R, T> {
 impl<P, R, T> SignerManager<P, R, T> {
     /// Creates a signer manager from the signer lifecycle dependencies.
     pub fn new(proof_provider: P, registry: R, tx_manager: T, config: SignerManagerConfig) -> Self {
-        let proof_semaphore = Arc::new(Semaphore::new(config.max_concurrency.max(1)));
+        let proof_semaphore = Semaphore::new(config.max_concurrency.max(1));
         Self {
             proof_provider,
             registry,
             tx_manager,
             proof_semaphore,
-            in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
-            signer_history: Arc::new(Mutex::new(HashMap::new())),
+            in_flight_registrations: Mutex::new(HashSet::new()),
+            signer_history: Mutex::new(HashMap::new()),
             config,
         }
     }

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -15,7 +15,7 @@ use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use tokio::{
     sync::Semaphore,
-    task::{self, JoinSet},
+    task::{self, JoinError, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -56,6 +56,17 @@ pub struct PendingRegistration {
     pub cancelled_by_reconcile: bool,
 }
 
+/// Terminal outcome returned by a spawned signer proof task.
+#[derive(Debug)]
+pub struct ProofTaskOutcome {
+    /// Signer address the task attempted to register.
+    pub signer: Address,
+    /// Source prover instance ID used for diagnostic logs.
+    pub instance_id: String,
+    /// Result of the signer registration attempt.
+    pub result: Result<()>,
+}
+
 /// Coordinates signer registration and orphan signer deregistration.
 pub struct SignerManager<P, R, T> {
     proof_provider: P,
@@ -91,6 +102,27 @@ impl<P, R, T> SignerManager<P, R, T> {
         &self.tx_manager
     }
 
+    /// Returns the `TEEProverRegistry` contract address on L1.
+    pub const fn registry_address(&self) -> Address {
+        self.config.registry_address
+    }
+
+    /// Returns the cancellation token shared by signer lifecycle work.
+    pub const fn cancel(&self) -> &CancellationToken {
+        &self.config.cancel
+    }
+
+    /// Returns the configured maximum signer lifecycle concurrency.
+    pub const fn max_concurrency(&self) -> usize {
+        self.config.max_concurrency
+    }
+}
+
+/// Stateless helpers for the driver's in-flight proof task set.
+#[derive(Debug)]
+pub struct ProofTaskSet;
+
+impl ProofTaskSet {
     /// Builds the protected-signer set for orphan deregistration.
     ///
     /// Includes both fetched prover signers and pending proof tasks so a signer
@@ -106,7 +138,7 @@ impl<P, R, T> SignerManager<P, R, T> {
 
     /// Drains every task that has already finished from `tasks`.
     pub fn reap_finished_tasks(
-        tasks: &mut JoinSet<Result<Address>>,
+        tasks: &mut JoinSet<ProofTaskOutcome>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
         while let Some(joined) = tasks.try_join_next_with_id() {
@@ -116,9 +148,17 @@ impl<P, R, T> SignerManager<P, R, T> {
 
     /// Consumes one `JoinSet` outcome and updates `pending` plus metrics.
     pub fn apply_join_outcome(
-        joined: std::result::Result<(task::Id, Result<Address>), tokio::task::JoinError>,
+        joined: std::result::Result<(task::Id, ProofTaskOutcome), JoinError>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
+        let remove_current_task = |pending: &mut HashMap<Address, PendingRegistration>,
+                                   signer: Address,
+                                   task_id: task::Id| {
+            match pending.get(&signer) {
+                Some(entry) if entry.task_id == task_id => pending.remove(&signer),
+                _ => None,
+            }
+        };
         let remove_by_task_id = |pending: &mut HashMap<Address, PendingRegistration>,
                                  task_id: task::Id| {
             pending
@@ -129,32 +169,32 @@ impl<P, R, T> SignerManager<P, R, T> {
 
         RegistrarMetrics::proof_tasks_completed().increment(1);
         match joined {
-            Ok((id, Ok(signer))) => {
-                let removed = match pending.get(&signer) {
-                    Some(entry) if entry.task_id == id => pending.remove(&signer),
-                    _ => None,
-                };
-                debug!(
-                    task_id = ?id,
-                    signer = %signer,
-                    instance = ?removed.as_ref().map(|t| t.instance_id.as_str()),
-                    superseded = removed.is_none(),
-                    "proof task completed",
-                );
-            }
-            Ok((id, Err(e))) => {
-                let removed = remove_by_task_id(pending, id);
-                let signer = removed.as_ref().map(|(signer, _)| *signer);
-                warn!(
-                    task_id = ?id,
-                    error = %e,
-                    signer = ?signer,
-                    instance = ?removed.as_ref().map(|(_, t)| t.instance_id.as_str()),
-                    pending_entry_found = removed.is_some(),
-                    "proof task failed"
-                );
-                RegistrarMetrics::processing_errors_total().increment(1);
-            }
+            Ok((id, outcome)) => match outcome.result {
+                Ok(()) => {
+                    let removed = remove_current_task(pending, outcome.signer, id);
+                    debug!(
+                        task_id = ?id,
+                        signer = %outcome.signer,
+                        instance = %outcome.instance_id,
+                        pending_entry_found = removed.is_some(),
+                        superseded = removed.is_none(),
+                        "proof task completed",
+                    );
+                }
+                Err(e) => {
+                    let removed = remove_current_task(pending, outcome.signer, id);
+                    warn!(
+                        task_id = ?id,
+                        error = %e,
+                        signer = %outcome.signer,
+                        instance = %outcome.instance_id,
+                        pending_entry_found = removed.is_some(),
+                        superseded = removed.is_none(),
+                        "proof task failed"
+                    );
+                    RegistrarMetrics::processing_errors_total().increment(1);
+                }
+            },
             Err(join_err) => {
                 let id = join_err.id();
                 let removed = remove_by_task_id(pending, id);
@@ -174,7 +214,7 @@ impl<P, R, T> SignerManager<P, R, T> {
 
     /// Cancels every pending task cooperatively and awaits natural completion.
     pub async fn drain_proof_tasks(
-        tasks: &mut JoinSet<Result<Address>>,
+        tasks: &mut JoinSet<ProofTaskOutcome>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
         for task in pending.values() {
@@ -200,7 +240,7 @@ where
     pub fn reconcile_proof_tasks(
         self: &Arc<Self>,
         resolution: &DiscoveryResolution,
-        tasks: &mut JoinSet<Result<Address>>,
+        tasks: &mut JoinSet<ProofTaskOutcome>,
         pending: &mut HashMap<Address, PendingRegistration>,
     ) {
         let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
@@ -241,15 +281,18 @@ where
             let manager = Arc::clone(self);
             let instance_owned = entry.instance.clone();
             let instance_id = instance_owned.instance_id.clone();
+            let outcome_instance_id = instance_id.clone();
             let attestation = entry.attestation.clone();
             let task_cancel = signer_cancel.clone();
             let signer = entry.signer;
             let enclave_index = entry.enclave_index;
 
             let handle = tasks.spawn(async move {
-                manager
+                let result = manager
                     .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
                     .await
+                    .map(|_| ());
+                ProofTaskOutcome { signer, instance_id: outcome_instance_id, result }
             });
             pending.insert(
                 signer,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -101,77 +101,105 @@ impl<P, R, T> SignerManager<P, R, T> {
     pub const fn tx_manager(&self) -> &T {
         &self.tx_manager
     }
+}
 
-    /// Returns the `TEEProverRegistry` contract address on L1.
-    pub const fn registry_address(&self) -> Address {
-        self.config.registry_address
-    }
+/// Driver-owned set of in-flight proof-generation tasks.
+pub struct ProofTaskSet {
+    tasks: JoinSet<ProofTaskOutcome>,
+    pending: HashMap<Address, PendingRegistration>,
+}
 
-    /// Returns the cancellation token shared by signer lifecycle work.
-    pub const fn cancel(&self) -> &CancellationToken {
-        &self.config.cancel
-    }
-
-    /// Returns the configured maximum signer lifecycle concurrency.
-    pub const fn max_concurrency(&self) -> usize {
-        self.config.max_concurrency
+impl fmt::Debug for ProofTaskSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProofTaskSet")
+            .field("tasks", &self.tasks.len())
+            .field("pending", &self.pending.len())
+            .finish()
     }
 }
 
-/// Stateless helpers for the driver's in-flight proof task set.
-#[derive(Debug)]
-pub struct ProofTaskSet;
-
 impl ProofTaskSet {
+    /// Creates an empty proof task set.
+    pub fn new() -> Self {
+        Self { tasks: JoinSet::new(), pending: HashMap::new() }
+    }
+
+    /// Returns the number of signers with a pending proof task.
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Returns whether no pending proof tasks remain.
+    #[cfg(test)]
+    pub fn is_pending_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Returns the pending proof-task entries keyed by signer.
+    #[cfg(test)]
+    pub const fn pending(&self) -> &HashMap<Address, PendingRegistration> {
+        &self.pending
+    }
+
+    /// Returns mutable access to the pending proof-task entries.
+    #[cfg(test)]
+    pub const fn pending_mut(&mut self) -> &mut HashMap<Address, PendingRegistration> {
+        &mut self.pending
+    }
+
+    /// Returns whether the underlying join set is empty.
+    #[cfg(test)]
+    pub fn is_join_set_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    /// Returns mutable access to the underlying join set.
+    #[cfg(test)]
+    pub const fn tasks_mut(&mut self) -> &mut JoinSet<ProofTaskOutcome> {
+        &mut self.tasks
+    }
+
     /// Builds the protected-signer set for orphan deregistration.
     ///
     /// Includes both fetched prover signers and pending proof tasks so a signer
     /// that registers mid-pass is not immediately deregistered.
-    pub fn protected_signers(
-        resolution: &DiscoveryResolution,
-        pending: &HashMap<Address, PendingRegistration>,
-    ) -> HashSet<Address> {
+    pub fn protected_signers(&self, resolution: &DiscoveryResolution) -> HashSet<Address> {
         let mut protected = resolution.active_signers.clone();
-        protected.extend(pending.keys().copied());
+        protected.extend(self.pending.keys().copied());
         protected
     }
 
     /// Drains every task that has already finished from `tasks`.
-    pub fn reap_finished_tasks(
-        tasks: &mut JoinSet<ProofTaskOutcome>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        while let Some(joined) = tasks.try_join_next_with_id() {
-            Self::apply_join_outcome(joined, pending);
+    pub fn reap_finished_tasks(&mut self) {
+        while let Some(joined) = self.tasks.try_join_next_with_id() {
+            self.apply_join_outcome(joined);
         }
     }
 
     /// Consumes one `JoinSet` outcome and updates `pending` plus metrics.
     pub fn apply_join_outcome(
+        &mut self,
         joined: std::result::Result<(task::Id, ProofTaskOutcome), JoinError>,
-        pending: &mut HashMap<Address, PendingRegistration>,
     ) {
-        let remove_current_task = |pending: &mut HashMap<Address, PendingRegistration>,
-                                   signer: Address,
-                                   task_id: task::Id| {
-            match pending.get(&signer) {
-                Some(entry) if entry.task_id == task_id => pending.remove(&signer),
+        let remove_current_task =
+            |tasks: &mut Self, signer: Address, task_id: task::Id| match tasks.pending.get(&signer)
+            {
+                Some(entry) if entry.task_id == task_id => tasks.pending.remove(&signer),
                 _ => None,
-            }
-        };
-        let remove_by_task_id = |pending: &mut HashMap<Address, PendingRegistration>,
-                                 task_id: task::Id| {
-            pending
+            };
+        let remove_by_task_id = |tasks: &mut Self, task_id: task::Id| {
+            tasks
+                .pending
                 .iter()
                 .find_map(|(addr, p)| (p.task_id == task_id).then_some(*addr))
-                .and_then(|signer| pending.remove(&signer).map(|entry| (signer, entry)))
+                .and_then(|signer| tasks.pending.remove(&signer).map(|entry| (signer, entry)))
         };
 
         RegistrarMetrics::proof_tasks_completed().increment(1);
         match joined {
             Ok((id, outcome)) => match outcome.result {
                 Ok(()) => {
-                    let removed = remove_current_task(pending, outcome.signer, id);
+                    let removed = remove_current_task(self, outcome.signer, id);
                     debug!(
                         task_id = ?id,
                         signer = %outcome.signer,
@@ -182,7 +210,7 @@ impl ProofTaskSet {
                     );
                 }
                 Err(e) => {
-                    let removed = remove_current_task(pending, outcome.signer, id);
+                    let removed = remove_current_task(self, outcome.signer, id);
                     warn!(
                         task_id = ?id,
                         error = %e,
@@ -197,7 +225,7 @@ impl ProofTaskSet {
             },
             Err(join_err) => {
                 let id = join_err.id();
-                let removed = remove_by_task_id(pending, id);
+                let removed = remove_by_task_id(self, id);
                 let signer = removed.as_ref().map(|(signer, _)| *signer);
                 warn!(
                     task_id = ?id,
@@ -213,20 +241,23 @@ impl ProofTaskSet {
     }
 
     /// Cancels every pending task cooperatively and awaits natural completion.
-    pub async fn drain_proof_tasks(
-        tasks: &mut JoinSet<ProofTaskOutcome>,
-        pending: &mut HashMap<Address, PendingRegistration>,
-    ) {
-        for task in pending.values() {
+    pub async fn drain_proof_tasks(&mut self) {
+        for task in self.pending.values() {
             if !task.cancelled_by_reconcile {
                 task.cancel.cancel();
                 RegistrarMetrics::proof_tasks_cancelled().increment(1);
             }
         }
-        while let Some(joined) = tasks.join_next_with_id().await {
-            Self::apply_join_outcome(joined, pending);
+        while let Some(joined) = self.tasks.join_next_with_id().await {
+            self.apply_join_outcome(joined);
         }
         RegistrarMetrics::proof_tasks_pending().set(0.0);
+    }
+}
+
+impl Default for ProofTaskSet {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -240,12 +271,11 @@ where
     pub fn reconcile_proof_tasks(
         self: &Arc<Self>,
         resolution: &DiscoveryResolution,
-        tasks: &mut JoinSet<ProofTaskOutcome>,
-        pending: &mut HashMap<Address, PendingRegistration>,
+        proof_tasks: &mut ProofTaskSet,
     ) {
         let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
 
-        for (signer, task) in pending.iter_mut() {
+        for (signer, task) in &mut proof_tasks.pending {
             if wanted.contains(signer) || task.cancel.is_cancelled() {
                 continue;
             }
@@ -267,7 +297,8 @@ where
             }
         }
 
-        let mut in_flight: HashSet<Address> = pending
+        let mut in_flight: HashSet<Address> = proof_tasks
+            .pending
             .iter()
             .filter(|(_, t)| !t.cancel.is_cancelled())
             .map(|(addr, _)| *addr)
@@ -287,13 +318,13 @@ where
             let signer = entry.signer;
             let enclave_index = entry.enclave_index;
 
-            let handle = tasks.spawn(async move {
+            let handle = proof_tasks.tasks.spawn(async move {
                 let result = manager
                     .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
                     .await;
                 ProofTaskOutcome { signer, instance_id: outcome_instance_id, result }
             });
-            pending.insert(
+            proof_tasks.pending.insert(
                 signer,
                 PendingRegistration {
                     instance_id,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -63,7 +63,6 @@ pub struct SignerManager<P, R, T> {
     tx_manager: T,
     proof_semaphore: Semaphore,
     in_flight_registrations: Mutex<HashSet<Address>>,
-    signer_history: Mutex<HashMap<Address, String>>,
     config: SignerManagerConfig,
 }
 
@@ -83,7 +82,6 @@ impl<P, R, T> SignerManager<P, R, T> {
             tx_manager,
             proof_semaphore,
             in_flight_registrations: Mutex::new(HashSet::new()),
-            signer_history: Mutex::new(HashMap::new()),
             config,
         }
     }
@@ -91,14 +89,6 @@ impl<P, R, T> SignerManager<P, R, T> {
     /// Returns the transaction manager used by signer lifecycle operations.
     pub const fn tx_manager(&self) -> &T {
         &self.tx_manager
-    }
-
-    /// Records last-known instance attribution for signer addresses.
-    pub fn record_signers(&self, addresses: &[Address], instance_id: &str) {
-        let mut history = self.signer_history.lock().unwrap_or_else(|e| e.into_inner());
-        for addr in addresses {
-            history.insert(*addr, instance_id.to_string());
-        }
     }
 
     /// Builds the protected-signer set for orphan deregistration.
@@ -320,7 +310,6 @@ where
             self.config.registry_address,
             &self.registry,
             &self.tx_manager,
-            &self.signer_history,
         );
 
         deregistration_manager.run_orphan_dereg(protected_signers, &self.config.cancel).await

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -58,9 +58,9 @@ pub struct PendingRegistration {
 
 /// Coordinates signer registration and orphan signer deregistration.
 pub struct SignerManager<P, R, T> {
-    proof_provider: Arc<P>,
-    registry: Arc<R>,
-    tx_manager: Arc<T>,
+    proof_provider: P,
+    registry: R,
+    tx_manager: T,
     proof_semaphore: Arc<Semaphore>,
     in_flight_registrations: Arc<Mutex<HashSet<Address>>>,
     signer_history: Arc<Mutex<HashMap<Address, String>>>,
@@ -78,9 +78,9 @@ impl<P, R, T> SignerManager<P, R, T> {
     pub fn new(proof_provider: P, registry: R, tx_manager: T, config: SignerManagerConfig) -> Self {
         let proof_semaphore = Arc::new(Semaphore::new(config.max_concurrency.max(1)));
         Self {
-            proof_provider: Arc::new(proof_provider),
-            registry: Arc::new(registry),
-            tx_manager: Arc::new(tx_manager),
+            proof_provider,
+            registry,
+            tx_manager,
             proof_semaphore,
             in_flight_registrations: Arc::new(Mutex::new(HashSet::new())),
             signer_history: Arc::new(Mutex::new(HashMap::new())),
@@ -90,7 +90,7 @@ impl<P, R, T> SignerManager<P, R, T> {
 
     /// Returns the transaction manager used by signer lifecycle operations.
     pub fn tx_manager(&self) -> &T {
-        self.tx_manager.as_ref()
+        &self.tx_manager
     }
 
     /// Records last-known instance attribution for signer addresses.
@@ -297,10 +297,10 @@ where
         signer_cancel: CancellationToken,
     ) -> Result<Address> {
         let registration_manager = RegistrationManager::new(
-            self.proof_provider.as_ref(),
-            self.registry.as_ref(),
-            self.tx_manager.as_ref(),
-            self.proof_semaphore.as_ref(),
+            &self.proof_provider,
+            &self.registry,
+            &self.tx_manager,
+            &self.proof_semaphore,
             &self.in_flight_registrations,
             ProofHandlerConfig {
                 registry_address: self.config.registry_address,
@@ -318,11 +318,10 @@ where
     pub async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
         let deregistration_manager = DeregistrationManager::new(
             self.config.registry_address,
-            self.registry.as_ref(),
-            self.tx_manager.as_ref(),
+            &self.registry,
+            &self.tx_manager,
             &self.signer_history,
-        )
-        .with_max_concurrency(self.config.max_concurrency);
+        );
 
         deregistration_manager.run_orphan_dereg(protected_signers, &self.config.cancel).await
     }

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use alloy_primitives::Address;
+use async_trait::async_trait;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use tokio::{
@@ -90,6 +91,57 @@ impl<P, R, T> SignerManager<P, R, T> {
     /// Returns the transaction manager used by signer lifecycle operations.
     pub const fn tx_manager(&self) -> &T {
         &self.tx_manager
+    }
+}
+
+/// Driver-facing signer lifecycle boundary.
+///
+/// The production implementation is [`SignerManager`], but the driver only
+/// needs to reconcile proof tasks, run orphan cleanup, and expose the tx
+/// manager for CRL revocation. Keeping this as a trait lets driver tests mock
+/// signer lifecycle behavior without standing up proof tasks or registry state.
+#[async_trait]
+pub trait SignerLifecycle: Send + Sync + fmt::Debug {
+    /// Transaction manager type used for CRL revocation checks.
+    type TransactionManager: TxManager + 'static;
+
+    /// Returns the transaction manager used by CRL revocation checks.
+    fn tx_manager(&self) -> &Self::TransactionManager;
+
+    /// Reconciles in-flight registration tasks against fetched prover signers.
+    fn reconcile_proof_tasks(
+        &self,
+        resolution: &DiscoveryResolution,
+        proof_tasks: &mut ProofTaskSet,
+    );
+
+    /// Queries onchain signers and deregisters orphans.
+    async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()>;
+}
+
+#[async_trait]
+impl<P, R, T> SignerLifecycle for Arc<SignerManager<P, R, T>>
+where
+    P: AttestationProofProvider + 'static,
+    R: RegistryClient + 'static,
+    T: TxManager + 'static,
+{
+    type TransactionManager = T;
+
+    fn tx_manager(&self) -> &Self::TransactionManager {
+        self.as_ref().tx_manager()
+    }
+
+    fn reconcile_proof_tasks(
+        &self,
+        resolution: &DiscoveryResolution,
+        proof_tasks: &mut ProofTaskSet,
+    ) {
+        SignerManager::reconcile_proof_tasks(self, resolution, proof_tasks);
+    }
+
+    async fn run_orphan_dereg(&self, protected_signers: &HashSet<Address>) -> Result<()> {
+        self.as_ref().run_orphan_dereg(protected_signers).await
     }
 }
 
@@ -358,5 +410,970 @@ where
         );
 
         deregistration_manager.run_orphan_dereg(protected_signers, &self.config.cancel).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{B256, Bloom, Bytes, address};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolCall;
+    use async_trait::async_trait;
+    use base_proof_contracts::ITEEProverRegistry;
+    use base_proof_tee_nitro_attestation_prover::AttestationProof;
+    use base_tx_manager::{SendHandle, TxCandidate};
+    use hex_literal::hex;
+    use k256::ecdsa::SigningKey;
+    use rstest::rstest;
+    use tokio::task;
+
+    use super::*;
+    use crate::{
+        DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
+        InstanceHealthStatus, ProverClient, RegisterableSigner, RegistrarError,
+    };
+
+    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    const HARDHAT_KEY_0: [u8; 32] =
+        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+    const HARDHAT_KEY_1: [u8; 32] =
+        hex!("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+    #[cfg(feature = "metrics")]
+    const HARDHAT_KEY_2: [u8; 32] =
+        hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
+    const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
+    const TEST_PENDING_INSTANCE_ID: &str = "i-pending-test";
+    const ORPHAN_A: Address = Address::repeat_byte(0xAA);
+    const ORPHAN_B: Address = Address::repeat_byte(0xBB);
+    const ORPHAN_C: Address = Address::repeat_byte(0xCC);
+    const EP1: &str = "10.0.0.1:8000";
+    const EP2: &str = "10.0.0.2:8000";
+    const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+    const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
+    const CANCEL_ABORT_BUDGET: Duration = Duration::from_secs(1);
+    const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
+
+    fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
+        let signing_key = SigningKey::from_slice(private_key).unwrap();
+        signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
+    }
+
+    fn signer_from_key(private_key: &[u8; 32]) -> Address {
+        ProverClient::derive_address(&public_key_from_private(private_key)).unwrap()
+    }
+
+    fn instance(host_port: &str) -> ProverInstance {
+        ProverInstance {
+            instance_id: format!("i-{host_port}"),
+            endpoint: url::Url::parse(&format!("http://{host_port}")).unwrap(),
+            health_status: InstanceHealthStatus::Healthy,
+            launch_time: None,
+        }
+    }
+
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockRegistry {
+        signers: Vec<Address>,
+    }
+
+    impl MockRegistry {
+        fn with_signers(signers: Vec<Address>) -> Self {
+            Self { signers }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for MockRegistry {
+        async fn is_registered(&self, signer: Address) -> Result<bool> {
+            Ok(self.signers.contains(&signer))
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct SharedTxManager {
+        sent: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl SharedTxManager {
+        fn new() -> Self {
+            Self { sent: Arc::new(Mutex::new(vec![])) }
+        }
+
+        fn sent_calldata(&self) -> Vec<Bytes> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl TxManager for SharedTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent.lock().unwrap().push(candidate.tx_data);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            unimplemented!("not used in signer_manager tests")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct RecordingProofProvider {
+        recorded: Arc<Mutex<HashMap<Address, Vec<u8>>>>,
+    }
+
+    impl RecordingProofProvider {
+        fn snapshot(&self) -> HashMap<Address, Vec<u8>> {
+            self.recorded.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AttestationProofProvider for RecordingProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            unreachable!("signer manager should route proof generation through signer-aware API")
+        }
+
+        async fn generate_proof_for_signer(
+            &self,
+            attestation_bytes: &[u8],
+            signer_address: Address,
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            self.recorded.lock().unwrap().insert(signer_address, attestation_bytes.to_vec());
+            Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
+                "RecordingProofProvider exits after capturing attestation".into(),
+            ))
+        }
+    }
+
+    fn config(cancel: CancellationToken) -> SignerManagerConfig {
+        SignerManagerConfig {
+            registry_address: TEST_REGISTRY_ADDRESS,
+            cancel,
+            max_concurrency: DEFAULT_MAX_CONCURRENCY,
+            max_tx_retries: DEFAULT_MAX_TX_RETRIES,
+            tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
+        }
+    }
+
+    fn manager(
+        proof_provider: RecordingProofProvider,
+        registry: MockRegistry,
+        tx: SharedTxManager,
+        cancel: CancellationToken,
+    ) -> Arc<SignerManager<RecordingProofProvider, MockRegistry, SharedTxManager>> {
+        Arc::new(SignerManager::new(proof_provider, registry, tx, config(cancel)))
+    }
+
+    fn dr_from_kept(kept: &[(&str, &[u8; 32])]) -> DiscoveryResolution {
+        let mut registerable = Vec::new();
+        let mut active_signers = HashSet::new();
+        for (ep, key) in kept {
+            let inst = instance(ep);
+            let addr = signer_from_key(key);
+            active_signers.insert(addr);
+            registerable.push(RegisterableSigner {
+                instance: inst,
+                signer: addr,
+                attestation: b"gated-attestation".to_vec(),
+                enclave_index: 0,
+            });
+        }
+        let total = kept.len();
+        DiscoveryResolution {
+            registerable,
+            active_signers,
+            reachable_count: total,
+            total_count: total,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::new(),
+        }
+    }
+
+    fn proof_task_success_for_test(signer: Address) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, result: Ok(()) }
+    }
+
+    fn proof_task_failure_for_test(signer: Address, error: RegistrarError) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, result: Err(error) }
+    }
+
+    fn pending_registration_for_test(task_id: task::Id, instance_id: &str) -> PendingRegistration {
+        PendingRegistration {
+            instance_id: instance_id.to_string(),
+            task_id,
+            cancel: CancellationToken::new(),
+            cancelled_by_reconcile: false,
+        }
+    }
+
+    async fn wait_for(label: &str, predicate: impl Fn() -> bool) {
+        let started = std::time::Instant::now();
+        while !predicate() {
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("timed out waiting for: {label}");
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    async fn drain_test_tasks(proof_tasks: &mut ProofTaskSet) {
+        for task in proof_tasks.pending().values() {
+            task.cancel.cancel();
+        }
+        let tasks = proof_tasks.tasks_mut();
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+        proof_tasks.pending_mut().clear();
+    }
+
+    async fn reap_until_pending_empty(proof_tasks: &mut ProofTaskSet) {
+        let started = std::time::Instant::now();
+        while !proof_tasks.is_pending_empty() {
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("timed out reaping {} pending task(s)", proof_tasks.pending_len());
+            }
+            proof_tasks.reap_finished_tasks();
+            tokio::time::sleep(REAP_POLL_INTERVAL).await;
+        }
+    }
+
+    fn count_deregister_calls(sent: &[Bytes]) -> usize {
+        let sel = ITEEProverRegistry::deregisterSignerCall::SELECTOR;
+        sent.iter().filter(|c| c.len() >= 4 && c[..4] == sel).count()
+    }
+
+    #[rstest]
+    #[case::no_pending_spawns_all(&[], &[(EP1, &HARDHAT_KEY_0)], 1, 0)]
+    #[case::pending_for_kept_spawns_nothing(&[(EP1, &HARDHAT_KEY_0)], &[(EP1, &HARDHAT_KEY_0)], 0, 0)]
+    #[case::pending_for_dropped_cancels_one(&[(EP1, &HARDHAT_KEY_0)], &[], 0, 1)]
+    #[case::pending_one_kept_one_dropped(
+        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
+        &[(EP1, &HARDHAT_KEY_0)],
+        0,
+        1,
+    )]
+    #[case::two_new_signers_two_spawns(
+        &[],
+        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
+        2,
+        0,
+    )]
+    #[tokio::test]
+    async fn reconcile_proof_tasks_cancel_and_spawn_passes(
+        #[case] pre_existing: &[(&'static str, &'static [u8; 32])],
+        #[case] kept: &[(&'static str, &'static [u8; 32])],
+        #[case] expected_new_spawns: usize,
+        #[case] expected_cancels: usize,
+    ) {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            CancellationToken::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let mut seeded_cancels = Vec::new();
+
+        for (_, key) in pre_existing {
+            let signer = signer_from_key(key);
+            let task_cancel = CancellationToken::new();
+            let task_cancel_inner = task_cancel.clone();
+            let handle = proof_tasks.tasks_mut().spawn(async move {
+                task_cancel_inner.cancelled().await;
+                proof_task_success_for_test(signer)
+            });
+            proof_tasks.pending_mut().insert(
+                signer,
+                PendingRegistration {
+                    instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                    task_id: handle.id(),
+                    cancel: task_cancel.clone(),
+                    cancelled_by_reconcile: false,
+                },
+            );
+            seeded_cancels.push(task_cancel);
+        }
+
+        let resolution = dr_from_kept(kept);
+        let pre_spawn_count = proof_tasks.pending_len();
+        let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
+
+        manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+
+        let post_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
+        let new_spawns = proof_tasks.pending_len().saturating_sub(pre_spawn_count);
+
+        assert_eq!(new_spawns, expected_new_spawns, "spawn-pass count");
+        assert_eq!(post_cancelled - pre_cancelled, expected_cancels, "cancel-pass count");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_idempotent_when_resolution_unchanged() {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            CancellationToken::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
+
+        manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+        let after_first = proof_tasks.pending_len();
+        let snapshot_ids: HashSet<_> = proof_tasks.pending().keys().copied().collect();
+
+        manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+
+        assert_eq!(proof_tasks.pending_len(), after_first, "idempotent: no extra spawns");
+        let after_second: HashSet<_> = proof_tasks.pending().keys().copied().collect();
+        assert_eq!(snapshot_ids, after_second, "pending signer keys unchanged across reconciles");
+        for task in proof_tasks.pending().values() {
+            assert!(!task.cancel.is_cancelled(), "kept task must not be cancelled");
+        }
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            CancellationToken::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+
+        let stale_cancel = CancellationToken::new();
+        let stale_cancel_inner = stale_cancel.clone();
+        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
+            stale_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let stale_task_id = stale_handle.id();
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: stale_task_id,
+                cancel: stale_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        manager.reconcile_proof_tasks(&dr_from_kept(&[]), &mut proof_tasks);
+        assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
+        assert_eq!(
+            proof_tasks.pending().get(&signer).map(|p| p.task_id),
+            Some(stale_task_id),
+            "cancelled entry still keyed by signer until reaped",
+        );
+
+        manager.reconcile_proof_tasks(&dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]), &mut proof_tasks);
+
+        assert_eq!(proof_tasks.pending_len(), 1, "still exactly one entry per signer");
+        let fresh = proof_tasks.pending().get(&signer).expect("fresh entry keyed by signer");
+        assert_ne!(fresh.task_id, stale_task_id, "fresh task_id replaces the stale one");
+        assert!(!fresh.cancel.is_cancelled(), "fresh task carries a live cancel token");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            CancellationToken::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+
+        let task_cancel = CancellationToken::new();
+        let task_cancel_inner = task_cancel.clone();
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            task_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: handle.id(),
+                cancel: task_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let resolution = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 0,
+            total_count: 1,
+            ok_to_dereg: false,
+            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
+        };
+
+        manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+
+        assert!(
+            !task_cancel.is_cancelled(),
+            "task tied to an unresolved instance must be preserved",
+        );
+        assert_eq!(proof_tasks.pending_len(), 1, "no spurious spawn or eviction this cycle");
+
+        let resolution_conclusive = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 1,
+            total_count: 1,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        manager.reconcile_proof_tasks(&resolution_conclusive, &mut proof_tasks);
+        assert!(task_cancel.is_cancelled(), "conclusive absence must cancel the task");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_dedupes_signer_across_registerable_entries() {
+        let proof_provider = RecordingProofProvider::default();
+        let manager = manager(
+            proof_provider.clone(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            CancellationToken::new(),
+        );
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let resolution = DiscoveryResolution {
+            registerable: vec![
+                RegisterableSigner {
+                    instance: instance(EP1),
+                    signer,
+                    attestation: b"attestation-from-instance-a".to_vec(),
+                    enclave_index: 0,
+                },
+                RegisterableSigner {
+                    instance: instance(EP2),
+                    signer,
+                    attestation: b"attestation-from-instance-b".to_vec(),
+                    enclave_index: 0,
+                },
+            ],
+            active_signers: HashSet::from([signer]),
+            reachable_count: 2,
+            total_count: 2,
+            ok_to_dereg: false,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        let mut proof_tasks = ProofTaskSet::new();
+
+        manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+
+        assert_eq!(proof_tasks.pending_len(), 1, "exactly one task should spawn");
+        let (&only_signer, _entry) = proof_tasks.pending().iter().next().unwrap();
+        assert_eq!(only_signer, signer, "the task is keyed by the deduplicated signer");
+
+        wait_for("the lone spawned task recorded its attestation", || {
+            !proof_provider.snapshot().is_empty()
+        })
+        .await;
+        drain_test_tasks(&mut proof_tasks).await;
+
+        assert_eq!(proof_provider.snapshot().len(), 1, "exactly one signer recorded");
+    }
+
+    #[rstest]
+    #[case::forward_order(false)]
+    #[case::reversed_order(true)]
+    #[tokio::test]
+    async fn reconcile_proof_tasks_pairs_attestation_with_signer(#[case] reverse: bool) {
+        let signer_a = signer_from_key(&HARDHAT_KEY_0);
+        let signer_b = signer_from_key(&HARDHAT_KEY_1);
+        assert_ne!(signer_a, signer_b, "test setup: distinct signer addresses");
+
+        let att_a: Vec<u8> = b"attestation-aligned-to-A".to_vec();
+        let att_b: Vec<u8> = b"attestation-aligned-to-B".to_vec();
+        let entry_a = RegisterableSigner {
+            instance: instance(EP1),
+            signer: signer_a,
+            attestation: att_a.clone(),
+            enclave_index: 0,
+        };
+        let entry_b = RegisterableSigner {
+            instance: instance(EP2),
+            signer: signer_b,
+            attestation: att_b.clone(),
+            enclave_index: 0,
+        };
+        let registerable = if reverse { vec![entry_b, entry_a] } else { vec![entry_a, entry_b] };
+
+        let proof_provider = RecordingProofProvider::default();
+        let manager = manager(
+            proof_provider.clone(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            CancellationToken::new(),
+        );
+        let resolution = DiscoveryResolution {
+            registerable,
+            active_signers: HashSet::from([signer_a, signer_b]),
+            reachable_count: 2,
+            total_count: 2,
+            ok_to_dereg: false,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        let mut proof_tasks = ProofTaskSet::new();
+
+        manager.reconcile_proof_tasks(&resolution, &mut proof_tasks);
+
+        wait_for("both signers recorded their attestations", || {
+            proof_provider.snapshot().len() == 2
+        })
+        .await;
+        drain_test_tasks(&mut proof_tasks).await;
+
+        let snap = proof_provider.snapshot();
+        assert_eq!(snap.get(&signer_a), Some(&att_a), "signer A got A attestation");
+        assert_eq!(snap.get(&signer_b), Some(&att_b), "signer B got B attestation");
+    }
+
+    #[rstest]
+    #[case::ok_outcome(true)]
+    #[case::err_outcome(false)]
+    #[tokio::test]
+    async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            if succeed {
+                proof_task_success_for_test(HARDHAT_ACCOUNT)
+            } else {
+                proof_task_failure_for_test(
+                    HARDHAT_ACCOUNT,
+                    RegistrarError::Transaction("synthetic".into()),
+                )
+            }
+        });
+        proof_tasks.pending_mut().insert(
+            HARDHAT_ACCOUNT,
+            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
+        );
+
+        reap_until_pending_empty(&mut proof_tasks).await;
+
+        assert!(proof_tasks.is_pending_empty(), "completed task must be evicted");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
+    }
+
+    #[tokio::test]
+    async fn reap_finished_tasks_leaves_in_flight_alone() {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        let cancel = CancellationToken::new();
+        let cancel_inner = cancel.clone();
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            cancel_inner.cancelled().await;
+            proof_task_success_for_test(HARDHAT_ACCOUNT)
+        });
+        proof_tasks.pending_mut().insert(
+            HARDHAT_ACCOUNT,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: handle.id(),
+                cancel,
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        proof_tasks.reap_finished_tasks();
+
+        assert_eq!(proof_tasks.pending_len(), 1, "live task must remain pending");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reap_finished_tasks_is_noop_when_pending_is_empty() {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        proof_tasks.reap_finished_tasks();
+
+        assert!(proof_tasks.is_pending_empty(), "pending stays empty");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet stays empty");
+    }
+
+    #[tokio::test]
+    async fn apply_join_outcome_drops_pending_entry_when_task_panics() {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        let handle = proof_tasks.tasks_mut().spawn(async {
+            panic!("synthetic proof-task panic for apply_join_outcome test");
+        });
+        proof_tasks.pending_mut().insert(
+            HARDHAT_ACCOUNT,
+            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
+        );
+
+        reap_until_pending_empty(&mut proof_tasks).await;
+
+        assert!(proof_tasks.is_pending_empty(), "panicked task must be evicted");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
+    }
+
+    #[tokio::test]
+    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_completes_for_same_signer() {
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = HARDHAT_ACCOUNT;
+
+        let stale_handle =
+            proof_tasks.tasks_mut().spawn(async move { proof_task_success_for_test(signer) });
+        let stale_task_id = stale_handle.id();
+
+        let fresh_cancel = CancellationToken::new();
+        let fresh_cancel_inner = fresh_cancel.clone();
+        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
+            fresh_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let fresh_task_id = fresh_handle.id();
+        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
+
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: fresh_task_id,
+                cancel: fresh_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let started = std::time::Instant::now();
+        loop {
+            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+                proof_tasks.apply_join_outcome(joined);
+                break;
+            }
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("stale task never resolved");
+            }
+            tokio::time::sleep(REAP_POLL_INTERVAL).await;
+        }
+
+        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale completion");
+        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
+        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
+        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
+     {
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = HARDHAT_ACCOUNT;
+
+        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
+            proof_task_failure_for_test(
+                signer,
+                RegistrarError::Config("synthetic stale proof failure".to_string()),
+            )
+        });
+        let stale_task_id = stale_handle.id();
+
+        let fresh_cancel = CancellationToken::new();
+        let fresh_cancel_inner = fresh_cancel.clone();
+        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
+            fresh_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let fresh_task_id = fresh_handle.id();
+        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
+
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: fresh_task_id,
+                cancel: fresh_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let started = std::time::Instant::now();
+        loop {
+            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+                proof_tasks.apply_join_outcome(joined);
+                break;
+            }
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("stale task never resolved");
+            }
+            tokio::time::sleep(REAP_POLL_INTERVAL).await;
+        }
+
+        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale Err");
+        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
+        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
+        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn protected_signers_union_blocks_dereg_of_freshly_registered_signer() {
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let tx = SharedTxManager::new();
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![signer]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let task_cancel = CancellationToken::new();
+        let task_cancel_inner = task_cancel.clone();
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            task_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: handle.id(),
+                cancel: task_cancel,
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let resolution = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 1,
+            total_count: 1,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
+        };
+        let protected = proof_tasks.protected_signers(&resolution);
+        assert!(protected.contains(&signer), "protected set must include in-flight signer");
+
+        manager.run_orphan_dereg(&protected).await.unwrap();
+
+        assert_eq!(count_deregister_calls(&tx.sent_calldata()), 0);
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn protected_signers_union_does_not_shield_when_pending_empty() {
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let tx = SharedTxManager::new();
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![signer]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        let proof_tasks = ProofTaskSet::new();
+        let resolution = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 1,
+            total_count: 1,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        let protected = proof_tasks.protected_signers(&resolution);
+        assert!(protected.is_empty(), "no pending means protected set is empty");
+
+        manager.run_orphan_dereg(&protected).await.unwrap();
+
+        assert_eq!(count_deregister_calls(&tx.sent_calldata()), 1);
+    }
+
+    #[rstest]
+    #[case::single_orphan(vec![ORPHAN_A])]
+    #[case::multiple_orphans(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C])]
+    #[tokio::test]
+    async fn run_orphan_dereg_deregisters_all_unprotected_onchain_signers(
+        #[case] orphans: Vec<Address>,
+    ) {
+        let expected_count = orphans.len();
+        let tx = SharedTxManager::new();
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(orphans.clone()),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        manager.run_orphan_dereg(&HashSet::new()).await.unwrap();
+
+        let sent = tx.sent_calldata();
+        assert_eq!(sent.len(), expected_count, "all onchain signers should be deregistered");
+        for orphan in orphans {
+            let expected = ITEEProverRegistry::deregisterSignerCall { signer: orphan }.abi_encode();
+            assert!(sent.iter().any(|s| s[..] == expected[..]), "expected dereg of {orphan}");
+        }
+    }
+
+    struct StallingRegistry {
+        signers: Vec<Address>,
+    }
+
+    impl StallingRegistry {
+        fn stalling_get_registered_signers(signers: Vec<Address>) -> Self {
+            Self { signers }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for StallingRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            std::future::pending::<()>().await;
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn run_orphan_dereg_aborts_promptly_when_cancel_fires_during_registry_stall() {
+        let cancel = CancellationToken::new();
+        let manager = Arc::new(SignerManager::new(
+            RecordingProofProvider::default(),
+            StallingRegistry::stalling_get_registered_signers(vec![]),
+            SharedTxManager::new(),
+            config(cancel.clone()),
+        ));
+
+        let manager_clone = Arc::clone(&manager);
+        let handle = tokio::spawn(async move {
+            let active = HashSet::new();
+            let start = tokio::time::Instant::now();
+            let res = manager_clone.run_orphan_dereg(&active).await;
+            (res, start.elapsed())
+        });
+
+        tokio::time::sleep(PRE_CANCEL_WARMUP).await;
+        cancel.cancel();
+
+        let (result, elapsed) = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
+            .await
+            .expect("run_orphan_dereg must not hang past the timeout")
+            .expect("spawned task must not panic");
+
+        assert!(result.is_ok(), "cancel-induced exit must be Ok(()): {result:?}");
+        assert!(
+            elapsed < CANCEL_ABORT_BUDGET,
+            "cancel must abort registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    mod drain_metric_tests {
+        use metrics_exporter_prometheus::PrometheusBuilder;
+
+        use super::*;
+
+        #[test]
+        fn drain_counts_only_tasks_not_already_cancelled_by_reconcile() {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            let recorder = PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+
+            metrics::with_local_recorder(&recorder, || {
+                rt.block_on(async {
+                    let mut proof_tasks = ProofTaskSet::new();
+                    let seed: &[(&[u8; 32], bool)] =
+                        &[(&HARDHAT_KEY_0, true), (&HARDHAT_KEY_1, false), (&HARDHAT_KEY_2, false)];
+
+                    for (key, flagged) in seed {
+                        let signer = signer_from_key(key);
+                        let cancel = CancellationToken::new();
+                        let cancel_inner = cancel.clone();
+                        let handle = proof_tasks.tasks_mut().spawn(async move {
+                            cancel_inner.cancelled().await;
+                            proof_task_success_for_test(signer)
+                        });
+                        proof_tasks.pending_mut().insert(
+                            signer,
+                            PendingRegistration {
+                                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                                task_id: handle.id(),
+                                cancel: cancel.clone(),
+                                cancelled_by_reconcile: *flagged,
+                            },
+                        );
+                        if *flagged {
+                            cancel.cancel();
+                        }
+                    }
+
+                    proof_tasks.drain_proof_tasks().await;
+                });
+            });
+
+            let rendered = handle.render();
+            assert!(
+                rendered.contains("base_registrar_proof_tasks_cancelled 2"),
+                "drain must count only the unflagged tasks once each. Got:\n{rendered}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Extracts signer and registration management logic out of the registrar `RegistrationDriver` into a dedicated `SignerManager` module, slimming down `driver.rs` (~390 lines removed).

## Changes
- Add `signer_manager.rs` with `SignerManager`, `SignerManagerConfig`, and `PendingRegistration`
- Move `PendingRegistration` out of `driver` and re-export it from `signer_manager` in `lib.rs`
- Update `driver.rs` and `deregistration_manager.rs` to use the new `SignerManager`

## Notes
Draft PR opened from uncommitted working-tree changes.