### PR TITLE
feat(trie/rocksdb): implement RocksDB read path, cursors, and node wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4682,6 +4682,7 @@ dependencies = [
  "base-metrics",
  "bincode 2.0.1",
  "bytes",
+ "criterion",
  "derive_more 2.1.1",
  "eyre",
  "metrics",
@@ -5925,9 +5926,7 @@ dependencies = [
 name = "base-proofs-extension"
 version = "0.0.0"
 dependencies = [
- "base-common-consensus",
  "base-execution-exex",
- "base-execution-payload-builder",
  "base-execution-rpc",
  "base-execution-trie",
  "base-node-core",

--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -10,7 +10,7 @@
 //! - `per_flashblock` (`calculate_state_root = true`) — state root
 //!   recomputed from scratch after every flashblock.
 //!
-//! The benchmarks use an MDBX-backed [`MdbxProofsStorage`] pre-populated with
+//! The benchmarks use a RocksDB-backed [`RocksdbProofsStorage`] pre-populated with
 //! 50k base-state accounts so that state root computation exercises real disk
 //! I/O through the production trie overlay path.
 //!
@@ -25,7 +25,7 @@ use std::{hint::black_box, sync::Arc};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorage, MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorage, RocksdbProofsStorage,
     provider::BaseProofsStateProviderRef,
 };
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -41,7 +41,7 @@ const FLASHBLOCKS: usize = 10;
 /// Storage slots per account.
 const SLOTS_PER_ACCOUNT: usize = 5;
 
-/// Number of pre-existing accounts in the MDBX base state.
+/// Number of pre-existing accounts in the `RocksDB` base state.
 ///
 /// This simulates a realistic chain state where the trie already contains
 /// existing accounts before any flashblock deltas are applied.
@@ -105,12 +105,13 @@ fn setup_flashblock_data(
     (deltas, full_state)
 }
 
-/// Creates an MDBX-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
+/// Creates a RocksDB-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
 /// accounts and their storage slots. Returns the temp directory handle (must be
 /// kept alive) and the wrapped storage.
-fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStorage>>) {
+fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<RocksdbProofsStorage>>) {
     let dir = TempDir::new().expect("failed to create temp dir");
-    let mdbx = Arc::new(MdbxProofsStorage::new(dir.path()).expect("failed to create MDBX storage"));
+    let rocksdb =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("failed to create RocksDB storage"));
 
     // Generate base state accounts.
     let mut rng = StdRng::seed_from_u64(42);
@@ -119,19 +120,21 @@ fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStora
     // Pre-populate hashed accounts.
     let hashed_accounts: Vec<(B256, Option<Account>)> =
         accounts.iter().map(|(addr, acct, _)| (*addr, Some(*acct))).collect();
-    mdbx.store_hashed_accounts(hashed_accounts).expect("failed to store hashed accounts");
+    rocksdb.store_hashed_accounts(hashed_accounts).expect("failed to store hashed accounts");
 
     // Pre-populate hashed storages.
     for (addr, _, slots) in &accounts {
         let slot_data: Vec<(B256, U256)> = slots.iter().map(|(k, v)| (*k, *v)).collect();
-        mdbx.store_hashed_storages(*addr, slot_data).expect("failed to store hashed storages");
+        rocksdb.store_hashed_storages(*addr, slot_data).expect("failed to store hashed storages");
     }
 
     // Set initial state anchor and commit.
-    mdbx.set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO)).expect("failed to set anchor");
-    mdbx.commit_initial_state().expect("failed to commit initial state");
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("failed to set anchor");
+    rocksdb.commit_initial_state().expect("failed to commit initial state");
 
-    let storage = BaseProofsStorage::from(mdbx);
+    let storage = BaseProofsStorage::from(rocksdb);
     (dir, storage)
 }
 

--- a/crates/execution/cli/src/commands/base_proofs/init.rs
+++ b/crates/execution/cli/src/commands/base_proofs/init.rs
@@ -5,8 +5,10 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStore, InitializationJob, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, InitializationJob,
+    MdbxProofsStorage, RocksdbProofsStorage,
 };
+use base_node_core::args::{ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs};
 use clap::Parser;
 use reth_chainspec::ChainInfo;
 use reth_cli::chainspec::ChainSpecParser;
@@ -34,6 +36,14 @@ pub struct InitCommand<C: ChainSpecParser> {
         required = true
     )]
     pub storage_path: PathBuf,
+
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
 }
 
 impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
@@ -42,19 +52,52 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {
+        let Self { env, storage_path, proofs_history_db, proofs_history_rocksdb } = self;
+
         info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Initializing Base proofs storage");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Initializing Base proofs storage"
+        );
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO, runtime)?;
 
-        // Create the proofs storage
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &storage_path,
+                        proofs_history_rocksdb.storage_options(),
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::initialize_storage(storage, &provider_factory)?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::initialize_storage(storage, &provider_factory)?;
+            }
+        }
 
+        Ok(())
+    }
+
+    fn initialize_storage<S, F>(
+        storage: BaseProofsStorage<Arc<S>>,
+        provider_factory: &F,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsInitialStateStore + BaseProofsStore + 'static,
+        F: BlockNumReader + DatabaseProviderFactory,
+    {
         // Check if already initialized
         if let Some((block_number, block_hash)) = storage.get_earliest_block_number()? {
             info!(

--- a/crates/execution/cli/src/commands/base_proofs/prune.rs
+++ b/crates/execution/cli/src/commands/base_proofs/prune.rs
@@ -5,7 +5,12 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage,
+    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, MdbxProofsStorage,
+    RocksdbProofsStorage,
+};
+use base_node_core::{
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs,
+    TWELVE_HOURS_IN_BLOCKS,
 };
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
@@ -27,21 +32,36 @@ pub struct PruneCommand<C: ChainSpecParser> {
     )]
     pub storage_path: PathBuf,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
+    ///
+    /// Must be greater than 12 hours of blocks based on 2 seconds block time.
     #[arg(
         long = "proofs-history.window",
-        default_value_t = 1_296_000,
-        value_name = "PROOFS_HISTORY_WINDOW"
+        default_value_t = DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        value_name = "PROOFS_HISTORY_WINDOW",
+        value_parser = clap::value_parser!(u64).range((TWELVE_HOURS_IN_BLOCKS + 1)..)
     )]
     pub proofs_history_window: u64,
 
     /// The batch size for pruning operations.
+    ///
+    /// Each batch materializes up to this many blocks of change-set keys before committing, so
+    /// reduce this value to bound memory usage when pruning a large range.
     #[arg(
         long = "proofs-history.prune-batch-size",
         default_value_t = 1000,
-        value_name = "PROOFS_HISTORY_PRUNE_BATCH_SIZE"
+        value_name = "PROOFS_HISTORY_PRUNE_BATCH_SIZE",
+        value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub proofs_history_prune_batch_size: u64,
 }
@@ -52,18 +72,70 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {
+        let Self {
+            env,
+            storage_path,
+            proofs_history_db,
+            proofs_history_rocksdb,
+            proofs_history_window,
+            proofs_history_prune_batch_size,
+        } = self;
+
         info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Pruning Base proofs storage");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Pruning Base proofs storage"
+        );
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO, runtime)?;
 
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &storage_path,
+                        proofs_history_rocksdb.storage_options(),
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::prune_storage(
+                    storage,
+                    provider_factory,
+                    proofs_history_window,
+                    proofs_history_prune_batch_size,
+                )?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::prune_storage(
+                    storage,
+                    provider_factory,
+                    proofs_history_window,
+                    proofs_history_prune_batch_size,
+                )?;
+            }
+        }
 
+        Ok(())
+    }
+    fn prune_storage<S, H>(
+        storage: BaseProofsStorage<Arc<S>>,
+        hash_reader: H,
+        proofs_history_window: u64,
+        proofs_history_prune_batch_size: u64,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsStore + 'static,
+        H: reth_provider::BlockHashReader,
+    {
         let earliest_block = storage.get_earliest_block_number()?;
         let latest_block = storage.get_latest_block_number()?;
         info!(
@@ -75,9 +147,9 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
 
         let pruner = BaseProofStoragePruner::new(
             storage,
-            provider_factory,
-            self.proofs_history_window,
-            self.proofs_history_prune_batch_size,
+            hash_reader,
+            proofs_history_window,
+            proofs_history_prune_batch_size,
         );
         pruner.run();
         Ok(())

--- a/crates/execution/cli/src/commands/base_proofs/unwind.rs
+++ b/crates/execution/cli/src/commands/base_proofs/unwind.rs
@@ -4,11 +4,14 @@ use std::{path::PathBuf, sync::Arc};
 
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_trie::{BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage};
+use base_execution_trie::{
+    BaseProofsStorage, BaseProofsStore, MdbxProofsStorage, RocksdbProofsStorage,
+};
+use base_node_core::args::{ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs};
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
-use reth_node_core::version::version_metadata;
+use reth_node_core::{primitives::AlloyBlockHeader as _, version::version_metadata};
 use reth_provider::{BlockReader, TransactionVariant};
 use tracing::{info, warn};
 
@@ -28,17 +31,97 @@ pub struct UnwindCommand<C: ChainSpecParser> {
     )]
     pub storage_path: PathBuf,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "rocksdb")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
+
     /// The target block number to unwind to.
     ///
-    /// All history *after* this block will be removed.
+    /// All history *at and after* this block will be removed.
     #[arg(long, value_name = "TARGET_BLOCK")]
     pub target: u64,
 }
 
-impl<C: ChainSpecParser> UnwindCommand<C> {
+impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
+    /// Execute [`UnwindCommand`].
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
+        self,
+        runtime: reth_tasks::Runtime,
+    ) -> eyre::Result<()> {
+        let Self { env, storage_path, proofs_history_db, proofs_history_rocksdb, target } = self;
+
+        info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Unwinding Base proofs storage"
+        );
+
+        // Initialize the environment with read-only access
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO, runtime)?;
+
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &storage_path,
+                        proofs_history_rocksdb.storage_options(),
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::unwind_storage(target, &provider_factory, storage)?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::unwind_storage(target, &provider_factory, storage)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn unwind_storage<S, P>(
+        target: u64,
+        provider_factory: &P,
+        storage: BaseProofsStorage<Arc<S>>,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsStore + 'static,
+        P: BlockReader,
+    {
+        // Validate that the target block is within a valid range for unwinding
+        if !Self::validate_unwind_range(target, &storage)? {
+            return Ok(());
+        }
+
+        // Get the target block from the main database
+        let block = provider_factory
+            .recovered_block(target.into(), TransactionVariant::NoHash)?
+            .ok_or_else(|| eyre::eyre!("Target block {} not found in the main database", target))?;
+
+        info!(
+            target: "reth::cli",
+            block_number = block.number(),
+            block_hash = %block.hash(),
+            "Unwinding to target block"
+        );
+        storage.unwind_history(block.block_with_parent())?;
+        Ok(())
+    }
+
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: BaseProofsStore>(
-        &self,
+        target: u64,
         storage: &BaseProofsStorage<Store>,
     ) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
@@ -48,55 +131,17 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
             return Ok(false);
         };
 
-        if self.target <= earliest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
+        if target <= earliest {
+            warn!(target: "reth::cli", unwind_target = ?target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
-        if self.target > latest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
+        if target > latest {
+            warn!(target: "reth::cli", unwind_target = ?target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
         Ok(true)
-    }
-}
-
-impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
-    /// Execute [`UnwindCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
-        self,
-        runtime: reth_tasks::Runtime,
-    ) -> eyre::Result<()> {
-        info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Unwinding Base proofs storage");
-
-        // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
-
-        // Create the proofs storage
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
-
-        // Validate that the target block is within a valid range for unwinding
-        if !self.validate_unwind_range(&storage)? {
-            return Ok(());
-        }
-
-        // Get the target block from the main database
-        let block = provider_factory
-            .recovered_block(self.target.into(), TransactionVariant::NoHash)?
-            .ok_or_else(|| {
-                eyre::eyre!("Target block {} not found in the main database", self.target)
-            })?;
-
-        info!(target: "reth::cli", block_number = block.number, block_hash = %block.hash(), "Unwinding to target block");
-        storage.unwind_history(block.block_with_parent())?;
-
-        Ok(())
     }
 }
 

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -36,8 +36,12 @@ use tracing::{debug, error, info};
 /// [`BaseProofsExExBuilder::with_max_prune_blocks_startup`].
 const DEFAULT_MAX_PRUNE_BLOCKS_STARTUP: u64 = 100_000;
 
-/// How many blocks to process in a single batch before yielding. Default is 50 blocks.
-const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
+/// How many blocks to process in a single sync turn before yielding.
+const SYNC_BLOCKS_PER_TURN: usize = 50;
+
+fn sync_turn_end(latest: u64, target: u64) -> u64 {
+    latest.saturating_add(SYNC_BLOCKS_PER_TURN as u64).min(target)
+}
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -135,7 +139,7 @@ where
 /// use base_execution_chainspec::BaseChainSpec;
 /// use base_execution_exex::BaseProofsExEx;
 /// use base_node_core::{BaseNode, args::RollupArgs};
-/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, db::MdbxProofsStorage};
+/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, RocksdbProofsStorage};
 /// use reth_provider::providers::BlockchainProvider;
 /// use std::{sync::Arc, time::Duration};
 ///
@@ -152,8 +156,8 @@ where
 /// # let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
 /// # let storage_path = temp_dir.path().join("proofs_storage");
 ///
-/// # let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-/// #    MdbxProofsStorage::new(&storage_path).expect("Failed to create MdbxProofsStorage"),
+/// # let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+/// #    RocksdbProofsStorage::new(&storage_path).expect("Failed to create RocksdbProofsStorage"),
 /// # ).into();
 ///
 /// let storage_exec = storage.clone();
@@ -459,14 +463,14 @@ where
                 return;
             }
 
-            let end = (latest + SYNC_BLOCKS_BATCH_SIZE as u64).min(target);
+            let end = sync_turn_end(latest, target);
             info!(
                 target: "base::exex",
                 start = latest + 1,
                 end,
                 target,
-                batch_size = end - latest,
-                "Processing proofs storage sync batch"
+                blocks = end - latest,
+                "Processing proofs storage sync turn"
             );
 
             let mut batch: Vec<BatchBlock<Primitives>> =
@@ -709,7 +713,7 @@ mod tests {
     use alloy_consensus::private::alloy_primitives::B256;
     use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
     use base_execution_trie::{
-        BaseProofsStorage, BaseProofsStore, BlockStateDiff, db::MdbxProofsStorage,
+        BaseProofsStorage, BaseProofsStore, BlockStateDiff, RocksdbProofsStorage,
     };
     use reth_db::test_utils::tempdir_path;
     use reth_ethereum_primitives::{Block, Receipt};
@@ -818,12 +822,21 @@ mod tests {
             .build()
     }
 
+    #[test]
+    fn sync_turn_end_advances_up_to_sync_blocks_per_turn() {
+        assert_eq!(sync_turn_end(0, 10), 10);
+        assert_eq!(sync_turn_end(9, 10), 10);
+        assert_eq!(sync_turn_end(10, 10), 10);
+        assert_eq!(sync_turn_end(0, 1000), SYNC_BLOCKS_PER_TURN as u64);
+        assert_eq!(sync_turn_end(50, 1000), 100);
+    }
+
     #[tokio::test]
     async fn handle_notification_chain_committed() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -849,8 +862,8 @@ mod tests {
     async fn handle_notification_chain_committed_caches_already_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -883,8 +896,8 @@ mod tests {
     async fn handle_notification_chain_reorged() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -927,8 +940,8 @@ mod tests {
     async fn handle_notification_chain_reorged_beyond_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -967,8 +980,8 @@ mod tests {
     async fn handle_notification_chain_reverted() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -1005,8 +1018,8 @@ mod tests {
     async fn handle_notification_chain_reverted_beyond_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 5, &proofs);
@@ -1043,8 +1056,8 @@ mod tests {
     async fn ensure_initialized_errors_on_storage_not_initialized() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -1057,8 +1070,8 @@ mod tests {
     async fn ensure_initialized_errors_when_prune_exceeds_threshold() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1085,8 +1098,8 @@ mod tests {
     async fn ensure_initialized_succeeds() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1101,8 +1114,8 @@ mod tests {
     async fn handle_notification_schedules_async_on_gap() {
         // MDBX proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -4,7 +4,27 @@
 
 use std::{path::PathBuf, time::Duration};
 
-use clap::{ValueEnum, builder::ArgPredicate};
+use base_execution_trie::RocksdbProofsStorageOptions;
+use clap::{ArgAction, ValueEnum, builder::ArgPredicate};
+
+/// Default proofs history window: 1 month of blocks at 2s block time.
+pub const DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS: u64 = 1_296_000;
+
+/// Twelve hours of blocks at 2s block time.
+pub const TWELVE_HOURS_IN_BLOCKS: u64 = 21_600;
+
+const MIB: u64 = 1024 * 1024;
+const DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_MIB: u64 = 1024;
+const DEFAULT_ROCKSDB_BYTES_PER_SYNC_MIB: u64 = 1;
+const DEFAULT_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB: u64 = 0;
+const DEFAULT_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: i32 = 4;
+const DEFAULT_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER: i32 = 20;
+const DEFAULT_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER: i32 = 36;
+const DEFAULT_ROCKSDB_MAX_BACKGROUND_JOBS: i32 = 4;
+const DEFAULT_ROCKSDB_MAX_SUBCOMPACTIONS: u32 = 1;
+const DEFAULT_ROCKSDB_MAX_WRITE_BUFFER_NUMBER: i32 = 3;
+const DEFAULT_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB: u64 = 256;
+const DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB: u64 = 64;
 
 /// Transaction ordering strategy for the mempool.
 ///
@@ -23,6 +43,194 @@ pub enum TxpoolOrdering {
     /// Transactions are ordered by when they were received by the mempool,
     /// regardless of the fees they offer.
     Timestamp,
+}
+
+/// On-disk database backend for proofs history.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ProofsHistoryDbBackend {
+    /// Store proofs history in `RocksDB`. Also accepted as `v2`.
+    #[value(alias = "v2")]
+    Rocksdb,
+    /// Store proofs history in `MDBX`.
+    #[default]
+    Mdbx,
+}
+
+/// Runtime tuning options for the `RocksDB` proofs history backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::Args)]
+pub struct ProofsHistoryRocksdbArgs {
+    /// `RocksDB` block cache size in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.block-cache-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_BLOCK_CACHE_SIZE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_MIB,
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub block_cache_size_mib: u64,
+
+    /// Bytes-per-sync threshold in `MiB`. Set 0 to disable.
+    #[arg(
+        long = "proofs-history.rocksdb.bytes-per-sync-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_BYTES_PER_SYNC_MIB",
+        default_value_t = DEFAULT_ROCKSDB_BYTES_PER_SYNC_MIB,
+        hide = true
+    )]
+    pub bytes_per_sync_mib: u64,
+
+    /// Readahead size in `MiB` for compaction input reads. Set 0 to disable.
+    #[arg(
+        long = "proofs-history.rocksdb.compaction-readahead-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB,
+        hide = true
+    )]
+    pub compaction_readahead_size_mib: u64,
+
+    /// Number of L0 files that triggers compaction.
+    #[arg(
+        long = "proofs-history.rocksdb.level-zero-file-num-compaction-trigger",
+        value_name = "PROOFS_HISTORY_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER",
+        default_value_t = DEFAULT_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub level_zero_file_num_compaction_trigger: i32,
+
+    /// Number of L0 files that triggers write slowdown. Set 0 to disable slowdown.
+    #[arg(
+        long = "proofs-history.rocksdb.level-zero-slowdown-writes-trigger",
+        value_name = "PROOFS_HISTORY_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER",
+        default_value_t = DEFAULT_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER,
+        value_parser = clap::value_parser!(i32).range(0..),
+        hide = true
+    )]
+    pub level_zero_slowdown_writes_trigger: i32,
+
+    /// Number of L0 files that stops writes.
+    #[arg(
+        long = "proofs-history.rocksdb.level-zero-stop-writes-trigger",
+        value_name = "PROOFS_HISTORY_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER",
+        default_value_t = DEFAULT_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub level_zero_stop_writes_trigger: i32,
+
+    /// Maximum `RocksDB` background jobs for proof history.
+    #[arg(
+        long = "proofs-history.rocksdb.max-background-jobs",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_BACKGROUND_JOBS",
+        default_value_t = DEFAULT_ROCKSDB_MAX_BACKGROUND_JOBS,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub max_background_jobs: i32,
+
+    /// Maximum subcompactions per compaction.
+    #[arg(
+        long = "proofs-history.rocksdb.max-subcompactions",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_SUBCOMPACTIONS",
+        default_value_t = DEFAULT_ROCKSDB_MAX_SUBCOMPACTIONS,
+        value_parser = clap::value_parser!(u32).range(1..),
+        hide = true
+    )]
+    pub max_subcompactions: u32,
+
+    /// Maximum total WAL size in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.max-total-wal-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_TOTAL_WAL_SIZE_MIB",
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub max_total_wal_size_mib: Option<u64>,
+
+    /// Maximum write buffers per proof-history column family.
+    #[arg(
+        long = "proofs-history.rocksdb.max-write-buffer-number",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_WRITE_BUFFER_NUMBER",
+        default_value_t = DEFAULT_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub max_write_buffer_number: i32,
+
+    /// Base target SST file size in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.target-file-size-base-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB,
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub target_file_size_base_mib: u64,
+
+    /// Write buffer size per proof-history column family in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.write-buffer-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_WRITE_BUFFER_SIZE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB,
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub write_buffer_size_mib: u64,
+
+    /// Enable direct I/O for `RocksDB` flush and compaction.
+    #[arg(
+        long = "proofs-history.rocksdb.direct-io-for-flush-and-compaction",
+        default_value_t = true,
+        action = ArgAction::Set,
+        hide = true
+    )]
+    pub direct_io_for_flush_and_compaction: bool,
+}
+
+impl Default for ProofsHistoryRocksdbArgs {
+    fn default() -> Self {
+        Self {
+            block_cache_size_mib: DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_MIB,
+            bytes_per_sync_mib: DEFAULT_ROCKSDB_BYTES_PER_SYNC_MIB,
+            compaction_readahead_size_mib: DEFAULT_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB,
+            level_zero_file_num_compaction_trigger:
+                DEFAULT_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
+            level_zero_slowdown_writes_trigger: DEFAULT_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER,
+            level_zero_stop_writes_trigger: DEFAULT_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER,
+            max_background_jobs: DEFAULT_ROCKSDB_MAX_BACKGROUND_JOBS,
+            max_subcompactions: DEFAULT_ROCKSDB_MAX_SUBCOMPACTIONS,
+            max_total_wal_size_mib: None,
+            max_write_buffer_number: DEFAULT_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,
+            target_file_size_base_mib: DEFAULT_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB,
+            write_buffer_size_mib: DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB,
+            direct_io_for_flush_and_compaction: true,
+        }
+    }
+}
+
+impl ProofsHistoryRocksdbArgs {
+    /// Converts CLI arguments into storage options.
+    pub fn storage_options(self) -> RocksdbProofsStorageOptions {
+        RocksdbProofsStorageOptions {
+            block_cache_size: mib_to_usize(self.block_cache_size_mib),
+            bytes_per_sync: self.bytes_per_sync_mib.saturating_mul(MIB),
+            compaction_readahead_size: mib_to_usize(self.compaction_readahead_size_mib),
+            level_zero_file_num_compaction_trigger: self.level_zero_file_num_compaction_trigger,
+            level_zero_slowdown_writes_trigger: self.level_zero_slowdown_writes_trigger,
+            level_zero_stop_writes_trigger: self.level_zero_stop_writes_trigger,
+            max_background_jobs: self.max_background_jobs,
+            max_subcompactions: self.max_subcompactions,
+            max_total_wal_size: self.max_total_wal_size_mib.map(|size| size.saturating_mul(MIB)),
+            max_write_buffer_number: self.max_write_buffer_number,
+            target_file_size_base: self.target_file_size_base_mib.saturating_mul(MIB),
+            write_buffer_size: mib_to_usize(self.write_buffer_size_mib),
+            use_direct_io_for_flush_and_compaction: self.direct_io_for_flush_and_compaction,
+        }
+    }
+}
+
+fn mib_to_usize(size_mib: u64) -> usize {
+    usize::try_from(size_mib.saturating_mul(MIB)).unwrap_or(usize::MAX)
 }
 
 /// Parameters for rollup configuration
@@ -89,13 +297,24 @@ pub struct RollupArgs {
     #[arg(long = "proofs-history.storage-path", value_name = "PROOFS_HISTORY_STORAGE_PATH")]
     pub proofs_history_storage_path: Option<PathBuf>,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "mdbx")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
+    ///
+    /// Must be greater than 12 hours of blocks based on 2 seconds block time.
     #[arg(
         long = "proofs-history.window",
-        default_value_t = 1_296_000,
-        value_name = "PROOFS_HISTORY_WINDOW"
+        default_value_t = DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        value_name = "PROOFS_HISTORY_WINDOW",
+        value_parser = clap::value_parser!(u64).range((TWELVE_HOURS_IN_BLOCKS + 1)..)
     )]
     pub proofs_history_window: u64,
 
@@ -118,6 +337,7 @@ pub struct RollupArgs {
         value_parser = humantime::parse_duration
     )]
     pub proofs_history_prune_interval: Duration,
+
     /// Verification interval: perform full block execution every N blocks for data integrity.
     /// - 0: Disabled (Default) (always use fast path with pre-computed data from notifications)
     /// - 1: Always verify (always execute blocks, slowest)
@@ -148,7 +368,9 @@ impl Default for RollupArgs {
             max_inflight_delegated_slots: 1,
             proofs_history: false,
             proofs_history_storage_path: None,
-            proofs_history_window: 1_296_000,
+            proofs_history_db: ProofsHistoryDbBackend::default(),
+            proofs_history_rocksdb: Default::default(),
+            proofs_history_window: DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
         }
@@ -157,7 +379,7 @@ impl Default for RollupArgs {
 
 #[cfg(test)]
 mod tests {
-    use clap::{Args, Parser};
+    use clap::{Args, CommandFactory, Parser};
 
     use super::*;
 
@@ -270,5 +492,114 @@ mod tests {
         ])
         .args;
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_default() {
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_v2_alias() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.db", "v2"]).args;
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Rocksdb);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_mdbx() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history",
+            "--proofs-history.db",
+            "mdbx",
+        ])
+        .args;
+        assert!(args.proofs_history);
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_without_enabling_history() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.db", "mdbx"]).args;
+        assert!(!args.proofs_history);
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_rocksdb_tuning_options() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history.rocksdb.block-cache-size-mib",
+            "256",
+            "--proofs-history.rocksdb.bytes-per-sync-mib",
+            "4",
+            "--proofs-history.rocksdb.compaction-readahead-size-mib",
+            "8",
+            "--proofs-history.rocksdb.level-zero-file-num-compaction-trigger",
+            "6",
+            "--proofs-history.rocksdb.level-zero-slowdown-writes-trigger",
+            "0",
+            "--proofs-history.rocksdb.level-zero-stop-writes-trigger",
+            "64",
+            "--proofs-history.rocksdb.max-background-jobs",
+            "2",
+            "--proofs-history.rocksdb.max-subcompactions",
+            "2",
+            "--proofs-history.rocksdb.max-total-wal-size-mib",
+            "1024",
+            "--proofs-history.rocksdb.max-write-buffer-number",
+            "4",
+            "--proofs-history.rocksdb.target-file-size-base-mib",
+            "512",
+            "--proofs-history.rocksdb.write-buffer-size-mib",
+            "128",
+            "--proofs-history.rocksdb.direct-io-for-flush-and-compaction",
+            "false",
+        ])
+        .args;
+
+        let options = args.proofs_history_rocksdb.storage_options();
+        assert_eq!(options.block_cache_size, mib_to_usize(256));
+        assert_eq!(options.bytes_per_sync, 4 * MIB);
+        assert_eq!(options.compaction_readahead_size, mib_to_usize(8));
+        assert_eq!(options.level_zero_file_num_compaction_trigger, 6);
+        assert_eq!(options.level_zero_slowdown_writes_trigger, 0);
+        assert_eq!(options.level_zero_stop_writes_trigger, 64);
+        assert_eq!(options.max_background_jobs, 2);
+        assert_eq!(options.max_subcompactions, 2);
+        assert_eq!(options.max_total_wal_size, Some(1024 * MIB));
+        assert_eq!(options.max_write_buffer_number, 4);
+        assert_eq!(options.target_file_size_base, 512 * MIB);
+        assert_eq!(options.write_buffer_size, mib_to_usize(128));
+        assert!(!options.use_direct_io_for_flush_and_compaction);
+    }
+
+    #[test]
+    fn test_proofs_history_rocksdb_tuning_options_hidden_from_help() {
+        let help = CommandParser::<RollupArgs>::command().render_help().to_string();
+        assert!(!help.contains("proofs-history.rocksdb.compression"));
+        assert!(!help.contains("proofs-history.rocksdb.max-background-jobs"));
+        assert!(!help.contains("proofs-history.rocksdb.rate-limit-mib-per-sec"));
+    }
+
+    #[test]
+    fn test_parse_proofs_history_window() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.window", "21601"])
+                .args;
+        assert_eq!(args.proofs_history_window, 21_601);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_window_rejects_twelve_hours_or_less() {
+        let result = CommandParser::<RollupArgs>::try_parse_from([
+            "reth",
+            "--proofs-history.window",
+            "21600",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -12,7 +12,10 @@ use reth_db_api as _;
 
 /// CLI argument parsing for the Base node.
 pub mod args;
-pub use args::TxpoolOrdering;
+pub use args::{
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs,
+    TWELVE_HOURS_IN_BLOCKS, TxpoolOrdering,
+};
 
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)
 /// trait.

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -1,109 +1,161 @@
-//! Node luncher with proof history support.
+//! Node launcher with proof history support.
 
 use std::{sync::Arc, time::Duration};
 
-use base_common_consensus::BaseTxEnvelope;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_exex::BaseProofsExEx;
-use base_execution_payload_builder::BasePayloadBuilderAttributes;
 use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{BaseProofsStorage, db::MdbxProofsStorage};
+use base_execution_trie::{
+    BaseProofsBatchStore, BaseProofsStorage, MdbxProofsStorage, RocksdbProofsStorage,
+};
 use eyre::ErrReport;
 use futures::FutureExt;
 use reth_db::DatabaseEnv;
 use reth_db_api::database_metrics::DatabaseMetrics;
-use reth_node_builder::{FullNodeComponents, NodeBuilder, WithLaunchContext};
+use reth_node_builder::{
+    FullNodeComponents, Node as RethNode, NodeBuilder, NodeBuilderWithComponents, RethFullAdapter,
+    WithLaunchContext,
+};
 use reth_tasks::TaskExecutor;
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::{BaseNode, args::RollupArgs};
+use crate::{
+    BaseNode, BaseNodeComponentBuilder,
+    args::{ProofsHistoryDbBackend, RollupArgs},
+};
+
+type ProofHistoryNodeTypes = RethFullAdapter<Arc<DatabaseEnv>, BaseNode>;
+type ProofHistoryNodeBuilder = WithLaunchContext<
+    NodeBuilderWithComponents<
+        ProofHistoryNodeTypes,
+        BaseNodeComponentBuilder<ProofHistoryNodeTypes>,
+        <BaseNode as RethNode<ProofHistoryNodeTypes>>::AddOns,
+    >,
+>;
 
 /// - no proofs history (plain node),
 /// - in-mem proofs storage,
-/// - MDBX proofs storage.
+/// - on-disk proofs storage.
 pub async fn launch_node_with_proof_history(
     builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, BaseChainSpec>>,
     args: RollupArgs,
 ) -> eyre::Result<(), ErrReport> {
     let RollupArgs {
         proofs_history,
+        proofs_history_storage_path,
+        proofs_history_db,
+        proofs_history_rocksdb,
         proofs_history_window,
         proofs_history_prune_interval,
         proofs_history_verification_interval,
         ..
-    } = args;
+    } = args.clone();
 
     // Start from a plain BaseNode builder
-    let mut node_builder = builder.node(BaseNode::new(args.clone()));
+    let mut node_builder = builder.node(BaseNode::new(args));
 
     if proofs_history {
-        let path = args
-            .proofs_history_storage_path
-            .clone()
-            .expect("Path must be provided if not using in-memory storage");
+        let path = proofs_history_storage_path.ok_or_else(|| {
+            eyre::eyre!("--proofs-history requires --proofs-history.storage-path")
+        })?;
         info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
-        let mdbx = Arc::new(
-            MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        );
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
-
-        let storage_exec = storage.clone();
-
-        node_builder = node_builder
-            .on_node_started(move |node| {
-                spawn_proofs_db_metrics(
-                    node.task_executor,
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let rocksdb = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &path,
+                        proofs_history_rocksdb.storage_options(),
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                );
+                node_builder = install_proofs_history(
+                    node_builder,
+                    rocksdb,
+                    proofs_history_window,
+                    proofs_history_prune_interval,
+                    proofs_history_verification_interval,
+                );
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let mdbx = Arc::new(
+                    MdbxProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                );
+                node_builder = install_proofs_history(
+                    node_builder,
                     mdbx,
-                    node.config.metrics.push_gateway_interval,
+                    proofs_history_window,
+                    proofs_history_prune_interval,
+                    proofs_history_verification_interval,
                 );
-                Ok(())
-            })
-            .install_exex("proofs-history", async move |exex_context| {
-                Ok(BaseProofsExEx::builder(exex_context, storage_exec)
-                    .with_proofs_history_window(proofs_history_window)
-                    .with_proofs_history_prune_interval(proofs_history_prune_interval)
-                    .with_verification_interval(proofs_history_verification_interval)
-                    .build()
-                    .run()
-                    .boxed())
-            })
-            .extend_rpc_modules(move |ctx| {
-                let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
-                let debug_ext: DebugApiExt<
-                    _,
-                    _,
-                    _,
-                    _,
-                    BasePayloadBuilderAttributes<BaseTxEnvelope>,
-                > = DebugApiExt::new(
-                    ctx.node().provider().clone(),
-                    ctx.registry.eth_api().clone(),
-                    storage,
-                    ctx.node().task_executor().clone(),
-                    ctx.node().evm_config().clone(),
-                );
-                ctx.modules.replace_configured(api_ext.into_rpc())?;
-                ctx.modules.replace_configured(debug_ext.into_rpc())?;
-                Ok(())
-            });
+            }
+        }
     }
 
     // In all cases (with or without proofs), launch the node.
     let handle = node_builder.launch_with_debug_capabilities().await?;
     handle.node_exit_future.await
 }
+
+fn install_proofs_history<S>(
+    node_builder: ProofHistoryNodeBuilder,
+    storage_backend: Arc<S>,
+    proofs_history_window: u64,
+    proofs_history_prune_interval: Duration,
+    proofs_history_verification_interval: u64,
+) -> ProofHistoryNodeBuilder
+where
+    S: BaseProofsBatchStore + DatabaseMetrics + Send + Sync + 'static,
+{
+    let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
+    let storage_exec = storage.clone();
+
+    node_builder
+        .on_node_started(move |node| {
+            spawn_proofs_db_metrics(
+                node.task_executor,
+                storage_backend,
+                node.config.metrics.push_gateway_interval,
+            );
+            Ok(())
+        })
+        .install_exex("proofs-history", async move |exex_context| {
+            Ok(BaseProofsExEx::builder(exex_context, storage_exec)
+                .with_proofs_history_window(proofs_history_window)
+                .with_proofs_history_prune_interval(proofs_history_prune_interval)
+                .with_verification_interval(proofs_history_verification_interval)
+                .build()
+                .run()
+                .boxed())
+        })
+        .extend_rpc_modules(move |ctx| {
+            let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+            let debug_ext = DebugApiExt::new(
+                ctx.node().provider().clone(),
+                ctx.registry.eth_api().clone(),
+                storage,
+                ctx.node().task_executor().clone(),
+                ctx.node().evm_config().clone(),
+            );
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            ctx.modules.replace_configured(debug_ext.into_rpc())?;
+            Ok(())
+        })
+}
+
 /// Spawns a task that periodically reports metrics for the proofs DB.
-fn spawn_proofs_db_metrics(
+fn spawn_proofs_db_metrics<S>(
     executor: TaskExecutor,
-    storage: Arc<MdbxProofsStorage>,
+    storage: Arc<S>,
     metrics_report_interval: Duration,
-) {
+) where
+    S: DatabaseMetrics + Send + Sync + 'static,
+{
     executor.spawn_critical_task("base-proofs-storage-metrics", async move {
         info!(
             target: "reth::cli",

--- a/crates/execution/proofs/Cargo.toml
+++ b/crates/execution/proofs/Cargo.toml
@@ -22,8 +22,6 @@ reth-node-api.workspace = true
 base-node-core.workspace = true
 base-execution-rpc.workspace = true
 base-execution-trie.workspace = true
-base-common-consensus.workspace = true
-base-execution-payload-builder.workspace = true
 base-execution-exex = { workspace = true, features = ["metrics"] }
 
 # tokio

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -1,14 +1,14 @@
 use std::{sync::Arc, time::Duration};
 
-use base_common_consensus::BaseTxEnvelope;
 use base_execution_exex::BaseProofsExEx;
-use base_execution_payload_builder::BasePayloadBuilderAttributes;
 use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{BaseProofsStorage, MdbxProofsStorage};
-use base_node_core::args::RollupArgs;
+use base_execution_trie::{
+    BaseProofsBatchStore, BaseProofsStorage, MdbxProofsStorage, RocksdbProofsStorage,
+};
+use base_node_core::args::{ProofsHistoryDbBackend, RollupArgs};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_db::database_metrics::DatabaseMetrics;
 use reth_node_api::FullNodeComponents;
@@ -39,68 +39,73 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         // TODO: if NodeHooks exposes the underlying Builder, we can call launch_node_with_proof_history
         let args = self.config;
         let proofs_history_enabled = args.proofs_history;
+        let proofs_history_db = args.proofs_history_db;
+        let proofs_history_rocksdb = args.proofs_history_rocksdb;
         let proofs_history_window = args.proofs_history_window;
         let proofs_history_prune_interval = args.proofs_history_prune_interval;
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
 
         if proofs_history_enabled {
-            let path = args
-                .proofs_history_storage_path
-                .expect("Path must be provided if not using in-memory storage");
+            let Some(path) = args.proofs_history_storage_path else {
+                error!(
+                    target: "reth::cli",
+                    "--proofs-history requires --proofs-history.storage-path"
+                );
+                return hooks.add_node_started_hook(|_| {
+                    Err(eyre::eyre!("--proofs-history requires --proofs-history.storage-path"))
+                });
+            };
             info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
-            let mdbx = match MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
-            {
-                Ok(mdbx) => mdbx,
-                Err(e) => {
-                    error!(target: "reth::cli", error = ?e, "Failed to create MdbxProofsStorage, continuing without proofs history");
-                    return hooks;
-                }
-            };
-            let mdbx = Arc::new(mdbx);
-            let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
-
-            let storage_exec = storage.clone();
-
-            // ignore unused if metrics feature is disabled
-            hooks = hooks.add_node_started_hook(move |node| {
-                spawn_proofs_db_metrics(
-                    node.task_executor,
-                    mdbx,
-                    node.config.metrics.push_gateway_interval,
-                );
-                Ok(())
-            });
-
-            hooks = hooks
-                .install_exex("proofs-history", async move |exex_context| {
-                    Ok(BaseProofsExEx::builder(exex_context, storage_exec)
-                        .with_proofs_history_prune_interval(proofs_history_prune_interval)
-                        .with_proofs_history_window(proofs_history_window)
-                        .with_verification_interval(proofs_history_verification_interval)
-                        .build()
-                        .run())
-                })
-                .add_rpc_module(move |ctx| {
-                    let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
-                    let debug_ext: DebugApiExt<
-                        _,
-                        _,
-                        _,
-                        _,
-                        BasePayloadBuilderAttributes<BaseTxEnvelope>,
-                    > = DebugApiExt::new(
-                        ctx.node().provider().clone(),
-                        ctx.registry.eth_api().clone(),
-                        storage,
-                        ctx.node().task_executor().clone(),
-                        ctx.node().evm_config().clone(),
+            match proofs_history_db {
+                ProofsHistoryDbBackend::Rocksdb => {
+                    let rocksdb = match RocksdbProofsStorage::new_with_options(
+                        &path,
+                        proofs_history_rocksdb.storage_options(),
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))
+                    {
+                        Ok(rocksdb) => rocksdb,
+                        Err(e) => {
+                            error!(
+                                target: "reth::cli",
+                                error = ?e,
+                                "Failed to create RocksdbProofsStorage"
+                            );
+                            return hooks.add_node_started_hook(move |_| Err(e));
+                        }
+                    };
+                    hooks = install_proofs_history(
+                        hooks,
+                        Arc::new(rocksdb),
+                        proofs_history_window,
+                        proofs_history_prune_interval,
+                        proofs_history_verification_interval,
                     );
-                    ctx.modules.replace_configured(api_ext.into_rpc())?;
-                    ctx.modules.replace_configured(debug_ext.into_rpc())?;
-                    Ok(())
-                });
+                }
+                ProofsHistoryDbBackend::Mdbx => {
+                    let mdbx = match MdbxProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
+                    {
+                        Ok(mdbx) => mdbx,
+                        Err(e) => {
+                            error!(
+                                target: "reth::cli",
+                                error = ?e,
+                                "Failed to create MdbxProofsStorage"
+                            );
+                            return hooks.add_node_started_hook(move |_| Err(e));
+                        }
+                    };
+                    hooks = install_proofs_history(
+                        hooks,
+                        Arc::new(mdbx),
+                        proofs_history_window,
+                        proofs_history_prune_interval,
+                        proofs_history_verification_interval,
+                    );
+                }
+            }
         }
         hooks
     }
@@ -114,12 +119,60 @@ impl FromExtensionConfig for ProofsHistoryExtension {
     }
 }
 
+fn install_proofs_history<S>(
+    mut hooks: NodeHooks,
+    storage_backend: Arc<S>,
+    proofs_history_window: u64,
+    proofs_history_prune_interval: Duration,
+    proofs_history_verification_interval: u64,
+) -> NodeHooks
+where
+    S: BaseProofsBatchStore + DatabaseMetrics + Send + Sync + 'static,
+{
+    let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
+    let storage_exec = storage.clone();
+
+    hooks = hooks.add_node_started_hook(move |node| {
+        spawn_proofs_db_metrics(
+            node.task_executor,
+            storage_backend,
+            node.config.metrics.push_gateway_interval,
+        );
+        Ok(())
+    });
+
+    hooks
+        .install_exex("proofs-history", async move |exex_context| {
+            Ok(BaseProofsExEx::builder(exex_context, storage_exec)
+                .with_proofs_history_prune_interval(proofs_history_prune_interval)
+                .with_proofs_history_window(proofs_history_window)
+                .with_verification_interval(proofs_history_verification_interval)
+                .build()
+                .run())
+        })
+        .add_rpc_module(move |ctx| {
+            let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+            let debug_ext = DebugApiExt::new(
+                ctx.node().provider().clone(),
+                ctx.registry.eth_api().clone(),
+                storage,
+                ctx.node().task_executor().clone(),
+                ctx.node().evm_config().clone(),
+            );
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            ctx.modules.replace_configured(debug_ext.into_rpc())?;
+            Ok(())
+        })
+}
+
 /// Spawns a task that periodically reports metrics for the proofs DB.
-fn spawn_proofs_db_metrics(
+fn spawn_proofs_db_metrics<S>(
     executor: TaskExecutor,
-    storage: Arc<MdbxProofsStorage>,
+    storage: Arc<S>,
     metrics_report_interval: Duration,
-) {
+) where
+    S: DatabaseMetrics + Send + Sync + 'static,
+{
     executor.spawn_critical_task("base-proofs-storage-metrics", async move {
         info!(
             target: "reth::cli",

--- a/crates/execution/trie/Cargo.toml
+++ b/crates/execution/trie/Cargo.toml
@@ -81,6 +81,15 @@ tokio = { workspace = true, features = ["test-util", "rt-multi-thread", "macros"
 
 # misc
 serial_test.workspace = true
+criterion = { workspace = true, features = ["html_reports"] }
+
+[[bench]]
+name = "witness_reads"
+harness = false
+
+[[bench]]
+name = "deep_history_reads"
+harness = false
 
 [features]
 serde-bincode-compat = [

--- a/crates/execution/trie/benches/deep_history_reads.rs
+++ b/crates/execution/trie/benches/deep_history_reads.rs
@@ -1,0 +1,228 @@
+//! Benchmarks the proofs-history read path against DEEP per-key version chains.
+//!
+//! Seeds a [`RocksDB`] proofs-history store with `BASE_ACCOUNTS` accounts, each
+//! one updated `VERSIONS_PER_KEY` times across sequential blocks, so every
+//! `HashedAccountHistory` user-key has a long version chain. Then drives
+//! `TARGET_ACCOUNTS` reads through the same `StateProviderDatabase` path that
+//! block execution uses, at two read snapshots: chain head (latest version
+//! sits at the start of the chain) and chain midpoint (the cursor must skip
+//! over the newer half of the chain before landing on its answer).
+//!
+//! This is where the complement-key encoding's asymptotic win should show: the
+//! reversed encoding turns the "latest version <= N" lookup into a single
+//! `seek()` instead of a `seek_for_prev()` that on the LSM-tree memtable runs
+//! 7-8x slower (`RocksDB` PR #5535).
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_trie::{
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, BlockStateDiff,
+    RocksdbProofsStorage, provider::BaseProofsStateProviderRef,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand_08::{RngCore, SeedableRng, rngs::StdRng};
+use reth_primitives_traits::Account;
+use reth_provider::{AccountReader, noop::NoopProvider};
+use reth_revm::{Database, State, database::StateProviderDatabase};
+use reth_trie_common::{HashedPostState, updates::TrieUpdates};
+use tempfile::TempDir;
+
+const BASE_ACCOUNTS: usize = 1_000;
+const VERSIONS_PER_KEY: u64 = 100;
+const TARGET_ACCOUNTS: usize = 256;
+const MISSING_ACCOUNTS: usize = 64;
+
+#[derive(Clone)]
+struct SeedAccount {
+    address: Address,
+    hashed_address: B256,
+}
+
+struct DeepHistoryFixture {
+    _dir: TempDir,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    accounts: Vec<SeedAccount>,
+    targets: Vec<SeedAccount>,
+    missing_addresses: Vec<Address>,
+}
+
+fn random_bytes<const N: usize>(rng: &mut StdRng) -> [u8; N] {
+    let mut bytes = [0; N];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
+fn account_at_version(index: usize, version: u64) -> Account {
+    Account {
+        nonce: version,
+        balance: U256::from((index as u64 + 1) * 1_000 + version),
+        bytecode_hash: None,
+    }
+}
+
+fn generate_accounts(count: usize) -> Vec<SeedAccount> {
+    let mut rng = StdRng::seed_from_u64(0xDEAD_BEEF);
+    (0..count)
+        .map(|_| {
+            let address = Address::from(random_bytes::<20>(&mut rng));
+            let hashed_address = keccak256(address);
+            SeedAccount { address, hashed_address }
+        })
+        .collect()
+}
+
+fn missing_addresses() -> Vec<Address> {
+    (0..MISSING_ACCOUNTS).map(|index| Address::repeat_byte(0x80 | index as u8)).collect()
+}
+
+const fn block_for(number: u64, parent: B256) -> BlockWithParent {
+    BlockWithParent {
+        parent,
+        block: BlockNumHash {
+            number,
+            hash: if number == 0 { B256::ZERO } else { B256::repeat_byte(number as u8) },
+        },
+    }
+}
+
+fn diff_for_all_accounts(accounts: &[SeedAccount], version: u64) -> BlockStateDiff {
+    let mut post_state = HashedPostState::default();
+    for (index, account) in accounts.iter().enumerate() {
+        post_state
+            .accounts
+            .insert(account.hashed_address, Some(account_at_version(index, version)));
+    }
+    BlockStateDiff {
+        sorted_trie_updates: TrieUpdates::default().into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    }
+}
+
+fn create_fixture(compact: bool) -> DeepHistoryFixture {
+    let dir = TempDir::new().expect("create temp dir");
+    let rocksdb = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("create RocksDB storage"));
+    let accounts = generate_accounts(BASE_ACCOUNTS);
+
+    rocksdb
+        .store_hashed_accounts(
+            accounts
+                .iter()
+                .enumerate()
+                .map(|(index, account)| {
+                    (account.hashed_address, Some(account_at_version(index, 0)))
+                })
+                .collect(),
+        )
+        .expect("store hashed accounts");
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("set initial state anchor");
+    rocksdb.commit_initial_state().expect("commit initial state");
+
+    let mut parent_hash = B256::ZERO;
+    for version in 1..=VERSIONS_PER_KEY {
+        let block_ref = block_for(version, parent_hash);
+        let diff = diff_for_all_accounts(&accounts, version);
+        rocksdb.store_trie_updates(block_ref, diff).expect("store version");
+        parent_hash = block_ref.block.hash;
+    }
+
+    if compact {
+        rocksdb.flush_and_compact().expect("flush and compact RocksDB fixture");
+    }
+
+    let targets = accounts.iter().take(TARGET_ACCOUNTS).cloned().collect::<Vec<_>>();
+    let storage = BaseProofsStorage::from(rocksdb);
+    let fixture = DeepHistoryFixture {
+        _dir: dir,
+        storage,
+        accounts,
+        targets,
+        missing_addresses: missing_addresses(),
+    };
+    validate_fixture(&fixture);
+    fixture
+}
+
+fn validate_fixture(fixture: &DeepHistoryFixture) {
+    let head_provider = BaseProofsStateProviderRef::new(
+        Box::<NoopProvider>::default(),
+        &fixture.storage,
+        VERSIONS_PER_KEY,
+    );
+    let mid_block = VERSIONS_PER_KEY / 2;
+    let mid_provider = BaseProofsStateProviderRef::new(
+        Box::<NoopProvider>::default(),
+        &fixture.storage,
+        mid_block,
+    );
+
+    for (index, target) in fixture.accounts.iter().enumerate().take(8) {
+        let head =
+            head_provider.basic_account(&target.address).expect("head read").expect("head exists");
+        assert_eq!(head, account_at_version(index, VERSIONS_PER_KEY));
+
+        let mid =
+            mid_provider.basic_account(&target.address).expect("mid read").expect("mid exists");
+        assert_eq!(mid, account_at_version(index, mid_block));
+    }
+
+    for missing_address in fixture.missing_addresses.iter().take(8) {
+        assert!(head_provider.basic_account(missing_address).expect("missing read").is_none());
+    }
+}
+
+fn read_accounts_at_block(fixture: &DeepHistoryFixture, max_block: u64) -> usize {
+    let provider = BaseProofsStateProviderRef::new(
+        Box::<NoopProvider>::default(),
+        &fixture.storage,
+        max_block,
+    );
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+
+    let mut reads = 0;
+    for target in &fixture.targets {
+        black_box(state.basic(target.address).expect("read account").expect("account exists"));
+        reads += 1;
+    }
+    for missing_address in &fixture.missing_addresses {
+        black_box(state.basic(*missing_address).expect("read missing account"));
+        reads += 1;
+    }
+    reads
+}
+
+fn deep_history_benches(c: &mut Criterion) {
+    let uncompacted = create_fixture(false);
+    let compacted = create_fixture(true);
+    let mid_block = VERSIONS_PER_KEY / 2;
+
+    let mut group = c.benchmark_group("deep_history_reads");
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("chain_head_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&uncompacted, VERSIONS_PER_KEY)));
+    });
+
+    group.bench_function(BenchmarkId::new("chain_mid_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&uncompacted, mid_block)));
+    });
+
+    group.bench_function(BenchmarkId::new("chain_head_reads_compacted", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&compacted, VERSIONS_PER_KEY)));
+    });
+
+    group.bench_function(BenchmarkId::new("chain_mid_reads_compacted", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&compacted, mid_block)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, deep_history_benches);
+criterion_main!(benches);

--- a/crates/execution/trie/benches/witness_reads.rs
+++ b/crates/execution/trie/benches/witness_reads.rs
@@ -1,0 +1,262 @@
+//! Benchmarks the proofs-history read path used by debug witness generation.
+//!
+//! This benchmark seeds a `RocksDB` proofs-history store with deterministic
+//! account and storage data, then repeatedly performs the DB-bound reads that
+//! `debug_executionWitness` drives through `StateProviderDatabase` and
+//! `revm::State` while EVM execution records touched state.
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_eips::BlockNumHash;
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_trie::{
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, RocksdbProofsStorage,
+    provider::BaseProofsStateProviderRef,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand_08::{RngCore, SeedableRng, rngs::StdRng};
+use reth_primitives_traits::Account;
+use reth_provider::{AccountReader, StateProofProvider, StateProvider, noop::NoopProvider};
+use reth_revm::{
+    Database, State, database::StateProviderDatabase, witness::ExecutionWitnessRecord,
+};
+use reth_trie_common::{ExecutionWitnessMode, TrieInput};
+use tempfile::TempDir;
+
+const BASE_ACCOUNTS: usize = 10_000;
+const SLOTS_PER_ACCOUNT: usize = 8;
+const TARGET_ACCOUNTS: usize = 256;
+const MISSING_ACCOUNTS: usize = 64;
+
+#[derive(Clone)]
+struct SeedAccount {
+    address: Address,
+    hashed_address: B256,
+    account: Account,
+    slots: Vec<(B256, B256, U256)>,
+}
+
+struct WitnessReadFixture {
+    _dir: TempDir,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    targets: Vec<SeedAccount>,
+    missing_addresses: Vec<Address>,
+}
+
+fn random_bytes<const N: usize>(rng: &mut StdRng) -> [u8; N] {
+    let mut bytes = [0; N];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
+fn account_for(index: usize) -> Account {
+    Account {
+        nonce: index as u64,
+        balance: U256::from((index as u64 + 1) * 1_000),
+        bytecode_hash: None,
+    }
+}
+
+fn generate_accounts(count: usize, slots_per_account: usize) -> Vec<SeedAccount> {
+    let mut rng = StdRng::seed_from_u64(0xBEEF_F00D);
+    (0..count)
+        .map(|index| {
+            let address = Address::from(random_bytes::<20>(&mut rng));
+            let hashed_address = keccak256(address);
+            let account = account_for(index);
+            let slots = (0..slots_per_account)
+                .map(|slot_index| {
+                    let storage_key = B256::from(random_bytes::<32>(&mut rng));
+                    let hashed_storage_key = keccak256(storage_key);
+                    let value = U256::from((index as u64 + 1) * 10_000 + slot_index as u64);
+                    (storage_key, hashed_storage_key, value)
+                })
+                .collect();
+            SeedAccount { address, hashed_address, account, slots }
+        })
+        .collect()
+}
+
+fn missing_addresses() -> Vec<Address> {
+    (0..MISSING_ACCOUNTS).map(|index| Address::repeat_byte(0x80 | index as u8)).collect()
+}
+
+fn create_fixture(compact: bool) -> WitnessReadFixture {
+    let dir = TempDir::new().expect("create temp dir");
+    let rocksdb = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("create RocksDB storage"));
+    let accounts = generate_accounts(BASE_ACCOUNTS, SLOTS_PER_ACCOUNT);
+
+    rocksdb
+        .store_hashed_accounts(
+            accounts
+                .iter()
+                .map(|account| (account.hashed_address, Some(account.account)))
+                .collect(),
+        )
+        .expect("store hashed accounts");
+
+    for account in &accounts {
+        let storages = account
+            .slots
+            .iter()
+            .map(|(_, hashed_storage_key, value)| (*hashed_storage_key, *value));
+        rocksdb
+            .store_hashed_storages(account.hashed_address, storages.collect())
+            .expect("store hashed storage");
+    }
+
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("set initial state anchor");
+    rocksdb.commit_initial_state().expect("commit initial state");
+
+    if compact {
+        rocksdb.flush_and_compact().expect("flush and compact RocksDB fixture");
+    }
+
+    let targets = accounts.into_iter().take(TARGET_ACCOUNTS).collect::<Vec<_>>();
+    let storage = BaseProofsStorage::from(rocksdb);
+    let fixture =
+        WitnessReadFixture { _dir: dir, storage, targets, missing_addresses: missing_addresses() };
+    validate_fixture(&fixture);
+    fixture
+}
+
+fn validate_fixture(fixture: &WitnessReadFixture) {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+
+    for target in &fixture.targets {
+        let account =
+            provider.basic_account(&target.address).expect("read account").expect("account exists");
+        assert_eq!(account, target.account);
+
+        for (storage_key, _, value) in &target.slots {
+            let storage_value = provider
+                .storage(target.address, *storage_key)
+                .expect("read storage")
+                .expect("storage exists");
+            assert_eq!(storage_value, *value);
+        }
+
+        assert!(
+            provider
+                .storage(target.address, B256::repeat_byte(0xFE))
+                .expect("read missing storage")
+                .is_none()
+        );
+    }
+
+    for missing_address in &fixture.missing_addresses {
+        assert!(provider.basic_account(missing_address).expect("read missing account").is_none());
+    }
+}
+
+fn read_accounts_and_storage_with_provider<Storage>(
+    provider: &BaseProofsStateProviderRef<'_, Storage>,
+    fixture: &WitnessReadFixture,
+) -> usize
+where
+    Storage: BaseProofsStore + Clone,
+{
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(provider))
+        .with_bundle_update()
+        .build();
+    read_accounts_and_storage_with_state(&mut state, fixture)
+}
+
+fn read_accounts_and_storage_with_state<DB>(
+    state: &mut State<StateProviderDatabase<DB>>,
+    fixture: &WitnessReadFixture,
+) -> usize
+where
+    State<StateProviderDatabase<DB>>: reth_revm::Database,
+{
+    let mut reads = 0;
+
+    for target in &fixture.targets {
+        black_box(state.basic(target.address).expect("read account").expect("account exists"));
+        reads += 1;
+
+        for (storage_key, _, _) in &target.slots {
+            black_box(state.storage(target.address, (*storage_key).into()).expect("read storage"));
+            reads += 1;
+        }
+
+        black_box(
+            state
+                .storage(target.address, B256::repeat_byte(0xFE).into())
+                .expect("read missing storage"),
+        );
+        reads += 1;
+    }
+
+    for missing_address in &fixture.missing_addresses {
+        black_box(state.basic(*missing_address).expect("read missing account"));
+        reads += 1;
+    }
+
+    reads
+}
+
+fn read_accounts_and_storage(fixture: &WitnessReadFixture) -> usize {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+    read_accounts_and_storage_with_provider(&provider, fixture)
+}
+
+fn read_accounts_storage_and_witness(fixture: &WitnessReadFixture) -> usize {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+    let reads = read_accounts_and_storage_with_state(&mut state, fixture);
+    let ExecutionWitnessRecord { hashed_state, codes, keys, lowest_block_number } =
+        ExecutionWitnessRecord::from_executed_state(&state, ExecutionWitnessMode::default());
+    black_box(codes);
+    black_box(keys);
+    black_box(lowest_block_number);
+    black_box(
+        provider
+            .witness(TrieInput::default(), hashed_state, ExecutionWitnessMode::default())
+            .expect("build witness"),
+    );
+    reads
+}
+
+fn witness_read_benches(c: &mut Criterion) {
+    let fixture = create_fixture(false);
+    let compacted_fixture = create_fixture(true);
+    let mut group = c.benchmark_group("debug_execution_witness/proofs_history_reads");
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("account_storage_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_and_storage(&fixture)));
+    });
+
+    group.bench_function(BenchmarkId::new("reads_plus_witness_overlay", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_storage_and_witness(&fixture)));
+    });
+
+    group.bench_function(
+        BenchmarkId::new("account_storage_reads_compacted", TARGET_ACCOUNTS),
+        |b| {
+            b.iter(|| black_box(read_accounts_and_storage(&compacted_fixture)));
+        },
+    );
+
+    group.bench_function(
+        BenchmarkId::new("reads_plus_witness_overlay_compacted", TARGET_ACCOUNTS),
+        |b| {
+            b.iter(|| black_box(read_accounts_storage_and_witness(&compacted_fixture)));
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, witness_read_benches);
+criterion_main!(benches);

--- a/crates/execution/trie/src/db/rocksdb.rs
+++ b/crates/execution/trie/src/db/rocksdb.rs
@@ -24,7 +24,10 @@ use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
 };
-use reth_trie_common::{BranchNodeCompact, Nibbles, StoredNibbles};
+use reth_trie_common::{
+    BranchNodeCompact, HashedPostState, Nibbles, StoredNibbles,
+    updates::{StorageTrieUpdates, TrieUpdates},
+};
 use rocksdb::{
     BlockBasedIndexType, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
     CompactionPri, DBCompressionType, DBWithThreadMode, Direction, IteratorMode, MultiThreaded,
@@ -136,7 +139,7 @@ impl RocksdbProofsStorageOptions {
 /// Sealed marker trait for `RocksDB` history column families.
 ///
 /// Implemented by the four history tables: [`AccountTrieHistory`], [`StorageTrieHistory`],
-/// [`HashedAccountHistory`], and [`HashedStorageHistory`].  The blanket impl provides the
+/// [`HashedAccountHistory`], and [`HashedStorageHistory`]. The blanket impl provides the
 /// key-encoding and decoding logic needed by the versioned cursor.
 pub trait RocksDbHistoryTable: Table + DupSort<SubKey = u64> {
     /// Fixed encoded table-key length before the block-number suffix.
@@ -166,12 +169,9 @@ pub struct RocksdbProofsStorage {
 /// Preprocessed prune plan for a target block number.
 #[derive(Debug, Clone)]
 pub struct RocksdbPrunePlan {
-    /// Earliest block number currently retained before pruning.
-    pub earliest_block: u64,
-    /// Hash of the earliest retained block.
-    pub earliest_hash: B256,
-    /// Account trie keys and survivor block numbers that must be kept.
-    pub acc_survivors: Vec<(StoredNibbles, u64)>,
+    earliest_block: u64,
+    earliest_hash: B256,
+    acc_survivors: Vec<(StoredNibbles, u64)>,
     storage_survivors: Vec<(StorageTrieKey, u64)>,
     hashed_acc_survivors: Vec<(B256, u64)>,
     hashed_storage_survivors: Vec<(HashedStorageKey, u64)>,
@@ -189,31 +189,21 @@ impl RocksdbPrunePlan {
 /// Preprocessed delete work for a prune commit.
 #[derive(Debug, Clone)]
 pub struct RocksdbPreparedPrune {
-    /// Earliest block number expected when applying this prepared prune.
-    pub expected_earliest_block: u64,
-    /// Earliest block hash expected when applying this prepared prune.
-    pub expected_earliest_hash: B256,
-    /// New earliest block number after prune commit.
-    pub target_block: u64,
-    /// Hash of the new earliest block after prune commit.
-    pub target_hash: B256,
-    /// Raw history keys grouped by table for deletion.
-    pub deletes: RocksdbPreparedHistoryDeletes,
-    /// Write counters for delete operations in this prune batch.
-    pub counts: WriteCounts,
+    expected_earliest_block: u64,
+    expected_earliest_hash: B256,
+    target_block: u64,
+    target_hash: B256,
+    deletes: RocksdbPreparedHistoryDeletes,
+    counts: WriteCounts,
 }
 
 /// Raw history keys to delete during a prune commit.
 #[derive(Debug, Default, Clone)]
 pub struct RocksdbPreparedHistoryDeletes {
-    /// Raw account trie history keys scheduled for deletion.
-    pub account_trie: Vec<Vec<u8>>,
-    /// Raw storage trie history keys scheduled for deletion.
-    pub storage_trie: Vec<Vec<u8>>,
-    /// Raw hashed account history keys scheduled for deletion.
-    pub hashed_account: Vec<Vec<u8>>,
-    /// Raw hashed storage history keys scheduled for deletion.
-    pub hashed_storage: Vec<Vec<u8>>,
+    account_trie: Vec<Vec<u8>>,
+    storage_trie: Vec<Vec<u8>>,
+    hashed_account: Vec<Vec<u8>>,
+    hashed_storage: Vec<Vec<u8>>,
 }
 
 impl RocksdbPreparedHistoryDeletes {
@@ -228,16 +218,11 @@ impl RocksdbPreparedHistoryDeletes {
 /// Preprocessed delete work for a prune range.
 #[derive(Debug, Default)]
 pub struct RocksdbHistoryDeleteBatch {
-    /// Block numbers whose `BlockChangeSet` rows should be removed.
-    pub block_numbers: Vec<u64>,
-    /// Account trie history keys and block numbers to delete.
-    pub account_trie: Vec<(<AccountTrieHistory as Table>::Key, u64)>,
-    /// Storage trie history keys and block numbers to delete.
-    pub storage_trie: Vec<(<StorageTrieHistory as Table>::Key, u64)>,
-    /// Hashed account history keys and block numbers to delete.
-    pub hashed_account: Vec<(<HashedAccountHistory as Table>::Key, u64)>,
-    /// Hashed storage history keys and block numbers to delete.
-    pub hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
+    block_numbers: Vec<u64>,
+    account_trie: Vec<(<AccountTrieHistory as Table>::Key, u64)>,
+    storage_trie: Vec<(<StorageTrieHistory as Table>::Key, u64)>,
+    hashed_account: Vec<(<HashedAccountHistory as Table>::Key, u64)>,
+    hashed_storage: Vec<(<HashedStorageHistory as Table>::Key, u64)>,
 }
 
 /// Request-scoped read snapshot for [`RocksdbProofsStorage`].
@@ -247,62 +232,47 @@ pub struct RocksdbHistoryDeleteBatch {
 /// acquire one snapshot with [`BaseProofsStore::ro_tx`] and pass it to the `*_with_tx` cursor
 /// factories.
 pub struct RocksdbReadSnapshot<'db> {
-    /// Underlying `RocksDB` database handle.
-    pub db: &'db RocksDb,
-    /// Snapshot pinned for consistent reads.
-    pub snapshot: SnapshotWithThreadMode<'db, RocksDb>,
+    db: &'db RocksDb,
+    snapshot: SnapshotWithThreadMode<'db, RocksDb>,
 }
 
 /// Cursor over `RocksDB` versioned history rows.
 pub struct RocksdbVersionedCursor<'db, T: Table + DupSort> {
-    /// Shared read snapshot used for cursor lookups.
-    pub snapshot: Arc<RocksdbReadSnapshot<'db>>,
-    /// Maximum block number visible to this cursor.
-    pub max_block_number: u64,
-    /// Current logical key position in the cursor.
-    pub current_key: Option<T::Key>,
-    /// Marker for the table type parameter.
-    pub _table: PhantomData<T>,
+    snapshot: Arc<RocksdbReadSnapshot<'db>>,
+    max_block_number: u64,
+    current_key: Option<T::Key>,
+    _table: PhantomData<T>,
 }
 
 /// `RocksDB` implementation of [`TrieCursor`].
 pub struct RocksdbTrieCursor<'db, T: Table + DupSort> {
-    /// Underlying versioned history cursor.
-    pub inner: RocksdbVersionedCursor<'db, T>,
-    /// Optional hashed address scope for storage-trie iteration.
-    pub hashed_address: Option<B256>,
+    inner: RocksdbVersionedCursor<'db, T>,
+    hashed_address: Option<B256>,
 }
 
 /// `RocksDB` implementation of [`HashedCursor`] for storage state.
 pub struct RocksdbStorageCursor<'db> {
-    /// Underlying versioned history cursor.
-    pub inner: RocksdbVersionedCursor<'db, HashedStorageHistory>,
-    /// Address whose storage slots are being iterated.
-    pub hashed_address: B256,
+    inner: RocksdbVersionedCursor<'db, HashedStorageHistory>,
+    hashed_address: B256,
 }
 
 /// `RocksDB` implementation of [`HashedCursor`] for account state.
 pub struct RocksdbAccountCursor<'db> {
-    /// Underlying versioned history cursor.
-    pub inner: RocksdbVersionedCursor<'db, HashedAccountHistory>,
+    inner: RocksdbVersionedCursor<'db, HashedAccountHistory>,
 }
 
 /// In-memory replacement overlays for wiped storage trie and hashed storage state.
 #[derive(Debug, Default)]
 pub struct RocksdbReplacementState {
-    /// Replacement entries for storage trie nodes keyed by address/path.
-    pub storage_trie: BTreeMap<StorageTrieKey, Option<BranchNodeCompact>>,
-    /// Replacement entries for hashed storage slots keyed by address/slot.
-    pub hashed_storage: BTreeMap<HashedStorageKey, Option<StorageValue>>,
+    storage_trie: BTreeMap<StorageTrieKey, Option<BranchNodeCompact>>,
+    hashed_storage: BTreeMap<HashedStorageKey, Option<StorageValue>>,
 }
 
 /// Earliest and latest block/hash pair currently retained in proof storage.
 #[derive(Debug, Clone, Copy)]
 pub struct ProofWindowValue {
-    /// Earliest retained block/hash pair.
-    pub earliest: NumHash,
-    /// Latest retained block/hash pair.
-    pub latest: NumHash,
+    earliest: NumHash,
+    latest: NumHash,
 }
 
 impl fmt::Debug for RocksdbProofsStorage {
@@ -325,8 +295,7 @@ impl<'db> RocksdbReadSnapshot<'db> {
             .ok_or_else(|| DatabaseError::Other(format!("missing RocksDB column family {name}")))
     }
 
-    /// Returns the underlying `RocksDB` snapshot.
-    pub const fn snapshot(&self) -> &SnapshotWithThreadMode<'db, RocksDb> {
+    const fn snapshot(&self) -> &SnapshotWithThreadMode<'db, RocksDb> {
         &self.snapshot
     }
 }
@@ -502,11 +471,7 @@ impl RocksdbProofsStorage {
         })
     }
 
-    /// Builds top-level `RocksDB` database options from storage tuning settings.
-    pub fn db_options(
-        block_cache: &Cache,
-        storage_options: RocksdbProofsStorageOptions,
-    ) -> Options {
+    fn db_options(block_cache: &Cache, storage_options: RocksdbProofsStorageOptions) -> Options {
         let table_options = Self::table_options(block_cache);
         let mut options = Options::default();
         options.set_block_based_table_factory(&table_options);
@@ -527,13 +492,11 @@ impl RocksdbProofsStorage {
         options
     }
 
-    /// Returns the configured maximum total WAL size for all column families.
-    pub fn max_total_wal_size(storage_options: RocksdbProofsStorageOptions) -> u64 {
+    fn max_total_wal_size(storage_options: RocksdbProofsStorageOptions) -> u64 {
         storage_options.max_total_wal_size(Self::column_families().len())
     }
 
-    /// Builds shared block-based table options for non-history column families.
-    pub fn table_options(block_cache: &Cache) -> BlockBasedOptions {
+    fn table_options(block_cache: &Cache) -> BlockBasedOptions {
         let mut table_options = BlockBasedOptions::default();
         table_options.set_block_size(DEFAULT_BLOCK_SIZE);
         table_options.set_cache_index_and_filter_blocks(true);
@@ -542,8 +505,7 @@ impl RocksdbProofsStorage {
         table_options
     }
 
-    /// Builds block-based table options optimized for history column families.
-    pub fn history_table_options(block_cache: &Cache) -> BlockBasedOptions {
+    fn history_table_options(block_cache: &Cache) -> BlockBasedOptions {
         let mut table_options = Self::table_options(block_cache);
         table_options.set_bloom_filter(DEFAULT_BLOOM_BITS_PER_KEY, false);
         table_options.set_whole_key_filtering(true);
@@ -554,8 +516,7 @@ impl RocksdbProofsStorage {
         table_options
     }
 
-    /// Builds per-column-family options for the given proofs storage table.
-    pub fn cf_options(
+    fn cf_options(
         name: &'static str,
         block_cache: &Cache,
         storage_options: RocksdbProofsStorageOptions,
@@ -592,8 +553,7 @@ impl RocksdbProofsStorage {
         options
     }
 
-    /// Returns the fixed history-key prefix length for a history table name.
-    pub fn history_prefix_len(name: &'static str) -> Option<usize> {
+    fn history_prefix_len(name: &'static str) -> Option<usize> {
         match name {
             <AccountTrieHistory as Table>::NAME => {
                 Some(<AccountTrieHistory as RocksDbHistoryTable>::KEY_LEN)
@@ -611,8 +571,7 @@ impl RocksdbProofsStorage {
         }
     }
 
-    /// Returns the set of proofs storage column families.
-    pub const fn column_families() -> [&'static str; 6] {
+    const fn column_families() -> [&'static str; 6] {
         [
             <AccountTrieHistory as Table>::NAME,
             <StorageTrieHistory as Table>::NAME,
@@ -623,16 +582,14 @@ impl RocksdbProofsStorage {
         ]
     }
 
-    /// Returns a column family handle for the provided table name.
-    pub fn cf(&self, name: &'static str) -> BaseProofsStorageResult<Arc<BoundColumnFamily<'_>>> {
+    fn cf(&self, name: &'static str) -> BaseProofsStorageResult<Arc<BoundColumnFamily<'_>>> {
         self.db
             .cf_handle(name)
             .ok_or_else(|| DatabaseError::Other(format!("missing RocksDB column family {name}")))
             .map_err(Into::into)
     }
 
-    /// Encodes and writes one table row into the provided write batch.
-    pub fn put_table<T: Table>(
+    fn put_table<T: Table>(
         &self,
         batch: &mut WriteBatch,
         key: T::Key,
@@ -643,8 +600,7 @@ impl RocksdbProofsStorage {
         Ok(())
     }
 
-    /// Reads one table row from the live database.
-    pub fn get_table<T: Table>(&self, key: T::Key) -> BaseProofsStorageResult<Option<T::Value>> {
+    fn get_table<T: Table>(&self, key: T::Key) -> BaseProofsStorageResult<Option<T::Value>> {
         let cf = self.cf(T::NAME)?;
         self.db
             .get_cf(&cf, encode_table_key::<T>(key))
@@ -653,8 +609,7 @@ impl RocksdbProofsStorage {
             .transpose()
     }
 
-    /// Reads one table row from the provided read snapshot.
-    pub fn get_table_from_snapshot<T: Table>(
+    fn get_table_from_snapshot<T: Table>(
         &self,
         snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
         key: T::Key,
@@ -667,8 +622,7 @@ impl RocksdbProofsStorage {
             .transpose()
     }
 
-    /// Persists versioned history rows for a block and returns written logical keys.
-    pub fn persist_history_batch<T, I, V>(
+    fn persist_history_batch<T, I, V>(
         &self,
         batch: &mut WriteBatch,
         block_number: u64,
@@ -717,8 +671,7 @@ impl RocksdbProofsStorage {
         Ok(keys)
     }
 
-    /// Deletes dup-sorted history entries identified by `(key, block_number)` pairs.
-    pub fn delete_dup_sorted<T, I, V>(
+    fn delete_dup_sorted<T, I, V>(
         &self,
         batch: &mut WriteBatch,
         items: I,
@@ -736,8 +689,7 @@ impl RocksdbProofsStorage {
         Ok(())
     }
 
-    /// Collects raw history keys older than each survivor version to prune.
-    pub fn collect_history_preceding_deletes<T, V>(
+    fn collect_history_preceding_deletes<T, V>(
         &self,
         snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
         cutoff_items: Vec<(T::Key, u64)>,
@@ -820,8 +772,7 @@ impl RocksdbProofsStorage {
         Ok(deletes)
     }
 
-    /// Deletes raw encoded history keys for a specific table.
-    pub fn delete_raw_history_keys<T>(
+    fn delete_raw_history_keys<T>(
         &self,
         batch: &mut WriteBatch,
         keys: Vec<Vec<u8>>,
@@ -836,8 +787,7 @@ impl RocksdbProofsStorage {
         Ok(())
     }
 
-    /// Wipes existing key space and overlays replacement entries for one address scope.
-    pub fn wipe_and_overlay<T, Next, I, K, VV, V>(
+    fn wipe_and_overlay<T, Next, I, K, VV, V>(
         &self,
         batch: &mut WriteBatch,
         block_number: u64,
@@ -878,8 +828,7 @@ impl RocksdbProofsStorage {
         Ok(keys)
     }
 
-    /// Stores trie and hashed-state updates for one block into the batch.
-    pub fn store_trie_updates_for_block(
+    fn store_trie_updates_for_block(
         &self,
         batch: &mut WriteBatch,
         block_number: u64,
@@ -972,8 +921,7 @@ impl RocksdbProofsStorage {
         })
     }
 
-    /// Appends one block update, validating parent continuity against latest stored block.
-    pub fn store_trie_updates_append_only(
+    fn store_trie_updates_append_only(
         &self,
         batch: &mut WriteBatch,
         block_ref: BlockWithParent,
@@ -1011,8 +959,7 @@ impl RocksdbProofsStorage {
         })
     }
 
-    /// Appends replacement-mode updates and records the resulting block change set.
-    pub fn store_replacement_trie_updates_append_only(
+    fn store_replacement_trie_updates_append_only(
         &self,
         batch: &mut WriteBatch,
         base_block_number: u64,
@@ -1045,8 +992,7 @@ impl RocksdbProofsStorage {
         })
     }
 
-    /// Stores replacement-mode trie updates for a specific block number.
-    pub fn store_replacement_trie_updates_for_block(
+    fn store_replacement_trie_updates_for_block(
         &self,
         batch: &mut WriteBatch,
         base_block_number: u64,
@@ -1136,16 +1082,14 @@ impl RocksdbProofsStorage {
         })
     }
 
-    /// Reads a proof-window block number/hash pair for the given key.
-    pub fn get_block_number_hash(
+    fn get_block_number_hash(
         &self,
         key: ProofWindowKey,
     ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         Ok(self.get_table::<ProofWindow>(key)?.map(|value| (value.number(), *value.hash())))
     }
 
-    /// Reads a proof-window block number/hash pair from a snapshot.
-    pub fn get_block_number_hash_from_snapshot(
+    fn get_block_number_hash_from_snapshot(
         &self,
         snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
         key: ProofWindowKey,
@@ -1155,8 +1099,7 @@ impl RocksdbProofsStorage {
             .map(|value| (value.number(), *value.hash())))
     }
 
-    /// Returns the latest known block number/hash, falling back to earliest when needed.
-    pub fn get_latest_block_number_hash(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+    fn get_latest_block_number_hash(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let block = self.get_block_number_hash(ProofWindowKey::LatestBlock)?;
         if block.is_some() {
             return Ok(block);
@@ -1165,8 +1108,7 @@ impl RocksdbProofsStorage {
         self.get_block_number_hash(ProofWindowKey::EarliestBlock)
     }
 
-    /// Returns both earliest and latest retained proof-window bounds.
-    pub fn get_proof_window(&self) -> BaseProofsStorageResult<Option<ProofWindowValue>> {
+    fn get_proof_window(&self) -> BaseProofsStorageResult<Option<ProofWindowValue>> {
         let Some((earliest_number, earliest_hash)) =
             self.get_block_number_hash(ProofWindowKey::EarliestBlock)?
         else {
@@ -1184,8 +1126,7 @@ impl RocksdbProofsStorage {
         }))
     }
 
-    /// Writes one proof-window block number/hash value into the batch.
-    pub fn put_proof_window(
+    fn put_proof_window(
         &self,
         batch: &mut WriteBatch,
         key: ProofWindowKey,
@@ -1195,8 +1136,7 @@ impl RocksdbProofsStorage {
         self.put_table::<ProofWindow>(batch, key, &BlockNumberHash::new(block_number, hash))
     }
 
-    /// Sets the earliest retained block number/hash under the history write lock.
-    pub fn set_earliest_block_number_hash(
+    fn set_earliest_block_number_hash(
         &self,
         block_number: u64,
         hash: B256,
@@ -1205,8 +1145,7 @@ impl RocksdbProofsStorage {
         self.set_earliest_block_number_hash_unlocked(block_number, hash)
     }
 
-    /// Sets the earliest retained block number/hash without taking the history lock.
-    pub fn set_earliest_block_number_hash_unlocked(
+    fn set_earliest_block_number_hash_unlocked(
         &self,
         block_number: u64,
         hash: B256,
@@ -1217,8 +1156,7 @@ impl RocksdbProofsStorage {
         Ok(())
     }
 
-    /// Computes survivor keys and prune metadata up to the target block.
-    pub fn calculate_prune_plan(
+    fn calculate_prune_plan(
         &self,
         snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
         target_block: u64,
@@ -1312,8 +1250,7 @@ impl RocksdbProofsStorage {
         Ok(Some(plan))
     }
 
-    /// Collects all history rows referenced by change sets in a block range.
-    pub fn collect_history_ranged(
+    fn collect_history_ranged(
         &self,
         block_range: impl RangeBounds<u64>,
     ) -> BaseProofsStorageResult<RocksdbHistoryDeleteBatch> {
@@ -1343,8 +1280,7 @@ impl RocksdbProofsStorage {
         Ok(history)
     }
 
-    /// Deletes all history rows and change sets contained in a prepared range batch.
-    pub fn delete_history_ranged(
+    fn delete_history_ranged(
         &self,
         batch: &mut WriteBatch,
         history: RocksdbHistoryDeleteBatch,
@@ -1376,8 +1312,7 @@ impl RocksdbProofsStorage {
         Ok(counts)
     }
 
-    /// Iterates decoded block change sets in ascending block order for the range.
-    pub fn iter_change_sets(
+    fn iter_change_sets(
         &self,
         block_range: impl RangeBounds<u64>,
     ) -> BaseProofsStorageResult<Vec<(u64, ChangeSet)>> {
@@ -1399,8 +1334,7 @@ impl RocksdbProofsStorage {
         Ok(rows)
     }
 
-    /// Iterates decoded block change sets from a snapshot for the range.
-    pub fn iter_change_sets_from_snapshot(
+    fn iter_change_sets_from_snapshot(
         &self,
         snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
         block_range: impl RangeBounds<u64> + 'static,
@@ -1431,8 +1365,7 @@ impl RocksdbProofsStorage {
         Ok(iter)
     }
 
-    /// Prepares a prune batch for advancing the earliest retained block.
-    pub fn prepare_prune(
+    fn prepare_prune(
         &self,
         new_earliest_block_ref: BlockWithParent,
     ) -> BaseProofsStorageResult<Option<RocksdbPreparedPrune>> {
@@ -1641,13 +1574,11 @@ impl RocksdbProofsStorage {
         Ok(counts)
     }
 
-    /// Returns the initial-state anchor block if one has been stored.
-    pub fn get_initial_state_anchor(&self) -> BaseProofsStorageResult<Option<BlockNumHash>> {
+    fn get_initial_state_anchor(&self) -> BaseProofsStorageResult<Option<BlockNumHash>> {
         Ok(self.get_table::<ProofWindow>(ProofWindowKey::InitialStateAnchor)?.map(Into::into))
     }
 
-    /// Returns the lexicographically greatest logical history key in a table.
-    pub fn get_latest_history_key<T>(&self) -> BaseProofsStorageResult<Option<T::Key>>
+    fn get_latest_history_key<T>(&self) -> BaseProofsStorageResult<Option<T::Key>>
     where
         T: RocksDbHistoryTable,
     {
@@ -1690,7 +1621,7 @@ impl BaseProofsStore for RocksdbProofsStorage {
         Self: 'tx;
 
     fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(Arc::new(RocksdbReadSnapshot::new(self.db.as_ref())))
     }
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
@@ -1703,82 +1634,100 @@ impl BaseProofsStore for RocksdbProofsStorage {
 
     fn storage_trie_cursor<'tx>(
         &'tx self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        // Standalone cursor factories intentionally create independent snapshots. Use `ro_tx` and
+        // the `*_with_tx` factories when multiple cursors need one consistent view.
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new(
+            self.db.as_ref(),
+            max_block_number,
+            Some(hashed_address),
+        ))
     }
 
     fn account_trie_cursor<'tx>(
         &'tx self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new(self.db.as_ref(), max_block_number, None))
     }
 
     fn storage_hashed_cursor<'tx>(
         &'tx self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbStorageCursor::new(self.db.as_ref(), max_block_number, hashed_address))
     }
 
     fn account_hashed_cursor<'tx>(
         &'tx self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbAccountCursor::new(self.db.as_ref(), max_block_number))
     }
 
     fn storage_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            Some(hashed_address),
+        ))
     }
 
     fn account_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            None,
+        ))
     }
 
     fn storage_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbStorageCursor::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            hashed_address,
+        ))
     }
 
     fn account_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbAccountCursor::new_with_snapshot(Arc::clone(tx), max_block_number))
     }
 
     fn store_trie_updates(
@@ -1795,8 +1744,112 @@ impl BaseProofsStore for RocksdbProofsStorage {
         Ok(counts)
     }
 
-    fn fetch_trie_updates(&self, _block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
-        unimplemented!("read path not yet implemented")
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        let snapshot = self.db.snapshot();
+        let change_set = self
+            .get_table_from_snapshot::<BlockChangeSet>(&snapshot, block_number)?
+            .ok_or(BaseProofsStorageError::NoChangeSetForBlock(block_number))?;
+
+        let mut trie_updates = TrieUpdates::default();
+        for key in change_set.account_trie_keys {
+            let entry = match get_history_exact::<AccountTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingAccountTrieHistory(
+                        key.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            if let Some(value) = entry {
+                trie_updates.account_nodes.insert(key.0, value);
+            } else {
+                trie_updates.removed_nodes.insert(key.0);
+            }
+        }
+
+        for key in change_set.storage_trie_keys {
+            let entry = match get_history_exact::<StorageTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingStorageTrieHistory(
+                        key.hashed_address,
+                        key.path.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            let storage_updates = trie_updates
+                .storage_tries
+                .entry(key.hashed_address)
+                .or_insert_with(StorageTrieUpdates::default);
+            if let Some(value) = entry {
+                storage_updates.storage_nodes.insert(key.path.0, value);
+            } else {
+                storage_updates.removed_nodes.insert(key.path.0);
+            }
+        }
+
+        let mut post_state = HashedPostState::with_capacity(change_set.hashed_account_keys.len());
+        for key in change_set.hashed_account_keys {
+            let entry = match get_history_exact::<HashedAccountHistory, _>(
+                &snapshot,
+                &self.db,
+                key,
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedAccountHistory(
+                        key,
+                        block_number,
+                    ));
+                }
+            };
+            post_state.accounts.insert(key, entry);
+        }
+
+        for key in change_set.hashed_storage_keys {
+            let entry = match get_history_exact::<HashedStorageHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedStorageHistory {
+                        hashed_address: key.hashed_address,
+                        hashed_storage_key: key.hashed_storage_key,
+                        block_number,
+                    });
+                }
+            };
+
+            let storage = post_state.storages.entry(key.hashed_address).or_default();
+            if let Some(value) = entry {
+                storage.storage.insert(key.hashed_storage_key, value.0);
+            } else {
+                storage.storage.insert(key.hashed_storage_key, U256::ZERO);
+            }
+        }
+
+        Ok(BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        })
     }
 
     fn prune_earliest_state(
@@ -1872,10 +1925,53 @@ impl BaseProofsStore for RocksdbProofsStorage {
 
     fn replace_updates(
         &self,
-        _latest_common_block: BlockNumHash,
-        _blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+        latest_common_block: BlockNumHash,
+        mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
     ) -> BaseProofsStorageResult<()> {
-        unimplemented!("read path not yet implemented")
+        blocks_to_add.sort_unstable_by_key(|(block, _)| block.block.number);
+
+        let mut latest_block_hash = latest_common_block.hash;
+        for (block_with_parent, _) in &blocks_to_add {
+            let block_number = block_with_parent.block.number;
+            if latest_block_hash != block_with_parent.parent {
+                return Err(BaseProofsStorageError::OutOfOrder {
+                    block_number,
+                    parent_block_hash: block_with_parent.parent,
+                    latest_block_hash,
+                });
+            }
+            latest_block_hash = block_with_parent.block.hash;
+        }
+
+        let _guard = self.history_gate.write();
+        let history_to_delete = if let Some(start_block) = latest_common_block.number.checked_add(1)
+        {
+            self.collect_history_ranged(start_block..)?
+        } else {
+            RocksdbHistoryDeleteBatch::default()
+        };
+        let mut batch = WriteBatch::default();
+        self.delete_history_ranged(&mut batch, history_to_delete)?;
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::LatestBlock,
+            latest_common_block.number,
+            latest_common_block.hash,
+        )?;
+
+        let mut replacement_state = RocksdbReplacementState::default();
+        for (block_with_parent, diff) in blocks_to_add {
+            self.store_replacement_trie_updates_append_only(
+                &mut batch,
+                latest_common_block.number,
+                &mut replacement_state,
+                block_with_parent,
+                diff,
+            )?;
+        }
+
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
     }
 
     fn set_earliest_block_number(
@@ -2045,15 +2141,12 @@ impl BaseProofsInitialStateStore for RocksdbProofsStorage {
 /// after each `store_trie_updates` so subsequent block reads observe the prior commit.
 #[derive(Debug)]
 pub struct RocksdbBatchSession<'a> {
-    /// Backend storage handle the session writes through.
-    pub storage: &'a RocksdbProofsStorage,
-    /// Shared read snapshot reused across all cursor reads in the session.
-    pub snapshot: Arc<RocksdbReadSnapshot<'a>>,
+    storage: &'a RocksdbProofsStorage,
+    snapshot: Arc<RocksdbReadSnapshot<'a>>,
 }
 
 impl<'a> RocksdbBatchSession<'a> {
-    /// Opens a new batch session holding a single shared read snapshot.
-    pub fn new(storage: &'a RocksdbProofsStorage) -> Self {
+    fn new(storage: &'a RocksdbProofsStorage) -> Self {
         let snapshot = Arc::new(RocksdbReadSnapshot::new(storage.db.as_ref()));
         Self { storage, snapshot }
     }
@@ -2087,32 +2180,32 @@ impl BaseProofsBatchSession for RocksdbBatchSession<'_> {
 
     fn storage_trie_cursor(
         &self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.storage_trie_cursor_with_tx(&self.snapshot, hashed_address, max_block_number)
     }
 
     fn account_trie_cursor(
         &self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.account_trie_cursor_with_tx(&self.snapshot, max_block_number)
     }
 
     fn storage_hashed_cursor(
         &self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.storage_hashed_cursor_with_tx(&self.snapshot, hashed_address, max_block_number)
     }
 
     fn account_hashed_cursor(
         &self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.account_hashed_cursor_with_tx(&self.snapshot, max_block_number)
     }
 
     fn store_trie_updates(
@@ -2232,181 +2325,298 @@ where
     T::Value: Decompress,
 {
     /// Creates a cursor over a `RocksDB` history column family.
-    pub fn new(_db: &'db RocksDb, _max_block_number: u64) -> Self {
-        unimplemented!("read path not yet implemented")
+    fn new(db: &'db RocksDb, max_block_number: u64) -> Self {
+        let snapshot = Arc::new(RocksdbReadSnapshot::new(db));
+        Self::new_with_snapshot(snapshot, max_block_number)
     }
 
-    /// Creates a versioned cursor that reads from a shared snapshot.
-    pub fn new_with_snapshot(
-        _snapshot: Arc<RocksdbReadSnapshot<'db>>,
-        _max_block_number: u64,
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
     ) -> Self {
-        unimplemented!("read path not yet implemented")
+        Self { snapshot, max_block_number, current_key: None, _table: PhantomData }
     }
 
-    /// Returns the column family handle for this cursor's history table.
-    pub fn cf(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn cf(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
+        self.snapshot.cf(T::NAME)
     }
 
-    /// Returns encoded lower and upper bounds for an exact key lookup.
-    pub fn exact_lookup_bounds(&self, _key: &T::Key) -> Result<(Vec<u8>, Vec<u8>), DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn exact_lookup_bounds(&self, key: &T::Key) -> Result<(Vec<u8>, Vec<u8>), DatabaseError> {
+        let mut target = encode_history_key_prefix::<T>(key)?;
+        let prefix = target.clone();
+        // History keys are encoded with the block-number suffix complemented
+        // (`u64::MAX - block_number`), so larger block numbers produce SMALLER
+        // suffixes. The "target" is therefore the smallest encoded key that
+        // could match: a forward `seek(target)` lands on the first stored
+        // version V with `complement(V) >= complement(max_block_number)`, i.e.
+        // `V <= max_block_number` — the newest version at or below the bound.
+        target.extend_from_slice(&encode_history_block_suffix(self.max_block_number));
+        Ok((prefix, target))
     }
 
-    /// Returns the latest visible version for the provided logical key.
-    pub fn latest_version_for_key(&self, _key: T::Key) -> RocksDbLatestVersionResult<T> {
-        unimplemented!("read path not yet implemented")
+    fn latest_version_for_key(&self, key: T::Key) -> RocksDbLatestVersionResult<T> {
+        let cf = self.cf()?;
+        let (prefix, target) = self.exact_lookup_bounds(&key)?;
+        let read_options = exact_prefix_read_options(&prefix);
+        let mut iter = self.snapshot.snapshot().raw_iterator_cf_opt(&cf, read_options);
+        // Forward `seek` is the fast path: with reversed block-suffix encoding
+        // the newest version-at-or-below `max_block_number` sorts FIRST within
+        // the prefix box, so we land directly on it instead of paying the
+        // documented 7-8x penalty of `seek_for_prev` (RocksDB PR #5535).
+        iter.seek(&target);
+        if !iter.valid() {
+            iter.status().map_err(rocksdb_error)?;
+            return Ok(None);
+        }
+
+        let raw_key = iter.key().ok_or(DatabaseError::Decode)?;
+        if !raw_key.starts_with(&prefix) {
+            return Ok(None);
+        }
+
+        let (decoded_key, _) = decode_history_key::<T>(raw_key)?;
+        let raw_value = iter.value().ok_or(DatabaseError::Decode)?;
+        let value = T::Value::decompress(raw_value)?;
+        Ok(Some((decoded_key, value)))
     }
 
-    /// Seeks to an exact key and returns its decoded visible value.
-    pub fn seek_exact(&self, _key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn seek_exact(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.current_key = Some(key.clone());
+        if let Some((latest_key, latest_value)) = self.latest_version_for_key(key)?
+            && let MaybeDeleted(Some(value)) = latest_value.value
+        {
+            return Ok(Some((latest_key, value)));
+        }
+        Ok(None)
     }
 
-    /// Seeks to the first key at or after the provided start key.
-    pub fn seek(&self, _start_key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn seek(&mut self, start_key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_from(start_key)
     }
 
-    /// Advances the cursor to the next decoded row.
-    pub fn next(&self) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn next(&mut self) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        if let Some(key) = self.current_key.clone() {
+            self.next_live_after(key)
+        } else {
+            self.next_live_from(T::Key::default())
+        }
     }
 
-    /// Returns the next live row at or after the given key.
-    pub fn next_live_from(&self, _key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn next_live_from(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, false, total_order_read_options())
     }
 
-    /// Returns the next live row strictly after the given key.
-    pub fn next_live_after(&self, _key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn next_live_after(&mut self, key: T::Key) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        self.next_live_candidate(key, true, total_order_read_options())
     }
 
-    /// Seeks using an explicit encoded prefix bound.
-    pub fn seek_with_prefix(
-        &self,
-        _key: T::Key,
-        _prefix: Vec<u8>,
+    fn seek_with_prefix(
+        &mut self,
+        key: T::Key,
+        prefix: Vec<u8>,
     ) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        self.next_live_candidate(key, false, prefix_read_options(&prefix))
     }
 
-    /// Advances to the next row constrained to the provided prefix.
-    pub fn next_with_prefix(&self, _prefix: Vec<u8>) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn next_with_prefix(&mut self, prefix: Vec<u8>) -> Result<Option<(T::Key, V)>, DatabaseError> {
+        if let Some(key) = self.current_key.clone() {
+            self.next_live_candidate(key, true, prefix_read_options(&prefix))
+        } else {
+            self.next_live_candidate(T::Key::default(), false, prefix_read_options(&prefix))
+        }
     }
 
-    /// Returns the next candidate row while optionally skipping tombstoned values.
-    pub fn next_live_candidate(
-        &self,
-        _key: T::Key,
-        _exclusive: bool,
-        _read_options: ReadOptions,
+    fn next_live_candidate(
+        &mut self,
+        key: T::Key,
+        exclusive: bool,
+        read_options: ReadOptions,
     ) -> Result<Option<(T::Key, V)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        let found = {
+            let cf = self.cf()?;
+            // Under the reversed block-suffix encoding, within a given key's
+            // prefix the SMALLEST encoded suffix is `u64::MAX - u64::MAX = 0`
+            // (i.e. block `u64::MAX`) and the LARGEST is `u64::MAX - 0 =
+            // u64::MAX` (i.e. block `0`). So to start a forward scan at the
+            // first encoded row of `key`, use block `u64::MAX`; to start
+            // strictly after all of `key`'s rows, use block `0` (the
+            // `before_start` filter below then skips the equal-key row).
+            let start_block = if exclusive { 0 } else { u64::MAX };
+            let start_key = encode_history_key::<T>(&key, start_block)?;
+            let iter = self.snapshot.snapshot().iterator_cf_opt(
+                &cf,
+                read_options,
+                IteratorMode::From(&start_key, Direction::Forward),
+            );
+            let mut last_candidate = None;
+            let mut found = None;
+
+            for item in iter {
+                let (raw_key, _) = item.map_err(rocksdb_error)?;
+                let (candidate, _) = decode_history_key::<T>(&raw_key)?;
+                let before_start = if exclusive { candidate <= key } else { candidate < key };
+                if before_start || last_candidate.as_ref() == Some(&candidate) {
+                    continue;
+                }
+
+                last_candidate = Some(candidate.clone());
+                if let Some((live_key, latest_value)) = self.latest_version_for_key(candidate)?
+                    && let MaybeDeleted(Some(value)) = latest_value.value
+                {
+                    found = Some((live_key, value));
+                    break;
+                }
+            }
+
+            found
+        };
+
+        if let Some((key, value)) = found {
+            self.current_key = Some(key.clone());
+            return Ok(Some((key, value)));
+        }
+
+        self.current_key = None;
+        Ok(None)
     }
 
-    /// Returns `true` when the cursor currently points at a key.
-    pub const fn is_positioned(&self) -> bool {
+    const fn is_positioned(&self) -> bool {
         self.current_key.is_some()
     }
 }
 
 impl<'db> RocksdbTrieCursor<'db, AccountTrieHistory> {
     /// Creates a `RocksDB` trie cursor.
-    pub fn new(_db: &'db RocksDb, _max_block_number: u64, _hashed_address: Option<B256>) -> Self {
-        unimplemented!("read path not yet implemented")
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: Option<B256>) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
     }
 
-    /// Creates a `RocksDB` trie cursor over a shared read snapshot.
-    /// Creates a `RocksDB` storage cursor over a shared read snapshot.
-    pub fn new_with_snapshot(
-        _snapshot: Arc<RocksdbReadSnapshot<'db>>,
-        _max_block_number: u64,
-        _hashed_address: Option<B256>,
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: Option<B256>,
     ) -> Self {
-        unimplemented!("read path not yet implemented")
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
     }
 }
 
 impl<'db> RocksdbTrieCursor<'db, StorageTrieHistory> {
     /// Creates a `RocksDB` trie cursor.
-    pub fn new(_db: &'db RocksDb, _max_block_number: u64, _hashed_address: Option<B256>) -> Self {
-        unimplemented!("read path not yet implemented")
+    pub fn new(db: &'db RocksDb, max_block_number: u64, hashed_address: Option<B256>) -> Self {
+        Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
     }
 
-    /// Creates a `RocksDB` trie cursor over a shared read snapshot.
-    /// Creates a `RocksDB` account cursor over a shared read snapshot.
-    pub fn new_with_snapshot(
-        _snapshot: Arc<RocksdbReadSnapshot<'db>>,
-        _max_block_number: u64,
-        _hashed_address: Option<B256>,
+    const fn new_with_snapshot(
+        snapshot: Arc<RocksdbReadSnapshot<'db>>,
+        max_block_number: u64,
+        hashed_address: Option<B256>,
     ) -> Self {
-        unimplemented!("read path not yet implemented")
+        Self {
+            inner: RocksdbVersionedCursor::new_with_snapshot(snapshot, max_block_number),
+            hashed_address,
+        }
     }
 }
 
 impl TrieCursor for RocksdbTrieCursor<'_, AccountTrieHistory> {
     fn seek_exact(
         &mut self,
-        _path: Nibbles,
+        path: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        Ok(self
+            .inner
+            .seek_exact(StoredNibbles(path))?
+            .map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
     }
 
     fn seek(
         &mut self,
-        _path: Nibbles,
+        path: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        Ok(self
+            .inner
+            .seek(StoredNibbles(path))?
+            .map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
     }
 
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        Ok(self.inner.next()?.map(|(StoredNibbles(nibbles), node)| (nibbles, node)))
     }
 
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        Ok(self.inner.current_key.clone().map(|StoredNibbles(nibbles)| nibbles))
     }
 
     fn reset(&mut self) {
-        unimplemented!("read path not yet implemented")
+        self.inner.current_key = None;
     }
 }
 
 impl TrieCursor for RocksdbTrieCursor<'_, StorageTrieHistory> {
     fn seek_exact(
         &mut self,
-        _path: Nibbles,
+        path: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        let key = StorageTrieKey::new(address, StoredNibbles(path));
+        Ok(self
+            .inner
+            .seek_exact(key)?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
     }
 
     fn seek(
         &mut self,
-        _path: Nibbles,
+        path: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        let key = StorageTrieKey::new(address, StoredNibbles(path));
+        Ok(self
+            .inner
+            .seek_with_prefix(key, hashed_address_prefix(address))?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
     }
 
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        if !self.inner.is_positioned() {
+            return self.seek(Nibbles::default());
+        }
+        Ok(self
+            .inner
+            .next_with_prefix(hashed_address_prefix(address))?
+            .and_then(|(key, node)| (key.hashed_address == address).then_some((key.path.0, node))))
     }
 
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        let Some(address) = self.hashed_address else {
+            return Ok(None);
+        };
+        Ok(self
+            .inner
+            .current_key
+            .clone()
+            .and_then(|key| (key.hashed_address == address).then_some(key.path.0)))
     }
 
     fn reset(&mut self) {
-        unimplemented!("read path not yet implemented")
+        self.inner.current_key = None;
     }
 }
 
 impl TrieStorageCursor for RocksdbTrieCursor<'_, StorageTrieHistory> {
-    fn set_hashed_address(&mut self, _hashed_address: B256) {
-        unimplemented!("read path not yet implemented")
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = Some(hashed_address);
+        self.inner.current_key = None;
     }
 }
 
@@ -2416,8 +2626,7 @@ impl<'db> RocksdbStorageCursor<'db> {
         Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
     }
 
-    /// Creates a `RocksDB` storage cursor over a shared read snapshot.
-    pub fn new_with_snapshot(
+    const fn new_with_snapshot(
         snapshot: Arc<RocksdbReadSnapshot<'db>>,
         max_block_number: u64,
         hashed_address: B256,
@@ -2432,26 +2641,62 @@ impl<'db> RocksdbStorageCursor<'db> {
 impl HashedCursor for RocksdbStorageCursor<'_> {
     type Value = U256;
 
-    fn seek(&mut self, _key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        let storage_key = HashedStorageKey::new(self.hashed_address, key);
+        let result = self
+            .inner
+            .seek_with_prefix(storage_key, hashed_address_prefix(self.hashed_address))?
+            .and_then(|(key, value)| {
+                (key.hashed_address == self.hashed_address)
+                    .then_some((key.hashed_storage_key, value.0))
+            });
+
+        if let Some((_, value)) = result
+            && value.is_zero()
+        {
+            return self.next();
+        }
+
+        Ok(result)
     }
 
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        if !self.inner.is_positioned() {
+            return self.seek(B256::ZERO);
+        }
+
+        loop {
+            let result = self
+                .inner
+                .next_with_prefix(hashed_address_prefix(self.hashed_address))?
+                .and_then(|(key, value)| {
+                    (key.hashed_address == self.hashed_address)
+                        .then_some((key.hashed_storage_key, value.0))
+                });
+
+            let Some((key, value)) = result else {
+                return Ok(None);
+            };
+            if value.is_zero() {
+                continue;
+            }
+            return Ok(Some((key, value)));
+        }
     }
 
     fn reset(&mut self) {
-        unimplemented!("read path not yet implemented")
+        self.inner.current_key = None;
     }
 }
 
 impl HashedStorageCursor for RocksdbStorageCursor<'_> {
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        Ok(self.seek(B256::ZERO)?.is_none())
     }
 
-    fn set_hashed_address(&mut self, _hashed_address: B256) {
-        unimplemented!("read path not yet implemented")
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.hashed_address = hashed_address;
+        self.inner.current_key = None;
     }
 }
 
@@ -2461,8 +2706,7 @@ impl<'db> RocksdbAccountCursor<'db> {
         Self { inner: RocksdbVersionedCursor::new(db, max_block_number) }
     }
 
-    /// Creates a `RocksDB` account cursor over a shared read snapshot.
-    pub fn new_with_snapshot(
+    const fn new_with_snapshot(
         snapshot: Arc<RocksdbReadSnapshot<'db>>,
         max_block_number: u64,
     ) -> Self {
@@ -2473,16 +2717,16 @@ impl<'db> RocksdbAccountCursor<'db> {
 impl HashedCursor for RocksdbAccountCursor<'_> {
     type Value = Account;
 
-    fn seek(&mut self, _key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        self.inner.seek(key)
     }
 
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        unimplemented!("read path not yet implemented")
+        self.inner.next()
     }
 
     fn reset(&mut self) {
-        unimplemented!("read path not yet implemented")
+        self.inner.current_key = None;
     }
 }
 
@@ -2532,7 +2776,6 @@ where
 }
 
 /// Reads one exact history value for a key at a specific block number.
-#[expect(dead_code, reason = "used by the RocksDB read/cursor path implemented in a later PR")]
 fn get_history_exact<T, V>(
     snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
     db: &Arc<RocksDb>,
@@ -2744,7 +2987,6 @@ fn exact_prefix_read_options(prefix: &[u8]) -> ReadOptions {
 }
 
 /// Builds read options with total-order seek enabled.
-#[expect(dead_code, reason = "used by the RocksDB read/cursor path implemented in a later PR")]
 fn total_order_read_options() -> ReadOptions {
     let mut read_options = ReadOptions::default();
     read_options.set_total_order_seek(true);
@@ -2752,7 +2994,6 @@ fn total_order_read_options() -> ReadOptions {
 }
 
 /// Returns the encoded key prefix for a hashed address.
-#[expect(dead_code, reason = "used by the RocksDB read/cursor path implemented in a later PR")]
 fn hashed_address_prefix(hashed_address: B256) -> Vec<u8> {
     hashed_address.as_slice().to_vec()
 }
@@ -2769,4 +3010,513 @@ fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    };
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn temp_storage() -> (Arc<RocksdbProofsStorage>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).unwrap());
+        (storage, dir)
+    }
+
+    #[test]
+    fn max_total_wal_size_tracks_column_family_write_buffers() {
+        let options = RocksdbProofsStorageOptions::default();
+        assert_eq!(
+            RocksdbProofsStorage::max_total_wal_size(options),
+            RocksdbProofsStorage::column_families().len() as u64
+                * options.write_buffer_size as u64
+                * options.max_write_buffer_number as u64
+        );
+    }
+
+    #[test]
+    fn max_total_wal_size_uses_explicit_override() {
+        let options = RocksdbProofsStorageOptions {
+            max_total_wal_size: Some(512 * 1024 * 1024),
+            ..Default::default()
+        };
+        assert_eq!(RocksdbProofsStorage::max_total_wal_size(options), 512 * 1024 * 1024);
+    }
+
+    #[test]
+    fn default_options_use_sync_friendly_settings() {
+        let options = RocksdbProofsStorageOptions::default();
+        assert_eq!(options.block_cache_size, DEFAULT_BLOCK_CACHE_SIZE);
+        assert_eq!(options.bytes_per_sync, DEFAULT_BYTES_PER_SYNC);
+        assert_eq!(options.compaction_readahead_size, DEFAULT_COMPACTION_READAHEAD_SIZE);
+        assert_eq!(
+            options.level_zero_file_num_compaction_trigger,
+            DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+        );
+        assert_eq!(
+            options.level_zero_slowdown_writes_trigger,
+            DEFAULT_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER
+        );
+        assert_eq!(options.level_zero_stop_writes_trigger, DEFAULT_LEVEL_ZERO_STOP_WRITES_TRIGGER);
+        assert_eq!(options.max_background_jobs, DEFAULT_MAX_BACKGROUND_JOBS);
+        assert_eq!(options.max_subcompactions, DEFAULT_MAX_SUBCOMPACTIONS);
+        assert_eq!(options.max_write_buffer_number, DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        assert_eq!(options.target_file_size_base, DEFAULT_TARGET_FILE_SIZE_BASE);
+        assert_eq!(options.write_buffer_size, DEFAULT_WRITE_BUFFER_SIZE);
+        assert!(options.use_direct_io_for_flush_and_compaction);
+    }
+
+    #[test]
+    fn history_prefix_lengths_match_encoded_key_prefixes() {
+        let account_path = StoredNibbles(Nibbles::from_nibbles_unchecked([1, 2, 3]));
+        let storage_path = StorageTrieKey::new(
+            B256::repeat_byte(0x01),
+            StoredNibbles(Nibbles::from_nibbles_unchecked([4, 5, 6])),
+        );
+        let hashed_account = B256::repeat_byte(0x02);
+        let hashed_storage =
+            HashedStorageKey::new(B256::repeat_byte(0x03), B256::repeat_byte(0x04));
+
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<AccountTrieHistory as Table>::NAME),
+            Some(PACKED_NIBBLES_KEY_LEN)
+        );
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<StorageTrieHistory as Table>::NAME),
+            Some(HASH_KEY_LEN + PACKED_NIBBLES_KEY_LEN)
+        );
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<HashedAccountHistory as Table>::NAME),
+            Some(HASH_KEY_LEN)
+        );
+        assert_eq!(
+            RocksdbProofsStorage::history_prefix_len(<HashedStorageHistory as Table>::NAME),
+            Some(HASH_KEY_LEN * 2)
+        );
+        assert_eq!(RocksdbProofsStorage::history_prefix_len(<ProofWindow as Table>::NAME), None);
+
+        assert_eq!(
+            encode_history_key_prefix::<AccountTrieHistory>(&account_path).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<AccountTrieHistory as Table>::NAME).unwrap()
+        );
+        assert_eq!(
+            encode_history_key_prefix::<StorageTrieHistory>(&storage_path).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<StorageTrieHistory as Table>::NAME).unwrap()
+        );
+        assert_eq!(
+            encode_history_key_prefix::<HashedAccountHistory>(&hashed_account).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<HashedAccountHistory as Table>::NAME)
+                .unwrap()
+        );
+        assert_eq!(
+            encode_history_key_prefix::<HashedStorageHistory>(&hashed_storage).unwrap().len(),
+            RocksdbProofsStorage::history_prefix_len(<HashedStorageHistory as Table>::NAME)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn opens_with_history_prefix_filter_options() {
+        let dir = TempDir::new().unwrap();
+        let storage = RocksdbProofsStorage::new_with_options(
+            dir.path(),
+            RocksdbProofsStorageOptions::default(),
+        )
+        .unwrap();
+        let account = B256::repeat_byte(0x55);
+
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+        storage.store_trie_updates(block(1, B256::ZERO), account_update(account, 1)).unwrap();
+
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        let (key, acc) = storage
+            .account_hashed_cursor(1)
+            .unwrap()
+            .seek(account)
+            .unwrap()
+            .expect("account exists");
+        assert_eq!(key, account);
+        assert_eq!(acc.nonce, 1);
+    }
+
+    fn block(number: u64, parent: B256) -> BlockWithParent {
+        BlockWithParent {
+            parent,
+            block: BlockNumHash {
+                number,
+                hash: if number == 0 { B256::ZERO } else { B256::repeat_byte(number as u8) },
+            },
+        }
+    }
+
+    fn account_update(address: B256, nonce: u64) -> BlockStateDiff {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdates::default().into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    }
+
+    fn assert_completes(rx: mpsc::Receiver<BaseProofsStorageResult<()>>) {
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("operation should complete")
+            .expect("operation should succeed");
+    }
+
+    #[test]
+    fn packed_nibbles_round_trip() {
+        let nibbles = Nibbles::from_nibbles_unchecked([0, 1, 0, 2, 15, 0, 3]);
+        let encoded = encode_packed_nibbles(&nibbles).unwrap();
+
+        assert_eq!(encoded[HASH_KEY_LEN], 7);
+        assert_eq!(decode_packed_nibbles(&encoded).unwrap(), nibbles);
+    }
+
+    #[test]
+    fn packed_nibbles_preserve_lexicographic_order() {
+        let keys = [
+            vec![],
+            vec![0],
+            vec![0, 0],
+            vec![0, 1],
+            vec![1],
+            vec![1, 0],
+            vec![1, 1],
+            vec![2],
+            vec![15],
+            vec![15, 15],
+        ];
+
+        for left in &keys {
+            for right in &keys {
+                let left = Nibbles::from_nibbles_unchecked(left);
+                let right = Nibbles::from_nibbles_unchecked(right);
+                assert_eq!(
+                    left.cmp(&right),
+                    encode_packed_nibbles(&left)
+                        .unwrap()
+                        .cmp(&encode_packed_nibbles(&right).unwrap())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hashed_history_keys_preserve_full_byte_ordering() {
+        let keys = [B256::ZERO, B256::repeat_byte(2), B256::repeat_byte(255)];
+
+        for left in keys {
+            for right in keys {
+                assert_eq!(
+                    left.cmp(&right),
+                    encode_history_key_prefix::<HashedAccountHistory>(&left)
+                        .unwrap()
+                        .cmp(&encode_history_key_prefix::<HashedAccountHistory>(&right).unwrap())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn history_block_suffix_round_trip_covers_endpoints_and_interior() {
+        for block_number in [0u64, 1, 42, 1 << 20, u64::MAX / 2, u64::MAX - 1, u64::MAX] {
+            let encoded = encode_history_block_suffix(block_number);
+            let decoded = decode_history_block_suffix(&encoded).unwrap();
+            assert_eq!(decoded, block_number, "round-trip failed at block {block_number}");
+        }
+    }
+
+    #[test]
+    fn history_block_suffix_reverses_lexicographic_order() {
+        // Complement encoding: newer block must sort BEFORE older block under the default
+        // BytewiseComparator, so a forward seek(target) + next() finds "latest version <= N".
+        let blocks = [0u64, 1, 2, 100, 1_000_000, u64::MAX - 1, u64::MAX];
+        for left in blocks {
+            for right in blocks {
+                let encoded_cmp =
+                    encode_history_block_suffix(left).cmp(&encode_history_block_suffix(right));
+                assert_eq!(
+                    encoded_cmp,
+                    right.cmp(&left),
+                    "expected reversed ordering for ({left}, {right})",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn history_block_suffix_boundary_values_are_complementary() {
+        assert_eq!(encode_history_block_suffix(0), [0xFF; BLOCK_NUMBER_KEY_LEN]);
+        assert_eq!(encode_history_block_suffix(u64::MAX), [0x00; BLOCK_NUMBER_KEY_LEN]);
+        assert_eq!(decode_history_block_suffix(&[0xFF; BLOCK_NUMBER_KEY_LEN]).unwrap(), 0);
+        assert_eq!(decode_history_block_suffix(&[0x00; BLOCK_NUMBER_KEY_LEN]).unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn decode_history_block_suffix_rejects_wrong_length() {
+        assert!(decode_history_block_suffix(&[]).is_err());
+        assert!(decode_history_block_suffix(&[0u8; BLOCK_NUMBER_KEY_LEN - 1]).is_err());
+        assert!(decode_history_block_suffix(&[0u8; BLOCK_NUMBER_KEY_LEN + 1]).is_err());
+    }
+
+    #[test]
+    fn encoded_history_key_orders_newer_blocks_before_older_for_same_prefix() {
+        let prefix = B256::repeat_byte(0x7F);
+        let older = encode_history_key::<HashedAccountHistory>(&prefix, 10).unwrap();
+        let newer = encode_history_key::<HashedAccountHistory>(&prefix, 100).unwrap();
+        assert!(newer < older, "newer block must sort before older under complement encoding");
+
+        // Shared prefix preservation is what keeps RocksDB prefix bloom filters correct
+        // for forward seeks on history tables.
+        let prefix_bytes = encode_history_key_prefix::<HashedAccountHistory>(&prefix).unwrap();
+        assert!(older.starts_with(&prefix_bytes));
+        assert!(newer.starts_with(&prefix_bytes));
+    }
+
+    #[test]
+    fn packed_nibbles_reject_invalid_padding() {
+        let mut encoded =
+            encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1, 2, 3])).unwrap();
+        encoded[HASH_KEY_LEN - 1] = 1;
+        assert!(decode_packed_nibbles(&encoded).is_err());
+
+        let mut encoded = encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1])).unwrap();
+        encoded[0] |= 1;
+        assert!(decode_packed_nibbles(&encoded).is_err());
+    }
+
+    #[test]
+    fn append_can_run_while_prune_holds_history_read_gate() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert_completes(rx);
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+    }
+
+    #[test]
+    fn exclusive_history_gate_blocks_append() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let history_guard = storage.history_gate.write();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_lock_serializes_append_writers() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let append_guard = storage.append_lock.lock();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(append_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn prune_history_read_gate_blocks_history_rewrite() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage.replace_updates(BlockNumHash::new(0, B256::ZERO), vec![]);
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_during_prepared_prune_preserves_latest_block() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+        storage.store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default()).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), BlockStateDiff::default())
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared =
+            storage.prepare_prune(block(1, B256::ZERO)).unwrap().expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), BlockStateDiff::default())
+            .unwrap();
+        storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert!(latest_diff.sorted_trie_updates.account_nodes_ref().is_empty());
+        assert!(latest_diff.sorted_trie_updates.storage_tries_ref().is_empty());
+        assert!(latest_diff.sorted_post_state.accounts.is_empty());
+        assert!(latest_diff.sorted_post_state.storages.is_empty());
+    }
+
+    #[test]
+    fn append_inside_requested_prune_range_survives() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let address = B256::repeat_byte(0xAA);
+        storage.store_trie_updates(block(1, B256::ZERO), account_update(address, 1)).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), account_update(address, 2))
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared = storage
+            .prepare_prune(block(10, B256::repeat_byte(2)))
+            .unwrap()
+            .expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), account_update(address, 3))
+            .unwrap();
+        let counts = storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(counts.hashed_accounts_written_total, 1);
+        assert_eq!(counts.account_trie_updates_written_total, 0);
+        assert_eq!(counts.storage_trie_updates_written_total, 0);
+        assert_eq!(counts.hashed_storages_written_total, 0);
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((2, B256::repeat_byte(2))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert_eq!(
+            &latest_diff.sorted_post_state.accounts[..],
+            &[(address, Some(Account { nonce: 3, ..Default::default() }))]
+        );
+
+        let mut cursor = storage.account_hashed_cursor(3).unwrap();
+        assert_eq!(
+            cursor.seek(address).unwrap(),
+            Some((address, Account { nonce: 3, ..Default::default() }))
+        );
+    }
+
+    #[test]
+    fn storage_trie_cursor_finds_all_nibble_paths_after_flush() {
+        let (storage, _dir) = temp_storage();
+        let address = B256::repeat_byte(0xAA);
+
+        let nibble_paths = [
+            Nibbles::from_nibbles_unchecked(vec![0, 1]),
+            Nibbles::from_nibbles_unchecked(vec![1, 0]),
+            Nibbles::from_nibbles_unchecked(vec![2, 3, 4]),
+            Nibbles::from_nibbles_unchecked(vec![15, 0, 1]),
+        ];
+
+        let branch = BranchNodeCompact::new(
+            reth_trie_common::TrieMask::new(0b11),
+            reth_trie_common::TrieMask::default(),
+            reth_trie_common::TrieMask::default(),
+            vec![],
+            None,
+        );
+
+        let mut parent_hash = B256::ZERO;
+        for (i, path) in nibble_paths.iter().enumerate() {
+            let block_number = (i + 1) as u64;
+            let parent = block(block_number.saturating_sub(1), parent_hash);
+
+            let mut trie_updates = TrieUpdates::default();
+            let mut storage_updates = StorageTrieUpdates::default();
+            storage_updates.storage_nodes.insert(*path, branch.clone());
+            trie_updates.storage_tries.insert(address, storage_updates);
+
+            let diff = BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostState::default().into_sorted(),
+            };
+
+            parent_hash = parent.block.hash;
+            storage.store_trie_updates(parent, diff).expect("store should succeed");
+
+            storage.flush_and_compact().expect("flush should succeed");
+        }
+
+        // seek_exact uses exact_prefix_read_options (with prefix_same_as_start)
+        // and should find each entry individually.
+        for path in &nibble_paths {
+            let mut cursor =
+                storage.storage_trie_cursor(address, u64::MAX).expect("cursor should open");
+            let result = cursor.seek_exact(*path).expect("seek_exact should succeed");
+            assert!(result.is_some(), "seek_exact should find entry for path {path:?}");
+        }
+
+        // seek/next use prefix_read_options with a 32-byte address prefix
+        // on a CF with a 65-byte prefix extractor. After flush, the bloom
+        // filter can cause the iterator to skip SST blocks whose 65-byte
+        // prefix doesn't match the one extracted from the seek key.
+        let mut cursor =
+            storage.storage_trie_cursor(address, u64::MAX).expect("cursor should open");
+
+        let first = cursor.seek(Nibbles::default()).expect("seek should succeed");
+        assert!(first.is_some(), "seek should find at least one entry");
+
+        let mut found = vec![first.unwrap().0];
+        while let Some((path, _)) = cursor.next().expect("next should succeed") {
+            found.push(path);
+        }
+
+        let expected: Vec<Nibbles> = nibble_paths.to_vec();
+        assert_eq!(
+            found, expected,
+            "cursor should find all nibble paths for the address after flush"
+        );
+    }
 }

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -459,708 +459,783 @@ impl<C> InitTable for StoragesTrieInit<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use alloy_primitives::{Address, U256, keccak256};
-    use reth_db::{
-        Database, cursor::DbCursorRW, test_utils::create_test_rw_db, transaction::DbTxMut,
-    };
-    use reth_primitives_traits::Account;
-    use reth_trie::{
-        BranchNodeCompact, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey, TrieMask,
-        hashed_cursor::HashedCursor, trie_cursor::TrieCursor,
-    };
-    use tempfile::TempDir;
-
-    use super::*;
-    use crate::MdbxProofsStorage;
-
-    /// Helper function to create a key
-    fn k(b: u8) -> B256 {
-        let mut bytes = [0u8; 32];
-        bytes[0] = b;
-        B256::from(bytes)
-    }
-
-    /// Helper function to create a test branch node
-    fn create_test_branch_node() -> BranchNodeCompact {
-        let mut state_mask = TrieMask::default();
-        state_mask.set_bit(0);
-        state_mask.set_bit(1);
-
-        BranchNodeCompact {
-            state_mask,
-            tree_mask: TrieMask::default(),
-            hash_mask: TrieMask::default(),
-            hashes: Arc::new(vec![]),
-            root_hash: None,
-        }
-    }
-
-    #[test]
-    fn test_initialize_hashed_accounts() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test accounts into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-
-        let mut accounts = vec![
-            (
-                keccak256(Address::repeat_byte(0x01)),
-                Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
-            ),
-            (
-                keccak256(Address::repeat_byte(0x02)),
-                Account { nonce: 2, balance: U256::from(200), bytecode_hash: None },
-            ),
-            (
-                keccak256(Address::repeat_byte(0x03)),
-                Account { nonce: 3, balance: U256::from(300), bytecode_hash: None },
-            ),
-        ];
-
-        // Sort accounts by address for cursor.append (which requires sorted order)
-        accounts.sort_by_key(|(addr, _)| *addr);
-
-        for (addr, account) in &accounts {
-            cursor.append(*addr, account).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_hashed_accounts(None).unwrap();
-
-        // Verify data was stored (will be in sorted order)
-        let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
-        let mut count = 0;
-        while let Some((key, account)) = account_cursor.next().unwrap() {
-            // Find matching account in our test data
-            let expected = accounts.iter().find(|(addr, _)| *addr == key).unwrap();
-            assert_eq!((key, account), *expected);
-            count += 1;
-        }
-        assert_eq!(count, 3);
-    }
-
-    #[test]
-    fn test_initialize_hashed_storage() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test storage into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-
-        let addr1 = keccak256(Address::repeat_byte(0x01));
-        let addr2 = keccak256(Address::repeat_byte(0x02));
-
-        let storage_entries = vec![
-            (
-                addr1,
-                StorageEntry { key: keccak256(B256::repeat_byte(0x10)), value: U256::from(100) },
-            ),
-            (
-                addr1,
-                StorageEntry { key: keccak256(B256::repeat_byte(0x20)), value: U256::from(200) },
-            ),
-            (
-                addr2,
-                StorageEntry { key: keccak256(B256::repeat_byte(0x30)), value: U256::from(300) },
-            ),
-        ];
-
-        for (addr, entry) in &storage_entries {
-            cursor.upsert(*addr, entry).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_hashed_storages(None).unwrap();
-
-        // Verify data was stored for addr1
-        let mut storage_cursor = storage.storage_hashed_cursor(addr1, 100).unwrap();
-        let mut found = vec![];
-        while let Some((key, value)) = storage_cursor.next().unwrap() {
-            found.push((key, value));
-        }
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0], (storage_entries[0].1.key, storage_entries[0].1.value));
-        assert_eq!(found[1], (storage_entries[1].1.key, storage_entries[1].1.value));
-
-        // Verify data was stored for addr2
-        let mut storage_cursor = storage.storage_hashed_cursor(addr2, 100).unwrap();
-        let mut found = vec![];
-        while let Some((key, value)) = storage_cursor.next().unwrap() {
-            found.push((key, value));
-        }
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0], (storage_entries[2].1.key, storage_entries[2].1.value));
-    }
-
-    #[test]
-    fn test_initialize_accounts_trie() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test trie nodes into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-
-        let branch = create_test_branch_node();
-        let nodes = vec![
-            (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])), branch.clone()),
-            (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2])), branch.clone()),
-            (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3])), branch),
-        ];
-
-        for (path, node) in &nodes {
-            cursor.append(path.clone(), node).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_accounts_trie(None).unwrap();
-
-        // Verify data was stored
-        let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
-        let mut count = 0;
-        while let Some((path, _node)) = trie_cursor.next().unwrap() {
-            assert_eq!(path, nodes[count].0.0);
-            count += 1;
-        }
-        assert_eq!(count, 3);
-    }
-
-    #[test]
-    fn test_initialize_storages_trie() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test storage trie nodes into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-
-        let branch = create_test_branch_node();
-        let addr1 = keccak256(Address::repeat_byte(0x01));
-        let addr2 = keccak256(Address::repeat_byte(0x02));
-
-        let nodes = vec![
-            (
-                addr1,
-                StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1])),
-                    node: branch.clone(),
-                },
-            ),
-            (
-                addr1,
-                StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![2])),
-                    node: branch.clone(),
-                },
-            ),
-            (
-                addr2,
-                StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![3])),
-                    node: branch,
-                },
-            ),
-        ];
-
-        for (addr, entry) in &nodes {
-            cursor.upsert(*addr, entry).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_storages_trie(None).unwrap();
-
-        // Verify data was stored for addr1
-        let mut trie_cursor = storage.storage_trie_cursor(addr1, 100).unwrap();
-        let mut found = vec![];
-        while let Some((path, _node)) = trie_cursor.next().unwrap() {
-            found.push(path);
-        }
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0], nodes[0].1.nibbles.0);
-        assert_eq!(found[1], nodes[1].1.nibbles.0);
-
-        // Verify data was stored for addr2
-        let mut trie_cursor = storage.storage_trie_cursor(addr2, 100).unwrap();
-        let mut found = vec![];
-        while let Some((path, _node)) = trie_cursor.next().unwrap() {
-            found.push(path);
-        }
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0], nodes[2].1.nibbles.0);
-    }
-
-    #[test]
-    fn test_full_initialize_run() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert some test data
-        let tx = db.tx_mut().unwrap();
-
-        // Add accounts
-        let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-        let addr = keccak256(Address::repeat_byte(0x01));
-        cursor
-            .append(addr, &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None })
-            .unwrap();
-        drop(cursor);
-
-        // Add storage
-        let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-        cursor
-            .upsert(
-                addr,
-                &StorageEntry { key: keccak256(B256::repeat_byte(0x10)), value: U256::from(100) },
-            )
-            .unwrap();
-        drop(cursor);
-
-        // Add account trie
-        let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-        cursor
-            .append(
-                StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])),
-                &create_test_branch_node(),
-            )
-            .unwrap();
-        drop(cursor);
-
-        // Add storage trie
-        let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-        cursor
-            .upsert(
-                addr,
-                &StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1])),
-                    node: create_test_branch_node(),
-                },
-            )
-            .unwrap();
-        drop(cursor);
-
-        tx.commit().unwrap();
-
-        // Run full initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        let best_number = 100;
-        let best_hash = B256::repeat_byte(0x42);
-
-        // Should be None initially
-        assert_eq!(storage.initial_state_anchor().unwrap().block, None);
-        assert_eq!(storage.get_earliest_block_number().unwrap(), None);
-
-        job.run(best_number, best_hash).unwrap();
-
-        // Should be set after initialization
-        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((best_number, best_hash)));
-
-        // Verify data was initialized
-        let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
-        assert!(account_cursor.next().unwrap().is_some());
-
-        let mut storage_cursor = storage.storage_hashed_cursor(addr, 100).unwrap();
-        assert!(storage_cursor.next().unwrap().is_some());
-
-        let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
-        assert!(trie_cursor.next().unwrap().is_some());
-
-        let mut storage_trie_cursor = storage.storage_trie_cursor(addr, 100).unwrap();
-        assert!(storage_trie_cursor.next().unwrap().is_some());
-    }
-
-    #[test]
-    fn test_initialize_run_skips_if_already_done() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // set and commit initial state anchor
-        storage
-            .set_initial_state_anchor(BlockNumHash::new(50, B256::repeat_byte(0x01)))
-            .expect("set anchor");
-        storage.commit_initial_state().expect("commit anchor");
-
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-
-        // Run initialization - should skip
-        job.run(100, B256::repeat_byte(0x42)).unwrap();
-
-        // Should still have the old anchor
-        let anchor_block =
-            storage.initial_state_anchor().expect("get anchor").block.expect("block");
-        assert_eq!(
-            Some((anchor_block.number, anchor_block.hash)),
-            Some((50, B256::repeat_byte(0x01)))
-        );
-
-        // Should still have the old earliest block
-        assert_eq!(
-            storage.get_earliest_block_number().unwrap(),
-            Some((50, B256::repeat_byte(0x01)))
-        );
-    }
-
-    #[test]
-    fn test_initialize_resumes_hashed_accounts_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        // Phase 1 in source: k1, k2
-        let k1 = k(1);
-        let k2 = k(2);
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-            cur.append(k1, &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None })
-                .unwrap();
-            cur.append(k2, &Account { nonce: 2, balance: U256::from(200), bytecode_hash: None })
-                .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_accounts(None).unwrap();
-        }
-
-        // Resume point must be k2 (max)
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
-            Some(k2)
-        );
-
-        // Phase 2 in source: k3, k4
-        let k3 = k(3);
-        let k4 = k(4);
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-            cur.append(k3, &Account { nonce: 3, balance: U256::from(300), bytecode_hash: None })
-                .unwrap();
-            cur.append(k4, &Account { nonce: 4, balance: U256::from(400), bytecode_hash: None })
-                .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2 (restart)
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_accounts(Some(k2)).unwrap();
-        }
-
-        // Now resume point must be k4
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
-            Some(k4)
-        );
-
-        // Verify order + no dupes by iterating proofs cursor
-        let mut cur = store.account_hashed_cursor(0).unwrap();
-        let mut got = Vec::new();
-        while let Some((key, acct)) = cur.next().unwrap() {
-            got.push((key, acct));
-        }
-
-        // Expect exactly 4, in increasing key order.
-        assert_eq!(got.len(), 4);
-        assert_eq!(got[0].0, k1);
-        assert_eq!(got[1].0, k2);
-        assert_eq!(got[2].0, k3);
-        assert_eq!(got[3].0, k4);
-
-        // No dupes
-        for w in got.windows(2) {
-            assert!(w[0].0 < w[1].0);
-        }
-    }
-
-    #[test]
-    fn test_initialize_resumes_hashed_storages_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        let a1 = k(0x10);
-        let a2 = k(0x20);
-
-        let s11 = k(0x01);
-        let s12 = k(0x02);
-        let s21 = k(0x03);
-        let s22 = k(0x04);
-
-        // Phase 1 source:
-        // a1: s11,s12
-        // a2: s21
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-            cur.upsert(a1, &StorageEntry { key: s11, value: U256::from(11) }).unwrap();
-            cur.upsert(a1, &StorageEntry { key: s12, value: U256::from(12) }).unwrap();
-            cur.upsert(a2, &StorageEntry { key: s21, value: U256::from(21) }).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_storages(None).unwrap();
-        }
-
-        // Latest key must be (a2, s21) because a2 > a1
-        let last1 = store
-            .initial_state_anchor()
-            .expect("get anchor")
-            .latest_hashed_storage_key
-            .expect("ok");
-        assert_eq!(last1.hashed_address, a2);
-        assert_eq!(last1.hashed_storage_key, s21);
-
-        // Phase 2 source: add s22 to a2
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-            cur.upsert(a2, &StorageEntry { key: s22, value: U256::from(22) }).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_storages(Some(HashedStorageKey::new(a2, s21))).unwrap();
-        }
-
-        // Latest key now must be (a2, s22)
-        let last2 = store
-            .initial_state_anchor()
-            .expect("get anchor")
-            .latest_hashed_storage_key
-            .expect("ok");
-        assert_eq!(last2.hashed_address, a2);
-        assert_eq!(last2.hashed_storage_key, s22);
-
-        // Verify no dupes by iterating per-address
-        {
-            let mut c = store.storage_hashed_cursor(a1, 0).unwrap();
-            let mut got = Vec::new();
-            while let Some((slot, val)) = c.next().unwrap() {
-                got.push((slot, val));
+    macro_rules! proof_storage_init_tests {
+        ($mod_name:ident, $storage:ident) => {
+            mod $mod_name {
+                use std::sync::Arc;
+
+                use alloy_primitives::{Address, U256, keccak256};
+                use reth_db::{
+                    Database, cursor::DbCursorRW, test_utils::create_test_rw_db,
+                    transaction::DbTxMut,
+                };
+                use reth_primitives_traits::Account;
+                use reth_trie::{
+                    BranchNodeCompact, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
+                    TrieMask, hashed_cursor::HashedCursor, trie_cursor::TrieCursor,
+                };
+                use tempfile::TempDir;
+
+                use super::super::*;
+                use crate::$storage;
+
+                /// Helper function to create a key
+                fn k(b: u8) -> B256 {
+                    let mut bytes = [0u8; 32];
+                    bytes[0] = b;
+                    B256::from(bytes)
+                }
+
+                /// Helper function to create a test branch node
+                fn create_test_branch_node() -> BranchNodeCompact {
+                    let mut state_mask = TrieMask::default();
+                    state_mask.set_bit(0);
+                    state_mask.set_bit(1);
+
+                    BranchNodeCompact {
+                        state_mask,
+                        tree_mask: TrieMask::default(),
+                        hash_mask: TrieMask::default(),
+                        hashes: Arc::new(vec![]),
+                        root_hash: None,
+                    }
+                }
+
+                #[test]
+                fn test_initialize_hashed_accounts() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test accounts into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+
+                    let mut accounts = vec![
+                        (
+                            keccak256(Address::repeat_byte(0x01)),
+                            Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
+                        ),
+                        (
+                            keccak256(Address::repeat_byte(0x02)),
+                            Account { nonce: 2, balance: U256::from(200), bytecode_hash: None },
+                        ),
+                        (
+                            keccak256(Address::repeat_byte(0x03)),
+                            Account { nonce: 3, balance: U256::from(300), bytecode_hash: None },
+                        ),
+                    ];
+
+                    // Sort accounts by address for cursor.append (which requires sorted order)
+                    accounts.sort_by_key(|(addr, _)| *addr);
+
+                    for (addr, account) in &accounts {
+                        cursor.append(*addr, account).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_hashed_accounts(None).unwrap();
+
+                    // Verify data was stored (will be in sorted order)
+                    let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
+                    let mut count = 0;
+                    while let Some((key, account)) = account_cursor.next().unwrap() {
+                        // Find matching account in our test data
+                        let expected = accounts.iter().find(|(addr, _)| *addr == key).unwrap();
+                        assert_eq!((key, account), *expected);
+                        count += 1;
+                    }
+                    assert_eq!(count, 3);
+                }
+
+                #[test]
+                fn test_initialize_hashed_storage() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test storage into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+
+                    let addr1 = keccak256(Address::repeat_byte(0x01));
+                    let addr2 = keccak256(Address::repeat_byte(0x02));
+
+                    let storage_entries = vec![
+                        (
+                            addr1,
+                            StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x10)),
+                                value: U256::from(100),
+                            },
+                        ),
+                        (
+                            addr1,
+                            StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x20)),
+                                value: U256::from(200),
+                            },
+                        ),
+                        (
+                            addr2,
+                            StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x30)),
+                                value: U256::from(300),
+                            },
+                        ),
+                    ];
+
+                    for (addr, entry) in &storage_entries {
+                        cursor.upsert(*addr, entry).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_hashed_storages(None).unwrap();
+
+                    // Verify data was stored for addr1
+                    let mut storage_cursor = storage.storage_hashed_cursor(addr1, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((key, value)) = storage_cursor.next().unwrap() {
+                        found.push((key, value));
+                    }
+                    assert_eq!(found.len(), 2);
+                    assert_eq!(found[0], (storage_entries[0].1.key, storage_entries[0].1.value));
+                    assert_eq!(found[1], (storage_entries[1].1.key, storage_entries[1].1.value));
+
+                    // Verify data was stored for addr2
+                    let mut storage_cursor = storage.storage_hashed_cursor(addr2, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((key, value)) = storage_cursor.next().unwrap() {
+                        found.push((key, value));
+                    }
+                    assert_eq!(found.len(), 1);
+                    assert_eq!(found[0], (storage_entries[2].1.key, storage_entries[2].1.value));
+                }
+
+                #[test]
+                fn test_initialize_accounts_trie() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test trie nodes into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+
+                    let branch = create_test_branch_node();
+                    let nodes = vec![
+                        (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])), branch.clone()),
+                        (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2])), branch.clone()),
+                        (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3])), branch),
+                    ];
+
+                    for (path, node) in &nodes {
+                        cursor.append(path.clone(), node).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_accounts_trie(None).unwrap();
+
+                    // Verify data was stored
+                    let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
+                    let mut count = 0;
+                    while let Some((path, _node)) = trie_cursor.next().unwrap() {
+                        assert_eq!(path, nodes[count].0.0);
+                        count += 1;
+                    }
+                    assert_eq!(count, 3);
+                }
+
+                #[test]
+                fn test_initialize_storages_trie() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test storage trie nodes into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+
+                    let branch = create_test_branch_node();
+                    let addr1 = keccak256(Address::repeat_byte(0x01));
+                    let addr2 = keccak256(Address::repeat_byte(0x02));
+
+                    let nodes = vec![
+                        (
+                            addr1,
+                            StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![1],
+                                )),
+                                node: branch.clone(),
+                            },
+                        ),
+                        (
+                            addr1,
+                            StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![2],
+                                )),
+                                node: branch.clone(),
+                            },
+                        ),
+                        (
+                            addr2,
+                            StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![3],
+                                )),
+                                node: branch,
+                            },
+                        ),
+                    ];
+
+                    for (addr, entry) in &nodes {
+                        cursor.upsert(*addr, entry).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_storages_trie(None).unwrap();
+
+                    // Verify data was stored for addr1
+                    let mut trie_cursor = storage.storage_trie_cursor(addr1, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((path, _node)) = trie_cursor.next().unwrap() {
+                        found.push(path);
+                    }
+                    assert_eq!(found.len(), 2);
+                    assert_eq!(found[0], nodes[0].1.nibbles.0);
+                    assert_eq!(found[1], nodes[1].1.nibbles.0);
+
+                    // Verify data was stored for addr2
+                    let mut trie_cursor = storage.storage_trie_cursor(addr2, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((path, _node)) = trie_cursor.next().unwrap() {
+                        found.push(path);
+                    }
+                    assert_eq!(found.len(), 1);
+                    assert_eq!(found[0], nodes[2].1.nibbles.0);
+                }
+
+                #[test]
+                fn test_full_initialize_run() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert some test data
+                    let tx = db.tx_mut().unwrap();
+
+                    // Add accounts
+                    let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+                    let addr = keccak256(Address::repeat_byte(0x01));
+                    cursor
+                        .append(
+                            addr,
+                            &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    // Add storage
+                    let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+                    cursor
+                        .upsert(
+                            addr,
+                            &StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x10)),
+                                value: U256::from(100),
+                            },
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    // Add account trie
+                    let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+                    cursor
+                        .append(
+                            StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])),
+                            &create_test_branch_node(),
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    // Add storage trie
+                    let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+                    cursor
+                        .upsert(
+                            addr,
+                            &StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![1],
+                                )),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    tx.commit().unwrap();
+
+                    // Run full initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let best_number = 100;
+                    let best_hash = B256::repeat_byte(0x42);
+
+                    // Should be None initially
+                    assert_eq!(storage.initial_state_anchor().unwrap().block, None);
+                    assert_eq!(storage.get_earliest_block_number().unwrap(), None);
+
+                    job.run(best_number, best_hash).unwrap();
+
+                    // Should be set after initialization
+                    assert_eq!(
+                        storage.get_earliest_block_number().unwrap(),
+                        Some((best_number, best_hash))
+                    );
+
+                    // Verify data was initialized
+                    let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
+                    assert!(account_cursor.next().unwrap().is_some());
+
+                    let mut storage_cursor = storage.storage_hashed_cursor(addr, 100).unwrap();
+                    assert!(storage_cursor.next().unwrap().is_some());
+
+                    let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
+                    assert!(trie_cursor.next().unwrap().is_some());
+
+                    let mut storage_trie_cursor = storage.storage_trie_cursor(addr, 100).unwrap();
+                    assert!(storage_trie_cursor.next().unwrap().is_some());
+                }
+
+                #[test]
+                fn test_initialize_run_skips_if_already_done() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // set and commit initial state anchor
+                    storage
+                        .set_initial_state_anchor(BlockNumHash::new(50, B256::repeat_byte(0x01)))
+                        .expect("set anchor");
+                    storage.commit_initial_state().expect("commit anchor");
+
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+
+                    // Run initialization - should skip
+                    job.run(100, B256::repeat_byte(0x42)).unwrap();
+
+                    // Should still have the old anchor
+                    let anchor_block =
+                        storage.initial_state_anchor().expect("get anchor").block.expect("block");
+                    assert_eq!(
+                        Some((anchor_block.number, anchor_block.hash)),
+                        Some((50, B256::repeat_byte(0x01)))
+                    );
+
+                    // Should still have the old earliest block
+                    assert_eq!(
+                        storage.get_earliest_block_number().unwrap(),
+                        Some((50, B256::repeat_byte(0x01)))
+                    );
+                }
+
+                #[test]
+                fn test_initialize_resumes_hashed_accounts_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    // Phase 1 in source: k1, k2
+                    let k1 = k(1);
+                    let k2 = k(2);
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+                        cur.append(
+                            k1,
+                            &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        cur.append(
+                            k2,
+                            &Account { nonce: 2, balance: U256::from(200), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_accounts(None).unwrap();
+                    }
+
+                    // Resume point must be k2 (max)
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
+                        Some(k2)
+                    );
+
+                    // Phase 2 in source: k3, k4
+                    let k3 = k(3);
+                    let k4 = k(4);
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+                        cur.append(
+                            k3,
+                            &Account { nonce: 3, balance: U256::from(300), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        cur.append(
+                            k4,
+                            &Account { nonce: 4, balance: U256::from(400), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2 (restart)
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_accounts(Some(k2)).unwrap();
+                    }
+
+                    // Now resume point must be k4
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
+                        Some(k4)
+                    );
+
+                    // Verify order + no dupes by iterating proofs cursor
+                    let mut cur = store.account_hashed_cursor(0).unwrap();
+                    let mut got = Vec::new();
+                    while let Some((key, acct)) = cur.next().unwrap() {
+                        got.push((key, acct));
+                    }
+
+                    // Expect exactly 4, in increasing key order.
+                    assert_eq!(got.len(), 4);
+                    assert_eq!(got[0].0, k1);
+                    assert_eq!(got[1].0, k2);
+                    assert_eq!(got[2].0, k3);
+                    assert_eq!(got[3].0, k4);
+
+                    // No dupes
+                    for w in got.windows(2) {
+                        assert!(w[0].0 < w[1].0);
+                    }
+                }
+
+                #[test]
+                fn test_initialize_resumes_hashed_storages_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    let a1 = k(0x10);
+                    let a2 = k(0x20);
+
+                    let s11 = k(0x01);
+                    let s12 = k(0x02);
+                    let s21 = k(0x03);
+                    let s22 = k(0x04);
+
+                    // Phase 1 source:
+                    // a1: s11,s12
+                    // a2: s21
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+                        cur.upsert(a1, &StorageEntry { key: s11, value: U256::from(11) }).unwrap();
+                        cur.upsert(a1, &StorageEntry { key: s12, value: U256::from(12) }).unwrap();
+                        cur.upsert(a2, &StorageEntry { key: s21, value: U256::from(21) }).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_storages(None).unwrap();
+                    }
+
+                    // Latest key must be (a2, s21) because a2 > a1
+                    let last1 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_hashed_storage_key
+                        .expect("ok");
+                    assert_eq!(last1.hashed_address, a2);
+                    assert_eq!(last1.hashed_storage_key, s21);
+
+                    // Phase 2 source: add s22 to a2
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+                        cur.upsert(a2, &StorageEntry { key: s22, value: U256::from(22) }).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_storages(Some(HashedStorageKey::new(a2, s21)))
+                            .unwrap();
+                    }
+
+                    // Latest key now must be (a2, s22)
+                    let last2 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_hashed_storage_key
+                        .expect("ok");
+                    assert_eq!(last2.hashed_address, a2);
+                    assert_eq!(last2.hashed_storage_key, s22);
+
+                    // Verify no dupes by iterating per-address
+                    {
+                        let mut c = store.storage_hashed_cursor(a1, 0).unwrap();
+                        let mut got = Vec::new();
+                        while let Some((slot, val)) = c.next().unwrap() {
+                            got.push((slot, val));
+                        }
+                        assert_eq!(got.len(), 2);
+                        assert_eq!(got[0].0, s11);
+                        assert_eq!(got[1].0, s12);
+                    }
+                    {
+                        let mut c = store.storage_hashed_cursor(a2, 0).unwrap();
+                        let mut got = Vec::new();
+                        while let Some((slot, val)) = c.next().unwrap() {
+                            got.push((slot, val));
+                        }
+                        assert_eq!(got.len(), 2);
+                        assert_eq!(got[0].0, s21);
+                        assert_eq!(got[1].0, s22);
+                    }
+                }
+
+                #[test]
+                fn test_initialize_resumes_accounts_trie_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    let p1 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1]));
+                    let p2 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2]));
+                    let p3 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3]));
+                    let p4 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![4]));
+
+                    // Phase 1 source: p1,p2
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+                        cur.append(p1.clone(), &create_test_branch_node()).unwrap();
+                        cur.append(p2.clone(), &create_test_branch_node()).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_accounts_trie(None).unwrap();
+                    }
+
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
+                        Some(p2.clone())
+                    );
+
+                    // Phase 2 source: p3,p4
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+                        cur.append(p3.clone(), &create_test_branch_node()).unwrap();
+                        cur.append(p4.clone(), &create_test_branch_node()).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_accounts_trie(Some(p2.clone())).unwrap();
+                    }
+
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
+                        Some(p4.clone())
+                    );
+
+                    // Verify 4 ordered, no dupes
+                    let mut c = store.account_trie_cursor(0).unwrap();
+                    let mut got = Vec::new();
+                    while let Some((path, _node)) = c.next().unwrap() {
+                        got.push(path);
+                    }
+                    assert_eq!(got.len(), 4);
+                    assert_eq!(got[0], p1.0);
+                    assert_eq!(got[1], p2.0);
+                    assert_eq!(got[2], p3.0);
+                    assert_eq!(got[3], p4.0);
+                }
+
+                #[test]
+                fn test_initialize_resumes_storages_trie_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    let a1 = k(0x10);
+                    let a2 = k(0x20);
+
+                    let n1 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1]));
+                    let n2 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![2]));
+                    let n3 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![3]));
+
+                    // Phase 1 source: (a1,n1), (a2,n2)
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+                        cur.upsert(
+                            a1,
+                            &StorageTrieEntry {
+                                nibbles: n1.clone(),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                        cur.upsert(
+                            a2,
+                            &StorageTrieEntry {
+                                nibbles: n2.clone(),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_storages_trie(None).unwrap();
+                    }
+
+                    // Latest must be (a2, n2) because a2 > a1
+                    let last1 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_storage_trie_key
+                        .expect("ok");
+                    assert_eq!(last1.hashed_address, a2);
+                    assert_eq!(last1.path.0, n2.0);
+
+                    // Phase 2 source: add (a2,n3)
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+                        cur.upsert(
+                            a2,
+                            &StorageTrieEntry {
+                                nibbles: n3.clone(),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_storages_trie(Some(StorageTrieKey::new(
+                            a2,
+                            StoredNibbles::from(n2.0),
+                        )))
+                        .unwrap();
+                    }
+
+                    // Latest must now be (a2,n3)
+                    let last2 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_storage_trie_key
+                        .expect("ok");
+                    assert_eq!(last2.hashed_address, a2);
+                    assert_eq!(last2.path.0, n3.0);
+
+                    // Verify per-address no dupes and stable ordering
+                    {
+                        let mut c = store.storage_trie_cursor(a1, 0).unwrap();
+
+                        let mut got = Vec::new();
+
+                        // next returns the rest
+                        while let Some((path, _node)) = c.next().unwrap() {
+                            got.push(path);
+                        }
+
+                        assert_eq!(got, vec![n1.0]);
+                    }
+                    {
+                        let mut c = store.storage_trie_cursor(a2, 0).unwrap();
+
+                        let mut got = Vec::new();
+
+                        // next returns the rest
+                        while let Some((path, _node)) = c.next().unwrap() {
+                            got.push(path);
+                        }
+                        assert_eq!(got, vec![n2.0, n3.0]);
+                    }
+                }
             }
-            assert_eq!(got.len(), 2);
-            assert_eq!(got[0].0, s11);
-            assert_eq!(got[1].0, s12);
-        }
-        {
-            let mut c = store.storage_hashed_cursor(a2, 0).unwrap();
-            let mut got = Vec::new();
-            while let Some((slot, val)) = c.next().unwrap() {
-                got.push((slot, val));
-            }
-            assert_eq!(got.len(), 2);
-            assert_eq!(got[0].0, s21);
-            assert_eq!(got[1].0, s22);
-        }
+        };
     }
 
-    #[test]
-    fn test_initialize_resumes_accounts_trie_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        let p1 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1]));
-        let p2 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2]));
-        let p3 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3]));
-        let p4 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![4]));
-
-        // Phase 1 source: p1,p2
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-            cur.append(p1.clone(), &create_test_branch_node()).unwrap();
-            cur.append(p2.clone(), &create_test_branch_node()).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_accounts_trie(None).unwrap();
-        }
-
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
-            Some(p2.clone())
-        );
-
-        // Phase 2 source: p3,p4
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-            cur.append(p3.clone(), &create_test_branch_node()).unwrap();
-            cur.append(p4.clone(), &create_test_branch_node()).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_accounts_trie(Some(p2.clone())).unwrap();
-        }
-
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
-            Some(p4.clone())
-        );
-
-        // Verify 4 ordered, no dupes
-        let mut c = store.account_trie_cursor(0).unwrap();
-        let mut got = Vec::new();
-        while let Some((path, _node)) = c.next().unwrap() {
-            got.push(path);
-        }
-        assert_eq!(got.len(), 4);
-        assert_eq!(got[0], p1.0);
-        assert_eq!(got[1], p2.0);
-        assert_eq!(got[2], p3.0);
-        assert_eq!(got[3], p4.0);
-    }
-
-    #[test]
-    fn test_initialize_resumes_storages_trie_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        let a1 = k(0x10);
-        let a2 = k(0x20);
-
-        let n1 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1]));
-        let n2 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![2]));
-        let n3 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![3]));
-
-        // Phase 1 source: (a1,n1), (a2,n2)
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-            cur.upsert(
-                a1,
-                &StorageTrieEntry { nibbles: n1.clone(), node: create_test_branch_node() },
-            )
-            .unwrap();
-            cur.upsert(
-                a2,
-                &StorageTrieEntry { nibbles: n2.clone(), node: create_test_branch_node() },
-            )
-            .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_storages_trie(None).unwrap();
-        }
-
-        // Latest must be (a2, n2) because a2 > a1
-        let last1 =
-            store.initial_state_anchor().expect("get anchor").latest_storage_trie_key.expect("ok");
-        assert_eq!(last1.hashed_address, a2);
-        assert_eq!(last1.path.0, n2.0);
-
-        // Phase 2 source: add (a2,n3)
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-            cur.upsert(
-                a2,
-                &StorageTrieEntry { nibbles: n3.clone(), node: create_test_branch_node() },
-            )
-            .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_storages_trie(Some(StorageTrieKey::new(a2, StoredNibbles::from(n2.0))))
-                .unwrap();
-        }
-
-        // Latest must now be (a2,n3)
-        let last2 =
-            store.initial_state_anchor().expect("get anchor").latest_storage_trie_key.expect("ok");
-        assert_eq!(last2.hashed_address, a2);
-        assert_eq!(last2.path.0, n3.0);
-
-        // Verify per-address no dupes and stable ordering
-        {
-            let mut c = store.storage_trie_cursor(a1, 0).unwrap();
-
-            let mut got = Vec::new();
-
-            // next returns the rest
-            while let Some((path, _node)) = c.next().unwrap() {
-                got.push(path);
-            }
-
-            assert_eq!(got, vec![n1.0]);
-        }
-        {
-            let mut c = store.storage_trie_cursor(a2, 0).unwrap();
-
-            let mut got = Vec::new();
-
-            // next returns the rest
-            while let Some((path, _node)) = c.next().unwrap() {
-                got.push(path);
-            }
-            assert_eq!(got, vec![n2.0, n3.0]);
-        }
-    }
+    proof_storage_init_tests!(mdbx_tests, MdbxProofsStorage);
+    proof_storage_init_tests!(rocksdb_tests, RocksdbProofsStorage);
 }

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -208,23 +208,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use alloy_eips::{BlockHashOrNumber, NumHash};
-    use alloy_primitives::{B256, BlockNumber, U256, keccak256};
+    use alloy_primitives::{B256, BlockNumber, keccak256};
     use mockall::mock;
-    use reth_primitives_traits::Account;
     use reth_storage_errors::provider::ProviderResult;
-    use reth_trie::{
-        BranchNodeCompact, HashedPostState, HashedStorage, Nibbles,
-        hashed_cursor::HashedCursor,
-        trie_cursor::TrieCursor,
-        updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
-    };
-    use tempfile::TempDir;
 
     use super::*;
-    use crate::{BlockStateDiff, db::MdbxProofsStorage};
 
     mock! (
         #[derive(Debug)]
@@ -255,356 +244,408 @@ mod tests {
         BlockWithParent::new(parent, NumHash::new(n, b256(n)))
     }
 
-    #[tokio::test]
-    async fn run_inner_and_and_verify_updated_state() {
-        // --- env/store ---
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+    macro_rules! proof_storage_pruner_tests {
+        ($mod_name:ident, $storage:ident) => {
+            mod $mod_name {
+                use std::sync::Arc;
 
-        store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
+                use alloy_primitives::{B256, U256};
+                use reth_primitives_traits::Account;
+                use reth_trie::{
+                    BranchNodeCompact, HashedPostState, HashedStorage, Nibbles,
+                    hashed_cursor::HashedCursor,
+                    trie_cursor::TrieCursor,
+                    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
+                };
+                use tempfile::TempDir;
 
-        // --- entities ---
-        // accounts
-        let a1 = B256::from([0xA1; 32]);
-        let a2 = B256::from([0xA2; 32]);
-        let a3 = B256::from([0xA3; 32]); // introduced later
+                use super::{super::*, MockBlockHashReader, b256, block};
+                use crate::{BlockStateDiff, $storage};
 
-        // one storage address with 3 slots
-        let stor_addr = B256::from([0x10; 32]);
-        let s1 = B256::from([0xB1; 32]);
-        let s2 = B256::from([0xB2; 32]);
-        let s3 = B256::from([0xB3; 32]);
+                #[tokio::test]
+                async fn run_inner_and_and_verify_updated_state() {
+                    // --- env/store ---
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
 
-        // account-trie paths (p1 gets removed by block 3; p2 remains; p3 added later)
-        let p1 = Nibbles::from_nibbles_unchecked([0x01, 0x02]);
-        let p2 = Nibbles::from_nibbles_unchecked([0x03, 0x04]);
-        let p3 = Nibbles::from_nibbles_unchecked([0x05, 0x06]);
+                    store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
-        let node_p1 = BranchNodeCompact::new(0b1, 0, 0, vec![], Some(B256::from([0x11; 32])));
-        let node_p2 = BranchNodeCompact::new(0b10, 0, 0, vec![], Some(B256::from([0x22; 32])));
-        let node_p3 = BranchNodeCompact::new(0b11, 0, 0, vec![], Some(B256::from([0x33; 32])));
+                    // --- entities ---
+                    // accounts
+                    let a1 = B256::from([0xA1; 32]);
+                    let a2 = B256::from([0xA2; 32]);
+                    let a3 = B256::from([0xA3; 32]); // introduced later
 
-        // storage-trie paths (st1 removed by block 3; st2 remains; st3 added later)
-        let st1 = Nibbles::from_nibbles_unchecked([0x0A]);
-        let st2 = Nibbles::from_nibbles_unchecked([0x0B]);
-        let st3 = Nibbles::from_nibbles_unchecked([0x0C]);
+                    // one storage address with 3 slots
+                    let stor_addr = B256::from([0x10; 32]);
+                    let s1 = B256::from([0xB1; 32]);
+                    let s2 = B256::from([0xB2; 32]);
+                    let s3 = B256::from([0xB3; 32]);
 
-        let node_st2 = BranchNodeCompact::new(0b101, 0, 0, vec![], Some(B256::from([0x44; 32])));
-        let node_st3 = BranchNodeCompact::new(0b110, 0, 0, vec![], Some(B256::from([0x55; 32])));
+                    // account-trie paths (p1 gets removed by block 3; p2 remains; p3 added later)
+                    let p1 = Nibbles::from_nibbles_unchecked([0x01, 0x02]);
+                    let p2 = Nibbles::from_nibbles_unchecked([0x03, 0x04]);
+                    let p3 = Nibbles::from_nibbles_unchecked([0x05, 0x06]);
 
-        // --- write 5 blocks manually ---
-        let mut parent = B256::ZERO;
+                    let node_p1 =
+                        BranchNodeCompact::new(0b1, 0, 0, vec![], Some(B256::from([0x11; 32])));
+                    let node_p2 =
+                        BranchNodeCompact::new(0b10, 0, 0, vec![], Some(B256::from([0x22; 32])));
+                    let node_p3 =
+                        BranchNodeCompact::new(0b11, 0, 0, vec![], Some(B256::from([0x33; 32])));
 
-        // Block 1: add a1,a2; s1=100, s2=200; add p1, st1
-        {
-            let b1 = block(1, parent);
+                    // storage-trie paths (st1 removed by block 3; st2 remains; st3 added later)
+                    let st1 = Nibbles::from_nibbles_unchecked([0x0A]);
+                    let st2 = Nibbles::from_nibbles_unchecked([0x0B]);
+                    let st3 = Nibbles::from_nibbles_unchecked([0x0C]);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                    let node_st2 =
+                        BranchNodeCompact::new(0b101, 0, 0, vec![], Some(B256::from([0x44; 32])));
+                    let node_st3 =
+                        BranchNodeCompact::new(0b110, 0, 0, vec![], Some(B256::from([0x55; 32])));
 
-            d_post_state.accounts.insert(
-                a1,
-                Some(Account { nonce: 1, balance: U256::from(1_001), ..Default::default() }),
-            );
-            d_post_state.accounts.insert(
-                a2,
-                Some(Account { nonce: 1, balance: U256::from(1_002), ..Default::default() }),
-            );
+                    // --- write 5 blocks manually ---
+                    let mut parent = B256::ZERO;
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s1, U256::from(100));
-            hs.storage.insert(s2, U256::from(200));
-            d_post_state.storages.insert(stor_addr, hs);
+                    // Block 1: add a1,a2; s1=100, s2=200; add p1, st1
+                    {
+                        let b1 = block(1, parent);
 
-            d_trie_updates.account_nodes.insert(p1, node_p1);
-            let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
-            e.storage_nodes.insert(st1, BranchNodeCompact::default());
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b1, d).expect("b1");
-            parent = b256(1);
-        }
+                        d_post_state.accounts.insert(
+                            a1,
+                            Some(Account {
+                                nonce: 1,
+                                balance: U256::from(1_001),
+                                ..Default::default()
+                            }),
+                        );
+                        d_post_state.accounts.insert(
+                            a2,
+                            Some(Account {
+                                nonce: 1,
+                                balance: U256::from(1_002),
+                                ..Default::default()
+                            }),
+                        );
 
-        // Block 2: update a2; add a3; s2=220, s3=300; add p2, st2
-        {
-            let b2 = block(2, parent);
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s1, U256::from(100));
+                        hs.storage.insert(s2, U256::from(200));
+                        d_post_state.storages.insert(stor_addr, hs);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                        d_trie_updates.account_nodes.insert(p1, node_p1);
+                        let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
+                        e.storage_nodes.insert(st1, BranchNodeCompact::default());
 
-            d_post_state.accounts.insert(
-                a2,
-                Some(Account { nonce: 2, balance: U256::from(2_002), ..Default::default() }),
-            );
-            d_post_state.accounts.insert(
-                a3,
-                Some(Account { nonce: 1, balance: U256::from(1_003), ..Default::default() }),
-            );
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b1, d).expect("b1");
+                        parent = b256(1);
+                    }
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s2, U256::from(220));
-            hs.storage.insert(s3, U256::from(300));
-            d_post_state.storages.insert(stor_addr, hs);
+                    // Block 2: update a2; add a3; s2=220, s3=300; add p2, st2
+                    {
+                        let b2 = block(2, parent);
 
-            d_trie_updates.account_nodes.insert(p2, node_p2.clone());
-            let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
-            e.storage_nodes.insert(st2, node_st2.clone());
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b2, d).expect("b2");
-            parent = b256(2);
-        }
+                        d_post_state.accounts.insert(
+                            a2,
+                            Some(Account {
+                                nonce: 2,
+                                balance: U256::from(2_002),
+                                ..Default::default()
+                            }),
+                        );
+                        d_post_state.accounts.insert(
+                            a3,
+                            Some(Account {
+                                nonce: 1,
+                                balance: U256::from(1_003),
+                                ..Default::default()
+                            }),
+                        );
 
-        // Block 3: delete a1; leave a2,a3; remove p1; remove st1 (storage-trie)
-        {
-            let b3 = block(3, parent);
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s2, U256::from(220));
+                        hs.storage.insert(s3, U256::from(300));
+                        d_post_state.storages.insert(stor_addr, hs);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                        d_trie_updates.account_nodes.insert(p2, node_p2.clone());
+                        let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
+                        e.storage_nodes.insert(st2, node_st2.clone());
 
-            // delete a1, keep a2 & a3 values unchanged for this block
-            d_post_state.accounts.insert(a1, None);
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b2, d).expect("b2");
+                        parent = b256(2);
+                    }
 
-            // remove account trie node p1
-            d_trie_updates.removed_nodes.insert(p1);
+                    // Block 3: delete a1; leave a2,a3; remove p1; remove st1 (storage-trie)
+                    {
+                        let b3 = block(3, parent);
 
-            // remove storage-trie node st1
-            let mut st_upd = StorageTrieUpdates::default();
-            st_upd.removed_nodes.insert(st1);
-            d_trie_updates.storage_tries.insert(stor_addr, st_upd);
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b3, d).expect("b3");
-            parent = b256(3);
-        }
+                        // delete a1, keep a2 & a3 values unchanged for this block
+                        d_post_state.accounts.insert(a1, None);
 
-        // Block 4 (kept): update a2; s1=140; add p3, st3
-        {
-            let b4 = block(4, parent);
+                        // remove account trie node p1
+                        d_trie_updates.removed_nodes.insert(p1);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                        // remove storage-trie node st1
+                        let mut st_upd = StorageTrieUpdates::default();
+                        st_upd.removed_nodes.insert(st1);
+                        d_trie_updates.storage_tries.insert(stor_addr, st_upd);
 
-            d_post_state.accounts.insert(
-                a2,
-                Some(Account { nonce: 3, balance: U256::from(3_002), ..Default::default() }),
-            );
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b3, d).expect("b3");
+                        parent = b256(3);
+                    }
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s1, U256::from(140));
-            d_post_state.storages.insert(stor_addr, hs);
-            d_trie_updates.account_nodes.insert(p3, node_p3.clone());
-            let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
-            e.storage_nodes.insert(st3, node_st3.clone());
+                    // Block 4 (kept): update a2; s1=140; add p3, st3
+                    {
+                        let b4 = block(4, parent);
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b4, d).expect("b4");
-            parent = b256(4);
-        }
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-        // Block 5 (kept): update a3; s3=330
-        {
-            let b5 = block(5, parent);
+                        d_post_state.accounts.insert(
+                            a2,
+                            Some(Account {
+                                nonce: 3,
+                                balance: U256::from(3_002),
+                                ..Default::default()
+                            }),
+                        );
 
-            let mut d_post_state = HashedPostState::default();
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s1, U256::from(140));
+                        d_post_state.storages.insert(stor_addr, hs);
+                        d_trie_updates.account_nodes.insert(p3, node_p3.clone());
+                        let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
+                        e.storage_nodes.insert(st3, node_st3.clone());
 
-            d_post_state.accounts.insert(
-                a3,
-                Some(Account { nonce: 2, balance: U256::from(2_003), ..Default::default() }),
-            );
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b4, d).expect("b4");
+                        parent = b256(4);
+                    }
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s3, U256::from(330));
-            d_post_state.storages.insert(stor_addr, hs);
+                    // Block 5 (kept): update a3; s3=330
+                    {
+                        let b5 = block(5, parent);
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: TrieUpdatesSorted::default(),
-            };
-            store.store_trie_updates(b5, d).expect("b5");
-        }
+                        let mut d_post_state = HashedPostState::default();
 
-        // sanity: earliest=0, latest=5
-        {
-            let e = store.get_earliest_block_number().expect("earliest").expect("some");
-            let l = store.get_latest_block_number().expect("latest").expect("some");
-            assert_eq!(e.0, 0);
-            assert_eq!(l.0, 5);
-        }
+                        d_post_state.accounts.insert(
+                            a3,
+                            Some(Account {
+                                nonce: 2,
+                                balance: U256::from(2_003),
+                                ..Default::default()
+                            }),
+                        );
 
-        // --- prune: remove the first 3 blocks, keep 4 and 5
-        // new_earliest = 5-1 = 4
-        let mut block_hash_reader = MockBlockHashReader::new();
-        block_hash_reader
-            .expect_block_hash()
-            .withf(move |block_num| *block_num == 4)
-            .returning(move |_| Ok(Some(b256(4))));
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s3, U256::from(330));
+                        d_post_state.storages.insert(stor_addr, hs);
 
-        let pruner = BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
-        let out = pruner.run_inner().expect("pruner ok");
-        assert_eq!(out.start_block, 0);
-        assert_eq!(out.end_block, 4, "pruned up to 4 (inclusive); new earliest is 4");
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: TrieUpdatesSorted::default(),
+                        };
+                        store.store_trie_updates(b5, d).expect("b5");
+                    }
 
-        // proof window moved: earliest=4, latest=5
-        {
-            let e = store.get_earliest_block_number().expect("earliest").expect("some");
-            let l = store.get_latest_block_number().expect("latest").expect("some");
-            assert_eq!(e.0, 4);
-            assert_eq!(e.1, b256(4));
-            assert_eq!(l.0, 5);
-            assert_eq!(l.1, b256(5));
-        }
+                    // sanity: earliest=0, latest=5
+                    {
+                        let e = store.get_earliest_block_number().expect("earliest").expect("some");
+                        let l = store.get_latest_block_number().expect("latest").expect("some");
+                        assert_eq!(e.0, 0);
+                        assert_eq!(l.0, 5);
+                    }
 
-        // --- DB checks
-        let mut acc_cur = store.account_hashed_cursor(4).expect("acc cur");
-        let mut stor_cur = store.storage_hashed_cursor(stor_addr, 4).expect("stor cur");
-        let mut acc_trie_cur = store.account_trie_cursor(4).expect("acc trie cur");
-        let mut stor_trie_cur = store.storage_trie_cursor(stor_addr, 4).expect("stor trie cur");
+                    // --- prune: remove the first 3 blocks, keep 4 and 5
+                    // new_earliest = 5-1 = 4
+                    let mut block_hash_reader = MockBlockHashReader::new();
+                    block_hash_reader
+                        .expect_block_hash()
+                        .withf(move |block_num| *block_num == 4)
+                        .returning(move |_| Ok(Some(b256(4))));
 
-        // Check these histories have been removed
-        let pruned_hashed_account = a1;
-        let pruned_trie_accounts = p1;
-        let pruned_trie_storage = st1;
+                    let pruner =
+                        BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
+                    let out = pruner.run_inner().expect("pruner ok");
+                    assert_eq!(out.start_block, 0);
+                    assert_eq!(out.end_block, 4, "pruned up to 4 (inclusive); new earliest is 4");
 
-        assert_ne!(
-            acc_cur.seek(pruned_hashed_account).expect("seek").unwrap().0,
-            pruned_hashed_account,
-            "deleted account must not exist in earliest snapshot"
-        );
-        assert_ne!(
-            acc_trie_cur.seek(pruned_trie_accounts).expect("seek").unwrap().0,
-            pruned_trie_accounts,
-            "deleted account trie must not exist in earliest snapshot"
-        );
-        assert_ne!(
-            stor_trie_cur.seek(pruned_trie_storage).expect("seek").unwrap().0,
-            pruned_trie_storage,
-            "deleted storage trie must not exist in earliest snapshot"
-        );
+                    // proof window moved: earliest=4, latest=5
+                    {
+                        let e = store.get_earliest_block_number().expect("earliest").expect("some");
+                        let l = store.get_latest_block_number().expect("latest").expect("some");
+                        assert_eq!(e.0, 4);
+                        assert_eq!(e.1, b256(4));
+                        assert_eq!(l.0, 5);
+                        assert_eq!(l.1, b256(5));
+                    }
 
-        // Check these histories have been updated - till block 4
-        let updated_hashed_accounts = vec![
-            (a2, Account { nonce: 3, balance: U256::from(3_002), ..Default::default() }), /* block 4 */
-            (a3, Account { nonce: 1, balance: U256::from(1_003), ..Default::default() }), /* block 2 */
-        ];
-        let updated_hashed_storage = vec![
-            (s1, U256::from(140)), // block 4
-            (s2, U256::from(220)), // block 2
-            (s3, U256::from(300)), // block 2
-        ];
-        let updated_trie_accounts = vec![
-            (p2, node_p2), // block 2
-            (p3, node_p3), // block 4
-        ];
-        let updated_trie_storage = vec![
-            (st2, node_st2), // block 2
-            (st3, node_st3), // block 4
-        ];
+                    // --- DB checks
+                    let mut acc_cur = store.account_hashed_cursor(4).expect("acc cur");
+                    let mut stor_cur = store.storage_hashed_cursor(stor_addr, 4).expect("stor cur");
+                    let mut acc_trie_cur = store.account_trie_cursor(4).expect("acc trie cur");
+                    let mut stor_trie_cur =
+                        store.storage_trie_cursor(stor_addr, 4).expect("stor trie cur");
 
-        for (key, val) in updated_hashed_accounts {
-            let (k, vv) = acc_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
+                    // Check these histories have been removed
+                    let pruned_hashed_account = a1;
+                    let pruned_trie_accounts = p1;
+                    let pruned_trie_storage = st1;
 
-        for (key, val) in updated_hashed_storage {
-            let (k, vv) = stor_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
+                    assert_ne!(
+                        acc_cur.seek(pruned_hashed_account).expect("seek").unwrap().0,
+                        pruned_hashed_account,
+                        "deleted account must not exist in earliest snapshot"
+                    );
+                    assert_ne!(
+                        acc_trie_cur.seek(pruned_trie_accounts).expect("seek").unwrap().0,
+                        pruned_trie_accounts,
+                        "deleted account trie must not exist in earliest snapshot"
+                    );
+                    assert_ne!(
+                        stor_trie_cur.seek(pruned_trie_storage).expect("seek").unwrap().0,
+                        pruned_trie_storage,
+                        "deleted storage trie must not exist in earliest snapshot"
+                    );
 
-        for (key, val) in updated_trie_accounts {
-            let (k, vv) = acc_trie_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
-        for (key, val) in updated_trie_storage {
-            let (k, vv) = stor_trie_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
+                    // Check these histories have been updated - till block 4
+                    let updated_hashed_accounts = vec![
+                        (
+                            a2,
+                            Account { nonce: 3, balance: U256::from(3_002), ..Default::default() },
+                        ),
+                        (
+                            a3,
+                            Account { nonce: 1, balance: U256::from(1_003), ..Default::default() },
+                        ),
+                    ];
+                    let updated_hashed_storage =
+                        vec![(s1, U256::from(140)), (s2, U256::from(220)), (s3, U256::from(300))];
+                    let updated_trie_accounts = vec![(p2, node_p2), (p3, node_p3)];
+                    let updated_trie_storage = vec![(st2, node_st2), (st3, node_st3)];
+
+                    for (key, val) in updated_hashed_accounts {
+                        let (k, vv) = acc_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+
+                    for (key, val) in updated_hashed_storage {
+                        let (k, vv) = stor_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+
+                    for (key, val) in updated_trie_accounts {
+                        let (k, vv) = acc_trie_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+                    for (key, val) in updated_trie_storage {
+                        let (k, vv) = stor_trie_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+                }
+
+                // Both latest and earliest blocks are None -> early return default; DB untouched.
+                #[tokio::test]
+                async fn run_inner_where_latest_block_is_none() {
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
+
+                    let earliest = store.get_earliest_block_number().unwrap();
+                    let latest = store.get_latest_block_number().unwrap();
+                    assert!(earliest.is_none());
+                    assert!(latest.is_none());
+
+                    let block_hash_reader = MockBlockHashReader::new();
+                    let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 10, 1000);
+                    let out = pruner.run_inner().expect("ok");
+                    assert_eq!(out, PrunerOutput::default(), "should early-return default output");
+                }
+
+                // The earliest block is None, but the latest block exists -> early return default.
+                #[tokio::test]
+                async fn run_inner_earliest_none_real_db() {
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
+
+                    // Write a single block to set *latest* only.
+                    store
+                        .store_trie_updates(block(3, B256::ZERO), BlockStateDiff::default())
+                        .expect("store b1");
+
+                    let earliest = store.get_earliest_block_number().unwrap();
+                    let latest = store.get_latest_block_number().unwrap();
+                    assert!(earliest.is_none(), "earliest must remain None");
+                    assert_eq!(latest.unwrap().0, 3);
+
+                    let block_hash_reader = MockBlockHashReader::new();
+                    let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 1, 1000);
+                    let out = pruner.run_inner().expect("ok");
+                    assert_eq!(out, PrunerOutput::default(), "should early-return default output");
+                }
+
+                // interval < min_block_interval -> "Nothing to prune" path; default output.
+                #[tokio::test]
+                async fn run_inner_interval_too_small_real_db() {
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
+
+                    // Set earliest=4 explicitly
+                    let earliest_num = 4u64;
+                    let h4 = b256(4);
+                    store.set_earliest_block_number(earliest_num, h4).expect("set earliest");
+
+                    // Set latest=5 by storing block 5
+                    let b5 = block(5, h4);
+                    store.store_trie_updates(b5, BlockStateDiff::default()).expect("store b5");
+
+                    // Sanity: earliest=4, latest=5 => interval=1
+                    let e = store.get_earliest_block_number().unwrap().unwrap();
+                    let l = store.get_latest_block_number().unwrap().unwrap();
+                    assert_eq!(e.0, 4);
+                    assert_eq!(l.0, 5);
+
+                    // Require min_block_interval=2 (or greater) so interval < min
+                    let block_hash_reader = MockBlockHashReader::new();
+                    let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 2, 1000);
+                    let out = pruner.run_inner().expect("ok");
+                    assert_eq!(out, PrunerOutput::default(), "no pruning should occur");
+                }
+            }
+        };
     }
 
-    // Both latest and earliest blocks are None -> early return default; DB untouched.
-    #[tokio::test]
-    async fn run_inner_where_latest_block_is_none() {
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
-
-        let earliest = store.get_earliest_block_number().unwrap();
-        let latest = store.get_latest_block_number().unwrap();
-        assert!(earliest.is_none());
-        assert!(latest.is_none());
-
-        let block_hash_reader = MockBlockHashReader::new();
-        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 10, 1000);
-        let out = pruner.run_inner().expect("ok");
-        assert_eq!(out, PrunerOutput::default(), "should early-return default output");
-    }
-
-    // The earliest block is None, but the latest block exists -> early return default.
-    #[tokio::test]
-    async fn run_inner_earliest_none_real_db() {
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
-
-        // Write a single block to set *latest* only.
-        store
-            .store_trie_updates(block(3, B256::ZERO), BlockStateDiff::default())
-            .expect("store b1");
-
-        let earliest = store.get_earliest_block_number().unwrap();
-        let latest = store.get_latest_block_number().unwrap();
-        assert!(earliest.is_none(), "earliest must remain None");
-        assert_eq!(latest.unwrap().0, 3);
-
-        let block_hash_reader = MockBlockHashReader::new();
-        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 1, 1000);
-        let out = pruner.run_inner().expect("ok");
-        assert_eq!(out, PrunerOutput::default(), "should early-return default output");
-    }
-
-    // interval < min_block_interval -> "Nothing to prune" path; default output.
-    #[tokio::test]
-    async fn run_inner_interval_too_small_real_db() {
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
-
-        // Set earliest=4 explicitly
-        let earliest_num = 4u64;
-        let h4 = b256(4);
-        store.set_earliest_block_number(earliest_num, h4).expect("set earliest");
-
-        // Set latest=5 by storing block 5
-        let b5 = block(5, h4);
-        store.store_trie_updates(b5, BlockStateDiff::default()).expect("store b5");
-
-        // Sanity: earliest=4, latest=5 => interval=1
-        let e = store.get_earliest_block_number().unwrap().unwrap();
-        let l = store.get_latest_block_number().unwrap().unwrap();
-        assert_eq!(e.0, 4);
-        assert_eq!(l.0, 5);
-
-        // Require min_block_interval=2 (or greater) so interval < min
-        let block_hash_reader = MockBlockHashReader::new();
-        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 2, 1000);
-        let out = pruner.run_inner().expect("ok");
-        assert_eq!(out, PrunerOutput::default(), "no pruning should occur");
-    }
+    proof_storage_pruner_tests!(mdbx_tests, MdbxProofsStorage);
+    proof_storage_pruner_tests!(rocksdb_tests, RocksdbProofsStorage);
 }

--- a/crates/execution/trie/tests/branch_cursors/mod.rs
+++ b/crates/execution/trie/tests/branch_cursors/mod.rs
@@ -1,0 +1,693 @@
+//! Branch trie cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+// =============================================================================
+// 1. Basic Cursor Operations
+// =============================================================================
+
+/// Test cursor operations on empty trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // All operations should return None on empty trie
+    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
+    assert!(cursor.seek(Nibbles::default())?.is_none());
+    assert!(cursor.next()?.is_none());
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with single entry
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    // Store single entry
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test seek_exact
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Test current position
+    assert_eq!(cursor.current()?.unwrap(), path);
+
+    // Test next from end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with multiple entries
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![2, 3]),
+    ];
+    let branch = create_test_branch();
+
+    // Store multiple entries
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test that we can iterate through all entries
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    assert_eq!(found_paths.len(), 4);
+    // Paths should be in lexicographic order
+    for i in 0..paths.len() {
+        assert_eq!(found_paths[i], paths[i]);
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// 2. Seek Operations
+// =============================================================================
+
+/// Test `seek_exact` with existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test `seek_exact` with non-existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let non_existing = nibbles_from(vec![4, 5, 6]);
+    assert!(cursor.seek_exact(non_existing)?.is_none());
+
+    Ok(())
+}
+
+/// Test `seek_exact` with empty path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
+    assert_eq!(result.0, Nibbles::default());
+
+    Ok(())
+}
+
+/// Test seek to existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test seek between existing nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path between 1 and 3, should return path 3
+    let seek_path = nibbles_from(vec![2]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test seek after all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path after all nodes
+    let seek_path = nibbles_from(vec![9]);
+    assert!(cursor.seek(seek_path)?.is_none());
+
+    Ok(())
+}
+
+/// Test seek before all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![5]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path before all nodes, should return first node
+    let seek_path = nibbles_from(vec![1]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+// =============================================================================
+// 3. Navigation Tests
+// =============================================================================
+
+/// Test next without prior seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // next() without prior seek should start from beginning
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test next after seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path1)?;
+
+    // next() should return second node
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test next at end of trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path)?;
+
+    // next() at end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test multiple consecutive next calls
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Iterate through all with consecutive next() calls
+    for expected_path in &paths {
+        let result = cursor.next()?.unwrap();
+        assert_eq!(result.0, *expected_path);
+    }
+
+    // Final next() should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test current after operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None initially
+    assert!(cursor.current()?.is_none());
+
+    // After seek, current should track position
+    cursor.seek(path1)?;
+    assert_eq!(cursor.current()?.unwrap(), path1);
+
+    // After next, current should update
+    cursor.next()?;
+    assert_eq!(cursor.current()?.unwrap(), path2);
+
+    Ok(())
+}
+
+/// Test current with no prior operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None when no operations performed
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 4. Block Number Filtering
+// =============================================================================
+
+/// Test same path with different blocks
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch1 = create_test_branch();
+    let branch2 = create_test_branch_variant();
+
+    // Store same path at different blocks
+    storage.store_account_branches(vec![(path, Some(branch1))])?;
+    storage.store_account_branches(vec![(path, Some(branch2))])?;
+
+    // Cursor with max_block_number=75 should see only block 50 data
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    let result75 = cursor75.seek_exact(path)?.unwrap();
+    assert_eq!(result75.0, path);
+
+    // Cursor with max_block_number=150 should see block 100 data (latest)
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    let result150 = cursor150.seek_exact(path)?.unwrap();
+    assert_eq!(result150.0, path);
+
+    Ok(())
+}
+
+/// Test deleted branch nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Store branch node, then delete it (store None)
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // Cursor before deletion should see the node
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    assert!(cursor75.seek_exact(path)?.is_some());
+
+    let mut block_state_diff_trie_updates = TrieUpdates::default();
+    block_state_diff_trie_updates.removed_nodes.insert(path);
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should not see the node
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    assert!(cursor150.seek_exact(path)?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 5. Hashed Address Filtering
+// =============================================================================
+
+/// Test account-specific cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr1 = B256::repeat_byte(0x01);
+    let addr2 = B256::repeat_byte(0x02);
+    let branch = create_test_branch();
+
+    // Store same path for different accounts (using storage branches)
+    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
+    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
+
+    // Cursor for addr1 should only see addr1 data
+    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
+    let result1 = cursor1.seek_exact(path)?.unwrap();
+    assert_eq!(result1.0, path);
+
+    // Cursor for addr2 should only see addr2 data
+    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
+    let result2 = cursor2.seek_exact(path)?.unwrap();
+    assert_eq!(result2.0, path);
+
+    // Cursor for addr1 should not see addr2 data when iterating
+    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
+    let mut found_count = 0;
+    while cursor1_iter.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
+
+    Ok(())
+}
+
+/// Test state trie cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store data for account trie and state trie
+    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // State trie cursor (None address) should only see state trie data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let result = state_cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Verify state cursor doesn't see account data when iterating
+    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
+    let mut found_count = 0;
+    while state_cursor_iter.next()?.is_some() {
+        found_count += 1;
+    }
+
+    assert_eq!(found_count, 1); // Should only see state trie entry
+
+    Ok(())
+}
+
+/// Test mixed account and state data
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store mixed account and state trie data
+    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    // Account cursor should only see account data
+    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
+    let mut account_paths = Vec::new();
+    while let Some((path, _)) = account_cursor.next()? {
+        account_paths.push(path);
+    }
+    assert_eq!(account_paths.len(), 1);
+    assert_eq!(account_paths[0], path1);
+
+    // State cursor should only see state data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let mut state_paths = Vec::new();
+    while let Some((path, _)) = state_cursor.next()? {
+        state_paths.push(path);
+    }
+    assert_eq!(state_paths.len(), 1);
+    assert_eq!(state_paths[0], path2);
+
+    Ok(())
+}
+
+// =============================================================================
+// 6. Path Ordering Tests
+// =============================================================================
+
+/// Test lexicographic ordering
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![3, 1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![1]),
+    ];
+    let branch = create_test_branch();
+
+    // Store paths in random order
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
+    let expected_order = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![3, 1]),
+    ];
+
+    assert_eq!(found_paths, expected_order);
+
+    Ok(())
+}
+
+/// Test path prefix scenarios
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),       // Prefix of next
+        nibbles_from(vec![1, 2]),    // Extends first
+        nibbles_from(vec![1, 2, 3]), // Extends second
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Seek to prefix should find exact match
+    let result = cursor.seek_exact(paths[0])?.unwrap();
+    assert_eq!(result.0, paths[0]);
+
+    // Next should go to next path, not skip prefixed paths
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[1]);
+
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[2]);
+
+    Ok(())
+}
+
+/// Test complex nibble combinations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test various nibble patterns including edge values
+    let paths = vec![
+        nibbles_from(vec![0]),
+        nibbles_from(vec![0, 15]),
+        nibbles_from(vec![15]),
+        nibbles_from(vec![15, 0]),
+        nibbles_from(vec![7, 8, 9]),
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // All paths should be found and in correct order
+    assert_eq!(found_paths.len(), 5);
+
+    // Verify specific ordering for edge cases
+    assert_eq!(found_paths[0], nibbles_from(vec![0]));
+    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
+    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/hashed_cursors/mod.rs
+++ b/crates/execution/trie/tests/hashed_cursors/mod.rs
@@ -1,0 +1,704 @@
+//! Hashed account and storage cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+fn account_exact<S: BaseProofsStore>(
+    storage: &S,
+    key: B256,
+    max_block: u64,
+) -> Result<Option<Account>, BaseProofsStorageError> {
+    Ok(storage
+        .account_hashed_cursor(max_block)?
+        .seek(key)?
+        .and_then(|(k, v)| (k == key).then_some(v)))
+}
+
+fn storage_exact<S: BaseProofsStore>(
+    storage: &S,
+    hashed_address: B256,
+    key: B256,
+    max_block: u64,
+) -> Result<Option<U256>, BaseProofsStorageError> {
+    Ok(storage
+        .storage_hashed_cursor(hashed_address, max_block)?
+        .seek(key)?
+        .and_then(|(k, v)| (k == key).then_some(v)))
+}
+
+// =============================================================================
+// 7. Leaf Node Tests (Hashed Accounts and Storage)
+// =============================================================================
+
+/// Test store and retrieve single account
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account = create_test_account();
+
+    // Store account
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let result = cursor.seek(account_key)?.unwrap();
+
+    assert_eq!(result.0, account_key);
+    assert_eq!(result.1.nonce, account.nonce);
+    assert_eq!(result.1.balance, account.balance);
+    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
+
+    Ok(())
+}
+
+/// Test account cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let accounts = [
+        (B256::repeat_byte(0x01), create_test_account()),
+        (B256::repeat_byte(0x03), create_test_account()),
+        (B256::repeat_byte(0x05), create_test_account()),
+    ];
+
+    // Store accounts
+    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
+    storage.store_hashed_accounts(accounts_to_store)?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Test seeking to exact key
+    let result = cursor.seek(accounts[1].0)?.unwrap();
+    assert_eq!(result.0, accounts[1].0);
+
+    // Test seeking to key that doesn't exist (should return next greater)
+    let seek_key = B256::repeat_byte(0x02);
+    let result = cursor.seek(seek_key)?.unwrap();
+    assert_eq!(result.0, accounts[1].0); // Should find 0x03
+
+    // Test next() navigation
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, accounts[2].0); // Should find 0x05
+
+    // Test next() at end
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test that a `RocksDB` cursor reads from the snapshot captured when it is created.
+#[test]
+#[serial]
+fn test_rocksdb_account_cursor_uses_creation_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let key1 = B256::repeat_byte(0x01);
+    let key2 = B256::repeat_byte(0x02);
+    let account1 = create_test_account_with_values(1, 100, 0xAA);
+    let account2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(key1, Some(account1));
+    post_state.accounts.insert(key2, Some(account2));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let mut cursor = storage.account_hashed_cursor(1)?;
+    let first = cursor.seek(key1)?.expect("first account exists");
+    assert_eq!(first.0, key1);
+
+    let replacement_block1 =
+        BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x22)));
+    let mut replacement_post_state = HashedPostState::default();
+    replacement_post_state.accounts.insert(key1, Some(account1));
+    storage.replace_updates(
+        BlockNumHash::new(0, B256::ZERO),
+        vec![(
+            replacement_block1,
+            BlockStateDiff {
+                sorted_trie_updates: TrieUpdatesSorted::default(),
+                sorted_post_state: replacement_post_state.into_sorted(),
+            },
+        )],
+    )?;
+
+    let next = cursor.next()?.expect("existing cursor keeps its original snapshot");
+    assert_eq!(next.0, key2);
+    assert_eq!(next.1.nonce, account2.nonce);
+
+    let mut fresh_cursor = storage.account_hashed_cursor(1)?;
+    let fresh_result = fresh_cursor.seek(key2)?;
+    assert!(
+        !matches!(fresh_result, Some((found_key, _)) if found_key == key2),
+        "fresh cursor should not see the replaced account"
+    );
+
+    Ok(())
+}
+
+/// Test account block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
+    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
+
+    // Store account at different blocks
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
+
+    // Cursor with max_block_number=75 should see v1
+    let mut cursor75 = storage.account_hashed_cursor(75)?;
+    let result75 = cursor75.seek(account_key)?.unwrap();
+    assert_eq!(result75.1.nonce, account_v1.nonce);
+    assert_eq!(result75.1.balance, account_v1.balance);
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
+
+    // After update, Cursor with max_block_number=150 should see v2
+    let mut cursor150 = storage.account_hashed_cursor(150)?;
+    let result150 = cursor150.seek(account_key)?.unwrap();
+    assert_eq!(result150.1.nonce, account_v2.nonce);
+    assert_eq!(result150.1.balance, account_v2.balance);
+
+    Ok(())
+}
+
+/// Test store and retrieve storage
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+
+fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+    ];
+
+    // Store storage slots
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Test seeking to each slot
+    for (key, expected_value) in &storage_slots {
+        let result = cursor.seek(*key)?.unwrap();
+        assert_eq!(result.0, *key);
+        assert_eq!(result.1, *expected_value);
+    }
+
+    Ok(())
+}
+
+/// Test storage cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x50), U256::from(500)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Start from beginning with next()
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    assert_eq!(found_slots.len(), 3);
+    assert_eq!(found_slots[0], storage_slots[0]);
+    assert_eq!(found_slots[1], storage_slots[1]);
+    assert_eq!(found_slots[2], storage_slots[2]);
+
+    Ok(())
+}
+
+/// Test storage account isolation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let address1 = B256::repeat_byte(0x01);
+    let address2 = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store same storage key for different accounts
+    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
+    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
+
+    // Verify each account sees only its own storage
+    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
+    let result1 = cursor1.seek(storage_key)?.unwrap();
+    assert_eq!(result1.1, U256::from(100));
+
+    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
+    let result2 = cursor2.seek(storage_key)?.unwrap();
+    assert_eq!(result2.1, U256::from(200));
+
+    // Verify cursor1 doesn't see address2's storage
+    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
+    let mut count = 0;
+    while cursor1_iter.next()?.is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 1); // Should only see one entry
+
+    Ok(())
+}
+
+/// Test storage block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store storage at different blocks
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor with max_block_number=75 should see old value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
+    // Cursor with max_block_number=150 should see new value
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?.unwrap();
+    assert_eq!(result150.1, U256::from(200));
+
+    Ok(())
+}
+
+/// Test storage zero value deletion
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store non-zero value
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor before deletion should see the value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    // "Delete" by storing zero value at block 100
+    let mut block_state_diff_post_state = HashedPostState::default();
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::ZERO);
+    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
+
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: block_state_diff_post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should NOT see the entry (zero values are skipped)
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?;
+    assert!(result150.is_none(), "Zero values should be skipped/deleted");
+
+    Ok(())
+}
+
+/// Test that zero values are skipped during iteration
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+
+    // Create a mix of non-zero and zero value storage slots
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
+        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
+        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
+    ];
+
+    // Store all slots
+    storage.store_hashed_storages(hashed_address, storage_slots)?;
+
+    // Create cursor and iterate through all entries
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    // Should only find 3 non-zero values
+    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
+
+    // Verify the non-zero values are the ones we stored
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
+
+    // Verify seeking to a zero-value slot returns None or skips to next non-zero
+    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
+
+    // Should either return None or skip to the next non-zero value (0x30)
+    if let Some((key, value)) = seek_result {
+        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
+        assert_eq!(value, U256::from(300));
+    }
+
+    Ok(())
+}
+
+/// Test empty cursors
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test empty account cursor
+    let mut account_cursor = storage.account_hashed_cursor(100)?;
+    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
+    assert!(account_cursor.next()?.is_none());
+
+    // Test empty storage cursor
+    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
+    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
+    assert!(storage_cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor boundary conditions
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x80); // Middle value
+    let account = create_test_account();
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Seek to minimum key should find our account
+    let result = cursor.seek(B256::ZERO)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    // Seek to maximum key should find nothing
+    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
+
+    // Seek to key just before our account should find our account
+    let just_before = B256::repeat_byte(0x7F);
+    let result = cursor.seek(just_before)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    Ok(())
+}
+
+/// Test large batch operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Create large batch of accounts
+    let mut accounts = Vec::new();
+    for i in 0..100 {
+        let key = B256::from([i as u8; 32]);
+        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
+        accounts.push((key, Some(account)));
+    }
+
+    // Store in batch
+    storage.store_hashed_accounts(accounts.clone())?;
+
+    // Verify all accounts can be retrieved
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let mut found_count = 0;
+    while cursor.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 100);
+
+    // Test specific account retrieval
+    let test_key = B256::from([42u8; 32]);
+    let result = cursor.seek(test_key)?.unwrap();
+    assert_eq!(result.0, test_key);
+    assert_eq!(result.1.nonce, 42);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_exact_account_reads_do_not_return_lower_bound_neighbor<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let left_key = B256::repeat_byte(0x10);
+    let missing_key = B256::repeat_byte(0x20);
+    let right_key = B256::repeat_byte(0x30);
+    let left_account = create_test_account_with_values(1, 100, 0xAA);
+    let right_account = create_test_account_with_values(2, 200, 0xBB);
+
+    storage.store_hashed_accounts(vec![
+        (left_key, Some(left_account)),
+        (right_key, Some(right_account)),
+    ])?;
+
+    assert_eq!(account_exact(&storage, left_key, 100)?, Some(left_account));
+    assert_eq!(account_exact(&storage, right_key, 100)?, Some(right_account));
+    assert_eq!(account_exact(&storage, missing_key, 100)?, None);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_exact_storage_reads_do_not_return_lower_bound_neighbor<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0xA0);
+    let left_key = B256::repeat_byte(0x10);
+    let missing_key = B256::repeat_byte(0x20);
+    let right_key = B256::repeat_byte(0x30);
+
+    storage.store_hashed_storages(
+        hashed_address,
+        vec![(left_key, U256::from(100)), (right_key, U256::from(300))],
+    )?;
+
+    assert_eq!(storage_exact(&storage, hashed_address, left_key, 100)?, Some(U256::from(100)));
+    assert_eq!(storage_exact(&storage, hashed_address, right_key, 100)?, Some(U256::from(300)));
+    assert_eq!(storage_exact(&storage, hashed_address, missing_key, 100)?, None);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_exact_reads_hide_deleted_account_and_zero_storage<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let deleted_account_key = B256::repeat_byte(0x40);
+    let live_account_key = B256::repeat_byte(0x50);
+    let hashed_address = B256::repeat_byte(0x60);
+    let zero_slot = B256::repeat_byte(0x70);
+    let live_slot = B256::repeat_byte(0x80);
+    let live_account = create_test_account();
+
+    storage.store_hashed_accounts(vec![
+        (deleted_account_key, None),
+        (live_account_key, Some(live_account)),
+    ])?;
+    storage.store_hashed_storages(
+        hashed_address,
+        vec![(zero_slot, U256::ZERO), (live_slot, U256::from(1))],
+    )?;
+
+    assert_eq!(account_exact(&storage, deleted_account_key, 100)?, None);
+    assert_eq!(account_exact(&storage, live_account_key, 100)?, Some(live_account));
+    assert_eq!(storage_exact(&storage, hashed_address, zero_slot, 100)?, None);
+    assert_eq!(storage_exact(&storage, hashed_address, live_slot, 100)?, Some(U256::from(1)));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rocksdb_exact_reads_use_supplied_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x01);
+    let hashed_address = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x03);
+    let account_v1 = create_test_account_with_values(1, 100, 0xAA);
+    let account_v2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::from(10));
+    post_state.storages.insert(hashed_address, hashed_storage);
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let tx = storage.storage.ro_tx()?;
+
+    let block2 = BlockWithParent::new(block1.block.hash, NumHash::new(2, B256::repeat_byte(0x22)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v2));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::from(20));
+    post_state.storages.insert(hashed_address, hashed_storage);
+    storage.store_trie_updates(
+        block2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let (k, v) = storage
+        .storage
+        .account_hashed_cursor_with_tx(&tx, 2)?
+        .seek(account_key)?
+        .expect("account exists in snapshot");
+    assert_eq!(k, account_key);
+    assert_eq!(v, account_v1);
+
+    assert_eq!(account_exact(&storage.storage, account_key, 2)?, Some(account_v2));
+
+    let (k, v) = storage
+        .storage
+        .storage_hashed_cursor_with_tx(&tx, hashed_address, 2)?
+        .seek(storage_key)?
+        .expect("storage exists in snapshot");
+    assert_eq!(k, storage_key);
+    assert_eq!(v, U256::from(10));
+
+    assert_eq!(
+        storage_exact(&storage.storage, hashed_address, storage_key, 2)?,
+        Some(U256::from(20))
+    );
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rocksdb_exact_lookup_finds_latest_version_at_or_below_bound()
+-> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x51);
+    let account_v1 = create_test_account_with_values(1, 100, 0xAA);
+    let account_v3 = create_test_account_with_values(3, 300, 0xCC);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v1));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let block3 = BlockWithParent::new(block1.block.hash, NumHash::new(3, B256::repeat_byte(0x33)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v3));
+    storage.store_trie_updates(
+        block3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    assert_eq!(account_exact(&storage.storage, account_key, 2)?, Some(account_v1));
+    assert_eq!(account_exact(&storage.storage, account_key, 3)?, Some(account_v3));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rocksdb_exact_lookup_returns_none_when_versions_are_above_bound()
+-> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x61);
+    let account = create_test_account_with_values(10, 1_000, 0xAA);
+
+    let block10 = BlockWithParent::new(B256::ZERO, NumHash::new(10, B256::repeat_byte(0x10)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account));
+    storage.store_trie_updates(
+        block10,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    assert_eq!(account_exact(&storage.storage, account_key, 9)?, None);
+    assert_eq!(account_exact(&storage.storage, account_key, 10)?, Some(account));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/history/mod.rs
+++ b/crates/execution/trie/tests/history/mod.rs
@@ -1,0 +1,292 @@
+//! History fetch, prune, and unwind behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_fetch_trie_updates_basic<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = test_block(B256::ZERO, 1, 0x11);
+    let account_address = B256::repeat_byte(0x11);
+    let deleted_account = B256::repeat_byte(0x22);
+    let storage_address = B256::repeat_byte(0x33);
+    let trie_storage_address = B256::repeat_byte(0x44);
+    let slot = B256::repeat_byte(0xA1);
+    let account = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(nibbles_from(vec![0, 1, 2, 3]), BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates
+        .storage_nodes
+        .insert(nibbles_from(vec![1, 2, 3, 4]), BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(trie_storage_address, storage_trie_updates);
+
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_address, Some(account));
+    post_state.accounts.insert(deleted_account, None);
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(slot, U256::from(1234));
+    post_state.storages.insert(storage_address, hashed_storage);
+
+    let expected = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, expected.clone())?;
+
+    let actual = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(
+        actual.sorted_trie_updates.account_nodes_ref(),
+        expected.sorted_trie_updates.account_nodes_ref()
+    );
+    assert_eq!(
+        actual.sorted_trie_updates.storage_tries_ref(),
+        expected.sorted_trie_updates.storage_tries_ref()
+    );
+    assert_eq!(actual.sorted_post_state.accounts, expected.sorted_post_state.accounts);
+    assert_eq!(actual.sorted_post_state.storages, expected.sorted_post_state.storages);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_out_of_order_rejects<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let block_42 = test_block(B256::ZERO, 42, 0x42);
+    storage.store_trie_updates(block_42, BlockStateDiff::default())?;
+
+    let bad_block = test_block(B256::repeat_byte(0xFF), 99, 0x99);
+    let error = storage.store_trie_updates(bad_block, BlockStateDiff::default()).unwrap_err();
+    assert!(matches!(error, BaseProofsStorageError::OutOfOrder { .. }));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_address = B256::repeat_byte(1);
+    let storage_slot = B256::repeat_byte(2);
+    let account_path = nibbles_from(vec![1]);
+    let storage_path = nibbles_from(vec![3]);
+    let account_v1 = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+    let account_v2 = Account { nonce: 2, balance: U256::from(200), ..Default::default() };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(account_path, BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates.storage_nodes.insert(storage_path, BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(account_address, storage_trie_updates);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_address, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_slot, U256::from(1234));
+    post_state_1.storages.insert(account_address, hashed_storage);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_address, Some(account_v2));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.prune_earliest_state(block_3)?;
+
+    assert_account_at(&storage, 3, account_address, account_v2)?;
+    assert_storage_at(&storage, account_address, 3, storage_slot, U256::from(1234))?;
+    assert_account_branch_present(&storage, 3, account_path)?;
+
+    let mut storage_cursor = storage.storage_trie_cursor(account_address, 3)?;
+    assert!(storage_cursor.seek_exact(storage_path)?.is_some());
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_returns_correct_counts<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(address, Some(Account { nonce: 1, ..Default::default() }));
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(address, Some(Account { nonce: 2, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+
+    let counts = storage.prune_earliest_state(block_2)?;
+    assert_eq!(counts.hashed_accounts_written_total, 1);
+    assert_eq!(counts.account_trie_updates_written_total, 0);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_with_trie_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let path_1 = nibbles_from(vec![1]);
+    let path_2 = nibbles_from(vec![2]);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    for (block, path) in [(block_1, path_1), (block_2, path_2), (block_3, path_1)] {
+        let mut trie_updates = TrieUpdates::default();
+        trie_updates.account_nodes.insert(path, BranchNodeCompact::default());
+        storage.store_trie_updates(
+            block,
+            BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostStateSorted::default(),
+            },
+        )?;
+    }
+
+    storage.unwind_history(block_2)?;
+    assert_account_branch_present(&storage, 10, path_1)?;
+    assert_account_branch_missing(&storage, 10, path_2)
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_1 = B256::repeat_byte(1);
+    let account_2 = B256::repeat_byte(2);
+    let slot_1 = B256::repeat_byte(3);
+    let slot_2 = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_1, Some(Account::default()));
+    let mut storage_1 = HashedStorage::default();
+    storage_1.storage.insert(slot_1, U256::from(1111));
+    post_state_1.storages.insert(account_1, storage_1);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_2, Some(Account::default()));
+    let mut storage_2 = HashedStorage::default();
+    storage_2.storage.insert(slot_2, U256::from(2222));
+    post_state_2.storages.insert(account_2, storage_2);
+
+    let mut post_state_3 = HashedPostState::default();
+    post_state_3.accounts.insert(account_1, Some(Account { nonce: 9, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_3.into_sorted(),
+        },
+    )?;
+
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    assert_eq!(storage.get_latest_block_number()?, Some((1, block_1.block.hash)));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_unwind_history_idempotent<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(1);
+    let make_diff = |nonce| {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    storage.store_trie_updates(block_1, make_diff(10))?;
+    storage.store_trie_updates(block_2, make_diff(20))?;
+    storage.store_trie_updates(block_3, make_diff(30))?;
+
+    storage.unwind_history(block_2)?;
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    Ok(())
+}

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -5,19 +5,19 @@ use std::sync::Arc;
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    InMemoryProofsStorage, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStorageResult, BaseProofsStore,
+    BlockStateDiff, InMemoryProofsStorage,
+    api::{InitialStateAnchor, WriteCounts},
+    db::{MdbxProofsStorage, RocksdbProofsStorage},
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
     BranchNodeCompact, HashedPostState, HashedPostStateSorted, HashedStorage, Nibbles, TrieMask,
     hashed_cursor::HashedCursor,
     trie_cursor::TrieCursor,
-    updates::{TrieUpdates, TrieUpdatesSorted},
+    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
 };
-use serial_test::serial;
 use tempfile::TempDir;
-use test_case::test_case;
 
 /// Helper to create a simple test branch node
 fn create_test_branch() -> BranchNodeCompact {
@@ -77,1978 +77,265 @@ fn create_mdbx_proofs_storage() -> MdbxProofsStorage {
     MdbxProofsStorage::new(path.path()).unwrap()
 }
 
-/// Test basic storage and retrieval of earliest block number
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Initially should be None
-    let earliest = storage.get_earliest_block_number()?;
-    assert!(earliest.is_none());
-
-    // Set earliest block
-    let block_hash = B256::repeat_byte(0x42);
-    storage.set_earliest_block_number(100, block_hash)?;
-
-    // Should retrieve the same values
-    let earliest = storage.get_earliest_block_number()?;
-    assert_eq!(earliest, Some((100, block_hash)));
-
-    Ok(())
+#[derive(Debug)]
+struct TestRocksdbProofsStorage {
+    storage: RocksdbProofsStorage,
+    _dir: TempDir,
 }
 
-/// Test storing and retrieving trie updates
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-    let sorted_trie_updates = TrieUpdatesSorted::default();
-    let sorted_post_state = HashedPostStateSorted::default();
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: sorted_trie_updates.clone(),
-        sorted_post_state: sorted_post_state.clone(),
-    };
-
-    // Store trie updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Retrieve and verify
-    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
-    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
-
-    Ok(())
+fn create_rocksdb_proofs_storage() -> TestRocksdbProofsStorage {
+    let dir = TempDir::new().unwrap();
+    let storage = RocksdbProofsStorage::new(dir.path()).unwrap();
+    TestRocksdbProofsStorage { storage, _dir: dir }
 }
 
-// =============================================================================
-// 1. Basic Cursor Operations
-// =============================================================================
+impl BaseProofsStore for TestRocksdbProofsStorage {
+    type StorageTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type StorageCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountHashedCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountHashedCursor<'tx>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::Tx<'tx>
+    where
+        Self: 'tx;
 
-/// Test cursor operations on empty trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // All operations should return None on empty trie
-    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
-    assert!(cursor.seek(Nibbles::default())?.is_none());
-    assert!(cursor.next()?.is_none());
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with single entry
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    // Store single entry
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test seek_exact
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Test current position
-    assert_eq!(cursor.current()?.unwrap(), path);
-
-    // Test next from end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with multiple entries
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![2, 3]),
-    ];
-    let branch = create_test_branch();
-
-    // Store multiple entries
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_earliest_block_number()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test that we can iterate through all entries
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_latest_block_number()
     }
 
-    assert_eq!(found_paths.len(), 4);
-    // Paths should be in lexicographic order
-    for i in 0..paths.len() {
-        assert_eq!(found_paths[i], paths[i]);
+    fn storage_trie_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+        self.storage.storage_trie_cursor(hashed_address, max_block_number)
     }
 
-    Ok(())
-}
-
-// =============================================================================
-// 2. Seek Operations
-// =============================================================================
-
-/// Test `seek_exact` with existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test `seek_exact` with non-existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let non_existing = nibbles_from(vec![4, 5, 6]);
-    assert!(cursor.seek_exact(non_existing)?.is_none());
-
-    Ok(())
-}
-
-/// Test `seek_exact` with empty path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
-    assert_eq!(result.0, Nibbles::default());
-
-    Ok(())
-}
-
-/// Test seek to existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test seek between existing nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path between 1 and 3, should return path 3
-    let seek_path = nibbles_from(vec![2]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test seek after all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path after all nodes
-    let seek_path = nibbles_from(vec![9]);
-    assert!(cursor.seek(seek_path)?.is_none());
-
-    Ok(())
-}
-
-/// Test seek before all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![5]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path before all nodes, should return first node
-    let seek_path = nibbles_from(vec![1]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-// =============================================================================
-// 3. Navigation Tests
-// =============================================================================
-
-/// Test next without prior seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // next() without prior seek should start from beginning
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test next after seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path1)?;
-
-    // next() should return second node
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test next at end of trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path)?;
-
-    // next() at end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test multiple consecutive next calls
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+        self.storage.account_trie_cursor(max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Iterate through all with consecutive next() calls
-    for expected_path in &paths {
-        let result = cursor.next()?.unwrap();
-        assert_eq!(result.0, *expected_path);
+    fn storage_hashed_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
+        self.storage.storage_hashed_cursor(hashed_address, max_block_number)
     }
 
-    // Final next() should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test current after operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None initially
-    assert!(cursor.current()?.is_none());
-
-    // After seek, current should track position
-    cursor.seek(path1)?;
-    assert_eq!(cursor.current()?.unwrap(), path1);
-
-    // After next, current should update
-    cursor.next()?;
-    assert_eq!(cursor.current()?.unwrap(), path2);
-
-    Ok(())
-}
-
-/// Test current with no prior operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None when no operations performed
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 4. Block Number Filtering
-// =============================================================================
-
-/// Test same path with different blocks
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch1 = create_test_branch();
-    let branch2 = create_test_branch_variant();
-
-    // Store same path at different blocks
-    storage.store_account_branches(vec![(path, Some(branch1))])?;
-    storage.store_account_branches(vec![(path, Some(branch2))])?;
-
-    // Cursor with max_block_number=75 should see only block 50 data
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    let result75 = cursor75.seek_exact(path)?.unwrap();
-    assert_eq!(result75.0, path);
-
-    // Cursor with max_block_number=150 should see block 100 data (latest)
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    let result150 = cursor150.seek_exact(path)?.unwrap();
-    assert_eq!(result150.0, path);
-
-    Ok(())
-}
-
-/// Test deleted branch nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Store branch node, then delete it (store None)
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // Cursor before deletion should see the node
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    assert!(cursor75.seek_exact(path)?.is_some());
-
-    let mut block_state_diff_trie_updates = TrieUpdates::default();
-    block_state_diff_trie_updates.removed_nodes.insert(path);
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should not see the node
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    assert!(cursor150.seek_exact(path)?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 5. Hashed Address Filtering
-// =============================================================================
-
-/// Test account-specific cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr1 = B256::repeat_byte(0x01);
-    let addr2 = B256::repeat_byte(0x02);
-    let branch = create_test_branch();
-
-    // Store same path for different accounts (using storage branches)
-    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
-    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
-
-    // Cursor for addr1 should only see addr1 data
-    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
-    let result1 = cursor1.seek_exact(path)?.unwrap();
-    assert_eq!(result1.0, path);
-
-    // Cursor for addr2 should only see addr2 data
-    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
-    let result2 = cursor2.seek_exact(path)?.unwrap();
-    assert_eq!(result2.0, path);
-
-    // Cursor for addr1 should not see addr2 data when iterating
-    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
-    let mut found_count = 0;
-    while cursor1_iter.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
-
-    Ok(())
-}
-
-/// Test state trie cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store data for account trie and state trie
-    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // State trie cursor (None address) should only see state trie data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let result = state_cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Verify state cursor doesn't see account data when iterating
-    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
-    let mut found_count = 0;
-    while state_cursor_iter.next()?.is_some() {
-        found_count += 1;
+    fn account_hashed_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        self.storage.account_hashed_cursor(max_block_number)
     }
 
-    assert_eq!(found_count, 1); // Should only see state trie entry
-
-    Ok(())
-}
-
-/// Test mixed account and state data
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store mixed account and state trie data
-    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    // Account cursor should only see account data
-    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
-    let mut account_paths = Vec::new();
-    while let Some((path, _)) = account_cursor.next()? {
-        account_paths.push(path);
-    }
-    assert_eq!(account_paths.len(), 1);
-    assert_eq!(account_paths[0], path1);
-
-    // State cursor should only see state data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let mut state_paths = Vec::new();
-    while let Some((path, _)) = state_cursor.next()? {
-        state_paths.push(path);
-    }
-    assert_eq!(state_paths.len(), 1);
-    assert_eq!(state_paths[0], path2);
-
-    Ok(())
-}
-
-// =============================================================================
-// 6. Path Ordering Tests
-// =============================================================================
-
-/// Test lexicographic ordering
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![3, 1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![1]),
-    ];
-    let branch = create_test_branch();
-
-    // Store paths in random order
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
+        self.storage.ro_tx()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
-    let expected_order = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![3, 1]),
-    ];
-
-    assert_eq!(found_paths, expected_order);
-
-    Ok(())
-}
-
-/// Test path prefix scenarios
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),       // Prefix of next
-        nibbles_from(vec![1, 2]),    // Extends first
-        nibbles_from(vec![1, 2, 3]), // Extends second
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_trie_cursor_with_tx(tx, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Seek to prefix should find exact match
-    let result = cursor.seek_exact(paths[0])?.unwrap();
-    assert_eq!(result.0, paths[0]);
-
-    // Next should go to next path, not skip prefixed paths
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[1]);
-
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[2]);
-
-    Ok(())
-}
-
-/// Test complex nibble combinations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Test various nibble patterns including edge values
-    let paths = vec![
-        nibbles_from(vec![0]),
-        nibbles_from(vec![0, 15]),
-        nibbles_from(vec![15]),
-        nibbles_from(vec![15, 0]),
-        nibbles_from(vec![7, 8, 9]),
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_hashed_cursor_with_tx(tx, max_block_number)
     }
 
-    // All paths should be found and in correct order
-    assert_eq!(found_paths.len(), 5);
-
-    // Verify specific ordering for edge cases
-    assert_eq!(found_paths[0], nibbles_from(vec![0]));
-    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
-    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
-
-    Ok(())
-}
-
-// =============================================================================
-// 7. Leaf Node Tests (Hashed Accounts and Storage)
-// =============================================================================
-
-/// Test store and retrieve single account
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account = create_test_account();
-
-    // Store account
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let result = cursor.seek(account_key)?.unwrap();
-
-    assert_eq!(result.0, account_key);
-    assert_eq!(result.1.nonce, account.nonce);
-    assert_eq!(result.1.balance, account.balance);
-    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
-
-    Ok(())
-}
-
-/// Test account cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let accounts = [
-        (B256::repeat_byte(0x01), create_test_account()),
-        (B256::repeat_byte(0x03), create_test_account()),
-        (B256::repeat_byte(0x05), create_test_account()),
-    ];
-
-    // Store accounts
-    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
-    storage.store_hashed_accounts(accounts_to_store)?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Test seeking to exact key
-    let result = cursor.seek(accounts[1].0)?.unwrap();
-    assert_eq!(result.0, accounts[1].0);
-
-    // Test seeking to key that doesn't exist (should return next greater)
-    let seek_key = B256::repeat_byte(0x02);
-    let result = cursor.seek(seek_key)?.unwrap();
-    assert_eq!(result.0, accounts[1].0); // Should find 0x03
-
-    // Test next() navigation
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, accounts[2].0); // Should find 0x05
-
-    // Test next() at end
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test account block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
-    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
-
-    // Store account at different blocks
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
-
-    // Cursor with max_block_number=75 should see v1
-    let mut cursor75 = storage.account_hashed_cursor(75)?;
-    let result75 = cursor75.seek(account_key)?.unwrap();
-    assert_eq!(result75.1.nonce, account_v1.nonce);
-    assert_eq!(result75.1.balance, account_v1.balance);
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
-
-    // After update, Cursor with max_block_number=150 should see v2
-    let mut cursor150 = storage.account_hashed_cursor(150)?;
-    let result150 = cursor150.seek(account_key)?.unwrap();
-    assert_eq!(result150.1.nonce, account_v2.nonce);
-    assert_eq!(result150.1.balance, account_v2.balance);
-
-    Ok(())
-}
-
-/// Test store and retrieve storage
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-
-fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-    ];
-
-    // Store storage slots
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Test seeking to each slot
-    for (key, expected_value) in &storage_slots {
-        let result = cursor.seek(*key)?.unwrap();
-        assert_eq!(result.0, *key);
-        assert_eq!(result.1, *expected_value);
+    fn store_trie_updates(
+        &self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.store_trie_updates(block_ref, block_state_diff)
     }
 
-    Ok(())
-}
-
-/// Test storage cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x50), U256::from(500)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Start from beginning with next()
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        self.storage.fetch_trie_updates(block_number)
     }
 
-    assert_eq!(found_slots.len(), 3);
-    assert_eq!(found_slots[0], storage_slots[0]);
-    assert_eq!(found_slots[1], storage_slots[1]);
-    assert_eq!(found_slots[2], storage_slots[2]);
-
-    Ok(())
-}
-
-/// Test storage account isolation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let address1 = B256::repeat_byte(0x01);
-    let address2 = B256::repeat_byte(0x02);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store same storage key for different accounts
-    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
-    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
-
-    // Verify each account sees only its own storage
-    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
-    let result1 = cursor1.seek(storage_key)?.unwrap();
-    assert_eq!(result1.1, U256::from(100));
-
-    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
-    let result2 = cursor2.seek(storage_key)?.unwrap();
-    assert_eq!(result2.1, U256::from(200));
-
-    // Verify cursor1 doesn't see address2's storage
-    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
-    let mut count = 0;
-    while cursor1_iter.next()?.is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 1); // Should only see one entry
-
-    Ok(())
-}
-
-/// Test storage block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store storage at different blocks
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor with max_block_number=75 should see old value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
-    // Cursor with max_block_number=150 should see new value
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?.unwrap();
-    assert_eq!(result150.1, U256::from(200));
-
-    Ok(())
-}
-
-/// Test storage zero value deletion
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store non-zero value
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor before deletion should see the value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    // "Delete" by storing zero value at block 100
-    let mut block_state_diff_post_state = HashedPostState::default();
-    let mut hashed_storage = HashedStorage::default();
-    hashed_storage.storage.insert(storage_key, U256::ZERO);
-    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: block_state_diff_post_state.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should NOT see the entry (zero values are skipped)
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?;
-    assert!(result150.is_none(), "Zero values should be skipped/deleted");
-
-    Ok(())
-}
-
-/// Test that zero values are skipped during iteration
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-
-    // Create a mix of non-zero and zero value storage slots
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
-        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
-        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
-    ];
-
-    // Store all slots
-    storage.store_hashed_storages(hashed_address, storage_slots)?;
-
-    // Create cursor and iterate through all entries
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn prune_earliest_state(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.prune_earliest_state(new_earliest_block_ref)
     }
 
-    // Should only find 3 non-zero values
-    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
-
-    // Verify the non-zero values are the ones we stored
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
-
-    // Verify seeking to a zero-value slot returns None or skips to next non-zero
-    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
-
-    // Should either return None or skip to the next non-zero value (0x30)
-    if let Some((key, value)) = seek_result {
-        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
-        assert_eq!(value, U256::from(300));
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
+        self.storage.unwind_history(to)
     }
 
-    Ok(())
+    fn replace_updates(
+        &self,
+        latest_common_block: BlockNumHash,
+        blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.replace_updates(latest_common_block, blocks_to_add)
+    }
+
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.set_earliest_block_number(block_number, hash)
+    }
 }
 
-/// Test empty cursors
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+impl BaseProofsInitialStateStore for TestRocksdbProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
+        self.storage.initial_state_anchor()
+    }
+
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
+        self.storage.set_initial_state_anchor(anchor)
+    }
+
+    fn store_account_branches(
+        &self,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_account_branches(account_nodes)
+    }
+
+    fn store_storage_branches(
+        &self,
+        hashed_address: B256,
+        storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_storage_branches(hashed_address, storage_nodes)
+    }
+
+    fn store_hashed_accounts(
+        &self,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_accounts(accounts)
+    }
+
+    fn store_hashed_storages(
+        &self,
+        hashed_address: B256,
+        storages: Vec<(B256, U256)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_storages(hashed_address, storages)
+    }
+
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
+        self.storage.commit_initial_state()
+    }
+}
+
+const fn test_block(parent: B256, number: u64, hash_byte: u8) -> BlockWithParent {
+    BlockWithParent::new(parent, NumHash::new(number, B256::repeat_byte(hash_byte)))
+}
+
+fn assert_account_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    key: B256,
+    expected: Account,
 ) -> Result<(), BaseProofsStorageError> {
-    // Test empty account cursor
-    let mut account_cursor = storage.account_hashed_cursor(100)?;
-    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
-    assert!(account_cursor.next()?.is_none());
-
-    // Test empty storage cursor
-    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
-    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
-    assert!(storage_cursor.next()?.is_none());
-
+    let mut cursor = storage.account_hashed_cursor(at)?;
+    assert_eq!(cursor.seek(key)?, Some((key, expected)));
     Ok(())
 }
 
-/// Test cursor boundary conditions
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_present<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x80); // Middle value
-    let account = create_test_account();
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Seek to minimum key should find our account
-    let result = cursor.seek(B256::ZERO)?.unwrap();
-    assert_eq!(result.0, account_key);
-
-    // Seek to maximum key should find nothing
-    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
-
-    // Seek to key just before our account should find our account
-    let just_before = B256::repeat_byte(0x7F);
-    let result = cursor.seek(just_before)?.unwrap();
-    assert_eq!(result.0, account_key);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_some());
     Ok(())
 }
 
-/// Test large batch operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_missing<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    // Create large batch of accounts
-    let mut accounts = Vec::new();
-    for i in 0..100 {
-        let key = B256::from([i as u8; 32]);
-        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
-        accounts.push((key, Some(account)));
-    }
-
-    // Store in batch
-    storage.store_hashed_accounts(accounts.clone())?;
-
-    // Verify all accounts can be retrieved
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let mut found_count = 0;
-    while cursor.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 100);
-
-    // Test specific account retrieval
-    let test_key = B256::from([42u8; 32]);
-    let result = cursor.seek(test_key)?.unwrap();
-    assert_eq!(result.0, test_key);
-    assert_eq!(result.1.nonce, 42);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_none());
     Ok(())
 }
 
-/// Test wiped storage in [`HashedPostState`]
-///
-/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
-/// it should iterate all existing values for that address and create deletion entries for them.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_storage_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    hashed_address: B256,
+    at: u64,
+    slot: B256,
+    expected: U256,
 ) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::HashedStorage;
-
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // First, store some storage values at block 50
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x40), U256::from(400)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Verify all values are present at block 75
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        found_slots.push((key, value));
-    }
-    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
-
-    // Now create a HashedPostState with wiped=true for this address at block 100
-    let mut post_state = HashedPostState::default();
-    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
-    post_state.storages.insert(hashed_address, wiped_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the wiped state
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // After wiping, cursor at block 150 should see NO storage values
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found_slots_after_wipe = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found_slots_after_wipe.push((key, value));
-    }
-
-    assert_eq!(
-        found_slots_after_wipe.len(),
-        0,
-        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
-    );
-
-    // Verify individual seeks also return None
-    for (slot, _) in &storage_slots {
-        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
-        let result = seek_cursor.seek(*slot)?;
-        assert!(
-            result.is_none() || result.unwrap().0 != *slot,
-            "Storage slot {slot:?} should be deleted after wipe"
-        );
-    }
-
-    // Verify cursor at block 75 (before wipe) still sees all values
-    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots_before_wipe = Vec::new();
-    while let Some((key, value)) = cursor75_after.next()? {
-        found_slots_before_wipe.push((key, value));
-    }
-    assert_eq!(
-        found_slots_before_wipe.len(),
-        4,
-        "All storage slots should still be present when querying before wipe block"
-    );
-
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, at)?;
+    assert_eq!(cursor.seek(slot)?, Some((slot, expected)));
     Ok(())
 }
 
-/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
-/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
-/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
-/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
-/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
-/// return `None` for the new slots, producing divergent storage / state / output roots
-/// downstream of `LiveTrieCollector`.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage_and_new_slots<
-    S: BaseProofsStore + BaseProofsInitialStateStore,
->(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    let pre_existing_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-    ];
-    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
-
-    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
-    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
-
-    let mut post_state = HashedPostState::default();
-    let wiped_with_new =
-        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
-    post_state.storages.insert(hashed_address, wiped_with_new);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found.push((key, value));
-    }
-
-    assert_eq!(
-        found,
-        vec![new_slot_overwriting_old, new_slot_kept],
-        "After wipe+recreate, only the new post-recreation slots must be visible",
-    );
-
-    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_kept.seek(new_slot_kept.0)?,
-        Some(new_slot_kept),
-        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
-    );
-
-    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_overwritten.seek(new_slot_overwriting_old.0)?,
-        Some(new_slot_overwriting_old),
-        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
-    );
-
-    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_dropped.seek(B256::repeat_byte(0x20))?,
-        Some(new_slot_kept),
-        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
-         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
-    );
-
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut pre_wipe_found = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        pre_wipe_found.push((key, value));
-    }
-    assert_eq!(
-        pre_wipe_found, pre_existing_slots,
-        "Cursor positioned before the wipe block must still see the original slot values",
-    );
-
-    Ok(())
-}
-
-/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
-///
-/// This test verifies that all data stored via `store_trie_updates` can be read back
-/// through the cursor APIs.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Create comprehensive trie updates with branches, leaves, and removals
-    let mut trie_updates = TrieUpdates::default();
-
-    // Add account branch nodes
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let account_branch1 = create_test_branch();
-    let account_branch2 = create_test_branch_variant();
-
-    trie_updates.account_nodes.insert(account_path1, account_branch1);
-    trie_updates.account_nodes.insert(account_path2, account_branch2);
-
-    // Add removed account nodes
-    let removed_account_path = nibbles_from(vec![7, 8, 9]);
-    trie_updates.removed_nodes.insert(removed_account_path);
-
-    // Add storage branch nodes for an address
-    let hashed_address = B256::repeat_byte(0x42);
-    let storage_path1 = nibbles_from(vec![1, 1]);
-    let storage_path2 = nibbles_from(vec![2, 2]);
-    let storage_branch = create_test_branch();
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
-
-    // Add removed storage node
-    let removed_storage_path = nibbles_from(vec![3, 3]);
-    storage_trie.removed_nodes.insert(removed_storage_path);
-
-    trie_updates.insert_storage_updates(hashed_address, storage_trie);
-
-    // Create post state with accounts and storage
-    let mut post_state = HashedPostState::default();
-
-    // Add accounts
-    let account1_addr = B256::repeat_byte(0x10);
-    let account2_addr = B256::repeat_byte(0x20);
-    let account1 = create_test_account_with_values(1, 1000, 0xAA);
-    let account2 = create_test_account_with_values(2, 2000, 0xBB);
-
-    post_state.accounts.insert(account1_addr, Some(account1));
-    post_state.accounts.insert(account2_addr, Some(account2));
-
-    // Add deleted account
-    let deleted_account_addr = B256::repeat_byte(0x30);
-    post_state.accounts.insert(deleted_account_addr, None);
-
-    // Add storage for an address
-    let storage_addr = B256::repeat_byte(0x50);
-    let mut hashed_storage = HashedStorage::new(false);
-    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
-    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
-    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
-    post_state.storages.insert(storage_addr, hashed_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: trie_updates.into_sorted(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // ========== Verify Account Branch Nodes ==========
-    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
-
-    // Should find the added branches
-    let result1 = account_trie_cursor.seek_exact(account_path1)?;
-    assert!(result1.is_some(), "Account branch node 1 should be found");
-    assert_eq!(result1.unwrap().0, account_path1);
-
-    let result2 = account_trie_cursor.seek_exact(account_path2)?;
-    assert!(result2.is_some(), "Account branch node 2 should be found");
-    assert_eq!(result2.unwrap().0, account_path2);
-
-    // Removed node should not be found
-    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
-    assert!(removed_result.is_none(), "Removed account node should not be found");
-
-    // ========== Verify Storage Branch Nodes ==========
-    let mut storage_trie_cursor =
-        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
-
-    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
-    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
-
-    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
-    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
-
-    // Removed storage node should not be found
-    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
-    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
-
-    // ========== Verify Account Leaves ==========
-    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
-
-    let acc1_result = account_cursor.seek(account1_addr)?;
-    assert!(acc1_result.is_some(), "Account 1 should be found");
-    assert_eq!(acc1_result.unwrap().0, account1_addr);
-    assert_eq!(acc1_result.unwrap().1.nonce, 1);
-    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
-
-    let acc2_result = account_cursor.seek(account2_addr)?;
-    assert!(acc2_result.is_some(), "Account 2 should be found");
-    assert_eq!(acc2_result.unwrap().1.nonce, 2);
-
-    // Deleted account should not be found
-    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
-    assert!(
-        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
-        "Deleted account should not be found"
-    );
-
-    // ========== Verify Storage Leaves ==========
-    let mut storage_cursor =
-        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
-
-    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
-    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
-    assert_eq!(slot1_result.unwrap().1, U256::from(111));
-
-    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
-    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
-    assert_eq!(slot2_result.unwrap().1, U256::from(222));
-
-    // Zero-valued storage should not be found (deleted)
-    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
-    assert!(
-        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
-        "Zero-valued storage slot should not be found"
-    );
-
-    // ========== Verify fetch_trie_updates can retrieve the data ==========
-    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-
-    // Check that trie updates are stored
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
-        3,
-        "Should have 3 account nodes, including removed"
-    );
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
-        1,
-        "Should have 1 storage trie"
-    );
-
-    // Check that post state is stored
-    assert_eq!(
-        fetched_diff.sorted_post_state.accounts.len(),
-        3,
-        "Should have 3 accounts (including deleted)"
-    );
-    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
-
-    Ok(())
-}
-
-/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
-///
-/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
-/// and `post_states` directly without populating the internal data structures
-/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
-    let initial_account_addr = B256::repeat_byte(0x10);
-    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
-
-    let initial_storage_addr = B256::repeat_byte(0x20);
-    let initial_storage_slot = B256::repeat_byte(0x01);
-    let initial_storage_value = U256::from(100);
-
-    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
-    let initial_branch = create_test_branch();
-
-    // Store initial data at block 50
-    let mut initial_trie_updates_50 = TrieUpdates::default();
-    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_50 = HashedPostState::default();
-    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
-
-    let initial_diff_50 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
-        sorted_post_state: initial_post_state_50.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
-
-    // Store data at block 100 (common block)
-    let mut initial_trie_updates_100 = TrieUpdates::default();
-    let common_branch_path = nibbles_from(vec![4, 5, 6]);
-    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_100 = HashedPostState::default();
-    let mut initial_storage_100 = HashedStorage::new(false);
-    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
-    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
-
-    let initial_diff_100 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
-        sorted_post_state: initial_post_state_100.into_sorted(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
-
-    // Store data at block 101 (will be replaced)
-    let mut initial_trie_updates_101 = TrieUpdates::default();
-    let old_branch_path = nibbles_from(vec![7, 8, 9]);
-    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
-
-    let mut initial_post_state_101 = HashedPostState::default();
-    let old_account_addr = B256::repeat_byte(0x30);
-    let old_account = create_test_account_with_values(99, 9999, 0xFF);
-    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
-
-    let initial_diff_101 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
-        sorted_post_state: initial_post_state_101.into_sorted(),
-    };
-    let block_ref_101 =
-        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
-    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
-
-    let block_ref_102 =
-        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
-
-    // ========== Verify initial state exists ==========
-    // Verify block 50 data exists
-    let mut cursor_initial = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
-        "Initial branch should exist before replace"
-    );
-
-    // Verify block 101 old data exists
-    let mut cursor_old = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old.seek_exact(old_branch_path)?.is_some(),
-        "Old branch at block 101 should exist before replace"
-    );
-
-    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
-    assert!(
-        account_cursor_old.seek(old_account_addr)?.is_some(),
-        "Old account at block 101 should exist before replace"
-    );
-
-    // ========== Call replace_updates to replace blocks after 100 ==========
-    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
-
-    // New data for block 101
-    let new_account_addr = B256::repeat_byte(0x40);
-    let new_account = create_test_account_with_values(5, 5000, 0xCC);
-
-    let new_storage_addr = B256::repeat_byte(0x50);
-    let new_storage_slot = B256::repeat_byte(0x02);
-    let new_storage_value = U256::from(999);
-
-    let new_branch_path = nibbles_from(vec![10, 11, 12]);
-    let new_branch = create_test_branch_variant();
-
-    let storage_branch_path = nibbles_from(vec![5, 5]);
-    let storage_hashed_addr = B256::repeat_byte(0x60);
-
-    let mut new_trie_updates = TrieUpdates::default();
-    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
-
-    // Add storage trie updates
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
-    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
-
-    let mut new_post_state = HashedPostState::default();
-    new_post_state.accounts.insert(new_account_addr, Some(new_account));
-
-    let mut new_storage = HashedStorage::new(false);
-    new_storage.storage.insert(new_storage_slot, new_storage_value);
-    new_post_state.storages.insert(new_storage_addr, new_storage);
-
-    blocks_to_add.push((
-        block_ref_101,
-        BlockStateDiff {
-            sorted_trie_updates: new_trie_updates.into_sorted(),
-            sorted_post_state: new_post_state.into_sorted(),
-        },
-    ));
-
-    // New data for block 102
-    let block_102_account_addr = B256::repeat_byte(0x70);
-    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
-
-    let mut trie_updates_102 = TrieUpdates::default();
-    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
-    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
-
-    let mut post_state_102 = HashedPostState::default();
-    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
-
-    blocks_to_add.push((
-        block_ref_102,
-        BlockStateDiff {
-            sorted_trie_updates: trie_updates_102.into_sorted(),
-            sorted_post_state: post_state_102.into_sorted(),
-        },
-    ));
-
-    // Execute replace_updates
-    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
-    // ========== Verify that data up to block 100 still exists ==========
-    let mut cursor_50 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_50.seek_exact(initial_branch_path)?.is_some(),
-        "Block 50 branch should still exist after replace"
-    );
-
-    let mut cursor_100 = storage.account_trie_cursor(100)?;
-    assert!(
-        cursor_100.seek_exact(common_branch_path)?.is_some(),
-        "Block 100 branch should still exist after replace"
-    );
-
-    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
-    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
-    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
-    assert_eq!(
-        result_100.unwrap().1,
-        initial_storage_value,
-        "Block 100 storage value should be unchanged"
-    );
-
-    // ========== Verify that old data after block 100 is gone ==========
-    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
-        "Old branch at block 101 should be removed after replace"
-    );
-
-    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
-    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
-    assert!(
-        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
-        "Old account at block 101 should be removed after replace"
-    );
-
-    // ========== Verify new data is properly accessible via cursors ==========
-
-    // Verify new account branch nodes
-    let mut trie_cursor = storage.account_trie_cursor(150)?;
-    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
-    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
-    assert_eq!(branch_result.unwrap().0, new_branch_path);
-
-    // Verify new storage branch nodes
-    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
-    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
-    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
-    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
-
-    // Verify new hashed accounts
-    let mut account_cursor = storage.account_hashed_cursor(150)?;
-    let account_result = account_cursor.seek(new_account_addr)?;
-    assert!(account_result.is_some(), "New account should be accessible via cursor");
-    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
-    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
-    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
-    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
-
-    // Verify new hashed storages
-    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
-    let storage_result = storage_cursor.seek(new_storage_slot)?;
-    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
-    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
-    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
-
-    // Verify block 102 data
-    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
-    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
-    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
-    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
-
-    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
-    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
-    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
-    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
-    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
-
-    // Verify fetch_trie_updates returns the new data
-    let fetched_101 = storage.fetch_trie_updates(101)?;
-    assert_eq!(
-        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
-        1,
-        "Should have 1 account branch node at block 101"
-    );
-    assert!(
-        fetched_101
-            .sorted_trie_updates
-            .account_nodes_ref()
-            .iter()
-            .any(|(addr, _)| *addr == new_branch_path),
-        "New branch path should be in trie_updates"
-    );
-    assert_eq!(
-        fetched_101.sorted_post_state.accounts.len(),
-        1,
-        "Should have 1 account at block 101"
-    );
-    assert!(
-        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
-        "New account should be in post_state"
-    );
-
-    Ok(())
-}
-
-/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
-///
-/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
-/// it is properly stored as a deletion and subsequent queries return None for that path.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let storage_path1 = nibbles_from(vec![7, 8, 9]);
-    let storage_path2 = nibbles_from(vec![10, 11, 12]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
-    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path1)?.is_some(),
-        "Initial account branch 1 should exist at block 75"
-    );
-    assert!(
-        cursor_75.seek_exact(account_path2)?.is_some(),
-        "Initial account branch 2 should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
-        "Initial storage branch 1 should exist at block 75"
-    );
-    assert!(
-        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
-        "Initial storage branch 2 should exist at block 75"
-    );
-
-    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
-    let mut deletion_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes ONLY (no updates)
-    deletion_trie_updates.removed_nodes.insert(account_path1);
-
-    // Do the same for storage branch
-    let mut deletion_storage_trie = StorageTrieUpdates::default();
-    deletion_storage_trie.removed_nodes.insert(storage_path1);
-    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
-
-    let deletion_diff = BlockStateDiff {
-        sorted_trie_updates: deletion_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, deletion_diff)?;
-
-    // ========== Verify that deleted nodes return None at block 150 ==========
-
-    // Deleted account branch should not be found
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path1)?;
-    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
-
-    // Non-deleted account branch should still exist
-    let account_result2 = cursor_150.seek_exact(account_path2)?;
-    assert!(
-        account_result2.is_some(),
-        "Non-deleted account branch should still exist at block 150"
-    );
-
-    // Deleted storage branch should not be found
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
-    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
-
-    // Non-deleted storage branch should still exist
-    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
-    assert!(
-        storage_result2.is_some(),
-        "Non-deleted storage branch should still exist at block 150"
-    );
-
-    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75_after.seek_exact(account_path1)?.is_some(),
-        "Deleted node should still exist at block 75 (before deletion)"
-    );
-
-    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
-        "Deleted storage node should still exist at block 75 (before deletion)"
-    );
-
-    // ========== Verify iteration skips deleted nodes ==========
-    let mut cursor_iter = storage.account_trie_cursor(150)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor_iter.next()? {
-        found_paths.push(path);
-    }
-
-    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
-    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
-
-    Ok(())
-}
-
-/// Test that updates take precedence over removals when both are present
-///
-/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
-/// the update from `account_nodes` takes precedence. This is critical for correctness
-/// when processing trie updates that both remove and update the same node.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path = nibbles_from(vec![1, 2, 3]);
-    let storage_path = nibbles_from(vec![4, 5, 6]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path)?.is_some(),
-        "Initial account branch should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path)?.is_some(),
-        "Initial storage branch should exist at block 75"
-    );
-
-    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
-    // This simulates a scenario where a node is both removed and updated
-    // The update should take precedence
-    let updated_branch = create_test_branch_variant();
-
-    let mut conflicting_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes
-    conflicting_trie_updates.removed_nodes.insert(account_path);
-
-    // Also add to account_nodes (this should take precedence)
-    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
-
-    // Do the same for storage branch
-    let mut conflicting_storage_trie = StorageTrieUpdates::default();
-    conflicting_storage_trie.removed_nodes.insert(storage_path);
-    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
-    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
-
-    let conflicting_diff = BlockStateDiff {
-        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
-
-    // ========== Verify that updates took precedence at block 150 ==========
-
-    // Account branch should exist (not deleted) with the updated value
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path)?;
-    assert!(
-        account_result.is_some(),
-        "Account branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_path, found_branch) = account_result.unwrap();
-    assert_eq!(found_path, account_path);
-    // Verify it's the updated branch, not the initial one
-    assert_eq!(
-        found_branch.state_mask, updated_branch.state_mask,
-        "Account branch should be the updated version, not the initial one"
-    );
-
-    // Storage branch should exist (not deleted) with the updated value
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
-    assert!(
-        storage_result.is_some(),
-        "Storage branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
-    assert_eq!(found_storage_path, storage_path);
-    // Verify it's the updated branch
-    assert_eq!(
-        found_storage_branch.state_mask, updated_branch.state_mask,
-        "Storage branch should be the updated version, not the initial one"
-    );
-
-    // ========== Verify that the old version still exists at block 75 ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    let result_75 = cursor_75_after.seek_exact(account_path)?;
-    assert!(result_75.is_some(), "Initial version should still exist at block 75");
-    let (_, branch_75) = result_75.unwrap();
-    assert_eq!(
-        branch_75.state_mask, initial_branch.state_mask,
-        "Block 75 should see the initial branch, not the updated one"
-    );
-
-    Ok(())
-}
+mod branch_cursors;
+mod hashed_cursors;
+mod history;
+mod proof_window;
+mod trie_updates;

--- a/crates/execution/trie/tests/live.rs
+++ b/crates/execution/trie/tests/live.rs
@@ -1,12 +1,12 @@
 //! End-to-end test of the live trie collector.
 
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
-use alloy_consensus::{BlockHeader, Header, TxEip2930, constants::ETH_TO_WEI};
+use alloy_consensus::{BlockHeader, Header, SignableTransaction, TxEip2930, constants::ETH_TO_WEI};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStorageError, MdbxProofsStorage, initialize::InitializationJob,
+    BaseProofsStorage, BaseProofsStorageError, RocksdbProofsStorage, initialize::InitializationJob,
     live::LiveTrieCollector,
 };
 use derive_more::Constructor;
@@ -17,7 +17,7 @@ use reth_ethereum_primitives::{Block, BlockBody, Receipt, Transaction, Transacti
 use reth_evm::{ConfigureEvm, execute::Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{NodePrimitives, NodeTypesWithDB};
-use reth_primitives_traits::{Block as _, RecoveredBlock};
+use reth_primitives_traits::{Block as _, RecoveredBlock, crypto::secp256k1::sign_message};
 use reth_provider::{
     BlockWriter as _, ExecutionOutcome, HashedPostStateProvider, LatestStateProviderRef,
     ProviderFactory, StateRootProvider,
@@ -28,6 +28,30 @@ use reth_revm::database::StateProviderDatabase;
 use secp256k1::{Keypair, Secp256k1};
 use tempfile::TempDir;
 
+#[cfg(not(feature = "metrics"))]
+fn rocksdb_storage(path: &Path) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::new(RocksdbProofsStorage::new(path).expect("env"))
+}
+
+#[cfg(feature = "metrics")]
+fn rocksdb_storage(path: &Path) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::new(RocksdbProofsStorage::new(path).expect("env")).into()
+}
+
+#[cfg(not(feature = "metrics"))]
+fn clone_storage(
+    storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    Arc::clone(storage)
+}
+
+#[cfg(feature = "metrics")]
+fn clone_storage(
+    storage: &BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+) -> BaseProofsStorage<Arc<RocksdbProofsStorage>> {
+    storage.clone()
+}
+
 /// Converts a secp256k1 public key to an Ethereum address.
 fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
     let hash = keccak256(&pubkey.serialize_uncompressed()[1..]);
@@ -36,8 +60,6 @@ fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
 
 /// Signs a transaction with the given keypair.
 fn sign_tx_with_key_pair(key_pair: Keypair, tx: Transaction) -> TransactionSigned {
-    use alloy_consensus::SignableTransaction;
-    use reth_primitives_traits::crypto::secp256k1::sign_message;
     let secret = B256::from_slice(&key_pair.secret_bytes());
     let sig = sign_message(secret, tx.signature_hash()).unwrap();
     tx.into_signed(sig).into()
@@ -220,7 +242,7 @@ fn run_test_scenario<N>(
     provider_factory: ProviderFactory<N>,
     chain_spec: Arc<ChainSpec>,
     key_pair: Keypair,
-    storage: BaseProofsStorage<Arc<MdbxProofsStorage>>,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
 ) -> eyre::Result<()>
 where
     N: ProviderNodeTypes<
@@ -254,7 +276,7 @@ where
     {
         let provider = provider_factory.db_ref();
         let tx = provider.tx()?;
-        let initialization_job = InitializationJob::new(storage.clone(), tx);
+        let initialization_job = InitializationJob::new(clone_storage(&storage), tx);
         initialization_job.run(last_block_number, last_block_hash)?;
     }
 
@@ -299,8 +321,7 @@ where
 #[test]
 fn test_execute_and_store_block_updates() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     // Create a keypair for signing transactions
     let secp = Secp256k1::new();
@@ -332,8 +353,7 @@ fn test_execute_and_store_block_updates() {
 #[test]
 fn test_execute_and_store_block_updates_missing_parent_block() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -352,7 +372,7 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
         provider_factory.clone(),
         Arc::clone(&chain_spec),
         key_pair,
-        storage.clone(),
+        clone_storage(&storage),
     )
     .unwrap();
 
@@ -386,8 +406,7 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
 #[test]
 fn test_execute_and_store_block_updates_state_root_mismatch() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -409,7 +428,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
         provider_factory.clone(),
         Arc::clone(&chain_spec),
         key_pair,
-        storage.clone(),
+        clone_storage(&storage),
     )
     .unwrap();
 
@@ -451,8 +470,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
 #[test]
 fn test_multiple_blocks_before_and_after_initialization() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -489,8 +507,7 @@ fn test_multiple_blocks_before_and_after_initialization() {
 #[test]
 fn test_blocks_with_multiple_transactions() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = rocksdb_storage(dir.path());
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());

--- a/crates/execution/trie/tests/proof_window/mod.rs
+++ b/crates/execution/trie/tests/proof_window/mod.rs
@@ -1,0 +1,48 @@
+//! Proof window metadata behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test basic storage and retrieval of earliest block number
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Initially should be None
+    let earliest = storage.get_earliest_block_number()?;
+    assert!(earliest.is_none());
+
+    // Set earliest block
+    let block_hash = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(100, block_hash)?;
+
+    // Should retrieve the same values
+    let earliest = storage.get_earliest_block_number()?;
+    assert_eq!(earliest, Some((100, block_hash)));
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_proof_window<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    assert_eq!(storage.get_earliest_block_number()?, None);
+    let block_hash_42 = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(42, block_hash_42)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((42, block_hash_42)));
+
+    let block_hash_100 = B256::repeat_byte(0x64);
+    storage.set_earliest_block_number(100, block_hash_100)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((100, block_hash_100)));
+    assert_eq!(storage.get_latest_block_number()?, Some((100, block_hash_100)));
+    Ok(())
+}

--- a/crates/execution/trie/tests/trie_updates/mod.rs
+++ b/crates/execution/trie/tests/trie_updates/mod.rs
@@ -1,0 +1,970 @@
+//! Trie update storage and replacement behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test storing and retrieving trie updates
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+    let sorted_trie_updates = TrieUpdatesSorted::default();
+    let sorted_post_state = HashedPostStateSorted::default();
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: sorted_trie_updates.clone(),
+        sorted_post_state: sorted_post_state.clone(),
+    };
+
+    // Store trie updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Retrieve and verify
+    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
+    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
+
+    Ok(())
+}
+
+/// Test wiped storage in [`HashedPostState`]
+///
+/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
+/// it should iterate all existing values for that address and create deletion entries for them.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // First, store some storage values at block 50
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x40), U256::from(400)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Verify all values are present at block 75
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        found_slots.push((key, value));
+    }
+    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
+
+    // Now create a HashedPostState with wiped=true for this address at block 100
+    let mut post_state = HashedPostState::default();
+    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
+    post_state.storages.insert(hashed_address, wiped_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the wiped state
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // After wiping, cursor at block 150 should see NO storage values
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found_slots_after_wipe = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found_slots_after_wipe.push((key, value));
+    }
+
+    assert_eq!(
+        found_slots_after_wipe.len(),
+        0,
+        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
+    );
+
+    // Verify individual seeks also return None
+    for (slot, _) in &storage_slots {
+        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
+        let result = seek_cursor.seek(*slot)?;
+        assert!(
+            result.is_none() || result.unwrap().0 != *slot,
+            "Storage slot {slot:?} should be deleted after wipe"
+        );
+    }
+
+    // Verify cursor at block 75 (before wipe) still sees all values
+    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots_before_wipe = Vec::new();
+    while let Some((key, value)) = cursor75_after.next()? {
+        found_slots_before_wipe.push((key, value));
+    }
+    assert_eq!(
+        found_slots_before_wipe.len(),
+        4,
+        "All storage slots should still be present when querying before wipe block"
+    );
+
+    Ok(())
+}
+
+/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
+/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
+/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
+/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
+/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
+/// return `None` for the new slots, producing divergent storage / state / output roots
+/// downstream of `LiveTrieCollector`.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage_and_new_slots<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    let pre_existing_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+    ];
+    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
+
+    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
+    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
+
+    let mut post_state = HashedPostState::default();
+    let wiped_with_new =
+        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
+    post_state.storages.insert(hashed_address, wiped_with_new);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found.push((key, value));
+    }
+
+    assert_eq!(
+        found,
+        vec![new_slot_overwriting_old, new_slot_kept],
+        "After wipe+recreate, only the new post-recreation slots must be visible",
+    );
+
+    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_kept.seek(new_slot_kept.0)?,
+        Some(new_slot_kept),
+        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
+    );
+
+    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_overwritten.seek(new_slot_overwriting_old.0)?,
+        Some(new_slot_overwriting_old),
+        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
+    );
+
+    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_dropped.seek(B256::repeat_byte(0x20))?,
+        Some(new_slot_kept),
+        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
+         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
+    );
+
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut pre_wipe_found = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        pre_wipe_found.push((key, value));
+    }
+    assert_eq!(
+        pre_wipe_found, pre_existing_slots,
+        "Cursor positioned before the wipe block must still see the original slot values",
+    );
+
+    Ok(())
+}
+
+/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
+///
+/// This test verifies that all data stored via `store_trie_updates` can be read back
+/// through the cursor APIs.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Create comprehensive trie updates with branches, leaves, and removals
+    let mut trie_updates = TrieUpdates::default();
+
+    // Add account branch nodes
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let account_branch1 = create_test_branch();
+    let account_branch2 = create_test_branch_variant();
+
+    trie_updates.account_nodes.insert(account_path1, account_branch1);
+    trie_updates.account_nodes.insert(account_path2, account_branch2);
+
+    // Add removed account nodes
+    let removed_account_path = nibbles_from(vec![7, 8, 9]);
+    trie_updates.removed_nodes.insert(removed_account_path);
+
+    // Add storage branch nodes for an address
+    let hashed_address = B256::repeat_byte(0x42);
+    let storage_path1 = nibbles_from(vec![1, 1]);
+    let storage_path2 = nibbles_from(vec![2, 2]);
+    let storage_branch = create_test_branch();
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
+
+    // Add removed storage node
+    let removed_storage_path = nibbles_from(vec![3, 3]);
+    storage_trie.removed_nodes.insert(removed_storage_path);
+
+    trie_updates.insert_storage_updates(hashed_address, storage_trie);
+
+    // Create post state with accounts and storage
+    let mut post_state = HashedPostState::default();
+
+    // Add accounts
+    let account1_addr = B256::repeat_byte(0x10);
+    let account2_addr = B256::repeat_byte(0x20);
+    let account1 = create_test_account_with_values(1, 1000, 0xAA);
+    let account2 = create_test_account_with_values(2, 2000, 0xBB);
+
+    post_state.accounts.insert(account1_addr, Some(account1));
+    post_state.accounts.insert(account2_addr, Some(account2));
+
+    // Add deleted account
+    let deleted_account_addr = B256::repeat_byte(0x30);
+    post_state.accounts.insert(deleted_account_addr, None);
+
+    // Add storage for an address
+    let storage_addr = B256::repeat_byte(0x50);
+    let mut hashed_storage = HashedStorage::new(false);
+    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
+    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
+    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
+    post_state.storages.insert(storage_addr, hashed_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // ========== Verify Account Branch Nodes ==========
+    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
+
+    // Should find the added branches
+    let result1 = account_trie_cursor.seek_exact(account_path1)?;
+    assert!(result1.is_some(), "Account branch node 1 should be found");
+    assert_eq!(result1.unwrap().0, account_path1);
+
+    let result2 = account_trie_cursor.seek_exact(account_path2)?;
+    assert!(result2.is_some(), "Account branch node 2 should be found");
+    assert_eq!(result2.unwrap().0, account_path2);
+
+    // Removed node should not be found
+    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
+    assert!(removed_result.is_none(), "Removed account node should not be found");
+
+    // ========== Verify Storage Branch Nodes ==========
+    let mut storage_trie_cursor =
+        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
+
+    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
+    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
+
+    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
+    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
+
+    // Removed storage node should not be found
+    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
+    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
+
+    // ========== Verify Account Leaves ==========
+    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
+
+    let acc1_result = account_cursor.seek(account1_addr)?;
+    assert!(acc1_result.is_some(), "Account 1 should be found");
+    assert_eq!(acc1_result.unwrap().0, account1_addr);
+    assert_eq!(acc1_result.unwrap().1.nonce, 1);
+    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
+
+    let acc2_result = account_cursor.seek(account2_addr)?;
+    assert!(acc2_result.is_some(), "Account 2 should be found");
+    assert_eq!(acc2_result.unwrap().1.nonce, 2);
+
+    // Deleted account should not be found
+    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
+    assert!(
+        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
+        "Deleted account should not be found"
+    );
+
+    // ========== Verify Storage Leaves ==========
+    let mut storage_cursor =
+        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
+
+    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
+    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
+    assert_eq!(slot1_result.unwrap().1, U256::from(111));
+
+    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
+    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
+    assert_eq!(slot2_result.unwrap().1, U256::from(222));
+
+    // Zero-valued storage should not be found (deleted)
+    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
+    assert!(
+        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
+        "Zero-valued storage slot should not be found"
+    );
+
+    // ========== Verify fetch_trie_updates can retrieve the data ==========
+    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+
+    // Check that trie updates are stored
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
+        3,
+        "Should have 3 account nodes, including removed"
+    );
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
+        1,
+        "Should have 1 storage trie"
+    );
+
+    // Check that post state is stored
+    assert_eq!(
+        fetched_diff.sorted_post_state.accounts.len(),
+        3,
+        "Should have 3 accounts (including deleted)"
+    );
+    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
+
+    Ok(())
+}
+
+/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
+///
+/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
+/// and `post_states` directly without populating the internal data structures
+/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
+    let initial_account_addr = B256::repeat_byte(0x10);
+    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
+
+    let initial_storage_addr = B256::repeat_byte(0x20);
+    let initial_storage_slot = B256::repeat_byte(0x01);
+    let initial_storage_value = U256::from(100);
+
+    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
+    let initial_branch = create_test_branch();
+
+    // Store initial data at block 50
+    let mut initial_trie_updates_50 = TrieUpdates::default();
+    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_50 = HashedPostState::default();
+    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
+
+    let initial_diff_50 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
+        sorted_post_state: initial_post_state_50.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
+
+    // Store data at block 100 (common block)
+    let mut initial_trie_updates_100 = TrieUpdates::default();
+    let common_branch_path = nibbles_from(vec![4, 5, 6]);
+    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_100 = HashedPostState::default();
+    let mut initial_storage_100 = HashedStorage::new(false);
+    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
+    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
+
+    let initial_diff_100 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
+        sorted_post_state: initial_post_state_100.into_sorted(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
+
+    // Store data at block 101 (will be replaced)
+    let mut initial_trie_updates_101 = TrieUpdates::default();
+    let old_branch_path = nibbles_from(vec![7, 8, 9]);
+    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
+
+    let mut initial_post_state_101 = HashedPostState::default();
+    let old_account_addr = B256::repeat_byte(0x30);
+    let old_account = create_test_account_with_values(99, 9999, 0xFF);
+    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
+
+    let initial_diff_101 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
+        sorted_post_state: initial_post_state_101.into_sorted(),
+    };
+    let block_ref_101 =
+        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
+    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
+
+    let block_ref_102 =
+        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
+
+    // ========== Verify initial state exists ==========
+    // Verify block 50 data exists
+    let mut cursor_initial = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
+        "Initial branch should exist before replace"
+    );
+
+    // Verify block 101 old data exists
+    let mut cursor_old = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old.seek_exact(old_branch_path)?.is_some(),
+        "Old branch at block 101 should exist before replace"
+    );
+
+    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
+    assert!(
+        account_cursor_old.seek(old_account_addr)?.is_some(),
+        "Old account at block 101 should exist before replace"
+    );
+
+    // ========== Call replace_updates to replace blocks after 100 ==========
+    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
+
+    // New data for block 101
+    let new_account_addr = B256::repeat_byte(0x40);
+    let new_account = create_test_account_with_values(5, 5000, 0xCC);
+
+    let new_storage_addr = B256::repeat_byte(0x50);
+    let new_storage_slot = B256::repeat_byte(0x02);
+    let new_storage_value = U256::from(999);
+
+    let new_branch_path = nibbles_from(vec![10, 11, 12]);
+    let new_branch = create_test_branch_variant();
+
+    let storage_branch_path = nibbles_from(vec![5, 5]);
+    let storage_hashed_addr = B256::repeat_byte(0x60);
+
+    let mut new_trie_updates = TrieUpdates::default();
+    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
+
+    // Add storage trie updates
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
+    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
+
+    let mut new_post_state = HashedPostState::default();
+    new_post_state.accounts.insert(new_account_addr, Some(new_account));
+
+    let mut new_storage = HashedStorage::new(false);
+    new_storage.storage.insert(new_storage_slot, new_storage_value);
+    new_post_state.storages.insert(new_storage_addr, new_storage);
+
+    blocks_to_add.push((
+        block_ref_101,
+        BlockStateDiff {
+            sorted_trie_updates: new_trie_updates.into_sorted(),
+            sorted_post_state: new_post_state.into_sorted(),
+        },
+    ));
+
+    // New data for block 102
+    let block_102_account_addr = B256::repeat_byte(0x70);
+    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
+
+    let mut trie_updates_102 = TrieUpdates::default();
+    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
+    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
+
+    let mut post_state_102 = HashedPostState::default();
+    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
+
+    blocks_to_add.push((
+        block_ref_102,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates_102.into_sorted(),
+            sorted_post_state: post_state_102.into_sorted(),
+        },
+    ));
+
+    // Execute replace_updates
+    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
+    // ========== Verify that data up to block 100 still exists ==========
+    let mut cursor_50 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_50.seek_exact(initial_branch_path)?.is_some(),
+        "Block 50 branch should still exist after replace"
+    );
+
+    let mut cursor_100 = storage.account_trie_cursor(100)?;
+    assert!(
+        cursor_100.seek_exact(common_branch_path)?.is_some(),
+        "Block 100 branch should still exist after replace"
+    );
+
+    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
+    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
+    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
+    assert_eq!(
+        result_100.unwrap().1,
+        initial_storage_value,
+        "Block 100 storage value should be unchanged"
+    );
+
+    // ========== Verify that old data after block 100 is gone ==========
+    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
+        "Old branch at block 101 should be removed after replace"
+    );
+
+    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
+    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
+    assert!(
+        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
+        "Old account at block 101 should be removed after replace"
+    );
+
+    // ========== Verify new data is properly accessible via cursors ==========
+
+    // Verify new account branch nodes
+    let mut trie_cursor = storage.account_trie_cursor(150)?;
+    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
+    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
+    assert_eq!(branch_result.unwrap().0, new_branch_path);
+
+    // Verify new storage branch nodes
+    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
+    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
+    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
+    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
+
+    // Verify new hashed accounts
+    let mut account_cursor = storage.account_hashed_cursor(150)?;
+    let account_result = account_cursor.seek(new_account_addr)?;
+    assert!(account_result.is_some(), "New account should be accessible via cursor");
+    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
+    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
+    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
+    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
+
+    // Verify new hashed storages
+    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
+    let storage_result = storage_cursor.seek(new_storage_slot)?;
+    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
+    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
+    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
+
+    // Verify block 102 data
+    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
+    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
+    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
+    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
+
+    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
+    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
+    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
+    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
+    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
+
+    // Verify fetch_trie_updates returns the new data
+    let fetched_101 = storage.fetch_trie_updates(101)?;
+    assert_eq!(
+        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
+        1,
+        "Should have 1 account branch node at block 101"
+    );
+    assert!(
+        fetched_101
+            .sorted_trie_updates
+            .account_nodes_ref()
+            .iter()
+            .any(|(addr, _)| *addr == new_branch_path),
+        "New branch path should be in trie_updates"
+    );
+    assert_eq!(
+        fetched_101.sorted_post_state.accounts.len(),
+        1,
+        "Should have 1 account at block 101"
+    );
+    assert!(
+        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
+        "New account should be in post_state"
+    );
+
+    Ok(())
+}
+
+/// Test that multi-block replacements make wiped storage see storage added earlier in the
+/// replacement chain.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_replace_updates_wipes_storage_added_by_prior_replacement_block<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let common_block = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0xA1)));
+    storage.store_trie_updates(common_block, BlockStateDiff::default())?;
+
+    let old_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xB2)));
+    let old_block_3 =
+        BlockWithParent::new(old_block_2.block.hash, NumHash::new(3, B256::repeat_byte(0xB3)));
+    storage.store_trie_updates(old_block_2, BlockStateDiff::default())?;
+    storage.store_trie_updates(old_block_3, BlockStateDiff::default())?;
+
+    let storage_address = B256::repeat_byte(0x44);
+    let storage_slot = B256::repeat_byte(0x55);
+    let storage_value = U256::from(0x1234);
+
+    let replacement_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xC2)));
+    let replacement_block_3 = BlockWithParent::new(
+        replacement_block_2.block.hash,
+        NumHash::new(3, B256::repeat_byte(0xC3)),
+    );
+
+    let mut replacement_post_state_2 = HashedPostState::default();
+    let mut replacement_storage_2 = HashedStorage::new(false);
+    replacement_storage_2.storage.insert(storage_slot, storage_value);
+    replacement_post_state_2.storages.insert(storage_address, replacement_storage_2);
+
+    let mut replacement_post_state_3 = HashedPostState::default();
+    replacement_post_state_3.storages.insert(storage_address, HashedStorage::new(true));
+
+    storage.replace_updates(
+        BlockNumHash::new(common_block.block.number, common_block.block.hash),
+        vec![
+            (
+                replacement_block_2,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_2.into_sorted(),
+                },
+            ),
+            (
+                replacement_block_3,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_3.into_sorted(),
+                },
+            ),
+        ],
+    )?;
+
+    let mut storage_cursor = storage.storage_hashed_cursor(storage_address, 3)?;
+    let storage_result = storage_cursor.seek(storage_slot)?;
+    assert!(
+        !matches!(storage_result, Some((found_slot, _)) if found_slot == storage_slot),
+        "storage added by replacement block 2 should be wiped by replacement block 3"
+    );
+
+    Ok(())
+}
+
+/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
+///
+/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
+/// it is properly stored as a deletion and subsequent queries return None for that path.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let storage_path1 = nibbles_from(vec![7, 8, 9]);
+    let storage_path2 = nibbles_from(vec![10, 11, 12]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
+    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path1)?.is_some(),
+        "Initial account branch 1 should exist at block 75"
+    );
+    assert!(
+        cursor_75.seek_exact(account_path2)?.is_some(),
+        "Initial account branch 2 should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
+        "Initial storage branch 1 should exist at block 75"
+    );
+    assert!(
+        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
+        "Initial storage branch 2 should exist at block 75"
+    );
+
+    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
+    let mut deletion_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes ONLY (no updates)
+    deletion_trie_updates.removed_nodes.insert(account_path1);
+
+    // Do the same for storage branch
+    let mut deletion_storage_trie = StorageTrieUpdates::default();
+    deletion_storage_trie.removed_nodes.insert(storage_path1);
+    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
+
+    let deletion_diff = BlockStateDiff {
+        sorted_trie_updates: deletion_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, deletion_diff)?;
+
+    // ========== Verify that deleted nodes return None at block 150 ==========
+
+    // Deleted account branch should not be found
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path1)?;
+    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
+
+    // Non-deleted account branch should still exist
+    let account_result2 = cursor_150.seek_exact(account_path2)?;
+    assert!(
+        account_result2.is_some(),
+        "Non-deleted account branch should still exist at block 150"
+    );
+
+    // Deleted storage branch should not be found
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
+    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
+
+    // Non-deleted storage branch should still exist
+    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
+    assert!(
+        storage_result2.is_some(),
+        "Non-deleted storage branch should still exist at block 150"
+    );
+
+    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75_after.seek_exact(account_path1)?.is_some(),
+        "Deleted node should still exist at block 75 (before deletion)"
+    );
+
+    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
+        "Deleted storage node should still exist at block 75 (before deletion)"
+    );
+
+    // ========== Verify iteration skips deleted nodes ==========
+    let mut cursor_iter = storage.account_trie_cursor(150)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor_iter.next()? {
+        found_paths.push(path);
+    }
+
+    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
+    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
+
+    Ok(())
+}
+
+/// Test that updates take precedence over removals when both are present
+///
+/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
+/// the update from `account_nodes` takes precedence. This is critical for correctness
+/// when processing trie updates that both remove and update the same node.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
+#[serial]
+fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path = nibbles_from(vec![1, 2, 3]);
+    let storage_path = nibbles_from(vec![4, 5, 6]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path)?.is_some(),
+        "Initial account branch should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path)?.is_some(),
+        "Initial storage branch should exist at block 75"
+    );
+
+    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
+    // This simulates a scenario where a node is both removed and updated
+    // The update should take precedence
+    let updated_branch = create_test_branch_variant();
+
+    let mut conflicting_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes
+    conflicting_trie_updates.removed_nodes.insert(account_path);
+
+    // Also add to account_nodes (this should take precedence)
+    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
+
+    // Do the same for storage branch
+    let mut conflicting_storage_trie = StorageTrieUpdates::default();
+    conflicting_storage_trie.removed_nodes.insert(storage_path);
+    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
+    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
+
+    let conflicting_diff = BlockStateDiff {
+        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
+
+    // ========== Verify that updates took precedence at block 150 ==========
+
+    // Account branch should exist (not deleted) with the updated value
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path)?;
+    assert!(
+        account_result.is_some(),
+        "Account branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_path, found_branch) = account_result.unwrap();
+    assert_eq!(found_path, account_path);
+    // Verify it's the updated branch, not the initial one
+    assert_eq!(
+        found_branch.state_mask, updated_branch.state_mask,
+        "Account branch should be the updated version, not the initial one"
+    );
+
+    // Storage branch should exist (not deleted) with the updated value
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
+    assert!(
+        storage_result.is_some(),
+        "Storage branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
+    assert_eq!(found_storage_path, storage_path);
+    // Verify it's the updated branch
+    assert_eq!(
+        found_storage_branch.state_mask, updated_branch.state_mask,
+        "Storage branch should be the updated version, not the initial one"
+    );
+
+    // ========== Verify that the old version still exists at block 75 ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    let result_75 = cursor_75_after.seek_exact(account_path)?;
+    assert!(result_75.is_some(), "Initial version should still exist at block 75");
+    let (_, branch_75) = result_75.unwrap();
+    assert_eq!(
+        branch_75.state_mask, initial_branch.state_mask,
+        "Block 75 should see the initial branch, not the updated one"
+    );
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -27,7 +27,8 @@ use base_execution_trie::{
 };
 use reth_primitives_traits::Account;
 use reth_provider::{
-    StateProofProvider, StateRootProvider, StorageRootProvider, noop::NoopProvider,
+    AccountReader, StateProofProvider, StateProvider, StateRootProvider, StorageRootProvider,
+    noop::NoopProvider,
 };
 use reth_trie_common::{
     ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProofTargets, TrieInput,
@@ -236,6 +237,19 @@ fn storage_root_acquires_one_tx_per_call() {
         provider
             .storage_multiproof(address, &slots, hashed_storage.clone())
             .expect("storage_multiproof");
+    });
+}
+
+#[test]
+fn evm_state_reads_share_one_lazy_tx_per_provider() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
+
+    assert_tx_acquisitions(&storage, 1, "evm_state_reads", || {
+        provider.basic_account(&address).expect("account");
+        provider.storage(address, slots[0]).expect("storage 0");
+        provider.storage(address, slots[1]).expect("storage 1");
     });
 }
 


### PR DESCRIPTION
## Summary
- implement RocksDB read path and all cursor implementations
- restore RocksDB tests in trie initialize/pruner/rocksdb and add trie tests directory modules
- add trie benchmark targets and bench files
- add node/CLI/exex/proofs wiring updates

## Validation
- cargo +nightly fmt -p base-execution-trie -- --check
- cargo check -p base-execution-trie
- cargo check -p base-node-core -p base-proofs-extension -p base-execution-cli -p base-execution-exex --tests