### PR TITLE
ci: use GITHUB_TOKEN for base-std access now that base-std is public (BOP-374)

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -117,7 +117,7 @@ jobs:
         id: base-std
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.BASE_STD_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -159,7 +159,7 @@ jobs:
         if: matrix.settings.smoke_test
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.BASE_STD_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_STD_SHA: ${{ steps.base-std.outputs.sha }}
         run: |
           set -euo pipefail
@@ -168,7 +168,6 @@ jobs:
           base_std_dir="$workdir/base-std"
           mkdir -p "$workdir"
 
-          gh auth setup-git
           gh repo clone base/base-std "$base_std_dir" -- --filter=blob:none --no-checkout
           git -C "$base_std_dir" fetch --depth 1 origin "$BASE_STD_SHA"
           git -C "$base_std_dir" checkout --detach FETCH_HEAD

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -51,9 +51,7 @@ jobs:
       - name: Clone fork-test repositories
         shell: bash
         env:
-          # BASE_STD_TOKEN must be a PAT with Contents:Read on base/base-std.
-          # GITHUB_TOKEN is repo-scoped and cannot access other repos, even internal ones.
-          GH_TOKEN: ${{ secrets.BASE_STD_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -61,7 +59,6 @@ jobs:
           rm -rf "$workdir"
           mkdir -p "$workdir"
 
-          # base-std is internal — use gh CLI with a cross-repo PAT.
           gh repo clone base/base-std "$workdir/base-std" -- \
             --depth 1 --single-branch --branch "$BASE_STD_REF" \
             --recurse-submodules --shallow-submodules


### PR DESCRIPTION
## What
Replace the `BASE_STD_TOKEN` PAT with the built-in `GITHUB_TOKEN` for base-std access in `base-anvil-package.yml` and `base-std-fork-tests.yml`, and drop the `gh auth setup-git` step that only existed for the PAT.

## Why
`BASE_STD_TOKEN` was needed when base-std was private. base-std is now public, so the repo-scoped `GITHUB_TOKEN` can read it — removing a managed secret from the critical path.

## Follow-up
After this merges, delete the `BASE_STD_TOKEN` repo secret (tracked in BOP-374).

Closes BOP-374.
