### PR TITLE
feat(zk-benchmarks): add load-test-backed ZK benchmark runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6534,6 +6534,33 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 [[package]]
 name = "base-zk-benchmarks"
 version = "0.0.0"
+dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "base-load-tests",
+ "base-optimism-rpc",
+ "base-prover-service-client",
+ "base-prover-service-protocol",
+ "eyre",
+ "nanoid",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "base-zk-benchmarks-bin"
+version = "0.0.0"
+dependencies = [
+ "base-cli-utils",
+ "base-load-tests",
+ "base-prover-service-protocol",
+ "base-zk-benchmarks",
+ "clap",
+ "eyre",
+ "url",
+]
 
 [[package]]
 name = "base16ct"

--- a/bin/zk-benchmarks/Cargo.toml
+++ b/bin/zk-benchmarks/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "base-zk-benchmarks-bin"
+description = "Base ZK Benchmark Binary"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-zk-benchmarks"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+# base
+base-cli-utils.workspace = true
+base-load-tests.workspace = true
+base-zk-benchmarks.workspace = true
+base-prover-service-protocol.workspace = true
+
+# misc
+url.workspace = true
+eyre.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }

--- a/bin/zk-benchmarks/src/cli.rs
+++ b/bin/zk-benchmarks/src/cli.rs
@@ -1,0 +1,170 @@
+//! CLI argument parsing and execution for the ZK benchmark binary.
+
+use std::path::PathBuf;
+
+use base_cli_utils::RuntimeManager;
+use base_load_tests::{
+    LoadTestCleanupSummary, LoadTestDisplay, LoadTestExecutor, LoadTestRunOptions, TestConfig,
+};
+use base_prover_service_protocol::ZkBackend;
+use base_zk_benchmarks::{ZkBenchConfig, ZkBenchRunner, ZkBenchSummary};
+use clap::{Args, Parser, ValueEnum};
+use eyre::{Result, bail};
+
+/// The Base ZK benchmark CLI.
+#[derive(Parser, Clone, Debug)]
+#[command(author, version = env!("CARGO_PKG_VERSION"), about = "Base ZK benchmarks")]
+pub(crate) struct Cli {
+    /// ZK benchmark arguments.
+    #[command(flatten)]
+    args: ZkBenchArgs,
+}
+
+impl Cli {
+    /// Runs the selected benchmark.
+    pub(crate) fn run(self) -> Result<()> {
+        RuntimeManager::new()
+            .tokio_runtime()?
+            .block_on(async move { run_zk_benchmark(self.args).await })
+    }
+}
+
+/// ZK benchmark command arguments.
+#[derive(Args, Clone, Debug)]
+struct ZkBenchArgs {
+    /// ZK proof backend.
+    #[arg(long, value_enum)]
+    mode: ZkBackendArg,
+
+    /// Rollup node RPC URL. This is the op-node RPC, not the L2 execution RPC.
+    #[arg(
+        long = "rollup-rpc-url",
+        env = "ROLLUP_RPC_URL",
+        default_value = "http://localhost:8649"
+    )]
+    rollup_rpc_url: url::Url,
+
+    /// Prover-service requester JSON-RPC URL.
+    #[arg(
+        long = "prover-service-url",
+        env = "PROVER_SERVICE_URL",
+        default_value = "http://localhost:9000"
+    )]
+    prover_service_url: url::Url,
+
+    /// Load test YAML configuration.
+    #[arg(value_name = "CONFIG")]
+    config: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum ZkBackendArg {
+    DryRun,
+    Cluster,
+    Network,
+}
+
+impl From<ZkBackendArg> for ZkBackend {
+    fn from(mode: ZkBackendArg) -> Self {
+        match mode {
+            ZkBackendArg::DryRun => Self::DryRun,
+            ZkBackendArg::Cluster => Self::Cluster,
+            ZkBackendArg::Network => Self::Network,
+        }
+    }
+}
+
+async fn run_zk_benchmark(args: ZkBenchArgs) -> Result<()> {
+    let _mp = LoadTestDisplay::init_tracing();
+
+    if !args.config.exists() {
+        bail!("config file not found: {}", args.config.display());
+    }
+
+    let test_config = TestConfig::load(&args.config)?;
+    let zk_config = ZkBenchConfig::new(
+        args.rollup_rpc_url.clone(),
+        args.prover_service_url.clone(),
+        args.mode.into(),
+    );
+
+    println!("=== Base ZK Benchmark Runner ===");
+    println!("Config: {}", args.config.display());
+    println!(
+        "Backend: {} | Rollup RPC: {} | Prover: {}",
+        zk_config.zk_backend, zk_config.rollup_rpc_url, zk_config.prover_url
+    );
+    println!();
+
+    let output = LoadTestExecutor::run(
+        test_config,
+        LoadTestRunOptions { install_signal_handler: true, ..Default::default() },
+    )
+    .await?;
+
+    let summary = output.summary;
+    if let Ok(output_path) = std::env::var("LOAD_TEST_OUTPUT") {
+        match summary.to_json() {
+            Ok(json) => match std::fs::write(&output_path, &json) {
+                Ok(()) => println!("Load test results written to {output_path}"),
+                Err(e) => {
+                    eprintln!("Warning: failed to write load test results to {output_path}: {e}")
+                }
+            },
+            Err(e) => eprintln!("Warning: failed to serialize load test results: {e}"),
+        }
+    }
+    print_cleanup_warnings(&output.cleanup);
+    if let Some(error) = output.run_error {
+        return Err(error.into());
+    }
+
+    println!();
+    println!("Running ZK benchmark...");
+    let zk_summary = ZkBenchRunner::run(&summary, zk_config).await?;
+    print_zk_bench_summary(&zk_summary);
+
+    if let Ok(output_path) = std::env::var("ZK_BENCH_OUTPUT") {
+        match zk_summary.to_json() {
+            Ok(json) => match std::fs::write(&output_path, &json) {
+                Ok(()) => println!("ZK bench results written to {output_path}"),
+                Err(e) => {
+                    eprintln!("Warning: failed to write ZK bench results to {output_path}: {e}")
+                }
+            },
+            Err(e) => eprintln!("Warning: failed to serialize ZK bench results: {e}"),
+        }
+    }
+
+    Ok(())
+}
+
+fn print_cleanup_warnings(cleanup: &LoadTestCleanupSummary) {
+    if let Some(error) = &cleanup.b20_teardown_error {
+        eprintln!("Warning: B-20 teardown failed: {error}");
+    }
+    if let Some(error) = &cleanup.drain_error {
+        eprintln!("Warning: drain failed: {error}");
+    }
+}
+
+fn print_zk_bench_summary(summary: &ZkBenchSummary) {
+    println!("Target: block {} ({})", summary.target.block, summary.target.reason);
+    println!(
+        "Proof: session={} protocol_parent={} l1_head={} duration={:.2?}",
+        summary.proof.session_id,
+        summary.proof.start_block_number,
+        summary.proof.l1_head,
+        summary.proof.proof_duration
+    );
+
+    if let Some(stats) = &summary.execution_stats {
+        println!(
+            "Execution: cycles={} sp1_gas={} witness_ms={} execution_ms={}",
+            stats.total_instruction_cycles,
+            stats.total_sp1_gas,
+            stats.witness_generation_ms,
+            stats.execution_ms
+        );
+    }
+}

--- a/bin/zk-benchmarks/src/main.rs
+++ b/bin/zk-benchmarks/src/main.rs
@@ -1,0 +1,7 @@
+//! Base ZK benchmark binary entrypoint.
+
+mod cli;
+
+fn main() {
+    base_cli_utils::run_cli_main!(cli::Cli);
+}

--- a/crates/infra/zk-benchmarks/Cargo.toml
+++ b/crates/infra/zk-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base-zk-benchmarks"
-description = "ZK proving benchmark scenarios for Base devnets"
+description = "ZK proof benchmarking for Base load-test runs"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -10,3 +10,22 @@ repository.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+# alloy
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+
+# base
+base-load-tests.workspace = true
+base-optimism-rpc.workspace = true
+base-prover-service-client.workspace = true
+base-prover-service-protocol.workspace = true
+
+# misc
+url.workspace = true
+eyre.workspace = true
+nanoid.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["time"] }
+serde = { workspace = true, features = ["derive"] }

--- a/crates/infra/zk-benchmarks/README.md
+++ b/crates/infra/zk-benchmarks/README.md
@@ -1,6 +1,3 @@
 # Base ZK Benchmarks
 
-Reusable ZK proving benchmark scenarios for Base devnets.
-
-Scenarios describe the workload to run. Runtime profiles provide endpoint defaults, and proof
-configuration selects how the resulting block range is proven.
+ZK proof benchmarking utilities for Base load-test runs.

--- a/crates/infra/zk-benchmarks/src/lib.rs
+++ b/crates/infra/zk-benchmarks/src/lib.rs
@@ -1,2 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod types;
+pub use types::{ZkBenchConfig, ZkBenchProofOutcome, ZkBenchSummary, ZkBenchTarget};
+
+mod runner;
+pub use runner::ZkBenchRunner;

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -43,8 +43,7 @@ impl ZkBenchRunner {
         Ok(ZkBenchSummary::new(target, proof, execution_stats))
     }
 
-    /// Selects the fullest confirmed block by gas as the proof target.
-    pub fn select_proof_target(summary: &MetricsSummary) -> Result<ZkBenchTarget> {
+    fn select_proof_target(summary: &MetricsSummary) -> Result<ZkBenchTarget> {
         ensure!(
             summary.receipt_coverage.is_complete(),
             "cannot select fullest block with incomplete receipt coverage"
@@ -62,8 +61,7 @@ impl ZkBenchRunner {
         })
     }
 
-    /// Waits for the target block to become safe, requests a proof, and polls for completion.
-    pub async fn prove_safe_block(
+    async fn prove_safe_block(
         rollup_provider: &QueryProvider,
         block_number: u64,
         config: ZkBenchConfig,
@@ -79,8 +77,7 @@ impl ZkBenchRunner {
         Self::prove_block(block_number, l1_head, config).await
     }
 
-    /// Waits for a workload block to become safe and returns the current L1 head.
-    pub async fn wait_for_safe_l2(
+    async fn wait_for_safe_l2(
         provider: &QueryProvider,
         block_number: u64,
         wait_timeout: Duration,
@@ -103,8 +100,7 @@ impl ZkBenchRunner {
         .wrap_err("timed out waiting for workload block to become safe")?
     }
 
-    /// Requests a proof for a single block and polls for completion.
-    pub async fn prove_block(
+    async fn prove_block(
         block_number: u64,
         l1_head: B256,
         config: ZkBenchConfig,
@@ -125,7 +121,7 @@ impl ZkBenchRunner {
 
         let execution_stats = Self::poll_proof(
             &client,
-            response.session_id.clone(),
+            &response.session_id,
             zk_backend,
             proof_timeout,
             poll_interval,
@@ -142,8 +138,9 @@ impl ZkBenchRunner {
         Ok((outcome, execution_stats))
     }
 
-    /// Builds a compressed SP1 proof request for a single benchmark block.
-    pub const fn proof_request(
+    // Heap-backed request builder; not intended for const evaluation.
+    #[allow(clippy::missing_const_for_fn)]
+    fn proof_request(
         session_id: String,
         start_block_number: u64,
         l1_head: B256,
@@ -165,26 +162,25 @@ impl ZkBenchRunner {
         }
     }
 
-    /// Polls a proof job until it succeeds or fails.
-    pub async fn poll_proof(
+    async fn poll_proof(
         client: &ProofRequesterClient,
-        session_id: String,
+        session_id: &str,
         zk_backend: ZkBackend,
         proof_timeout: Duration,
         poll_interval: Duration,
     ) -> Result<Option<ExecutionStats>> {
-        let timeout_session_id = session_id.clone();
+        let get_proof_request = GetProofRequest { session_id: session_id.to_owned() };
         timeout(proof_timeout, async {
             let start = Instant::now();
             loop {
                 let response = client
-                    .get_proof(GetProofRequest { session_id: session_id.clone() })
+                    .get_proof(get_proof_request.clone())
                     .await
                     .wrap_err("get-proof request failed")?;
 
                 match response.status {
                     ProofStatus::Succeeded => {
-                        return Self::proof_result(zk_backend, &session_id, response.result);
+                        return Self::proof_result(zk_backend, session_id, response.result);
                     }
                     ProofStatus::Failed => {
                         return Err(eyre::eyre!(
@@ -200,11 +196,10 @@ impl ZkBenchRunner {
             }
         })
         .await
-        .wrap_err_with(|| format!("timed out waiting for proof request {timeout_session_id}"))?
+        .wrap_err_with(|| format!("timed out waiting for proof request {session_id}"))?
     }
 
-    /// Validates a successful proof result and extracts dry-run execution statistics.
-    pub fn proof_result(
+    fn proof_result(
         zk_backend: ZkBackend,
         session_id: &str,
         result: Option<ProofResult>,

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -138,8 +138,7 @@ impl ZkBenchRunner {
         Ok((outcome, execution_stats))
     }
 
-    // Heap-backed request builder; not intended for const evaluation.
-    #[allow(clippy::missing_const_for_fn)]
+    #[allow(clippy::missing_const_for_fn)] // heap types; not meant for const eval
     fn proof_request(
         session_id: String,
         start_block_number: u64,

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -1,0 +1,365 @@
+//! ZK proof benchmark runner for completed load-test runs.
+
+use std::time::{Duration, Instant};
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use base_load_tests::{MetricsSummary, QueryProvider, RpcProviders};
+use base_optimism_rpc::OptimismRollupProviderExt;
+use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
+use base_prover_service_protocol::{
+    ExecutionStats, GetProofRequest, ProofRequest, ProofRequestKind, ProofResult, ProofStatus,
+    ProveBlockRangeRequest, ZkBackend, ZkProofRequest, ZkVm,
+};
+use eyre::{Result, WrapErr, ensure};
+use nanoid::nanoid;
+use tokio::time::{sleep, timeout};
+
+use crate::types::{ZkBenchConfig, ZkBenchProofOutcome, ZkBenchSummary, ZkBenchTarget};
+
+const SAFE_L2_TIMEOUT: Duration = Duration::from_secs(300);
+const SAFE_L2_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Runs ZK proof benchmarks for completed load-test summaries.
+#[derive(Debug)]
+pub struct ZkBenchRunner;
+
+impl ZkBenchRunner {
+    /// Selects the proof target, waits for safe L2, requests a proof, and polls for completion.
+    pub async fn run(summary: &MetricsSummary, config: ZkBenchConfig) -> Result<ZkBenchSummary> {
+        if let Some(error) = &summary.error {
+            return Err(
+                eyre::eyre!("{error}").wrap_err("cannot run ZK bench: load test reported an error")
+            );
+        }
+
+        let target = Self::select_proof_target(summary)?;
+        let rollup_provider = RpcProviders::query(config.rollup_rpc_url.clone())
+            .map_err(eyre::Report::from)
+            .wrap_err_with(|| format!("failed to connect rollup RPC {}", config.rollup_rpc_url))?;
+        let (proof, execution_stats) =
+            Self::prove_safe_block(&rollup_provider, target.block, config).await?;
+
+        Ok(ZkBenchSummary::new(target, proof, execution_stats))
+    }
+
+    /// Selects the fullest confirmed block by gas as the proof target.
+    pub fn select_proof_target(summary: &MetricsSummary) -> Result<ZkBenchTarget> {
+        ensure!(
+            summary.receipt_coverage.is_complete(),
+            "cannot select fullest block with incomplete receipt coverage"
+        );
+        let block = summary
+            .fullest_block
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("cannot select fullest block from empty load-test run"))?;
+        Ok(ZkBenchTarget {
+            block: block.block_number,
+            reason: format!(
+                "fullest block by gas: gas={}, txs={}",
+                block.total_gas, block.confirmed_count
+            ),
+        })
+    }
+
+    /// Waits for the target block to become safe, requests a proof, and polls for completion.
+    pub async fn prove_safe_block(
+        rollup_provider: &QueryProvider,
+        block_number: u64,
+        config: ZkBenchConfig,
+    ) -> Result<(ZkBenchProofOutcome, Option<ExecutionStats>)> {
+        let l1_head = Self::wait_for_safe_l2(
+            rollup_provider,
+            block_number,
+            SAFE_L2_TIMEOUT,
+            SAFE_L2_POLL_INTERVAL,
+        )
+        .await?;
+
+        Self::prove_block(block_number, l1_head, config).await
+    }
+
+    /// Waits for a workload block to become safe and returns the current L1 head.
+    pub async fn wait_for_safe_l2(
+        provider: &QueryProvider,
+        block_number: u64,
+        wait_timeout: Duration,
+        poll_interval: Duration,
+    ) -> Result<B256> {
+        timeout(wait_timeout, async {
+            loop {
+                let status = provider.optimism_sync_status().await?;
+                if status.safe_l2.number >= block_number {
+                    // Preflight: output root must exist before proving.
+                    let _ = provider
+                        .optimism_output_at_block(BlockNumberOrTag::Number(block_number))
+                        .await?;
+                    return Ok::<_, eyre::Error>(status.head_l1.hash);
+                }
+                sleep(poll_interval).await;
+            }
+        })
+        .await
+        .wrap_err("timed out waiting for workload block to become safe")?
+    }
+
+    /// Requests a proof for a single block and polls for completion.
+    pub async fn prove_block(
+        block_number: u64,
+        l1_head: B256,
+        config: ZkBenchConfig,
+    ) -> Result<(ZkBenchProofOutcome, Option<ExecutionStats>)> {
+        let start_block_number =
+            block_number.checked_sub(1).ok_or_else(|| eyre::eyre!("cannot prove genesis block"))?;
+        let zk_backend = config.zk_backend;
+        let client_config = ProverServiceClientConfig::new(config.prover_url.as_str());
+        let proof_timeout = client_config.max_wait();
+        let poll_interval = client_config.poll_interval();
+        let client = ProofRequesterClient::connect(&client_config)
+            .wrap_err_with(|| format!("failed to connect prover service {}", config.prover_url))?;
+        let session_id = format!("zk-benchmarks-{}-{}", zk_backend.as_str(), nanoid!());
+        let request = Self::proof_request(session_id, start_block_number, l1_head, zk_backend);
+        let proof_started = Instant::now();
+        let response =
+            client.prove_block_range(request).await.wrap_err("prove-block-range request failed")?;
+
+        let execution_stats = Self::poll_proof(
+            &client,
+            response.session_id.clone(),
+            zk_backend,
+            proof_timeout,
+            poll_interval,
+        )
+        .await?;
+        let outcome = ZkBenchProofOutcome {
+            zk_backend,
+            session_id: response.session_id,
+            start_block_number,
+            l1_head,
+            proof_duration: proof_started.elapsed(),
+        };
+
+        Ok((outcome, execution_stats))
+    }
+
+    /// Builds a compressed SP1 proof request for a single benchmark block.
+    pub const fn proof_request(
+        session_id: String,
+        start_block_number: u64,
+        l1_head: B256,
+        zk_backend: ZkBackend,
+    ) -> ProveBlockRangeRequest {
+        ProveBlockRangeRequest {
+            proof: ProofRequest {
+                session_id,
+                request: ProofRequestKind::Compressed(ZkProofRequest {
+                    start_block_number,
+                    number_of_blocks_to_prove: 1,
+                    sequence_window: None,
+                    l1_head: Some(l1_head),
+                    intermediate_root_interval: None,
+                    zk_vm: ZkVm::Sp1,
+                    zk_backend,
+                }),
+            },
+        }
+    }
+
+    /// Polls a proof job until it succeeds or fails.
+    pub async fn poll_proof(
+        client: &ProofRequesterClient,
+        session_id: String,
+        zk_backend: ZkBackend,
+        proof_timeout: Duration,
+        poll_interval: Duration,
+    ) -> Result<Option<ExecutionStats>> {
+        let timeout_session_id = session_id.clone();
+        timeout(proof_timeout, async {
+            let start = Instant::now();
+            loop {
+                let response = client
+                    .get_proof(GetProofRequest { session_id: session_id.clone() })
+                    .await
+                    .wrap_err("get-proof request failed")?;
+
+                match response.status {
+                    ProofStatus::Succeeded => {
+                        return Self::proof_result(zk_backend, &session_id, response.result);
+                    }
+                    ProofStatus::Failed => {
+                        return Err(eyre::eyre!(
+                            "proof request failed after {:?}: {}",
+                            start.elapsed(),
+                            response
+                                .error_message
+                                .unwrap_or_else(|| "missing error message".to_string())
+                        ));
+                    }
+                    ProofStatus::Queued | ProofStatus::Running => sleep(poll_interval).await,
+                }
+            }
+        })
+        .await
+        .wrap_err_with(|| format!("timed out waiting for proof request {timeout_session_id}"))?
+    }
+
+    /// Validates a successful proof result and extracts dry-run execution statistics.
+    pub fn proof_result(
+        zk_backend: ZkBackend,
+        session_id: &str,
+        result: Option<ProofResult>,
+    ) -> Result<Option<ExecutionStats>> {
+        let compressed = match result {
+            Some(ProofResult::Compressed(compressed)) => compressed,
+            Some(ProofResult::SnarkPlonk(_)) => {
+                eyre::bail!("proof request {session_id} returned snark_plonk result")
+            }
+            Some(ProofResult::Tee(_)) => {
+                eyre::bail!("proof request {session_id} returned tee result")
+            }
+            None => eyre::bail!("proof request {session_id} succeeded without a result"),
+        };
+
+        match zk_backend {
+            ZkBackend::DryRun => compressed.execution_stats.map(Some).ok_or_else(|| {
+                eyre::eyre!("dry-run proof request {session_id} returned no execution stats")
+            }),
+            ZkBackend::Cluster | ZkBackend::Network => Ok(compressed.execution_stats),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy_primitives::B256;
+    use base_load_tests::{BlockLoadMetrics, MetricsSummary, ReceiptCoverage};
+    use base_prover_service_protocol::{
+        ExecutionStats, ProofRequestKind, ProofResult, SnarkPlonkProofResult, ZkBackend,
+        ZkProofResult, ZkVm,
+    };
+
+    use super::*;
+
+    #[test]
+    fn select_proof_target_picks_fullest_block_by_gas() {
+        let summary = summary(Some(block_load(11, 5, 2_000)));
+
+        let target = ZkBenchRunner::select_proof_target(&summary).unwrap();
+
+        assert_eq!(target.block, 11);
+        assert_eq!(target.reason, "fullest block by gas: gas=2000, txs=5");
+    }
+
+    #[test]
+    fn select_proof_target_rejects_incomplete_receipt_coverage() {
+        let mut summary = summary(Some(block_load(11, 5, 2_000)));
+        summary.receipt_coverage =
+            ReceiptCoverage { blocks_total: 1, blocks_failed: 1, ..ReceiptCoverage::default() };
+
+        let error = ZkBenchRunner::select_proof_target(&summary).unwrap_err();
+        assert!(error.to_string().contains("incomplete receipt coverage"));
+    }
+
+    #[test]
+    fn select_proof_target_rejects_missing_fullest_block() {
+        let error = ZkBenchRunner::select_proof_target(&summary(None)).unwrap_err();
+        assert!(error.to_string().contains("empty load-test run"));
+    }
+
+    #[test]
+    fn proof_request_uses_parent_block_single_block_and_selected_backend() {
+        let request = ZkBenchRunner::proof_request(
+            "session".to_string(),
+            9,
+            B256::repeat_byte(0xaa),
+            ZkBackend::Cluster,
+        );
+        let ProofRequestKind::Compressed(proof) = request.proof.request else {
+            panic!("expected compressed proof request");
+        };
+
+        assert_eq!(proof.start_block_number, 9);
+        assert_eq!(proof.number_of_blocks_to_prove, 1);
+        assert_eq!(proof.l1_head, Some(B256::repeat_byte(0xaa)));
+        assert_eq!(proof.zk_backend, ZkBackend::Cluster);
+    }
+
+    #[test]
+    fn dry_run_requires_and_returns_execution_stats() {
+        let error = ZkBenchRunner::proof_result(
+            ZkBackend::DryRun,
+            "session",
+            Some(compressed_result(None)),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("returned no execution stats"));
+
+        let stats = execution_stats();
+        let result = ZkBenchRunner::proof_result(
+            ZkBackend::DryRun,
+            "session",
+            Some(compressed_result(Some(stats.clone()))),
+        )
+        .unwrap();
+        assert_eq!(result, Some(stats));
+    }
+
+    #[test]
+    fn proving_backends_accept_compressed_result_without_execution_stats() {
+        for zk_backend in [ZkBackend::Cluster, ZkBackend::Network] {
+            assert_eq!(
+                ZkBenchRunner::proof_result(zk_backend, "session", Some(compressed_result(None)))
+                    .unwrap(),
+                None
+            );
+        }
+        assert!(
+            ZkBenchRunner::proof_result(ZkBackend::Cluster, "session", None)
+                .unwrap_err()
+                .to_string()
+                .contains("succeeded without a result")
+        );
+    }
+
+    #[test]
+    fn successful_request_rejects_wrong_result_type() {
+        let result = ProofResult::SnarkPlonk(SnarkPlonkProofResult { proof: zk_result(None) });
+
+        let error =
+            ZkBenchRunner::proof_result(ZkBackend::Cluster, "session", Some(result)).unwrap_err();
+
+        assert!(error.to_string().contains("returned snark_plonk result"));
+    }
+
+    fn summary(fullest_block: Option<BlockLoadMetrics>) -> MetricsSummary {
+        MetricsSummary { fullest_block, ..MetricsSummary::default() }
+    }
+
+    const fn block_load(
+        block_number: u64,
+        confirmed_count: u64,
+        total_gas: u64,
+    ) -> BlockLoadMetrics {
+        BlockLoadMetrics { block_number, confirmed_count, total_gas }
+    }
+
+    fn compressed_result(execution_stats: Option<ExecutionStats>) -> ProofResult {
+        ProofResult::Compressed(zk_result(execution_stats))
+    }
+
+    fn zk_result(execution_stats: Option<ExecutionStats>) -> ZkProofResult {
+        ZkProofResult { zk_vm: ZkVm::Sp1, proof: Default::default(), execution_stats }
+    }
+
+    fn execution_stats() -> ExecutionStats {
+        ExecutionStats {
+            total_instruction_cycles: 10,
+            total_sp1_gas: 20,
+            cycle_tracker: HashMap::new(),
+            witness_generation_ms: 30,
+            execution_ms: 40,
+        }
+    }
+}

--- a/crates/infra/zk-benchmarks/src/types.rs
+++ b/crates/infra/zk-benchmarks/src/types.rs
@@ -1,0 +1,128 @@
+//! Public types for ZK proof benchmarks.
+
+use std::time::Duration;
+
+use alloy_primitives::B256;
+use base_prover_service_protocol::{ExecutionStats, ZkBackend};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+mod duration_millis {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Duration::from_millis(u64::deserialize(deserializer)?))
+    }
+}
+
+/// Runtime configuration for proving a completed load-test run.
+#[derive(Clone, Debug)]
+pub struct ZkBenchConfig {
+    /// Proof backend.
+    pub zk_backend: ZkBackend,
+    /// Rollup node RPC URL.
+    pub rollup_rpc_url: Url,
+    /// ZK prover RPC URL.
+    pub prover_url: Url,
+}
+
+impl ZkBenchConfig {
+    /// Builds ZK bench config from endpoint URLs and proof backend.
+    pub const fn new(rollup_rpc_url: Url, prover_url: Url, zk_backend: ZkBackend) -> Self {
+        Self { zk_backend, rollup_rpc_url, prover_url }
+    }
+}
+
+/// The single L2 block selected for proof.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZkBenchTarget {
+    /// L2 block selected for proof.
+    pub block: u64,
+    /// Human-readable selection reason.
+    pub reason: String,
+}
+
+/// Proof request summary.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZkBenchProofOutcome {
+    /// Proof backend.
+    pub zk_backend: ZkBackend,
+    /// ZK prover session ID.
+    pub session_id: String,
+    /// Prover start block number (the proven block's parent).
+    pub start_block_number: u64,
+    /// L1 head hash passed to the prover.
+    pub l1_head: B256,
+    /// Proof wall-clock duration (JSON: milliseconds).
+    #[serde(with = "duration_millis")]
+    pub proof_duration: Duration,
+}
+
+/// Completed ZK benchmark summary.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZkBenchSummary {
+    /// Block selected from the load-test run for proof.
+    pub target: ZkBenchTarget,
+    /// Proof summary.
+    pub proof: ZkBenchProofOutcome,
+    /// Dry-run execution stats, when the prover returned them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_stats: Option<ExecutionStats>,
+}
+
+impl ZkBenchSummary {
+    /// Builds a completed ZK benchmark summary.
+    pub const fn new(
+        target: ZkBenchTarget,
+        proof: ZkBenchProofOutcome,
+        execution_stats: Option<ExecutionStats>,
+    ) -> Self {
+        Self { target, proof, execution_stats }
+    }
+
+    /// Serializes the summary to pretty JSON.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use alloy_primitives::B256;
+    use base_prover_service_protocol::ZkBackend;
+
+    use super::{ZkBenchProofOutcome, ZkBenchSummary, ZkBenchTarget};
+
+    #[test]
+    fn summary_json_encodes_proof_duration_as_millis() {
+        let summary = ZkBenchSummary::new(
+            ZkBenchTarget { block: 11, reason: "fullest".to_string() },
+            ZkBenchProofOutcome {
+                zk_backend: ZkBackend::DryRun,
+                session_id: "session".to_string(),
+                start_block_number: 10,
+                l1_head: B256::ZERO,
+                proof_duration: Duration::from_millis(1_250),
+            },
+            None,
+        );
+
+        let json = summary.to_json().unwrap();
+        assert!(json.contains("\"proof_duration\": 1250"), "{json}");
+        assert!(!json.contains("\"secs\""), "{json}");
+    }
+}


### PR DESCRIPTION
## Summary
Add a load-test-backed ZK benchmark runner that proves the fullest confirmed block across dry-run, cluster, and network backends, reporting proof latency and dry-run execution stats. Depends on #4009.