### PR TITLE
fix(b20-factory): validate stablecoin currency before token existence check

### DIFF
--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -340,9 +340,22 @@ impl TokenCreateParams {
     }
 
     /// Validates stablecoin initialization fields.
-    pub const fn validate_stablecoin(_init: &B20StablecoinInit) -> Result<()> {
-        // Currency validation is delegated to `B20StablecoinStorage::initialize`, which rejects
-        // empty values with `MissingRequiredField` and non-A-Z values with `InvalidCurrency`.
+    ///
+    /// Returns `MissingRequiredField` for an empty `currency` and `InvalidCurrency` for
+    /// a value that contains any character outside `A-Z`. Validating here ensures that
+    /// currency errors are returned before the token existence check, so callers cannot
+    /// infer address occupancy from which error they receive.
+    pub fn validate_stablecoin(init: &B20StablecoinInit) -> Result<()> {
+        if init.currency.is_empty() {
+            return Err(BasePrecompileError::revert(IB20Factory::MissingRequiredField {
+                field: "currency".to_string(),
+            }));
+        }
+        if !init.currency.bytes().all(|b| b.is_ascii_uppercase()) {
+            return Err(BasePrecompileError::revert(IB20Factory::InvalidCurrency {
+                code: init.currency.clone(),
+            }));
+        }
         Ok(())
     }
 
@@ -756,6 +769,79 @@ mod tests {
         };
 
         StorageCtx::enter(&mut storage, |ctx| {
+            assert_output(
+                dispatch_factory_revert(ctx, call),
+                IB20Factory::InvalidCurrency { code: "usd".to_string() }.abi_encode(),
+            );
+        });
+    }
+
+    /// Regression test for BOP-393: currency validation must fire before the token existence
+    /// check so callers cannot infer address occupancy from which error they receive.
+    #[test]
+    fn test_invalid_currency_errors_take_precedence_over_token_already_exists() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_precompiles(&mut storage);
+        let caller = Address::repeat_byte(0x55);
+        let salt = B256::repeat_byte(0xF1);
+
+        // Create a valid stablecoin at (caller, salt).
+        StorageCtx::enter(&mut storage, |ctx| {
+            let valid_params = IB20Factory::B20StablecoinCreateParams {
+                version: B20Variant::Stablecoin.supported_version(),
+                name: "Stablecoin".to_string(),
+                symbol: "STB".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                currency: "USD".to_string(),
+            };
+            let call = IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::STABLECOIN,
+                salt,
+                params: valid_params.abi_encode().into(),
+                initCalls: Vec::new(),
+            };
+            let mut factory = B20FactoryStorage::new(ctx);
+            factory.create_b20(caller, call).unwrap();
+        });
+
+        // Retry with empty currency at the same (caller, salt): must return MissingRequiredField,
+        // not TokenAlreadyExists.
+        StorageCtx::enter(&mut storage, |ctx| {
+            let params = IB20Factory::B20StablecoinCreateParams {
+                version: B20Variant::Stablecoin.supported_version(),
+                name: "Stablecoin".to_string(),
+                symbol: "STB".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                currency: "".to_string(),
+            };
+            let call = IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::STABLECOIN,
+                salt,
+                params: params.abi_encode().into(),
+                initCalls: Vec::new(),
+            };
+            assert_output(
+                dispatch_factory_revert(ctx, call),
+                IB20Factory::MissingRequiredField { field: "currency".to_string() }.abi_encode(),
+            );
+        });
+
+        // Retry with non-uppercase currency at the same (caller, salt): must return
+        // InvalidCurrency, not TokenAlreadyExists.
+        StorageCtx::enter(&mut storage, |ctx| {
+            let params = IB20Factory::B20StablecoinCreateParams {
+                version: B20Variant::Stablecoin.supported_version(),
+                name: "Stablecoin".to_string(),
+                symbol: "STB".to_string(),
+                initialAdmin: Address::repeat_byte(0xAB),
+                currency: "usd".to_string(),
+            };
+            let call = IB20Factory::createB20Call {
+                variant: IB20Factory::B20Variant::STABLECOIN,
+                salt,
+                params: params.abi_encode().into(),
+                initCalls: Vec::new(),
+            };
             assert_output(
                 dispatch_factory_revert(ctx, call),
                 IB20Factory::InvalidCurrency { code: "usd".to_string() }.abi_encode(),


### PR DESCRIPTION
## What

`TokenCreateParams::validate_stablecoin` was a no-op that delegated currency
validation to `B20StablecoinStorage::initialize`. Because the token existence
check (`already_deployed`) fires between `params.validate()` and `initialize()`,
a caller supplying an invalid currency (empty or non-uppercase) for an address
that is already occupied received `TokenAlreadyExists` instead of
`MissingRequiredField` or `InvalidCurrency`. This leaks whether a given
`(caller, salt)` address slot is already occupied.

## Fix

Implement the empty and non-A-Z currency checks directly in
`TokenCreateParams::validate_stablecoin` so they execute before the existence
check. The existing validation in `B20StablecoinStorage::initialize` is
unchanged -- currency is still validated there, so the behavior for new
deployments is unaffected. A regression test creates a stablecoin at a
`(caller, salt)` address, then retries with empty and non-uppercase currency
over the same address and asserts the currency errors are returned rather than
`TokenAlreadyExists`.

## References

- Cantina finding: https://cantina.xyz/code/73a6cf79-adb2-4d94-9e8b-3a5fdef7f64e/findings/31
- Linear ticket: https://linear.app/coinbase/issue/BOP-393
