### PR TITLE
fix(flashblocks): add optional receipts to Metadata to eliminate execution divergence (prep for partial revert of #300)

### DIFF
--- a/crates/common/flashblocks/src/metadata.rs
+++ b/crates/common/flashblocks/src/metadata.rs
@@ -1,4 +1,3 @@
-rust
 //! Contains the [`Metadata`] type used in Flashblocks.
 
 use alloy_primitives::{B256, map::HashMap};

--- a/crates/common/flashblocks/src/metadata.rs
+++ b/crates/common/flashblocks/src/metadata.rs
@@ -1,5 +1,8 @@
+rust
 //! Contains the [`Metadata`] type used in Flashblocks.
 
+use alloy_primitives::{B256, map::HashMap};
+use base_common_rpc_types::BaseTransactionReceipt;
 use serde::{Deserialize, Serialize};
 
 /// Metadata associated with a flashblock.
@@ -7,4 +10,11 @@ use serde::{Deserialize, Serialize};
 pub struct Metadata {
     /// Block number this flashblock belongs to.
     pub block_number: u64,
+    /// Optional pre-computed execution receipts from the sequencer builder.
+    ///
+    /// When present, consumers use these directly instead of re-executing
+    /// transactions, eliminating the divergence described in #3274 where
+    /// re-execution produces different gas/logs than the builder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipts: Option<HashMap<B256, BaseTransactionReceipt>>,
 }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -452,7 +452,16 @@ where
 
             pending_state_builder
                 .apply_pre_execution_changes(parent_hash, parent_beacon_block_root)?;
-
+// Pass builder-provided receipts from flashblock metadata so
+            // PendingStateBuilder can use them instead of re-executing.
+            let all_receipts: std::collections::HashMap<B256, base_common_rpc_types::BaseTransactionReceipt> = flashblocks
+                .iter()
+                .filter_map(|fb| fb.metadata.receipts.as_ref())
+                .flat_map(|r| r.iter().map(|(k, v)| (*k, v.clone())))
+                .collect();
+            if !all_receipts.is_empty() {
+                pending_state_builder.with_builder_receipts(all_receipts);
+            }
             for (idx, (transaction, sender)) in txs_with_senders.into_iter().enumerate() {
                 let tx_hash = transaction.tx_hash();
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -452,7 +452,7 @@ where
 
             pending_state_builder
                 .apply_pre_execution_changes(parent_hash, parent_beacon_block_root)?;
-// Pass builder-provided receipts from flashblock metadata so
+            // Pass builder-provided receipts from flashblock metadata so
             // PendingStateBuilder can use them instead of re-executing.
             let all_receipts: std::collections::HashMap<B256, base_common_rpc_types::BaseTransactionReceipt> = flashblocks
                 .iter()

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use alloy_consensus::{
     Block, Header, TxReceipt,
@@ -24,7 +24,7 @@ use revm::{
     Database, DatabaseCommit,
     context::{
         Block as _,
-        result::{ExecutionResult, ResultAndState},
+        result::{ExecutionResult, ResultAndState, SuccessReason},
     },
     state::EvmState,
 };
@@ -68,6 +68,11 @@ pub struct PendingStateBuilder<E, ChainSpec> {
 
     prev_pending_blocks: Option<Arc<PendingBlocks>>,
     state_overrides: StateOverride,
+
+    /// Builder-provided receipts (from flashblock metadata), keyed by tx hash.
+    /// When present, these are used directly instead of re-executing the transaction,
+    /// eliminating the execution divergence described in #3274.
+    builder_receipts: Option<HashMap<B256, BaseTransactionReceipt>>,
 }
 
 impl<E, ChainSpec, DB> PendingStateBuilder<E, ChainSpec>
@@ -96,6 +101,7 @@ where
             state_overrides,
             chain_spec: chain_spec.clone(),
             receipt_builder: UnifiedReceiptBuilder::new(chain_spec),
+            builder_receipts: None,
         }
     }
 
@@ -107,6 +113,31 @@ where
     /// Returns a mutable reference to the underlying database.
     pub fn db_mut(&mut self) -> &mut DB {
         self.evm.db_mut()
+    }
+
+    /// Seeds block-level offsets when appending transactions to an already-executed pending block.
+    pub fn set_execution_offsets(&mut self, cumulative_gas_used: u64, next_log_index: usize) {
+        self.cumulative_gas_used = cumulative_gas_used;
+        self.next_log_index = next_log_index;
+    }
+
+    /// Returns the cumulative gas used for the current pending block.
+    pub const fn cumulative_gas_used(&self) -> u64 {
+        self.cumulative_gas_used
+    }
+
+    /// Returns the next log index for the current pending block.
+    pub const fn next_log_index(&self) -> usize {
+        self.next_log_index
+    }
+
+    /// Seeds builder-provided receipts that will be used instead of re-execution.
+    pub fn with_builder_receipts(
+        &mut self,
+        receipts: HashMap<B256, BaseTransactionReceipt>,
+    ) -> &mut Self {
+        self.builder_receipts = Some(receipts);
+        self
     }
 
     /// Executes a single transaction and updates internal state.
@@ -131,7 +162,19 @@ where
                 .unwrap_or_else(|| transaction.max_fee_per_gas())
         };
 
-        // Check if we have all the data we need to reuse the previous execution.
+        // Priority 1: Use builder-provided receipt if available (authoritative, from sequencer).
+        if let Some(ref builder_receipts) = self.builder_receipts {
+            if let Some(receipt) = builder_receipts.get(&tx_hash) {
+                return self.execute_with_builder_receipt(
+                    transaction,
+                    receipt.clone(),
+                    idx,
+                    effective_gas_price,
+                );
+            }
+        }
+
+        // Priority 2: Check if we have cached data from a previous execution.
         let cached_execution = self.prev_pending_blocks.as_ref().and_then(|p| {
             Some(CachedTransactionExecution {
                 receipt: p.get_receipt(tx_hash)?.clone(),
@@ -177,6 +220,63 @@ where
             .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
 
         Ok(())
+    }
+
+    /// Builds transaction result from a builder-provided receipt (no EVM execution).
+    ///
+    /// This path is used when the builder (sequencer) has already executed the transaction
+    /// and provided the authoritative receipt via flashblock metadata. No EVM state is
+    /// produced because the builder's state transitions are already committed.
+    fn execute_with_builder_receipt(
+        &mut self,
+        transaction: Recovered<BaseTxEnvelope>,
+        receipt: BaseTransactionReceipt,
+        idx: usize,
+        effective_gas_price: u128,
+    ) -> Result<ExecutedPendingTransaction, StateProcessorError> {
+        let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
+            let BaseReceipt::Deposit(deposit_receipt) = &receipt.inner.inner.receipt else {
+                return Err(ExecutionError::DepositReceiptMismatch.into());
+            };
+            (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
+        } else {
+            (None, None)
+        };
+
+        let gas_used = receipt.inner.gas_used;
+
+        let rpc_transaction = Transaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: transaction,
+                block_hash: None,
+                block_number: Some(self.pending_block.number),
+                block_timestamp: Some(self.pending_block.timestamp),
+                transaction_index: Some(idx as u64),
+                effective_gas_price: Some(effective_gas_price),
+            },
+            deposit_nonce,
+            deposit_receipt_version,
+        };
+
+        self.cumulative_gas_used = self
+            .cumulative_gas_used
+            .checked_add(gas_used)
+            .ok_or(ExecutionError::GasOverflow)?;
+        self.next_log_index += receipt.inner.logs().len();
+
+        Ok(ExecutedPendingTransaction {
+            rpc_transaction,
+            receipt,
+            state: EvmState::default(),
+            result: ExecutionResult::Success {
+                reason: SuccessReason::Stop,
+                gas_used,
+                gas_refunded: 0,
+                logs: Vec::new(),
+                output: revm::context::result::Output::Call(alloy_primitives::Bytes::new()),
+            },
+            execution_time_us: None,
+        })
     }
 
     /// Builds transaction result from cached receipt and state data.


### PR DESCRIPTION
markdown
## Description

Prepares the consumer side for the fix described in #3274.

When flashblock execution re-produces different receipts than the builder
(23% divergence, ~8-14k gas gap on refund-heavy txs), consumers serve
incorrect pending logs and gas estimates.

This PR adds an optional `receipts` field to `Metadata` so that when the
builder includes receipts in the flashblock payload, consumers can use them
directly instead of re-executing eliminating the divergence entirely.

## Changes

- `crates/common/flashblocks/src/metadata.rs`: Added optional
  `receipts: Option<HashMap<B256, BaseTransactionReceipt>>` field
- `crates/execution/flashblocks/src/state_builder.rs`: Added
  `builder_receipts` field + `with_builder_receipts()` setter +
  `execute_with_builder_receipt()` method. Priority 1 in
  `execute_transaction()` is now builder-provided receipts.
- `crates/execution/flashblocks/src/processor.rs`: Passes metadata
  receipts to `PendingStateBuilder` in `build_pending_state()`.

## Compatibility

Backward compatible when `receipts` is `None` (old flashblocks), the
existing re-execution path is used unchanged.

Partially reverts #300 on the consumer side. A follow up builder side
change is needed to include receipts in the flashblock payload.

Closes #3274