### PR TITLE
feat(proof): add worker proof task control

### DIFF
--- a/crates/proof/worker/src/lib.rs
+++ b/crates/proof/worker/src/lib.rs
@@ -21,3 +21,6 @@ pub use job_discovery::{
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterError};
+
+mod task;
+pub use task::{ProofSubmissionTask, ProofTaskController};

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -16,7 +16,7 @@ use base_prover_service_protocol::{
 };
 use base_retry::{DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY, RetryConfig};
 use thiserror::Error;
-use tokio::time::sleep;
+use tokio::{task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -293,6 +293,24 @@ where
     }
 }
 
+impl<Client> ProofSubmitter<Client>
+where
+    Client: Clone + ProverWorkerProvider + 'static,
+{
+    /// Spawns proof submission as an async Tokio task.
+    #[must_use = "dropping the JoinHandle detaches the submission task"]
+    pub fn spawn_until_delivered(
+        &self,
+        request: WorkerSubmitProofRequest,
+        cancel: CancellationToken,
+    ) -> JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>> {
+        let submitter = self.clone();
+        tokio::spawn(async move {
+            submitter.submit_until_delivered_or_cancelled(request, &cancel).await
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -310,6 +328,7 @@ mod tests {
     use tokio::{sync::Notify, time::timeout};
 
     use super::*;
+    use crate::ProofTaskController;
 
     #[derive(Clone, Debug)]
     struct MockWorkerClient {
@@ -516,6 +535,61 @@ mod tests {
         let result = timeout(Duration::from_secs(1), handle)
             .await
             .expect("submission task should finish after cancellation")
+            .expect("submission task should not panic");
+
+        assert!(matches!(result, Err(ProofSubmitterError::Cancelled)));
+        assert_eq!(client.submission_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn spawned_submitter_delivers_successfully() {
+        let client = MockWorkerClient::new(Vec::new());
+        let submitter = ProofSubmitter::new(client.clone());
+
+        let handle = submitter.spawn_until_delivered(submit_request(), CancellationToken::new());
+        let response = handle
+            .await
+            .expect("submission task should not panic")
+            .expect("submission should eventually succeed");
+
+        assert_eq!(response.job.status, ProofJobStatus::Succeeded);
+        assert_eq!(client.submission_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn spawned_submitter_stops_when_cancelled_before_submission() {
+        let client = MockWorkerClient::new(Vec::new());
+        let submitter = ProofSubmitter::new(client.clone());
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let handle = submitter.spawn_until_delivered(submit_request(), cancel);
+        let result = timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("cancelled submission task should finish")
+            .expect("submission task should not panic");
+
+        assert!(matches!(result, Err(ProofSubmitterError::Cancelled)));
+        assert_eq!(client.submission_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn task_controller_cancels_spawned_submission() {
+        let client = MockWorkerClient::new(vec![retryable_error()]);
+        let submitter = ProofSubmitter::new(client.clone()).with_backoff_config(
+            RetryConfig::unbounded(Duration::from_secs(60), Duration::from_secs(60)),
+        );
+        let controller = ProofTaskController::new();
+
+        let handle = controller.spawn_submission(&submitter, submit_request());
+        timeout(Duration::from_secs(1), client.wait_for_submission_count(1))
+            .await
+            .expect("first submission attempt should happen");
+        controller.cancel_submissions();
+
+        let result = timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("cancelled submission task should finish")
             .expect("submission task should not panic");
 
         assert!(matches!(result, Err(ProofSubmitterError::Cancelled)));

--- a/crates/proof/worker/src/task.rs
+++ b/crates/proof/worker/src/task.rs
@@ -1,0 +1,83 @@
+//! Worker proof submission task metadata and cancellation control.
+
+use base_prover_service_client::ProverWorkerProvider;
+use base_prover_service_protocol::{WorkerSubmitProofRequest, WorkerSubmitProofResponse};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::{ClaimedProofJobMetadata, ProofSubmitter, ProofSubmitterError};
+
+/// Handle for a proof submission task spawned after successful proof generation.
+#[derive(Debug)]
+pub struct ProofSubmissionTask {
+    /// Claim metadata for the proof job being submitted.
+    pub claim: ClaimedProofJobMetadata,
+    /// Spawned proof submission task.
+    pub submit_handle: JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>>,
+}
+
+impl ProofSubmissionTask {
+    /// Creates a submission task handle from claim metadata and a spawned task.
+    pub const fn new(
+        claim: ClaimedProofJobMetadata,
+        submit_handle: JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>>,
+    ) -> Self {
+        Self { claim, submit_handle }
+    }
+}
+
+/// Cancellation control for proof generation and submission handoff.
+#[derive(Debug, Clone)]
+pub struct ProofTaskController {
+    submission_cancel: CancellationToken,
+}
+
+impl ProofTaskController {
+    /// Creates a task controller with a fresh submission cancellation token.
+    pub fn new() -> Self {
+        Self { submission_cancel: CancellationToken::new() }
+    }
+
+    /// Uses a caller-provided cancellation token for spawned submission tasks.
+    #[must_use]
+    pub fn with_submission_cancel(mut self, submission_cancel: CancellationToken) -> Self {
+        self.submission_cancel = submission_cancel;
+        self
+    }
+
+    /// Returns the cancellation token used for spawned submission tasks.
+    pub const fn submission_cancel(&self) -> &CancellationToken {
+        &self.submission_cancel
+    }
+
+    /// Signals spawned submission tasks to stop during worker shutdown.
+    ///
+    /// This permanently cancels the controller's submission token. Treat the
+    /// controller as shutdown-only after calling this method; later calls to
+    /// [`Self::spawn_submission`] will create immediately-cancelled tasks.
+    pub fn cancel_submissions(&self) {
+        self.submission_cancel.cancel();
+    }
+
+    /// Spawns proof submission using the controller's cancellation token.
+    ///
+    /// Do not call this after [`Self::cancel_submissions`], because the shared
+    /// cancellation token is permanently cancelled during shutdown.
+    #[must_use = "dropping the JoinHandle detaches the submission task"]
+    pub fn spawn_submission<Client>(
+        &self,
+        submitter: &ProofSubmitter<Client>,
+        request: WorkerSubmitProofRequest,
+    ) -> JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>>
+    where
+        Client: Clone + ProverWorkerProvider + 'static,
+    {
+        submitter.spawn_until_delivered(request, self.submission_cancel.clone())
+    }
+}
+
+impl Default for ProofTaskController {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary

Adds shared spawned-submission task metadata and a ProofTaskController that owns submission cancellation, allowing proof hosts to hand off proof delivery and cancel background submissions during shutdown.