### PR TITLE
fix(precompile-macros): handle binary/octal/suffixed integer literals in parse_slot_value

### DIFF
--- a/crates/common/precompile-macros/src/utils.rs
+++ b/crates/common/precompile-macros/src/utils.rs
@@ -413,4 +413,28 @@ mod tests {
         let lit: Lit = parse_quote!(0x2au64);
         assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(42u64));
     }
+
+    #[test]
+    fn test_parse_slot_value_hex_with_underscores() {
+        let lit: Lit = parse_quote!(0xFF_FF);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(0xFFFFu64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_binary_with_underscores() {
+        let lit: Lit = parse_quote!(0b1010_0101);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(0b10100101u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_decimal_with_underscores() {
+        let lit: Lit = parse_quote!(1_000);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(1000u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_octal_with_underscores() {
+        let lit: Lit = parse_quote!(0o7_7);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(0o77u64));
+    }
 }

--- a/crates/common/precompile-macros/src/utils.rs
+++ b/crates/common/precompile-macros/src/utils.rs
@@ -16,19 +16,47 @@ type ExtractedAttributes = (Option<U256>, Option<U256>, Option<NamespaceInfo>);
 /// Parses a slot value from a literal.
 ///
 /// Supports:
-/// - Integer literals: decimal (`42`) or hexadecimal (`0x2a`)
+/// - Integer literals in any Rust base:
+///   - Decimal (`42`, `42u64`)
+///   - Hexadecimal (`0x2a`, `0x2au64`)
+///   - Binary (`0b101`, `0b101u64`)
+///   - Octal (`0o17`, `0o17u64`)
 /// - String literals: computes keccak256 hash of the string
 fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
     match value {
         Lit::Int(int) => {
-            let lit_str = int.to_string();
-            let slot = lit_str
-                .strip_prefix("0x")
-                .map_or_else(
-                    || U256::from_str_radix(&lit_str, 10),
-                    |hex| U256::from_str_radix(hex, 16),
-                )
-                .map_err(|_| syn::Error::new_spanned(int, "Invalid slot number"))?;
+            let raw = int.to_string();
+            // Strip any Rust integer type suffix (e.g. u64, usize, i32, …).
+            const SUFFIXES: &[&str] = &[
+                "u128", "u64", "u32", "u16", "u8", "usize", "i128", "i64", "i32", "i16", "i8",
+                "isize",
+            ];
+            let stripped =
+                SUFFIXES.iter().find_map(|s| raw.strip_suffix(s)).unwrap_or(raw.as_str());
+
+            let slot = if let Some(hex) =
+                stripped.strip_prefix("0x").or_else(|| stripped.strip_prefix("0X"))
+            {
+                // Hexadecimal literal.
+                let digits: String = hex.chars().filter(|&c| c != '_').collect();
+                U256::from_str_radix(&digits, 16)
+            } else if let Some(bin) =
+                stripped.strip_prefix("0b").or_else(|| stripped.strip_prefix("0B"))
+            {
+                // Binary literal.
+                let digits: String = bin.chars().filter(|&c| c != '_').collect();
+                U256::from_str_radix(&digits, 2)
+            } else if let Some(oct) =
+                stripped.strip_prefix("0o").or_else(|| stripped.strip_prefix("0O"))
+            {
+                // Octal literal.
+                let digits: String = oct.chars().filter(|&c| c != '_').collect();
+                U256::from_str_radix(&digits, 8)
+            } else {
+                // Decimal literal: use base10_digits() which already strips suffix and separators.
+                U256::from_str_radix(int.base10_digits(), 10)
+            }
+            .map_err(|_| syn::Error::new_spanned(int, "Invalid slot number"))?;
             Ok(slot)
         }
         Lit::Str(lit) => Ok(keccak256(lit.value().as_bytes()).into()),
@@ -348,5 +376,41 @@ mod tests {
     fn test_parse_namespace_id_rejects_whitespace() {
         let id: LitStr = parse_quote!("b20 policy");
         assert!(parse_namespace_id(id).is_err());
+    }
+
+    #[test]
+    fn test_parse_slot_value_decimal() {
+        let lit: Lit = parse_quote!(42);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(42u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_hex() {
+        let lit: Lit = parse_quote!(0x2a);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(42u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_binary() {
+        let lit: Lit = parse_quote!(0b101);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(5u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_octal() {
+        let lit: Lit = parse_quote!(0o17);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(15u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_decimal_with_suffix() {
+        let lit: Lit = parse_quote!(42u64);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(42u64));
+    }
+
+    #[test]
+    fn test_parse_slot_value_hex_with_suffix() {
+        let lit: Lit = parse_quote!(0x2au64);
+        assert_eq!(parse_slot_value(&lit).unwrap(), U256::from(42u64));
     }
 }


### PR DESCRIPTION
[BOP-388](https://linear.app/coinbase/issue/BOP-388)

## Motivation

`parse_slot_value` called `int.to_string()` on a `LitInt`, which preserves Rust base prefixes (`0b`, `0o`) and type suffixes (`u64`, `usize`, etc.). The function then only checked for a `0x` prefix before passing the string to `U256::from_str_radix` with radix 10. This caused valid Rust integer literals like `0b101`, `0o17`, and `42u64` to be incorrectly rejected with a misleading "Invalid slot number" error.

Cantina finding: https://cantina.xyz/code/c75e122d-bfec-4090-8ae7-2f591169e2b1/findings/36

## What changed

- Strip any Rust integer type suffix (`u8`, `u16`, `u32`, `u64`, `u128`, `usize`, `i8`, `i16`, `i32`, `i64`, `i128`, `isize`) from the raw `to_string()` output before inspecting the prefix.
- Dispatch to the correct `from_str_radix` radix based on prefix: `0x`/`0X` hex (16), `0b`/`0B` binary (2), `0o`/`0O` octal (8).
- Filter underscores before calling `from_str_radix` (ruint does not accept them in non-decimal inputs).
- Use `base10_digits()` for the decimal fallback, which already strips suffixes and underscore separators.
- Update the doc comment on `parse_slot_value` to list all four supported bases.
- Add unit tests for `0b101`, `0o17`, `42u64`, `0x2au64`, plain `42`, and `0x2a`.

## What was tried / considered

An alternative approach was to use `int.base10_digits()` for decimal and call `syn`'s own `LitInt::suffix()` to get the suffix, then inspect the prefix separately. However, `LitInt` does not expose `suffix()` in a way that makes prefix detection clean for non-decimal bases. The approach of stripping known suffixes from the raw `to_string()` result and dispatching on prefix is explicit and covers all cases without relying on undocumented syn internals.
