### PR TITLE
refactor(registrar): move CRL revocation into cert manager

### DIFF
--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -6,6 +6,7 @@
 
 use std::{fmt, sync::Arc};
 
+use async_trait::async_trait;
 use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::TxManager;
 use tracing::{debug, warn};
@@ -16,32 +17,75 @@ use crate::{
 };
 
 /// Manages Nitro certificate revocation checks and revocation transaction submission.
-pub struct CertManager {
+pub struct CertManager<T> {
     http_client: reqwest::Client,
-    nitro_verifier: Arc<dyn NitroVerifierClient>,
+    nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
+    tx_manager: T,
 }
 
-impl fmt::Debug for CertManager {
+impl<T> fmt::Debug for CertManager<T>
+where
+    T: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CertManager").finish_non_exhaustive()
     }
 }
 
-impl CertManager {
-    /// Creates a certificate manager from CRL configuration and a verifier client.
+/// Checks certificate revocation state and submits revocation transactions when needed.
+#[async_trait]
+pub trait CertRevocationChecker: Send + Sync + fmt::Debug {
+    /// Checks an attestation's intermediate certificates and submits revocations.
+    ///
+    /// Returns `Ok(true)` if any intermediate is revoked by either the
+    /// onchain sentinel or the AWS CRL layer, `Ok(false)` if every checked
+    /// intermediate is clean.
+    async fn check_and_revoke_crls(
+        &self,
+        attestation_bytes: &[u8],
+        instance: &ProverInstance,
+    ) -> Result<bool>;
+}
+
+impl<T> CertManager<T>
+where
+    T: TxManager,
+{
+    /// Creates a certificate manager from CRL configuration, verifier client,
+    /// and transaction manager.
     ///
     /// # Errors
     ///
-    /// Returns [`RegistrarError::Config`] if the CRL HTTP client cannot be built.
-    pub fn new(config: &CrlConfig, nitro_verifier: Arc<dyn NitroVerifierClient>) -> Result<Self> {
+    /// Returns [`RegistrarError::Config`] if CRL checking is enabled without a
+    /// verifier client, or if the CRL HTTP client cannot be built.
+    pub fn new(
+        config: &CrlConfig,
+        nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
+        tx_manager: T,
+    ) -> Result<Self> {
+        if config.enabled && nitro_verifier.is_none() {
+            return Err(RegistrarError::Config(
+                "CRL checking enabled but nitro_verifier client not configured; \
+                 a NitroEnclaveVerifier client is required as both the revokeCert \
+                 destination and the onchain revokedCerts sentinel source"
+                    .into(),
+            ));
+        }
+
         let http_client = crl::build_crl_http_client(config.fetch_timeout).map_err(|e| {
             RegistrarError::Config(format!(
                 "failed to build CRL HTTP client (Layer 2 / AWS CRL fetch): {e}"
             ))
         })?;
-        Ok(Self { http_client, nitro_verifier })
+        Ok(Self { http_client, nitro_verifier, tx_manager })
     }
+}
 
+#[async_trait]
+impl<T> CertRevocationChecker for CertManager<T>
+where
+    T: TxManager + 'static,
+{
     /// Checks an attestation's intermediate certificates and submits revocations.
     ///
     /// Returns `Ok(true)` if any intermediate is revoked by either the
@@ -52,15 +96,11 @@ impl CertManager {
     /// intermediates even if AWS later prunes its CRL. AWS CRLs are then
     /// checked for each intermediate, and every CRL hit is checked onchain
     /// before a `revokeCert` transaction is submitted.
-    pub async fn check_and_revoke_crls<T>(
+    async fn check_and_revoke_crls(
         &self,
         attestation_bytes: &[u8],
         instance: &ProverInstance,
-        tx_manager: &T,
-    ) -> Result<bool>
-    where
-        T: TxManager,
-    {
+    ) -> Result<bool> {
         let cert_infos = {
             let report = AttestationReport::parse(attestation_bytes).map_err(|e| {
                 RegistrarError::ProverClient {
@@ -95,9 +135,31 @@ impl CertManager {
         }
 
         RegistrarMetrics::crl_revocations_detected().increment(revoked_certs.len() as u64);
-        self.submit_revocations_for_revoked_certs(&revoked_certs, instance, tx_manager).await;
+        self.submit_revocations_for_revoked_certs(&revoked_certs, instance).await;
 
         Ok(true)
+    }
+}
+
+impl<T> CertManager<T>
+where
+    T: TxManager,
+{
+    /// Returns the configured Nitro verifier client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::Config`] when no verifier was configured.
+    /// This is valid only while CRL checking is disabled because the manager is
+    /// built unconditionally by the registrar service.
+    pub fn nitro_verifier(&self) -> Result<&dyn NitroVerifierClient> {
+        self.nitro_verifier.as_deref().ok_or_else(|| {
+            RegistrarError::Config(
+                "CRL verifier client is not configured; this should only be called when CRL \
+                 checking is enabled"
+                    .into(),
+            )
+        })
     }
 
     /// Checks whether any intermediate certificate has already been revoked onchain.
@@ -115,8 +177,9 @@ impl CertManager {
         cert_infos: &[crl::CertCrlInfo],
         instance_id: &str,
     ) -> Result<bool> {
+        let nitro_verifier = self.nitro_verifier()?;
         for info in crl::CertCrlInfo::intermediates(cert_infos) {
-            if self.nitro_verifier.is_revoked(info.path_digest).await? {
+            if nitro_verifier.is_revoked(info.path_digest).await? {
                 let cert = info.intermediate_label();
                 warn!(
                     cert = %cert,
@@ -134,20 +197,28 @@ impl CertManager {
     }
 
     /// Checks each CRL-hit against the onchain sentinel and submits needed revocations.
-    pub async fn submit_revocations_for_revoked_certs<T>(
+    pub async fn submit_revocations_for_revoked_certs(
         &self,
         revoked_certs: &[crl::RevokedCertInfo],
         instance: &ProverInstance,
-        tx_manager: &T,
-    ) where
-        T: TxManager,
-    {
-        let verifier_address = self.nitro_verifier.address();
-        let cert_revoker = CertRevoker::new(verifier_address, tx_manager);
+    ) {
+        let nitro_verifier = match self.nitro_verifier() {
+            Ok(nitro_verifier) => nitro_verifier,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    instance = %instance.instance_id,
+                    "cannot submit revokeCert without a Nitro verifier client"
+                );
+                return;
+            }
+        };
+        let verifier_address = nitro_verifier.address();
+        let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
 
         for revoked in revoked_certs {
             let cert = revoked.intermediate_label();
-            match self.nitro_verifier.is_revoked(revoked.path_digest).await {
+            match nitro_verifier.is_revoked(revoked.path_digest).await {
                 Ok(true) => {
                     warn!(
                         cert = %cert,
@@ -190,6 +261,7 @@ mod tests {
             Mutex,
             atomic::{AtomicU32, Ordering},
         },
+        time::Duration,
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
@@ -313,8 +385,12 @@ mod tests {
         u32::try_from(full_chain_der().len().saturating_sub(2)).unwrap()
     }
 
-    fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager {
-        CertManager { http_client: reqwest::Client::new(), nitro_verifier: verifier }
+    fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
+        CertManager {
+            http_client: reqwest::Client::new(),
+            nitro_verifier: Some(verifier),
+            tx_manager: MockTxManager::default(),
+        }
     }
 
     fn test_instance() -> ProverInstance {
@@ -324,6 +400,23 @@ mod tests {
             health_status: crate::InstanceHealthStatus::Healthy,
             launch_time: None,
         }
+    }
+
+    fn crl_config(enabled: bool) -> CrlConfig {
+        CrlConfig { enabled, nitro_verifier_address: None, fetch_timeout: Duration::from_secs(1) }
+    }
+
+    #[test]
+    fn new_allows_disabled_crl_without_verifier() {
+        let result = CertManager::new(&crl_config(false), None, MockTxManager::default());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn new_rejects_enabled_crl_without_verifier() {
+        let err = CertManager::new(&crl_config(true), None, MockTxManager::default())
+            .expect_err("enabled CRL requires a verifier");
+        assert!(matches!(err, RegistrarError::Config(_)));
     }
 
     fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {
@@ -500,15 +593,10 @@ mod tests {
             }
         };
         let cert_manager = test_cert_manager(Arc::clone(&verifier));
-        let tx_manager = MockTxManager::default();
         let instance = test_instance();
 
         cert_manager
-            .submit_revocations_for_revoked_certs(
-                &[revoked_cert(path_digest)],
-                &instance,
-                &tx_manager,
-            )
+            .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
             .await;
 
         assert_eq!(
@@ -516,7 +604,7 @@ mod tests {
             1,
             "CRL-hit cert should be checked onchain before deciding whether to submit revokeCert",
         );
-        let candidates = tx_manager.take_candidates();
+        let candidates = cert_manager.tx_manager.take_candidates();
         assert_eq!(
             candidates.len(),
             usize::from(expect_revoke_cert),

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -6,7 +6,6 @@
 
 use std::{fmt, sync::Arc};
 
-use async_trait::async_trait;
 use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::TxManager;
 use tracing::{debug, warn};
@@ -32,21 +31,6 @@ where
     }
 }
 
-/// Checks certificate revocation state and submits revocation transactions when needed.
-#[async_trait]
-pub trait CertRevocationChecker: Send + Sync + fmt::Debug {
-    /// Checks an attestation's intermediate certificates and submits revocations.
-    ///
-    /// Returns `Ok(true)` if any intermediate is revoked by either the
-    /// onchain sentinel or the AWS CRL layer, `Ok(false)` if every checked
-    /// intermediate is clean.
-    async fn check_and_revoke_crls(
-        &self,
-        attestation_bytes: &[u8],
-        instance: &ProverInstance,
-    ) -> Result<bool>;
-}
-
 impl<T> CertManager<T>
 where
     T: TxManager,
@@ -69,13 +53,7 @@ where
         })?;
         Ok(Self { http_client, nitro_verifier, tx_manager })
     }
-}
 
-#[async_trait]
-impl<T> CertRevocationChecker for CertManager<T>
-where
-    T: TxManager + 'static,
-{
     /// Checks an attestation's intermediate certificates and submits revocations.
     ///
     /// Returns `Ok(true)` if any intermediate is revoked by either the
@@ -86,7 +64,7 @@ where
     /// intermediates even if AWS later prunes its CRL. AWS CRLs are then
     /// checked for each intermediate, and every CRL hit is checked onchain
     /// before a `revokeCert` transaction is submitted.
-    async fn check_and_revoke_crls(
+    pub async fn check_and_revoke_crls(
         &self,
         attestation_bytes: &[u8],
         instance: &ProverInstance,
@@ -129,12 +107,7 @@ where
 
         Ok(true)
     }
-}
 
-impl<T> CertManager<T>
-where
-    T: TxManager,
-{
     /// Checks whether any intermediate certificate has already been revoked onchain.
     ///
     /// Root and leaf certificates are skipped because only intermediate

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Manages Nitro certificate revocation checks and revocation transaction submission.
 pub struct CertManager<T> {
     http_client: reqwest::Client,
-    nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
+    nitro_verifier: Arc<dyn NitroVerifierClient>,
     tx_manager: T,
 }
 
@@ -56,22 +56,12 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`RegistrarError::Config`] if CRL checking is enabled without a
-    /// verifier client, or if the CRL HTTP client cannot be built.
+    /// Returns [`RegistrarError::Config`] if the CRL HTTP client cannot be built.
     pub fn new(
         config: &CrlConfig,
-        nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
+        nitro_verifier: Arc<dyn NitroVerifierClient>,
         tx_manager: T,
     ) -> Result<Self> {
-        if config.enabled && nitro_verifier.is_none() {
-            return Err(RegistrarError::Config(
-                "CRL checking enabled but nitro_verifier client not configured; \
-                 a NitroEnclaveVerifier client is required as both the revokeCert \
-                 destination and the onchain revokedCerts sentinel source"
-                    .into(),
-            ));
-        }
-
         let http_client = crl::build_crl_http_client(config.fetch_timeout).map_err(|e| {
             RegistrarError::Config(format!(
                 "failed to build CRL HTTP client (Layer 2 / AWS CRL fetch): {e}"
@@ -145,23 +135,6 @@ impl<T> CertManager<T>
 where
     T: TxManager,
 {
-    /// Returns the configured Nitro verifier client.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`RegistrarError::Config`] when no verifier was configured.
-    /// This is valid only while CRL checking is disabled because the manager is
-    /// built unconditionally by the registrar service.
-    pub fn nitro_verifier(&self) -> Result<&dyn NitroVerifierClient> {
-        self.nitro_verifier.as_deref().ok_or_else(|| {
-            RegistrarError::Config(
-                "CRL verifier client is not configured; this should only be called when CRL \
-                 checking is enabled"
-                    .into(),
-            )
-        })
-    }
-
     /// Checks whether any intermediate certificate has already been revoked onchain.
     ///
     /// Root and leaf certificates are skipped because only intermediate
@@ -177,9 +150,8 @@ where
         cert_infos: &[crl::CertCrlInfo],
         instance_id: &str,
     ) -> Result<bool> {
-        let nitro_verifier = self.nitro_verifier()?;
         for info in crl::CertCrlInfo::intermediates(cert_infos) {
-            if nitro_verifier.is_revoked(info.path_digest).await? {
+            if self.nitro_verifier.is_revoked(info.path_digest).await? {
                 let cert = info.intermediate_label();
                 warn!(
                     cert = %cert,
@@ -202,23 +174,12 @@ where
         revoked_certs: &[crl::RevokedCertInfo],
         instance: &ProverInstance,
     ) {
-        let nitro_verifier = match self.nitro_verifier() {
-            Ok(nitro_verifier) => nitro_verifier,
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    instance = %instance.instance_id,
-                    "cannot submit revokeCert without a Nitro verifier client"
-                );
-                return;
-            }
-        };
-        let verifier_address = nitro_verifier.address();
+        let verifier_address = self.nitro_verifier.address();
         let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
 
         for revoked in revoked_certs {
             let cert = revoked.intermediate_label();
-            match nitro_verifier.is_revoked(revoked.path_digest).await {
+            match self.nitro_verifier.is_revoked(revoked.path_digest).await {
                 Ok(true) => {
                     warn!(
                         cert = %cert,
@@ -388,7 +349,7 @@ mod tests {
     fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
         CertManager {
             http_client: reqwest::Client::new(),
-            nitro_verifier: Some(verifier),
+            nitro_verifier: verifier,
             tx_manager: MockTxManager::default(),
         }
     }
@@ -402,21 +363,19 @@ mod tests {
         }
     }
 
-    fn crl_config(enabled: bool) -> CrlConfig {
-        CrlConfig { enabled, nitro_verifier_address: None, fetch_timeout: Duration::from_secs(1) }
+    fn crl_config() -> CrlConfig {
+        CrlConfig {
+            enabled: true,
+            nitro_verifier_address: None,
+            fetch_timeout: Duration::from_secs(1),
+        }
     }
 
     #[test]
-    fn new_allows_disabled_crl_without_verifier() {
-        let result = CertManager::new(&crl_config(false), None, MockTxManager::default());
+    fn new_builds_crl_manager_with_verifier() {
+        let verifier = Arc::new(MockNitroVerifier::default());
+        let result = CertManager::new(&crl_config(), verifier, MockTxManager::default());
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn new_rejects_enabled_crl_without_verifier() {
-        let err = CertManager::new(&crl_config(true), None, MockTxManager::default())
-            .expect_err("enabled CRL requires a verifier");
-        assert!(matches!(err, RegistrarError::Config(_)));
     }
 
     fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -25,9 +25,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CertManager, CrlConfig, DeregistrationManager, InstanceDiscovery, InstanceHealthStatus,
-    NitroVerifierClient, ProofHandlerConfig, ProverClient, ProverInstance, RegistrarError,
-    RegistrarMetrics, RegistrationManager, RegistryClient, Result, SignerClient,
+    CertManager, CertRevocationChecker, CrlConfig, DeregistrationManager, InstanceDiscovery,
+    InstanceHealthStatus, NitroVerifierClient, ProofHandlerConfig, ProverClient, ProverInstance,
+    RegistrarError, RegistrarMetrics, RegistrationManager, RegistryClient, Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -236,7 +236,7 @@ pub struct RegistrationDriver<D, P, R, T, S> {
     config: DriverConfig,
     /// Optional certificate revocation manager. Built once at construction
     /// time when CRL checking is enabled. `None` when CRL checking is disabled.
-    cert_manager: Option<CertManager>,
+    cert_manager: Option<CertManager<T>>,
     /// Bounds the number of proof-generation calls that may be in-flight
     /// across the spawned task pool at once. Sized from
     /// [`DriverConfig::max_concurrency`], matching the discovery/resolve
@@ -262,7 +262,7 @@ where
     D: InstanceDiscovery + 'static,
     P: AttestationProofProvider + 'static,
     R: RegistryClient + 'static,
-    T: TxManager + 'static,
+    T: TxManager + Clone + 'static,
     S: SignerClient + 'static,
 {
     /// Creates a new registration driver.
@@ -270,15 +270,14 @@ where
     /// When CRL checking is enabled, pre-builds the HTTP client used for
     /// CRL fetches so it can be reused across registration cycles. The
     /// optional `nitro_verifier` client consults the onchain durable
-    /// revocation sentinel before each registration; pass `None` to disable
-    /// the onchain pre-check (useful for tests and unit deployments).
+    /// revocation sentinel before each registration and provides the
+    /// `revokeCert` transaction destination.
     ///
     /// # Errors
     ///
-    /// Returns [`RegistrarError::Config`] when `config.crl.enabled` is `true`
-    /// and either the `nitro_verifier` client is missing or the
-    /// [`CertManager`] fails to initialize. Failing fast prevents a
-    /// misconfigured driver from silently bypassing CRL protection at runtime.
+    /// Returns [`RegistrarError::Config`] when the [`CertManager`] fails to
+    /// initialize. Failing fast prevents a misconfigured driver from silently
+    /// bypassing CRL protection at runtime.
     pub fn new(
         discovery: D,
         proof_provider: P,
@@ -289,15 +288,7 @@ where
         nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
     ) -> Result<Self> {
         let cert_manager = if config.crl.enabled {
-            let Some(nitro_verifier) = nitro_verifier else {
-                return Err(RegistrarError::Config(
-                    "CRL checking enabled but nitro_verifier client not configured; \
-                     a NitroEnclaveVerifier client is required as both the revokeCert \
-                     destination and the onchain revokedCerts sentinel source"
-                        .into(),
-                ));
-            };
-            Some(CertManager::new(&config.crl, nitro_verifier)?)
+            Some(CertManager::new(&config.crl, nitro_verifier, tx_manager.clone())?)
         } else {
             None
         };
@@ -601,10 +592,7 @@ where
                 })?;
             let cert_manager =
                 self.cert_manager.as_ref().expect("cert_manager required when CRL enabled");
-            match cert_manager
-                .check_and_revoke_crls(first_attestation, instance, &self.tx_manager)
-                .await
-            {
+            match cert_manager.check_and_revoke_crls(first_attestation, instance).await {
                 Ok(true) => {
                     warn!(
                         instance = %instance.instance_id,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -269,15 +269,16 @@ where
     ///
     /// When CRL checking is enabled, pre-builds the HTTP client used for
     /// CRL fetches so it can be reused across registration cycles. The
-    /// optional `nitro_verifier` client consults the onchain durable
+    /// required `nitro_verifier` client consults the onchain durable
     /// revocation sentinel before each registration and provides the
     /// `revokeCert` transaction destination.
     ///
     /// # Errors
     ///
-    /// Returns [`RegistrarError::Config`] when the [`CertManager`] fails to
-    /// initialize. Failing fast prevents a misconfigured driver from silently
-    /// bypassing CRL protection at runtime.
+    /// Returns [`RegistrarError::Config`] when `config.crl.enabled` is `true`
+    /// and either the `nitro_verifier` client is missing or the
+    /// [`CertManager`] fails to initialize. Failing fast prevents a
+    /// misconfigured driver from silently bypassing CRL protection at runtime.
     pub fn new(
         discovery: D,
         proof_provider: P,
@@ -288,6 +289,14 @@ where
         nitro_verifier: Option<Arc<dyn NitroVerifierClient>>,
     ) -> Result<Self> {
         let cert_manager = if config.crl.enabled {
+            let Some(nitro_verifier) = nitro_verifier else {
+                return Err(RegistrarError::Config(
+                    "CRL checking enabled but nitro_verifier client not configured; \
+                     a NitroEnclaveVerifier client is required as both the revokeCert \
+                     destination and the onchain revokedCerts sentinel source"
+                        .into(),
+                ));
+            };
             Some(CertManager::new(&config.crl, nitro_verifier, tx_manager.clone())?)
         } else {
             None
@@ -1537,6 +1546,25 @@ mod tests {
             )
             .expect("test driver construction succeeds"),
         )
+    }
+
+    #[test]
+    fn new_rejects_crl_enabled_without_nitro_verifier() {
+        let mut config = default_config(CancellationToken::new());
+        config.crl.enabled = true;
+
+        let err = RegistrationDriver::new(
+            MockDiscovery { instances: vec![] },
+            StubProofProvider,
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+            MockSignerClient::from_keys(&[]),
+            config,
+            None,
+        )
+        .expect_err("enabled CRL requires a Nitro verifier client");
+
+        assert!(matches!(err, RegistrarError::Config(_)));
     }
 
     // ── Proof-task mock types ─────────────────────────────────────────

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -25,9 +25,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CertManager, CertRevocationChecker, CrlConfig, DeregistrationManager, InstanceDiscovery,
-    InstanceHealthStatus, NitroVerifierClient, ProofHandlerConfig, ProverClient, ProverInstance,
-    RegistrarError, RegistrarMetrics, RegistrationManager, RegistryClient, Result, SignerClient,
+    CertManager, CrlConfig, DeregistrationManager, InstanceDiscovery, InstanceHealthStatus,
+    NitroVerifierClient, ProofHandlerConfig, ProverClient, ProverInstance, RegistrarError,
+    RegistrarMetrics, RegistrationManager, RegistryClient, Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -11,7 +11,7 @@ mod cert_revoker;
 pub use cert_revoker::CertRevoker;
 
 mod cert_manager;
-pub use cert_manager::CertManager;
+pub use cert_manager::{CertManager, CertRevocationChecker};
 
 mod crl;
 pub use crl::{

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -11,7 +11,7 @@ mod cert_revoker;
 pub use cert_revoker::CertRevoker;
 
 mod cert_manager;
-pub use cert_manager::{CertManager, CertRevocationChecker};
+pub use cert_manager::CertManager;
 
 mod crl;
 pub use crl::{


### PR DESCRIPTION
### What changed? Why?

Extracts the CRL `revokeCert` submission path into `CertManager` by giving it its own tx manager handle. This keeps CRL revocation details behind the cert manager instead of threading a tx manager through every check call, and moves enabled-CRL verifier validation into `CertManager::new`.

### How has it been tested?

- `cargo fmt` (completed with existing stable-rustfmt warnings for nightly-only config options)
- `RISC0_SKIP_BUILD_KERNELS=1 cargo check -p base-proof-tee-registrar -p base-proof-tee-registrar-bin`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar-bin`