### PR TITLE
fix(succinct): replace unwrap() with ok_or_else in OPSuccinctDataFetcher to prevent panics on missing RPC data

### DIFF
--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -235,9 +235,9 @@ impl OPSuccinctDataFetcher {
         let block_data = stream::iter(start + 1..=end)
             .map(|block_number| async move {
                 let block =
-                    self.l2_provider.get_block_by_number(block_number.into()).await?.unwrap();
+                    self.l2_provider.get_block_by_number(block_number.into()).await?.ok_or_else(|| anyhow::anyhow!("block {block_number} not found on L2 RPC"))?;
                 let receipts =
-                    self.l2_provider.get_block_receipts(block_number.into()).await?.unwrap();
+                    self.l2_provider.get_block_receipts(block_number.into()).await?.ok_or_else(|| anyhow::anyhow!("receipts for block {block_number} not found on L2 RPC"))?;
                 let total_l1_fees: u128 =
                     receipts.iter().map(|tx| tx.l1_block_info.l1_fee.unwrap_or(0)).sum();
                 let total_tx_fees: u128 = receipts
@@ -762,7 +762,7 @@ impl OPSuccinctDataFetcher {
         let agreed_l2_output_root = keccak256(l2_output_encoded.abi_encode());
 
         // Get L2 claim data.
-        let l2_claim_block = l2_provider.get_block_by_number(l2_end_block.into()).await?.unwrap();
+        let l2_claim_block = l2_provider.get_block_by_number(l2_end_block.into()).await?.ok_or_else(|| anyhow::anyhow!("block {l2_end_block} not found on L2 RPC"))?;
         let l2_claim_state_root = l2_claim_block.header.state_root;
         let l2_claim_hash = l2_claim_block.header.hash;
         let l2_claim_storage_hash = l2_provider


### PR DESCRIPTION
markdown
## Description

`OPSuccinctDataFetcher` panics when the L2 RPC returns `null` for a requested block or receipts. Three `unwrap()` calls on `Option` values crash the proposer/proof utility instead of returning a recoverable error.

## Changes

- `get_l2_block_data_range`: replaced `.unwrap()` on block and receipt fetches (lines 238, 240) with `.ok_or_else()` returning a contextual error with the block number
- `get_host_args`: replaced `.unwrap()` on the end-block fetch (line 765) with `.ok_or_else()`, matching the existing start-block error handling pattern on the same function

All three now return `Err(...)` with the missing block/receipt number instead of panicking. The caller can retry, mark the range failed, or surface the error without crashing the process.

Closes #3488