### PR TITLE
feat(proof): add worker proof submitter types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5864,6 +5864,7 @@ dependencies = [
  "async-trait",
  "base-prover-service-client",
  "base-prover-service-protocol",
+ "base-retry",
  "chrono",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/proof/worker/Cargo.toml
+++ b/crates/proof/worker/Cargo.toml
@@ -13,9 +13,9 @@ workspace = true
 
 [dependencies]
 # base
+base-retry.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
-base-retry.workspace = true
 
 # async
 tokio-util.workspace = true

--- a/crates/proof/worker/Cargo.toml
+++ b/crates/proof/worker/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # base
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
+base-retry.workspace = true
 
 # async
 tokio-util.workspace = true

--- a/crates/proof/worker/src/lib.rs
+++ b/crates/proof/worker/src/lib.rs
@@ -18,3 +18,9 @@ pub use job_discovery::{
     DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobClaimFilter, JobDiscovery, JobDiscoveryConfig,
     JobDiscoveryPollOutcome, JobDiscoveryTask, MIN_JOB_DISCOVERY_POLL_INTERVAL, ZkProofClaimType,
 };
+
+mod proof_submitter;
+pub use proof_submitter::{
+    DEFAULT_PROOF_SUBMITTER_INITIAL_BACKOFF, DEFAULT_PROOF_SUBMITTER_MAX_BACKOFF,
+    MIN_PROOF_SUBMITTER_BACKOFF, ProofSubmitter, ProofSubmitterBackoffConfig, ProofSubmitterError,
+};

--- a/crates/proof/worker/src/lib.rs
+++ b/crates/proof/worker/src/lib.rs
@@ -20,7 +20,4 @@ pub use job_discovery::{
 };
 
 mod proof_submitter;
-pub use proof_submitter::{
-    DEFAULT_PROOF_SUBMITTER_INITIAL_BACKOFF, DEFAULT_PROOF_SUBMITTER_MAX_BACKOFF,
-    MIN_PROOF_SUBMITTER_BACKOFF, ProofSubmitter, ProofSubmitterBackoffConfig, ProofSubmitterError,
-};
+pub use proof_submitter::{ProofSubmitter, ProofSubmitterError};

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -4,25 +4,9 @@
 //! `WorkerSubmitProofRequest` from their own proof result type, then hand the
 //! request to this shared worker component for delivery.
 
-use std::time::Duration;
-
 use base_prover_service_client::ProverServiceClientError;
-use base_retry::{
-    DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY, MIN_RETRY_DELAY, RetryConfig,
-};
+use base_retry::{DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY, RetryConfig};
 use thiserror::Error;
-
-/// Minimum delay used to avoid tight retry loops.
-pub const MIN_PROOF_SUBMITTER_BACKOFF: Duration = MIN_RETRY_DELAY;
-
-/// Default initial retry delay for proof submission.
-pub const DEFAULT_PROOF_SUBMITTER_INITIAL_BACKOFF: Duration = DEFAULT_UNBOUNDED_INITIAL_DELAY;
-
-/// Default maximum retry delay for proof submission.
-pub const DEFAULT_PROOF_SUBMITTER_MAX_BACKOFF: Duration = DEFAULT_UNBOUNDED_MAX_DELAY;
-
-/// Exponential backoff configuration for proof submission retries.
-pub type ProofSubmitterBackoffConfig = RetryConfig;
 
 /// Errors raised while preparing or submitting a generated proof.
 #[derive(Debug, Error)]
@@ -50,7 +34,7 @@ impl ProofSubmitterError {
 #[derive(Clone, Debug)]
 pub struct ProofSubmitter<Client> {
     client: Client,
-    backoff: ProofSubmitterBackoffConfig,
+    backoff: RetryConfig,
 }
 
 impl<Client> ProofSubmitter<Client> {
@@ -58,21 +42,21 @@ impl<Client> ProofSubmitter<Client> {
     pub const fn new(client: Client) -> Self {
         Self {
             client,
-            backoff: ProofSubmitterBackoffConfig::unbounded(
-                DEFAULT_PROOF_SUBMITTER_INITIAL_BACKOFF,
-                DEFAULT_PROOF_SUBMITTER_MAX_BACKOFF,
+            backoff: RetryConfig::unbounded(
+                DEFAULT_UNBOUNDED_INITIAL_DELAY,
+                DEFAULT_UNBOUNDED_MAX_DELAY,
             ),
         }
     }
 
     /// Sets the retry backoff config.
-    pub const fn with_backoff_config(mut self, backoff: ProofSubmitterBackoffConfig) -> Self {
+    pub const fn with_backoff_config(mut self, backoff: RetryConfig) -> Self {
         self.backoff = backoff;
         self
     }
 
     /// Returns the configured retry backoff.
-    pub const fn backoff_config(&self) -> ProofSubmitterBackoffConfig {
+    pub const fn backoff_config(&self) -> RetryConfig {
         self.backoff
     }
 

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -1,0 +1,83 @@
+//! Proof submission types for prover-service worker delivery.
+//!
+//! [`ProofSubmitter`] is backend-neutral: hosts build a
+//! `WorkerSubmitProofRequest` from their own proof result type, then hand the
+//! request to this shared worker component for delivery.
+
+use std::time::Duration;
+
+use base_prover_service_client::ProverServiceClientError;
+use base_retry::{
+    DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY, MIN_RETRY_DELAY, RetryConfig,
+};
+use thiserror::Error;
+
+/// Minimum delay used to avoid tight retry loops.
+pub const MIN_PROOF_SUBMITTER_BACKOFF: Duration = MIN_RETRY_DELAY;
+
+/// Default initial retry delay for proof submission.
+pub const DEFAULT_PROOF_SUBMITTER_INITIAL_BACKOFF: Duration = DEFAULT_UNBOUNDED_INITIAL_DELAY;
+
+/// Default maximum retry delay for proof submission.
+pub const DEFAULT_PROOF_SUBMITTER_MAX_BACKOFF: Duration = DEFAULT_UNBOUNDED_MAX_DELAY;
+
+/// Exponential backoff configuration for proof submission retries.
+pub type ProofSubmitterBackoffConfig = RetryConfig;
+
+/// Errors raised while preparing or submitting a generated proof.
+#[derive(Debug, Error)]
+pub enum ProofSubmitterError {
+    /// The generated proof result is not one this worker can submit.
+    #[error("proof submitter received an unsupported proof result")]
+    UnsupportedProofResult,
+    /// Prover service worker API submission failed.
+    #[error(transparent)]
+    Submit(#[from] ProverServiceClientError),
+}
+
+impl ProofSubmitterError {
+    /// Returns `true` when retrying the submission may succeed.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::UnsupportedProofResult => false,
+            Self::Submit(error) => error.is_retryable(),
+        }
+    }
+}
+
+/// Submitter for delivering generated proofs to the prover-service worker API.
+#[derive(Clone, Debug)]
+pub struct ProofSubmitter<Client> {
+    client: Client,
+    backoff: ProofSubmitterBackoffConfig,
+}
+
+impl<Client> ProofSubmitter<Client> {
+    /// Creates a proof submitter using the default backoff config.
+    pub const fn new(client: Client) -> Self {
+        Self {
+            client,
+            backoff: ProofSubmitterBackoffConfig::unbounded(
+                DEFAULT_PROOF_SUBMITTER_INITIAL_BACKOFF,
+                DEFAULT_PROOF_SUBMITTER_MAX_BACKOFF,
+            ),
+        }
+    }
+
+    /// Sets the retry backoff config.
+    pub const fn with_backoff_config(mut self, backoff: ProofSubmitterBackoffConfig) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// Returns the configured retry backoff.
+    pub const fn backoff_config(&self) -> ProofSubmitterBackoffConfig {
+        self.backoff
+    }
+
+    /// Returns the underlying worker client.
+    pub const fn client(&self) -> &Client {
+        &self.client
+    }
+}


### PR DESCRIPTION
## Summary

Adds the backend-neutral proof submitter module with shared backoff configuration, error types, and public re-exports so proof hosts have a stable API surface before delivery behavior is introduced.