### PR TITLE
feat: add basectl conductor commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6622,6 +6622,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -26,4 +26,6 @@ serde_json = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }
+tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -14,18 +14,18 @@ workspace = true
 [dependencies]
 url = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
 alloy-eips = { workspace = true }
 basectl-cli = { workspace = true }
 alloy-provider = { workspace = true }
 base-common-network = { workspace = true }
 base-consensus-peers = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
+serde_json = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
-serde_json = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }
-tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -13,7 +13,7 @@ Global options:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-c, --config <CONFIG>` | `mainnet` | Chain config: `mainnet`, `sepolia`, `devnet`, or a path to a config file |
-| `--conductor-rpc <URL>` | `http://localhost:5545` | Bootstrap conductor JSON-RPC URL for runtime cluster discovery. Overrides any hardcoded conductor list in the chain config. Set via `BASECTL_CONDUCTOR_RPC`. |
+| `--conductor-rpc <URL>` | | Bootstrap conductor JSON-RPC URL for runtime cluster discovery when the chain config has no hardcoded conductor list. If omitted, basectl uses `discovery.bootstrap_rpc` from config. Set via `BASECTL_CONDUCTOR_RPC`. |
 
 ## Commands
 
@@ -150,6 +150,48 @@ Important EL RPC note:
 - CL data comes from `opp2p_self`, `opp2p_peerStats`, and `opp2p_peers(true)` on the consensus RPC.
 - CL ban/unban commands use `opp2p_blockPeer`, `opp2p_unblockPeer`, and `opp2p_listBlockedPeers` underneath, but the basectl command surface uses ban/unban terminology so it can stay consistent when EL ban support is added later.
 
+### `basectl conductor`
+
+Conductor inspection and control commands for HA sequencer clusters.
+
+- `basectl conductor status` shows cluster membership, leader, pause state,
+  sequencer health, L1/L2 heads, and peer counts per node.
+- `basectl conductor transfer-leader [TARGET]` transfers raft leadership away
+  from the current leader, or to a named target node when `TARGET` is provided.
+- `basectl conductor pause <NODE>` pauses op-conductor's control loop on one
+  node.
+- `basectl conductor unpause <NODE>` resumes op-conductor's control loop on one
+  node.
+- `basectl conductor pause-all` pauses op-conductor's control loop on every
+  current raft member from `conductor_clusterMembership`.
+- `basectl conductor unpause-all` resumes op-conductor's control loop on every
+  current raft member from `conductor_clusterMembership`.
+
+Conductor commands use the selected config's hardcoded `conductors` list when
+present. Otherwise, they discover the live raft membership from the global
+`--conductor-rpc` bootstrap URL or `discovery.bootstrap_rpc` in the config.
+
+| Flag | Description |
+|------|-------------|
+| `--json` | For `status`, emit a structured cluster status summary instead of the pretty table output. |
+
+Destructive conductor commands also support:
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Skip the interactive confirmation prompt for single-node actions. For `pause-all` / `unpause-all`, pass twice (`--yes --yes`) to skip the typed network-name confirmation. |
+| `--json` | Emit a structured action outcome instead of pretty text. Single-node actions require `--yes`; cluster-wide actions require `--yes --yes` so scripts do not hang on interactive confirmation. |
+
+Safety notes:
+
+- `pause` / `unpause` prompts with the exact node name and conductor RPC URL.
+- `transfer-leader` prompts with the target node or selected network.
+- `pause-all` / `unpause-all` require typing the selected network name unless
+  `--yes --yes` is provided.
+- Cluster-wide actions can partially succeed before one node fails. Pretty and
+  JSON output include the success and failure sets, and the command exits
+  non-zero when any node fails.
+
 ### `basectl doctor`
 
 Runs read-only diagnostics for a single node and prints one row per check. The
@@ -262,6 +304,23 @@ basectl -c sepolia p2p unban-all --cl-rpc https://your-cl.example/ --yes
 
 # If the EL RPC is restricted, EL peer count still works but EL admin-backed fields may be unavailable
 basectl -c sepolia p2p info --el-rpc https://your-public-el.example/ --cl-rpc https://your-cl.example/
+
+# Show devnet conductor cluster status
+basectl -c devnet conductor status
+
+# Conductor status as structured JSON
+basectl -c devnet conductor status --json | jq '{leader, paused, nodes: [.nodes[].name]}'
+
+# Transfer conductor leadership to a target node after confirmation
+basectl -c devnet conductor transfer-leader op-conductor-1
+
+# Pause and unpause one conductor node
+basectl -c devnet conductor pause op-conductor-0
+basectl -c devnet conductor unpause op-conductor-0 --yes --json | jq .
+
+# Cluster-wide conductor actions require typed confirmation, or --yes --yes for scripts
+basectl -c devnet conductor pause-all
+basectl -c devnet conductor unpause-all --yes --yes --json | jq .
 
 # Run doctor with values from the selected config
 basectl -c mainnet doctor

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -163,13 +163,18 @@ Conductor inspection and control commands for HA sequencer clusters.
 - `basectl conductor unpause <NODE>` resumes op-conductor's control loop on one
   node.
 - `basectl conductor pause-all` pauses op-conductor's control loop on every
-  current raft member from `conductor_clusterMembership`.
+  current raft member from `conductor_clusterMembership`, falling back to the
+  configured conductor list for static configs if membership lookup is unavailable.
 - `basectl conductor unpause-all` resumes op-conductor's control loop on every
-  current raft member from `conductor_clusterMembership`.
+  current raft member from `conductor_clusterMembership`, falling back to the
+  configured conductor list for static configs if membership lookup is unavailable.
 
 Conductor commands use the selected config's hardcoded `conductors` list when
 present. Otherwise, they discover the live raft membership from the global
 `--conductor-rpc` bootstrap URL or `discovery.bootstrap_rpc` in the config.
+Cluster-wide `pause-all` / `unpause-all` actions still prefer live membership
+when it is reachable so stale static entries are skipped, but they no longer
+hard-fail on static configs when the membership RPC is temporarily unavailable.
 
 | Flag | Description |
 |------|-------------|

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -163,18 +163,13 @@ Conductor inspection and control commands for HA sequencer clusters.
 - `basectl conductor unpause <NODE>` resumes op-conductor's control loop on one
   node.
 - `basectl conductor pause-all` pauses op-conductor's control loop on every
-  current raft member from `conductor_clusterMembership`, falling back to the
-  configured conductor list for static configs if membership lookup is unavailable.
+  node in the cluster.
 - `basectl conductor unpause-all` resumes op-conductor's control loop on every
-  current raft member from `conductor_clusterMembership`, falling back to the
-  configured conductor list for static configs if membership lookup is unavailable.
+  node in the cluster.
 
 Conductor commands use the selected config's hardcoded `conductors` list when
-present. Otherwise, they discover the live raft membership from the global
-`--conductor-rpc` bootstrap URL or `discovery.bootstrap_rpc` in the config.
-Cluster-wide `pause-all` / `unpause-all` actions still prefer live membership
-when it is reachable so stale static entries are skipped, but they no longer
-hard-fail on static configs when the membership RPC is temporarily unavailable.
+present. Otherwise they discover the cluster via the `--conductor-rpc` bootstrap
+URL or `discovery.bootstrap_rpc` in the config.
 
 | Flag | Description |
 |------|-------------|
@@ -184,15 +179,15 @@ Destructive conductor commands also support:
 
 | Flag | Description |
 |------|-------------|
-| `--yes` | Skip the interactive confirmation prompt for single-node actions. For `pause-all` / `unpause-all`, pass twice (`--yes --yes`) to skip the typed network-name confirmation. |
-| `--json` | Emit a structured action outcome instead of pretty text. Single-node actions require `--yes`; cluster-wide actions require `--yes --yes` so scripts do not hang on interactive confirmation. |
+| `--yes` | Skip the interactive confirmation prompt. |
+| `--json` | Emit a structured action outcome instead of pretty text. Requires `--yes` so scripts do not hang on interactive confirmation. |
 
 Safety notes:
 
 - `pause` / `unpause` prompts with the exact node name and conductor RPC URL.
 - `transfer-leader` prompts with the target node or selected network.
 - `pause-all` / `unpause-all` require typing the selected network name unless
-  `--yes --yes` is provided.
+  `--yes` is provided.
 - Cluster-wide actions can partially succeed before one node fails. Pretty and
   JSON output include the success and failure sets, and the command exits
   non-zero when any node fails.
@@ -323,9 +318,9 @@ basectl -c devnet conductor transfer-leader op-conductor-1
 basectl -c devnet conductor pause op-conductor-0
 basectl -c devnet conductor unpause op-conductor-0 --yes --json | jq .
 
-# Cluster-wide conductor actions require typed confirmation, or --yes --yes for scripts
+# Cluster-wide conductor actions require typed confirmation, or --yes for scripts
 basectl -c devnet conductor pause-all
-basectl -c devnet conductor unpause-all --yes --yes --json | jq .
+basectl -c devnet conductor unpause-all --yes --json | jq .
 
 # Run doctor with values from the selected config
 basectl -c mainnet doctor

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -262,9 +262,11 @@ pub(crate) enum ConductorCommands {
     Pause(ConductorNodeActionArgs),
     /// Resume op-conductor's control loop on one node.
     Unpause(ConductorNodeActionArgs),
-    /// Pause op-conductor's control loop on every current raft member.
+    /// Pause op-conductor's control loop on every current raft member, falling
+    /// back to the configured conductor list if static membership lookup is unavailable.
     PauseAll(ConductorClusterActionArgs),
-    /// Resume op-conductor's control loop on every current raft member.
+    /// Resume op-conductor's control loop on every current raft member, falling
+    /// back to the configured conductor list if static membership lookup is unavailable.
     UnpauseAll(ConductorClusterActionArgs),
 }
 

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -16,19 +16,13 @@ pub(crate) struct Cli {
     pub(crate) config: String,
     /// Bootstrap conductor JSON-RPC URL for runtime cluster discovery.
     ///
-    /// When set, basectl ignores any hardcoded conductor list in the chain
-    /// config and instead asks this URL for the live raft membership, then
-    /// polls all discovered peers via templated ports.
+    /// When no hardcoded conductor list exists in the chain config, basectl
+    /// asks this URL for the live raft membership. If omitted, basectl uses
+    /// `discovery.bootstrap_rpc` from config.
     ///
-    /// Only applies to the conductor view (and views that embed it, like the
-    /// command center). Ignored by `flashblocks` and other non-TUI
-    /// subcommands.
-    #[arg(
-        long = "conductor-rpc",
-        env = "BASECTL_CONDUCTOR_RPC",
-        global = true,
-        default_value = "http://localhost:5545"
-    )]
+    /// Applies to the conductor view, views that embed it, and non-TUI
+    /// `basectl conductor` commands. Ignored by unrelated non-TUI subcommands.
+    #[arg(long = "conductor-rpc", env = "BASECTL_CONDUCTOR_RPC", global = true)]
     pub(crate) conductor_rpc: Option<Url>,
     #[command(subcommand)]
     pub(crate) command: Option<Commands>,
@@ -95,6 +89,11 @@ pub(crate) enum Commands {
     P2p {
         #[command(subcommand)]
         command: P2pCommands,
+    },
+    /// Inspect and control an HA conductor cluster.
+    Conductor {
+        #[command(subcommand)]
+        command: ConductorCommands,
     },
     /// Run read-only diagnostics for a single node.
     Doctor(DoctorArgs),
@@ -252,6 +251,70 @@ pub(crate) struct DestructiveClBulkArgs {
     pub(crate) json: bool,
 }
 
+/// HA conductor inspection and control commands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum ConductorCommands {
+    /// Show current cluster status.
+    Status(ConductorStatusArgs),
+    /// Transfer raft leadership away from the current leader or to a target node.
+    TransferLeader(ConductorLeaderArgs),
+    /// Pause op-conductor's control loop on one node.
+    Pause(ConductorNodeActionArgs),
+    /// Resume op-conductor's control loop on one node.
+    Unpause(ConductorNodeActionArgs),
+    /// Pause op-conductor's control loop on every current raft member.
+    PauseAll(ConductorClusterActionArgs),
+    /// Resume op-conductor's control loop on every current raft member.
+    UnpauseAll(ConductorClusterActionArgs),
+}
+
+/// Flags for `basectl conductor status`.
+#[derive(Debug, Args)]
+pub(crate) struct ConductorStatusArgs {
+    /// Emit a structured JSON status summary instead of pretty text.
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+/// Flags for `basectl conductor transfer-leader`.
+#[derive(Debug, Args)]
+pub(crate) struct ConductorLeaderArgs {
+    /// Optional target node name. If omitted, the leader transfers to any available peer.
+    #[arg(value_name = "TARGET")]
+    pub(crate) target: Option<String>,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub(crate) yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text.
+    #[arg(long, requires = "yes")]
+    pub(crate) json: bool,
+}
+
+/// Shared flags for single-node destructive `basectl conductor` commands.
+#[derive(Debug, Args)]
+pub(crate) struct ConductorNodeActionArgs {
+    /// Conductor node name from the selected config or discovered raft server ID.
+    #[arg(value_name = "NODE")]
+    pub(crate) node: String,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub(crate) yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text.
+    #[arg(long, requires = "yes")]
+    pub(crate) json: bool,
+}
+
+/// Shared flags for cluster-wide destructive `basectl conductor` commands.
+#[derive(Debug, Args)]
+pub(crate) struct ConductorClusterActionArgs {
+    /// Skip the typed network-name confirmation prompt.
+    #[arg(long)]
+    pub(crate) yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text. Requires `--yes`.
+    #[arg(long, requires = "yes")]
+    pub(crate) json: bool,
+}
+
 /// TUI monitor views.
 #[derive(Debug, Subcommand)]
 pub(crate) enum MonitorCommands {
@@ -396,6 +459,50 @@ mod tests {
                 "http://127.0.0.1:8545",
             ])
             .is_err()
+        );
+    }
+
+    #[test]
+    fn conductor_commands_parse() {
+        assert!(Cli::try_parse_from(["basectl", "conductor", "status", "--json"]).is_ok());
+        assert!(
+            Cli::try_parse_from([
+                "basectl",
+                "conductor",
+                "transfer-leader",
+                "op-conductor-1",
+                "--yes",
+                "--json",
+            ])
+            .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(["basectl", "conductor", "pause", "op-conductor-0", "--yes",])
+                .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(["basectl", "conductor", "unpause", "op-conductor-0", "--yes",])
+                .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(["basectl", "conductor", "pause-all", "--yes", "--json",]).is_ok()
+        );
+        assert!(Cli::try_parse_from(["basectl", "conductor", "unpause-all"]).is_ok());
+    }
+
+    #[test]
+    fn destructive_conductor_json_requires_yes() {
+        assert!(
+            Cli::try_parse_from(["basectl", "conductor", "pause", "op-conductor-0", "--json",])
+                .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(["basectl", "conductor", "transfer-leader", "--json"]).is_err()
+        );
+        assert!(Cli::try_parse_from(["basectl", "conductor", "pause-all", "--json"]).is_err());
+        assert!(Cli::try_parse_from(["basectl", "conductor", "unpause-all", "--json"]).is_err());
+        assert!(
+            Cli::try_parse_from(["basectl", "conductor", "pause-all", "--yes", "--json"]).is_ok()
         );
     }
 }

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -361,22 +361,20 @@ mod tests {
 
     use super::Cli;
 
+    fn try_parse<const N: usize>(args: [&str; N]) -> Result<Cli, clap::Error> {
+        Cli::try_parse_from(args)
+    }
+
     #[test]
     fn destructive_p2p_json_requires_yes() {
+        assert!(try_parse(["basectl", "p2p", "add-peer", "enr:example", "--json"]).is_err());
+        assert!(try_parse(["basectl", "p2p", "ban", "16Uiu2HAmExamplePeerId", "--json",]).is_err());
         assert!(
-            Cli::try_parse_from(["basectl", "p2p", "add-peer", "enr:example", "--json"]).is_err()
+            try_parse(["basectl", "p2p", "unban", "16Uiu2HAmExamplePeerId", "--json",]).is_err()
         );
+        assert!(try_parse(["basectl", "p2p", "unban-all", "--json"]).is_err());
         assert!(
-            Cli::try_parse_from(["basectl", "p2p", "ban", "16Uiu2HAmExamplePeerId", "--json",])
-                .is_err()
-        );
-        assert!(
-            Cli::try_parse_from(["basectl", "p2p", "unban", "16Uiu2HAmExamplePeerId", "--json",])
-                .is_err()
-        );
-        assert!(Cli::try_parse_from(["basectl", "p2p", "unban-all", "--json"]).is_err());
-        assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "p2p",
                 "remove-peer",
@@ -387,7 +385,7 @@ mod tests {
             .is_ok()
         );
         assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "p2p",
                 "ban",
@@ -400,7 +398,7 @@ mod tests {
             .is_ok()
         );
         assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "p2p",
                 "unban",
@@ -413,7 +411,7 @@ mod tests {
             .is_ok()
         );
         assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "p2p",
                 "unban-all",
@@ -429,7 +427,7 @@ mod tests {
     #[test]
     fn destructive_cl_p2p_commands_reject_el_rpc() {
         assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "p2p",
                 "ban",
@@ -440,7 +438,7 @@ mod tests {
             .is_err()
         );
         assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "p2p",
                 "unban",
@@ -451,22 +449,16 @@ mod tests {
             .is_err()
         );
         assert!(
-            Cli::try_parse_from([
-                "basectl",
-                "p2p",
-                "unban-all",
-                "--el-rpc",
-                "http://127.0.0.1:8545",
-            ])
-            .is_err()
+            try_parse(["basectl", "p2p", "unban-all", "--el-rpc", "http://127.0.0.1:8545",])
+                .is_err()
         );
     }
 
     #[test]
     fn conductor_commands_parse() {
-        assert!(Cli::try_parse_from(["basectl", "conductor", "status", "--json"]).is_ok());
+        assert!(try_parse(["basectl", "conductor", "status", "--json"]).is_ok());
         assert!(
-            Cli::try_parse_from([
+            try_parse([
                 "basectl",
                 "conductor",
                 "transfer-leader",
@@ -476,33 +468,19 @@ mod tests {
             ])
             .is_ok()
         );
-        assert!(
-            Cli::try_parse_from(["basectl", "conductor", "pause", "op-conductor-0", "--yes",])
-                .is_ok()
-        );
-        assert!(
-            Cli::try_parse_from(["basectl", "conductor", "unpause", "op-conductor-0", "--yes",])
-                .is_ok()
-        );
-        assert!(
-            Cli::try_parse_from(["basectl", "conductor", "pause-all", "--yes", "--json",]).is_ok()
-        );
-        assert!(Cli::try_parse_from(["basectl", "conductor", "unpause-all"]).is_ok());
+        assert!(try_parse(["basectl", "conductor", "pause", "op-conductor-0", "--yes",]).is_ok());
+        assert!(try_parse(["basectl", "conductor", "unpause", "op-conductor-0", "--yes",]).is_ok());
+        assert!(try_parse(["basectl", "conductor", "pause-all", "--yes", "--json",]).is_ok());
+        assert!(try_parse(["basectl", "conductor", "unpause-all"]).is_ok());
     }
 
     #[test]
     fn destructive_conductor_json_requires_yes() {
-        assert!(
-            Cli::try_parse_from(["basectl", "conductor", "pause", "op-conductor-0", "--json",])
-                .is_err()
-        );
-        assert!(
-            Cli::try_parse_from(["basectl", "conductor", "transfer-leader", "--json"]).is_err()
-        );
-        assert!(Cli::try_parse_from(["basectl", "conductor", "pause-all", "--json"]).is_err());
-        assert!(Cli::try_parse_from(["basectl", "conductor", "unpause-all", "--json"]).is_err());
-        assert!(
-            Cli::try_parse_from(["basectl", "conductor", "pause-all", "--yes", "--json"]).is_ok()
-        );
+        assert!(try_parse(["basectl", "conductor", "pause", "op-conductor-0", "--json",]).is_err());
+        assert!(try_parse(["basectl", "conductor", "transfer-leader", "--json"]).is_err());
+        assert!(try_parse(["basectl", "conductor", "pause-all", "--json"]).is_err());
+        assert!(try_parse(["basectl", "conductor", "unpause-all", "--json"]).is_err());
+        assert!(try_parse(["basectl", "conductor", "pause-all", "--yes", "--json"]).is_ok());
+        assert!(try_parse(["basectl", "conductor", "unpause-all", "--yes", "--json"]).is_ok());
     }
 }

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -9,6 +9,7 @@ use basectl_cli::{
     MonitoringConfig,
 };
 use serde::Serialize;
+use tracing::warn;
 use url::Url;
 
 use crate::{
@@ -38,6 +39,21 @@ impl NodeActionKind {
 enum ClusterActionKind {
     PauseAll,
     UnpauseAll,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ClusterNodeScope {
+    CurrentRaftMembers,
+    ConfiguredNodes,
+}
+
+impl ClusterNodeScope {
+    const fn description(self) -> &'static str {
+        match self {
+            Self::CurrentRaftMembers => "current raft members",
+            Self::ConfiguredNodes => "configured conductors",
+        }
+    }
 }
 
 impl ClusterActionKind {
@@ -169,20 +185,22 @@ async fn run_cluster_action(
     args: ConductorClusterActionArgs,
     action: ClusterActionKind,
 ) -> Result<()> {
-    let nodes = current_nodes_for_all(&source).await?;
+    let (nodes, node_scope) = current_nodes_for_cluster_action(&source).await?;
     let names = nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ");
     let json_action = action.action();
     let prompt = match action {
         ClusterActionKind::PauseAll => format!(
-            "Type {} to pause conductor control loop on all {} current raft members ({}): ",
+            "Type {} to pause conductor control loop on all {} {} ({}): ",
             config.name,
             nodes.len(),
+            node_scope.description(),
             names
         ),
         ClusterActionKind::UnpauseAll => format!(
-            "Type {} to unpause conductor control loop on all {} current raft members ({}): ",
+            "Type {} to unpause conductor control loop on all {} {} ({}): ",
             config.name,
             nodes.len(),
+            node_scope.description(),
             names
         ),
     };
@@ -217,6 +235,34 @@ async fn current_nodes_for_action(source: &ConductorSource) -> Result<Vec<Conduc
     match source {
         ConductorSource::Static(nodes) => Ok(nodes.clone()),
         ConductorSource::Discover { .. } => current_nodes_for_all(source).await,
+    }
+}
+
+async fn current_nodes_for_cluster_action(
+    source: &ConductorSource,
+) -> Result<(Vec<ConductorNodeConfig>, ClusterNodeScope)> {
+    match source {
+        // Prefer live membership when it is reachable so stale static entries are
+        // not mutated unnecessarily, but fall back to the configured list so a
+        // temporary membership RPC outage does not block bulk actions entirely.
+        ConductorSource::Static(nodes) => {
+            match ConductorControl::current_membership(source).await {
+                Ok(membership) => Ok((
+                    ConductorControl::nodes_from_membership(source, &membership)?,
+                    ClusterNodeScope::CurrentRaftMembers,
+                )),
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        "membership lookup failed for static conductor source; falling back to configured node list"
+                    );
+                    Ok((nodes.clone(), ClusterNodeScope::ConfiguredNodes))
+                }
+            }
+        }
+        ConductorSource::Discover { .. } => {
+            Ok((current_nodes_for_all(source).await?, ClusterNodeScope::CurrentRaftMembers))
+        }
     }
 }
 

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -265,7 +265,13 @@ fn print_fanout_action(action: &ConductorFanoutJson, json: bool) -> Result<()> {
         JsonOutput::print(action)?;
     } else {
         let mut stdout = io::stdout().lock();
-        if action.total > 0 && action.failures.is_empty() {
+        if action.total == 0 {
+            writeln!(
+                stdout,
+                "WARN no conductor nodes to {}",
+                action.action.infinitive()
+            )?;
+        } else if action.failures.is_empty() {
             writeln!(
                 stdout,
                 "OK conductor {} on {}/{} nodes",
@@ -312,6 +318,14 @@ impl ConductorAction {
             Self::TransferLeader => "transferred",
             Self::Pause | Self::PauseAll => "paused",
             Self::Unpause | Self::UnpauseAll => "resumed",
+        }
+    }
+
+    const fn infinitive(self) -> &'static str {
+        match self {
+            Self::TransferLeader => "transfer",
+            Self::Pause | Self::PauseAll => "pause",
+            Self::Unpause | Self::UnpauseAll => "resume",
         }
     }
 }

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -96,6 +96,8 @@ async fn run_transfer_leader(
 ) -> Result<()> {
     let nodes = current_nodes_for_action(&source).await?;
     if let Some(target) = args.target.as_deref() {
+        // Validate before prompting so a typo does not ask for confirmation and only
+        // fail after the operator already answered yes.
         find_node(&nodes, target)?;
     }
 

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -266,11 +266,7 @@ fn print_fanout_action(action: &ConductorFanoutJson, json: bool) -> Result<()> {
     } else {
         let mut stdout = io::stdout().lock();
         if action.total == 0 {
-            writeln!(
-                stdout,
-                "WARN no conductor nodes to {}",
-                action.action.infinitive()
-            )?;
+            writeln!(stdout, "WARN no conductor nodes to {}", action.action.infinitive())?;
         } else if action.failures.is_empty() {
             writeln!(
                 stdout,

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -241,6 +241,9 @@ fn print_status_pretty(status: &ConductorStatusJson) -> Result<()> {
     if let Some(version) = status.membership_version {
         table.row("membership_version", version.to_string());
     }
+    if let Some(error) = &status.membership_error {
+        table.row("membership_error", error);
+    }
     table.row("leader", status.leader.as_deref().unwrap_or("unknown"));
     table.row("paused", format!("{}/{} known paused", status.paused.paused, status.paused.known));
     for node in &status.nodes {
@@ -389,6 +392,8 @@ struct ConductorStatusJson {
     source: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     membership_version: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    membership_error: Option<String>,
     leader: Option<String>,
     paused: PausedSummaryJson,
     nodes: Vec<ConductorNodeJson>,
@@ -416,6 +421,7 @@ impl ConductorStatusJson {
             network: network.to_string(),
             source,
             membership_version: snapshot.membership.as_ref().map(|membership| membership.version),
+            membership_error: snapshot.membership_error.clone(),
             leader,
             paused,
             nodes,
@@ -636,6 +642,7 @@ mod tests {
                 status("op-conductor-1", false, true),
             ],
             membership: None,
+            membership_error: None,
             discovered: false,
         };
 
@@ -645,6 +652,22 @@ mod tests {
         assert_eq!(value["leader"], "op-conductor-0");
         assert_eq!(value["paused"], json!({"known": 2, "paused": 1}));
         assert_eq!(value["nodes"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn status_json_includes_membership_error_when_lookup_fails() {
+        let snapshot = ConductorClusterSnapshot {
+            nodes: vec![node("op-conductor-0")],
+            statuses: vec![status("op-conductor-0", true, false)],
+            membership: None,
+            membership_error: Some("membership request timed out".to_string()),
+            discovered: false,
+        };
+
+        let value =
+            serde_json::to_value(ConductorStatusJson::from_snapshot("devnet", &snapshot)).unwrap();
+
+        assert_eq!(value["membershipError"], "membership request timed out");
     }
 
     #[test]

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -19,6 +19,36 @@ use crate::{
     confirm::{confirm_or_abort, confirm_typed_or_abort},
 };
 
+#[derive(Debug, Clone, Copy)]
+enum NodeActionKind {
+    Pause,
+    Unpause,
+}
+
+impl NodeActionKind {
+    const fn action(self) -> ConductorAction {
+        match self {
+            Self::Pause => ConductorAction::Pause,
+            Self::Unpause => ConductorAction::Unpause,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ClusterActionKind {
+    PauseAll,
+    UnpauseAll,
+}
+
+impl ClusterActionKind {
+    const fn action(self) -> ConductorAction {
+        match self {
+            Self::PauseAll => ConductorAction::PauseAll,
+            Self::UnpauseAll => ConductorAction::UnpauseAll,
+        }
+    }
+}
+
 /// Runs the `basectl conductor` command group.
 pub(crate) async fn run(
     config: MonitoringConfig,
@@ -30,16 +60,16 @@ pub(crate) async fn run(
         ConductorCommands::Status(args) => run_status(config, source, args).await,
         ConductorCommands::TransferLeader(args) => run_transfer_leader(config, source, args).await,
         ConductorCommands::Pause(args) => {
-            run_node_action(config, source, args, ConductorAction::Pause).await
+            run_node_action(config, source, args, NodeActionKind::Pause).await
         }
         ConductorCommands::Unpause(args) => {
-            run_node_action(config, source, args, ConductorAction::Unpause).await
+            run_node_action(config, source, args, NodeActionKind::Unpause).await
         }
         ConductorCommands::PauseAll(args) => {
-            run_cluster_action(config, source, args, ConductorAction::PauseAll).await
+            run_cluster_action(config, source, args, ClusterActionKind::PauseAll).await
         }
         ConductorCommands::UnpauseAll(args) => {
-            run_cluster_action(config, source, args, ConductorAction::UnpauseAll).await
+            run_cluster_action(config, source, args, ClusterActionKind::UnpauseAll).await
         }
     }
 }
@@ -98,36 +128,35 @@ async fn run_node_action(
     config: MonitoringConfig,
     source: ConductorSource,
     args: ConductorNodeActionArgs,
-    action: ConductorAction,
+    action: NodeActionKind,
 ) -> Result<()> {
     let nodes = current_nodes_for_action(&source).await?;
     let node = find_node(&nodes, &args.node)?;
+    let json_action = action.action();
     let prompt = match action {
-        ConductorAction::Pause => {
+        NodeActionKind::Pause => {
             format!(
                 "Pause conductor control loop on {} ({})? [y/N] ",
                 node.name, node.conductor_rpc
             )
         }
-        ConductorAction::Unpause => {
+        NodeActionKind::Unpause => {
             format!(
                 "Unpause conductor control loop on {} ({})? [y/N] ",
                 node.name, node.conductor_rpc
             )
         }
-        _ => unreachable!("single-node conductor action must be pause or unpause"),
     };
     if !confirm_or_abort(&prompt, args.yes)? {
         return Ok(());
     }
 
     let message = match action {
-        ConductorAction::Pause => ConductorControl::pause_node(node).await?,
-        ConductorAction::Unpause => ConductorControl::resume_node(node).await?,
-        _ => unreachable!("single-node conductor action must be pause or unpause"),
+        NodeActionKind::Pause => ConductorControl::pause_node(node).await?,
+        NodeActionKind::Unpause => ConductorControl::resume_node(node).await?,
     };
     print_single_action(
-        &ConductorActionJson::single(&config.name, action, Some(node.name.clone()), message),
+        &ConductorActionJson::single(&config.name, json_action, Some(node.name.clone()), message),
         args.json,
     )
 }
@@ -136,39 +165,38 @@ async fn run_cluster_action(
     config: MonitoringConfig,
     source: ConductorSource,
     args: ConductorClusterActionArgs,
-    action: ConductorAction,
+    action: ClusterActionKind,
 ) -> Result<()> {
     let nodes = current_nodes_for_all(&source).await?;
     let names = nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ");
+    let json_action = action.action();
     let prompt = match action {
-        ConductorAction::PauseAll => format!(
+        ClusterActionKind::PauseAll => format!(
             "Type {} to pause conductor control loop on all {} current raft members ({}): ",
             config.name,
             nodes.len(),
             names
         ),
-        ConductorAction::UnpauseAll => format!(
+        ClusterActionKind::UnpauseAll => format!(
             "Type {} to unpause conductor control loop on all {} current raft members ({}): ",
             config.name,
             nodes.len(),
             names
         ),
-        _ => unreachable!("cluster conductor action must be pause-all or unpause-all"),
     };
     if !confirm_typed_or_abort(&prompt, &config.name, args.yes)? {
         return Ok(());
     }
 
     let report = match action {
-        ConductorAction::PauseAll => ConductorControl::pause_all(nodes).await,
-        ConductorAction::UnpauseAll => ConductorControl::resume_all(nodes).await,
-        _ => unreachable!("cluster conductor action must be pause-all or unpause-all"),
+        ClusterActionKind::PauseAll => ConductorControl::pause_all(nodes).await,
+        ClusterActionKind::UnpauseAll => ConductorControl::resume_all(nodes).await,
     };
     print_fanout_action(
-        &ConductorFanoutJson::from_report(&config.name, action, &report),
+        &ConductorFanoutJson::from_report(&config.name, json_action, &report),
         args.json,
     )?;
-    if report.is_success() { Ok(()) } else { bail!(report.summary(action.past_tense())) }
+    if report.is_success() { Ok(()) } else { bail!(report.summary(json_action.past_tense())) }
 }
 
 fn resolve_source(

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -327,18 +327,18 @@ fn print_fanout_action(action: &ConductorFanoutJson, json: bool) -> Result<()> {
                 action.total
             )?;
         } else {
+            let failures = action
+                .failures
+                .iter()
+                .map(|f| format!("{}: {}", f.name, f.error))
+                .collect::<Vec<_>>()
+                .join("; ");
             writeln!(
                 stdout,
-                "WARN conductor {} on {}/{} nodes; failures: {}",
+                "WARN conductor {} on {}/{} nodes; failures: {failures}",
                 action.action.past_tense(),
                 action.successes.len(),
-                action.total,
-                action
-                    .failures
-                    .iter()
-                    .map(|failure| format!("{}: {}", failure.name, failure.error))
-                    .collect::<Vec<_>>()
-                    .join("; ")
+                action.total
             )?;
         }
     }

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -1,0 +1,621 @@
+//! Implementation of the `basectl conductor` command group.
+
+use std::io::{self, Write};
+
+use anyhow::{Result, anyhow, bail};
+use basectl_cli::{
+    ConductorClusterSnapshot, ConductorControl, ConductorFanoutReport, ConductorNodeConfig,
+    ConductorNodeFailure, ConductorNodeStatus, ConductorSource, JsonOutput, KeyValueTable,
+    MonitoringConfig,
+};
+use serde::Serialize;
+use url::Url;
+
+use crate::{
+    cli::{
+        ConductorClusterActionArgs, ConductorCommands, ConductorLeaderArgs,
+        ConductorNodeActionArgs, ConductorStatusArgs,
+    },
+    confirm::{confirm_or_abort, confirm_typed_or_abort},
+};
+
+/// Runs the `basectl conductor` command group.
+pub(crate) async fn run(
+    config: MonitoringConfig,
+    conductor_rpc: Option<Url>,
+    command: ConductorCommands,
+) -> Result<()> {
+    let source = resolve_source(&config, conductor_rpc)?;
+    match command {
+        ConductorCommands::Status(args) => run_status(config, source, args).await,
+        ConductorCommands::TransferLeader(args) => run_transfer_leader(config, source, args).await,
+        ConductorCommands::Pause(args) => {
+            run_node_action(config, source, args, ConductorAction::Pause).await
+        }
+        ConductorCommands::Unpause(args) => {
+            run_node_action(config, source, args, ConductorAction::Unpause).await
+        }
+        ConductorCommands::PauseAll(args) => {
+            run_cluster_action(config, source, args, ConductorAction::PauseAll).await
+        }
+        ConductorCommands::UnpauseAll(args) => {
+            run_cluster_action(config, source, args, ConductorAction::UnpauseAll).await
+        }
+    }
+}
+
+async fn run_status(
+    config: MonitoringConfig,
+    source: ConductorSource,
+    args: ConductorStatusArgs,
+) -> Result<()> {
+    let snapshot = ConductorControl::snapshot(source).await?;
+    let status = ConductorStatusJson::from_snapshot(&config.name, &snapshot);
+    if args.json {
+        JsonOutput::print(&status)?;
+    } else {
+        print_status_pretty(&status)?;
+    }
+    Ok(())
+}
+
+async fn run_transfer_leader(
+    config: MonitoringConfig,
+    source: ConductorSource,
+    args: ConductorLeaderArgs,
+) -> Result<()> {
+    let nodes = current_nodes_for_action(&source).await?;
+    if let Some(target) = args.target.as_deref() {
+        find_node(&nodes, target)?;
+    }
+
+    let prompt = args.target.as_deref().map_or_else(
+        || {
+            format!(
+                "Transfer conductor leadership away from the current leader for {}? [y/N] ",
+                config.name
+            )
+        },
+        |target| format!("Transfer conductor leadership to {target} for {}? [y/N] ", config.name),
+    );
+    if !confirm_or_abort(&prompt, args.yes)? {
+        return Ok(());
+    }
+
+    let message = ConductorControl::transfer_leader(&nodes, args.target.as_deref()).await?;
+    print_single_action(
+        &ConductorActionJson::single(
+            &config.name,
+            ConductorAction::TransferLeader,
+            args.target,
+            message,
+        ),
+        args.json,
+    )
+}
+
+async fn run_node_action(
+    config: MonitoringConfig,
+    source: ConductorSource,
+    args: ConductorNodeActionArgs,
+    action: ConductorAction,
+) -> Result<()> {
+    let nodes = current_nodes_for_action(&source).await?;
+    let node = find_node(&nodes, &args.node)?;
+    let prompt = match action {
+        ConductorAction::Pause => {
+            format!(
+                "Pause conductor control loop on {} ({})? [y/N] ",
+                node.name, node.conductor_rpc
+            )
+        }
+        ConductorAction::Unpause => {
+            format!(
+                "Unpause conductor control loop on {} ({})? [y/N] ",
+                node.name, node.conductor_rpc
+            )
+        }
+        _ => unreachable!("single-node conductor action must be pause or unpause"),
+    };
+    if !confirm_or_abort(&prompt, args.yes)? {
+        return Ok(());
+    }
+
+    let message = match action {
+        ConductorAction::Pause => ConductorControl::pause_node(node).await?,
+        ConductorAction::Unpause => ConductorControl::resume_node(node).await?,
+        _ => unreachable!("single-node conductor action must be pause or unpause"),
+    };
+    print_single_action(
+        &ConductorActionJson::single(&config.name, action, Some(node.name.clone()), message),
+        args.json,
+    )
+}
+
+async fn run_cluster_action(
+    config: MonitoringConfig,
+    source: ConductorSource,
+    args: ConductorClusterActionArgs,
+    action: ConductorAction,
+) -> Result<()> {
+    let nodes = current_nodes_for_all(&source).await?;
+    let names = nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ");
+    let prompt = match action {
+        ConductorAction::PauseAll => format!(
+            "Type {} to pause conductor control loop on all {} current raft members ({}): ",
+            config.name,
+            nodes.len(),
+            names
+        ),
+        ConductorAction::UnpauseAll => format!(
+            "Type {} to unpause conductor control loop on all {} current raft members ({}): ",
+            config.name,
+            nodes.len(),
+            names
+        ),
+        _ => unreachable!("cluster conductor action must be pause-all or unpause-all"),
+    };
+    if !confirm_typed_or_abort(&prompt, &config.name, args.yes)? {
+        return Ok(());
+    }
+
+    let report = match action {
+        ConductorAction::PauseAll => ConductorControl::pause_all(nodes).await,
+        ConductorAction::UnpauseAll => ConductorControl::resume_all(nodes).await,
+        _ => unreachable!("cluster conductor action must be pause-all or unpause-all"),
+    };
+    print_fanout_action(
+        &ConductorFanoutJson::from_report(&config.name, action, &report),
+        args.json,
+    )?;
+    if report.is_success() { Ok(()) } else { bail!(report.summary(action.past_tense())) }
+}
+
+fn resolve_source(
+    config: &MonitoringConfig,
+    conductor_rpc: Option<Url>,
+) -> Result<ConductorSource> {
+    config.conductor_source(conductor_rpc).ok_or_else(|| {
+        anyhow!(
+            "conductor commands need conductor config or a bootstrap RPC URL for '{}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`.",
+            config.name
+        )
+    })
+}
+
+async fn current_nodes_for_action(source: &ConductorSource) -> Result<Vec<ConductorNodeConfig>> {
+    match source {
+        ConductorSource::Static(nodes) => Ok(nodes.clone()),
+        ConductorSource::Discover { .. } => current_nodes_for_all(source).await,
+    }
+}
+
+async fn current_nodes_for_all(source: &ConductorSource) -> Result<Vec<ConductorNodeConfig>> {
+    let membership = ConductorControl::current_membership(source).await?;
+    ConductorControl::nodes_from_membership(source, &membership)
+}
+
+fn find_node<'a>(nodes: &'a [ConductorNodeConfig], name: &str) -> Result<&'a ConductorNodeConfig> {
+    nodes.iter().find(|node| node.name == name).ok_or_else(|| {
+        anyhow!(
+            "conductor node {name} not found. Available nodes: {}",
+            nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ")
+        )
+    })
+}
+
+fn print_status_pretty(status: &ConductorStatusJson) -> Result<()> {
+    let mut table = KeyValueTable::new();
+    table
+        .row("network", &status.network)
+        .row("source", status.source)
+        .row("nodes", status.nodes.len().to_string());
+    if let Some(version) = status.membership_version {
+        table.row("membership_version", version.to_string());
+    }
+    table.row("leader", status.leader.as_deref().unwrap_or("unknown"));
+    table.row("paused", format!("{}/{} known paused", status.paused.paused, status.paused.known));
+    for node in &status.nodes {
+        table.row(format!("node.{}", node.name), node.compact_status());
+    }
+    table.print()?;
+    Ok(())
+}
+
+fn print_single_action(action: &ConductorActionJson, json: bool) -> Result<()> {
+    if json {
+        JsonOutput::print(action)?;
+    } else {
+        let mut stdout = io::stdout().lock();
+        writeln!(stdout, "OK {}", action.message)?;
+    }
+    Ok(())
+}
+
+fn print_fanout_action(action: &ConductorFanoutJson, json: bool) -> Result<()> {
+    if json {
+        JsonOutput::print(action)?;
+    } else {
+        let mut stdout = io::stdout().lock();
+        if action.total > 0 && action.failures.is_empty() {
+            writeln!(
+                stdout,
+                "OK conductor {} on {}/{} nodes",
+                action.action.past_tense(),
+                action.successes.len(),
+                action.total
+            )?;
+        } else {
+            writeln!(
+                stdout,
+                "WARN conductor {} on {}/{} nodes; failures: {}",
+                action.action.past_tense(),
+                action.successes.len(),
+                action.total,
+                action
+                    .failures
+                    .iter()
+                    .map(|failure| format!("{}: {}", failure.name, failure.error))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+enum ConductorAction {
+    #[serde(rename = "transferLeader")]
+    TransferLeader,
+    #[serde(rename = "pause")]
+    Pause,
+    #[serde(rename = "unpause")]
+    Unpause,
+    #[serde(rename = "pauseAll")]
+    PauseAll,
+    #[serde(rename = "unpauseAll")]
+    UnpauseAll,
+}
+
+impl ConductorAction {
+    const fn past_tense(self) -> &'static str {
+        match self {
+            Self::TransferLeader => "transferred",
+            Self::Pause | Self::PauseAll => "paused",
+            Self::Unpause | Self::UnpauseAll => "resumed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConductorActionJson {
+    network: String,
+    action: ConductorAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<String>,
+    message: String,
+}
+
+impl ConductorActionJson {
+    fn single(
+        network: &str,
+        action: ConductorAction,
+        target: Option<String>,
+        message: String,
+    ) -> Self {
+        Self { network: network.to_string(), action, target, message }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConductorFanoutJson {
+    network: String,
+    action: ConductorAction,
+    total: usize,
+    successes: Vec<String>,
+    failures: Vec<ConductorFailureJson>,
+}
+
+impl ConductorFanoutJson {
+    fn from_report(network: &str, action: ConductorAction, report: &ConductorFanoutReport) -> Self {
+        Self {
+            network: network.to_string(),
+            action,
+            total: report.total,
+            successes: report.successes.clone(),
+            failures: report.failures.iter().map(ConductorFailureJson::from_failure).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConductorFailureJson {
+    name: String,
+    error: String,
+}
+
+impl ConductorFailureJson {
+    fn from_failure(failure: &ConductorNodeFailure) -> Self {
+        Self { name: failure.name.clone(), error: failure.error.clone() }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConductorStatusJson {
+    network: String,
+    source: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    membership_version: Option<u64>,
+    leader: Option<String>,
+    paused: PausedSummaryJson,
+    nodes: Vec<ConductorNodeJson>,
+}
+
+impl ConductorStatusJson {
+    fn from_snapshot(network: &str, snapshot: &ConductorClusterSnapshot) -> Self {
+        let source = if snapshot.discovered { "discovered" } else { "static" };
+        let nodes = snapshot
+            .nodes
+            .iter()
+            .map(|node| {
+                let status = snapshot.statuses.iter().find(|status| status.name == node.name);
+                ConductorNodeJson::from_node_status(node, status)
+            })
+            .collect::<Vec<_>>();
+        let leader =
+            nodes.iter().find(|node| node.is_leader == Some(true)).map(|node| node.name.clone());
+        let paused = PausedSummaryJson {
+            known: nodes.iter().filter(|node| node.conductor_paused.is_some()).count(),
+            paused: nodes.iter().filter(|node| node.conductor_paused == Some(true)).count(),
+        };
+
+        Self {
+            network: network.to_string(),
+            source,
+            membership_version: snapshot.membership.as_ref().map(|membership| membership.version),
+            leader,
+            paused,
+            nodes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PausedSummaryJson {
+    known: usize,
+    paused: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConductorNodeJson {
+    name: String,
+    server_id: String,
+    raft_addr: String,
+    conductor_rpc: String,
+    is_leader: Option<bool>,
+    conductor_active: Option<bool>,
+    conductor_paused: Option<bool>,
+    conductor_stopped: Option<bool>,
+    sequencer_healthy: Option<bool>,
+    sequencer_active: Option<bool>,
+    unsafe_l2_block: Option<u64>,
+    unsafe_l2_hash: Option<String>,
+    safe_l2_block: Option<u64>,
+    safe_l2_hash: Option<String>,
+    finalized_l2_block: Option<u64>,
+    current_l1_block: Option<u64>,
+    head_l1_block: Option<u64>,
+    cl_peer_count: Option<u32>,
+    el_block: Option<u64>,
+    el_syncing: Option<bool>,
+    el_peer_count: Option<u32>,
+    suffrage: Option<String>,
+    discovered: bool,
+}
+
+impl ConductorNodeJson {
+    fn from_node_status(node: &ConductorNodeConfig, status: Option<&ConductorNodeStatus>) -> Self {
+        Self {
+            name: node.name.clone(),
+            server_id: node.server_id.clone(),
+            raft_addr: node.raft_addr.clone(),
+            conductor_rpc: node.conductor_rpc.to_string(),
+            is_leader: status.and_then(|status| status.is_leader),
+            conductor_active: status.and_then(|status| status.conductor_active),
+            conductor_paused: status.and_then(|status| status.conductor_paused),
+            conductor_stopped: status.and_then(|status| status.conductor_stopped),
+            sequencer_healthy: status.and_then(|status| status.sequencer_healthy),
+            sequencer_active: status.and_then(|status| status.sequencer_active),
+            unsafe_l2_block: status.and_then(|status| status.unsafe_l2_block),
+            unsafe_l2_hash: status
+                .and_then(|status| status.unsafe_l2_hash)
+                .map(|hash| hash.to_string()),
+            safe_l2_block: status.and_then(|status| status.safe_l2_block),
+            safe_l2_hash: status
+                .and_then(|status| status.safe_l2_hash)
+                .map(|hash| hash.to_string()),
+            finalized_l2_block: status.and_then(|status| status.finalized_l2_block),
+            current_l1_block: status.and_then(|status| status.current_l1_block),
+            head_l1_block: status.and_then(|status| status.head_l1_block),
+            cl_peer_count: status.and_then(|status| status.cl_peer_count),
+            el_block: status.and_then(|status| status.el_block),
+            el_syncing: status.and_then(|status| status.el_syncing),
+            el_peer_count: status.and_then(|status| status.el_peer_count),
+            suffrage: status.and_then(|status| {
+                status.suffrage.map(|suffrage| format!("{suffrage:?}").to_ascii_lowercase())
+            }),
+            discovered: status.is_some_and(|status| status.discovered),
+        }
+    }
+
+    fn compact_status(&self) -> String {
+        format!(
+            "leader={} active={} paused={} stopped={} healthy={} unsafe={} safe={} cl_peers={} el_peers={}",
+            fmt_bool(self.is_leader),
+            fmt_bool(self.conductor_active),
+            fmt_bool(self.conductor_paused),
+            fmt_bool(self.conductor_stopped),
+            fmt_bool(self.sequencer_healthy),
+            fmt_u64(self.unsafe_l2_block),
+            fmt_u64(self.safe_l2_block),
+            fmt_u32(self.cl_peer_count),
+            fmt_u32(self.el_peer_count),
+        )
+    }
+}
+
+const fn fmt_bool(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "true",
+        Some(false) => "false",
+        None => "unknown",
+    }
+}
+
+fn fmt_u64(value: Option<u64>) -> String {
+    value.map_or_else(|| "unknown".to_string(), |value| value.to_string())
+}
+
+fn fmt_u32(value: Option<u32>) -> String {
+    value.map_or_else(|| "unknown".to_string(), |value| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use basectl_cli::{ConductorClusterSnapshot, ConductorNodeConfig, ConductorNodeFailure};
+    use serde_json::json;
+    use url::Url;
+
+    use super::{
+        ConductorAction, ConductorActionJson, ConductorFanoutJson, ConductorStatusJson, find_node,
+    };
+
+    fn node(name: &str) -> ConductorNodeConfig {
+        ConductorNodeConfig {
+            name: name.to_string(),
+            conductor_rpc: Url::parse("http://127.0.0.1:6545").unwrap(),
+            cl_rpc: Url::parse("http://127.0.0.1:7545").unwrap(),
+            server_id: name.to_string(),
+            raft_addr: format!("{name}:5050"),
+            el_rpc: None,
+            docker_conductor: None,
+            docker_el: None,
+            docker_cl: None,
+            flashblocks_ws: None,
+        }
+    }
+
+    fn status(name: &str, leader: bool, paused: bool) -> basectl_cli::ConductorNodeStatus {
+        basectl_cli::ConductorNodeStatus {
+            name: name.to_string(),
+            is_leader: Some(leader),
+            conductor_active: Some(leader),
+            conductor_paused: Some(paused),
+            conductor_stopped: Some(false),
+            sequencer_healthy: Some(true),
+            sequencer_active: Some(leader),
+            unsafe_l2_block: Some(10),
+            unsafe_l2_hash: Some(B256::with_last_byte(1)),
+            safe_l2_block: Some(8),
+            safe_l2_hash: Some(B256::with_last_byte(2)),
+            finalized_l2_block: Some(6),
+            current_l1_block: Some(100),
+            head_l1_block: Some(101),
+            cl_peer_count: Some(3),
+            el_block: Some(10),
+            el_syncing: Some(false),
+            el_peer_count: Some(4),
+            suffrage: None,
+            discovered: false,
+        }
+    }
+
+    #[test]
+    fn conductor_action_json_serializes_camel_case_action() {
+        let value = serde_json::to_value(ConductorActionJson::single(
+            "devnet",
+            ConductorAction::TransferLeader,
+            Some("op-conductor-1".to_string()),
+            "leadership transferred to op-conductor-1".to_string(),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "network": "devnet",
+                "action": "transferLeader",
+                "target": "op-conductor-1",
+                "message": "leadership transferred to op-conductor-1",
+            })
+        );
+    }
+
+    #[test]
+    fn conductor_fanout_json_serializes_failures() {
+        let report = basectl_cli::ConductorFanoutReport {
+            total: 2,
+            successes: vec!["op-conductor-0".to_string()],
+            failures: vec![ConductorNodeFailure {
+                name: "op-conductor-1".to_string(),
+                error: "request timed out".to_string(),
+            }],
+        };
+
+        let value = serde_json::to_value(ConductorFanoutJson::from_report(
+            "devnet",
+            ConductorAction::PauseAll,
+            &report,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "network": "devnet",
+                "action": "pauseAll",
+                "total": 2,
+                "successes": ["op-conductor-0"],
+                "failures": [{"name": "op-conductor-1", "error": "request timed out"}],
+            })
+        );
+    }
+
+    #[test]
+    fn status_json_derives_leader_and_paused_summary() {
+        let snapshot = ConductorClusterSnapshot {
+            nodes: vec![node("op-conductor-0"), node("op-conductor-1")],
+            statuses: vec![
+                status("op-conductor-0", true, false),
+                status("op-conductor-1", false, true),
+            ],
+            membership: None,
+            discovered: false,
+        };
+
+        let value =
+            serde_json::to_value(ConductorStatusJson::from_snapshot("devnet", &snapshot)).unwrap();
+
+        assert_eq!(value["leader"], "op-conductor-0");
+        assert_eq!(value["paused"], json!({"known": 2, "paused": 1}));
+        assert_eq!(value["nodes"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn find_node_reports_missing_name() {
+        let nodes = vec![node("op-conductor-0")];
+
+        let err = find_node(&nodes, "op-conductor-1").expect_err("missing node should error");
+
+        assert!(err.to_string().contains("op-conductor-1"));
+        assert!(err.to_string().contains("op-conductor-0"));
+    }
+}

--- a/bin/basectl/src/confirm.rs
+++ b/bin/basectl/src/confirm.rs
@@ -11,6 +11,31 @@ pub(crate) fn confirm(prompt: &str, skip: bool) -> Result<bool> {
     confirm_with_io(prompt, skip, &mut stdin.lock(), &mut stdout.lock())
 }
 
+/// Confirms a destructive action and prints `aborted` when declined.
+pub(crate) fn confirm_or_abort(prompt: &str, skip: bool) -> Result<bool> {
+    let confirmed = confirm(prompt, skip)?;
+    if !confirmed {
+        println!("aborted");
+    }
+    Ok(confirmed)
+}
+
+/// Confirms a destructive action by requiring an exact typed value.
+pub(crate) fn confirm_typed(prompt: &str, expected: &str, skip: bool) -> Result<bool> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    confirm_typed_with_io(prompt, expected, skip, &mut stdin.lock(), &mut stdout.lock())
+}
+
+/// Confirms a typed destructive action and prints `aborted` when declined.
+pub(crate) fn confirm_typed_or_abort(prompt: &str, expected: &str, skip: bool) -> Result<bool> {
+    let confirmed = confirm_typed(prompt, expected, skip)?;
+    if !confirmed {
+        println!("aborted");
+    }
+    Ok(confirmed)
+}
+
 fn confirm_with_io<R: BufRead, W: Write>(
     prompt: &str,
     skip: bool,
@@ -29,11 +54,30 @@ fn confirm_with_io<R: BufRead, W: Write>(
     Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
 }
 
+fn confirm_typed_with_io<R: BufRead, W: Write>(
+    prompt: &str,
+    expected: &str,
+    skip: bool,
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<bool> {
+    if skip {
+        return Ok(true);
+    }
+
+    write!(writer, "{prompt}").context("writing typed confirmation prompt")?;
+    writer.flush().context("flushing typed confirmation prompt")?;
+
+    let mut answer = String::new();
+    reader.read_line(&mut answer).context("reading typed confirmation answer")?;
+    Ok(answer.trim() == expected)
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
 
-    use super::confirm_with_io;
+    use super::{confirm_typed_with_io, confirm_with_io};
 
     #[test]
     fn confirm_accepts_y_and_yes() {
@@ -61,6 +105,40 @@ mod tests {
         let mut writer = Vec::new();
 
         assert!(confirm_with_io("Proceed? [y/N] ", true, &mut reader, &mut writer).unwrap());
+        assert!(writer.is_empty());
+    }
+
+    #[test]
+    fn confirm_typed_accepts_exact_expected_value() {
+        let mut reader = Cursor::new(b"devnet\n".as_slice());
+        let mut writer = Vec::new();
+
+        assert!(
+            confirm_typed_with_io("Type devnet: ", "devnet", false, &mut reader, &mut writer)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn confirm_typed_rejects_mismatched_value() {
+        let mut reader = Cursor::new(b"mainnet\n".as_slice());
+        let mut writer = Vec::new();
+
+        assert!(
+            !confirm_typed_with_io("Type devnet: ", "devnet", false, &mut reader, &mut writer)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn confirm_typed_skip_does_not_prompt() {
+        let mut reader = Cursor::new(b"".as_slice());
+        let mut writer = Vec::new();
+
+        assert!(
+            confirm_typed_with_io("Type devnet: ", "devnet", true, &mut reader, &mut writer)
+                .unwrap()
+        );
         assert!(writer.is_empty());
     }
 }

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -2,6 +2,7 @@
 
 mod block;
 mod cli;
+mod conductor;
 mod confirm;
 mod doctor;
 mod p2p;
@@ -41,6 +42,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(cli::Commands::P2p { command }) => {
             p2p::run(MonitoringConfig::load(config).await?, command).await
+        }
+        Some(cli::Commands::Conductor { command }) => {
+            conductor::run(MonitoringConfig::load(config).await?, conductor_rpc, command).await
         }
         Some(cli::Commands::Doctor(args)) => {
             let has_failures = doctor::run(MonitoringConfig::load(config).await?, args).await?;

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -19,6 +19,18 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = cli::Cli::parse();
 
+    // Install a tracing subscriber for CLI subcommands only. The TUI (monitor) is excluded
+    // because a subscriber writing to stderr while ratatui holds the terminal corrupts the UI.
+    if !matches!(cli.command, Some(cli::Commands::Monitor { .. }) | None) {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| "warn".into()),
+            )
+            .with_writer(std::io::stderr)
+            .init();
+    }
+
     let config = &cli.config;
     let conductor_rpc = cli.conductor_rpc.clone();
     match cli.command {

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -252,10 +252,12 @@ impl App {
         let conductor_rpc = self.conductor_rpc.clone();
         tokio::spawn(async move {
             let mut load = MonitoringConfig::load(&name).await;
-            if let (Ok(config), Some(bootstrap)) = (load.as_mut(), conductor_rpc.as_ref())
+            if let Ok(config) = load.as_mut()
                 && config.conductors.is_none()
+                && let Some(source) = config.conductor_source(conductor_rpc)
+                && let crate::config::ConductorSource::Discover { bootstrap, .. } = source
             {
-                let detect_rpc = config.detect_rpc_for(Some(bootstrap));
+                let detect_rpc = config.detect_rpc_for(Some(&bootstrap));
                 if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
                     config.name = detected;
                 }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -22,8 +22,8 @@ use crate::{
 
 /// Launches the TUI application starting from the specified view and network.
 ///
-/// `conductor_rpc` is the optional `--conductor-rpc` CLI override; when set it
-/// forces the conductor source into `Discover` mode regardless of config.
+/// `conductor_rpc` is the optional `--conductor-rpc` CLI override. Static
+/// conductor config takes precedence over the override.
 pub async fn run_app(
     initial_view: ViewId,
     network: &str,
@@ -31,9 +31,10 @@ pub async fn run_app(
 ) -> Result<()> {
     let mut config = MonitoringConfig::load(network).await?;
     if config.conductors.is_none()
-        && let Some(bootstrap) = conductor_rpc.as_ref()
+        && let Some(source) = config.conductor_source(conductor_rpc.clone())
+        && let ConductorSource::Discover { bootstrap, .. } = source
     {
-        let detect_rpc = config.detect_rpc_for(Some(bootstrap));
+        let detect_rpc = config.detect_rpc_for(Some(&bootstrap));
         if let Some(detected) = MonitoringConfig::detect_name_from_rpc(&detect_rpc).await {
             config.name = detected;
         }
@@ -42,32 +43,6 @@ pub async fn run_app(
     start_background_services(&config, &mut resources, conductor_rpc.clone());
     let app = App::new(resources, initial_view, conductor_rpc);
     app.run(create_view).await
-}
-
-/// Resolves the active conductor source from CLI flag and config.
-///
-/// Precedence: hand-configured `conductors` list > CLI `--conductor-rpc` flag >
-/// `discovery.bootstrap_rpc` from config. Static config wins so local devnet
-/// (which ships with a hardcoded 3-node list) isn't accidentally clobbered by
-/// the default `--conductor-rpc` value. Returns `None` when no source is
-/// configured (conductor view will simply show no nodes).
-fn resolve_conductor_source(
-    cli_flag: Option<Url>,
-    config: &MonitoringConfig,
-) -> Option<ConductorSource> {
-    if let Some(nodes) = config.conductors.clone() {
-        return Some(ConductorSource::Static(nodes));
-    }
-    if let Some(bootstrap) = cli_flag {
-        let ports = config.discovery.as_ref().map(|d| d.ports.clone()).unwrap_or_default();
-        return Some(ConductorSource::Discover { bootstrap, ports });
-    }
-    if let Some(d) = config.discovery.as_ref()
-        && let Some(bootstrap) = d.bootstrap_rpc.clone()
-    {
-        return Some(ConductorSource::Discover { bootstrap, ports: d.ports.clone() });
-    }
-    None
 }
 
 /// Starts all background data-fetching services, wiring their channels into `resources`.
@@ -152,7 +127,7 @@ pub fn start_background_services(
         }
     });
 
-    if let Some(source) = resolve_conductor_source(conductor_rpc, config) {
+    if let Some(source) = config.conductor_source(conductor_rpc) {
         let (conductor_tx, conductor_rx) = mpsc::channel::<ConductorPollUpdate>(8);
         resources.conductor.set_channel(conductor_rx);
         resources.conductor.set_source_label(match &source {

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -404,6 +404,26 @@ impl MonitoringConfig {
         }
         candidate
     }
+
+    /// Resolves the active conductor source from CLI flag and config.
+    ///
+    /// Precedence: hand-configured `conductors` list > CLI `--conductor-rpc`
+    /// flag > `discovery.bootstrap_rpc` from config.
+    pub fn conductor_source(&self, cli_flag: Option<Url>) -> Option<ConductorSource> {
+        if let Some(nodes) = self.conductors.clone() {
+            return Some(ConductorSource::Static(nodes));
+        }
+        if let Some(bootstrap) = cli_flag {
+            let ports = self.discovery.as_ref().map(|d| d.ports.clone()).unwrap_or_default();
+            return Some(ConductorSource::Discover { bootstrap, ports });
+        }
+        if let Some(d) = self.discovery.as_ref()
+            && let Some(bootstrap) = d.bootstrap_rpc.clone()
+        {
+            return Some(ConductorSource::Discover { bootstrap, ports: d.ports.clone() });
+        }
+        None
+    }
 }
 
 const fn default_blob_target() -> u64 {
@@ -755,5 +775,52 @@ mod tests {
     async fn test_unknown_config() {
         let result = MonitoringConfig::load("nonexistent").await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn conductor_source_prefers_static_nodes() {
+        let mut config = MonitoringConfig::devnet_base();
+        let cli_url = Url::parse("http://127.0.0.1:5545").unwrap();
+
+        let Some(ConductorSource::Static(nodes)) = config.conductor_source(Some(cli_url)) else {
+            panic!("expected static conductor source");
+        };
+
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(nodes[0].name, "op-conductor-0");
+        config.conductors = None;
+        assert!(config.conductor_source(None).is_none());
+    }
+
+    #[test]
+    fn conductor_source_uses_cli_flag_without_static_nodes() {
+        let mut config = MonitoringConfig::mainnet();
+        let cli_url = Url::parse("http://127.0.0.1:5545").unwrap();
+
+        let Some(ConductorSource::Discover { bootstrap, ports }) =
+            config.conductor_source(Some(cli_url.clone()))
+        else {
+            panic!("expected discovered conductor source");
+        };
+
+        assert_eq!(bootstrap, cli_url);
+        assert_eq!(ports.conductor_rpc, 5545);
+        config.discovery = None;
+        assert!(config.conductor_source(None).is_none());
+    }
+
+    #[test]
+    fn conductor_source_uses_config_discovery_bootstrap() {
+        let mut config = MonitoringConfig::mainnet();
+        let bootstrap = Url::parse("http://10.0.0.1:5545").unwrap();
+        config.discovery.as_mut().unwrap().bootstrap_rpc = Some(bootstrap.clone());
+
+        let Some(ConductorSource::Discover { bootstrap: resolved, .. }) =
+            config.conductor_source(None)
+        else {
+            panic!("expected discovered conductor source");
+        };
+
+        assert_eq!(resolved, bootstrap);
     }
 }

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -36,6 +36,7 @@ pub use doctor::{
 mod rpc;
 pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ClInfoReport,
+    ConductorClusterSnapshot, ConductorControl, ConductorFanoutReport, ConductorNodeFailure,
     ConductorNodeStatus, ConductorPollUpdate, DiscoveryInfo, ElInfoReport, InitialBacklog,
     L1BlockInfo, L1ConnectionMode, LatestProposal, NodeEndpoint, NodeInfoReport, PausedPeers,
     PeerListReport, PeerStatsReport, PeerSummary, PodGroupStatus, PodStatus, PodsPoller,

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -308,7 +308,8 @@ impl ConductorControl {
                         let observed = wait_for_stable_leader(nodes, Some(target)).await?;
                         return Ok(format!("leadership already on {observed}"));
                     }
-                    let target_node = target_node.expect("target node was validated above");
+                    let target_node = target_node
+                        .ok_or_else(|| anyhow::anyhow!("target node {target} not found"))?;
                     match ConductorApiClient::conductor_transfer_leader_to_server(
                         &leader,
                         target_node.server_id.clone(),
@@ -403,7 +404,7 @@ async fn wait_for_stable_leader(
     const LEADER_RPC_TIMEOUT: Duration = Duration::from_millis(500);
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
     // Keep a short stabilization barrier so back-to-back conductor actions do
-    // not race leader churn, without forcing operators to wait for the old 12s window.
+    // not race leader churn, while still returning quickly once leadership settles.
     const OBSERVATION_TIMEOUT: Duration = Duration::from_secs(6);
     const STABLE_OBSERVATIONS: usize = 2;
 

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -6,12 +6,12 @@ use base_consensus_rpc::{
 };
 use futures::{StreamExt, stream};
 use jsonrpsee::{
-    core::client::ClientT,
+    core::client::{ClientT, Error as JsonRpcClientError},
     http_client::{HttpClient, HttpClientBuilder},
     rpc_params,
 };
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::config::{ConductorNodeConfig, ConductorSource};
 
@@ -94,6 +94,8 @@ pub struct ConductorClusterSnapshot {
     pub statuses: Vec<ConductorNodeStatus>,
     /// Raft membership observed while fetching the snapshot.
     pub membership: Option<ClusterMembership>,
+    /// Error returned by the best-effort membership lookup for static snapshots.
+    pub membership_error: Option<String>,
     /// Whether this snapshot was built from discovered raft membership.
     pub discovered: bool,
 }
@@ -168,13 +170,20 @@ impl ConductorControl {
 
         match &source {
             ConductorSource::Static(nodes) => {
-                let membership = Self::current_membership(&source).await.ok();
+                let (membership, membership_error) = match Self::current_membership(&source).await {
+                    Ok(membership) => (Some(membership), None),
+                    Err(error) => {
+                        warn!(error = %error, "failed to fetch conductor cluster membership for static snapshot");
+                        (None, Some(error.to_string()))
+                    }
+                };
                 let clients = build_conductor_clients(nodes, RPC_TIMEOUT);
                 let statuses = fetch_conductor_statuses(&clients, membership.as_ref(), false).await;
                 Ok(ConductorClusterSnapshot {
                     nodes: nodes.clone(),
                     statuses,
                     membership,
+                    membership_error,
                     discovered: false,
                 })
             }
@@ -187,6 +196,7 @@ impl ConductorControl {
                     nodes,
                     statuses,
                     membership: Some(membership),
+                    membership_error: None,
                     discovered: true,
                 })
             }
@@ -284,8 +294,12 @@ impl ConductorControl {
         let mut last_error = None;
 
         for _ in 0..SUBMIT_ATTEMPTS {
-            let Some((leader_name, leader)) = find_conductor_leader(nodes, TIMEOUT).await else {
-                last_error = Some("no leader found in cluster".to_string());
+            let leader_lookup = find_conductor_leader(nodes, TIMEOUT).await;
+            let failure_summary = leader_lookup.failure_summary();
+            let Some((leader_name, leader)) = leader_lookup.leader else {
+                last_error = Some(
+                    failure_summary.unwrap_or_else(|| "no leader found in cluster".to_string()),
+                );
                 tokio::time::sleep(TIMEOUT).await;
                 continue;
             };
@@ -294,9 +308,7 @@ impl ConductorControl {
                 None => match ConductorApiClient::conductor_transfer_leader(&leader).await {
                     Ok(()) => {
                         let observed = wait_for_stable_leader(nodes, None).await?;
-                        return Ok(format!(
-                            "leadership transferred from {leader_name} to {observed}"
-                        ));
+                        return describe_untargeted_transfer(&leader_name, &observed);
                     }
                     Err(error) if is_stale_leader_error(&error) => {
                         last_error = Some(error.to_string());
@@ -306,9 +318,7 @@ impl ConductorControl {
                 },
                 Some(target_node) => {
                     if leader_name == target_node.name.as_str() {
-                        let observed =
-                            wait_for_stable_leader(nodes, Some(target_node.name.as_str())).await?;
-                        return Ok(format!("leadership already on {observed}"));
+                        return Ok(format!("leadership already on {}", target_node.name));
                     }
                     match ConductorApiClient::conductor_transfer_leader_to_server(
                         &leader,
@@ -380,23 +390,52 @@ impl ConductorControl {
     }
 }
 
-async fn find_conductor_leader(
-    nodes: &[ConductorNodeConfig],
-    timeout: Duration,
-) -> Option<(String, HttpClient)> {
-    futures::future::join_all(nodes.iter().map(|node| async move {
+#[derive(Debug)]
+struct LeaderLookup {
+    leader: Option<(String, HttpClient)>,
+    failures: Vec<ConductorNodeFailure>,
+}
+
+impl LeaderLookup {
+    fn failure_summary(&self) -> Option<String> {
+        (!self.failures.is_empty()).then(|| {
+            self.failures
+                .iter()
+                .map(|failure| format!("{}: {}", failure.name, failure.error))
+                .collect::<Vec<_>>()
+                .join("; ")
+        })
+    }
+}
+
+async fn find_conductor_leader(nodes: &[ConductorNodeConfig], timeout: Duration) -> LeaderLookup {
+    let results = futures::future::join_all(nodes.iter().map(|node| async move {
         let client = HttpClientBuilder::default()
             .request_timeout(timeout)
             .build(node.conductor_rpc.as_str())
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let is_leader = ConductorApiClient::conductor_leader(&client).await.unwrap_or(false);
-        Ok::<_, anyhow::Error>((node.name.clone(), client, is_leader))
+            .map_err(|error| {
+                debug!(error = %error, node = %node.name, rpc = %node.conductor_rpc, "failed to build conductor client for leader probe");
+                ConductorNodeFailure { name: node.name.clone(), error: error.to_string() }
+            })?;
+        let is_leader = ConductorApiClient::conductor_leader(&client).await.map_err(|error| {
+            debug!(error = %error, node = %node.name, rpc = %node.conductor_rpc, "failed to probe conductor leader");
+            ConductorNodeFailure { name: node.name.clone(), error: error.to_string() }
+        })?;
+        Ok::<_, ConductorNodeFailure>((node.name.clone(), client, is_leader))
     }))
-    .await
-    .into_iter()
-    .filter_map(Result::ok)
-    .find(|(_, _, is_leader)| *is_leader)
-    .map(|(name, client, _)| (name, client))
+    .await;
+
+    let mut leader = None;
+    let mut failures = Vec::new();
+    for result in results {
+        match result {
+            Ok((name, client, true)) if leader.is_none() => leader = Some((name, client)),
+            Ok(_) => {}
+            Err(failure) => failures.push(failure),
+        }
+    }
+
+    LeaderLookup { leader, failures }
 }
 
 async fn wait_for_stable_leader(
@@ -412,13 +451,17 @@ async fn wait_for_stable_leader(
 
     let deadline = tokio::time::Instant::now() + OBSERVATION_TIMEOUT;
     let mut last_observed = None;
+    let mut last_probe_error = None;
     let mut stable_name: Option<String> = None;
     let mut stable_observations = 0usize;
 
     loop {
-        let observed = find_conductor_leader(nodes, LEADER_RPC_TIMEOUT).await.map(|(name, _)| name);
+        let leader_lookup = find_conductor_leader(nodes, LEADER_RPC_TIMEOUT).await;
+        let failure_summary = leader_lookup.failure_summary();
+        let observed = leader_lookup.leader.map(|(name, _)| name);
         if let Some(name) = observed {
             last_observed = Some(name.clone());
+            let _ = last_probe_error.take();
             if expected.is_none_or(|target| name == target) {
                 if stable_name.as_deref() == Some(name.as_str()) {
                     stable_observations += 1;
@@ -434,6 +477,7 @@ async fn wait_for_stable_leader(
                 stable_observations = 0;
             }
         } else {
+            last_probe_error = failure_summary;
             stable_name = None;
             stable_observations = 0;
         }
@@ -445,20 +489,38 @@ async fn wait_for_stable_leader(
     }
 
     let last = last_observed.as_deref().unwrap_or("none");
+    let probe_suffix = last_probe_error
+        .as_deref()
+        .map_or_else(String::new, |error| format!("; last probe errors: {error}"));
     if let Some(target) = expected {
         anyhow::bail!(
-            "leadership transfer submitted, but target {target} was not observed as stable leader after {}s (last observed leader: {last})",
-            OBSERVATION_TIMEOUT.as_secs()
+            "leadership transfer submitted, but target {target} was not observed as stable leader after {}s (last observed leader: {last}{probe_suffix})",
+            OBSERVATION_TIMEOUT.as_secs(),
         );
     }
     anyhow::bail!(
-        "leadership transfer submitted, but no stable leader was observed after {}s (last observed leader: {last})",
-        OBSERVATION_TIMEOUT.as_secs()
+        "leadership transfer submitted, but no stable leader was observed after {}s (last observed leader: {last}{probe_suffix})",
+        OBSERVATION_TIMEOUT.as_secs(),
     )
 }
 
-fn is_stale_leader_error(error: &jsonrpsee::core::client::Error) -> bool {
-    error.to_string().contains("node is not the leader")
+fn describe_untargeted_transfer(leader_name: &str, observed: &str) -> anyhow::Result<String> {
+    if leader_name == observed {
+        anyhow::bail!("leadership transfer submitted, but leader remained on {leader_name}");
+    }
+    Ok(format!("leadership transferred from {leader_name} to {observed}"))
+}
+
+fn is_stale_leader_error(error: &JsonRpcClientError) -> bool {
+    const SERVER_ERROR_CODE: i32 = -32000;
+    const STALE_LEADER_MESSAGE: &str = "node is not the leader";
+
+    matches!(
+        error,
+        JsonRpcClientError::Call(payload)
+            if payload.code() == SERVER_ERROR_CODE
+                && payload.message() == STALE_LEADER_MESSAGE
+    )
 }
 
 /// Finds the current Raft leader and transfers leadership.
@@ -904,9 +966,13 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
 #[cfg(test)]
 mod tests {
     use base_consensus_rpc::{ClusterMembership, ServerInfo, ServerSuffrage};
+    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
     use url::Url;
 
-    use super::{ConductorControl, ConductorFanoutReport, ConductorNodeFailure};
+    use super::{
+        ConductorControl, ConductorFanoutReport, ConductorNodeFailure, LeaderLookup,
+        describe_untargeted_transfer, is_stale_leader_error,
+    };
     use crate::config::{ConductorNodeConfig, ConductorSource};
 
     fn node(name: &str, server_id: &str) -> ConductorNodeConfig {
@@ -999,5 +1065,55 @@ mod tests {
             .expect_err("unknown member should fail");
 
         assert!(err.to_string().contains("sequencer-1"));
+    }
+
+    #[test]
+    fn leader_lookup_failure_summary_formats_node_errors() {
+        let lookup = LeaderLookup {
+            leader: None,
+            failures: vec![
+                ConductorNodeFailure { name: "a".to_string(), error: "timeout".to_string() },
+                ConductorNodeFailure {
+                    name: "b".to_string(),
+                    error: "connection refused".to_string(),
+                },
+            ],
+        };
+
+        assert_eq!(lookup.failure_summary().as_deref(), Some("a: timeout; b: connection refused"));
+    }
+
+    #[test]
+    fn untargeted_transfer_requires_observed_leader_change() {
+        let err = describe_untargeted_transfer("op-conductor-0", "op-conductor-0").unwrap_err();
+
+        assert!(err.to_string().contains("leader remained on op-conductor-0"));
+        assert_eq!(
+            describe_untargeted_transfer("op-conductor-0", "op-conductor-1").unwrap(),
+            "leadership transferred from op-conductor-0 to op-conductor-1"
+        );
+    }
+
+    #[test]
+    fn stale_leader_error_matches_typed_jsonrpc_shape() {
+        let stale = JsonRpcClientError::Call(ErrorObjectOwned::owned(
+            -32000,
+            "node is not the leader",
+            None::<()>,
+        ));
+        let other_message = JsonRpcClientError::Call(ErrorObjectOwned::owned(
+            -32000,
+            "different server error",
+            None::<()>,
+        ));
+        let other_code = JsonRpcClientError::Call(ErrorObjectOwned::owned(
+            -32603,
+            "node is not the leader",
+            None::<()>,
+        ));
+
+        assert!(is_stale_leader_error(&stale));
+        assert!(!is_stale_leader_error(&other_message));
+        assert!(!is_stale_leader_error(&other_code));
     }
 }

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -272,14 +272,15 @@ impl ConductorControl {
         const TIMEOUT: Duration = Duration::from_millis(500);
         const SUBMIT_ATTEMPTS: usize = 3;
 
-        let target_node = target_name
-            .map(|target| {
+        let target_node = match target_name {
+            Some(target) => Some(
                 nodes
                     .iter()
                     .find(|n| n.name == target)
-                    .ok_or_else(|| anyhow::anyhow!("target node {target} not found"))
-            })
-            .transpose()?;
+                    .ok_or_else(|| anyhow::anyhow!("target node {target} not found"))?,
+            ),
+            None => None,
+        };
         let mut last_error = None;
 
         for _ in 0..SUBMIT_ATTEMPTS {
@@ -289,7 +290,7 @@ impl ConductorControl {
                 continue;
             };
 
-            match target_name {
+            match target_node {
                 None => match ConductorApiClient::conductor_transfer_leader(&leader).await {
                     Ok(()) => {
                         let observed = wait_for_stable_leader(nodes, None).await?;
@@ -303,13 +304,12 @@ impl ConductorControl {
                     }
                     Err(error) => return Err(anyhow::anyhow!("{error}")),
                 },
-                Some(target) => {
-                    if leader_name == target {
-                        let observed = wait_for_stable_leader(nodes, Some(target)).await?;
+                Some(target_node) => {
+                    if leader_name == target_node.name.as_str() {
+                        let observed =
+                            wait_for_stable_leader(nodes, Some(target_node.name.as_str())).await?;
                         return Ok(format!("leadership already on {observed}"));
                     }
-                    let target_node = target_node
-                        .ok_or_else(|| anyhow::anyhow!("target node {target} not found"))?;
                     match ConductorApiClient::conductor_transfer_leader_to_server(
                         &leader,
                         target_node.server_id.clone(),
@@ -318,7 +318,9 @@ impl ConductorControl {
                     .await
                     {
                         Ok(()) => {
-                            let observed = wait_for_stable_leader(nodes, Some(target)).await?;
+                            let observed =
+                                wait_for_stable_leader(nodes, Some(target_node.name.as_str()))
+                                    .await?;
                             return Ok(format!("leadership transferred to {observed}"));
                         }
                         Err(error) if is_stale_leader_error(&error) => {

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -307,8 +307,14 @@ impl ConductorControl {
             match target_node {
                 None => match ConductorApiClient::conductor_transfer_leader(&leader).await {
                     Ok(()) => {
-                        let observed = wait_for_stable_leader(nodes, None).await?;
-                        return describe_untargeted_transfer(&leader_name, &observed);
+                        let observed = wait_for_stable_leader(
+                            nodes,
+                            StableLeaderGoal::ReplacementFor(&leader_name),
+                        )
+                        .await?;
+                        return Ok(format!(
+                            "leadership transferred from {leader_name} to {observed}"
+                        ));
                     }
                     Err(error) if is_stale_leader_error(&error) => {
                         last_error = Some(error.to_string());
@@ -328,9 +334,11 @@ impl ConductorControl {
                     .await
                     {
                         Ok(()) => {
-                            let observed =
-                                wait_for_stable_leader(nodes, Some(target_node.name.as_str()))
-                                    .await?;
+                            let observed = wait_for_stable_leader(
+                                nodes,
+                                StableLeaderGoal::Specific(target_node.name.as_str()),
+                            )
+                            .await?;
                             return Ok(format!("leadership transferred to {observed}"));
                         }
                         Err(error) if is_stale_leader_error(&error) => {
@@ -396,6 +404,39 @@ struct LeaderLookup {
     failures: Vec<ConductorNodeFailure>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StableLeaderGoal<'a> {
+    Specific(&'a str),
+    ReplacementFor(&'a str),
+}
+
+impl StableLeaderGoal<'_> {
+    fn matches(self, observed: &str) -> bool {
+        match self {
+            Self::Specific(target) => observed == target,
+            Self::ReplacementFor(original) => observed != original,
+        }
+    }
+
+    fn timeout_message(
+        self,
+        observation_timeout: Duration,
+        last_observed: &str,
+        probe_suffix: &str,
+    ) -> String {
+        match self {
+            Self::Specific(target) => format!(
+                "leadership transfer submitted, but target {target} was not observed as stable leader after {}s (last observed leader: {last_observed}{probe_suffix})",
+                observation_timeout.as_secs(),
+            ),
+            Self::ReplacementFor(original) => format!(
+                "leadership transfer submitted, but no stable replacement leader for {original} was observed after {}s (last observed leader: {last_observed}{probe_suffix})",
+                observation_timeout.as_secs(),
+            ),
+        }
+    }
+}
+
 impl LeaderLookup {
     fn failure_summary(&self) -> Option<String> {
         (!self.failures.is_empty()).then(|| {
@@ -445,7 +486,7 @@ async fn find_conductor_leader(nodes: &[ConductorNodeConfig], timeout: Duration)
 
 async fn wait_for_stable_leader(
     nodes: &[ConductorNodeConfig],
-    expected: Option<&str>,
+    goal: StableLeaderGoal<'_>,
 ) -> anyhow::Result<String> {
     const LEADER_RPC_TIMEOUT: Duration = Duration::from_millis(500);
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -454,20 +495,24 @@ async fn wait_for_stable_leader(
     const OBSERVATION_TIMEOUT: Duration = Duration::from_secs(6);
     const STABLE_OBSERVATIONS: usize = 2;
 
-    let deadline = tokio::time::Instant::now() + OBSERVATION_TIMEOUT;
+    let deadline = tokio::time::sleep(OBSERVATION_TIMEOUT);
+    tokio::pin!(deadline);
     let mut last_observed = None;
     let mut last_probe_error = None;
     let mut stable_name: Option<String> = None;
     let mut stable_observations = 0usize;
 
     loop {
-        let leader_lookup = find_conductor_leader(nodes, LEADER_RPC_TIMEOUT).await;
+        let leader_lookup = tokio::select! {
+            _ = &mut deadline => break,
+            leader_lookup = find_conductor_leader(nodes, LEADER_RPC_TIMEOUT) => leader_lookup,
+        };
         let failure_summary = leader_lookup.failure_summary();
         let observed = leader_lookup.leader.map(|(name, _)| name);
         if let Some(name) = observed {
             last_observed = Some(name.clone());
             let _ = last_probe_error.take();
-            if expected.is_none_or(|target| name == target) {
+            if goal.matches(name.as_str()) {
                 if stable_name.as_deref() == Some(name.as_str()) {
                     stable_observations += 1;
                 } else {
@@ -487,33 +532,17 @@ async fn wait_for_stable_leader(
             stable_observations = 0;
         }
 
-        if tokio::time::Instant::now() >= deadline {
-            break;
+        tokio::select! {
+            _ = &mut deadline => break,
+            _ = tokio::time::sleep(POLL_INTERVAL) => {}
         }
-        tokio::time::sleep(POLL_INTERVAL).await;
     }
 
     let last = last_observed.as_deref().unwrap_or("none");
     let probe_suffix = last_probe_error
         .as_deref()
         .map_or_else(String::new, |error| format!("; last probe errors: {error}"));
-    if let Some(target) = expected {
-        anyhow::bail!(
-            "leadership transfer submitted, but target {target} was not observed as stable leader after {}s (last observed leader: {last}{probe_suffix})",
-            OBSERVATION_TIMEOUT.as_secs(),
-        );
-    }
-    anyhow::bail!(
-        "leadership transfer submitted, but no stable leader was observed after {}s (last observed leader: {last}{probe_suffix})",
-        OBSERVATION_TIMEOUT.as_secs(),
-    )
-}
-
-fn describe_untargeted_transfer(leader_name: &str, observed: &str) -> anyhow::Result<String> {
-    if leader_name == observed {
-        anyhow::bail!("leadership transfer submitted, but leader remained on {leader_name}");
-    }
-    Ok(format!("leadership transferred from {leader_name} to {observed}"))
+    anyhow::bail!(goal.timeout_message(OBSERVATION_TIMEOUT, last, &probe_suffix))
 }
 
 fn is_stale_leader_error(error: &JsonRpcClientError) -> bool {
@@ -970,13 +999,15 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use base_consensus_rpc::{ClusterMembership, ServerInfo, ServerSuffrage};
     use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
     use url::Url;
 
     use super::{
         ConductorControl, ConductorFanoutReport, ConductorNodeFailure, LeaderLookup,
-        describe_untargeted_transfer, is_stale_leader_error,
+        StableLeaderGoal, is_stale_leader_error,
     };
     use crate::config::{ConductorNodeConfig, ConductorSource};
 
@@ -1089,13 +1120,35 @@ mod tests {
     }
 
     #[test]
-    fn untargeted_transfer_requires_observed_leader_change() {
-        let err = describe_untargeted_transfer("op-conductor-0", "op-conductor-0").unwrap_err();
+    fn stable_leader_goal_matches_expected_observations() {
+        assert!(StableLeaderGoal::Specific("op-conductor-1").matches("op-conductor-1"));
+        assert!(!StableLeaderGoal::Specific("op-conductor-1").matches("op-conductor-0"));
+        assert!(StableLeaderGoal::ReplacementFor("op-conductor-0").matches("op-conductor-1"));
+        assert!(!StableLeaderGoal::ReplacementFor("op-conductor-0").matches("op-conductor-0"));
+    }
 
-        assert!(err.to_string().contains("leader remained on op-conductor-0"));
-        assert_eq!(
-            describe_untargeted_transfer("op-conductor-0", "op-conductor-1").unwrap(),
-            "leadership transferred from op-conductor-0 to op-conductor-1"
+    #[test]
+    fn stable_leader_goal_formats_timeout_messages() {
+        let targeted = StableLeaderGoal::Specific("op-conductor-1").timeout_message(
+            Duration::from_secs(6),
+            "op-conductor-0",
+            "; last probe errors: timeout",
+        );
+        let replacement = StableLeaderGoal::ReplacementFor("op-conductor-0").timeout_message(
+            Duration::from_secs(6),
+            "op-conductor-0",
+            "",
+        );
+
+        assert!(
+            targeted.contains("target op-conductor-1 was not observed as stable leader after 6s")
+        );
+        assert!(
+            targeted.contains("last observed leader: op-conductor-0; last probe errors: timeout")
+        );
+        assert!(
+            replacement
+                .contains("no stable replacement leader for op-conductor-0 was observed after 6s")
         );
     }
 

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -430,6 +430,11 @@ async fn find_conductor_leader(nodes: &[ConductorNodeConfig], timeout: Duration)
     for result in results {
         match result {
             Ok((name, client, true)) if leader.is_none() => leader = Some((name, client)),
+            Ok((name, _, true)) => {
+                let first_leader =
+                    leader.as_ref().map_or("unknown", |(leader_name, _)| leader_name.as_str());
+                warn!(first_leader = %first_leader, node = %name, "multiple nodes report is_leader=true; possible split-brain");
+            }
             Ok(_) => {}
             Err(failure) => failures.push(failure),
         }

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -5,7 +5,11 @@ use base_consensus_rpc::{
     ServerSuffrage,
 };
 use futures::{StreamExt, stream};
-use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+use jsonrpsee::{
+    core::client::ClientT,
+    http_client::{HttpClient, HttpClientBuilder},
+    rpc_params,
+};
 use tokio::sync::mpsc;
 use tracing::warn;
 
@@ -77,6 +81,383 @@ pub struct ConductorNodeStatus {
     pub discovered: bool,
 }
 
+/// Typed conductor RPC helper surface for non-TUI commands.
+#[derive(Debug)]
+pub struct ConductorControl;
+
+/// One-shot conductor cluster snapshot.
+#[derive(Debug, Clone)]
+pub struct ConductorClusterSnapshot {
+    /// Node configs used for this snapshot.
+    pub nodes: Vec<ConductorNodeConfig>,
+    /// Per-node status rows fetched from the cluster.
+    pub statuses: Vec<ConductorNodeStatus>,
+    /// Raft membership observed while fetching the snapshot.
+    pub membership: Option<ClusterMembership>,
+    /// Whether this snapshot was built from discovered raft membership.
+    pub discovered: bool,
+}
+
+/// Result of running a conductor control RPC across several nodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConductorFanoutReport {
+    /// Total nodes targeted.
+    pub total: usize,
+    /// Node names whose RPC succeeded.
+    pub successes: Vec<String>,
+    /// Node names and errors for failed RPCs.
+    pub failures: Vec<ConductorNodeFailure>,
+}
+
+/// Per-node fanout failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConductorNodeFailure {
+    /// Node name.
+    pub name: String,
+    /// Error returned while mutating the node.
+    pub error: String,
+}
+
+impl ConductorFanoutReport {
+    /// Returns true only when at least one node was targeted and every RPC succeeded.
+    pub const fn is_success(&self) -> bool {
+        self.total > 0 && self.failures.is_empty()
+    }
+
+    /// Formats the same summary string used by the TUI toast path.
+    ///
+    /// `verb` is the past-tense action used for success and partial-failure
+    /// summaries. Add new verbs to [`empty_fanout_verb`] so the zero-target
+    /// branch can render the infinitive form.
+    pub fn summary(&self, verb: &str) -> String {
+        if self.total == 0 {
+            return format!("no conductor nodes to {}", empty_fanout_verb(verb));
+        }
+        let ok_count = self.successes.len();
+        if self.failures.is_empty() {
+            format!("conductor {verb} on {ok_count}/{} nodes", self.total)
+        } else {
+            let detail = self
+                .failures
+                .iter()
+                .map(|failure| format!("{}: {}", failure.name, failure.error))
+                .collect::<Vec<_>>()
+                .join("; ");
+            format!("conductor {verb} on {ok_count}/{} nodes; failures: {detail}", self.total)
+        }
+    }
+
+    /// Converts the report into the TUI's success-or-warning result shape.
+    pub fn to_result(&self, verb: &str) -> Result<String, String> {
+        if self.is_success() { Ok(self.summary(verb)) } else { Err(self.summary(verb)) }
+    }
+}
+
+fn empty_fanout_verb(verb: &str) -> &str {
+    match verb {
+        "paused" => "pause",
+        "resumed" => "resume",
+        other => other,
+    }
+}
+
+impl ConductorControl {
+    /// Fetches a one-shot conductor cluster snapshot.
+    pub async fn snapshot(source: ConductorSource) -> anyhow::Result<ConductorClusterSnapshot> {
+        const RPC_TIMEOUT: Duration = Duration::from_millis(500);
+
+        match &source {
+            ConductorSource::Static(nodes) => {
+                let membership = Self::current_membership(&source).await.ok();
+                let clients = build_conductor_clients(nodes, RPC_TIMEOUT);
+                let statuses = fetch_conductor_statuses(&clients, membership.as_ref(), false).await;
+                Ok(ConductorClusterSnapshot {
+                    nodes: nodes.clone(),
+                    statuses,
+                    membership,
+                    discovered: false,
+                })
+            }
+            ConductorSource::Discover { .. } => {
+                let membership = Self::current_membership(&source).await?;
+                let nodes = Self::nodes_from_membership(&source, &membership)?;
+                let clients = build_conductor_clients(&nodes, RPC_TIMEOUT);
+                let statuses = fetch_conductor_statuses(&clients, Some(&membership), true).await;
+                Ok(ConductorClusterSnapshot {
+                    nodes,
+                    statuses,
+                    membership: Some(membership),
+                    discovered: true,
+                })
+            }
+        }
+    }
+
+    /// Fetches live raft membership from the configured conductor source.
+    pub async fn current_membership(source: &ConductorSource) -> anyhow::Result<ClusterMembership> {
+        const TIMEOUT: Duration = Duration::from_millis(500);
+
+        let nodes: Vec<ConductorNodeConfig> = match source {
+            ConductorSource::Static(nodes) => nodes.clone(),
+            ConductorSource::Discover { .. } => source.bootstrap_node().into_iter().collect(),
+        };
+        if nodes.is_empty() {
+            anyhow::bail!("no conductor nodes configured");
+        }
+
+        let mut failures = Vec::new();
+        for node in nodes {
+            let client = match HttpClientBuilder::default()
+                .request_timeout(TIMEOUT)
+                .build(node.conductor_rpc.as_str())
+            {
+                Ok(client) => client,
+                Err(error) => {
+                    failures.push(format!("{}: {error}", node.name));
+                    continue;
+                }
+            };
+            match ConductorApiClient::conductor_cluster_membership(&client).await {
+                Ok(membership) => return Ok(membership),
+                Err(error) => failures.push(format!("{}: {error}", node.name)),
+            }
+        }
+
+        anyhow::bail!(
+            "failed to fetch conductor cluster membership from any node: {}",
+            failures.join("; ")
+        )
+    }
+
+    /// Resolves node configs for every server in a live raft membership snapshot.
+    pub fn nodes_from_membership(
+        source: &ConductorSource,
+        membership: &ClusterMembership,
+    ) -> anyhow::Result<Vec<ConductorNodeConfig>> {
+        match source {
+            ConductorSource::Discover { .. } => {
+                source.synthesize_nodes(membership).filter(|nodes| !nodes.is_empty()).ok_or_else(
+                    || anyhow::anyhow!("failed to synthesize conductor nodes from membership"),
+                )
+            }
+            ConductorSource::Static(configured) => {
+                let mut nodes = Vec::new();
+                let mut missing = Vec::new();
+                for server in &membership.servers {
+                    if let Some(node) = configured.iter().find(|node| node.server_id == server.id) {
+                        nodes.push(node.clone());
+                    } else {
+                        missing.push(server.id.clone());
+                    }
+                }
+                if !missing.is_empty() {
+                    anyhow::bail!(
+                        "raft membership contains server(s) missing from conductor config: {}",
+                        missing.join(", ")
+                    );
+                }
+                if nodes.is_empty() {
+                    anyhow::bail!("conductor cluster membership is empty");
+                }
+                Ok(nodes)
+            }
+        }
+    }
+
+    /// Finds the current Raft leader and transfers leadership.
+    pub async fn transfer_leader(
+        nodes: &[ConductorNodeConfig],
+        target_name: Option<&str>,
+    ) -> anyhow::Result<String> {
+        const TIMEOUT: Duration = Duration::from_millis(500);
+        const SUBMIT_ATTEMPTS: usize = 3;
+
+        let target_node = target_name
+            .map(|target| {
+                nodes
+                    .iter()
+                    .find(|n| n.name == target)
+                    .ok_or_else(|| anyhow::anyhow!("target node {target} not found"))
+            })
+            .transpose()?;
+        let mut last_error = None;
+
+        for _ in 0..SUBMIT_ATTEMPTS {
+            let Some((leader_name, leader)) = find_conductor_leader(nodes, TIMEOUT).await else {
+                last_error = Some("no leader found in cluster".to_string());
+                tokio::time::sleep(TIMEOUT).await;
+                continue;
+            };
+
+            match target_name {
+                None => match ConductorApiClient::conductor_transfer_leader(&leader).await {
+                    Ok(()) => {
+                        let observed = wait_for_stable_leader(nodes, None).await?;
+                        return Ok(format!(
+                            "leadership transferred from {leader_name} to {observed}"
+                        ));
+                    }
+                    Err(error) if is_stale_leader_error(&error) => {
+                        last_error = Some(error.to_string());
+                        tokio::time::sleep(TIMEOUT).await;
+                    }
+                    Err(error) => return Err(anyhow::anyhow!("{error}")),
+                },
+                Some(target) => {
+                    if leader_name == target {
+                        let observed = wait_for_stable_leader(nodes, Some(target)).await?;
+                        return Ok(format!("leadership already on {observed}"));
+                    }
+                    let target_node = target_node.expect("target node was validated above");
+                    match ConductorApiClient::conductor_transfer_leader_to_server(
+                        &leader,
+                        target_node.server_id.clone(),
+                        target_node.raft_addr.clone(),
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            let observed = wait_for_stable_leader(nodes, Some(target)).await?;
+                            return Ok(format!("leadership transferred to {observed}"));
+                        }
+                        Err(error) if is_stale_leader_error(&error) => {
+                            last_error = Some(error.to_string());
+                            tokio::time::sleep(TIMEOUT).await;
+                        }
+                        Err(error) => return Err(anyhow::anyhow!("{error}")),
+                    }
+                }
+            }
+        }
+
+        anyhow::bail!(
+            "failed to submit leadership transfer after {SUBMIT_ATTEMPTS} attempts: {}",
+            last_error.unwrap_or_else(|| "no leader found in cluster".to_string())
+        )
+    }
+
+    /// Pauses op-conductor's control loop on a single node.
+    pub async fn pause_node(node: &ConductorNodeConfig) -> anyhow::Result<String> {
+        const TIMEOUT: Duration = Duration::from_secs(5);
+
+        let client = HttpClientBuilder::default()
+            .request_timeout(TIMEOUT)
+            .build(node.conductor_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        ConductorApiClient::conductor_pause(&client).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(format!("conductor paused on {}", node.name))
+    }
+
+    /// Resumes op-conductor's control loop on a single node.
+    pub async fn resume_node(node: &ConductorNodeConfig) -> anyhow::Result<String> {
+        const TIMEOUT: Duration = Duration::from_secs(5);
+
+        let client = HttpClientBuilder::default()
+            .request_timeout(TIMEOUT)
+            .build(node.conductor_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        ConductorApiClient::conductor_resume(&client).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(format!("conductor resumed on {}", node.name))
+    }
+
+    /// Pauses op-conductor's control loop on every node in parallel.
+    pub async fn pause_all(nodes: Vec<ConductorNodeConfig>) -> ConductorFanoutReport {
+        fan_out_conductor_control(nodes, |client| async move {
+            ConductorApiClient::conductor_pause(&client).await.map_err(|e| anyhow::anyhow!("{e}"))
+        })
+        .await
+    }
+
+    /// Resumes op-conductor's control loop on every node in parallel.
+    pub async fn resume_all(nodes: Vec<ConductorNodeConfig>) -> ConductorFanoutReport {
+        fan_out_conductor_control(nodes, |client| async move {
+            ConductorApiClient::conductor_resume(&client).await.map_err(|e| anyhow::anyhow!("{e}"))
+        })
+        .await
+    }
+}
+
+async fn find_conductor_leader(
+    nodes: &[ConductorNodeConfig],
+    timeout: Duration,
+) -> Option<(String, HttpClient)> {
+    futures::future::join_all(nodes.iter().map(|node| async move {
+        let client = HttpClientBuilder::default()
+            .request_timeout(timeout)
+            .build(node.conductor_rpc.as_str())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let is_leader = ConductorApiClient::conductor_leader(&client).await.unwrap_or(false);
+        Ok::<_, anyhow::Error>((node.name.clone(), client, is_leader))
+    }))
+    .await
+    .into_iter()
+    .filter_map(Result::ok)
+    .find(|(_, _, is_leader)| *is_leader)
+    .map(|(name, client, _)| (name, client))
+}
+
+async fn wait_for_stable_leader(
+    nodes: &[ConductorNodeConfig],
+    expected: Option<&str>,
+) -> anyhow::Result<String> {
+    const LEADER_RPC_TIMEOUT: Duration = Duration::from_millis(500);
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    // Keep a short stabilization barrier so back-to-back conductor actions do
+    // not race leader churn, without forcing operators to wait for the old 12s window.
+    const OBSERVATION_TIMEOUT: Duration = Duration::from_secs(6);
+    const STABLE_OBSERVATIONS: usize = 2;
+
+    let deadline = tokio::time::Instant::now() + OBSERVATION_TIMEOUT;
+    let mut last_observed = None;
+    let mut stable_name: Option<String> = None;
+    let mut stable_observations = 0usize;
+
+    loop {
+        let observed = find_conductor_leader(nodes, LEADER_RPC_TIMEOUT).await.map(|(name, _)| name);
+        if let Some(name) = observed {
+            last_observed = Some(name.clone());
+            if expected.is_none_or(|target| name == target) {
+                if stable_name.as_deref() == Some(name.as_str()) {
+                    stable_observations += 1;
+                } else {
+                    stable_name = Some(name.clone());
+                    stable_observations = 1;
+                }
+                if stable_observations >= STABLE_OBSERVATIONS {
+                    return Ok(name);
+                }
+            } else {
+                stable_name = None;
+                stable_observations = 0;
+            }
+        } else {
+            stable_name = None;
+            stable_observations = 0;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    let last = last_observed.as_deref().unwrap_or("none");
+    if let Some(target) = expected {
+        anyhow::bail!(
+            "leadership transfer submitted, but target {target} was not observed as stable leader after {}s (last observed leader: {last})",
+            OBSERVATION_TIMEOUT.as_secs()
+        );
+    }
+    anyhow::bail!(
+        "leadership transfer submitted, but no stable leader was observed after {}s (last observed leader: {last})",
+        OBSERVATION_TIMEOUT.as_secs()
+    )
+}
+
+fn is_stale_leader_error(error: &jsonrpsee::core::client::Error) -> bool {
+    error.to_string().contains("node is not the leader")
+}
+
 /// Finds the current Raft leader and transfers leadership.
 ///
 /// If `target_name` is `None`, leadership is transferred to any available peer
@@ -89,50 +470,7 @@ pub async fn transfer_conductor_leader(
     target_name: Option<String>,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
-    const TIMEOUT: Duration = Duration::from_millis(500);
-
-    let outcome: anyhow::Result<String> = async {
-        let mut leader_client = None;
-        let mut leader_name = String::new();
-
-        for node in &nodes {
-            let client = HttpClientBuilder::default()
-                .request_timeout(TIMEOUT)
-                .build(node.conductor_rpc.as_str())
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-            if ConductorApiClient::conductor_leader(&client).await.unwrap_or(false) {
-                leader_client = Some(client);
-                leader_name = node.name.clone();
-                break;
-            }
-        }
-
-        let leader = leader_client.ok_or_else(|| anyhow::anyhow!("no leader found in cluster"))?;
-
-        match target_name {
-            None => {
-                ConductorApiClient::conductor_transfer_leader(&leader)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
-                Ok(format!("leadership transferred from {leader_name}"))
-            }
-            Some(ref target) => {
-                let target_node = nodes
-                    .iter()
-                    .find(|n| n.name == *target)
-                    .ok_or_else(|| anyhow::anyhow!("target node {target} not found"))?;
-                ConductorApiClient::conductor_transfer_leader_to_server(
-                    &leader,
-                    target_node.server_id.clone(),
-                    target_node.raft_addr.clone(),
-                )
-                .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-                Ok(format!("leadership transferred to {target}"))
-            }
-        }
-    }
-    .await;
+    let outcome = ConductorControl::transfer_leader(&nodes, target_name.as_deref()).await;
 
     let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
 }
@@ -146,17 +484,7 @@ pub async fn conductor_pause_node(
     node: ConductorNodeConfig,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
-    const TIMEOUT: Duration = Duration::from_secs(5);
-
-    let outcome: anyhow::Result<String> = async {
-        let client = HttpClientBuilder::default()
-            .request_timeout(TIMEOUT)
-            .build(node.conductor_rpc.as_str())
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        ConductorApiClient::conductor_pause(&client).await.map_err(|e| anyhow::anyhow!("{e}"))?;
-        Ok(format!("conductor paused on {}", node.name))
-    }
-    .await;
+    let outcome = ConductorControl::pause_node(&node).await;
 
     let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
 }
@@ -166,17 +494,7 @@ pub async fn conductor_resume_node(
     node: ConductorNodeConfig,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
-    const TIMEOUT: Duration = Duration::from_secs(5);
-
-    let outcome: anyhow::Result<String> = async {
-        let client = HttpClientBuilder::default()
-            .request_timeout(TIMEOUT)
-            .build(node.conductor_rpc.as_str())
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        ConductorApiClient::conductor_resume(&client).await.map_err(|e| anyhow::anyhow!("{e}"))?;
-        Ok(format!("conductor resumed on {}", node.name))
-    }
-    .await;
+    let outcome = ConductorControl::resume_node(&node).await;
 
     let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
 }
@@ -192,10 +510,7 @@ pub async fn conductor_pause_all_nodes(
     nodes: Vec<ConductorNodeConfig>,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
-    let summary = fan_out_conductor_control(nodes, "paused", |client| async move {
-        ConductorApiClient::conductor_pause(&client).await.map_err(|e| anyhow::anyhow!("{e}"))
-    })
-    .await;
+    let summary = ConductorControl::pause_all(nodes).await.to_result("paused");
     let _ = result_tx.send(summary).await;
 }
 
@@ -206,22 +521,15 @@ pub async fn conductor_resume_all_nodes(
     nodes: Vec<ConductorNodeConfig>,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
-    let summary = fan_out_conductor_control(nodes, "resumed", |client| async move {
-        ConductorApiClient::conductor_resume(&client).await.map_err(|e| anyhow::anyhow!("{e}"))
-    })
-    .await;
+    let summary = ConductorControl::resume_all(nodes).await.to_result("resumed");
     let _ = result_tx.send(summary).await;
 }
 
-/// Runs a per-node conductor control RPC against every node concurrently and
-/// builds a single summary toast string.
-///
-/// `verb` is the past-tense action ("paused" / "resumed") used in the message.
+/// Runs a per-node conductor control RPC against every node concurrently.
 async fn fan_out_conductor_control<F, Fut>(
     nodes: Vec<ConductorNodeConfig>,
-    verb: &'static str,
     call: F,
-) -> Result<String, String>
+) -> ConductorFanoutReport
 where
     F: Fn(jsonrpsee::http_client::HttpClient) -> Fut + Send + Sync + Clone + 'static,
     Fut: std::future::Future<Output = anyhow::Result<()>> + Send,
@@ -229,7 +537,7 @@ where
     const TIMEOUT: Duration = Duration::from_secs(5);
 
     if nodes.is_empty() {
-        return Err(format!("no conductor nodes to {verb}"));
+        return ConductorFanoutReport { total: 0, successes: Vec::new(), failures: Vec::new() };
     }
     let total = nodes.len();
 
@@ -252,22 +560,18 @@ where
         .collect()
         .await;
 
-    let (ok, failures): (Vec<_>, Vec<_>) = results.into_iter().partition(|(_, r)| r.is_ok());
-    let ok_count = ok.len();
-
-    if failures.is_empty() {
-        Ok(format!("conductor {verb} on {ok_count}/{total} nodes"))
-    } else {
-        let detail = failures
-            .iter()
-            .map(|(name, r)| {
-                let err = r.as_ref().err().map_or_else(String::new, ToString::to_string);
-                format!("{name}: {err}")
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        Err(format!("conductor {verb} on {ok_count}/{total} nodes; failures: {detail}"))
+    let mut successes = Vec::new();
+    let mut failures = Vec::new();
+    for (name, result) in results {
+        match result {
+            Ok(()) => successes.push(name),
+            Err(error) => failures.push(ConductorNodeFailure { name, error: error.to_string() }),
+        }
     }
+    successes.sort();
+    failures.sort_by(|a, b| a.name.cmp(&b.name));
+
+    ConductorFanoutReport { total, successes, failures }
 }
 
 /// Restarts the docker containers for a single conductor cluster node.
@@ -417,6 +721,96 @@ fn build_conductor_clients(
         .collect()
 }
 
+async fn fetch_conductor_statuses(
+    clients: &[ConductorClientTuple],
+    membership_for_lookup: Option<&ClusterMembership>,
+    discovered: bool,
+) -> Vec<ConductorNodeStatus> {
+    futures::future::join_all(clients.iter().map(
+        |(name, server_id, conductor_client, cl_client, el_client)| async move {
+            // Fire all RPCs concurrently so a single timed-out node does not
+            // stall the poll for the full sum of all call timeouts.
+            let (
+                is_leader,
+                conductor_active,
+                conductor_paused,
+                conductor_stopped,
+                sequencer_healthy,
+                sequencer_active,
+                sync,
+                cl_peer_stats,
+                el_block_r,
+                el_syncing_r,
+                el_peers_r,
+            ) = tokio::join!(
+                ConductorApiClient::conductor_leader(conductor_client),
+                ConductorApiClient::conductor_active(conductor_client),
+                ConductorApiClient::conductor_paused(conductor_client),
+                ConductorApiClient::conductor_stopped(conductor_client),
+                ConductorApiClient::conductor_sequencer_healthy(conductor_client),
+                AdminApiClient::admin_sequencer_active(cl_client),
+                RollupNodeApiClient::sync_status(cl_client),
+                BaseP2PApiClient::opp2p_peer_stats(cl_client),
+                async {
+                    if let Some(el) = el_client {
+                        let r: Result<alloy_primitives::U64, _> =
+                            ClientT::request(el, "eth_blockNumber", rpc_params![]).await;
+                        r.ok().map(|v| v.to::<u64>())
+                    } else {
+                        None
+                    }
+                },
+                async {
+                    if let Some(el) = el_client {
+                        let r: Result<serde_json::Value, _> =
+                            ClientT::request(el, "eth_syncing", rpc_params![]).await;
+                        r.ok().map(|v| !matches!(v, serde_json::Value::Bool(false)))
+                    } else {
+                        None
+                    }
+                },
+                async {
+                    if let Some(el) = el_client {
+                        let r: Result<alloy_primitives::U64, _> =
+                            ClientT::request(el, "net_peerCount", rpc_params![]).await;
+                        r.ok().map(|v| v.to::<u32>())
+                    } else {
+                        None
+                    }
+                },
+            );
+
+            let sync = sync.ok();
+            let suffrage = membership_for_lookup
+                .and_then(|m| m.servers.iter().find(|s| s.id == *server_id))
+                .map(|s| s.suffrage);
+            ConductorNodeStatus {
+                name: name.clone(),
+                is_leader: is_leader.ok(),
+                conductor_active: conductor_active.ok(),
+                conductor_paused: conductor_paused.ok(),
+                conductor_stopped: conductor_stopped.ok(),
+                sequencer_healthy: sequencer_healthy.ok(),
+                sequencer_active: sequencer_active.ok(),
+                unsafe_l2_block: sync.as_ref().map(|s| s.unsafe_l2.block_info.number),
+                unsafe_l2_hash: sync.as_ref().map(|s| s.unsafe_l2.block_info.hash),
+                safe_l2_block: sync.as_ref().map(|s| s.safe_l2.block_info.number),
+                safe_l2_hash: sync.as_ref().map(|s| s.safe_l2.block_info.hash),
+                finalized_l2_block: sync.as_ref().map(|s| s.finalized_l2.block_info.number),
+                current_l1_block: sync.as_ref().map(|s| s.current_l1.number),
+                head_l1_block: sync.as_ref().map(|s| s.head_l1.number),
+                cl_peer_count: cl_peer_stats.ok().map(|s| s.connected),
+                el_block: el_block_r,
+                el_syncing: el_syncing_r,
+                el_peer_count: el_peers_r,
+                suffrage,
+                discovered,
+            }
+        },
+    ))
+    .await
+}
+
 /// Polls every conductor in the active source every 200 ms and forwards updates.
 ///
 /// Builds one pair of HTTP clients per node (conductor RPC + CL RPC) so connection
@@ -463,89 +857,8 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
             ConductorApiClient::conductor_cluster_membership(conductor_client).await.ok()
         };
 
-        let membership_for_lookup = last_membership.as_ref();
-        let statuses_fut = futures::future::join_all(clients.iter().map(
-            |(name, server_id, conductor_client, cl_client, el_client)| async move {
-                // Fire all RPCs concurrently so a single timed-out node does not
-                // stall the poll for the full sum of all call timeouts (11 × 500 ms).
-                let (
-                    is_leader,
-                    conductor_active,
-                    conductor_paused,
-                    conductor_stopped,
-                    sequencer_healthy,
-                    sequencer_active,
-                    sync,
-                    cl_peer_stats,
-                    el_block_r,
-                    el_syncing_r,
-                    el_peers_r,
-                ) = tokio::join!(
-                    ConductorApiClient::conductor_leader(conductor_client),
-                    ConductorApiClient::conductor_active(conductor_client),
-                    ConductorApiClient::conductor_paused(conductor_client),
-                    ConductorApiClient::conductor_stopped(conductor_client),
-                    ConductorApiClient::conductor_sequencer_healthy(conductor_client),
-                    AdminApiClient::admin_sequencer_active(cl_client),
-                    RollupNodeApiClient::sync_status(cl_client),
-                    BaseP2PApiClient::opp2p_peer_stats(cl_client),
-                    async {
-                        if let Some(el) = el_client {
-                            let r: Result<alloy_primitives::U64, _> =
-                                ClientT::request(el, "eth_blockNumber", rpc_params![]).await;
-                            r.ok().map(|v| v.to::<u64>())
-                        } else {
-                            None
-                        }
-                    },
-                    async {
-                        if let Some(el) = el_client {
-                            let r: Result<serde_json::Value, _> =
-                                ClientT::request(el, "eth_syncing", rpc_params![]).await;
-                            r.ok().map(|v| !matches!(v, serde_json::Value::Bool(false)))
-                        } else {
-                            None
-                        }
-                    },
-                    async {
-                        if let Some(el) = el_client {
-                            let r: Result<alloy_primitives::U64, _> =
-                                ClientT::request(el, "net_peerCount", rpc_params![]).await;
-                            r.ok().map(|v| v.to::<u32>())
-                        } else {
-                            None
-                        }
-                    },
-                );
-
-                let sync = sync.ok();
-                let suffrage = membership_for_lookup
-                    .and_then(|m| m.servers.iter().find(|s| s.id == *server_id))
-                    .map(|s| s.suffrage);
-                ConductorNodeStatus {
-                    name: name.clone(),
-                    is_leader: is_leader.ok(),
-                    conductor_active: conductor_active.ok(),
-                    conductor_paused: conductor_paused.ok(),
-                    conductor_stopped: conductor_stopped.ok(),
-                    sequencer_healthy: sequencer_healthy.ok(),
-                    sequencer_active: sequencer_active.ok(),
-                    unsafe_l2_block: sync.as_ref().map(|s| s.unsafe_l2.block_info.number),
-                    unsafe_l2_hash: sync.as_ref().map(|s| s.unsafe_l2.block_info.hash),
-                    safe_l2_block: sync.as_ref().map(|s| s.safe_l2.block_info.number),
-                    safe_l2_hash: sync.as_ref().map(|s| s.safe_l2.block_info.hash),
-                    finalized_l2_block: sync.as_ref().map(|s| s.finalized_l2.block_info.number),
-                    current_l1_block: sync.as_ref().map(|s| s.current_l1.number),
-                    head_l1_block: sync.as_ref().map(|s| s.head_l1.number),
-                    cl_peer_count: cl_peer_stats.ok().map(|s| s.connected),
-                    el_block: el_block_r,
-                    el_syncing: el_syncing_r,
-                    el_peer_count: el_peers_r,
-                    suffrage,
-                    discovered,
-                }
-            },
-        ));
+        let statuses_fut =
+            fetch_conductor_statuses(&clients, last_membership.as_deref(), discovered);
 
         let (statuses, new_membership) = tokio::join!(statuses_fut, membership_fut);
 
@@ -582,5 +895,106 @@ pub async fn run_conductor_poller(source: ConductorSource, tx: mpsc::Sender<Cond
                 last_membership = Some(membership);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_consensus_rpc::{ClusterMembership, ServerInfo, ServerSuffrage};
+    use url::Url;
+
+    use super::{ConductorControl, ConductorFanoutReport, ConductorNodeFailure};
+    use crate::config::{ConductorNodeConfig, ConductorSource};
+
+    fn node(name: &str, server_id: &str) -> ConductorNodeConfig {
+        ConductorNodeConfig {
+            name: name.to_string(),
+            conductor_rpc: Url::parse("http://127.0.0.1:6545").unwrap(),
+            cl_rpc: Url::parse("http://127.0.0.1:7545").unwrap(),
+            server_id: server_id.to_string(),
+            raft_addr: format!("{name}:5050"),
+            el_rpc: None,
+            docker_conductor: None,
+            docker_el: None,
+            docker_cl: None,
+            flashblocks_ws: None,
+        }
+    }
+
+    fn membership(ids: &[&str]) -> ClusterMembership {
+        ClusterMembership {
+            version: 7,
+            servers: ids
+                .iter()
+                .map(|id| ServerInfo {
+                    id: (*id).to_string(),
+                    addr: format!("{id}:5050"),
+                    suffrage: ServerSuffrage::Voter,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn fanout_summary_formats_success() {
+        let report = ConductorFanoutReport {
+            total: 2,
+            successes: vec!["a".to_string(), "b".to_string()],
+            failures: Vec::new(),
+        };
+
+        assert!(report.is_success());
+        assert_eq!(report.summary("paused"), "conductor paused on 2/2 nodes");
+        assert_eq!(report.to_result("paused").unwrap(), "conductor paused on 2/2 nodes");
+    }
+
+    #[test]
+    fn fanout_summary_formats_partial_failure() {
+        let report = ConductorFanoutReport {
+            total: 2,
+            successes: vec!["a".to_string()],
+            failures: vec![ConductorNodeFailure {
+                name: "b".to_string(),
+                error: "request timed out".to_string(),
+            }],
+        };
+
+        assert!(!report.is_success());
+        assert_eq!(
+            report.summary("paused"),
+            "conductor paused on 1/2 nodes; failures: b: request timed out"
+        );
+        assert!(report.to_result("paused").is_err());
+    }
+
+    #[test]
+    fn fanout_summary_formats_empty_nodes() {
+        let report =
+            ConductorFanoutReport { total: 0, successes: Vec::new(), failures: Vec::new() };
+
+        assert!(!report.is_success());
+        assert_eq!(report.summary("paused"), "no conductor nodes to pause");
+    }
+
+    #[test]
+    fn nodes_from_membership_maps_static_nodes_by_server_id() {
+        let source = ConductorSource::Static(vec![node("op-conductor-0", "sequencer-0")]);
+        let membership = membership(&["sequencer-0"]);
+
+        let nodes = ConductorControl::nodes_from_membership(&source, &membership).unwrap();
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].name, "op-conductor-0");
+    }
+
+    #[test]
+    fn nodes_from_membership_rejects_unknown_static_member() {
+        let source = ConductorSource::Static(vec![node("op-conductor-0", "sequencer-0")]);
+        let membership = membership(&["sequencer-1"]);
+
+        let err = ConductorControl::nodes_from_membership(&source, &membership)
+            .expect_err("unknown member should fail");
+
+        assert!(err.to_string().contains("sequencer-1"));
     }
 }

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -7,6 +7,7 @@ pub use admin::{
 
 mod conductor;
 pub use conductor::{
+    ConductorClusterSnapshot, ConductorControl, ConductorFanoutReport, ConductorNodeFailure,
     ConductorNodeStatus, ConductorPollUpdate, PausedPeers, conductor_pause_all_nodes,
     conductor_pause_node, conductor_resume_all_nodes, conductor_resume_node,
     restart_conductor_node, run_conductor_poller, transfer_conductor_leader,


### PR DESCRIPTION
## Summary
- add a new `basectl conductor` command group for cluster status, leader transfer, and pause/unpause operations
- add shared conductor control helpers, confirmation flows, and JSON output for both single-node and cluster-wide actions
- document the new commands in the basectl README and cover the CLI/control-path behavior with tests

## Test Plan
- [x] `cargo test -p basectl-cli`
- [x] `cargo test -p basectl --bin basectl`
- [x] live devnet smoke test for `conductor status`, `pause`, `unpause`, `pause-all`, `unpause-all`, and both `transfer-leader` paths
- [x] manually verified the updated leader-settlement window for transfer-leader (`500ms` polling, `2` consecutive observations, `6s` max) against devnet