### PR TITLE
feat: support Base L1 tx format in batcher recent-tx scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,11 +3302,13 @@ dependencies = [
 name = "base-batcher-service"
 version = "0.0.0"
 dependencies = [
+ "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-provider 2.0.5",
  "alloy-rlp",
  "alloy-rpc-types-eth 2.0.5",
+ "alloy-signer 2.0.5",
  "alloy-signer-local 2.0.5",
  "async-trait",
  "base-batcher-admin",
@@ -3326,6 +3328,7 @@ dependencies = [
  "httpmock",
  "jsonrpsee",
  "miniz_oxide 0.9.1",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3770,9 +3773,11 @@ name = "base-common-network"
 version = "0.0.0"
 dependencies = [
  "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-provider 2.0.5",
+ "alloy-rpc-client 2.0.5",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.0.5",
  "alloy-transport 2.0.5",
@@ -3780,7 +3785,12 @@ dependencies = [
  "base-common-consensus",
  "base-common-rpc-types",
  "base-common-rpc-types-engine",
+ "httpmock",
  "rstest",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -7,7 +7,7 @@ use std::{
 
 use alloy_signer_local::PrivateKeySigner;
 use base_batcher_core::ThrottleConfig;
-use base_batcher_service::{BatcherConfig, BatcherService};
+use base_batcher_service::{BatcherConfig, BatcherService, L1TxFormat};
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_runtime::TokioRuntime;
 use clap::{Args, Parser, ValueEnum};
@@ -52,6 +52,13 @@ pub(crate) struct BatcherArgs {
     /// startup-time fallbacks only (no per-call rotation).
     #[arg(long = "l1-rpc-url", env = "BATCHER_L1_RPC_URL", value_delimiter = ',', num_args = 1..)]
     pub l1_rpc_url: Vec<Url>,
+
+    /// Transaction format of the L1 chain: `ethereum` (default) or `base`.
+    ///
+    /// Use `base` for an appchain settling to Base. Base L1 blocks can contain deposit and
+    /// EIP-8130 transactions that standard Ethereum full-block decoding rejects.
+    #[arg(long = "l1-tx-format", env = "BATCHER_L1_TX_FORMAT", default_value_t = L1TxFormat::default())]
+    pub l1_tx_format: L1TxFormat,
 
     /// L2 HTTP RPC endpoint(s) (used for all JSON-RPC calls including throttle control).
     ///
@@ -284,9 +291,9 @@ impl BatcherArgs {
             approx_compr_ratio: self.approx_compr_ratio,
             max_l1_tx_size_bytes: self.max_l1_tx_size_bytes,
         };
-        encoder_config.validate()?;
-        Ok(BatcherConfig {
+        let config = BatcherConfig {
             l1_rpc_url: self.l1_rpc_url,
+            l1_tx_format: self.l1_tx_format,
             l1_ws_url: self.l1_ws_url,
             l2_rpc_url: self.l2_rpc_url,
             l2_ws_url: self.l2_ws_url,
@@ -312,7 +319,9 @@ impl BatcherArgs {
             wait_node_sync: self.wait_node_sync,
             wait_node_sync_timeout: Duration::from_secs(self.wait_node_sync_timeout_secs),
             force_blobs_when_throttling: !self.no_force_blobs_when_throttling,
-        })
+        };
+        config.validate()?;
+        Ok(config)
     }
 
     /// Execute the batcher.
@@ -426,6 +435,36 @@ mod tests {
         let config = cli.args.into_config().expect("config should build");
 
         assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Calldata);
+    }
+
+    #[test]
+    fn into_config_rejects_base_l1_tx_format_with_blob_da() {
+        let cli = parse_cli(&["--l1-tx-format", "base"]);
+
+        assert!(cli.args.into_config().is_err());
+    }
+
+    #[test]
+    fn into_config_rejects_base_l1_tx_format_with_forced_blobs() {
+        let cli = parse_cli(&["--l1-tx-format", "base", "--data-availability-type", "calldata"]);
+
+        assert!(cli.args.into_config().is_err());
+    }
+
+    #[test]
+    fn into_config_accepts_base_l1_tx_format_with_calldata_only() {
+        let cli = parse_cli(&[
+            "--l1-tx-format",
+            "base",
+            "--data-availability-type",
+            "calldata",
+            "--no-force-blobs-when-throttling",
+        ]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.l1_tx_format, L1TxFormat::Base);
+        assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Calldata);
+        assert!(!config.force_blobs_when_throttling);
     }
 
     #[test]

--- a/crates/batcher/service/Cargo.toml
+++ b/crates/batcher/service/Cargo.toml
@@ -28,6 +28,7 @@ tracing = { workspace = true, features = ["std"] }
 derive_more = { workspace = true, features = ["debug"] }
 base-protocol = { workspace = true, features = ["std"] }
 base-runtime = { workspace = true, features = ["tokio"] }
+alloy-consensus = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-common-consensus = { workspace = true, features = ["std"] }
@@ -49,5 +50,7 @@ metrics = [
 httpmock.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
+alloy-signer.workspace = true
+serde_json.workspace = true
 miniz_oxide.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -4,7 +4,8 @@ use std::{net::SocketAddr, time::Duration};
 
 use alloy_signer_local::PrivateKeySigner;
 use base_batcher_core::ThrottleConfig;
-use base_batcher_encoder::EncoderConfig;
+use base_batcher_encoder::{DaType, EncoderConfig};
+use base_common_genesis::L1TxFormat;
 use url::Url;
 
 /// Full batcher configuration combining RPC endpoints, identity, encoding
@@ -20,6 +21,8 @@ pub struct BatcherConfig {
     /// startup and uses the first one that responds; later endpoints serve as
     /// startup-time fallbacks only (no per-call rotation). Must be non-empty.
     pub l1_rpc_url: Vec<Url>,
+    /// Transaction format exposed by the L1 RPC endpoint.
+    pub l1_tx_format: L1TxFormat,
     /// L2 HTTP RPC endpoint(s). Used for all JSON-RPC calls including throttle
     /// control (`miner_setMaxDASize`). Must be HTTP/HTTPS URLs.
     ///
@@ -107,6 +110,7 @@ impl Default for BatcherConfig {
     fn default() -> Self {
         Self {
             l1_rpc_url: vec!["http://localhost:8545".parse().expect("valid default URL")],
+            l1_tx_format: L1TxFormat::default(),
             l1_ws_url: None,
             l2_rpc_url: vec!["http://localhost:9545".parse().expect("valid default URL")],
             l2_ws_url: None,
@@ -125,5 +129,29 @@ impl Default for BatcherConfig {
             wait_node_sync_timeout: Duration::from_secs(600),
             force_blobs_when_throttling: true,
         }
+    }
+}
+
+impl BatcherConfig {
+    /// Validate config constraints that cannot be expressed by individual CLI parsers.
+    pub fn validate(&self) -> eyre::Result<()> {
+        self.encoder_config.validate()?;
+
+        if self.l1_tx_format == L1TxFormat::Base {
+            if self.encoder_config.da_type != DaType::Calldata {
+                eyre::bail!(
+                    "--l1-tx-format base requires --data-availability-type calldata because a \
+                     Base parent chain has no blob DA endpoint"
+                );
+            }
+            if self.force_blobs_when_throttling {
+                eyre::bail!(
+                    "--l1-tx-format base requires --no-force-blobs-when-throttling because \
+                     throttling cannot force blob submissions onto a calldata-only parent"
+                );
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+pub use base_common_genesis::L1TxFormat;
+
 mod config;
 pub use config::BatcherConfig;
 

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -2,10 +2,10 @@
 
 use std::collections::HashMap;
 
+use alloy_consensus::{Transaction, TxEnvelope, transaction::SignerRecoverable};
 use alloy_primitives::Address;
-use alloy_provider::{Provider, RootProvider};
-use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionTrait};
 use base_common_genesis::RollupConfig;
+use base_common_network::{L1RpcProvider, L1RpcProviderError};
 use base_protocol::{Batch, BatchReader, BlockInfo, Channel, ChannelId, Frame};
 use futures::StreamExt;
 use tracing::{debug, info};
@@ -20,6 +20,12 @@ pub const MAX_CHECK_RECENT_TXS_DEPTH: u64 = 128;
 /// Bounds peak memory to roughly this many full L1 blocks while still
 /// achieving significant speedup over sequential fetching.
 pub const SCAN_FETCH_CONCURRENCY: usize = 16;
+
+#[derive(Debug)]
+struct RecentL1Block {
+    info: BlockInfo,
+    transactions: Vec<TxEnvelope>,
+}
 
 /// Scans recent L1 blocks on startup to find the highest submitted L2 block.
 ///
@@ -46,7 +52,7 @@ impl RecentTxScanner {
     /// are never completed and will be silently missed. The caller should treat
     /// the result as a best-effort lower bound, not a guarantee.
     pub async fn highest_submitted_l2_block(
-        l1_provider: &RootProvider,
+        l1_provider: &L1RpcProvider,
         batcher_address: Address,
         batch_inbox: Address,
         depth: u64,
@@ -77,14 +83,7 @@ impl RecentTxScanner {
         let block_stream = futures::stream::iter(scan_start..=current_l1)
             .map(|block_num| {
                 let provider = l1_provider.clone();
-                async move {
-                    let block = provider
-                        .get_block_by_number(BlockNumberOrTag::Number(block_num))
-                        .full()
-                        .await
-                        .map_err(|e| eyre::eyre!("failed to fetch L1 block {block_num}: {e}"))?;
-                    eyre::Ok((block_num, block))
-                }
+                Self::fetch_recent_l1_block(provider, block_num)
             })
             .buffered(SCAN_FETCH_CONCURRENCY);
         futures::pin_mut!(block_stream);
@@ -99,24 +98,17 @@ impl RecentTxScanner {
                 }
             };
 
-            let block_info = BlockInfo {
-                hash: block.header.hash,
-                number: block_num,
-                parent_hash: block.header.inner.parent_hash,
-                timestamp: block.header.inner.timestamp,
-            };
-
-            for tx in block.transactions.txns() {
-                if tx.inner.signer() != batcher_address {
+            for tx in block.transactions {
+                if tx.to() != Some(batch_inbox) {
                     continue;
                 }
-                if tx.inner.to() != Some(batch_inbox) {
+                if tx.recover_signer().ok() != Some(batcher_address) {
                     continue;
                 }
 
                 // Only parse calldata (version-0) frames. Blob transactions have
                 // empty or absent calldata and will fail parse_frames gracefully.
-                let frames = match Frame::parse_frames(tx.inner.input()) {
+                let frames = match Frame::parse_frames(tx.input()) {
                     Ok(f) => f,
                     Err(_) => continue,
                 };
@@ -124,8 +116,8 @@ impl RecentTxScanner {
                 for frame in frames {
                     let channel = channels
                         .entry(frame.id)
-                        .or_insert_with(|| Channel::new(frame.id, block_info));
-                    if let Err(e) = channel.add_frame(frame, block_info) {
+                        .or_insert_with(|| Channel::new(frame.id, block.info));
+                    if let Err(e) = channel.add_frame(frame, block.info) {
                         debug!(error = %e, "ignoring rejected batcher frame during recent tx scan");
                     }
                 }
@@ -136,7 +128,7 @@ impl RecentTxScanner {
                 channels.iter().filter(|(_, ch)| ch.is_ready()).map(|(id, _)| *id).collect();
             for id in complete_ids {
                 if let Some(ch) = channels.remove(&id) {
-                    Self::decode_channel(&ch, block_info.timestamp, rollup_config, &mut highest_l2);
+                    Self::decode_channel(&ch, block.info.timestamp, rollup_config, &mut highest_l2);
                 }
             }
         }
@@ -148,6 +140,27 @@ impl RecentTxScanner {
         }
 
         Ok(highest_l2)
+    }
+
+    async fn fetch_recent_l1_block(
+        provider: L1RpcProvider,
+        block_num: u64,
+    ) -> eyre::Result<(u64, Option<RecentL1Block>)> {
+        let block = match provider.header_and_transactions_by_number(block_num).await {
+            Ok((header, transactions)) => {
+                let info = BlockInfo {
+                    hash: header.hash_slow(),
+                    number: block_num,
+                    parent_hash: header.parent_hash,
+                    timestamp: header.timestamp,
+                };
+                Some(RecentL1Block { info, transactions })
+            }
+            Err(L1RpcProviderError::BlockNotFound(_)) => None,
+            Err(e) => return Err(eyre::eyre!("failed to fetch L1 block {block_num}: {e}")),
+        };
+
+        Ok((block_num, block))
     }
 
     /// Decodes all batches from a complete channel and updates `highest_l2` with
@@ -176,11 +189,24 @@ impl RecentTxScanner {
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::{
+        SignableTransaction, TxEip1559, TxEnvelope, transaction::Recovered,
+        transaction::TransactionInfo,
+    };
     use alloy_eips::eip1898::BlockNumHash;
-    use alloy_primitives::B256;
+    use alloy_primitives::{Address, B256, TxKind, U256};
+    use alloy_provider::RootProvider;
     use alloy_rlp::Encodable;
+    use alloy_rpc_types_eth::Transaction as RpcTransaction;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
     use base_common_genesis::{ChainGenesis, RollupConfig};
-    use base_protocol::{Batch, BlockInfo, Channel, ChannelId, Frame, SingleBatch};
+    use base_common_network::{Base, L1RpcProvider};
+    use base_protocol::{
+        Batch, BlockInfo, Channel, ChannelId, DERIVATION_VERSION_0, Frame, SingleBatch,
+    };
+    use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
+    use serde_json::{Value, json};
 
     use super::RecentTxScanner;
 
@@ -226,6 +252,189 @@ mod tests {
         let frame = Frame { id, number: 0, data: payload, is_last: true };
         channel.add_frame(frame, block_info).expect("frame must be accepted");
         channel
+    }
+
+    fn json_rpc_response(req: &HttpMockRequest, result: Value) -> String {
+        let id = serde_json::from_slice::<Value>(&req.body_vec())
+            .ok()
+            .and_then(|body| body.get("id").cloned())
+            .unwrap_or(Value::Null);
+        json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
+    }
+
+    fn mock_rpc(server: &MockServer, method: &'static str, result: Value) {
+        server.mock(move |when, then| {
+            when.method(POST).path("/").json_body_includes(format!(r#"{{"method":"{method}"}}"#));
+            then.respond_with(move |req| {
+                HttpMockResponse::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(json_rpc_response(req, result.clone()))
+                    .build()
+            });
+        });
+    }
+
+    fn deposit_tx_json() -> Value {
+        json!({
+            "type": "0x7e",
+            "hash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
+            "nonce": "0x0",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "transactionIndex": "0x0",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "to": "0x4200000000000000000000000000000000000015",
+            "value": "0x0",
+            "gasPrice": "0x0",
+            "gas": "0xf4240",
+            "input": "0x",
+            "v": "0x0",
+            "r": "0x0",
+            "s": "0x0",
+            "sourceHash": "0x990d7122a1f121f3a6bc45723e28f4921c269037a77e77ffee3c8585136d1a92",
+            "mint": "0x0",
+            "depositReceiptVersion": "0x1"
+        })
+    }
+
+    fn eip8130_tx_json() -> Value {
+        json!({
+            "type": "0x7d",
+            "hash": "0x4242424242424242424242424242424242424242424242424242424242424242",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "transactionIndex": "0x1",
+            "from": "0x0000000000000000000000000000000000000011",
+            "gasPrice": "0x12a05f200",
+            "tx": {
+                "chainId": 8453,
+                "sender": "0x0000000000000000000000000000000000000011",
+                "nonceKey": "0x0",
+                "nonceSequence": 7,
+                "expiry": 0,
+                "maxPriorityFeePerGas": "0x3b9aca00",
+                "maxFeePerGas": "0x12a05f200",
+                "gasLimit": 1_000_000,
+                "accountChanges": [],
+                "calls": [],
+                "payer": null
+            },
+            "senderAuth": format!("0x{}", "ab".repeat(32)),
+            "payerAuth": "0x"
+        })
+    }
+
+    fn block_with_txs(txs: Vec<Value>) -> Value {
+        json!({
+            "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "parentHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "stateRoot": "0x3333333333333333333333333333333333333333333333333333333333333333",
+            "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "difficulty": "0x0",
+            "number": "0x2a",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "timestamp": "0x3f2",
+            "extraData": "0x",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce": "0x0000000000000000",
+            "baseFeePerGas": "0x1",
+            "transactions": txs,
+            "uncles": [],
+            "withdrawals": [],
+            "blobGasUsed": "0x0",
+            "excessBlobGas": "0x0"
+        })
+    }
+
+    fn frame_input_for_l2_timestamp(timestamp: u64) -> Vec<u8> {
+        let batch = SingleBatch { timestamp, ..Default::default() };
+        let frame = Frame::new([9u8; 16], 0, encode_single_batch(&batch), true);
+        let mut input = vec![DERIVATION_VERSION_0];
+        input.extend_from_slice(&frame.encode());
+        input
+    }
+
+    fn signed_batcher_tx_json(
+        signer: &PrivateKeySigner,
+        to: Address,
+        input: Vec<u8>,
+        index: u64,
+    ) -> Value {
+        let tx = TxEip1559 {
+            chain_id: 8453,
+            nonce: index,
+            gas_limit: 1_000_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1,
+            to: TxKind::Call(to),
+            value: U256::ZERO,
+            input: input.into(),
+            access_list: Default::default(),
+        };
+        let signature = signer.sign_hash_sync(&tx.signature_hash()).expect("tx signs");
+        let envelope: TxEnvelope = tx.into_signed(signature).into();
+        let rpc_tx = RpcTransaction::from_transaction(
+            Recovered::new_unchecked(envelope, signer.address()),
+            TransactionInfo {
+                hash: None,
+                index: Some(index),
+                block_hash: Some(B256::repeat_byte(0x11)),
+                block_number: Some(0x2a),
+                base_fee: Some(1),
+                block_timestamp: Some(0x3f2),
+            },
+        );
+        serde_json::to_value(rpc_tx).expect("transaction serializes")
+    }
+
+    async fn run_recent_scan(provider: L1RpcProvider, batcher: Address, inbox: Address) -> u64 {
+        let cfg = test_rollup_config(1000, 1000, 2);
+        RecentTxScanner::highest_submitted_l2_block(&provider, batcher, inbox, 1, &cfg)
+            .await
+            .expect("scan succeeds")
+            .expect("frame found")
+    }
+
+    #[tokio::test]
+    async fn highest_submitted_l2_block_base_block_drops_non_standard_txs() {
+        let server = MockServer::start_async().await;
+        let signer = PrivateKeySigner::from_slice(&[1u8; 32]).expect("valid signer");
+        let inbox = Address::repeat_byte(0x88);
+        let tx = signed_batcher_tx_json(&signer, inbox, frame_input_for_l2_timestamp(1010), 2);
+        mock_rpc(&server, "eth_blockNumber", json!("0x2a"));
+        mock_rpc(
+            &server,
+            "eth_getBlockByNumber",
+            block_with_txs(vec![deposit_tx_json(), eip8130_tx_json(), tx]),
+        );
+
+        let url = server.url("/").parse().expect("valid url");
+        let provider = L1RpcProvider::Base(RootProvider::<Base>::new_http(url));
+        let highest = run_recent_scan(provider, signer.address(), inbox).await;
+
+        assert_eq!(highest, 1005);
+    }
+
+    #[tokio::test]
+    async fn highest_submitted_l2_block_ethereum_path_recovers_frame() {
+        let server = MockServer::start_async().await;
+        let signer = PrivateKeySigner::from_slice(&[1u8; 32]).expect("valid signer");
+        let inbox = Address::repeat_byte(0x88);
+        let tx = signed_batcher_tx_json(&signer, inbox, frame_input_for_l2_timestamp(1012), 0);
+        mock_rpc(&server, "eth_blockNumber", json!("0x2a"));
+        mock_rpc(&server, "eth_getBlockByNumber", block_with_txs(vec![tx]));
+
+        let url = server.url("/").parse().expect("valid url");
+        let provider = L1RpcProvider::Ethereum(RootProvider::new_http(url));
+        let highest = run_recent_scan(provider, signer.address(), inbox).await;
+
+        assert_eq!(highest, 1006);
     }
 
     // ── decode_channel tests ─────────────────────────────────────────────────

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -190,8 +190,8 @@ impl RecentTxScanner {
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{
-        SignableTransaction, TxEip1559, TxEnvelope, transaction::Recovered,
-        transaction::TransactionInfo,
+        SignableTransaction, TxEip1559, TxEnvelope,
+        transaction::{Recovered, TransactionInfo},
     };
     use alloy_eips::eip1898::BlockNumHash;
     use alloy_primitives::{Address, B256, TxKind, U256};

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -515,6 +515,10 @@ impl BatcherService {
                 .as_ref()
                 .ok_or_else(|| eyre::eyre!("batcher_private_key must be set before starting"))?
                 .address();
+            // The Ethereum-typed `l1_provider` above is reused elsewhere (e.g. the tx
+            // manager), so for the Base format we open a second, Base-typed connection to
+            // the same URL(s) rather than reuse it: decoding deposit/EIP-8130 entries
+            // requires the Base network's tx envelopes, which the Ethereum provider rejects.
             let scan_provider = match self.config.l1_tx_format {
                 L1TxFormat::Ethereum => L1RpcProvider::Ethereum(l1_provider.clone()),
                 L1TxFormat::Base => L1RpcProvider::Base(

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -12,7 +12,8 @@ use base_batcher_core::{
 use base_batcher_encoder::BatchEncoder;
 use base_batcher_source::{BlockSubscription, HybridBlockSource, HybridL1HeadSource, SourceError};
 use base_common_consensus::BaseBlock;
-use base_common_network::Base;
+use base_common_genesis::L1TxFormat;
+use base_common_network::{Base, L1RpcProvider};
 use base_consensus_rpc::RollupNodeApiClient;
 use base_runtime::TokioRuntime;
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
@@ -376,7 +377,7 @@ impl BatcherService {
     /// The runtime's cancellation token is forwarded to the safe-head poller
     /// spawned here so it stops cleanly when the batcher shuts down.
     pub async fn setup(self, runtime: TokioRuntime) -> eyre::Result<ReadyBatcher> {
-        self.config.encoder_config.validate()?;
+        self.config.validate()?;
 
         if self.config.stopped && self.config.admin_addr.is_none() {
             eyre::bail!(
@@ -514,8 +515,22 @@ impl BatcherService {
                 .as_ref()
                 .ok_or_else(|| eyre::eyre!("batcher_private_key must be set before starting"))?
                 .address();
+            let scan_provider = match self.config.l1_tx_format {
+                L1TxFormat::Ethereum => L1RpcProvider::Ethereum(l1_provider.clone()),
+                L1TxFormat::Base => L1RpcProvider::Base(
+                    Self::connect_first(&self.config.l1_rpc_url, "l1-rpc-base-scan", |url| {
+                        let url = url.clone();
+                        async move {
+                            let provider = RootProvider::<Base>::new_http(url);
+                            provider.get_chain_id().await?;
+                            eyre::Ok(provider)
+                        }
+                    })
+                    .await?,
+                ),
+            };
             RecentTxScanner::highest_submitted_l2_block(
-                &l1_provider,
+                &scan_provider,
                 batcher_address,
                 rollup_config.batch_inbox_address,
                 self.config.check_recent_txs_depth,

--- a/crates/common/network/Cargo.toml
+++ b/crates/common/network/Cargo.toml
@@ -20,20 +20,27 @@ base-common-rpc-types-engine = { workspace = true, features = ["serde"] }
 base-common-consensus = { workspace = true, features = ["alloy-compat", "std"] }
 
 # Alloy
+alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-provider.workspace = true
 alloy-transport.workspace = true
+alloy-rpc-client.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["serde", "std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # misc
+thiserror.workspace = true
 async-trait.workspace = true
 
 
 [dev-dependencies]
+url.workspace = true
 rstest.workspace = true
+httpmock.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 std = [

--- a/crates/common/network/src/l1_rpc_provider.rs
+++ b/crates/common/network/src/l1_rpc_provider.rs
@@ -133,16 +133,7 @@ impl L1RpcProvider {
         hash: B256,
     ) -> Result<(Header, Vec<TxEnvelope>), L1RpcProviderError> {
         match self {
-            Self::Base(p) => {
-                let block = fetch_full_block(p, hash).await?;
-                let header = block.header.into_consensus();
-                let transactions = block
-                    .transactions
-                    .into_transactions()
-                    .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
-                    .collect();
-                Ok((header, transactions))
-            }
+            Self::Base(p) => Ok(base_block_into_header_and_txs(fetch_full_block(p, hash).await?)),
             Self::Ethereum(p) => {
                 let block = fetch_full_block(p, hash)
                     .await?
@@ -162,14 +153,7 @@ impl L1RpcProvider {
     ) -> Result<(Header, Vec<TxEnvelope>), L1RpcProviderError> {
         match self {
             Self::Base(p) => {
-                let block = fetch_full_block_by_number(p, number).await?;
-                let header = block.header.into_consensus();
-                let transactions = block
-                    .transactions
-                    .into_transactions()
-                    .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
-                    .collect();
-                Ok((header, transactions))
+                Ok(base_block_into_header_and_txs(fetch_full_block_by_number(p, number).await?))
             }
             Self::Ethereum(p) => {
                 let block = fetch_full_block_by_number(p, number)
@@ -180,6 +164,24 @@ impl L1RpcProvider {
             }
         }
     }
+}
+
+/// Converts a Base full-block response into a consensus [`Header`] and Ethereum [`TxEnvelope`]s.
+///
+/// Deposit (`0x7E`) and EIP-8130 (`0x7D`) txs have no Ethereum `TxEnvelope` representation, so
+/// [`TxEnvelope::try_from`] drops them. That conversion is an exhaustive match in
+/// `base-common-consensus`, so a future Base tx variant forces a deliberate map/drop decision
+/// there at compile time rather than vanishing silently here.
+fn base_block_into_header_and_txs(
+    block: <Base as Network>::BlockResponse,
+) -> (Header, Vec<TxEnvelope>) {
+    let header = block.header.into_consensus();
+    let transactions = block
+        .transactions
+        .into_transactions()
+        .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
+        .collect();
+    (header, transactions)
 }
 
 /// Fetches a block's receipts over JSON-RPC. Generic over the network so both providers share the

--- a/crates/common/network/src/l1_rpc_provider.rs
+++ b/crates/common/network/src/l1_rpc_provider.rs
@@ -1,0 +1,739 @@
+//! L1 JSON-RPC provider.
+
+use std::vec::Vec;
+
+use alloy_consensus::{Header, Receipt, TxEnvelope};
+use alloy_eips::{BlockId, eip2718::Encodable2718};
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::{Network, Provider, RootProvider, network::BlockResponse};
+use alloy_rpc_client::ClientRef;
+use alloy_transport::{RpcError, TransportErrorKind};
+use base_common_consensus::BaseReceiptEnvelope;
+
+use crate::Base;
+
+/// The L1 JSON-RPC provider.
+///
+/// A node derives from a single L1 chain, so the transaction format is fixed at construction. Neither
+/// transaction envelope is a superset of the other — Ethereum has EIP-4844 blobs that Base lacks;
+/// Base has deposit (`0x7E`) and EIP-8130 (`0x7D`) txs that Ethereum lacks — so the full-decode
+/// path is necessarily format-specific.
+#[derive(Debug, Clone)]
+pub enum L1RpcProvider {
+    /// Ethereum-typed provider; decodes standard blocks including EIP-4844.
+    Ethereum(RootProvider),
+    /// Base/OP-typed provider; decodes deposit and EIP-8130 entries the Ethereum envelopes reject.
+    Base(RootProvider<Base>),
+}
+
+impl L1RpcProvider {
+    /// Returns the RPC client used by the underlying provider.
+    pub fn client(&self) -> ClientRef<'_> {
+        match self {
+            Self::Ethereum(p) => p.client(),
+            Self::Base(p) => p.client(),
+        }
+    }
+
+    /// Fetches raw 2718 transaction bytes for every transaction trie entry.
+    pub async fn block_transaction_bytes_2718(
+        &self,
+        hash: B256,
+    ) -> Result<Vec<Vec<u8>>, L1RpcProviderError> {
+        match self {
+            Self::Ethereum(p) => fetch_block_transactions_2718(p, hash).await,
+            Self::Base(p) => fetch_block_transactions_2718(p, hash).await,
+        }
+    }
+
+    /// Returns the latest block number.
+    pub async fn get_block_number(&self) -> Result<u64, RpcError<TransportErrorKind>> {
+        match self {
+            Self::Ethereum(p) => p.get_block_number().await,
+            Self::Base(p) => p.get_block_number().await,
+        }
+    }
+
+    /// Returns the chain ID.
+    pub async fn get_chain_id(&self) -> Result<u64, RpcError<TransportErrorKind>> {
+        match self {
+            Self::Ethereum(p) => p.get_chain_id().await,
+            Self::Base(p) => p.get_chain_id().await,
+        }
+    }
+
+    /// Reads a storage slot at the given block. Format-agnostic.
+    pub async fn get_storage_at(
+        &self,
+        address: Address,
+        slot: U256,
+        block: BlockId,
+    ) -> Result<U256, RpcError<TransportErrorKind>> {
+        match self {
+            Self::Ethereum(p) => p.get_storage_at(address, slot).block_id(block).await,
+            Self::Base(p) => p.get_storage_at(address, slot).block_id(block).await,
+        }
+    }
+
+    /// Fetches the consensus [`Header`] for a block hash, header-only (no tx bodies).
+    pub async fn header_by_hash(&self, hash: B256) -> Result<Header, L1RpcProviderError> {
+        match self {
+            Self::Ethereum(p) => {
+                p.get_block_by_hash(hash).await.map(|b| b.map(|b| b.header.into_consensus()))
+            }
+            Self::Base(p) => {
+                p.get_block_by_hash(hash).await.map(|b| b.map(|b| b.header.into_consensus()))
+            }
+        }?
+        .ok_or(L1RpcProviderError::BlockNotFound(hash.into()))
+    }
+
+    /// Fetches the consensus [`Header`] for a block number, header-only (no tx bodies).
+    pub async fn header_by_number(&self, number: u64) -> Result<Header, L1RpcProviderError> {
+        match self {
+            Self::Ethereum(p) => p
+                .get_block_by_number(number.into())
+                .await
+                .map(|b| b.map(|b| b.header.into_consensus())),
+            Self::Base(p) => p
+                .get_block_by_number(number.into())
+                .await
+                .map(|b| b.map(|b| b.header.into_consensus())),
+        }?
+        .ok_or(L1RpcProviderError::BlockNotFound(number.into()))
+    }
+
+    /// Fetches a block's receipts and reduces each to its consensus [`Receipt`].
+    ///
+    /// All receipts are kept (incl. the index-0 deposit on a Base L1) so block-wide log-index
+    /// numbering is preserved.
+    pub async fn receipts_by_hash(&self, hash: B256) -> Result<Vec<Receipt>, L1RpcProviderError> {
+        match self {
+            Self::Base(p) => Ok(fetch_block_receipts(p, hash)
+                .await?
+                .into_iter()
+                .map(|r| Receipt::from(BaseReceiptEnvelope::from(r)))
+                .collect()),
+            Self::Ethereum(p) => fetch_block_receipts(p, hash)
+                .await?
+                .into_iter()
+                .map(|r| r.inner.into_primitives_receipt().as_receipt().cloned())
+                .collect::<Option<Vec<_>>>()
+                .ok_or(L1RpcProviderError::ReceiptsConversion(hash)),
+        }
+    }
+
+    /// Fetches a full block and returns its consensus [`Header`] and transactions.
+    ///
+    /// On a Base L1, deposit (`0x7E`) and EIP-8130 (`0x7D`) txs have no Ethereum representation,
+    /// so [`TxEnvelope::try_from`] drops them. L3 batcher submissions cannot use EIP-8130 until
+    /// the DA pipeline can inspect Base envelopes directly.
+    pub async fn header_and_transactions_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<(Header, Vec<TxEnvelope>), L1RpcProviderError> {
+        match self {
+            Self::Base(p) => {
+                let block = fetch_full_block(p, hash).await?;
+                let header = block.header.into_consensus();
+                let transactions = block
+                    .transactions
+                    .into_transactions()
+                    .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
+                    .collect();
+                Ok((header, transactions))
+            }
+            Self::Ethereum(p) => {
+                let block = fetch_full_block(p, hash)
+                    .await?
+                    .into_consensus()
+                    .map_transactions(|t| t.inner.into_inner());
+                Ok((block.header, block.body.transactions))
+            }
+        }
+    }
+
+    /// Fetches a full block by number and returns its consensus [`Header`] and transactions.
+    ///
+    /// Applies the same Base down-conversion as [`Self::header_and_transactions_by_hash`].
+    pub async fn header_and_transactions_by_number(
+        &self,
+        number: u64,
+    ) -> Result<(Header, Vec<TxEnvelope>), L1RpcProviderError> {
+        match self {
+            Self::Base(p) => {
+                let block = fetch_full_block_by_number(p, number).await?;
+                let header = block.header.into_consensus();
+                let transactions = block
+                    .transactions
+                    .into_transactions()
+                    .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
+                    .collect();
+                Ok((header, transactions))
+            }
+            Self::Ethereum(p) => {
+                let block = fetch_full_block_by_number(p, number)
+                    .await?
+                    .into_consensus()
+                    .map_transactions(|t| t.inner.into_inner());
+                Ok((block.header, block.body.transactions))
+            }
+        }
+    }
+}
+
+/// Fetches a block's receipts over JSON-RPC. Generic over the network so both providers share the
+/// fetch path; the caller converts the response into consensus receipts.
+async fn fetch_block_receipts<N: Network>(
+    provider: &RootProvider<N>,
+    hash: B256,
+) -> Result<Vec<N::ReceiptResponse>, L1RpcProviderError> {
+    provider
+        .get_block_receipts(hash.into())
+        .await?
+        .ok_or(L1RpcProviderError::BlockNotFound(hash.into()))
+}
+
+/// Fetches a full block (with transactions) over JSON-RPC. Generic over the network so both
+/// providers share the fetch path; the caller converts the response into consensus types.
+async fn fetch_full_block<N: Network>(
+    provider: &RootProvider<N>,
+    hash: B256,
+) -> Result<N::BlockResponse, L1RpcProviderError> {
+    provider
+        .get_block_by_hash(hash)
+        .full()
+        .await?
+        .ok_or(L1RpcProviderError::BlockNotFound(hash.into()))
+}
+
+/// Fetches a full block by number (with transactions) over JSON-RPC. Generic over the network so
+/// both providers share the fetch path; the caller converts the response into consensus types.
+async fn fetch_full_block_by_number<N: Network>(
+    provider: &RootProvider<N>,
+    number: u64,
+) -> Result<N::BlockResponse, L1RpcProviderError> {
+    provider
+        .get_block_by_number(number.into())
+        .full()
+        .await?
+        .ok_or(L1RpcProviderError::BlockNotFound(number.into()))
+}
+
+async fn fetch_block_transactions_2718<N: Network>(
+    provider: &RootProvider<N>,
+    hash: B256,
+) -> Result<Vec<Vec<u8>>, L1RpcProviderError>
+where
+    N::TxEnvelope: Encodable2718,
+{
+    let block = fetch_full_block(provider, hash).await?;
+    let transactions = block
+        .transactions()
+        .as_transactions()
+        .ok_or(L1RpcProviderError::TransactionBodiesUnavailable(hash))?;
+
+    Ok(transactions.iter().map(|tx| tx.as_ref().encoded_2718()).collect())
+}
+
+/// An error for the [`L1RpcProvider`].
+#[derive(Debug, thiserror::Error)]
+pub enum L1RpcProviderError {
+    /// Transport error.
+    #[error(transparent)]
+    Transport(#[from] RpcError<TransportErrorKind>),
+    /// Block not found.
+    #[error("Block not found: {0}")]
+    BlockNotFound(BlockId),
+    /// Full block response contained hashes, not transaction bodies.
+    #[error("Block transaction bodies unavailable: {0}")]
+    TransactionBodiesUnavailable(B256),
+    /// Failed to convert RPC receipts into consensus receipts.
+    #[error("Failed to convert RPC receipts into consensus receipts: {0}")]
+    ReceiptsConversion(B256),
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_provider::RootProvider;
+    use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    fn json_rpc_response(req: &HttpMockRequest, result: Value) -> String {
+        let id = serde_json::from_slice::<Value>(&req.body_vec())
+            .ok()
+            .and_then(|body| body.get("id").cloned())
+            .unwrap_or(Value::Null);
+        json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
+    }
+
+    /// A type-`0x7e` deposit transaction, as a Base/OP JSON-RPC endpoint returns it.
+    fn deposit_tx_json() -> Value {
+        json!({
+            "type": "0x7e",
+            "hash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
+            "nonce": "0x0",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "transactionIndex": "0x0",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "to": "0x4200000000000000000000000000000000000015",
+            "value": "0x0",
+            "gasPrice": "0x0",
+            "gas": "0xf4240",
+            "input": "0x",
+            "v": "0x0",
+            "r": "0x0",
+            "s": "0x0",
+            "sourceHash": "0x990d7122a1f121f3a6bc45723e28f4921c269037a77e77ffee3c8585136d1a92",
+            "mint": "0x0",
+            "depositReceiptVersion": "0x1"
+        })
+    }
+
+    /// A type-`0x7e` deposit receipt, as a Base/OP JSON-RPC endpoint returns it.
+    fn deposit_receipt_json() -> Value {
+        json!({
+            "type": "0x7e",
+            "status": "0x1",
+            "cumulativeGasUsed": "0x0",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "logs": [],
+            "transactionHash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
+            "transactionIndex": "0x0",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "to": "0x4200000000000000000000000000000000000015",
+            "gasUsed": "0x0",
+            "effectiveGasPrice": "0x0",
+            "contractAddress": null,
+            "depositNonce": "0x0",
+            "depositReceiptVersion": "0x1"
+        })
+    }
+
+    /// A type-`0x7d` EIP-8130 transaction, as a Base RPC endpoint returns it.
+    ///
+    /// Built to match the wire format produced by
+    /// `base_common_rpc_types::Transaction::from_transaction` for the `Eip8130` variant.
+    fn eip8130_tx_json() -> Value {
+        json!({
+            "type": "0x7d",
+            "hash": "0x4242424242424242424242424242424242424242424242424242424242424242",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "transactionIndex": "0x1",
+            "from": "0x0000000000000000000000000000000000000011",
+            "gasPrice": "0x12a05f200",
+            "tx": {
+                "chainId": 8453,
+                "sender": "0x0000000000000000000000000000000000000011",
+                "nonceKey": "0x0",
+                "nonceSequence": 7,
+                "expiry": 0,
+                "maxPriorityFeePerGas": "0x3b9aca00",
+                "maxFeePerGas": "0x12a05f200",
+                "gasLimit": 1_000_000,
+                "accountChanges": [],
+                "calls": [],
+                "payer": null
+            },
+            "senderAuth": format!("0x{}", "ab".repeat(32)),
+            "payerAuth": "0x"
+        })
+    }
+
+    /// A type-`0x7d` EIP-8130 receipt, as a Base RPC endpoint returns it.
+    fn eip8130_receipt_json() -> Value {
+        json!({
+            "type": "0x7d",
+            "status": "0x1",
+            "cumulativeGasUsed": "0x5208",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "logs": [],
+            "transactionHash": "0x4242424242424242424242424242424242424242424242424242424242424242",
+            "transactionIndex": "0x1",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "from": "0x0000000000000000000000000000000000000011",
+            "to": null,
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x12a05f200",
+            "contractAddress": null
+        })
+    }
+
+    /// A minimal EIP-1559 (type `0x02`) transaction with well-formed signature fields.
+    fn eip1559_tx_json() -> Value {
+        json!({
+            "type": "0x2",
+            "hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "transactionIndex": "0x2",
+            "from": "0x0000000000000000000000000000000000000099",
+            "to": "0x0000000000000000000000000000000000000088",
+            "value": "0x0",
+            "nonce": "0x5",
+            "gas": "0x5208",
+            "input": "0x",
+            "chainId": "0x2105",
+            "maxFeePerGas": "0x12a05f200",
+            "maxPriorityFeePerGas": "0x3b9aca00",
+            "accessList": [],
+            "v": "0x1",
+            "r": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "s": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "yParity": "0x1"
+        })
+    }
+
+    /// A minimal EIP-1559 (type `0x02`) receipt.
+    fn eip1559_receipt_json() -> Value {
+        json!({
+            "type": "0x2",
+            "status": "0x1",
+            "cumulativeGasUsed": "0xa410",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "logs": [{
+                "address": "0x0000000000000000000000000000000000000088",
+                "topics": ["0x0000000000000000000000000000000000000000000000000000000000000001"],
+                "data": "0x",
+                "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                "blockNumber": "0x2a",
+                "transactionHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "transactionIndex": "0x1",
+                "logIndex": "0x0",
+                "removed": false
+            }],
+            "transactionHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "transactionIndex": "0x1",
+            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "blockNumber": "0x2a",
+            "from": "0x0000000000000000000000000000000000000099",
+            "to": "0x0000000000000000000000000000000000000088",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x12a05f200",
+            "contractAddress": null
+        })
+    }
+
+    fn base_block_with_txs(txs: Vec<Value>) -> Value {
+        json!({
+            "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "parentHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "stateRoot": "0x3333333333333333333333333333333333333333333333333333333333333333",
+            "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "difficulty": "0x0",
+            "number": "0x2a",
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "timestamp": "0x1",
+            "extraData": "0x",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce": "0x0000000000000000",
+            "baseFeePerGas": "0x1",
+            "transactions": txs,
+            "uncles": [],
+            "withdrawals": [],
+            "blobGasUsed": "0x0",
+            "excessBlobGas": "0x0"
+        })
+    }
+
+    /// A Base-format block whose only transaction is a `0x7e` deposit.
+    fn base_block_with_deposit() -> Value {
+        base_block_with_txs(vec![deposit_tx_json()])
+    }
+
+    /// A Base-format block containing a deposit (`0x7E`) at index 0 and an EIP-8130 (`0x7D`) tx
+    /// at index 1.
+    fn base_block_with_eip8130() -> Value {
+        base_block_with_txs(vec![deposit_tx_json(), eip8130_tx_json()])
+    }
+
+    /// A Base-format block containing a deposit at index 0, an EIP-1559 tx at index 1, and an
+    /// EIP-8130 tx at index 2. This is the most realistic scenario: deposits + standard user
+    /// txs + AA txs coexisting in a single block.
+    fn base_block_mixed() -> Value {
+        let mut eip1559 = eip1559_tx_json();
+        eip1559["transactionIndex"] = json!("0x1");
+        let mut eip8130 = eip8130_tx_json();
+        eip8130["transactionIndex"] = json!("0x2");
+        base_block_with_txs(vec![deposit_tx_json(), eip1559, eip8130])
+    }
+
+    fn base_provider(server: &MockServer) -> L1RpcProvider {
+        let url: url::Url = server.url("/").parse().unwrap();
+        L1RpcProvider::Base(RootProvider::<Base>::new_http(url))
+    }
+
+    fn mock_block_by_number(server: &MockServer, block: Value) {
+        server.mock(|when, then| {
+            when.method(POST).path("/").json_body_includes(r#"{"method":"eth_getBlockByNumber"}"#);
+            then.respond_with(move |req| {
+                HttpMockResponse::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(json_rpc_response(req, block.clone()))
+                    .build()
+            });
+        });
+    }
+
+    /// Regression: a Base-format block carrying a `0x7e` deposit must decode through the
+    /// `RootProvider<Base>` path, and the deposit must be dropped from the down-converted txs
+    /// (never surfaced to the calldata scanner / batcher-auth path).
+    #[tokio::test]
+    async fn base_format_block_decodes_and_drops_deposit() {
+        let server = MockServer::start_async().await;
+        let block = base_block_with_deposit();
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, block.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let (header, txs) = provider.header_and_transactions_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(header.number, 0x2a);
+        assert!(
+            txs.is_empty(),
+            "the 0x7e deposit must be decoded then dropped from the down-converted transactions"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_format_block_transaction_bytes_keep_deposit() {
+        let server = MockServer::start_async().await;
+        let block = base_block_with_deposit();
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, block.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let url: url::Url = server.url("/").parse().unwrap();
+        let provider = L1RpcProvider::Base(RootProvider::<Base>::new_http(url));
+        let txs = provider.block_transaction_bytes_2718(B256::repeat_byte(0x11)).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(txs.len(), 1, "host preimage tx fetch must retain trie entries");
+        assert_eq!(txs[0].first().copied(), Some(0x7e));
+    }
+
+    /// Regression: a Base-format `0x7e` deposit receipt must decode and be kept — unlike the tx
+    /// path, receipts preserve deposits, since the index-0 deposit anchors block-wide log indices.
+    #[tokio::test]
+    async fn base_format_receipts_decode_and_preserve_deposit() {
+        let server = MockServer::start_async().await;
+        let receipts = json!([deposit_receipt_json()]);
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, receipts.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let receipts = provider.receipts_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(receipts.len(), 1, "the 0x7e deposit receipt must be decoded and preserved");
+    }
+
+    /// Regression: an EIP-8130 (`0x7D`) transaction in a Base-format block must be deserialized
+    /// by the `RootProvider<Base>` path but dropped from the down-converted `Vec<TxEnvelope>`
+    /// returned by `header_and_transactions_by_hash`.
+    #[tokio::test]
+    async fn base_format_block_decodes_and_drops_eip8130() {
+        let server = MockServer::start_async().await;
+        let block = base_block_with_eip8130();
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, block.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let (header, txs) = provider.header_and_transactions_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(header.number, 0x2a);
+        assert!(
+            txs.is_empty(),
+            "both 0x7e deposit and 0x7d EIP-8130 must be dropped from down-converted transactions"
+        );
+    }
+
+    /// Regression: an EIP-8130 (`0x7D`) receipt must be deserialized and preserved in the
+    /// `Vec<Receipt>` returned by `receipts_by_hash`.
+    #[tokio::test]
+    async fn base_format_receipts_decode_and_preserve_eip8130() {
+        let server = MockServer::start_async().await;
+        let receipts = json!([deposit_receipt_json(), eip8130_receipt_json()]);
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, receipts.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let receipts = provider.receipts_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(receipts.len(), 2, "both deposit and EIP-8130 receipts must be preserved");
+        assert_eq!(
+            receipts[1].status,
+            alloy_consensus::Eip658Value::Eip658(true),
+            "EIP-8130 receipt status must be correctly converted"
+        );
+    }
+
+    /// When a Base-format block contains a mix of non-Ethereum txs (deposit, EIP-8130) and
+    /// standard Ethereum-compatible txs (EIP-1559), only the standard txs survive the
+    /// down-conversion while the non-Ethereum txs are dropped.
+    #[tokio::test]
+    async fn base_format_mixed_block_preserves_standard_txs() {
+        let server = MockServer::start_async().await;
+        let block = base_block_mixed();
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, block.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let (header, txs) = provider.header_and_transactions_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(header.number, 0x2a);
+        assert_eq!(txs.len(), 1, "only the EIP-1559 tx should survive down-conversion");
+        assert!(matches!(txs[0], TxEnvelope::Eip1559(_)), "surviving tx must be EIP-1559");
+    }
+
+    /// When a Base-format block contains receipts of mixed types, ALL receipts are preserved
+    /// (including deposit and EIP-8130), maintaining block-wide log-index numbering.
+    #[tokio::test]
+    async fn base_format_mixed_receipts_preserve_all() {
+        let server = MockServer::start_async().await;
+        let receipts =
+            json!([deposit_receipt_json(), eip1559_receipt_json(), eip8130_receipt_json()]);
+        let mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.respond_with(move |req| {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, receipts.clone()))
+                        .build()
+                });
+            })
+            .await;
+
+        let provider = base_provider(&server);
+        let hash = B256::repeat_byte(0x11);
+        let receipts = provider.receipts_by_hash(hash).await.unwrap();
+
+        mock.assert_calls_async(1).await;
+        assert_eq!(receipts.len(), 3, "all three receipts must be preserved regardless of type");
+        assert_eq!(
+            receipts[0].status,
+            alloy_consensus::Eip658Value::Eip658(true),
+            "deposit receipt status"
+        );
+        assert_eq!(receipts[1].logs.len(), 1, "EIP-1559 receipt log preserved");
+        assert_eq!(
+            receipts[2].status,
+            alloy_consensus::Eip658Value::Eip658(true),
+            "EIP-8130 receipt status"
+        );
+    }
+
+    /// A Base-format block fetched by number must decode through the `RootProvider<Base>` path, with
+    /// the `0x7E` deposit and `0x7D` EIP-8130 txs dropped from the down-converted transactions while
+    /// the standard EIP-1559 tx survives.
+    #[tokio::test]
+    async fn base_by_number_drops_deposit_and_eip8130_keeps_standard() {
+        let server = MockServer::start_async().await;
+        mock_block_by_number(&server, base_block_mixed());
+
+        let url: url::Url = server.url("/").parse().unwrap();
+        let provider = L1RpcProvider::Base(RootProvider::<Base>::new_http(url));
+        let (header, txs) = provider.header_and_transactions_by_number(0x2a).await.unwrap();
+
+        assert_eq!(header.number, 0x2a);
+        assert_eq!(txs.len(), 1, "only the EIP-1559 tx survives down-conversion");
+        assert!(matches!(txs[0], TxEnvelope::Eip1559(_)), "surviving tx must be EIP-1559");
+    }
+}

--- a/crates/common/network/src/l1_rpc_provider.rs
+++ b/crates/common/network/src/l1_rpc_provider.rs
@@ -1,7 +1,5 @@
 //! L1 JSON-RPC provider.
 
-use std::vec::Vec;
-
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_eips::{BlockId, eip2718::Encodable2718};
 use alloy_primitives::{Address, B256, U256};

--- a/crates/common/network/src/lib.rs
+++ b/crates/common/network/src/lib.rs
@@ -15,6 +15,9 @@ const _ALLOY_PRIMITIVES_USED: alloy_primitives::Address = alloy_primitives::Addr
 mod base;
 pub use base::Base;
 
+mod l1_rpc_provider;
+pub use l1_rpc_provider::{L1RpcProvider, L1RpcProviderError};
+
 mod builder;
 
 mod engine;

--- a/crates/consensus/providers/src/chain_provider.rs
+++ b/crates/consensus/providers/src/chain_provider.rs
@@ -3,14 +3,12 @@
 use std::{boxed::Box, num::NonZeroUsize, vec::Vec};
 
 use alloy_consensus::{Header, Receipt, TxEnvelope};
-use alloy_eips::{BlockId, eip2718::Encodable2718};
+use alloy_eips::BlockId;
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::{Network, Provider, RootProvider, network::BlockResponse};
-use alloy_rpc_client::ClientRef;
+use alloy_provider::RootProvider;
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
-use base_common_consensus::BaseReceiptEnvelope;
-use base_common_network::Base;
+use base_common_network::{Base, L1RpcProvider, L1RpcProviderError};
 use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind, ResetError};
 use base_protocol::BlockInfo;
 use lru::LruCache;
@@ -31,205 +29,6 @@ pub struct AlloyChainProvider {
     receipts_by_hash_cache: LruCache<B256, Vec<Receipt>>,
     /// `block_info_and_transactions_by_hash` LRU cache.
     block_info_and_transactions_by_hash_cache: LruCache<B256, (BlockInfo, Vec<TxEnvelope>)>,
-}
-
-/// The L1 JSON-RPC provider.
-///
-/// A node derives from a single L1 chain, so the transaction format is fixed at construction. Neither
-/// transaction envelope is a superset of the other — Ethereum has EIP-4844 blobs that Base lacks;
-/// Base has deposit (`0x7E`) and EIP-8130 (`0x7D`) txs that Ethereum lacks — so the full-decode
-/// path is necessarily format-specific.
-#[derive(Debug, Clone)]
-pub enum L1RpcProvider {
-    /// Ethereum-typed provider; decodes standard blocks including EIP-4844.
-    Ethereum(RootProvider),
-    /// Base/OP-typed provider; decodes deposit and EIP-8130 entries the Ethereum envelopes reject.
-    Base(RootProvider<Base>),
-}
-
-impl L1RpcProvider {
-    /// Returns the RPC client used by the underlying provider.
-    pub fn client(&self) -> ClientRef<'_> {
-        match self {
-            Self::Ethereum(p) => p.client(),
-            Self::Base(p) => p.client(),
-        }
-    }
-
-    /// Fetches raw 2718 transaction bytes for every transaction trie entry.
-    pub async fn block_transaction_bytes_2718(
-        &self,
-        hash: B256,
-    ) -> Result<Vec<Vec<u8>>, AlloyChainProviderError> {
-        match self {
-            Self::Ethereum(p) => fetch_block_transactions_2718(p, hash).await,
-            Self::Base(p) => fetch_block_transactions_2718(p, hash).await,
-        }
-    }
-
-    /// Returns the latest block number.
-    async fn get_block_number(&self) -> Result<u64, RpcError<TransportErrorKind>> {
-        match self {
-            Self::Ethereum(p) => p.get_block_number().await,
-            Self::Base(p) => p.get_block_number().await,
-        }
-    }
-
-    /// Returns the chain ID.
-    async fn get_chain_id(&self) -> Result<u64, RpcError<TransportErrorKind>> {
-        match self {
-            Self::Ethereum(p) => p.get_chain_id().await,
-            Self::Base(p) => p.get_chain_id().await,
-        }
-    }
-
-    /// Reads a storage slot at the given block. Format-agnostic.
-    async fn get_storage_at(
-        &self,
-        address: Address,
-        slot: U256,
-        block: BlockId,
-    ) -> Result<U256, RpcError<TransportErrorKind>> {
-        match self {
-            Self::Ethereum(p) => p.get_storage_at(address, slot).block_id(block).await,
-            Self::Base(p) => p.get_storage_at(address, slot).block_id(block).await,
-        }
-    }
-
-    /// Fetches the consensus [`Header`] for a block hash, header-only (no tx bodies).
-    async fn header_by_hash(&self, hash: B256) -> Result<Header, AlloyChainProviderError> {
-        base_metrics::time!(Metrics::request_duration("header_by_hash"), {
-            match self {
-                Self::Ethereum(p) => {
-                    p.get_block_by_hash(hash).await.map(|b| b.map(|b| b.header.into_consensus()))
-                }
-                Self::Base(p) => {
-                    p.get_block_by_hash(hash).await.map(|b| b.map(|b| b.header.into_consensus()))
-                }
-            }
-        })
-        .inspect_err(|_e| {
-            Metrics::chain_rpc_errors("header_by_hash").increment(1);
-        })?
-        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))
-    }
-
-    /// Fetches the consensus [`Header`] for a block number, header-only (no tx bodies).
-    async fn header_by_number(&self, number: u64) -> Result<Header, AlloyChainProviderError> {
-        base_metrics::time!(Metrics::request_duration("block_by_number"), {
-            match self {
-                Self::Ethereum(p) => p
-                    .get_block_by_number(number.into())
-                    .await
-                    .map(|b| b.map(|b| b.header.into_consensus())),
-                Self::Base(p) => p
-                    .get_block_by_number(number.into())
-                    .await
-                    .map(|b| b.map(|b| b.header.into_consensus())),
-            }
-        })
-        .inspect_err(|_e| {
-            Metrics::chain_rpc_errors("block_by_number").increment(1);
-        })?
-        .ok_or(AlloyChainProviderError::BlockNotFound(number.into()))
-    }
-
-    /// Fetches a block's receipts and reduces each to its consensus [`Receipt`].
-    ///
-    /// All receipts are kept (incl. the index-0 deposit on a Base L1) so block-wide log-index
-    /// numbering is preserved.
-    async fn receipts_by_hash(&self, hash: B256) -> Result<Vec<Receipt>, AlloyChainProviderError> {
-        match self {
-            Self::Base(p) => Ok(fetch_block_receipts(p, hash)
-                .await?
-                .into_iter()
-                .map(|r| Receipt::from(BaseReceiptEnvelope::from(r)))
-                .collect()),
-            Self::Ethereum(p) => fetch_block_receipts(p, hash)
-                .await?
-                .into_iter()
-                .map(|r| r.inner.into_primitives_receipt().as_receipt().cloned())
-                .collect::<Option<Vec<_>>>()
-                .ok_or(AlloyChainProviderError::ReceiptsConversion(hash)),
-        }
-    }
-
-    /// Fetches a full block and returns its consensus [`Header`] and transactions.
-    ///
-    /// On a Base L1, deposit (`0x7E`) and EIP-8130 (`0x7D`) txs have no Ethereum representation,
-    /// so [`TxEnvelope::try_from`] drops them. L3 batcher submissions cannot use EIP-8130 until
-    /// the DA pipeline can inspect Base envelopes directly.
-    async fn header_and_transactions_by_hash(
-        &self,
-        hash: B256,
-    ) -> Result<(Header, Vec<TxEnvelope>), AlloyChainProviderError> {
-        match self {
-            Self::Base(p) => {
-                let block = fetch_full_block(p, hash).await?;
-                let header = block.header.into_consensus();
-                let transactions = block
-                    .transactions
-                    .into_transactions()
-                    .filter_map(|t| TxEnvelope::try_from(t.inner.into_inner()).ok())
-                    .collect();
-                Ok((header, transactions))
-            }
-            Self::Ethereum(p) => {
-                let block = fetch_full_block(p, hash)
-                    .await?
-                    .into_consensus()
-                    .map_transactions(|t| t.inner.into_inner());
-                Ok((block.header, block.body.transactions))
-            }
-        }
-    }
-}
-
-/// Fetches a block's receipts over JSON-RPC with timing/error metrics. Generic over the network so
-/// both providers share the fetch path; the caller converts the response into consensus receipts.
-async fn fetch_block_receipts<N: Network>(
-    provider: &RootProvider<N>,
-    hash: B256,
-) -> Result<Vec<N::ReceiptResponse>, AlloyChainProviderError> {
-    base_metrics::time!(Metrics::request_duration("receipts_by_hash"), {
-        provider.get_block_receipts(hash.into()).await
-    })
-    .inspect_err(|_e| {
-        Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
-    })?
-    .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))
-}
-
-/// Fetches a full block (with transactions) over JSON-RPC with timing/error metrics. Generic over
-/// the network so both providers share the fetch path; the caller converts the response into a
-/// [`BlockInfo`] and consensus transactions.
-async fn fetch_full_block<N: Network>(
-    provider: &RootProvider<N>,
-    hash: B256,
-) -> Result<N::BlockResponse, AlloyChainProviderError> {
-    base_metrics::time!(Metrics::request_duration("block_by_hash"), {
-        provider.get_block_by_hash(hash).full().await
-    })
-    .inspect_err(|_e| {
-        Metrics::chain_rpc_errors("block_by_hash").increment(1);
-    })?
-    .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))
-}
-
-async fn fetch_block_transactions_2718<N: Network>(
-    provider: &RootProvider<N>,
-    hash: B256,
-) -> Result<Vec<Vec<u8>>, AlloyChainProviderError>
-where
-    N::TxEnvelope: Encodable2718,
-{
-    let block = fetch_full_block(provider, hash).await?;
-    let transactions = block
-        .transactions()
-        .as_transactions()
-        .ok_or(AlloyChainProviderError::TransactionBodiesUnavailable(hash))?;
-
-    Ok(transactions.iter().map(|tx| tx.as_ref().encoded_2718()).collect())
 }
 
 impl AlloyChainProvider {
@@ -359,6 +158,19 @@ pub enum AlloyChainProviderError {
     ReceiptsConversion(B256),
 }
 
+impl From<L1RpcProviderError> for AlloyChainProviderError {
+    fn from(error: L1RpcProviderError) -> Self {
+        match error {
+            L1RpcProviderError::Transport(error) => Self::Transport(error),
+            L1RpcProviderError::BlockNotFound(id) => Self::BlockNotFound(id),
+            L1RpcProviderError::TransactionBodiesUnavailable(hash) => {
+                Self::TransactionBodiesUnavailable(hash)
+            }
+            L1RpcProviderError::ReceiptsConversion(hash) => Self::ReceiptsConversion(hash),
+        }
+    }
+}
+
 impl From<AlloyChainProviderError> for PipelineErrorKind {
     fn from(e: AlloyChainProviderError) -> Self {
         match e {
@@ -403,7 +215,12 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("header_by_hash").increment(1);
 
-        let header = self.inner.header_by_hash(hash).await?;
+        let header = base_metrics::time!(Metrics::request_duration("header_by_hash"), {
+            self.inner.header_by_hash(hash).await
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("header_by_hash").increment(1);
+        })?;
 
         // Verify the header hash matches what we requested
         self.verify_header_hash(&header, hash)?;
@@ -418,7 +235,12 @@ impl ChainProvider for AlloyChainProvider {
     async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error> {
         Metrics::chain_rpc_calls("block_by_number").increment(1);
 
-        let header = self.inner.header_by_number(number).await?;
+        let header = base_metrics::time!(Metrics::request_duration("block_by_number"), {
+            self.inner.header_by_number(number).await
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("block_by_number").increment(1);
+        })?;
 
         let block_info = BlockInfo {
             hash: header.hash_slow(),
@@ -439,7 +261,13 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("receipts_by_hash").increment(1);
 
-        let consensus_receipts = self.inner.receipts_by_hash(hash).await?;
+        let consensus_receipts =
+            base_metrics::time!(Metrics::request_duration("receipts_by_hash"), {
+                self.inner.receipts_by_hash(hash).await
+            })
+            .inspect_err(|_e| {
+                Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
+            })?;
 
         self.receipts_by_hash_cache.put(hash, consensus_receipts.clone());
 
@@ -462,7 +290,13 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("block_by_hash").increment(1);
 
-        let (header, transactions) = self.inner.header_and_transactions_by_hash(hash).await?;
+        let (header, transactions) =
+            base_metrics::time!(Metrics::request_duration("block_by_hash"), {
+                self.inner.header_and_transactions_by_hash(hash).await
+            })
+            .inspect_err(|_e| {
+                Metrics::chain_rpc_errors("block_by_hash").increment(1);
+            })?;
 
         // Verify the header hash matches what we requested
         self.verify_header_hash(&header, hash)?;
@@ -486,8 +320,6 @@ impl ChainProvider for AlloyChainProvider {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
-    use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
-    use serde_json::{Value, json};
 
     use super::*;
 
@@ -521,453 +353,6 @@ mod tests {
         assert!(
             matches!(kind, PipelineErrorKind::Temporary(_)),
             "number-based BlockNotFound must stay Temporary (block not yet produced)"
-        );
-    }
-
-    fn json_rpc_response(req: &HttpMockRequest, result: Value) -> String {
-        let id = serde_json::from_slice::<Value>(&req.body_vec())
-            .ok()
-            .and_then(|body| body.get("id").cloned())
-            .unwrap_or(Value::Null);
-        json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
-    }
-
-    /// A type-`0x7e` deposit transaction, as a Base/OP JSON-RPC endpoint returns it.
-    fn deposit_tx_json() -> Value {
-        json!({
-            "type": "0x7e",
-            "hash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
-            "nonce": "0x0",
-            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "blockNumber": "0x2a",
-            "transactionIndex": "0x0",
-            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
-            "to": "0x4200000000000000000000000000000000000015",
-            "value": "0x0",
-            "gasPrice": "0x0",
-            "gas": "0xf4240",
-            "input": "0x",
-            "v": "0x0",
-            "r": "0x0",
-            "s": "0x0",
-            "sourceHash": "0x990d7122a1f121f3a6bc45723e28f4921c269037a77e77ffee3c8585136d1a92",
-            "mint": "0x0",
-            "depositReceiptVersion": "0x1"
-        })
-    }
-
-    fn base_block_with_txs(txs: Vec<Value>) -> Value {
-        json!({
-            "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "parentHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
-            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-            "miner": "0x0000000000000000000000000000000000000000",
-            "stateRoot": "0x3333333333333333333333333333333333333333333333333333333333333333",
-            "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "logsBloom": format!("0x{}", "00".repeat(256)),
-            "difficulty": "0x0",
-            "number": "0x2a",
-            "gasLimit": "0x1c9c380",
-            "gasUsed": "0x0",
-            "timestamp": "0x1",
-            "extraData": "0x",
-            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "nonce": "0x0000000000000000",
-            "baseFeePerGas": "0x1",
-            "transactions": txs,
-            "uncles": [],
-            "withdrawals": [],
-            "blobGasUsed": "0x0",
-            "excessBlobGas": "0x0"
-        })
-    }
-
-    /// A Base-format block whose only transaction is a `0x7e` deposit.
-    fn base_block_with_deposit() -> Value {
-        base_block_with_txs(vec![deposit_tx_json()])
-    }
-
-    /// A type-`0x7e` deposit receipt, as a Base/OP JSON-RPC endpoint returns it.
-    fn deposit_receipt_json() -> Value {
-        json!({
-            "type": "0x7e",
-            "status": "0x1",
-            "cumulativeGasUsed": "0x0",
-            "logsBloom": format!("0x{}", "00".repeat(256)),
-            "logs": [],
-            "transactionHash": "0x096c03d72acb06339c9c7860d1c36b6451932ec0ff16fd34aa9e30a73a245e13",
-            "transactionIndex": "0x0",
-            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "blockNumber": "0x2a",
-            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
-            "to": "0x4200000000000000000000000000000000000015",
-            "gasUsed": "0x0",
-            "effectiveGasPrice": "0x0",
-            "contractAddress": null,
-            "depositNonce": "0x0",
-            "depositReceiptVersion": "0x1"
-        })
-    }
-
-    /// A type-`0x7d` EIP-8130 transaction, as a Base RPC endpoint returns it.
-    ///
-    /// Built to match the wire format produced by
-    /// `base_common_rpc_types::Transaction::from_transaction` for the `Eip8130` variant.
-    fn eip8130_tx_json() -> Value {
-        json!({
-            "type": "0x7d",
-            "hash": "0x4242424242424242424242424242424242424242424242424242424242424242",
-            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "blockNumber": "0x2a",
-            "transactionIndex": "0x1",
-            "from": "0x0000000000000000000000000000000000000011",
-            "gasPrice": "0x12a05f200",
-            "tx": {
-                "chainId": 8453,
-                "sender": "0x0000000000000000000000000000000000000011",
-                "nonceKey": "0x0",
-                "nonceSequence": 7,
-                "expiry": 0,
-                "maxPriorityFeePerGas": "0x3b9aca00",
-                "maxFeePerGas": "0x12a05f200",
-                "gasLimit": 1_000_000,
-                "accountChanges": [],
-                "calls": [],
-                "payer": null
-            },
-            "senderAuth": format!("0x{}", "ab".repeat(32)),
-            "payerAuth": "0x"
-        })
-    }
-
-    /// A type-`0x7d` EIP-8130 receipt, as a Base RPC endpoint returns it.
-    fn eip8130_receipt_json() -> Value {
-        json!({
-            "type": "0x7d",
-            "status": "0x1",
-            "cumulativeGasUsed": "0x5208",
-            "logsBloom": format!("0x{}", "00".repeat(256)),
-            "logs": [],
-            "transactionHash": "0x4242424242424242424242424242424242424242424242424242424242424242",
-            "transactionIndex": "0x1",
-            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "blockNumber": "0x2a",
-            "from": "0x0000000000000000000000000000000000000011",
-            "to": null,
-            "gasUsed": "0x5208",
-            "effectiveGasPrice": "0x12a05f200",
-            "contractAddress": null
-        })
-    }
-
-    /// A minimal EIP-1559 (type `0x02`) transaction with well-formed signature fields, as a
-    /// standard Ethereum-compatible RPC endpoint returns it.
-    fn eip1559_tx_json() -> Value {
-        json!({
-            "type": "0x2",
-            "hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "blockNumber": "0x2a",
-            "transactionIndex": "0x1",
-            "from": "0x0000000000000000000000000000000000000099",
-            "to": "0x0000000000000000000000000000000000000088",
-            "value": "0x0",
-            "nonce": "0x5",
-            "gas": "0x5208",
-            "input": "0x",
-            "chainId": "0x2105",
-            "maxFeePerGas": "0x12a05f200",
-            "maxPriorityFeePerGas": "0x3b9aca00",
-            "accessList": [],
-            "v": "0x1",
-            "r": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "s": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "yParity": "0x1"
-        })
-    }
-
-    /// A minimal EIP-1559 (type `0x02`) receipt.
-    fn eip1559_receipt_json() -> Value {
-        json!({
-            "type": "0x2",
-            "status": "0x1",
-            "cumulativeGasUsed": "0xa410",
-            "logsBloom": format!("0x{}", "00".repeat(256)),
-            "logs": [{
-                "address": "0x0000000000000000000000000000000000000088",
-                "topics": ["0x0000000000000000000000000000000000000000000000000000000000000001"],
-                "data": "0x",
-                "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-                "blockNumber": "0x2a",
-                "transactionHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "transactionIndex": "0x1",
-                "logIndex": "0x0",
-                "removed": false
-            }],
-            "transactionHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "transactionIndex": "0x1",
-            "blockHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-            "blockNumber": "0x2a",
-            "from": "0x0000000000000000000000000000000000000099",
-            "to": "0x0000000000000000000000000000000000000088",
-            "gasUsed": "0x5208",
-            "effectiveGasPrice": "0x12a05f200",
-            "contractAddress": null
-        })
-    }
-
-    /// A Base-format block containing a deposit (`0x7E`) at index 0 and an EIP-8130 (`0x7D`) tx
-    /// at index 1.
-    fn base_block_with_eip8130() -> Value {
-        base_block_with_txs(vec![deposit_tx_json(), eip8130_tx_json()])
-    }
-
-    /// A Base-format block containing a deposit at index 0, an EIP-1559 tx at index 1, and an
-    /// EIP-8130 tx at index 2. This is the most realistic scenario: deposits + standard user
-    /// txs + AA txs coexisting in a single block.
-    fn base_block_mixed() -> Value {
-        let mut eip1559 = eip1559_tx_json();
-        eip1559["transactionIndex"] = json!("0x1");
-        let mut eip8130 = eip8130_tx_json();
-        eip8130["transactionIndex"] = json!("0x2");
-        base_block_with_txs(vec![deposit_tx_json(), eip1559, eip8130])
-    }
-
-    fn base_provider(server: &MockServer) -> AlloyChainProvider {
-        let url: url::Url = server.url("/").parse().unwrap();
-        AlloyChainProvider::new_http_with_format(url, 16, true, L1TxFormat::Base)
-    }
-
-    /// Regression: a Base-format block carrying a `0x7e` deposit must decode through the
-    /// `RootProvider<Base>` path, and the deposit must be dropped from the down-converted txs
-    /// (never surfaced to the calldata scanner / batcher-auth path).
-    #[tokio::test]
-    async fn base_format_block_decodes_and_drops_deposit() {
-        let server = MockServer::start_async().await;
-        let block = base_block_with_deposit();
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, block.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let mut provider = base_provider(&server);
-        let hash = B256::repeat_byte(0x11);
-        let (info, txs) = provider.block_info_and_transactions_by_hash(hash).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(info.number, 0x2a);
-        assert!(
-            txs.is_empty(),
-            "the 0x7e deposit must be decoded then dropped from the down-converted transactions"
-        );
-    }
-
-    #[tokio::test]
-    async fn base_format_block_transaction_bytes_keep_deposit() {
-        let server = MockServer::start_async().await;
-        let block = base_block_with_deposit();
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, block.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let url: url::Url = server.url("/").parse().unwrap();
-        let provider = L1RpcProvider::Base(RootProvider::<Base>::new_http(url));
-        let txs = provider.block_transaction_bytes_2718(B256::repeat_byte(0x11)).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(txs.len(), 1, "host preimage tx fetch must retain trie entries");
-        assert_eq!(txs[0].first().copied(), Some(0x7e));
-    }
-
-    /// Regression: a Base-format `0x7e` deposit receipt must decode and be kept — unlike the tx
-    /// path, receipts preserve deposits, since the index-0 deposit anchors block-wide log indices.
-    #[tokio::test]
-    async fn base_format_receipts_decode_and_preserve_deposit() {
-        let server = MockServer::start_async().await;
-        let receipts = json!([deposit_receipt_json()]);
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, receipts.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let mut provider = base_provider(&server);
-        let hash = B256::repeat_byte(0x11);
-        let receipts = provider.receipts_by_hash(hash).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(receipts.len(), 1, "the 0x7e deposit receipt must be decoded and preserved");
-    }
-
-    /// Regression: an EIP-8130 (`0x7D`) transaction in a Base-format block must be deserialized
-    /// by the `RootProvider<Base>` path but dropped from the down-converted `Vec<TxEnvelope>`
-    /// returned by `block_info_and_transactions_by_hash`.
-    #[tokio::test]
-    async fn base_format_block_decodes_and_drops_eip8130() {
-        let server = MockServer::start_async().await;
-        let block = base_block_with_eip8130();
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, block.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let mut provider = base_provider(&server);
-        let hash = B256::repeat_byte(0x11);
-        let (info, txs) = provider.block_info_and_transactions_by_hash(hash).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(info.number, 0x2a);
-        assert!(
-            txs.is_empty(),
-            "both 0x7e deposit and 0x7d EIP-8130 must be dropped from down-converted transactions"
-        );
-    }
-
-    /// Regression: an EIP-8130 (`0x7D`) receipt must be deserialized and preserved in the
-    /// `Vec<Receipt>` returned by `receipts_by_hash`.
-    #[tokio::test]
-    async fn base_format_receipts_decode_and_preserve_eip8130() {
-        let server = MockServer::start_async().await;
-        let receipts = json!([deposit_receipt_json(), eip8130_receipt_json()]);
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, receipts.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let mut provider = base_provider(&server);
-        let hash = B256::repeat_byte(0x11);
-        let receipts = provider.receipts_by_hash(hash).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(receipts.len(), 2, "both deposit and EIP-8130 receipts must be preserved");
-        assert_eq!(
-            receipts[1].status,
-            alloy_consensus::Eip658Value::Eip658(true),
-            "EIP-8130 receipt status must be correctly converted"
-        );
-    }
-
-    /// When a Base-format block contains a mix of non-Ethereum txs (deposit, EIP-8130) and
-    /// standard Ethereum-compatible txs (EIP-1559), only the standard txs survive the
-    /// down-conversion while the non-Ethereum txs are dropped.
-    #[tokio::test]
-    async fn base_format_mixed_block_preserves_standard_txs() {
-        let server = MockServer::start_async().await;
-        let block = base_block_mixed();
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, block.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let mut provider = base_provider(&server);
-        let hash = B256::repeat_byte(0x11);
-        let (info, txs) = provider.block_info_and_transactions_by_hash(hash).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(info.number, 0x2a);
-        assert_eq!(txs.len(), 1, "only the EIP-1559 tx should survive down-conversion");
-        assert!(matches!(txs[0], TxEnvelope::Eip1559(_)), "surviving tx must be EIP-1559");
-    }
-
-    /// When a Base-format block contains receipts of mixed types, ALL receipts are preserved
-    /// (including deposit and EIP-8130), maintaining block-wide log-index numbering.
-    #[tokio::test]
-    async fn base_format_mixed_receipts_preserve_all() {
-        let server = MockServer::start_async().await;
-        let receipts =
-            json!([deposit_receipt_json(), eip1559_receipt_json(), eip8130_receipt_json()]);
-        let mock = server
-            .mock_async(move |when, then| {
-                when.method(POST)
-                    .path("/")
-                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
-                then.respond_with(move |req| {
-                    HttpMockResponse::builder()
-                        .status(200)
-                        .header("content-type", "application/json")
-                        .body(json_rpc_response(req, receipts.clone()))
-                        .build()
-                });
-            })
-            .await;
-
-        let mut provider = base_provider(&server);
-        let hash = B256::repeat_byte(0x11);
-        let receipts = provider.receipts_by_hash(hash).await.unwrap();
-
-        mock.assert_calls_async(1).await;
-        assert_eq!(receipts.len(), 3, "all three receipts must be preserved regardless of type");
-        assert_eq!(
-            receipts[0].status,
-            alloy_consensus::Eip658Value::Eip658(true),
-            "deposit receipt status"
-        );
-        assert_eq!(receipts[1].logs.len(), 1, "EIP-1559 receipt log preserved");
-        assert_eq!(
-            receipts[2].status,
-            alloy_consensus::Eip658Value::Eip658(true),
-            "EIP-8130 receipt status"
         );
     }
 }

--- a/crates/consensus/providers/src/lib.rs
+++ b/crates/consensus/providers/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub use base_common_genesis::L1TxFormat;
+pub use base_common_network::{L1RpcProvider, L1RpcProviderError};
 
 mod metrics;
 pub use metrics::Metrics;
@@ -23,7 +24,7 @@ pub use blobs::{
 };
 
 mod chain_provider;
-pub use chain_provider::{AlloyChainProvider, AlloyChainProviderError, L1RpcProvider};
+pub use chain_provider::{AlloyChainProvider, AlloyChainProviderError};
 
 mod conf_depth;
 pub use conf_depth::{ConfDepthProvider, L1HeadNumber};

--- a/crates/proof/host/src/error.rs
+++ b/crates/proof/host/src/error.rs
@@ -3,7 +3,7 @@ use std::array::TryFromSliceError;
 use alloy_primitives::B256;
 use alloy_rlp::Error as RlpError;
 use alloy_transport::TransportError;
-use base_consensus_providers::AlloyChainProviderError;
+use base_consensus_providers::L1RpcProviderError;
 use base_proof_client::FaultProofProgramError;
 use base_proof_preimage::errors::{PreimageOracleError, WitnessOracleError};
 use thiserror::Error;
@@ -129,13 +129,13 @@ pub enum HostError {
     Io(#[from] std::io::Error),
 }
 
-impl From<AlloyChainProviderError> for HostError {
-    fn from(error: AlloyChainProviderError) -> Self {
+impl From<L1RpcProviderError> for HostError {
+    fn from(error: L1RpcProviderError) -> Self {
         match error {
-            AlloyChainProviderError::BlockNotFound(id) => Self::BlockNotFound(id.to_string()),
-            AlloyChainProviderError::Transport(error) => Self::Transport(error),
-            AlloyChainProviderError::TransactionBodiesUnavailable(_)
-            | AlloyChainProviderError::ReceiptsConversion(_) => Self::Custom(error.to_string()),
+            L1RpcProviderError::BlockNotFound(id) => Self::BlockNotFound(id.to_string()),
+            L1RpcProviderError::Transport(error) => Self::Transport(error),
+            L1RpcProviderError::TransactionBodiesUnavailable(_)
+            | L1RpcProviderError::ReceiptsConversion(_) => Self::Custom(error.to_string()),
         }
     }
 }


### PR DESCRIPTION
Add an --l1-tx-format flag (ethereum|base) to the batcher so an appchain settling to Base can scan recent L1 txs whose blocks contain deposit and EIP-8130 entries that standard Ethereum full-block decoding rejects.

Move L1RpcProvider into base-common-network as a format-aware enum wrapping either an Ethereum or Base RootProvider, and route the recent-tx scanner through it. Validate that the base format is only used with calldata DA and no forced blobs, since a Base parent chain has no blob DA endpoint.