### PR TITLE
refactor(registrar): extract signer manager tests

### DIFF
--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1009,21 +1009,6 @@ mod tests {
         ))
     }
 
-    #[test]
-    fn new_accepts_injected_cert_manager() {
-        let mut config = default_config(CancellationToken::new());
-        config.crl.enabled = true;
-        let signer_manager = MockSignerManager::new(CancellationToken::new());
-        let cert_manager = mock_cert_manager(&config, NoopTxManager);
-
-        RegistrationDriver::new(
-            MockDiscovery { instances: vec![] },
-            MockSignerClient::from_keys(&[]),
-            config,
-            cert_manager,
-            signer_manager,
-        );
-    }
     const FAST_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
     #[tokio::test]
@@ -1094,7 +1079,7 @@ mod tests {
             resolution.active_signers.contains(&addr),
             "recently-launched unhealthy signer should be in active_signers"
         );
-        assert!(resolution.ok_to_dereg, "single reachable instance clears the majority guard");
+        assert!(resolution.ok_to_dereg, "resolved instance permits orphan cleanup");
     }
 
     // ── discover_and_resolve tests ─────────────────────────────────────
@@ -1113,37 +1098,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_majority_unreachable_clears_ok_to_dereg() {
-        // 3 instances discovered, but only 1 is reachable via MockSignerClient.
-        // reachable * 2 (= 2) <= total (= 3) → majority guard fires, so
-        // `ok_to_dereg` must be `false` and the orphan-dereg pass would
-        // be skipped by the production loop.
-        let instances = vec![
-            instance(EP1, InstanceHealthStatus::Healthy),
-            instance(EP2, InstanceHealthStatus::Healthy),
-            instance(EP3, InstanceHealthStatus::Healthy),
-        ];
-
-        // Only EP1 has a key; the other two will fail signer_public_key.
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
-
-        let resolution = driver.discover_and_resolve().await.unwrap();
-
-        assert_eq!(resolution.reachable_count, 1);
-        assert_eq!(resolution.total_count, 3);
-        assert!(
-            !resolution.ok_to_dereg,
-            "1/3 reachable: majority guard should block orphan-dereg pass",
-        );
-    }
-
-    #[tokio::test]
     async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_before_run() {
         // Cancellation observed by `discover_and_resolve` after the
         // resolve loop completes must drive `ok_to_dereg = false` so the
-        // production caller skips `run_orphan_dereg` entirely, even
-        // though the majority guard would otherwise pass.
+        // production caller skips `run_orphan_dereg` entirely.
         let instances = vec![
             instance(EP1, InstanceHealthStatus::Healthy),
             instance(EP2, InstanceHealthStatus::Healthy),
@@ -1158,10 +1116,7 @@ mod tests {
         cancel.cancel();
         let resolution = driver.discover_and_resolve().await.unwrap();
 
-        assert!(
-            !resolution.ok_to_dereg,
-            "cancellation must clear ok_to_dereg even if majority guard would pass",
-        );
+        assert!(!resolution.ok_to_dereg, "cancellation must clear ok_to_dereg",);
     }
 
     #[tokio::test]
@@ -1182,61 +1137,14 @@ mod tests {
             resolution.active_signers.contains(&HARDHAT_ACCOUNT),
             "draining instance must contribute its signer to active_signers",
         );
-        assert!(resolution.ok_to_dereg, "single reachable instance clears the majority guard");
+        assert!(resolution.ok_to_dereg, "resolved instance permits orphan cleanup");
     }
 
-    // ── Reachability guard boundary tests ────────────────────────────────
-    //
-    // The majority guard uses instance counts (not signer counts):
-    //
-    //     if !instances.is_empty() && reachable_instances * 2 <= instances.len()
-    //
-    // These tests verify the exact boundary and surrounding values:
-    //   - 1/4 reachable → 1*2 <= 4 → true  → deregistration skipped
-    //   - 2/4 reachable → 2*2 <= 4 → true  → deregistration skipped
-    //   - 3/4 reachable → majority clears, but unresolved instance skips deregistration
-    //   - 4/4 reachable → 4*2 <= 4 → false → deregistration proceeds
-
     /// All 4 endpoints and corresponding private keys, indexed for
-    /// dynamic slicing in the parametrized guard test.
+    /// dynamic slicing in the concurrency test.
     const ALL_ENDPOINTS: [&str; 4] = [EP1, EP2, EP3, EP4];
     const ALL_KEYS: [&[u8; 32]; 4] =
         [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];
-
-    #[rstest]
-    #[case::one_of_four(1, true)]
-    #[case::two_of_four(2, true)]
-    #[case::three_of_four(3, true)]
-    #[case::four_of_four(4, false)]
-    #[tokio::test]
-    async fn discover_and_resolve_reachability_guard_boundary(
-        #[case] reachable_count: usize,
-        #[case] should_skip_deregistration: bool,
-    ) {
-        // All 4 instances are discovered; only `reachable_count` have keys
-        // in the MockSignerClient (the rest will fail signer_public_key).
-        // Verify `ok_to_dereg` remains false while the majority guard
-        // does not clear.
-        let instances: Vec<_> =
-            ALL_ENDPOINTS.iter().map(|ep| instance(ep, InstanceHealthStatus::Healthy)).collect();
-
-        let keys: Vec<(&str, &[u8; 32])> = ALL_ENDPOINTS[..reachable_count]
-            .iter()
-            .zip(&ALL_KEYS[..reachable_count])
-            .map(|(ep, key)| (*ep, *key))
-            .collect();
-        let signer_client = MockSignerClient::from_keys(&keys);
-
-        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
-
-        let resolution = driver.discover_and_resolve().await.unwrap();
-        assert_eq!(resolution.reachable_count, reachable_count);
-        assert_eq!(resolution.total_count, ALL_ENDPOINTS.len());
-        assert_eq!(
-            resolution.ok_to_dereg, !should_skip_deregistration,
-            "{reachable_count}/4 reachable: ok_to_dereg mismatch"
-        );
-    }
 
     #[tokio::test]
     async fn discover_and_resolve_includes_all_reachable_when_one_instance_is_unreachable() {
@@ -1270,15 +1178,11 @@ mod tests {
             reachable.len(),
             "all reachable instances should be registerable despite 1 unreachable",
         );
-        assert_eq!(resolution.reachable_count, reachable.len());
         assert!(
             resolution.unresolved_instance_ids.contains(&unreachable.instance_id),
             "unreachable instance must be marked as unresolved so reconcile skips its cancel-pass",
         );
-        assert!(
-            !resolution.ok_to_dereg,
-            "unresolved instance must block orphan-dereg even when reachable majority clears",
-        );
+        assert!(!resolution.ok_to_dereg, "unresolved instance must block orphan-dereg",);
     }
 
     /// Signer client wrapper that cancels a token after returning keys.
@@ -1378,8 +1282,7 @@ mod tests {
         // reachable by the registrar (responds to JSON-RPC) must:
         //   1. NOT be registerable (should_register = false for Unhealthy
         //      outside the recent-launch window)
-        //   2. Count as reachable (increments `reachable_count`)
-        //   3. Contribute its signers to `active_signers` (preventing dereg)
+        //   2. Contribute its signers to `active_signers` (preventing dereg)
         //
         // This matters because "unhealthy" in ALB terms does not mean
         // the registrar can't connect — the instance may be failing
@@ -1399,7 +1302,6 @@ mod tests {
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
-        assert_eq!(resolution.reachable_count, 2, "both instances respond to RPC");
         assert_eq!(
             resolution.registerable.len(),
             1,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -668,9 +668,6 @@ mod tests {
         },
     };
 
-    // ── Mock implementations ────────────────────────────────────────────
-
-    /// Configurable mock discovery that returns a pre-set list of instances.
     #[derive(Debug)]
     struct MockDiscovery {
         instances: Vec<ProverInstance>,
@@ -683,61 +680,41 @@ mod tests {
         }
     }
 
-    /// Mock signer client that returns pre-configured public keys and attestations
-    /// per endpoint.
-    ///
-    /// If an endpoint is not in the `keys` map, the call returns an error
-    /// (simulating an unreachable instance).
     #[derive(Debug)]
     struct MockSignerClient {
-        /// Maps endpoint URL → list of uncompressed public key bytes (one per enclave).
         keys: HashMap<Url, Vec<Vec<u8>>>,
-        /// Maps endpoint URL → list of attestation blobs (one per enclave).
-        /// Falls back to `b"mock-attestation"` if not configured.
         attestations: HashMap<Url, Vec<Vec<u8>>>,
-        /// Endpoints whose attestation RPC should fail.
         fail_attestation: HashSet<Url>,
     }
 
     impl MockSignerClient {
-        /// Creates a mock with the given host:port-to-private-key mappings.
-        /// Each endpoint gets a single enclave key wrapped in a Vec.
-        /// The public key is derived automatically from each private key.
-        /// An `http://` scheme is prepended to each host:port string.
         fn from_keys(entries: &[(&str, &[u8; 32])]) -> Self {
             let keys = entries
                 .iter()
                 .map(|(ep, pk)| {
-                    let url = Url::parse(&format!("http://{ep}")).unwrap();
+                    let url = endpoint_url(ep);
                     (url, vec![public_key_from_private(pk)])
                 })
                 .collect();
             Self { keys, attestations: HashMap::new(), fail_attestation: HashSet::new() }
         }
 
-        /// Creates a mock that returns multiple public keys for a single endpoint,
-        /// simulating a multi-enclave instance.
         fn multi_enclave(host_port: &str, private_keys: &[&[u8; 32]]) -> Self {
-            let url = Url::parse(&format!("http://{host_port}")).unwrap();
             let pubs = private_keys.iter().map(|pk| public_key_from_private(pk)).collect();
             Self {
-                keys: HashMap::from([(url, pubs)]),
+                keys: HashMap::from([(endpoint_url(host_port), pubs)]),
                 attestations: HashMap::new(),
                 fail_attestation: HashSet::new(),
             }
         }
 
-        /// Configures attestation blobs for a given endpoint.
         fn with_attestations(mut self, host_port: &str, attestations: Vec<Vec<u8>>) -> Self {
-            let url = Url::parse(&format!("http://{host_port}")).unwrap();
-            self.attestations.insert(url, attestations);
+            self.attestations.insert(endpoint_url(host_port), attestations);
             self
         }
 
-        /// Configures the attestation RPC for a given endpoint to fail.
         fn with_attestation_failure(mut self, host_port: &str) -> Self {
-            let url = Url::parse(&format!("http://{host_port}")).unwrap();
-            self.fail_attestation.insert(url);
+            self.fail_attestation.insert(endpoint_url(host_port));
             self
         }
     }
@@ -766,10 +743,13 @@ mod tests {
             if let Some(atts) = self.attestations.get(endpoint) {
                 return Ok(atts.clone());
             }
-            // Default: one dummy attestation per key at this endpoint.
             let count = self.keys.get(endpoint).map_or(1, |k| k.len());
             Ok(vec![b"mock-attestation".to_vec(); count])
         }
+    }
+
+    fn endpoint_url(host_port: &str) -> Url {
+        Url::parse(&format!("http://{host_port}")).unwrap()
     }
 
     fn mock_cert_manager(
@@ -780,9 +760,6 @@ mod tests {
             .expect("test cert manager builds")
     }
 
-    /// Driver-level signer lifecycle mock. It records calls without running
-    /// proof generation or registry cleanup, keeping run-loop tests focused on
-    /// driver orchestration.
     #[derive(Debug, Clone)]
     struct MockSignerManager {
         reconcile_calls: Arc<AtomicUsize>,
@@ -829,8 +806,6 @@ mod tests {
             Ok(())
         }
     }
-
-    // ── Driver constructors ─────────────────────────────────────────────
 
     fn default_config(cancel: CancellationToken) -> DriverConfig {
         DriverConfig {
@@ -940,8 +915,6 @@ mod tests {
         assert!(resolution.ok_to_dereg, "resolved instance permits orphan cleanup");
     }
 
-    // ── discover_and_resolve tests ─────────────────────────────────────
-
     #[tokio::test]
     async fn discover_and_resolve_allows_orphan_pass_when_discovery_is_empty() {
         let driver =
@@ -957,9 +930,6 @@ mod tests {
 
     #[tokio::test]
     async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_before_run() {
-        // Cancellation observed by `discover_and_resolve` after the
-        // resolve loop completes must drive `ok_to_dereg = false` so the
-        // production caller skips `run_orphan_dereg` entirely.
         let instances = vec![healthy_prover_instance(EP1), healthy_prover_instance(EP2)];
 
         let signer_client =
@@ -976,11 +946,6 @@ mod tests {
 
     #[tokio::test]
     async fn discover_and_resolve_includes_all_reachable_when_one_instance_is_unreachable() {
-        // An unreachable instance must not prevent other instances from
-        // being resolved into `registerable` in the same cycle, and its
-        // instance id must land in `unresolved_instance_ids` so the
-        // production reconcile pass doesn't cancel any in-flight task
-        // tied to it.
         let unreachable = healthy_prover_instance(EP4);
         let reachable = [
             healthy_prover_instance(EP1),
@@ -991,7 +956,6 @@ mod tests {
             .chain(reachable.iter().cloned())
             .collect::<Vec<_>>();
 
-        // EP4 has no keys → signer_public_key will error.
         let signer_client = MockSignerClient::from_keys(&[
             (EP1, &HARDHAT_KEY_0),
             (EP2, &HARDHAT_KEY_1),
@@ -1016,9 +980,6 @@ mod tests {
     #[tokio::test]
     async fn discover_and_resolve_multi_enclave_draining_protects_all_signers_from_deregistration()
     {
-        // A draining multi-enclave instance must contribute ALL of its
-        // signer addresses to `active_signers` and must not appear in
-        // `registerable`.
         let addr0 = signer_from_private_key(&HARDHAT_KEY_0);
         let addr1 = signer_from_private_key(&HARDHAT_KEY_1);
 
@@ -1039,15 +1000,6 @@ mod tests {
 
     #[tokio::test]
     async fn discover_and_resolve_unhealthy_instance_is_reachable_but_not_registerable() {
-        // An unhealthy instance (failing ALB health checks) that is still
-        // reachable by the registrar (responds to JSON-RPC) must:
-        //   1. NOT be registerable (should_register = false for Unhealthy
-        //      outside the recent-launch window)
-        //   2. Contribute its signers to `active_signers` (preventing dereg)
-        //
-        // This matters because "unhealthy" in ALB terms does not mean
-        // the registrar can't connect — the instance may be failing
-        // application-level health checks while still responding to RPC.
         let addr_unhealthy = signer_from_private_key(&HARDHAT_KEY_0);
         let addr_healthy = signer_from_private_key(&HARDHAT_KEY_1);
 
@@ -1056,7 +1008,6 @@ mod tests {
             healthy_prover_instance(EP2),
         ];
 
-        // Both instances are reachable via MockSignerClient.
         let signer_client =
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
 
@@ -1083,12 +1034,6 @@ mod tests {
     async fn discover_and_resolve_attestation_failure_keeps_signer_active_and_unresolved(
         #[case] rpc_error: bool,
     ) {
-        // If the registrar reaches signer_public_key successfully but
-        // then cannot fetch or pair an attestation with the signer, the
-        // instance is still reachable and advertising that signer. The
-        // signer must remain protected from orphan deregistration, while
-        // the instance is marked unresolved so any in-flight proof task is
-        // preserved for a later conclusive cycle.
         let signer_addr = signer_from_private_key(&HARDHAT_KEY_0);
         let inst = healthy_prover_instance(EP1);
         let signer_client = if rpc_error {
@@ -1116,10 +1061,6 @@ mod tests {
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
     }
 
-    // ── Concurrency limit test ──────────────────────────────────────────
-
-    /// Signer client that tracks the peak number of concurrent
-    /// `signer_public_key` calls. Used to verify `max_concurrency`.
     #[derive(Debug)]
     struct ConcurrencyTrackingSignerClient {
         inner: MockSignerClient,
@@ -1142,7 +1083,6 @@ mod tests {
             let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
             self.peak.fetch_max(current, Ordering::SeqCst);
 
-            // Yield to give other futures a chance to enter concurrently.
             tokio::task::yield_now().await;
 
             let result = self.inner.signer_public_key(endpoint).await;
@@ -1162,10 +1102,6 @@ mod tests {
 
     #[tokio::test]
     async fn discover_and_resolve_respects_max_concurrency() {
-        // Resolve 4 instances with a limited `max_concurrency` and verify
-        // the peak concurrent `signer_public_key` count observed inside
-        // `discover_and_resolve`'s `buffer_unordered` loop never exceeds
-        // the configured bound. All 4 must end up in `registerable`.
         let max_concurrency = 2;
         let endpoints = [EP1, EP2, EP3, EP4];
         let private_keys = [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -655,80 +655,19 @@ mod tests {
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
-    use hex_literal::hex;
-    use k256::ecdsa::SigningKey;
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
-    use crate::{InstanceHealthStatus, NitroVerifierClient, Result, SignerClient};
-
-    // ── Shared constants ────────────────────────────────────────────────
-
-    /// Well-known Hardhat / Anvil account #0 private key.
-    const HARDHAT_KEY_0: [u8; 32] =
-        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
-
-    /// Hardhat / Anvil account #1 private key.
-    const HARDHAT_KEY_1: [u8; 32] =
-        hex!("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
-
-    /// Hardhat / Anvil account #2 private key.
-    const HARDHAT_KEY_2: [u8; 32] =
-        hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
-
-    /// Hardhat / Anvil account #3 private key.
-    const HARDHAT_KEY_3: [u8; 32] =
-        hex!("7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6");
-
-    /// Prover instance endpoints for tests. Each simulates a distinct
-    /// EC2 instance at a private IP.
-    const EP1: &str = "10.0.0.1:8000";
-    const EP2: &str = "10.0.0.2:8000";
-    const EP3: &str = "10.0.0.3:8000";
-    const EP4: &str = "10.0.0.4:8000";
-
-    /// Placeholder registry contract address used in `DriverConfig`.
-    const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
-
-    // ── Test helpers ─────────────────────────────────────────────────────
-
-    /// Derives the uncompressed 65-byte public key from a private key.
-    fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
-        let signing_key = SigningKey::from_slice(private_key).unwrap();
-        signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
-    }
-
-    /// Builds a [`ProverInstance`] with the given host:port and health status.
-    ///
-    /// Prepends `http://` to form a valid URL automatically. The `launch_time`
-    /// defaults to `None` — use [`instance_with_launch_time`] for tests that
-    /// need a specific launch time.
-    fn instance(host_port: &str, status: InstanceHealthStatus) -> ProverInstance {
-        let endpoint = Url::parse(&format!("http://{host_port}")).unwrap();
-        ProverInstance {
-            instance_id: format!("i-{host_port}"),
-            endpoint,
-            health_status: status,
-            launch_time: None,
-        }
-    }
-
-    /// Builds a [`ProverInstance`] with an explicit `launch_time`.
-    fn instance_with_launch_time(
-        host_port: &str,
-        status: InstanceHealthStatus,
-        launch_time: Option<SystemTime>,
-    ) -> ProverInstance {
-        let endpoint = Url::parse(&format!("http://{host_port}")).unwrap();
-        ProverInstance {
-            instance_id: format!("i-{host_port}"),
-            endpoint,
-            health_status: status,
-            launch_time,
-        }
-    }
+    use crate::{
+        InstanceHealthStatus, NitroVerifierClient, Result, SignerClient,
+        test_utils::{
+            EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
+            TEST_REGISTRY_ADDRESS, healthy_prover_instance, prover_instance,
+            public_key_from_private, signer_from_private_key,
+        },
+    };
 
     // ── Mock implementations ────────────────────────────────────────────
 
@@ -957,25 +896,21 @@ mod tests {
     type CycleDriver =
         RegistrationDriver<MockDiscovery, MockSignerClient, MockSignerManager, NoopTxManager>;
 
-    /// Builds a fully-configured driver for primitive-level tests that
-    /// invoke `discover_and_resolve` directly, without standing up the
-    /// production signer lifecycle. Returns an `Arc` so tests that spawn
-    /// the run loop can keep handles for state inspection.
     fn cycle_driver(
         instances: Vec<ProverInstance>,
         signer_client: MockSignerClient,
         cancel: CancellationToken,
-    ) -> Arc<CycleDriver> {
+    ) -> CycleDriver {
         let config = default_config(cancel);
         let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
-        Arc::new(RegistrationDriver::new(
+        RegistrationDriver::new(
             MockDiscovery { instances },
             signer_client,
             config,
             cert_manager,
             signer_manager,
-        ))
+        )
     }
 
     const FAST_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -988,17 +923,11 @@ mod tests {
 
         let signer_manager = MockSignerManager::new(cancel.clone());
         let signer_manager_handle = signer_manager.clone();
-        let signer = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0))
-            .expect("test key derives");
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
-        let driver = RegistrationDriver::<
-            MockDiscovery,
-            MockSignerClient,
-            MockSignerManager,
-            NoopTxManager,
-        >::new(
-            MockDiscovery { instances: vec![instance(EP1, InstanceHealthStatus::Healthy)] },
+        let driver = RegistrationDriver::new(
+            MockDiscovery { instances: vec![healthy_prover_instance(EP1)] },
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
             config,
             cert_manager,
@@ -1024,11 +953,11 @@ mod tests {
     async fn discover_and_resolve_admits_recently_launched_unhealthy_to_active_and_registerable() {
         // A recently-launched Unhealthy instance must be included in
         // `registerable` and contribute its signer to `active_signers`.
-        let addr = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
+        let addr = signer_from_private_key(&HARDHAT_KEY_0);
         let launch_time = Some(SystemTime::now() - Duration::from_secs(300));
 
         let instance_under_test =
-            instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time);
+            prover_instance(EP1, InstanceHealthStatus::Unhealthy, launch_time);
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
 
         let driver = cycle_driver(
@@ -1071,10 +1000,7 @@ mod tests {
         // Cancellation observed by `discover_and_resolve` after the
         // resolve loop completes must drive `ok_to_dereg = false` so the
         // production caller skips `run_orphan_dereg` entirely.
-        let instances = vec![
-            instance(EP1, InstanceHealthStatus::Healthy),
-            instance(EP2, InstanceHealthStatus::Healthy),
-        ];
+        let instances = vec![healthy_prover_instance(EP1), healthy_prover_instance(EP2)];
 
         let signer_client =
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
@@ -1101,11 +1027,11 @@ mod tests {
         // instance id must land in `unresolved_instance_ids` so the
         // production reconcile pass doesn't cancel any in-flight task
         // tied to it.
-        let unreachable = instance(EP4, InstanceHealthStatus::Healthy);
+        let unreachable = healthy_prover_instance(EP4);
         let reachable = [
-            instance(EP1, InstanceHealthStatus::Healthy),
-            instance(EP2, InstanceHealthStatus::Healthy),
-            instance(EP3, InstanceHealthStatus::Healthy),
+            healthy_prover_instance(EP1),
+            healthy_prover_instance(EP2),
+            healthy_prover_instance(EP3),
         ];
         let instances = std::iter::once(unreachable.clone())
             .chain(reachable.iter().cloned())
@@ -1173,7 +1099,7 @@ mod tests {
         // `run_orphan_dereg` entirely. `CancellingSignerClient` cancels
         // the shared token as a side effect of `signer_public_key`,
         // simulating a shutdown signal arriving mid-cycle.
-        let instances = vec![instance(EP1, InstanceHealthStatus::Healthy)];
+        let instances = vec![healthy_prover_instance(EP1)];
 
         let cancel = CancellationToken::new();
 
@@ -1185,13 +1111,13 @@ mod tests {
         let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
-        let driver = Arc::new(RegistrationDriver::new(
+        let driver = RegistrationDriver::new(
             MockDiscovery { instances },
             signer_client,
             config,
             cert_manager,
             signer_manager,
-        ));
+        );
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert!(
@@ -1206,10 +1132,10 @@ mod tests {
         // A draining multi-enclave instance must contribute ALL of its
         // signer addresses to `active_signers` and must not appear in
         // `registerable`.
-        let addr0 = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let addr1 = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_1)).unwrap();
+        let addr0 = signer_from_private_key(&HARDHAT_KEY_0);
+        let addr1 = signer_from_private_key(&HARDHAT_KEY_1);
 
-        let instances = vec![instance(EP1, InstanceHealthStatus::Draining)];
+        let instances = vec![prover_instance(EP1, InstanceHealthStatus::Draining, None)];
         let signer_client = MockSignerClient::multi_enclave(EP1, &[&HARDHAT_KEY_0, &HARDHAT_KEY_1]);
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
@@ -1235,13 +1161,13 @@ mod tests {
         // This matters because "unhealthy" in ALB terms does not mean
         // the registrar can't connect — the instance may be failing
         // application-level health checks while still responding to RPC.
-        let addr_unhealthy =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let addr_healthy =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_1)).unwrap();
+        let addr_unhealthy = signer_from_private_key(&HARDHAT_KEY_0);
+        let addr_healthy = signer_from_private_key(&HARDHAT_KEY_1);
 
-        let healthy_inst = instance(EP2, InstanceHealthStatus::Healthy);
-        let instances = vec![instance(EP1, InstanceHealthStatus::Unhealthy), healthy_inst.clone()];
+        let instances = vec![
+            prover_instance(EP1, InstanceHealthStatus::Unhealthy, None),
+            healthy_prover_instance(EP2),
+        ];
 
         // Both instances are reachable via MockSignerClient.
         let signer_client =
@@ -1276,9 +1202,8 @@ mod tests {
         // signer must remain protected from orphan deregistration, while
         // the instance is marked unresolved so any in-flight proof task is
         // preserved for a later conclusive cycle.
-        let signer_addr =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
+        let signer_addr = signer_from_private_key(&HARDHAT_KEY_0);
+        let inst = healthy_prover_instance(EP1);
         let signer_client = if rpc_error {
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestation_failure(EP1)
         } else {
@@ -1358,7 +1283,7 @@ mod tests {
         // `discover_and_resolve`'s `buffer_unordered` loop never exceeds
         // the configured bound. All 4 must end up in `registerable`.
         let instances: Vec<_> =
-            ALL_ENDPOINTS.iter().map(|ep| instance(ep, InstanceHealthStatus::Healthy)).collect();
+            ALL_ENDPOINTS.iter().map(|ep| healthy_prover_instance(ep)).collect();
 
         let keys: Vec<(&str, &[u8; 32])> =
             ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
@@ -1371,13 +1296,13 @@ mod tests {
         let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
-        let driver = Arc::new(RegistrationDriver::new(
+        let driver = RegistrationDriver::new(
             MockDiscovery { instances },
             signer_client,
             config,
             cert_manager,
             signer_manager,
-        ));
+        );
 
         let resolution = driver.discover_and_resolve().await.unwrap();
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -652,9 +652,7 @@ mod tests {
         time::SystemTime,
     };
 
-    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom};
-    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
     use hex_literal::hex;
@@ -700,32 +698,6 @@ mod tests {
     fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
         let signing_key = SigningKey::from_slice(private_key).unwrap();
         signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
-    }
-
-    /// Builds a minimal `TransactionReceipt` for mock tx managers.
-    fn stub_receipt() -> TransactionReceipt {
-        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt {
-                status: Eip658Value::Eip658(true),
-                cumulative_gas_used: 21_000,
-                logs: vec![],
-            },
-            logs_bloom: Bloom::ZERO,
-        });
-        TransactionReceipt {
-            inner,
-            transaction_hash: B256::ZERO,
-            transaction_index: Some(0),
-            block_hash: Some(B256::ZERO),
-            block_number: Some(1),
-            gas_used: 21_000,
-            effective_gas_price: 1_000_000_000,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
     }
 
     /// Builds a [`ProverInstance`] with the given host:port and health status.
@@ -897,7 +869,7 @@ mod tests {
 
     impl TxManager for NoopTxManager {
         async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            Ok(stub_receipt())
+            unreachable!("driver tests do not submit transactions")
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -653,12 +653,9 @@ mod tests {
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom, Bytes, address};
+    use alloy_primitives::{Address, B256, Bloom, address};
     use alloy_rpc_types_eth::TransactionReceipt;
-    use alloy_sol_types::SolCall;
     use async_trait::async_trait;
-    use base_proof_contracts::ITEEProverRegistry;
-    use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
     use hex_literal::hex;
     use k256::ecdsa::SigningKey;
@@ -667,10 +664,7 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::{
-        InstanceHealthStatus, NitroVerifierClient, RegistryClient, Result, SignerClient,
-        SignerManager,
-    };
+    use crate::{InstanceHealthStatus, NitroVerifierClient, Result, SignerClient};
 
     // ── Shared constants ────────────────────────────────────────────────
 
@@ -699,10 +693,6 @@ mod tests {
     const EP2: &str = "10.0.0.2:8000";
     const EP3: &str = "10.0.0.3:8000";
     const EP4: &str = "10.0.0.4:8000";
-
-    /// Synthetic orphan addresses for deregistration tests.
-    /// Each uses `Address::repeat_byte` for deterministic, readable values.
-    const ORPHAN_A: Address = Address::repeat_byte(0xAA);
 
     /// Placeholder registry contract address used in `DriverConfig`.
     const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
@@ -783,24 +773,6 @@ mod tests {
     impl InstanceDiscovery for MockDiscovery {
         async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
             Ok(self.instances.clone())
-        }
-    }
-
-    /// Mock proof provider that returns a dummy proof.
-    #[derive(Debug)]
-    struct StubProofProvider;
-
-    #[async_trait]
-    impl AttestationProofProvider for StubProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            Ok(AttestationProof {
-                output: Bytes::from_static(b"stub-output"),
-                proof_bytes: Bytes::from_static(b"stub-proof"),
-            })
         }
     }
 
@@ -893,44 +865,6 @@ mod tests {
         }
     }
 
-    /// Mock registry that returns a configured set of registered signers.
-    ///
-    /// By default, `is_registered` checks membership in the `signers` list
-    /// (matching real contract behavior). When `all_registered` is set, it
-    /// returns `true` unconditionally, which short-circuits the registration
-    /// path after the registry precheck.
-    #[derive(Debug)]
-    struct MockRegistry {
-        signers: Vec<Address>,
-        /// When `true`, `is_registered` returns `true` for all queries,
-        /// regardless of `signers` membership.
-        all_registered: bool,
-    }
-
-    impl MockRegistry {
-        fn with_signers(signers: Vec<Address>) -> Self {
-            Self { signers, all_registered: false }
-        }
-
-        fn all_registered(signers: Vec<Address>) -> Self {
-            Self { signers, all_registered: true }
-        }
-    }
-
-    #[async_trait]
-    impl RegistryClient for MockRegistry {
-        async fn is_registered(&self, signer: Address) -> Result<bool> {
-            if self.all_registered {
-                return Ok(true);
-            }
-            Ok(self.signers.contains(&signer))
-        }
-
-        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            Ok(self.signers.clone())
-        }
-    }
-
     /// Mock Nitro verifier used to satisfy the driver's required certificate
     /// manager dependency in tests that do not exercise CRL checks.
     #[derive(Debug)]
@@ -953,36 +887,24 @@ mod tests {
 
     fn mock_cert_manager(
         config: &DriverConfig,
-        tx_manager: SharedTxManager,
-    ) -> CertManager<SharedTxManager> {
+        tx_manager: NoopTxManager,
+    ) -> CertManager<NoopTxManager> {
         CertManager::new(&config.crl, mock_nitro_verifier(), tx_manager)
             .expect("test cert manager builds")
     }
 
-    /// Mock tx manager that records submitted calldata for assertion.
-    #[derive(Debug, Clone)]
-    struct SharedTxManager {
-        sent: Arc<Mutex<Vec<Bytes>>>,
-    }
+    /// Minimal tx manager used only to satisfy the driver's certificate-manager
+    /// dependency in tests that do not exercise transaction submission.
+    #[derive(Debug, Clone, Copy)]
+    struct NoopTxManager;
 
-    impl SharedTxManager {
-        fn new() -> Self {
-            Self { sent: Arc::new(Mutex::new(vec![])) }
-        }
-
-        fn sent_calldata(&self) -> Vec<Bytes> {
-            self.sent.lock().unwrap().clone()
-        }
-    }
-
-    impl TxManager for SharedTxManager {
-        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            self.sent.lock().unwrap().push(candidate.tx_data);
+    impl TxManager for NoopTxManager {
+        async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
             Ok(stub_receipt())
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-            unimplemented!("not used in tests")
+            unimplemented!("not used in driver tests")
         }
 
         fn sender_address(&self) -> Address {
@@ -1064,7 +986,7 @@ mod tests {
     }
 
     type CycleDriver =
-        RegistrationDriver<MockDiscovery, MockSignerClient, MockSignerManager, SharedTxManager>;
+        RegistrationDriver<MockDiscovery, MockSignerClient, MockSignerManager, NoopTxManager>;
 
     /// Builds a fully-configured driver for primitive-level tests that
     /// invoke `discover_and_resolve` directly, without standing up the
@@ -1076,9 +998,8 @@ mod tests {
         cancel: CancellationToken,
     ) -> Arc<CycleDriver> {
         let config = default_config(cancel);
-        let tx = SharedTxManager::new();
         let signer_manager = MockSignerManager::new(CancellationToken::new());
-        let cert_manager = mock_cert_manager(&config, tx);
+        let cert_manager = mock_cert_manager(&config, NoopTxManager);
         Arc::new(RegistrationDriver::new(
             MockDiscovery { instances },
             signer_client,
@@ -1092,9 +1013,8 @@ mod tests {
     fn new_accepts_injected_cert_manager() {
         let mut config = default_config(CancellationToken::new());
         config.crl.enabled = true;
-        let tx = SharedTxManager::new();
         let signer_manager = MockSignerManager::new(CancellationToken::new());
-        let cert_manager = mock_cert_manager(&config, tx);
+        let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
         RegistrationDriver::new(
             MockDiscovery { instances: vec![] },
@@ -1104,336 +1024,25 @@ mod tests {
             signer_manager,
         );
     }
-    // ── Pipeline test infrastructure ────────────────────────────────────
-    //
-    // Used by top-level `run` tests. Designed so the entire run loop can be
-    // driven from a `tokio::test` without real sleeps: the gated proof provider
-    // parks every spawned proof on a `CancellationToken` that the test releases
-    // when it has observed the behaviour it cares about.
-
-    /// Tightened poll interval for spawn-pipeline tests so we observe
-    /// multiple cycles without burning real wall-time.
-    const GATED_POLL_INTERVAL: Duration = Duration::from_millis(25);
-
-    /// Soft timeout for `wait_for` polling assertions. Generous enough
-    /// to absorb CI jitter while still failing fast on a stuck pipeline.
-    const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
-
-    /// Minimum number of run cycles a pipeline test must let elapse
-    /// before asserting that discovery is unblocked. Two cycles proves
-    /// the loop is not blocked behind a long proof (one would also pass
-    /// for a synchronous loop on its first iteration).
-    const MIN_CYCLES_IN_OBSERVATION_WINDOW: usize = 2;
-
-    /// Shared mutable state for [`GatedProofProvider`].
-    ///
-    /// `release` is a [`CancellationToken`] — not a [`tokio::sync::Notify`]
-    /// — so it is *latched*. A late-arriving proof task that calls
-    /// `generate_proof_for_signer` after `release_all()` returns
-    /// immediately, instead of missing a one-shot `notify_waiters` wakeup
-    /// and hanging forever. This eliminates a registration race the
-    /// earlier design suffered from.
-    #[derive(Debug, Default)]
-    struct GatedProofState {
-        release: CancellationToken,
-        call_count: AtomicUsize,
-        in_flight: AtomicUsize,
-        /// Optional per-signer failure routing. If a signer address is
-        /// present in this set, [`GatedProofProvider::generate_proof_for_signer`]
-        /// returns a synthetic [`ProverError::Boundless`] immediately
-        /// (skipping the release gate) so tests can observe the registration
-        /// failure path without having to stand up a second proof provider type. The check happens
-        /// before [`GatedProofState::call_count`] is incremented, so
-        /// failed signers do not contribute to the in-flight count
-        /// either.
-        fail_for: Mutex<HashSet<Address>>,
-    }
-
-    /// RAII guard that bumps and decrements [`GatedProofState::in_flight`].
-    struct InFlightGuard {
-        state: Arc<GatedProofState>,
-    }
-
-    impl InFlightGuard {
-        fn new(state: Arc<GatedProofState>) -> Self {
-            state.in_flight.fetch_add(1, Ordering::SeqCst);
-            Self { state }
-        }
-    }
-
-    impl Drop for InFlightGuard {
-        fn drop(&mut self) {
-            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
-        }
-    }
-
-    /// Proof provider that parks every call on a shared cancel token
-    /// until the test releases it, while tracking call and in-flight
-    /// counts (see [`GatedProofHandles::call_count`] and
-    /// [`GatedProofHandles::in_flight`]).
-    ///
-    /// Cancel-safe: the await on `release.cancelled()` is itself cancellable,
-    /// so when the registration manager's biased `select!` drops this future
-    /// on its own `signer_cancel`, no state is left hanging.
-    #[derive(Debug, Clone)]
-    struct GatedProofProvider {
-        state: Arc<GatedProofState>,
-    }
-
-    impl GatedProofProvider {
-        fn new() -> (Self, GatedProofHandles) {
-            let state = Arc::new(GatedProofState::default());
-            (Self { state: Arc::clone(&state) }, GatedProofHandles { state })
-        }
-    }
-
-    #[async_trait]
-    impl AttestationProofProvider for GatedProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            self.state.call_count.fetch_add(1, Ordering::SeqCst);
-            let _guard = InFlightGuard::new(Arc::clone(&self.state));
-            self.state.release.cancelled().await;
-            Ok(AttestationProof {
-                output: Bytes::from_static(b"gated-output"),
-                proof_bytes: Bytes::from_static(b"gated-proof"),
-            })
-        }
-
-        async fn generate_proof_for_signer(
-            &self,
-            attestation_bytes: &[u8],
-            signer_address: Address,
-            cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            if self.state.fail_for.lock().unwrap().contains(&signer_address) {
-                return Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
-                    "synthetic failure injected by GatedProofProvider".into(),
-                ));
-            }
-            self.generate_proof(attestation_bytes, cancel).await
-        }
-    }
-
-    /// Test-side handle for inspecting and releasing a [`GatedProofProvider`].
-    #[derive(Debug, Clone)]
-    struct GatedProofHandles {
-        state: Arc<GatedProofState>,
-    }
-
-    impl GatedProofHandles {
-        /// Releases every currently-blocked and every future proof call
-        /// (the token is latched).
-        fn release_all(&self) {
-            self.state.release.cancel();
-        }
-
-        fn call_count(&self) -> usize {
-            self.state.call_count.load(Ordering::SeqCst)
-        }
-
-        fn in_flight(&self) -> usize {
-            self.state.in_flight.load(Ordering::SeqCst)
-        }
-
-        /// Configures [`GatedProofProvider::generate_proof_for_signer`]
-        /// to return a synthetic [`ProverError::Boundless`] for the
-        /// given signer addresses on every subsequent call. The check
-        /// happens **before** the gate, so failing tasks do not affect
-        /// [`Self::call_count`] or [`Self::in_flight`].
-        fn fail_for_signers(&self, signers: impl IntoIterator<Item = Address>) {
-            self.state.fail_for.lock().unwrap().extend(signers);
-        }
-    }
-
-    /// Discovery whose returned instance list can be mutated mid-run.
-    ///
-    /// Lets a test simulate ASG scale-up/down between cycles without
-    /// restarting the driver.
-    #[derive(Debug, Clone)]
-    struct MutableDiscovery {
-        instances: Arc<Mutex<Vec<ProverInstance>>>,
-    }
-
-    impl MutableDiscovery {
-        fn new(initial: Vec<ProverInstance>) -> Self {
-            Self { instances: Arc::new(Mutex::new(initial)) }
-        }
-
-        fn set(&self, instances: Vec<ProverInstance>) {
-            *self.instances.lock().unwrap() = instances;
-        }
-    }
-
-    #[async_trait]
-    impl InstanceDiscovery for MutableDiscovery {
-        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-            Ok(self.instances.lock().unwrap().clone())
-        }
-    }
-
-    /// Type alias for the [`RegistrationDriver`] specialisation used by
-    /// the pipeline tests.
-    type RunDriver = RegistrationDriver<
-        MutableDiscovery,
-        MockSignerClient,
-        Arc<SignerManager<GatedProofProvider, MockRegistry, SharedTxManager>>,
-        SharedTxManager,
-    >;
-
-    /// Bundles every handle a pipeline test needs to drive the loop.
-    struct GatedRunHarness {
-        driver: Arc<RunDriver>,
-        cancel: CancellationToken,
-        discovery: MutableDiscovery,
-        proof: GatedProofHandles,
-        tx: SharedTxManager,
-    }
-
-    impl GatedRunHarness {
-        /// Builds a harness with the given initial instances + signer
-        /// keys; both come from `endpoints_to_keys` so the wiring
-        /// (instance ↔ key ↔ derived address) cannot drift.
-        fn new(
-            initial_instances: Vec<ProverInstance>,
-            endpoints_to_keys: &[(&str, &[u8; 32])],
-            registry: MockRegistry,
-        ) -> Self {
-            let discovery = MutableDiscovery::new(initial_instances);
-            let signer_client = MockSignerClient::from_keys(endpoints_to_keys);
-            let tx = SharedTxManager::new();
-            let cancel = CancellationToken::new();
-            let (proof_provider, proof_handles) = GatedProofProvider::new();
-
-            let mut config = default_config(cancel.clone());
-            config.poll_interval = GATED_POLL_INTERVAL;
-            let signer_manager = Arc::new(SignerManager::new(
-                proof_provider,
-                registry,
-                tx.clone(),
-                config.signer_manager.clone(),
-            ));
-            let cert_manager = mock_cert_manager(&config, tx.clone());
-
-            let driver = Arc::new(RegistrationDriver::new(
-                discovery.clone(),
-                signer_client,
-                config,
-                cert_manager,
-                signer_manager,
-            ));
-
-            Self { driver, cancel, discovery, proof: proof_handles, tx }
-        }
-
-        /// Spawns the registration loop on the current runtime, returning
-        /// the `JoinHandle` so the test can await shutdown.
-        fn spawn_run(&self) -> tokio::task::JoinHandle<Result<()>> {
-            let driver = Arc::clone(&self.driver);
-            tokio::spawn(async move { driver.run_loop().await })
-        }
-
-        /// Cancels the harness, awaits its run handle inside
-        /// [`GATED_WAIT_TIMEOUT`], and asserts the loop exited cleanly.
-        /// Every pipeline test must call this exactly once at the end
-        /// to drain in-flight proof tasks and surface unexpected panics.
-        async fn shutdown(&self, handle: tokio::task::JoinHandle<Result<()>>) {
-            self.cancel.cancel();
-            let outcome = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
-                .await
-                .expect("run() should observe cancel and stop within timeout")
-                .expect("run() task should not panic");
-            outcome.expect("run() should return Ok on graceful shutdown");
-        }
-    }
-
-    /// Polls `predicate` until it returns `true` or [`GATED_WAIT_TIMEOUT`]
-    /// elapses. Panics with `label` on timeout so test failures point at
-    /// the specific expectation that didn't fire.
-    async fn wait_for(label: &str, predicate: impl Fn() -> bool) {
-        let started = std::time::Instant::now();
-        while !predicate() {
-            if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("timed out waiting for: {label}");
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-    }
-
-    /// Counts the number of `registerSigner` calldata frames in a
-    /// captured tx-manager log.
-    fn count_register_calls(sent: &[Bytes]) -> usize {
-        let sel = ITEEProverRegistry::registerSignerCall::SELECTOR;
-        sent.iter().filter(|c| c.len() >= 4 && c[..4] == sel).count()
-    }
-
-    /// Counts the number of `deregisterSigner` calldata frames.
-    fn count_deregister_calls(sent: &[Bytes]) -> usize {
-        let sel = ITEEProverRegistry::deregisterSignerCall::SELECTOR;
-        sent.iter().filter(|c| c.len() >= 4 && c[..4] == sel).count()
-    }
-
-    /// Builds a [`MockRegistry`] that reports zero registered signers.
-    /// Used by every pipeline test that wants the onchain state to
-    /// start empty.
-    fn empty_registry() -> MockRegistry {
-        MockRegistry::with_signers(vec![])
-    }
-
-    /// Builds the single-instance / single-key `(EP1, HARDHAT_KEY_0)`
-    /// harness used by most pipeline tests, with no signers registered
-    /// onchain. Centralising this pair removes ~5 lines of boilerplate
-    /// per test and makes it impossible for them to drift out of sync.
-    fn single_healthy_harness() -> GatedRunHarness {
-        GatedRunHarness::new(
-            vec![instance(EP1, InstanceHealthStatus::Healthy)],
-            &[(EP1, &HARDHAT_KEY_0)],
-            empty_registry(),
-        )
-    }
-
-    /// Builds an `n`-instance harness with all healthy instances and
-    /// no signers registered onchain. The signer client is seeded with
-    /// **every** endpoint in [`ALL_ENDPOINTS`] (not just the initial
-    /// `n`) so scale-up tests that swap the discovery list mid-run can
-    /// resolve public keys for instances that weren't part of the
-    /// original snapshot.
-    fn multi_healthy_harness(num_instances: usize) -> GatedRunHarness {
-        assert!(
-            num_instances <= ALL_ENDPOINTS.len(),
-            "fixture has only {} endpoints; requested {num_instances}",
-            ALL_ENDPOINTS.len()
-        );
-        let initial: Vec<_> = ALL_ENDPOINTS[..num_instances]
-            .iter()
-            .map(|ep| instance(ep, InstanceHealthStatus::Healthy))
-            .collect();
-        let all_keys: Vec<(&str, &[u8; 32])> =
-            ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
-        GatedRunHarness::new(initial, &all_keys, empty_registry())
-    }
+    const FAST_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
     #[tokio::test]
     async fn run_loop_uses_injected_signer_manager_boundary() {
         let cancel = CancellationToken::new();
         let mut config = default_config(cancel.clone());
-        config.poll_interval = GATED_POLL_INTERVAL;
+        config.poll_interval = FAST_POLL_INTERVAL;
 
-        let tx = SharedTxManager::new();
         let signer_manager = MockSignerManager::new(cancel.clone());
         let signer_manager_handle = signer_manager.clone();
         let signer = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0))
             .expect("test key derives");
-        let cert_manager = mock_cert_manager(&config, tx);
+        let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
         let driver = RegistrationDriver::<
             MockDiscovery,
             MockSignerClient,
             MockSignerManager,
-            SharedTxManager,
+            NoopTxManager,
         >::new(
             MockDiscovery { instances: vec![instance(EP1, InstanceHealthStatus::Healthy)] },
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
@@ -1715,7 +1324,6 @@ mod tests {
         let instances = vec![instance(EP1, InstanceHealthStatus::Healthy)];
 
         let cancel = CancellationToken::new();
-        let tx = SharedTxManager::new();
 
         let signer_client = CancellingSignerClient {
             inner: MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
@@ -1723,7 +1331,7 @@ mod tests {
         };
         let config = default_config(cancel);
         let signer_manager = MockSignerManager::new(CancellationToken::new());
-        let cert_manager = mock_cert_manager(&config, tx.clone());
+        let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
         let driver = Arc::new(RegistrationDriver::new(
             MockDiscovery { instances },
@@ -1921,16 +1529,10 @@ mod tests {
         let (signer_client, peak) = ConcurrencyTrackingSignerClient::new(inner);
 
         let cancel = CancellationToken::new();
-        let tx = SharedTxManager::new();
         let mut config = default_config(cancel);
         config.signer_manager.max_concurrency = max_concurrency;
-        let signer_manager = Arc::new(SignerManager::new(
-            StubProofProvider,
-            MockRegistry::with_signers(vec![]),
-            tx.clone(),
-            config.signer_manager.clone(),
-        ));
-        let cert_manager = mock_cert_manager(&config, tx.clone());
+        let signer_manager = MockSignerManager::new(CancellationToken::new());
+        let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
         let driver = Arc::new(RegistrationDriver::new(
             MockDiscovery { instances },
@@ -1953,438 +1555,4 @@ mod tests {
             "all 4 healthy instances should resolve into the registerable set",
         );
     }
-
-    // ── run() spawn-and-reap pipeline tests ─────────────────────────────
-    //
-    // End-to-end tests for the new run() loop. Each test spawns the
-    // loop on the tokio runtime with a tightened poll interval, then
-    // observes the spawn/reap pipeline via the GatedProofProvider
-    // counters and the SharedTxManager calldata log. Cancellation is
-    // used to stop the loop cleanly between assertions.
-
-    #[rstest]
-    #[case::one_instance(1)]
-    #[case::two_instances(2)]
-    #[case::three_instances(3)]
-    #[case::four_instances(4)]
-    #[tokio::test]
-    async fn run_spawns_one_task_per_enclave_and_each_submits_registration(
-        #[case] num_instances: usize,
-    ) {
-        // `num_instances` healthy instances, one enclave each, none yet
-        // registered. The pipeline must spawn exactly `num_instances`
-        // proof tasks; once released they each submit a single
-        // registerSigner tx — independent of the fan-out width.
-        let harness = multi_healthy_harness(num_instances);
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("every proof task parked in gate", || harness.proof.in_flight() == num_instances)
-            .await;
-
-        // Release the gate so the proof tasks return and registrations submit.
-        harness.proof.release_all();
-
-        wait_for("every registerSigner tx submitted", || {
-            count_register_calls(&harness.tx.sent_calldata()) == num_instances
-        })
-        .await;
-
-        harness.shutdown(run_handle).await;
-
-        assert_eq!(harness.proof.call_count(), num_instances, "exactly one proof per enclave");
-    }
-
-    #[rstest]
-    // Scale-down 2 → 1: cancel either the first-discovered or the
-    // last-discovered task, exhaustively.
-    #[case::two_instances_drop_first(2, &[0])]
-    #[case::two_instances_drop_last(2, &[1])]
-    // Scale-down 3 → 1: cancel two of three (covers middle index too).
-    #[case::three_instances_drop_two_keep_first(3, &[1, 2])]
-    #[case::three_instances_drop_two_keep_last(3, &[0, 1])]
-    #[tokio::test]
-    async fn run_cancels_in_flight_tasks_when_instances_vanish_mid_proof(
-        #[case] initial_count: usize,
-        #[case] drop_indices: &[usize],
-    ) {
-        // Start with `initial_count` healthy instances; observe every
-        // proof task parked. Remove the instances at `drop_indices` from
-        // discovery; the next cycle must cancel their tasks cooperatively
-        // (the signer_cancel token fires inside the registration manager's
-        // biased select! around generate_proof_for_signer), and the cancelled
-        // tasks exit Ok(()) without submitting a tx.
-        let harness = multi_healthy_harness(initial_count);
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("every proof task parked in gate", || harness.proof.in_flight() == initial_count)
-            .await;
-
-        // Drop the chosen indices from discovery.
-        let drop_set: HashSet<usize> = drop_indices.iter().copied().collect();
-        let kept_endpoints: Vec<&'static str> = ALL_ENDPOINTS[..initial_count]
-            .iter()
-            .enumerate()
-            .filter_map(|(i, ep)| (!drop_set.contains(&i)).then_some(*ep))
-            .collect();
-        let kept_count = kept_endpoints.len();
-        let dropped_count = drop_indices.len();
-        harness.discovery.set(
-            kept_endpoints.iter().map(|ep| instance(ep, InstanceHealthStatus::Healthy)).collect(),
-        );
-
-        // The reconcile pass on the next cycle must cancel every
-        // dropped instance's task.
-        wait_for("dropped proof tasks cancelled", || harness.proof.in_flight() == kept_count).await;
-
-        // Surviving proofs are still parked; release the gate to let
-        // them through.
-        harness.proof.release_all();
-
-        wait_for("every surviving instance registered", || {
-            count_register_calls(&harness.tx.sent_calldata()) == kept_count
-        })
-        .await;
-
-        harness.shutdown(run_handle).await;
-
-        let sent = harness.tx.sent_calldata();
-        assert_eq!(
-            count_register_calls(&sent),
-            kept_count,
-            "{dropped_count} dropped instance(s) must NOT have submitted a registration"
-        );
-    }
-
-    #[rstest]
-    // The exact bug this entire refactor fixes: a long-running proof
-    // for one already-discovered instance must not block discovery
-    // from picking up newly-launched instances. We cover three
-    // scale-up sizes so a regression that, e.g., serialises one new
-    // task per N existing in-flight tasks would still be caught.
-    #[case::scale_up_1_to_2(1, 2)]
-    #[case::scale_up_1_to_3(1, 3)]
-    #[case::scale_up_2_to_4(2, 4)]
-    #[tokio::test]
-    async fn run_continues_discovery_while_proof_tasks_are_in_flight(
-        #[case] initial_count: usize,
-        #[case] final_count: usize,
-    ) {
-        assert!(final_count > initial_count, "test case must scale up");
-        let harness = multi_healthy_harness(initial_count);
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("initial proof tasks parked in gate", || {
-            harness.proof.in_flight() == initial_count
-        })
-        .await;
-        let initial_call_count = harness.proof.call_count();
-
-        // Now scale up: add the new instances while the initial ones'
-        // proofs are still parked in the gate.
-        harness.discovery.set(
-            ALL_ENDPOINTS[..final_count]
-                .iter()
-                .map(|ep| instance(ep, InstanceHealthStatus::Healthy))
-                .collect(),
-        );
-
-        // Every new instance must enter the proof pipeline.
-        wait_for("all proof tasks spawned despite existing in-flight tasks", || {
-            harness.proof.in_flight() == final_count
-        })
-        .await;
-        let added = final_count - initial_count;
-        assert_eq!(
-            harness.proof.call_count() - initial_call_count,
-            added,
-            "newly-discovered instances must each have generated a proof"
-        );
-
-        // Release everything and let them register.
-        harness.proof.release_all();
-        wait_for("every instance registered", || {
-            count_register_calls(&harness.tx.sent_calldata()) == final_count
-        })
-        .await;
-
-        harness.shutdown(run_handle).await;
-    }
-
-    /// Reasons a healthy-looking input still produces no proof and no
-    /// registration tx, used to parametrize
-    /// [`run_does_not_register_when`].
-    #[derive(Debug, Clone, Copy)]
-    enum NoRegisterReason {
-        /// Instance is `Draining` — `should_register()` is `false`.
-        InstanceDraining,
-        /// Instance is `Unhealthy` with no recent launch time —
-        /// `should_register()` is `false` and the unhealthy-grace
-        /// window doesn't apply.
-        InstanceUnhealthy,
-        /// Instance is `Healthy` but the derived signer is already on the
-        /// onchain registry, so registration short-circuits in `is_registered()`.
-        SignerAlreadyRegistered,
-    }
-
-    /// Builds the (instance-list, registry) pair for each
-    /// [`NoRegisterReason`] case.
-    fn build_no_register_inputs(reason: NoRegisterReason) -> (Vec<ProverInstance>, MockRegistry) {
-        match reason {
-            NoRegisterReason::InstanceDraining => {
-                (vec![instance(EP1, InstanceHealthStatus::Draining)], empty_registry())
-            }
-            NoRegisterReason::InstanceUnhealthy => {
-                (vec![instance(EP1, InstanceHealthStatus::Unhealthy)], empty_registry())
-            }
-            NoRegisterReason::SignerAlreadyRegistered => {
-                let signer =
-                    ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-                (
-                    vec![instance(EP1, InstanceHealthStatus::Healthy)],
-                    MockRegistry::all_registered(vec![signer]),
-                )
-            }
-        }
-    }
-
-    #[rstest]
-    #[case::instance_draining(NoRegisterReason::InstanceDraining)]
-    #[case::instance_unhealthy_no_launch_time(NoRegisterReason::InstanceUnhealthy)]
-    #[case::signer_already_registered(NoRegisterReason::SignerAlreadyRegistered)]
-    #[tokio::test]
-    async fn run_does_not_register_when(#[case] reason: NoRegisterReason) {
-        // For every reason listed above, the pipeline must observe the
-        // instance (otherwise this test would pass trivially with a
-        // broken discovery loop) and then choose not to spawn a proof
-        // / not to submit a registration. The two `assert_eq!(0, …)`s
-        // are the same invariant — only the *reason* the input failed
-        // to register differs.
-        let (initial_instances, registry) = build_no_register_inputs(reason);
-        let harness = GatedRunHarness::new(initial_instances, &[(EP1, &HARDHAT_KEY_0)], registry);
-
-        let run_handle = harness.spawn_run();
-
-        // Let multiple cycles elapse so we can be confident the loop
-        // observed the instance and chose not to register.
-        tokio::time::sleep(GATED_POLL_INTERVAL * MIN_CYCLES_IN_OBSERVATION_WINDOW as u32).await;
-
-        assert_eq!(
-            harness.proof.call_count(),
-            0,
-            "generate_proof must not be called for reason: {reason:?}"
-        );
-        assert_eq!(
-            count_register_calls(&harness.tx.sent_calldata()),
-            0,
-            "no registration tx must be submitted for reason: {reason:?}"
-        );
-
-        harness.shutdown(run_handle).await;
-    }
-
-    #[tokio::test]
-    async fn run_deregisters_orphan_signer_via_orphan_pass() {
-        // No discovered instances → active_signers is empty →
-        // every onchain signer is an orphan. ok_to_dereg is true
-        // when total_count == 0, so the orphan pass fires and
-        // deregisters ORPHAN_A.
-        let harness = GatedRunHarness::new(vec![], &[], MockRegistry::with_signers(vec![ORPHAN_A]));
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("ORPHAN_A deregistered", || {
-            count_deregister_calls(&harness.tx.sent_calldata()) == 1
-        })
-        .await;
-
-        harness.shutdown(run_handle).await;
-
-        assert_eq!(harness.proof.call_count(), 0, "no proofs needed for orphan-only cycle");
-    }
-
-    #[tokio::test]
-    async fn run_drains_pending_proof_tasks_on_shutdown() {
-        // When the cancel token fires while a proof task is still
-        // parked in the gate, the shutdown path must cancel + abort
-        // the JoinSet and the task must terminate cleanly (Ok via the
-        // signer_cancel select! branch).
-        let harness = single_healthy_harness();
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("EP1 proof parked", || harness.proof.in_flight() == 1).await;
-
-        // Don't release the gate — let shutdown handle the cleanup.
-        harness.shutdown(run_handle).await;
-
-        let sent = harness.tx.sent_calldata();
-        assert_eq!(count_register_calls(&sent), 0, "no registration submitted at shutdown");
-    }
-
-    // ── run() additional coverage ─────────────────────────────────────
-
-    #[tokio::test]
-    async fn run_isolates_proof_failure_and_continues_pipeline_for_other_signers() {
-        // EP1's proof errors out; EP2's proof must still complete and
-        // submit a registration. This proves:
-        //   1. The failing task does not park the gate (EP1 errors
-        //      before the await in `generate_proof`), so the loop sees
-        //      exactly one in-flight task.
-        //   2. EP2's registration lands — the failing task did not
-        //      block the pipeline serially behind it.
-        //   3. The failed task is evicted from `pending`, so shutdown
-        //      drains cleanly within [`GATED_WAIT_TIMEOUT`].
-        //
-        // The failing signer's proof returns `Err` before the
-        // `tx_manager.send()` call in the registration manager, so it can never
-        // produce a `registerSigner` calldata frame — regardless of
-        // how many cycles re-spawn it under the static `MockRegistry`.
-        // Every entry in `count_register_calls` is therefore attributable
-        // to the surviving signer.
-        let harness = multi_healthy_harness(2);
-        let failing_signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let surviving_signer =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_1)).unwrap();
-        assert_ne!(failing_signer, surviving_signer, "test setup: distinct signer addresses");
-        harness.proof.fail_for_signers([failing_signer]);
-
-        let run_handle = harness.spawn_run();
-
-        // Only the surviving signer's task should park in the gate; the failing
-        // task errors immediately and returns from registration without awaiting.
-        wait_for("exactly one proof parked (failing signer errored before the gate)", || {
-            harness.proof.in_flight() == 1
-        })
-        .await;
-
-        // Release the gate so the surviving signer can register.
-        harness.proof.release_all();
-        wait_for("surviving signer registered while failing signer errored", || {
-            count_register_calls(&harness.tx.sent_calldata()) >= 1
-        })
-        .await;
-
-        harness.shutdown(run_handle).await;
-
-        // Final state: at least one registration landed, the gate
-        // observed exactly one parked task (asserted above), and no
-        // tasks are still in flight after shutdown.
-        assert_eq!(harness.proof.in_flight(), 0, "every parked proof returned by shutdown");
-    }
-
-    #[tokio::test]
-    async fn run_handles_orphan_dereg_and_active_registration_in_same_cycle() {
-        // Mixed-mode cycle: EP1 is healthy + unregistered (so it must
-        // register), while ORPHAN_A is already onchain but has no
-        // backing instance (so it must be deregistered). Both passes
-        // must run in the same cycle and both transactions must land.
-        let harness = GatedRunHarness::new(
-            vec![instance(EP1, InstanceHealthStatus::Healthy)],
-            &[(EP1, &HARDHAT_KEY_0)],
-            MockRegistry::with_signers(vec![ORPHAN_A]),
-        );
-
-        let run_handle = harness.spawn_run();
-
-        // Orphan dereg runs in the foreground each cycle; it must
-        // submit immediately without waiting for the proof gate.
-        wait_for("ORPHAN_A deregistered", || {
-            count_deregister_calls(&harness.tx.sent_calldata()) == 1
-        })
-        .await;
-
-        // EP1's proof is parked in the gate; releasing it must let
-        // the registration through alongside the already-completed
-        // dereg.
-        wait_for("EP1 proof parked", || harness.proof.in_flight() == 1).await;
-        harness.proof.release_all();
-        wait_for("EP1 registered", || count_register_calls(&harness.tx.sent_calldata()) == 1).await;
-
-        harness.shutdown(run_handle).await;
-
-        let sent = harness.tx.sent_calldata();
-        assert_eq!(count_register_calls(&sent), 1, "EP1 registration submitted exactly once");
-        assert_eq!(
-            count_deregister_calls(&sent),
-            1,
-            "ORPHAN_A deregistration submitted exactly once"
-        );
-    }
-
-    /// `unhealthy_registration_window` parametric test: an `Unhealthy`
-    /// instance whose `launch_time` falls *inside* the window must register via
-    /// the full `run()` pipeline; one whose `launch_time` falls *outside* the
-    /// window, or who has no `launch_time` at all, must not register.
-    #[rstest]
-    // Recently-launched unhealthy instance: should register.
-    #[case::recent_launch_registers(
-        Some(Duration::from_secs(60 * 10)),
-        true,
-    )]
-    // Old unhealthy instance well past the window: should NOT register.
-    #[case::old_launch_does_not_register(
-        Some(Duration::from_secs(60 * 60 * 24)),
-        false,
-    )]
-    // Unhealthy instance with no launch_time: cannot age-gate, so
-    // defaults to the safe path and does NOT register.
-    #[case::missing_launch_does_not_register(None, false)]
-    #[tokio::test]
-    async fn run_registers_unhealthy_only_within_grace_window(
-        #[case] age_below_now: Option<Duration>,
-        #[case] expect_registration: bool,
-    ) {
-        let launch_time = age_below_now.map(|age| SystemTime::now() - age);
-        let inst = instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time);
-        let harness = GatedRunHarness::new(vec![inst], &[(EP1, &HARDHAT_KEY_0)], empty_registry());
-
-        let run_handle = harness.spawn_run();
-
-        if expect_registration {
-            // Eligible instance: a proof task must park on the gate,
-            // then the registration must land once we release.
-            wait_for("eligible unhealthy proof parked in gate", || harness.proof.in_flight() == 1)
-                .await;
-            harness.proof.release_all();
-            wait_for("unhealthy-within-window signer registered", || {
-                count_register_calls(&harness.tx.sent_calldata()) >= 1
-            })
-            .await;
-        } else {
-            // Ineligible instance: give the loop at least a couple of
-            // cycles so a faulty short-circuit would have time to
-            // spawn a proof task and submit a tx. The gate stays
-            // unreleased — if anything parked we'd never reach the
-            // shutdown timeout below.
-            tokio::time::sleep(GATED_POLL_INTERVAL * MIN_CYCLES_IN_OBSERVATION_WINDOW as u32).await;
-            assert_eq!(
-                harness.proof.in_flight(),
-                0,
-                "ineligible unhealthy instance must not spawn a proof task"
-            );
-            assert!(
-                count_register_calls(&harness.tx.sent_calldata()) == 0,
-                "ineligible unhealthy instance must not register"
-            );
-        }
-
-        harness.shutdown(run_handle).await;
-    }
-
-    // NOTE on real-data fixtures: the pipeline tests above intentionally
-    // use the [`GatedProofProvider`] (which synthesises empty
-    // attestation-proof bytes) and the [`MockSignerClient`]'s default
-    // `b"mock-attestation"` byte string. The end-to-end run loop never
-    // parses these blobs in this test configuration: CRL pre-checks are
-    // disabled in [`default_config`], and `MockRegistry` does not verify
-    // calldata. The canonical 4-certificate chain from
-    // `crate::test_utils` is exercised separately and exhaustively by
-    // the cert manager tests, which target the actual cert-parsing code
-    // paths. Mixing real cert bytes into these orchestration tests would
-    // not exercise any additional code and would add ~3 KB of attestation
-    // byte literals to every test run.
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -652,21 +652,32 @@ mod tests {
         time::SystemTime,
     };
 
-    use alloy_primitives::Address;
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{Address, B256, Bloom, Bytes};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolCall;
     use async_trait::async_trait;
+    use base_proof_contracts::ITEEProverRegistry;
+    use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
+    use base_tx_manager::{SendHandle, TxCandidate};
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
     use crate::{
-        InstanceHealthStatus, Result, SignerClient,
+        InstanceHealthStatus, RegistryClient, Result, SignerClient, SignerManager,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
             NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
             prover_instance, public_key_from_private, signer_from_private_key,
         },
     };
+
+    const ALL_ENDPOINTS: [&str; 4] = [EP1, EP2, EP3, EP4];
+    const ALL_KEYS: [&[u8; 32]; 4] =
+        [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];
+    const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
     #[derive(Debug)]
     struct MockDiscovery {
@@ -677,6 +688,28 @@ mod tests {
     impl InstanceDiscovery for MockDiscovery {
         async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
             Ok(self.instances.clone())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct MutableDiscovery {
+        instances: Arc<Mutex<Vec<ProverInstance>>>,
+    }
+
+    impl MutableDiscovery {
+        fn new(initial: Vec<ProverInstance>) -> Self {
+            Self { instances: Arc::new(Mutex::new(initial)) }
+        }
+
+        fn set(&self, instances: Vec<ProverInstance>) {
+            *self.instances.lock().unwrap() = instances;
+        }
+    }
+
+    #[async_trait]
+    impl InstanceDiscovery for MutableDiscovery {
+        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
+            Ok(self.instances.lock().unwrap().clone())
         }
     }
 
@@ -752,12 +785,246 @@ mod tests {
         Url::parse(&format!("http://{host_port}")).unwrap()
     }
 
-    fn mock_cert_manager(
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    fn mock_cert_manager<T: TxManager + 'static>(
         config: &DriverConfig,
-        tx_manager: NoopTxManager,
-    ) -> CertManager<NoopTxManager> {
+        tx_manager: T,
+    ) -> CertManager<T> {
         CertManager::new(&config.crl, Arc::new(NoopNitroVerifier), tx_manager)
             .expect("test cert manager builds")
+    }
+
+    #[derive(Debug, Clone)]
+    struct MockRegistry;
+
+    #[async_trait]
+    impl RegistryClient for MockRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(vec![])
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct SharedTxManager {
+        sent: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl SharedTxManager {
+        fn new() -> Self {
+            Self { sent: Arc::new(Mutex::new(vec![])) }
+        }
+
+        fn sent_calldata(&self) -> Vec<Bytes> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl TxManager for SharedTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent.lock().unwrap().push(candidate.tx_data);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            unreachable!("driver tests do not submit async transactions")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    #[derive(Debug)]
+    struct GatedProofState {
+        release: CancellationToken,
+        call_count: AtomicUsize,
+        in_flight: AtomicUsize,
+    }
+
+    impl Default for GatedProofState {
+        fn default() -> Self {
+            Self {
+                release: CancellationToken::new(),
+                call_count: AtomicUsize::new(0),
+                in_flight: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct GatedProofProvider {
+        state: Arc<GatedProofState>,
+    }
+
+    impl GatedProofProvider {
+        fn new() -> (Self, GatedProofHandles) {
+            let state = Arc::new(GatedProofState::default());
+            (Self { state: Arc::clone(&state) }, GatedProofHandles { state })
+        }
+    }
+
+    #[async_trait]
+    impl AttestationProofProvider for GatedProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            self.state.call_count.fetch_add(1, Ordering::SeqCst);
+            self.state.in_flight.fetch_add(1, Ordering::SeqCst);
+
+            let result = tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
+                        "proof cancelled by test harness".into(),
+                    ))
+                }
+                () = self.state.release.cancelled() => {
+                    Ok(AttestationProof {
+                        output: Bytes::new(),
+                        proof_bytes: Bytes::from_static(b"gated-proof"),
+                    })
+                }
+            };
+            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+            result
+        }
+
+        async fn generate_proof_for_signer(
+            &self,
+            attestation_bytes: &[u8],
+            signer_address: Address,
+            cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            let mut proof = self.generate_proof(attestation_bytes, cancel).await?;
+            proof.output = Bytes::copy_from_slice(signer_address.as_slice());
+            Ok(proof)
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct GatedProofHandles {
+        state: Arc<GatedProofState>,
+    }
+
+    impl GatedProofHandles {
+        fn release_all(&self) {
+            self.state.release.cancel();
+        }
+
+        fn call_count(&self) -> usize {
+            self.state.call_count.load(Ordering::SeqCst)
+        }
+
+        fn in_flight(&self) -> usize {
+            self.state.in_flight.load(Ordering::SeqCst)
+        }
+    }
+
+    type RunDriver = RegistrationDriver<
+        MutableDiscovery,
+        MockSignerClient,
+        Arc<SignerManager<GatedProofProvider, MockRegistry, SharedTxManager>>,
+        SharedTxManager,
+    >;
+
+    #[derive(Debug)]
+    struct GatedRunHarness {
+        driver: Arc<RunDriver>,
+        cancel: CancellationToken,
+        discovery: MutableDiscovery,
+        proof: GatedProofHandles,
+        tx: SharedTxManager,
+    }
+
+    impl GatedRunHarness {
+        fn new(
+            initial_instances: Vec<ProverInstance>,
+            endpoints_to_keys: &[(&str, &[u8; 32])],
+        ) -> Self {
+            let discovery = MutableDiscovery::new(initial_instances);
+            let signer_client = MockSignerClient::from_keys(endpoints_to_keys);
+            let cancel = CancellationToken::new();
+            let mut config = default_config(cancel.clone());
+            config.poll_interval = FAST_POLL_INTERVAL;
+            let registry = MockRegistry;
+            let tx = SharedTxManager::new();
+            let (proof_provider, proof_handles) = GatedProofProvider::new();
+            let signer_manager = Arc::new(SignerManager::new(
+                proof_provider,
+                registry,
+                tx.clone(),
+                config.signer_manager.clone(),
+            ));
+            let cert_manager = mock_cert_manager(&config, tx.clone());
+            let driver = Arc::new(RegistrationDriver::new(
+                discovery.clone(),
+                signer_client,
+                config,
+                cert_manager,
+                signer_manager,
+            ));
+
+            Self { driver, cancel, discovery, proof: proof_handles, tx }
+        }
+
+        fn spawn_run(&self) -> tokio::task::JoinHandle<Result<()>> {
+            let driver = Arc::clone(&self.driver);
+            tokio::spawn(async move { driver.run_loop().await })
+        }
+
+        async fn shutdown(&self, handle: tokio::task::JoinHandle<Result<()>>) {
+            self.cancel.cancel();
+            let outcome = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
+                .await
+                .expect("run loop should observe cancellation")
+                .expect("run loop task should not panic");
+            outcome.expect("run loop should stop cleanly");
+        }
+    }
+
+    async fn wait_for(label: &str, predicate: impl Fn() -> bool) {
+        let started = std::time::Instant::now();
+        while !predicate() {
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("timed out waiting for: {label}");
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    fn count_register_calls(sent: &[Bytes]) -> usize {
+        let sel = ITEEProverRegistry::registerSignerCall::SELECTOR;
+        sent.iter().filter(|c| c.starts_with(&sel)).count()
     }
 
     #[derive(Debug, Clone)]
@@ -882,6 +1149,56 @@ mod tests {
             orphan_inputs[0].contains(&signer),
             "driver passes active signer set into orphan protection",
         );
+    }
+
+    #[rstest]
+    #[case::one_instance(1)]
+    #[case::two_instances(2)]
+    #[tokio::test]
+    async fn run_loop_registers_each_discovered_enclave(#[case] num_instances: usize) {
+        let keys: Vec<(&str, &[u8; 32])> =
+            ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
+        let instances: Vec<_> =
+            ALL_ENDPOINTS[..num_instances].iter().map(|ep| healthy_prover_instance(ep)).collect();
+        let harness = GatedRunHarness::new(instances, &keys);
+
+        let run_handle = harness.spawn_run();
+
+        wait_for("every proof task parked in gate", || harness.proof.in_flight() == num_instances)
+            .await;
+        harness.proof.release_all();
+        wait_for("every registerSigner transaction submitted", || {
+            count_register_calls(&harness.tx.sent_calldata()) == num_instances
+        })
+        .await;
+        harness.shutdown(run_handle).await;
+
+        assert_eq!(harness.proof.call_count(), num_instances, "exactly one proof per enclave");
+    }
+
+    #[tokio::test]
+    async fn run_loop_continues_discovery_while_proofs_are_in_flight() {
+        let keys: Vec<(&str, &[u8; 32])> =
+            ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
+        let harness = GatedRunHarness::new(vec![healthy_prover_instance(EP1)], &keys);
+
+        let run_handle = harness.spawn_run();
+
+        wait_for("initial proof task parked in gate", || harness.proof.in_flight() == 1).await;
+        harness.discovery.set(vec![healthy_prover_instance(EP1), healthy_prover_instance(EP2)]);
+        wait_for("newly discovered proof task parked while first proof is still in flight", || {
+            harness.proof.in_flight() == 2
+        })
+        .await;
+
+        harness.proof.release_all();
+        wait_for("both registerSigner transactions submitted", || {
+            count_register_calls(&harness.tx.sent_calldata()) == 2
+        })
+        .await;
+        harness.shutdown(run_handle).await;
+
+        assert_eq!(harness.proof.call_count(), 2, "new signer must not wait for old proof");
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -652,20 +652,19 @@ mod tests {
         time::SystemTime,
     };
 
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::Address;
     use async_trait::async_trait;
-    use base_tx_manager::{SendHandle, TxCandidate, TxManager};
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
     use crate::{
-        InstanceHealthStatus, NitroVerifierClient, Result, SignerClient,
+        InstanceHealthStatus, Result, SignerClient,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
-            TEST_REGISTRY_ADDRESS, healthy_prover_instance, prover_instance,
-            public_key_from_private, signer_from_private_key,
+            NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
+            prover_instance, public_key_from_private, signer_from_private_key,
         },
     };
 
@@ -773,51 +772,12 @@ mod tests {
         }
     }
 
-    /// Mock Nitro verifier used to satisfy the driver's required certificate
-    /// manager dependency in tests that do not exercise CRL checks.
-    #[derive(Debug)]
-    struct MockNitroVerifier;
-
-    #[async_trait]
-    impl NitroVerifierClient for MockNitroVerifier {
-        fn address(&self) -> Address {
-            Address::ZERO
-        }
-
-        async fn is_revoked(&self, _cert_hash: B256) -> Result<bool> {
-            Ok(false)
-        }
-    }
-
-    fn mock_nitro_verifier() -> Arc<dyn NitroVerifierClient> {
-        Arc::new(MockNitroVerifier)
-    }
-
     fn mock_cert_manager(
         config: &DriverConfig,
         tx_manager: NoopTxManager,
     ) -> CertManager<NoopTxManager> {
-        CertManager::new(&config.crl, mock_nitro_verifier(), tx_manager)
+        CertManager::new(&config.crl, Arc::new(NoopNitroVerifier), tx_manager)
             .expect("test cert manager builds")
-    }
-
-    /// Minimal tx manager used only to satisfy the driver's certificate-manager
-    /// dependency in tests that do not exercise transaction submission.
-    #[derive(Debug, Clone, Copy)]
-    struct NoopTxManager;
-
-    impl TxManager for NoopTxManager {
-        async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            unreachable!("driver tests do not submit transactions")
-        }
-
-        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-            unimplemented!("not used in driver tests")
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
-        }
     }
 
     /// Driver-level signer lifecycle mock. It records calls without running
@@ -1014,12 +974,6 @@ mod tests {
         assert!(!resolution.ok_to_dereg, "cancellation must clear ok_to_dereg",);
     }
 
-    /// All 4 endpoints and corresponding private keys, indexed for
-    /// dynamic slicing in the concurrency test.
-    const ALL_ENDPOINTS: [&str; 4] = [EP1, EP2, EP3, EP4];
-    const ALL_KEYS: [&[u8; 32]; 4] =
-        [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];
-
     #[tokio::test]
     async fn discover_and_resolve_includes_all_reachable_when_one_instance_is_unreachable() {
         // An unreachable instance must not prevent other instances from
@@ -1057,73 +1011,6 @@ mod tests {
             "unreachable instance must be marked as unresolved so reconcile skips its cancel-pass",
         );
         assert!(!resolution.ok_to_dereg, "unresolved instance must block orphan-dereg",);
-    }
-
-    /// Signer client wrapper that cancels a token after returning keys.
-    ///
-    /// Delegates to an inner [`MockSignerClient`] for actual key/attestation
-    /// data, but cancels the given [`CancellationToken`] after the first
-    /// successful `signer_public_key` call. This simulates cancellation
-    /// occurring mid-cycle (after instance processing begins but before
-    /// orphan deregistration).
-    #[derive(Debug)]
-    struct CancellingSignerClient {
-        inner: MockSignerClient,
-        cancel: CancellationToken,
-    }
-
-    #[async_trait]
-    impl SignerClient for CancellingSignerClient {
-        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            let result = self.inner.signer_public_key(endpoint).await;
-            if result.is_ok() {
-                self.cancel.cancel();
-            }
-            result
-        }
-
-        async fn signer_attestation(
-            &self,
-            endpoint: &Url,
-            user_data: Option<Vec<u8>>,
-            nonce: Option<Vec<u8>>,
-        ) -> Result<Vec<Vec<u8>>> {
-            self.inner.signer_attestation(endpoint, user_data, nonce).await
-        }
-    }
-
-    #[tokio::test]
-    async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_mid_resolution() {
-        // Cancellation observed during instance resolution must drive
-        // `ok_to_dereg = false` so the production caller skips
-        // `run_orphan_dereg` entirely. `CancellingSignerClient` cancels
-        // the shared token as a side effect of `signer_public_key`,
-        // simulating a shutdown signal arriving mid-cycle.
-        let instances = vec![healthy_prover_instance(EP1)];
-
-        let cancel = CancellationToken::new();
-
-        let signer_client = CancellingSignerClient {
-            inner: MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
-            cancel: cancel.clone(),
-        };
-        let config = default_config(cancel);
-        let signer_manager = MockSignerManager::new(CancellationToken::new());
-        let cert_manager = mock_cert_manager(&config, NoopTxManager);
-
-        let driver = RegistrationDriver::new(
-            MockDiscovery { instances },
-            signer_client,
-            config,
-            cert_manager,
-            signer_manager,
-        );
-
-        let resolution = driver.discover_and_resolve().await.unwrap();
-        assert!(
-            !resolution.ok_to_dereg,
-            "cancellation observed during resolution must clear ok_to_dereg",
-        );
     }
 
     #[tokio::test]
@@ -1273,20 +1160,19 @@ mod tests {
         }
     }
 
-    #[rstest]
-    #[case::serial(1)]
-    #[case::limited(2)]
     #[tokio::test]
-    async fn discover_and_resolve_respects_max_concurrency(#[case] max_concurrency: usize) {
+    async fn discover_and_resolve_respects_max_concurrency() {
         // Resolve 4 instances with a limited `max_concurrency` and verify
         // the peak concurrent `signer_public_key` count observed inside
         // `discover_and_resolve`'s `buffer_unordered` loop never exceeds
         // the configured bound. All 4 must end up in `registerable`.
-        let instances: Vec<_> =
-            ALL_ENDPOINTS.iter().map(|ep| healthy_prover_instance(ep)).collect();
+        let max_concurrency = 2;
+        let endpoints = [EP1, EP2, EP3, EP4];
+        let private_keys = [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];
 
         let keys: Vec<(&str, &[u8; 32])> =
-            ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
+            endpoints.iter().copied().zip(private_keys.iter().copied()).collect();
+        let instances: Vec<_> = endpoints.iter().map(|ep| healthy_prover_instance(ep)).collect();
         let inner = MockSignerClient::from_keys(&keys);
         let (signer_client, peak) = ConcurrencyTrackingSignerClient::new(inner);
 
@@ -1313,7 +1199,7 @@ mod tests {
         );
         assert_eq!(
             resolution.registerable.len(),
-            ALL_ENDPOINTS.len(),
+            endpoints.len(),
             "all 4 healthy instances should resolve into the registerable set",
         );
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -655,7 +655,7 @@ mod tests {
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
     use alloy_primitives::{Address, B256, Bloom, Bytes};
     use alloy_rpc_types_eth::TransactionReceipt;
-    use alloy_sol_types::SolCall;
+    use alloy_sol_types::SolCall as _;
     use async_trait::async_trait;
     use base_proof_contracts::ITEEProverRegistry;
     use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
@@ -879,6 +879,23 @@ mod tests {
         }
     }
 
+    struct InFlightGuard {
+        state: Arc<GatedProofState>,
+    }
+
+    impl InFlightGuard {
+        fn new(state: Arc<GatedProofState>) -> Self {
+            state.in_flight.fetch_add(1, Ordering::SeqCst);
+            Self { state }
+        }
+    }
+
+    impl Drop for InFlightGuard {
+        fn drop(&mut self) {
+            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
     #[derive(Debug, Clone)]
     struct GatedProofProvider {
         state: Arc<GatedProofState>,
@@ -899,7 +916,7 @@ mod tests {
             cancel: &CancellationToken,
         ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
             self.state.call_count.fetch_add(1, Ordering::SeqCst);
-            self.state.in_flight.fetch_add(1, Ordering::SeqCst);
+            let _guard = InFlightGuard::new(Arc::clone(&self.state));
 
             let result = tokio::select! {
                 biased;
@@ -915,7 +932,6 @@ mod tests {
                     })
                 }
             };
-            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
             result
         }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -703,10 +703,6 @@ mod tests {
     /// Synthetic orphan addresses for deregistration tests.
     /// Each uses `Address::repeat_byte` for deterministic, readable values.
     const ORPHAN_A: Address = Address::repeat_byte(0xAA);
-    const ORPHAN_B: Address = Address::repeat_byte(0xBB);
-    const ORPHAN_C: Address = Address::repeat_byte(0xCC);
-    const ORPHAN_D: Address = Address::repeat_byte(0xDD);
-    const ORPHAN_E: Address = Address::repeat_byte(0xEE);
 
     /// Placeholder registry contract address used in `DriverConfig`.
     const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
@@ -805,23 +801,6 @@ mod tests {
                 output: Bytes::from_static(b"stub-output"),
                 proof_bytes: Bytes::from_static(b"stub-proof"),
             })
-        }
-    }
-
-    /// Mock proof provider that always fails, simulating Boundless errors.
-    #[derive(Debug)]
-    struct FailingProofProvider;
-
-    #[async_trait]
-    impl AttestationProofProvider for FailingProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            _cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
-                "simulated proof failure".into(),
-            ))
         }
     }
 
@@ -1084,31 +1063,21 @@ mod tests {
         }
     }
 
-    type CycleDriver = RegistrationDriver<
-        MockDiscovery,
-        MockSignerClient,
-        Arc<SignerManager<StubProofProvider, MockRegistry, SharedTxManager>>,
-        SharedTxManager,
-    >;
+    type CycleDriver =
+        RegistrationDriver<MockDiscovery, MockSignerClient, MockSignerManager, SharedTxManager>;
 
     /// Builds a fully-configured driver for primitive-level tests that
-    /// invoke `discover_and_resolve` and `run_orphan_dereg` directly
-    /// (rather than the spawn pipeline in `run`). Returns an `Arc` so tests
-    /// that spawn the run loop can keep handles for state inspection.
+    /// invoke `discover_and_resolve` directly, without standing up the
+    /// production signer lifecycle. Returns an `Arc` so tests that spawn
+    /// the run loop can keep handles for state inspection.
     fn cycle_driver(
         instances: Vec<ProverInstance>,
         signer_client: MockSignerClient,
-        registry: MockRegistry,
-        tx: SharedTxManager,
         cancel: CancellationToken,
     ) -> Arc<CycleDriver> {
         let config = default_config(cancel);
-        let signer_manager = Arc::new(SignerManager::new(
-            StubProofProvider,
-            registry,
-            tx.clone(),
-            config.signer_manager.clone(),
-        ));
+        let tx = SharedTxManager::new();
+        let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, tx);
         Arc::new(RegistrationDriver::new(
             MockDiscovery { instances },
@@ -1124,12 +1093,7 @@ mod tests {
         let mut config = default_config(CancellationToken::new());
         config.crl.enabled = true;
         let tx = SharedTxManager::new();
-        let signer_manager = Arc::new(SignerManager::new(
-            StubProofProvider,
-            MockRegistry::with_signers(vec![]),
-            tx.clone(),
-            config.signer_manager.clone(),
-        ));
+        let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, tx);
 
         RegistrationDriver::new(
@@ -1495,12 +1459,8 @@ mod tests {
 
     #[tokio::test]
     async fn discover_and_resolve_admits_recently_launched_unhealthy_to_active_and_registerable() {
-        // A recently-launched Unhealthy instance must (1) be included in
-        // `registerable` (the recent-launch exception in
-        // `is_recently_launched_unhealthy`), and (2) contribute its
-        // signer to `active_signers` (preventing premature
-        // deregistration). The orphan-dereg pass over the active set
-        // must NOT touch the signer even though it's already onchain.
+        // A recently-launched Unhealthy instance must be included in
+        // `registerable` and contribute its signer to `active_signers`.
         let addr = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
         let launch_time = Some(SystemTime::now() - Duration::from_secs(300));
 
@@ -1508,13 +1468,9 @@ mod tests {
             instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time);
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
 
-        let tx = SharedTxManager::new();
         let driver = cycle_driver(
             vec![instance_under_test.clone()],
             signer_client,
-            // addr is already onchain; without active_signers protection it would be deregistered.
-            MockRegistry::with_signers(vec![addr]),
-            tx.clone(),
             CancellationToken::new(),
         );
 
@@ -1530,31 +1486,14 @@ mod tests {
             "recently-launched unhealthy signer should be in active_signers"
         );
         assert!(resolution.ok_to_dereg, "single reachable instance clears the majority guard");
-
-        // Orphan-dereg pass must not deregister the signer (it's in active_signers).
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "already-registered signer should not be deregistered"
-        );
     }
 
-    // ── discover_and_resolve + run_orphan_dereg tests ──────────────────
+    // ── discover_and_resolve tests ─────────────────────────────────────
 
     #[tokio::test]
     async fn discover_and_resolve_allows_orphan_pass_when_discovery_is_empty() {
-        let driver = cycle_driver(
-            vec![],
-            MockSignerClient::from_keys(&[]),
-            MockRegistry::with_signers(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C]),
-            SharedTxManager::new(),
-            CancellationToken::new(),
-        );
+        let driver =
+            cycle_driver(vec![], MockSignerClient::from_keys(&[]), CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert!(resolution.active_signers.is_empty(), "no instances → no active signers");
@@ -1578,14 +1517,7 @@ mod tests {
 
         // Only EP1 has a key; the other two will fail signer_public_key.
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            MockRegistry::all_registered(vec![ORPHAN_B]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
 
@@ -1595,8 +1527,6 @@ mod tests {
             !resolution.ok_to_dereg,
             "1/3 reachable: majority guard should block orphan-dereg pass",
         );
-        // Resolution itself sends no onchain tx (no CRL revocation).
-        assert!(tx.sent_calldata().is_empty(), "discover_and_resolve must not send txs");
     }
 
     #[tokio::test]
@@ -1614,15 +1544,7 @@ mod tests {
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
 
         let cancel = CancellationToken::new();
-        let tx = SharedTxManager::new();
-
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            MockRegistry::all_registered(vec![ORPHAN_C]),
-            tx.clone(),
-            cancel.clone(),
-        );
+        let driver = cycle_driver(instances, signer_client, cancel.clone());
 
         cancel.cancel();
         let resolution = driver.discover_and_resolve().await.unwrap();
@@ -1631,35 +1553,16 @@ mod tests {
             !resolution.ok_to_dereg,
             "cancellation must clear ok_to_dereg even if majority guard would pass",
         );
-        // And `run_orphan_dereg` itself is cancel-aware — call it
-        // directly to confirm it bails out without loading the registry.
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-        assert!(tx.sent_calldata().is_empty(), "no txs should be sent after cancellation");
     }
 
     #[tokio::test]
     async fn discover_and_resolve_admits_draining_instance_to_active_only_not_registerable() {
         // A draining instance must contribute its signer to
-        // `active_signers` (protecting it from orphan-dereg) but must
-        // NOT appear in `registerable`. The orphan-dereg pass over the
-        // active set then must not deregister the onchain signer.
+        // `active_signers` but must NOT appear in `registerable`.
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
         let instances = vec![instance(EP1, InstanceHealthStatus::Draining)];
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            // The derived address for HARDHAT_KEY_0 is already onchain,
-            // so it should NOT be deregistered.
-            MockRegistry::with_signers(vec![HARDHAT_ACCOUNT]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert!(
@@ -1671,15 +1574,6 @@ mod tests {
             "draining instance must contribute its signer to active_signers",
         );
         assert!(resolution.ok_to_dereg, "single reachable instance clears the majority guard");
-
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        // No registration (draining) and no deregistration (signer is active).
-        assert!(tx.sent_calldata().is_empty());
     }
 
     // ── Reachability guard boundary tests ────────────────────────────────
@@ -1712,10 +1606,8 @@ mod tests {
     ) {
         // All 4 instances are discovered; only `reachable_count` have keys
         // in the MockSignerClient (the rest will fail signer_public_key).
-        // Verify `ok_to_dereg` remains false while any discovered instance
-        // is unresolved, and that the downstream `run_orphan_dereg` pass
-        // emits calldata only when every instance resolves and the majority
-        // guard clears.
+        // Verify `ok_to_dereg` remains false while the majority guard
+        // does not clear.
         let instances: Vec<_> =
             ALL_ENDPOINTS.iter().map(|ep| instance(ep, InstanceHealthStatus::Healthy)).collect();
 
@@ -1726,16 +1618,7 @@ mod tests {
             .collect();
         let signer_client = MockSignerClient::from_keys(&keys);
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            // All reachable signers already registered, so no registration txs.
-            // The orphan is onchain — deregistered only if guard passes.
-            MockRegistry::all_registered(vec![ORPHAN_D]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert_eq!(resolution.reachable_count, reachable_count);
@@ -1744,25 +1627,6 @@ mod tests {
             resolution.ok_to_dereg, !should_skip_deregistration,
             "{reachable_count}/4 reachable: ok_to_dereg mismatch"
         );
-
-        if resolution.ok_to_dereg {
-            driver
-                .signer_manager
-                .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-                .await
-                .unwrap();
-            let sent = tx.sent_calldata();
-            assert_eq!(sent.len(), 1, "{reachable_count}/4 reachable: should deregister orphan");
-            let expected =
-                ITEEProverRegistry::deregisterSignerCall { signer: ORPHAN_D }.abi_encode();
-            assert_eq!(sent[0], Bytes::from(expected));
-        } else {
-            // Production caller would skip run_orphan_dereg entirely.
-            assert!(
-                tx.sent_calldata().is_empty(),
-                "{reachable_count}/4 reachable: majority guard should skip deregistration",
-            );
-        }
     }
 
     #[tokio::test]
@@ -1789,15 +1653,7 @@ mod tests {
             (EP3, &HARDHAT_KEY_2),
         ]);
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            // No signers registered yet → all three reachable signers are registerable.
-            MockRegistry::with_signers(vec![]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert_eq!(
@@ -1814,8 +1670,6 @@ mod tests {
             !resolution.ok_to_dereg,
             "unresolved instance must block orphan-dereg even when reachable majority clears",
         );
-
-        assert!(tx.sent_calldata().is_empty(), "discovery resolution must not send txs");
     }
 
     /// Signer client wrapper that cancels a token after returning keys.
@@ -1868,12 +1722,7 @@ mod tests {
             cancel: cancel.clone(),
         };
         let config = default_config(cancel);
-        let signer_manager = Arc::new(SignerManager::new(
-            StubProofProvider,
-            MockRegistry::all_registered(vec![ORPHAN_E]),
-            tx.clone(),
-            config.signer_manager.clone(),
-        ));
+        let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, tx.clone());
 
         let driver = Arc::new(RegistrationDriver::new(
@@ -1889,42 +1738,21 @@ mod tests {
             !resolution.ok_to_dereg,
             "cancellation observed during resolution must clear ok_to_dereg",
         );
-        // run_orphan_dereg is cancel-aware — call it to confirm it bails
-        // out without loading the registry or sending any tx.
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "mid-cycle cancellation should prevent any orphan deregistration",
-        );
     }
 
     #[tokio::test]
     async fn discover_and_resolve_multi_enclave_draining_protects_all_signers_from_deregistration()
     {
         // A draining multi-enclave instance must contribute ALL of its
-        // signer addresses to `active_signers`, preventing orphan
-        // deregistration for each — and must not appear in
-        // `registerable` (draining → registration skipped).
+        // signer addresses to `active_signers` and must not appear in
+        // `registerable`.
         let addr0 = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
         let addr1 = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_1)).unwrap();
 
         let instances = vec![instance(EP1, InstanceHealthStatus::Draining)];
         let signer_client = MockSignerClient::multi_enclave(EP1, &[&HARDHAT_KEY_0, &HARDHAT_KEY_1]);
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            // Both signers are onchain — without active_signers protection
-            // they would be deregistered as orphans.
-            MockRegistry::with_signers(vec![addr0, addr1]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert!(
@@ -1934,19 +1762,6 @@ mod tests {
         assert!(resolution.active_signers.contains(&addr0));
         assert!(resolution.active_signers.contains(&addr1));
         assert!(resolution.ok_to_dereg);
-
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        // No registration (draining) and no deregistration (both signers
-        // are in active_signers).
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "draining multi-enclave instance should protect all signers from deregistration",
-        );
     }
 
     #[tokio::test]
@@ -1973,16 +1788,7 @@ mod tests {
         let signer_client =
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            instances,
-            signer_client,
-            // The unhealthy signer is onchain. Without active_signers protection it would be
-            // deregistered.
-            MockRegistry::with_signers(vec![addr_unhealthy]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert_eq!(resolution.reachable_count, 2, "both instances respond to RPC");
@@ -1997,17 +1803,6 @@ mod tests {
             "unhealthy signer must remain in active_signers to block dereg",
         );
         assert!(resolution.ok_to_dereg);
-
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "orphan pass must not deregister the unhealthy signer",
-        );
     }
 
     #[tokio::test]
@@ -2024,14 +1819,7 @@ mod tests {
         let signer_client =
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestations(EP1, vec![]);
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            vec![inst.clone()],
-            signer_client,
-            MockRegistry::with_signers(vec![signer_addr]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
 
@@ -2048,17 +1836,6 @@ mod tests {
             "partial resolution must preserve in-flight tasks for the instance",
         );
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
-
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "orphan pass must not deregister a signer advertised by a partially resolved instance",
-        );
     }
 
     #[tokio::test]
@@ -2072,14 +1849,7 @@ mod tests {
         let signer_client =
             MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestation_failure(EP1);
 
-        let tx = SharedTxManager::new();
-        let driver = cycle_driver(
-            vec![inst.clone()],
-            signer_client,
-            MockRegistry::with_signers(vec![signer_addr]),
-            tx.clone(),
-            CancellationToken::new(),
-        );
+        let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
 
         let resolution = driver.discover_and_resolve().await.unwrap();
 
@@ -2087,78 +1857,6 @@ mod tests {
         assert!(resolution.registerable.is_empty());
         assert!(resolution.unresolved_instance_ids.contains(&inst.instance_id));
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
-
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "attestation RPC failures must not orphan a signer whose public key resolved",
-        );
-    }
-
-    #[tokio::test]
-    async fn discover_and_resolve_does_not_invoke_proof_provider_so_active_set_survives_outage() {
-        // Under the spawn pipeline, proof generation runs only inside
-        // spawned `run_proof_task` futures — `discover_and_resolve`
-        // never touches the proof provider. So a complete Boundless
-        // outage cannot empty `active_signers` and cannot trigger
-        // orphan-dereg of a still-running signer.
-        //
-        // Asserted via `FailingProofProvider`: if `discover_and_resolve`
-        // ever invoked it, the resolution would error (or skip the
-        // signer); instead the signer must land in `active_signers` and
-        // `run_orphan_dereg` must emit no deregistration tx for the
-        // onchain signer.
-        let signer_addr =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-
-        let instances = vec![instance(EP1, InstanceHealthStatus::Healthy)];
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-
-        let tx = SharedTxManager::new();
-        let config = default_config(CancellationToken::new());
-        let signer_manager = Arc::new(SignerManager::new(
-            FailingProofProvider,
-            MockRegistry::with_signers(vec![signer_addr]),
-            tx.clone(),
-            config.signer_manager.clone(),
-        ));
-        let cert_manager = mock_cert_manager(&config, tx.clone());
-        let driver = Arc::new(RegistrationDriver::new(
-            MockDiscovery { instances },
-            signer_client,
-            config,
-            cert_manager,
-            signer_manager,
-        ));
-
-        let resolution = driver.discover_and_resolve().await.unwrap();
-        assert!(
-            resolution.active_signers.contains(&signer_addr),
-            "signer must remain in active_signers even with a failing proof provider",
-        );
-        assert_eq!(
-            resolution.registerable.len(),
-            1,
-            "registerable list is computed without invoking the proof provider",
-        );
-
-        driver
-            .signer_manager
-            .run_orphan_dereg(&resolution.active_signers, &driver.config.cancel)
-            .await
-            .unwrap();
-
-        // No deregistration tx (signer is in active_signers despite the
-        // proof failure path being possible downstream).
-        assert!(
-            tx.sent_calldata().is_empty(),
-            "proof-provider failures must not cause deregistration of the signer",
-        );
     }
 
     // ── Concurrency limit test ──────────────────────────────────────────
@@ -2254,8 +1952,6 @@ mod tests {
             ALL_ENDPOINTS.len(),
             "all 4 healthy instances should resolve into the registerable set",
         );
-        // Resolution itself emits no onchain tx — the spawn pass owns registration.
-        assert!(tx.sent_calldata().is_empty(), "discover_and_resolve must not send txs");
     }
 
     // ── run() spawn-and-reap pipeline tests ─────────────────────────────

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -653,7 +653,7 @@ mod tests {
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom, address};
+    use alloy_primitives::{Address, B256, Bloom};
     use alloy_rpc_types_eth::TransactionReceipt;
     use async_trait::async_trait;
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
@@ -667,9 +667,6 @@ mod tests {
     use crate::{InstanceHealthStatus, NitroVerifierClient, Result, SignerClient};
 
     // ── Shared constants ────────────────────────────────────────────────
-
-    /// Well-known Hardhat / Anvil account #0 address.
-    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
     /// Well-known Hardhat / Anvil account #0 private key.
     const HARDHAT_KEY_0: [u8; 32] =
@@ -1119,27 +1116,6 @@ mod tests {
         assert!(!resolution.ok_to_dereg, "cancellation must clear ok_to_dereg",);
     }
 
-    #[tokio::test]
-    async fn discover_and_resolve_admits_draining_instance_to_active_only_not_registerable() {
-        // A draining instance must contribute its signer to
-        // `active_signers` but must NOT appear in `registerable`.
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let instances = vec![instance(EP1, InstanceHealthStatus::Draining)];
-
-        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
-
-        let resolution = driver.discover_and_resolve().await.unwrap();
-        assert!(
-            resolution.registerable.is_empty(),
-            "draining instance must not be in the registerable set",
-        );
-        assert!(
-            resolution.active_signers.contains(&HARDHAT_ACCOUNT),
-            "draining instance must contribute its signer to active_signers",
-        );
-        assert!(resolution.ok_to_dereg, "resolved instance permits orphan cleanup");
-    }
-
     /// All 4 endpoints and corresponding private keys, indexed for
     /// dynamic slicing in the concurrency test.
     const ALL_ENDPOINTS: [&str; 4] = [EP1, EP2, EP3, EP4];
@@ -1315,19 +1291,27 @@ mod tests {
         assert!(resolution.ok_to_dereg);
     }
 
+    #[rstest]
+    #[case::mismatch(false)]
+    #[case::rpc_error(true)]
     #[tokio::test]
-    async fn discover_and_resolve_attestation_mismatch_keeps_signer_active_and_unresolved() {
+    async fn discover_and_resolve_attestation_failure_keeps_signer_active_and_unresolved(
+        #[case] rpc_error: bool,
+    ) {
         // If the registrar reaches signer_public_key successfully but
-        // then cannot pair an attestation with the signer, the instance
-        // is still reachable and advertising that signer. The signer
-        // must remain protected from orphan deregistration, while the
-        // instance is marked unresolved so any in-flight proof task is
+        // then cannot fetch or pair an attestation with the signer, the
+        // instance is still reachable and advertising that signer. The
+        // signer must remain protected from orphan deregistration, while
+        // the instance is marked unresolved so any in-flight proof task is
         // preserved for a later conclusive cycle.
         let signer_addr =
             ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
         let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let signer_client =
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestations(EP1, vec![]);
+        let signer_client = if rpc_error {
+            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestation_failure(EP1)
+        } else {
+            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestations(EP1, vec![])
+        };
 
         let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
 
@@ -1345,27 +1329,6 @@ mod tests {
             resolution.unresolved_instance_ids.contains(&inst.instance_id),
             "partial resolution must preserve in-flight tasks for the instance",
         );
-        assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
-    }
-
-    #[tokio::test]
-    async fn discover_and_resolve_attestation_error_keeps_signer_active_and_unresolved() {
-        // This is the production-shaped variant of the previous test:
-        // public key resolution succeeds, but the attestation RPC itself
-        // fails. The signer must still be protected from orphan dereg.
-        let signer_addr =
-            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
-        let inst = instance(EP1, InstanceHealthStatus::Healthy);
-        let signer_client =
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestation_failure(EP1);
-
-        let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
-
-        let resolution = driver.discover_and_resolve().await.unwrap();
-
-        assert!(resolution.active_signers.contains(&signer_addr));
-        assert!(resolution.registerable.is_empty());
-        assert!(resolution.unresolved_instance_ids.contains(&inst.instance_id));
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
     }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -828,14 +828,14 @@ mod tests {
         }
     }
 
-    type CycleDriver =
-        RegistrationDriver<MockDiscovery, MockSignerClient, MockSignerManager, NoopTxManager>;
-
-    fn cycle_driver(
+    fn cycle_driver<S>(
         instances: Vec<ProverInstance>,
-        signer_client: MockSignerClient,
+        signer_client: S,
         cancel: CancellationToken,
-    ) -> CycleDriver {
+    ) -> RegistrationDriver<MockDiscovery, S, MockSignerManager, NoopTxManager>
+    where
+        S: SignerClient + 'static,
+    {
         let config = default_config(cancel);
         let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
@@ -942,6 +942,66 @@ mod tests {
         let resolution = driver.discover_and_resolve().await.unwrap();
 
         assert!(!resolution.ok_to_dereg, "cancellation must clear ok_to_dereg",);
+    }
+
+    #[derive(Debug)]
+    struct CancellingSignerClient {
+        inner: MockSignerClient,
+        cancel: CancellationToken,
+    }
+
+    #[async_trait]
+    impl SignerClient for CancellingSignerClient {
+        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
+            let result = self.inner.signer_public_key(endpoint).await;
+            if result.is_ok() {
+                self.cancel.cancel();
+            }
+            result
+        }
+
+        async fn signer_attestation(
+            &self,
+            endpoint: &Url,
+            user_data: Option<Vec<u8>>,
+            nonce: Option<Vec<u8>>,
+        ) -> Result<Vec<Vec<u8>>> {
+            self.inner.signer_attestation(endpoint, user_data, nonce).await
+        }
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_mid_resolution() {
+        let cancel = CancellationToken::new();
+        let signer_client = CancellingSignerClient {
+            inner: MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
+            cancel: cancel.clone(),
+        };
+        let driver = cycle_driver(vec![healthy_prover_instance(EP1)], signer_client, cancel);
+
+        let resolution = driver.discover_and_resolve().await.unwrap();
+
+        assert!(
+            !resolution.ok_to_dereg,
+            "cancellation observed during resolution must clear ok_to_dereg",
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_majority_unreachable_clears_ok_to_dereg() {
+        let instances = vec![
+            healthy_prover_instance(EP1),
+            healthy_prover_instance(EP2),
+            healthy_prover_instance(EP3),
+        ];
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
+
+        let resolution = driver.discover_and_resolve().await.unwrap();
+
+        assert_eq!(resolution.reachable_count, 1);
+        assert_eq!(resolution.total_count, 3);
+        assert!(!resolution.ok_to_dereg, "1/3 reachable must block orphan-deregistration",);
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -1134,15 +1134,7 @@ mod tests {
         }
     }
 
-    struct StallingRegistry {
-        signers: Vec<Address>,
-    }
-
-    impl StallingRegistry {
-        fn stalling_get_registered_signers(signers: Vec<Address>) -> Self {
-            Self { signers }
-        }
-    }
+    struct StallingRegistry;
 
     #[async_trait]
     impl RegistryClient for StallingRegistry {
@@ -1152,7 +1144,7 @@ mod tests {
 
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
             std::future::pending::<()>().await;
-            Ok(self.signers.clone())
+            Ok(vec![])
         }
     }
 
@@ -1161,7 +1153,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let manager = Arc::new(SignerManager::new(
             RecordingProofProvider::default(),
-            StallingRegistry::stalling_get_registered_signers(vec![]),
+            StallingRegistry,
             SharedTxManager::new(),
             config(),
         ));

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -226,36 +226,6 @@ impl ProofTaskSet {
         self.pending.len()
     }
 
-    /// Returns whether no pending proof tasks remain.
-    #[cfg(test)]
-    pub fn is_pending_empty(&self) -> bool {
-        self.pending.is_empty()
-    }
-
-    /// Returns the pending proof-task entries keyed by signer.
-    #[cfg(test)]
-    pub const fn pending(&self) -> &HashMap<Address, PendingRegistration> {
-        &self.pending
-    }
-
-    /// Returns mutable access to the pending proof-task entries.
-    #[cfg(test)]
-    pub const fn pending_mut(&mut self) -> &mut HashMap<Address, PendingRegistration> {
-        &mut self.pending
-    }
-
-    /// Returns whether the underlying join set is empty.
-    #[cfg(test)]
-    pub fn is_join_set_empty(&self) -> bool {
-        self.tasks.is_empty()
-    }
-
-    /// Returns mutable access to the underlying join set.
-    #[cfg(test)]
-    pub const fn tasks_mut(&mut self) -> &mut JoinSet<ProofTaskOutcome> {
-        &mut self.tasks
-    }
-
     /// Builds the protected-signer set for orphan deregistration.
     ///
     /// Includes both fetched prover signers and pending proof tasks so a signer
@@ -683,18 +653,18 @@ mod tests {
     }
 
     async fn drain_test_tasks(proof_tasks: &mut ProofTaskSet) {
-        for task in proof_tasks.pending().values() {
+        for task in proof_tasks.pending.values() {
             task.cancel.cancel();
         }
-        let tasks = proof_tasks.tasks_mut();
+        let tasks = &mut proof_tasks.tasks;
         tasks.abort_all();
         while tasks.join_next().await.is_some() {}
-        proof_tasks.pending_mut().clear();
+        proof_tasks.pending.clear();
     }
 
     async fn reap_until_pending_empty(proof_tasks: &mut ProofTaskSet) {
         let started = std::time::Instant::now();
-        while !proof_tasks.is_pending_empty() {
+        while !proof_tasks.pending.is_empty() {
             if started.elapsed() > GATED_WAIT_TIMEOUT {
                 panic!("timed out reaping {} pending task(s)", proof_tasks.pending_len());
             }
@@ -743,11 +713,11 @@ mod tests {
             let signer = signer_from_key(key);
             let task_cancel = CancellationToken::new();
             let task_cancel_inner = task_cancel.clone();
-            let handle = proof_tasks.tasks_mut().spawn(async move {
+            let handle = proof_tasks.tasks.spawn(async move {
                 task_cancel_inner.cancelled().await;
                 proof_task_success_for_test(signer)
             });
-            proof_tasks.pending_mut().insert(
+            proof_tasks.pending.insert(
                 signer,
                 PendingRegistration {
                     instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -786,14 +756,14 @@ mod tests {
 
         reconcile(&manager, &resolution, &mut proof_tasks);
         let after_first = proof_tasks.pending_len();
-        let snapshot_ids: HashSet<_> = proof_tasks.pending().keys().copied().collect();
+        let snapshot_ids: HashSet<_> = proof_tasks.pending.keys().copied().collect();
 
         reconcile(&manager, &resolution, &mut proof_tasks);
 
         assert_eq!(proof_tasks.pending_len(), after_first, "idempotent: no extra spawns");
-        let after_second: HashSet<_> = proof_tasks.pending().keys().copied().collect();
+        let after_second: HashSet<_> = proof_tasks.pending.keys().copied().collect();
         assert_eq!(snapshot_ids, after_second, "pending signer keys unchanged across reconciles");
-        for task in proof_tasks.pending().values() {
+        for task in proof_tasks.pending.values() {
             assert!(!task.cancel.is_cancelled(), "kept task must not be cancelled");
         }
 
@@ -812,12 +782,12 @@ mod tests {
 
         let stale_cancel = CancellationToken::new();
         let stale_cancel_inner = stale_cancel.clone();
-        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
+        let stale_handle = proof_tasks.tasks.spawn(async move {
             stale_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer)
         });
         let stale_task_id = stale_handle.id();
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -830,7 +800,7 @@ mod tests {
         reconcile(&manager, &dr_from_kept(&[]), &mut proof_tasks);
         assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
         assert_eq!(
-            proof_tasks.pending().get(&signer).map(|p| p.task_id),
+            proof_tasks.pending.get(&signer).map(|p| p.task_id),
             Some(stale_task_id),
             "cancelled entry still keyed by signer until reaped",
         );
@@ -838,7 +808,7 @@ mod tests {
         reconcile(&manager, &dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]), &mut proof_tasks);
 
         assert_eq!(proof_tasks.pending_len(), 1, "still exactly one entry per signer");
-        let fresh = proof_tasks.pending().get(&signer).expect("fresh entry keyed by signer");
+        let fresh = proof_tasks.pending.get(&signer).expect("fresh entry keyed by signer");
         assert_ne!(fresh.task_id, stale_task_id, "fresh task_id replaces the stale one");
         assert!(!fresh.cancel.is_cancelled(), "fresh task carries a live cancel token");
 
@@ -857,11 +827,11 @@ mod tests {
 
         let task_cancel = CancellationToken::new();
         let task_cancel_inner = task_cancel.clone();
-        let handle = proof_tasks.tasks_mut().spawn(async move {
+        let handle = proof_tasks.tasks.spawn(async move {
             task_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer)
         });
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -937,7 +907,7 @@ mod tests {
         reconcile(&manager, &resolution, &mut proof_tasks);
 
         assert_eq!(proof_tasks.pending_len(), 1, "exactly one task should spawn");
-        let (&only_signer, _entry) = proof_tasks.pending().iter().next().unwrap();
+        let (&only_signer, _entry) = proof_tasks.pending.iter().next().unwrap();
         assert_eq!(only_signer, signer, "the task is keyed by the deduplicated signer");
 
         wait_for("the lone spawned task recorded its attestation", || {
@@ -1010,7 +980,7 @@ mod tests {
     async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
         let mut proof_tasks = ProofTaskSet::new();
 
-        let handle = proof_tasks.tasks_mut().spawn(async move {
+        let handle = proof_tasks.tasks.spawn(async move {
             if succeed {
                 proof_task_success_for_test(HARDHAT_ACCOUNT)
             } else {
@@ -1020,15 +990,15 @@ mod tests {
                 )
             }
         });
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             HARDHAT_ACCOUNT,
             pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
         );
 
         reap_until_pending_empty(&mut proof_tasks).await;
 
-        assert!(proof_tasks.is_pending_empty(), "completed task must be evicted");
-        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
+        assert!(proof_tasks.pending.is_empty(), "completed task must be evicted");
+        assert!(proof_tasks.tasks.is_empty(), "JoinSet must drain to empty");
     }
 
     #[tokio::test]
@@ -1037,11 +1007,11 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let cancel_inner = cancel.clone();
-        let handle = proof_tasks.tasks_mut().spawn(async move {
+        let handle = proof_tasks.tasks.spawn(async move {
             cancel_inner.cancelled().await;
             proof_task_success_for_test(HARDHAT_ACCOUNT)
         });
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             HARDHAT_ACCOUNT,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -1064,26 +1034,26 @@ mod tests {
 
         proof_tasks.reap_finished_tasks();
 
-        assert!(proof_tasks.is_pending_empty(), "pending stays empty");
-        assert!(proof_tasks.is_join_set_empty(), "JoinSet stays empty");
+        assert!(proof_tasks.pending.is_empty(), "pending stays empty");
+        assert!(proof_tasks.tasks.is_empty(), "JoinSet stays empty");
     }
 
     #[tokio::test]
     async fn apply_join_outcome_drops_pending_entry_when_task_panics() {
         let mut proof_tasks = ProofTaskSet::new();
 
-        let handle = proof_tasks.tasks_mut().spawn(async {
+        let handle = proof_tasks.tasks.spawn(async {
             panic!("synthetic proof-task panic for apply_join_outcome test");
         });
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             HARDHAT_ACCOUNT,
             pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
         );
 
         reap_until_pending_empty(&mut proof_tasks).await;
 
-        assert!(proof_tasks.is_pending_empty(), "panicked task must be evicted");
-        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
+        assert!(proof_tasks.pending.is_empty(), "panicked task must be evicted");
+        assert!(proof_tasks.tasks.is_empty(), "JoinSet must drain to empty");
     }
 
     #[tokio::test]
@@ -1092,19 +1062,19 @@ mod tests {
         let signer = HARDHAT_ACCOUNT;
 
         let stale_handle =
-            proof_tasks.tasks_mut().spawn(async move { proof_task_success_for_test(signer) });
+            proof_tasks.tasks.spawn(async move { proof_task_success_for_test(signer) });
         let stale_task_id = stale_handle.id();
 
         let fresh_cancel = CancellationToken::new();
         let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
+        let fresh_handle = proof_tasks.tasks.spawn(async move {
             fresh_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
 
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -1116,7 +1086,7 @@ mod tests {
 
         let started = std::time::Instant::now();
         loop {
-            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+            if let Some(joined) = proof_tasks.tasks.try_join_next_with_id() {
                 proof_tasks.apply_join_outcome(joined);
                 break;
             }
@@ -1127,7 +1097,7 @@ mod tests {
         }
 
         assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale completion");
-        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
+        let entry = proof_tasks.pending.get(&signer).expect("fresh entry still keyed by signer");
         assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
         assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
 
@@ -1140,7 +1110,7 @@ mod tests {
         let mut proof_tasks = ProofTaskSet::new();
         let signer = HARDHAT_ACCOUNT;
 
-        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
+        let stale_handle = proof_tasks.tasks.spawn(async move {
             proof_task_failure_for_test(
                 signer,
                 RegistrarError::Config("synthetic stale proof failure".to_string()),
@@ -1150,14 +1120,14 @@ mod tests {
 
         let fresh_cancel = CancellationToken::new();
         let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
+        let fresh_handle = proof_tasks.tasks.spawn(async move {
             fresh_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer)
         });
         let fresh_task_id = fresh_handle.id();
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
 
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -1169,7 +1139,7 @@ mod tests {
 
         let started = std::time::Instant::now();
         loop {
-            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+            if let Some(joined) = proof_tasks.tasks.try_join_next_with_id() {
                 proof_tasks.apply_join_outcome(joined);
                 break;
             }
@@ -1180,7 +1150,7 @@ mod tests {
         }
 
         assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale Err");
-        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
+        let entry = proof_tasks.pending.get(&signer).expect("fresh entry still keyed by signer");
         assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
         assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
 
@@ -1199,11 +1169,11 @@ mod tests {
         let mut proof_tasks = ProofTaskSet::new();
         let task_cancel = CancellationToken::new();
         let task_cancel_inner = task_cancel.clone();
-        let handle = proof_tasks.tasks_mut().spawn(async move {
+        let handle = proof_tasks.tasks.spawn(async move {
             task_cancel_inner.cancelled().await;
             proof_task_success_for_test(signer)
         });
-        proof_tasks.pending_mut().insert(
+        proof_tasks.pending.insert(
             signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
@@ -1364,11 +1334,11 @@ mod tests {
                         let signer = signer_from_key(key);
                         let cancel = CancellationToken::new();
                         let cancel_inner = cancel.clone();
-                        let handle = proof_tasks.tasks_mut().spawn(async move {
+                        let handle = proof_tasks.tasks.spawn(async move {
                             cancel_inner.cancelled().await;
                             proof_task_success_for_test(signer)
                         });
-                        proof_tasks.pending_mut().insert(
+                        proof_tasks.pending.insert(
                             signer,
                             PendingRegistration {
                                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -407,52 +407,26 @@ mod tests {
     use async_trait::async_trait;
     use base_proof_tee_nitro_attestation_prover::AttestationProof;
     use base_tx_manager::{SendHandle, TxCandidate};
-    use hex_literal::hex;
-    use k256::ecdsa::SigningKey;
     use rstest::rstest;
     use tokio::task;
 
     use super::*;
     use crate::{
         DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
-        InstanceHealthStatus, ProverClient, RegisterableSigner, RegistrarError,
+        RegisterableSigner, RegistrarError,
+        test_utils::{
+            EP1, EP2, HARDHAT_KEY_0, HARDHAT_KEY_1, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
+            signer_from_private_key,
+        },
     };
 
     const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    const HARDHAT_KEY_0: [u8; 32] =
-        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
-    const HARDHAT_KEY_1: [u8; 32] =
-        hex!("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
-    #[cfg(feature = "metrics")]
-    const HARDHAT_KEY_2: [u8; 32] =
-        hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
-    const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
     const TEST_PENDING_INSTANCE_ID: &str = "i-pending-test";
-    const EP1: &str = "10.0.0.1:8000";
-    const EP2: &str = "10.0.0.2:8000";
     const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
     const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
     type TestSignerManager =
         Arc<SignerManager<RecordingProofProvider, MockRegistry, NoopTxManager>>;
-
-    fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
-        let signing_key = SigningKey::from_slice(private_key).unwrap();
-        signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
-    }
-
-    fn signer_from_key(private_key: &[u8; 32]) -> Address {
-        ProverClient::derive_address(&public_key_from_private(private_key)).unwrap()
-    }
-
-    fn instance(host_port: &str) -> ProverInstance {
-        ProverInstance {
-            instance_id: format!("i-{host_port}"),
-            endpoint: url::Url::parse(&format!("http://{host_port}")).unwrap(),
-            health_status: InstanceHealthStatus::Healthy,
-            launch_time: None,
-        }
-    }
 
     #[derive(Debug)]
     struct MockRegistry;
@@ -545,8 +519,8 @@ mod tests {
         let mut registerable = Vec::new();
         let mut active_signers = HashSet::new();
         for (ep, key) in kept {
-            let inst = instance(ep);
-            let addr = signer_from_key(key);
+            let inst = healthy_prover_instance(ep);
+            let addr = signer_from_private_key(key);
             active_signers.insert(addr);
             registerable.push(RegisterableSigner {
                 instance: inst,
@@ -667,7 +641,7 @@ mod tests {
         let mut seeded_cancels = Vec::new();
 
         for (_, key) in pre_existing {
-            let signer = signer_from_key(key);
+            let signer = signer_from_private_key(key);
             let (_, task_cancel) = spawn_pending_success_task(
                 &mut proof_tasks,
                 signer,
@@ -698,7 +672,7 @@ mod tests {
     async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
         let manager = manager(RecordingProofProvider::default());
         let mut proof_tasks = ProofTaskSet::new();
-        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
 
         let (stale_task_id, stale_cancel) =
             spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
@@ -725,7 +699,7 @@ mod tests {
     async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
         let manager = manager(RecordingProofProvider::default());
         let mut proof_tasks = ProofTaskSet::new();
-        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
 
         let (_, task_cancel) =
             spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
@@ -764,17 +738,17 @@ mod tests {
     #[tokio::test]
     async fn reconcile_proof_tasks_dedupes_signer_across_registerable_entries() {
         let manager = manager(RecordingProofProvider::default());
-        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
         let resolution = DiscoveryResolution {
             registerable: vec![
                 RegisterableSigner {
-                    instance: instance(EP1),
+                    instance: healthy_prover_instance(EP1),
                     signer,
                     attestation: b"attestation-from-instance-a".to_vec(),
                     enclave_index: 0,
                 },
                 RegisterableSigner {
-                    instance: instance(EP2),
+                    instance: healthy_prover_instance(EP2),
                     signer,
                     attestation: b"attestation-from-instance-b".to_vec(),
                     enclave_index: 0,
@@ -799,8 +773,8 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_proof_tasks_pairs_attestation_with_signer() {
-        let signer_a = signer_from_key(&HARDHAT_KEY_0);
-        let signer_b = signer_from_key(&HARDHAT_KEY_1);
+        let signer_a = signer_from_private_key(&HARDHAT_KEY_0);
+        let signer_b = signer_from_private_key(&HARDHAT_KEY_1);
         assert_ne!(signer_a, signer_b, "test setup: distinct signer addresses");
 
         let att_a: Vec<u8> = b"attestation-aligned-to-A".to_vec();
@@ -810,13 +784,13 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: vec![
                 RegisterableSigner {
-                    instance: instance(EP1),
+                    instance: healthy_prover_instance(EP1),
                     signer: signer_a,
                     attestation: att_a.clone(),
                     enclave_index: 0,
                 },
                 RegisterableSigner {
-                    instance: instance(EP2),
+                    instance: healthy_prover_instance(EP2),
                     signer: signer_b,
                     attestation: att_b.clone(),
                     enclave_index: 0,
@@ -946,8 +920,8 @@ mod tests {
 
     #[tokio::test]
     async fn protected_signers_unions_active_and_pending_signers() {
-        let active_signer = signer_from_key(&HARDHAT_KEY_0);
-        let pending_signer = signer_from_key(&HARDHAT_KEY_1);
+        let active_signer = signer_from_private_key(&HARDHAT_KEY_0);
+        let pending_signer = signer_from_private_key(&HARDHAT_KEY_1);
         assert_ne!(active_signer, pending_signer, "test setup: distinct signers");
 
         let mut proof_tasks = ProofTaskSet::new();
@@ -980,6 +954,7 @@ mod tests {
         use metrics_exporter_prometheus::PrometheusBuilder;
 
         use super::*;
+        use crate::test_utils::HARDHAT_KEY_2;
 
         #[test]
         fn drain_counts_only_tasks_not_already_cancelled_by_reconcile() {
@@ -994,7 +969,7 @@ mod tests {
                         &[(&HARDHAT_KEY_0, true), (&HARDHAT_KEY_1, false), (&HARDHAT_KEY_2, false)];
 
                     for (key, flagged) in seed {
-                        let signer = signer_from_key(key);
+                        let signer = signer_from_private_key(key);
                         let (_, cancel) = spawn_pending_success_task(
                             &mut proof_tasks,
                             signer,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -403,12 +403,8 @@ mod tests {
         time::Duration,
     };
 
-    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{B256, Bloom, Bytes, address};
-    use alloy_rpc_types_eth::TransactionReceipt;
-    use alloy_sol_types::SolCall;
+    use alloy_primitives::{Address, address};
     use async_trait::async_trait;
-    use base_proof_contracts::ITEEProverRegistry;
     use base_proof_tee_nitro_attestation_prover::AttestationProof;
     use base_tx_manager::{SendHandle, TxCandidate};
     use hex_literal::hex;
@@ -432,18 +428,13 @@ mod tests {
         hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
     const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
     const TEST_PENDING_INSTANCE_ID: &str = "i-pending-test";
-    const ORPHAN_A: Address = Address::repeat_byte(0xAA);
-    const ORPHAN_B: Address = Address::repeat_byte(0xBB);
-    const ORPHAN_C: Address = Address::repeat_byte(0xCC);
     const EP1: &str = "10.0.0.1:8000";
     const EP2: &str = "10.0.0.2:8000";
     const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
     const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
-    const CANCEL_ABORT_BUDGET: Duration = Duration::from_secs(1);
-    const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
 
     type TestSignerManager =
-        Arc<SignerManager<RecordingProofProvider, MockRegistry, SharedTxManager>>;
+        Arc<SignerManager<RecordingProofProvider, MockRegistry, NoopTxManager>>;
 
     fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
         let signing_key = SigningKey::from_slice(private_key).unwrap();
@@ -463,72 +454,26 @@ mod tests {
         }
     }
 
-    fn stub_receipt() -> TransactionReceipt {
-        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt {
-                status: Eip658Value::Eip658(true),
-                cumulative_gas_used: 21_000,
-                logs: vec![],
-            },
-            logs_bloom: Bloom::ZERO,
-        });
-        TransactionReceipt {
-            inner,
-            transaction_hash: B256::ZERO,
-            transaction_index: Some(0),
-            block_hash: Some(B256::ZERO),
-            block_number: Some(1),
-            gas_used: 21_000,
-            effective_gas_price: 1_000_000_000,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
-    }
-
     #[derive(Debug)]
-    struct MockRegistry {
-        signers: Vec<Address>,
-    }
-
-    impl MockRegistry {
-        fn with_signers(signers: Vec<Address>) -> Self {
-            Self { signers }
-        }
-    }
+    struct MockRegistry;
 
     #[async_trait]
     impl RegistryClient for MockRegistry {
-        async fn is_registered(&self, signer: Address) -> Result<bool> {
-            Ok(self.signers.contains(&signer))
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            Ok(false)
         }
 
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            Ok(self.signers.clone())
+            unreachable!("signer manager unit tests do not run orphan deregistration")
         }
     }
 
-    #[derive(Debug, Clone)]
-    struct SharedTxManager {
-        sent: Arc<Mutex<Vec<Bytes>>>,
-    }
+    #[derive(Debug, Clone, Copy)]
+    struct NoopTxManager;
 
-    impl SharedTxManager {
-        fn new() -> Self {
-            Self { sent: Arc::new(Mutex::new(vec![])) }
-        }
-
-        fn sent_calldata(&self) -> Vec<Bytes> {
-            self.sent.lock().unwrap().clone()
-        }
-    }
-
-    impl TxManager for SharedTxManager {
-        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            self.sent.lock().unwrap().push(candidate.tx_data);
-            Ok(stub_receipt())
+    impl TxManager for NoopTxManager {
+        async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            unreachable!("signer manager unit tests do not submit transactions")
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
@@ -583,12 +528,8 @@ mod tests {
         }
     }
 
-    fn manager(
-        proof_provider: RecordingProofProvider,
-        registry: MockRegistry,
-        tx: SharedTxManager,
-    ) -> TestSignerManager {
-        Arc::new(SignerManager::new(proof_provider, registry, tx, config()))
+    fn manager(proof_provider: RecordingProofProvider) -> TestSignerManager {
+        Arc::new(SignerManager::new(proof_provider, MockRegistry, NoopTxManager, config()))
     }
 
     fn reconcile(
@@ -721,11 +662,7 @@ mod tests {
         #[case] expected_new_spawns: usize,
         #[case] expected_cancels: usize,
     ) {
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![]),
-            SharedTxManager::new(),
-        );
+        let manager = manager(RecordingProofProvider::default());
         let mut proof_tasks = ProofTaskSet::new();
         let mut seeded_cancels = Vec::new();
 
@@ -759,11 +696,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![]),
-            SharedTxManager::new(),
-        );
+        let manager = manager(RecordingProofProvider::default());
         let mut proof_tasks = ProofTaskSet::new();
         let signer = signer_from_key(&HARDHAT_KEY_0);
 
@@ -790,11 +723,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![]),
-            SharedTxManager::new(),
-        );
+        let manager = manager(RecordingProofProvider::default());
         let mut proof_tasks = ProofTaskSet::new();
         let signer = signer_from_key(&HARDHAT_KEY_0);
 
@@ -834,11 +763,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_proof_tasks_dedupes_signer_across_registerable_entries() {
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![]),
-            SharedTxManager::new(),
-        );
+        let manager = manager(RecordingProofProvider::default());
         let signer = signer_from_key(&HARDHAT_KEY_0);
         let resolution = DiscoveryResolution {
             registerable: vec![
@@ -881,11 +806,7 @@ mod tests {
         let att_a: Vec<u8> = b"attestation-aligned-to-A".to_vec();
         let att_b: Vec<u8> = b"attestation-aligned-to-B".to_vec();
         let proof_provider = RecordingProofProvider::default();
-        let manager = manager(
-            proof_provider.clone(),
-            MockRegistry::with_signers(vec![]),
-            SharedTxManager::new(),
-        );
+        let manager = manager(proof_provider.clone());
         let resolution = DiscoveryResolution {
             registerable: vec![
                 RegisterableSigner {
@@ -1052,76 +973,6 @@ mod tests {
 
         let protected_after_drain = proof_tasks.protected_signers(&resolution);
         assert_eq!(protected_after_drain, HashSet::from([active_signer]));
-    }
-
-    #[tokio::test]
-    async fn run_orphan_dereg_deregisters_all_unprotected_onchain_signers() {
-        let orphans = vec![ORPHAN_A, ORPHAN_B, ORPHAN_C];
-        let expected_count = orphans.len();
-        let tx = SharedTxManager::new();
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(orphans.clone()),
-            tx.clone(),
-        );
-
-        let cancel = CancellationToken::new();
-        manager.run_orphan_dereg(&HashSet::new(), &cancel).await.unwrap();
-
-        let sent = tx.sent_calldata();
-        assert_eq!(sent.len(), expected_count, "all onchain signers should be deregistered");
-        for orphan in orphans {
-            let expected = ITEEProverRegistry::deregisterSignerCall { signer: orphan }.abi_encode();
-            assert!(sent.iter().any(|s| s[..] == expected[..]), "expected dereg of {orphan}");
-        }
-    }
-
-    struct StallingRegistry;
-
-    #[async_trait]
-    impl RegistryClient for StallingRegistry {
-        async fn is_registered(&self, _signer: Address) -> Result<bool> {
-            Ok(false)
-        }
-
-        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            std::future::pending::<()>().await;
-            Ok(vec![])
-        }
-    }
-
-    #[tokio::test]
-    async fn run_orphan_dereg_aborts_promptly_when_cancel_fires_during_registry_stall() {
-        let cancel = CancellationToken::new();
-        let manager = Arc::new(SignerManager::new(
-            RecordingProofProvider::default(),
-            StallingRegistry,
-            SharedTxManager::new(),
-            config(),
-        ));
-
-        let manager_clone = Arc::clone(&manager);
-        let cancel_clone = cancel.clone();
-        let handle = tokio::spawn(async move {
-            let active = HashSet::new();
-            let start = tokio::time::Instant::now();
-            let res = manager_clone.run_orphan_dereg(&active, &cancel_clone).await;
-            (res, start.elapsed())
-        });
-
-        tokio::time::sleep(PRE_CANCEL_WARMUP).await;
-        cancel.cancel();
-
-        let (result, elapsed) = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
-            .await
-            .expect("run_orphan_dereg must not hang past the timeout")
-            .expect("spawned task must not panic");
-
-        assert!(result.is_ok(), "cancel-induced exit must be Ok(()): {result:?}");
-        assert!(
-            elapsed < CANCEL_ABORT_BUDGET,
-            "cancel must abort registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
-        );
     }
 
     #[cfg(feature = "metrics")]

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -741,42 +741,18 @@ mod tests {
         }
 
         let resolution = dr_from_kept(kept);
-        let pre_spawn_count = proof_tasks.pending_len();
+        let pre_task_count = proof_tasks.tasks.len();
+        let expected_pending = pre_existing.len() + expected_new_spawns;
         let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
 
         reconcile(&manager, &resolution, &mut proof_tasks);
 
         let post_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
-        let new_spawns = proof_tasks.pending_len().saturating_sub(pre_spawn_count);
+        let new_spawns = proof_tasks.tasks.len().saturating_sub(pre_task_count);
 
         assert_eq!(new_spawns, expected_new_spawns, "spawn-pass count");
         assert_eq!(post_cancelled - pre_cancelled, expected_cancels, "cancel-pass count");
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    #[tokio::test]
-    async fn reconcile_proof_tasks_idempotent_when_resolution_unchanged() {
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![]),
-            SharedTxManager::new(),
-        );
-        let mut proof_tasks = ProofTaskSet::new();
-        let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
-
-        reconcile(&manager, &resolution, &mut proof_tasks);
-        let after_first = proof_tasks.pending_len();
-        let snapshot_ids: HashSet<_> = proof_tasks.pending.keys().copied().collect();
-
-        reconcile(&manager, &resolution, &mut proof_tasks);
-
-        assert_eq!(proof_tasks.pending_len(), after_first, "idempotent: no extra spawns");
-        let after_second: HashSet<_> = proof_tasks.pending.keys().copied().collect();
-        assert_eq!(snapshot_ids, after_second, "pending signer keys unchanged across reconciles");
-        for task in proof_tasks.pending.values() {
-            assert!(!task.cancel.is_cancelled(), "kept task must not be cancelled");
-        }
+        assert_eq!(proof_tasks.pending_len(), expected_pending, "pending task count");
 
         drain_test_tasks(&mut proof_tasks).await;
     }

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -226,6 +226,36 @@ impl ProofTaskSet {
         self.pending.len()
     }
 
+    /// Returns whether no pending proof tasks remain.
+    #[cfg(test)]
+    pub fn is_pending_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Returns the pending proof-task entries keyed by signer.
+    #[cfg(test)]
+    pub const fn pending(&self) -> &HashMap<Address, PendingRegistration> {
+        &self.pending
+    }
+
+    /// Returns mutable access to the pending proof-task entries.
+    #[cfg(test)]
+    pub const fn pending_mut(&mut self) -> &mut HashMap<Address, PendingRegistration> {
+        &mut self.pending
+    }
+
+    /// Returns whether the underlying join set is empty.
+    #[cfg(test)]
+    pub fn is_join_set_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    /// Returns mutable access to the underlying join set.
+    #[cfg(test)]
+    pub const fn tasks_mut(&mut self) -> &mut JoinSet<ProofTaskOutcome> {
+        &mut self.tasks
+    }
+
     /// Builds the protected-signer set for orphan deregistration.
     ///
     /// Includes both fetched prover signers and pending proof tasks so a signer
@@ -392,5 +422,975 @@ where
         );
 
         deregistration_manager.run_orphan_dereg(protected_signers, cancel).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{B256, Bloom, Bytes, address};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolCall;
+    use async_trait::async_trait;
+    use base_proof_contracts::ITEEProverRegistry;
+    use base_proof_tee_nitro_attestation_prover::AttestationProof;
+    use base_tx_manager::{SendHandle, TxCandidate};
+    use hex_literal::hex;
+    use k256::ecdsa::SigningKey;
+    use rstest::rstest;
+    use tokio::task;
+
+    use super::*;
+    use crate::{
+        DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
+        InstanceHealthStatus, ProverClient, RegisterableSigner, RegistrarError,
+    };
+
+    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    const HARDHAT_KEY_0: [u8; 32] =
+        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+    const HARDHAT_KEY_1: [u8; 32] =
+        hex!("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+    #[cfg(feature = "metrics")]
+    const HARDHAT_KEY_2: [u8; 32] =
+        hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
+    const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
+    const TEST_PENDING_INSTANCE_ID: &str = "i-pending-test";
+    const ORPHAN_A: Address = Address::repeat_byte(0xAA);
+    const ORPHAN_B: Address = Address::repeat_byte(0xBB);
+    const ORPHAN_C: Address = Address::repeat_byte(0xCC);
+    const EP1: &str = "10.0.0.1:8000";
+    const EP2: &str = "10.0.0.2:8000";
+    const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+    const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
+    const CANCEL_ABORT_BUDGET: Duration = Duration::from_secs(1);
+    const PRE_CANCEL_WARMUP: Duration = Duration::from_millis(50);
+
+    type TestSignerManager =
+        Arc<SignerManager<RecordingProofProvider, MockRegistry, SharedTxManager>>;
+
+    fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
+        let signing_key = SigningKey::from_slice(private_key).unwrap();
+        signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
+    }
+
+    fn signer_from_key(private_key: &[u8; 32]) -> Address {
+        ProverClient::derive_address(&public_key_from_private(private_key)).unwrap()
+    }
+
+    fn instance(host_port: &str) -> ProverInstance {
+        ProverInstance {
+            instance_id: format!("i-{host_port}"),
+            endpoint: url::Url::parse(&format!("http://{host_port}")).unwrap(),
+            health_status: InstanceHealthStatus::Healthy,
+            launch_time: None,
+        }
+    }
+
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockRegistry {
+        signers: Vec<Address>,
+    }
+
+    impl MockRegistry {
+        fn with_signers(signers: Vec<Address>) -> Self {
+            Self { signers }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for MockRegistry {
+        async fn is_registered(&self, signer: Address) -> Result<bool> {
+            Ok(self.signers.contains(&signer))
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct SharedTxManager {
+        sent: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl SharedTxManager {
+        fn new() -> Self {
+            Self { sent: Arc::new(Mutex::new(vec![])) }
+        }
+
+        fn sent_calldata(&self) -> Vec<Bytes> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl TxManager for SharedTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent.lock().unwrap().push(candidate.tx_data);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            unimplemented!("not used in signer manager tests")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct RecordingProofProvider {
+        recorded: Arc<Mutex<HashMap<Address, Vec<u8>>>>,
+    }
+
+    impl RecordingProofProvider {
+        fn snapshot(&self) -> HashMap<Address, Vec<u8>> {
+            self.recorded.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AttestationProofProvider for RecordingProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            unreachable!("signer manager should route proof generation through signer-aware API")
+        }
+
+        async fn generate_proof_for_signer(
+            &self,
+            attestation_bytes: &[u8],
+            signer_address: Address,
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            self.recorded.lock().unwrap().insert(signer_address, attestation_bytes.to_vec());
+            Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
+                "RecordingProofProvider exits after capturing attestation".into(),
+            ))
+        }
+    }
+
+    fn config() -> SignerManagerConfig {
+        SignerManagerConfig {
+            registry_address: TEST_REGISTRY_ADDRESS,
+            max_concurrency: DEFAULT_MAX_CONCURRENCY,
+            max_tx_retries: DEFAULT_MAX_TX_RETRIES,
+            tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
+        }
+    }
+
+    fn manager(
+        proof_provider: RecordingProofProvider,
+        registry: MockRegistry,
+        tx: SharedTxManager,
+    ) -> TestSignerManager {
+        Arc::new(SignerManager::new(proof_provider, registry, tx, config()))
+    }
+
+    fn reconcile(
+        manager: &TestSignerManager,
+        resolution: &DiscoveryResolution,
+        proof_tasks: &mut ProofTaskSet,
+    ) {
+        let cancel = CancellationToken::new();
+        manager.reconcile_proof_tasks(resolution, proof_tasks, &cancel);
+    }
+
+    fn dr_from_kept(kept: &[(&str, &[u8; 32])]) -> DiscoveryResolution {
+        let mut registerable = Vec::new();
+        let mut active_signers = HashSet::new();
+        for (ep, key) in kept {
+            let inst = instance(ep);
+            let addr = signer_from_key(key);
+            active_signers.insert(addr);
+            registerable.push(RegisterableSigner {
+                instance: inst,
+                signer: addr,
+                attestation: b"gated-attestation".to_vec(),
+                enclave_index: 0,
+            });
+        }
+        let total = kept.len();
+        DiscoveryResolution {
+            registerable,
+            active_signers,
+            reachable_count: total,
+            total_count: total,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::new(),
+        }
+    }
+
+    fn proof_task_success_for_test(signer: Address) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, result: Ok(()) }
+    }
+
+    fn proof_task_failure_for_test(signer: Address, error: RegistrarError) -> ProofTaskOutcome {
+        ProofTaskOutcome { signer, result: Err(error) }
+    }
+
+    fn pending_registration_for_test(task_id: task::Id, instance_id: &str) -> PendingRegistration {
+        PendingRegistration {
+            instance_id: instance_id.to_string(),
+            task_id,
+            cancel: CancellationToken::new(),
+            cancelled_by_reconcile: false,
+        }
+    }
+
+    async fn wait_for(label: &str, predicate: impl Fn() -> bool) {
+        let started = std::time::Instant::now();
+        while !predicate() {
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("timed out waiting for: {label}");
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    async fn drain_test_tasks(proof_tasks: &mut ProofTaskSet) {
+        for task in proof_tasks.pending().values() {
+            task.cancel.cancel();
+        }
+        let tasks = proof_tasks.tasks_mut();
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+        proof_tasks.pending_mut().clear();
+    }
+
+    async fn reap_until_pending_empty(proof_tasks: &mut ProofTaskSet) {
+        let started = std::time::Instant::now();
+        while !proof_tasks.is_pending_empty() {
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("timed out reaping {} pending task(s)", proof_tasks.pending_len());
+            }
+            proof_tasks.reap_finished_tasks();
+            tokio::time::sleep(REAP_POLL_INTERVAL).await;
+        }
+    }
+
+    fn count_deregister_calls(sent: &[Bytes]) -> usize {
+        let sel = ITEEProverRegistry::deregisterSignerCall::SELECTOR;
+        sent.iter().filter(|c| c.len() >= 4 && c[..4] == sel).count()
+    }
+
+    #[rstest]
+    #[case::no_pending_spawns_all(&[], &[(EP1, &HARDHAT_KEY_0)], 1, 0)]
+    #[case::pending_for_kept_spawns_nothing(&[(EP1, &HARDHAT_KEY_0)], &[(EP1, &HARDHAT_KEY_0)], 0, 0)]
+    #[case::pending_for_dropped_cancels_one(&[(EP1, &HARDHAT_KEY_0)], &[], 0, 1)]
+    #[case::pending_one_kept_one_dropped(
+        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
+        &[(EP1, &HARDHAT_KEY_0)],
+        0,
+        1,
+    )]
+    #[case::two_new_signers_two_spawns(
+        &[],
+        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
+        2,
+        0,
+    )]
+    #[tokio::test]
+    async fn reconcile_proof_tasks_cancel_and_spawn_passes(
+        #[case] pre_existing: &[(&'static str, &'static [u8; 32])],
+        #[case] kept: &[(&'static str, &'static [u8; 32])],
+        #[case] expected_new_spawns: usize,
+        #[case] expected_cancels: usize,
+    ) {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let mut seeded_cancels = Vec::new();
+
+        for (_, key) in pre_existing {
+            let signer = signer_from_key(key);
+            let task_cancel = CancellationToken::new();
+            let task_cancel_inner = task_cancel.clone();
+            let handle = proof_tasks.tasks_mut().spawn(async move {
+                task_cancel_inner.cancelled().await;
+                proof_task_success_for_test(signer)
+            });
+            proof_tasks.pending_mut().insert(
+                signer,
+                PendingRegistration {
+                    instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                    task_id: handle.id(),
+                    cancel: task_cancel.clone(),
+                    cancelled_by_reconcile: false,
+                },
+            );
+            seeded_cancels.push(task_cancel);
+        }
+
+        let resolution = dr_from_kept(kept);
+        let pre_spawn_count = proof_tasks.pending_len();
+        let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
+
+        reconcile(&manager, &resolution, &mut proof_tasks);
+
+        let post_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
+        let new_spawns = proof_tasks.pending_len().saturating_sub(pre_spawn_count);
+
+        assert_eq!(new_spawns, expected_new_spawns, "spawn-pass count");
+        assert_eq!(post_cancelled - pre_cancelled, expected_cancels, "cancel-pass count");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_idempotent_when_resolution_unchanged() {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let resolution = dr_from_kept(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
+
+        reconcile(&manager, &resolution, &mut proof_tasks);
+        let after_first = proof_tasks.pending_len();
+        let snapshot_ids: HashSet<_> = proof_tasks.pending().keys().copied().collect();
+
+        reconcile(&manager, &resolution, &mut proof_tasks);
+
+        assert_eq!(proof_tasks.pending_len(), after_first, "idempotent: no extra spawns");
+        let after_second: HashSet<_> = proof_tasks.pending().keys().copied().collect();
+        assert_eq!(snapshot_ids, after_second, "pending signer keys unchanged across reconciles");
+        for task in proof_tasks.pending().values() {
+            assert!(!task.cancel.is_cancelled(), "kept task must not be cancelled");
+        }
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_respawns_after_vanish_and_reappear() {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+
+        let stale_cancel = CancellationToken::new();
+        let stale_cancel_inner = stale_cancel.clone();
+        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
+            stale_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let stale_task_id = stale_handle.id();
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: stale_task_id,
+                cancel: stale_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        reconcile(&manager, &dr_from_kept(&[]), &mut proof_tasks);
+        assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
+        assert_eq!(
+            proof_tasks.pending().get(&signer).map(|p| p.task_id),
+            Some(stale_task_id),
+            "cancelled entry still keyed by signer until reaped",
+        );
+
+        reconcile(&manager, &dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]), &mut proof_tasks);
+
+        assert_eq!(proof_tasks.pending_len(), 1, "still exactly one entry per signer");
+        let fresh = proof_tasks.pending().get(&signer).expect("fresh entry keyed by signer");
+        assert_ne!(fresh.task_id, stale_task_id, "fresh task_id replaces the stale one");
+        assert!(!fresh.cancel.is_cancelled(), "fresh task carries a live cancel token");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_preserves_task_when_instance_fails_to_resolve() {
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+
+        let task_cancel = CancellationToken::new();
+        let task_cancel_inner = task_cancel.clone();
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            task_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: handle.id(),
+                cancel: task_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let resolution = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 0,
+            total_count: 1,
+            ok_to_dereg: false,
+            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
+        };
+
+        reconcile(&manager, &resolution, &mut proof_tasks);
+
+        assert!(
+            !task_cancel.is_cancelled(),
+            "task tied to an unresolved instance must be preserved",
+        );
+        assert_eq!(proof_tasks.pending_len(), 1, "no spurious spawn or eviction this cycle");
+
+        let resolution_conclusive = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 1,
+            total_count: 1,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        reconcile(&manager, &resolution_conclusive, &mut proof_tasks);
+        assert!(task_cancel.is_cancelled(), "conclusive absence must cancel the task");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_proof_tasks_dedupes_signer_across_registerable_entries() {
+        let proof_provider = RecordingProofProvider::default();
+        let manager = manager(
+            proof_provider.clone(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+        );
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let resolution = DiscoveryResolution {
+            registerable: vec![
+                RegisterableSigner {
+                    instance: instance(EP1),
+                    signer,
+                    attestation: b"attestation-from-instance-a".to_vec(),
+                    enclave_index: 0,
+                },
+                RegisterableSigner {
+                    instance: instance(EP2),
+                    signer,
+                    attestation: b"attestation-from-instance-b".to_vec(),
+                    enclave_index: 0,
+                },
+            ],
+            active_signers: HashSet::from([signer]),
+            reachable_count: 2,
+            total_count: 2,
+            ok_to_dereg: false,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        let mut proof_tasks = ProofTaskSet::new();
+
+        reconcile(&manager, &resolution, &mut proof_tasks);
+
+        assert_eq!(proof_tasks.pending_len(), 1, "exactly one task should spawn");
+        let (&only_signer, _entry) = proof_tasks.pending().iter().next().unwrap();
+        assert_eq!(only_signer, signer, "the task is keyed by the deduplicated signer");
+
+        wait_for("the lone spawned task recorded its attestation", || {
+            !proof_provider.snapshot().is_empty()
+        })
+        .await;
+        drain_test_tasks(&mut proof_tasks).await;
+
+        assert_eq!(proof_provider.snapshot().len(), 1, "exactly one signer recorded");
+    }
+
+    #[rstest]
+    #[case::forward_order(false)]
+    #[case::reversed_order(true)]
+    #[tokio::test]
+    async fn reconcile_proof_tasks_pairs_attestation_with_signer(#[case] reverse: bool) {
+        let signer_a = signer_from_key(&HARDHAT_KEY_0);
+        let signer_b = signer_from_key(&HARDHAT_KEY_1);
+        assert_ne!(signer_a, signer_b, "test setup: distinct signer addresses");
+
+        let att_a: Vec<u8> = b"attestation-aligned-to-A".to_vec();
+        let att_b: Vec<u8> = b"attestation-aligned-to-B".to_vec();
+        let entry_a = RegisterableSigner {
+            instance: instance(EP1),
+            signer: signer_a,
+            attestation: att_a.clone(),
+            enclave_index: 0,
+        };
+        let entry_b = RegisterableSigner {
+            instance: instance(EP2),
+            signer: signer_b,
+            attestation: att_b.clone(),
+            enclave_index: 0,
+        };
+        let registerable = if reverse { vec![entry_b, entry_a] } else { vec![entry_a, entry_b] };
+
+        let proof_provider = RecordingProofProvider::default();
+        let manager = manager(
+            proof_provider.clone(),
+            MockRegistry::with_signers(vec![]),
+            SharedTxManager::new(),
+        );
+        let resolution = DiscoveryResolution {
+            registerable,
+            active_signers: HashSet::from([signer_a, signer_b]),
+            reachable_count: 2,
+            total_count: 2,
+            ok_to_dereg: false,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        let mut proof_tasks = ProofTaskSet::new();
+
+        reconcile(&manager, &resolution, &mut proof_tasks);
+
+        wait_for("both signers recorded their attestations", || {
+            proof_provider.snapshot().len() == 2
+        })
+        .await;
+        drain_test_tasks(&mut proof_tasks).await;
+
+        let snap = proof_provider.snapshot();
+        assert_eq!(snap.get(&signer_a), Some(&att_a), "signer A got A attestation");
+        assert_eq!(snap.get(&signer_b), Some(&att_b), "signer B got B attestation");
+    }
+
+    #[rstest]
+    #[case::ok_outcome(true)]
+    #[case::err_outcome(false)]
+    #[tokio::test]
+    async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            if succeed {
+                proof_task_success_for_test(HARDHAT_ACCOUNT)
+            } else {
+                proof_task_failure_for_test(
+                    HARDHAT_ACCOUNT,
+                    RegistrarError::Transaction("synthetic".into()),
+                )
+            }
+        });
+        proof_tasks.pending_mut().insert(
+            HARDHAT_ACCOUNT,
+            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
+        );
+
+        reap_until_pending_empty(&mut proof_tasks).await;
+
+        assert!(proof_tasks.is_pending_empty(), "completed task must be evicted");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
+    }
+
+    #[tokio::test]
+    async fn reap_finished_tasks_leaves_in_flight_alone() {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        let cancel = CancellationToken::new();
+        let cancel_inner = cancel.clone();
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            cancel_inner.cancelled().await;
+            proof_task_success_for_test(HARDHAT_ACCOUNT)
+        });
+        proof_tasks.pending_mut().insert(
+            HARDHAT_ACCOUNT,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: handle.id(),
+                cancel,
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        proof_tasks.reap_finished_tasks();
+
+        assert_eq!(proof_tasks.pending_len(), 1, "live task must remain pending");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn reap_finished_tasks_is_noop_when_pending_is_empty() {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        proof_tasks.reap_finished_tasks();
+
+        assert!(proof_tasks.is_pending_empty(), "pending stays empty");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet stays empty");
+    }
+
+    #[tokio::test]
+    async fn apply_join_outcome_drops_pending_entry_when_task_panics() {
+        let mut proof_tasks = ProofTaskSet::new();
+
+        let handle = proof_tasks.tasks_mut().spawn(async {
+            panic!("synthetic proof-task panic for apply_join_outcome test");
+        });
+        proof_tasks.pending_mut().insert(
+            HARDHAT_ACCOUNT,
+            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
+        );
+
+        reap_until_pending_empty(&mut proof_tasks).await;
+
+        assert!(proof_tasks.is_pending_empty(), "panicked task must be evicted");
+        assert!(proof_tasks.is_join_set_empty(), "JoinSet must drain to empty");
+    }
+
+    #[tokio::test]
+    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_completes_for_same_signer() {
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = HARDHAT_ACCOUNT;
+
+        let stale_handle =
+            proof_tasks.tasks_mut().spawn(async move { proof_task_success_for_test(signer) });
+        let stale_task_id = stale_handle.id();
+
+        let fresh_cancel = CancellationToken::new();
+        let fresh_cancel_inner = fresh_cancel.clone();
+        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
+            fresh_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let fresh_task_id = fresh_handle.id();
+        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
+
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: fresh_task_id,
+                cancel: fresh_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let started = std::time::Instant::now();
+        loop {
+            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+                proof_tasks.apply_join_outcome(joined);
+                break;
+            }
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("stale task never resolved");
+            }
+            tokio::time::sleep(REAP_POLL_INTERVAL).await;
+        }
+
+        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale completion");
+        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
+        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
+        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
+     {
+        let mut proof_tasks = ProofTaskSet::new();
+        let signer = HARDHAT_ACCOUNT;
+
+        let stale_handle = proof_tasks.tasks_mut().spawn(async move {
+            proof_task_failure_for_test(
+                signer,
+                RegistrarError::Config("synthetic stale proof failure".to_string()),
+            )
+        });
+        let stale_task_id = stale_handle.id();
+
+        let fresh_cancel = CancellationToken::new();
+        let fresh_cancel_inner = fresh_cancel.clone();
+        let fresh_handle = proof_tasks.tasks_mut().spawn(async move {
+            fresh_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let fresh_task_id = fresh_handle.id();
+        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
+
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: fresh_task_id,
+                cancel: fresh_cancel.clone(),
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let started = std::time::Instant::now();
+        loop {
+            if let Some(joined) = proof_tasks.tasks_mut().try_join_next_with_id() {
+                proof_tasks.apply_join_outcome(joined);
+                break;
+            }
+            if started.elapsed() > GATED_WAIT_TIMEOUT {
+                panic!("stale task never resolved");
+            }
+            tokio::time::sleep(REAP_POLL_INTERVAL).await;
+        }
+
+        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale Err");
+        let entry = proof_tasks.pending().get(&signer).expect("fresh entry still keyed by signer");
+        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
+        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn protected_signers_union_blocks_dereg_of_freshly_registered_signer() {
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let tx = SharedTxManager::new();
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![signer]),
+            tx.clone(),
+        );
+        let mut proof_tasks = ProofTaskSet::new();
+        let task_cancel = CancellationToken::new();
+        let task_cancel_inner = task_cancel.clone();
+        let handle = proof_tasks.tasks_mut().spawn(async move {
+            task_cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        proof_tasks.pending_mut().insert(
+            signer,
+            PendingRegistration {
+                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                task_id: handle.id(),
+                cancel: task_cancel,
+                cancelled_by_reconcile: false,
+            },
+        );
+
+        let resolution = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 1,
+            total_count: 1,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
+        };
+        let protected = proof_tasks.protected_signers(&resolution);
+        assert!(protected.contains(&signer), "protected set must include in-flight signer");
+
+        let cancel = CancellationToken::new();
+        manager.run_orphan_dereg(&protected, &cancel).await.unwrap();
+
+        assert_eq!(count_deregister_calls(&tx.sent_calldata()), 0);
+
+        drain_test_tasks(&mut proof_tasks).await;
+    }
+
+    #[tokio::test]
+    async fn protected_signers_union_does_not_shield_when_pending_empty() {
+        let signer = signer_from_key(&HARDHAT_KEY_0);
+        let tx = SharedTxManager::new();
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(vec![signer]),
+            tx.clone(),
+        );
+
+        let proof_tasks = ProofTaskSet::new();
+        let resolution = DiscoveryResolution {
+            registerable: Vec::new(),
+            active_signers: HashSet::new(),
+            reachable_count: 1,
+            total_count: 1,
+            ok_to_dereg: true,
+            unresolved_instance_ids: HashSet::new(),
+        };
+        let protected = proof_tasks.protected_signers(&resolution);
+        assert!(protected.is_empty(), "no pending means protected set is empty");
+
+        let cancel = CancellationToken::new();
+        manager.run_orphan_dereg(&protected, &cancel).await.unwrap();
+
+        assert_eq!(count_deregister_calls(&tx.sent_calldata()), 1);
+    }
+
+    #[rstest]
+    #[case::single_orphan(vec![ORPHAN_A])]
+    #[case::multiple_orphans(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C])]
+    #[tokio::test]
+    async fn run_orphan_dereg_deregisters_all_unprotected_onchain_signers(
+        #[case] orphans: Vec<Address>,
+    ) {
+        let expected_count = orphans.len();
+        let tx = SharedTxManager::new();
+        let manager = manager(
+            RecordingProofProvider::default(),
+            MockRegistry::with_signers(orphans.clone()),
+            tx.clone(),
+        );
+
+        let cancel = CancellationToken::new();
+        manager.run_orphan_dereg(&HashSet::new(), &cancel).await.unwrap();
+
+        let sent = tx.sent_calldata();
+        assert_eq!(sent.len(), expected_count, "all onchain signers should be deregistered");
+        for orphan in orphans {
+            let expected = ITEEProverRegistry::deregisterSignerCall { signer: orphan }.abi_encode();
+            assert!(sent.iter().any(|s| s[..] == expected[..]), "expected dereg of {orphan}");
+        }
+    }
+
+    struct StallingRegistry {
+        signers: Vec<Address>,
+    }
+
+    impl StallingRegistry {
+        fn stalling_get_registered_signers(signers: Vec<Address>) -> Self {
+            Self { signers }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for StallingRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            std::future::pending::<()>().await;
+            Ok(self.signers.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn run_orphan_dereg_aborts_promptly_when_cancel_fires_during_registry_stall() {
+        let cancel = CancellationToken::new();
+        let manager = Arc::new(SignerManager::new(
+            RecordingProofProvider::default(),
+            StallingRegistry::stalling_get_registered_signers(vec![]),
+            SharedTxManager::new(),
+            config(),
+        ));
+
+        let manager_clone = Arc::clone(&manager);
+        let cancel_clone = cancel.clone();
+        let handle = tokio::spawn(async move {
+            let active = HashSet::new();
+            let start = tokio::time::Instant::now();
+            let res = manager_clone.run_orphan_dereg(&active, &cancel_clone).await;
+            (res, start.elapsed())
+        });
+
+        tokio::time::sleep(PRE_CANCEL_WARMUP).await;
+        cancel.cancel();
+
+        let (result, elapsed) = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
+            .await
+            .expect("run_orphan_dereg must not hang past the timeout")
+            .expect("spawned task must not panic");
+
+        assert!(result.is_ok(), "cancel-induced exit must be Ok(()): {result:?}");
+        assert!(
+            elapsed < CANCEL_ABORT_BUDGET,
+            "cancel must abort registry stall within {CANCEL_ABORT_BUDGET:?} (took {elapsed:?})",
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    mod drain_metric_tests {
+        use metrics_exporter_prometheus::PrometheusBuilder;
+
+        use super::*;
+
+        #[test]
+        fn drain_counts_only_tasks_not_already_cancelled_by_reconcile() {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            let recorder = PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+
+            metrics::with_local_recorder(&recorder, || {
+                rt.block_on(async {
+                    let mut proof_tasks = ProofTaskSet::new();
+                    let seed: &[(&[u8; 32], bool)] =
+                        &[(&HARDHAT_KEY_0, true), (&HARDHAT_KEY_1, false), (&HARDHAT_KEY_2, false)];
+
+                    for (key, flagged) in seed {
+                        let signer = signer_from_key(key);
+                        let cancel = CancellationToken::new();
+                        let cancel_inner = cancel.clone();
+                        let handle = proof_tasks.tasks_mut().spawn(async move {
+                            cancel_inner.cancelled().await;
+                            proof_task_success_for_test(signer)
+                        });
+                        proof_tasks.pending_mut().insert(
+                            signer,
+                            PendingRegistration {
+                                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
+                                task_id: handle.id(),
+                                cancel: cancel.clone(),
+                                cancelled_by_reconcile: *flagged,
+                            },
+                        );
+                        if *flagged {
+                            cancel.cancel();
+                        }
+                    }
+
+                    proof_tasks.drain_proof_tasks().await;
+                });
+            });
+
+            let rendered = handle.render();
+            assert!(
+                rendered.contains("base_registrar_proof_tasks_cancelled 2"),
+                "drain must count only the unflagged tasks once each. Got:\n{rendered}",
+            );
+        }
     }
 }

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -673,11 +673,6 @@ mod tests {
         }
     }
 
-    fn count_deregister_calls(sent: &[Bytes]) -> usize {
-        let sel = ITEEProverRegistry::deregisterSignerCall::SELECTOR;
-        sent.iter().filter(|c| c.len() >= 4 && c[..4] == sel).count()
-    }
-
     #[rstest]
     #[case::no_pending_spawns_all(&[], &[(EP1, &HARDHAT_KEY_0)], 1, 0)]
     #[case::pending_for_kept_spawns_nothing(&[(EP1, &HARDHAT_KEY_0)], &[(EP1, &HARDHAT_KEY_0)], 0, 0)]
@@ -1056,65 +1051,25 @@ mod tests {
         assert!(proof_tasks.tasks.is_empty(), "JoinSet must drain to empty");
     }
 
+    #[rstest]
+    #[case::ok_outcome(true)]
+    #[case::err_outcome(false)]
     #[tokio::test]
-    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_completes_for_same_signer() {
-        let mut proof_tasks = ProofTaskSet::new();
-        let signer = HARDHAT_ACCOUNT;
-
-        let stale_handle =
-            proof_tasks.tasks.spawn(async move { proof_task_success_for_test(signer) });
-        let stale_task_id = stale_handle.id();
-
-        let fresh_cancel = CancellationToken::new();
-        let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = proof_tasks.tasks.spawn(async move {
-            fresh_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        let fresh_task_id = fresh_handle.id();
-        assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
-
-        proof_tasks.pending.insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: fresh_task_id,
-                cancel: fresh_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
-
-        let started = std::time::Instant::now();
-        loop {
-            if let Some(joined) = proof_tasks.tasks.try_join_next_with_id() {
-                proof_tasks.apply_join_outcome(joined);
-                break;
-            }
-            if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("stale task never resolved");
-            }
-            tokio::time::sleep(REAP_POLL_INTERVAL).await;
-        }
-
-        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale completion");
-        let entry = proof_tasks.pending.get(&signer).expect("fresh entry still keyed by signer");
-        assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
-        assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
-
-        drain_test_tasks(&mut proof_tasks).await;
-    }
-
-    #[tokio::test]
-    async fn apply_join_outcome_err_arm_preserves_fresh_entry_when_stale_task_fails_for_same_signer()
-     {
+    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_finishes_for_same_signer(
+        #[case] stale_succeeds: bool,
+    ) {
         let mut proof_tasks = ProofTaskSet::new();
         let signer = HARDHAT_ACCOUNT;
 
         let stale_handle = proof_tasks.tasks.spawn(async move {
-            proof_task_failure_for_test(
-                signer,
-                RegistrarError::Config("synthetic stale proof failure".to_string()),
-            )
+            if stale_succeeds {
+                proof_task_success_for_test(signer)
+            } else {
+                proof_task_failure_for_test(
+                    signer,
+                    RegistrarError::Config("synthetic stale proof failure".to_string()),
+                )
+            }
         });
         let stale_task_id = stale_handle.id();
 
@@ -1149,7 +1104,7 @@ mod tests {
             tokio::time::sleep(REAP_POLL_INTERVAL).await;
         }
 
-        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale Err");
+        assert_eq!(proof_tasks.pending_len(), 1, "fresh entry must survive stale task");
         let entry = proof_tasks.pending.get(&signer).expect("fresh entry still keyed by signer");
         assert_eq!(entry.task_id, fresh_task_id, "fresh task_id preserved");
         assert!(!entry.cancel.is_cancelled(), "fresh cancel handle untouched");
@@ -1158,23 +1113,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn protected_signers_union_blocks_dereg_of_freshly_registered_signer() {
-        let signer = signer_from_key(&HARDHAT_KEY_0);
-        let tx = SharedTxManager::new();
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![signer]),
-            tx.clone(),
-        );
+    async fn protected_signers_unions_active_and_pending_signers() {
+        let active_signer = signer_from_key(&HARDHAT_KEY_0);
+        let pending_signer = signer_from_key(&HARDHAT_KEY_1);
+        assert_ne!(active_signer, pending_signer, "test setup: distinct signers");
+
         let mut proof_tasks = ProofTaskSet::new();
         let task_cancel = CancellationToken::new();
         let task_cancel_inner = task_cancel.clone();
         let handle = proof_tasks.tasks.spawn(async move {
             task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
+            proof_task_success_for_test(pending_signer)
         });
         proof_tasks.pending.insert(
-            signer,
+            pending_signer,
             PendingRegistration {
                 instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
                 task_id: handle.id(),
@@ -1185,49 +1137,19 @@ mod tests {
 
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
-            active_signers: HashSet::new(),
+            active_signers: HashSet::from([active_signer]),
             reachable_count: 1,
             total_count: 1,
             ok_to_dereg: true,
             unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
         };
         let protected = proof_tasks.protected_signers(&resolution);
-        assert!(protected.contains(&signer), "protected set must include in-flight signer");
-
-        let cancel = CancellationToken::new();
-        manager.run_orphan_dereg(&protected, &cancel).await.unwrap();
-
-        assert_eq!(count_deregister_calls(&tx.sent_calldata()), 0);
+        assert_eq!(protected, HashSet::from([active_signer, pending_signer]));
 
         drain_test_tasks(&mut proof_tasks).await;
-    }
 
-    #[tokio::test]
-    async fn protected_signers_union_does_not_shield_when_pending_empty() {
-        let signer = signer_from_key(&HARDHAT_KEY_0);
-        let tx = SharedTxManager::new();
-        let manager = manager(
-            RecordingProofProvider::default(),
-            MockRegistry::with_signers(vec![signer]),
-            tx.clone(),
-        );
-
-        let proof_tasks = ProofTaskSet::new();
-        let resolution = DiscoveryResolution {
-            registerable: Vec::new(),
-            active_signers: HashSet::new(),
-            reachable_count: 1,
-            total_count: 1,
-            ok_to_dereg: true,
-            unresolved_instance_ids: HashSet::new(),
-        };
-        let protected = proof_tasks.protected_signers(&resolution);
-        assert!(protected.is_empty(), "no pending means protected set is empty");
-
-        let cancel = CancellationToken::new();
-        manager.run_orphan_dereg(&protected, &cancel).await.unwrap();
-
-        assert_eq!(count_deregister_calls(&tx.sent_calldata()), 1);
+        let protected_after_drain = proof_tasks.protected_signers(&resolution);
+        assert_eq!(protected_after_drain, HashSet::from([active_signer]));
     }
 
     #[rstest]

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -406,7 +406,6 @@ mod tests {
     use alloy_primitives::{Address, address};
     use async_trait::async_trait;
     use base_proof_tee_nitro_attestation_prover::AttestationProof;
-    use base_tx_manager::{SendHandle, TxCandidate};
     use rstest::rstest;
     use tokio::task;
 
@@ -415,8 +414,8 @@ mod tests {
         DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
         RegisterableSigner, RegistrarError,
         test_utils::{
-            EP1, EP2, HARDHAT_KEY_0, HARDHAT_KEY_1, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
-            signer_from_private_key,
+            EP1, EP2, HARDHAT_KEY_0, HARDHAT_KEY_1, NoopTxManager, TEST_REGISTRY_ADDRESS,
+            healthy_prover_instance, signer_from_private_key,
         },
     };
 
@@ -439,23 +438,6 @@ mod tests {
 
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
             unreachable!("signer manager unit tests do not run orphan deregistration")
-        }
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    struct NoopTxManager;
-
-    impl TxManager for NoopTxManager {
-        async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            unreachable!("signer manager unit tests do not submit transactions")
-        }
-
-        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-            unimplemented!("not used in signer manager tests")
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
         }
     }
 
@@ -617,18 +599,6 @@ mod tests {
     #[case::no_pending_spawns_all(&[], &[(EP1, &HARDHAT_KEY_0)], 1, 0)]
     #[case::pending_for_kept_spawns_nothing(&[(EP1, &HARDHAT_KEY_0)], &[(EP1, &HARDHAT_KEY_0)], 0, 0)]
     #[case::pending_for_dropped_cancels_one(&[(EP1, &HARDHAT_KEY_0)], &[], 0, 1)]
-    #[case::pending_one_kept_one_dropped(
-        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
-        &[(EP1, &HARDHAT_KEY_0)],
-        0,
-        1,
-    )]
-    #[case::two_new_signers_two_spawns(
-        &[],
-        &[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)],
-        2,
-        0,
-    )]
     #[tokio::test]
     async fn reconcile_proof_tasks_cancel_and_spawn_passes(
         #[case] pre_existing: &[(&'static str, &'static [u8; 32])],
@@ -817,23 +787,12 @@ mod tests {
         assert_eq!(snap.get(&signer_b), Some(&att_b), "signer B got B attestation");
     }
 
-    #[rstest]
-    #[case::ok_outcome(true)]
-    #[case::err_outcome(false)]
     #[tokio::test]
-    async fn reap_finished_tasks_drains_completed_and_evicts_pending(#[case] succeed: bool) {
+    async fn reap_finished_tasks_drains_completed_and_evicts_pending() {
         let mut proof_tasks = ProofTaskSet::new();
 
-        let handle = proof_tasks.tasks.spawn(async move {
-            if succeed {
-                proof_task_success_for_test(HARDHAT_ACCOUNT)
-            } else {
-                proof_task_failure_for_test(
-                    HARDHAT_ACCOUNT,
-                    RegistrarError::Transaction("synthetic".into()),
-                )
-            }
-        });
+        let handle =
+            proof_tasks.tasks.spawn(async move { proof_task_success_for_test(HARDHAT_ACCOUNT) });
         proof_tasks.pending.insert(
             HARDHAT_ACCOUNT,
             pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -403,11 +403,10 @@ mod tests {
         time::Duration,
     };
 
-    use alloy_primitives::{Address, address};
+    use alloy_primitives::Address;
     use async_trait::async_trait;
     use base_proof_tee_nitro_attestation_prover::AttestationProof;
     use rstest::rstest;
-    use tokio::task;
 
     use super::*;
     use crate::{
@@ -419,7 +418,6 @@ mod tests {
         },
     };
 
-    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     const TEST_PENDING_INSTANCE_ID: &str = "i-pending-test";
     const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
     const REAP_POLL_INTERVAL: Duration = Duration::from_millis(1);
@@ -497,7 +495,7 @@ mod tests {
         manager.reconcile_proof_tasks(resolution, proof_tasks, &cancel);
     }
 
-    fn dr_from_kept(kept: &[(&str, &[u8; 32])]) -> DiscoveryResolution {
+    fn resolution_from_registerable(kept: &[(&str, &[u8; 32])]) -> DiscoveryResolution {
         let mut registerable = Vec::new();
         let mut active_signers = HashSet::new();
         for (ep, key) in kept {
@@ -522,45 +520,21 @@ mod tests {
         }
     }
 
-    fn proof_task_success_for_test(signer: Address) -> ProofTaskOutcome {
-        ProofTaskOutcome { signer, result: Ok(()) }
-    }
-
-    fn proof_task_failure_for_test(signer: Address, error: RegistrarError) -> ProofTaskOutcome {
-        ProofTaskOutcome { signer, result: Err(error) }
-    }
-
-    fn pending_registration_for_test(task_id: task::Id, instance_id: &str) -> PendingRegistration {
-        PendingRegistration {
-            instance_id: instance_id.to_string(),
-            task_id,
-            cancel: CancellationToken::new(),
-            cancelled_by_reconcile: false,
-        }
-    }
-
     fn spawn_pending_success_task(
         proof_tasks: &mut ProofTaskSet,
         signer: Address,
         instance_id: &str,
         cancelled_by_reconcile: bool,
-    ) -> (task::Id, CancellationToken) {
+    ) -> (tokio::task::Id, CancellationToken) {
         let cancel = CancellationToken::new();
         let cancel_inner = cancel.clone();
-        let handle = proof_tasks.tasks.spawn(async move {
+        proof_tasks.spawn_task(signer, instance_id.to_string(), cancel.clone(), async move {
             cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
+            ProofTaskOutcome { signer, result: Ok(()) }
         });
-        let task_id = handle.id();
-        proof_tasks.pending.insert(
-            signer,
-            PendingRegistration {
-                instance_id: instance_id.to_string(),
-                task_id,
-                cancel: cancel.clone(),
-                cancelled_by_reconcile,
-            },
-        );
+        let entry = proof_tasks.pending.get_mut(&signer).expect("spawned task is pending");
+        entry.cancelled_by_reconcile = cancelled_by_reconcile;
+        let task_id = entry.task_id;
         (task_id, cancel)
     }
 
@@ -621,7 +595,7 @@ mod tests {
             seeded_cancels.push(task_cancel);
         }
 
-        let resolution = dr_from_kept(kept);
+        let resolution = resolution_from_registerable(kept);
         let pre_task_count = proof_tasks.tasks.len();
         let expected_pending = pre_existing.len() + expected_new_spawns;
         let pre_cancelled = seeded_cancels.iter().filter(|c| c.is_cancelled()).count();
@@ -647,7 +621,7 @@ mod tests {
         let (stale_task_id, stale_cancel) =
             spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
 
-        reconcile(&manager, &dr_from_kept(&[]), &mut proof_tasks);
+        reconcile(&manager, &resolution_from_registerable(&[]), &mut proof_tasks);
         assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
         assert_eq!(
             proof_tasks.pending.get(&signer).map(|p| p.task_id),
@@ -655,7 +629,11 @@ mod tests {
             "cancelled entry still keyed by signer until reaped",
         );
 
-        reconcile(&manager, &dr_from_kept(&[(EP1, &HARDHAT_KEY_0)]), &mut proof_tasks);
+        reconcile(
+            &manager,
+            &resolution_from_registerable(&[(EP1, &HARDHAT_KEY_0)]),
+            &mut proof_tasks,
+        );
 
         assert_eq!(proof_tasks.pending_len(), 1, "still exactly one entry per signer");
         let fresh = proof_tasks.pending.get(&signer).expect("fresh entry keyed by signer");
@@ -790,12 +768,13 @@ mod tests {
     #[tokio::test]
     async fn reap_finished_tasks_drains_completed_and_evicts_pending() {
         let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
 
-        let handle =
-            proof_tasks.tasks.spawn(async move { proof_task_success_for_test(HARDHAT_ACCOUNT) });
-        proof_tasks.pending.insert(
-            HARDHAT_ACCOUNT,
-            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
+        proof_tasks.spawn_task(
+            signer,
+            TEST_PENDING_INSTANCE_ID.to_string(),
+            CancellationToken::new(),
+            async move { ProofTaskOutcome { signer, result: Ok(()) } },
         );
 
         reap_until_pending_empty(&mut proof_tasks).await;
@@ -807,13 +786,9 @@ mod tests {
     #[tokio::test]
     async fn reap_finished_tasks_leaves_in_flight_alone() {
         let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
 
-        spawn_pending_success_task(
-            &mut proof_tasks,
-            HARDHAT_ACCOUNT,
-            TEST_PENDING_INSTANCE_ID,
-            false,
-        );
+        spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
 
         proof_tasks.reap_finished_tasks();
 
@@ -825,13 +800,15 @@ mod tests {
     #[tokio::test]
     async fn apply_join_outcome_drops_pending_entry_when_task_panics() {
         let mut proof_tasks = ProofTaskSet::new();
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
 
-        let handle = proof_tasks.tasks.spawn(async {
-            panic!("synthetic proof-task panic for apply_join_outcome test");
-        });
-        proof_tasks.pending.insert(
-            HARDHAT_ACCOUNT,
-            pending_registration_for_test(handle.id(), TEST_PENDING_INSTANCE_ID),
+        proof_tasks.spawn_task(
+            signer,
+            TEST_PENDING_INSTANCE_ID.to_string(),
+            CancellationToken::new(),
+            async {
+                panic!("synthetic proof-task panic for apply_join_outcome test");
+            },
         );
 
         reap_until_pending_empty(&mut proof_tasks).await;
@@ -843,13 +820,13 @@ mod tests {
     #[tokio::test]
     async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_fails_for_same_signer() {
         let mut proof_tasks = ProofTaskSet::new();
-        let signer = HARDHAT_ACCOUNT;
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
 
         let stale_handle = proof_tasks.tasks.spawn(async move {
-            proof_task_failure_for_test(
+            ProofTaskOutcome {
                 signer,
-                RegistrarError::Config("synthetic stale proof failure".to_string()),
-            )
+                result: Err(RegistrarError::Config("synthetic stale proof failure".to_string())),
+            }
         });
         let stale_task_id = stale_handle.id();
 

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -642,6 +642,31 @@ mod tests {
         }
     }
 
+    fn spawn_pending_success_task(
+        proof_tasks: &mut ProofTaskSet,
+        signer: Address,
+        instance_id: &str,
+        cancelled_by_reconcile: bool,
+    ) -> (task::Id, CancellationToken) {
+        let cancel = CancellationToken::new();
+        let cancel_inner = cancel.clone();
+        let handle = proof_tasks.tasks.spawn(async move {
+            cancel_inner.cancelled().await;
+            proof_task_success_for_test(signer)
+        });
+        let task_id = handle.id();
+        proof_tasks.pending.insert(
+            signer,
+            PendingRegistration {
+                instance_id: instance_id.to_string(),
+                task_id,
+                cancel: cancel.clone(),
+                cancelled_by_reconcile,
+            },
+        );
+        (task_id, cancel)
+    }
+
     async fn wait_for(label: &str, predicate: impl Fn() -> bool) {
         let started = std::time::Instant::now();
         while !predicate() {
@@ -706,20 +731,11 @@ mod tests {
 
         for (_, key) in pre_existing {
             let signer = signer_from_key(key);
-            let task_cancel = CancellationToken::new();
-            let task_cancel_inner = task_cancel.clone();
-            let handle = proof_tasks.tasks.spawn(async move {
-                task_cancel_inner.cancelled().await;
-                proof_task_success_for_test(signer)
-            });
-            proof_tasks.pending.insert(
+            let (_, task_cancel) = spawn_pending_success_task(
+                &mut proof_tasks,
                 signer,
-                PendingRegistration {
-                    instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                    task_id: handle.id(),
-                    cancel: task_cancel.clone(),
-                    cancelled_by_reconcile: false,
-                },
+                TEST_PENDING_INSTANCE_ID,
+                false,
             );
             seeded_cancels.push(task_cancel);
         }
@@ -775,22 +791,8 @@ mod tests {
         let mut proof_tasks = ProofTaskSet::new();
         let signer = signer_from_key(&HARDHAT_KEY_0);
 
-        let stale_cancel = CancellationToken::new();
-        let stale_cancel_inner = stale_cancel.clone();
-        let stale_handle = proof_tasks.tasks.spawn(async move {
-            stale_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        let stale_task_id = stale_handle.id();
-        proof_tasks.pending.insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: stale_task_id,
-                cancel: stale_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
+        let (stale_task_id, stale_cancel) =
+            spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
 
         reconcile(&manager, &dr_from_kept(&[]), &mut proof_tasks);
         assert!(stale_cancel.is_cancelled(), "stale task must be cancelled by reconcile");
@@ -820,21 +822,8 @@ mod tests {
         let mut proof_tasks = ProofTaskSet::new();
         let signer = signer_from_key(&HARDHAT_KEY_0);
 
-        let task_cancel = CancellationToken::new();
-        let task_cancel_inner = task_cancel.clone();
-        let handle = proof_tasks.tasks.spawn(async move {
-            task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        proof_tasks.pending.insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: handle.id(),
-                cancel: task_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
+        let (_, task_cancel) =
+            spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
 
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
@@ -1000,20 +989,11 @@ mod tests {
     async fn reap_finished_tasks_leaves_in_flight_alone() {
         let mut proof_tasks = ProofTaskSet::new();
 
-        let cancel = CancellationToken::new();
-        let cancel_inner = cancel.clone();
-        let handle = proof_tasks.tasks.spawn(async move {
-            cancel_inner.cancelled().await;
-            proof_task_success_for_test(HARDHAT_ACCOUNT)
-        });
-        proof_tasks.pending.insert(
+        spawn_pending_success_task(
+            &mut proof_tasks,
             HARDHAT_ACCOUNT,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: handle.id(),
-                cancel,
-                cancelled_by_reconcile: false,
-            },
+            TEST_PENDING_INSTANCE_ID,
+            false,
         );
 
         proof_tasks.reap_finished_tasks();
@@ -1073,24 +1053,9 @@ mod tests {
         });
         let stale_task_id = stale_handle.id();
 
-        let fresh_cancel = CancellationToken::new();
-        let fresh_cancel_inner = fresh_cancel.clone();
-        let fresh_handle = proof_tasks.tasks.spawn(async move {
-            fresh_cancel_inner.cancelled().await;
-            proof_task_success_for_test(signer)
-        });
-        let fresh_task_id = fresh_handle.id();
+        let (fresh_task_id, _) =
+            spawn_pending_success_task(&mut proof_tasks, signer, TEST_PENDING_INSTANCE_ID, false);
         assert_ne!(stale_task_id, fresh_task_id, "test setup: distinct task ids");
-
-        proof_tasks.pending.insert(
-            signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: fresh_task_id,
-                cancel: fresh_cancel.clone(),
-                cancelled_by_reconcile: false,
-            },
-        );
 
         let started = std::time::Instant::now();
         loop {
@@ -1119,20 +1084,11 @@ mod tests {
         assert_ne!(active_signer, pending_signer, "test setup: distinct signers");
 
         let mut proof_tasks = ProofTaskSet::new();
-        let task_cancel = CancellationToken::new();
-        let task_cancel_inner = task_cancel.clone();
-        let handle = proof_tasks.tasks.spawn(async move {
-            task_cancel_inner.cancelled().await;
-            proof_task_success_for_test(pending_signer)
-        });
-        proof_tasks.pending.insert(
+        spawn_pending_success_task(
+            &mut proof_tasks,
             pending_signer,
-            PendingRegistration {
-                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                task_id: handle.id(),
-                cancel: task_cancel,
-                cancelled_by_reconcile: false,
-            },
+            TEST_PENDING_INSTANCE_ID,
+            false,
         );
 
         let resolution = DiscoveryResolution {
@@ -1254,20 +1210,11 @@ mod tests {
 
                     for (key, flagged) in seed {
                         let signer = signer_from_key(key);
-                        let cancel = CancellationToken::new();
-                        let cancel_inner = cancel.clone();
-                        let handle = proof_tasks.tasks.spawn(async move {
-                            cancel_inner.cancelled().await;
-                            proof_task_success_for_test(signer)
-                        });
-                        proof_tasks.pending.insert(
+                        let (_, cancel) = spawn_pending_success_task(
+                            &mut proof_tasks,
                             signer,
-                            PendingRegistration {
-                                instance_id: TEST_PENDING_INSTANCE_ID.to_string(),
-                                task_id: handle.id(),
-                                cancel: cancel.clone(),
-                                cancelled_by_reconcile: *flagged,
-                            },
+                            TEST_PENDING_INSTANCE_ID,
+                            *flagged,
                         );
                         if *flagged {
                             cancel.cancel();

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -858,9 +858,8 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_proof_tasks_dedupes_signer_across_registerable_entries() {
-        let proof_provider = RecordingProofProvider::default();
         let manager = manager(
-            proof_provider.clone(),
+            RecordingProofProvider::default(),
             MockRegistry::with_signers(vec![]),
             SharedTxManager::new(),
         );
@@ -894,40 +893,17 @@ mod tests {
         let (&only_signer, _entry) = proof_tasks.pending.iter().next().unwrap();
         assert_eq!(only_signer, signer, "the task is keyed by the deduplicated signer");
 
-        wait_for("the lone spawned task recorded its attestation", || {
-            !proof_provider.snapshot().is_empty()
-        })
-        .await;
         drain_test_tasks(&mut proof_tasks).await;
-
-        assert_eq!(proof_provider.snapshot().len(), 1, "exactly one signer recorded");
     }
 
-    #[rstest]
-    #[case::forward_order(false)]
-    #[case::reversed_order(true)]
     #[tokio::test]
-    async fn reconcile_proof_tasks_pairs_attestation_with_signer(#[case] reverse: bool) {
+    async fn reconcile_proof_tasks_pairs_attestation_with_signer() {
         let signer_a = signer_from_key(&HARDHAT_KEY_0);
         let signer_b = signer_from_key(&HARDHAT_KEY_1);
         assert_ne!(signer_a, signer_b, "test setup: distinct signer addresses");
 
         let att_a: Vec<u8> = b"attestation-aligned-to-A".to_vec();
         let att_b: Vec<u8> = b"attestation-aligned-to-B".to_vec();
-        let entry_a = RegisterableSigner {
-            instance: instance(EP1),
-            signer: signer_a,
-            attestation: att_a.clone(),
-            enclave_index: 0,
-        };
-        let entry_b = RegisterableSigner {
-            instance: instance(EP2),
-            signer: signer_b,
-            attestation: att_b.clone(),
-            enclave_index: 0,
-        };
-        let registerable = if reverse { vec![entry_b, entry_a] } else { vec![entry_a, entry_b] };
-
         let proof_provider = RecordingProofProvider::default();
         let manager = manager(
             proof_provider.clone(),
@@ -935,7 +911,20 @@ mod tests {
             SharedTxManager::new(),
         );
         let resolution = DiscoveryResolution {
-            registerable,
+            registerable: vec![
+                RegisterableSigner {
+                    instance: instance(EP1),
+                    signer: signer_a,
+                    attestation: att_a.clone(),
+                    enclave_index: 0,
+                },
+                RegisterableSigner {
+                    instance: instance(EP2),
+                    signer: signer_b,
+                    attestation: att_b.clone(),
+                    enclave_index: 0,
+                },
+            ],
             active_signers: HashSet::from([signer_a, signer_b]),
             reachable_count: 2,
             total_count: 2,
@@ -1004,16 +993,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reap_finished_tasks_is_noop_when_pending_is_empty() {
-        let mut proof_tasks = ProofTaskSet::new();
-
-        proof_tasks.reap_finished_tasks();
-
-        assert!(proof_tasks.pending.is_empty(), "pending stays empty");
-        assert!(proof_tasks.tasks.is_empty(), "JoinSet stays empty");
-    }
-
-    #[tokio::test]
     async fn apply_join_outcome_drops_pending_entry_when_task_panics() {
         let mut proof_tasks = ProofTaskSet::new();
 
@@ -1031,25 +1010,16 @@ mod tests {
         assert!(proof_tasks.tasks.is_empty(), "JoinSet must drain to empty");
     }
 
-    #[rstest]
-    #[case::ok_outcome(true)]
-    #[case::err_outcome(false)]
     #[tokio::test]
-    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_finishes_for_same_signer(
-        #[case] stale_succeeds: bool,
-    ) {
+    async fn apply_join_outcome_preserves_fresh_entry_when_stale_task_fails_for_same_signer() {
         let mut proof_tasks = ProofTaskSet::new();
         let signer = HARDHAT_ACCOUNT;
 
         let stale_handle = proof_tasks.tasks.spawn(async move {
-            if stale_succeeds {
-                proof_task_success_for_test(signer)
-            } else {
-                proof_task_failure_for_test(
-                    signer,
-                    RegistrarError::Config("synthetic stale proof failure".to_string()),
-                )
-            }
+            proof_task_failure_for_test(
+                signer,
+                RegistrarError::Config("synthetic stale proof failure".to_string()),
+            )
         });
         let stale_task_id = stale_handle.id();
 
@@ -1108,13 +1078,9 @@ mod tests {
         assert_eq!(protected_after_drain, HashSet::from([active_signer]));
     }
 
-    #[rstest]
-    #[case::single_orphan(vec![ORPHAN_A])]
-    #[case::multiple_orphans(vec![ORPHAN_A, ORPHAN_B, ORPHAN_C])]
     #[tokio::test]
-    async fn run_orphan_dereg_deregisters_all_unprotected_onchain_signers(
-        #[case] orphans: Vec<Address>,
-    ) {
+    async fn run_orphan_dereg_deregisters_all_unprotected_onchain_signers() {
+        let orphans = vec![ORPHAN_A, ORPHAN_B, ORPHAN_C];
         let expected_count = orphans.len();
         let tx = SharedTxManager::new();
         let manager = manager(

--- a/crates/proof/tee/registrar/src/test_utils.rs
+++ b/crates/proof/tee/registrar/src/test_utils.rs
@@ -6,11 +6,13 @@
 
 use std::time::SystemTime;
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
+use async_trait::async_trait;
+use base_tx_manager::{SendHandle, TxCandidate, TxManager};
 use hex_literal::hex;
 use k256::ecdsa::SigningKey;
 
-use crate::{InstanceHealthStatus, ProverClient, ProverInstance};
+use crate::{InstanceHealthStatus, NitroVerifierClient, ProverClient, ProverInstance, Result};
 
 /// Well-known Hardhat / Anvil account #0 private key.
 pub const HARDHAT_KEY_0: [u8; 32] =
@@ -42,6 +44,39 @@ pub const EP4: &str = "10.0.0.4:8000";
 
 /// Placeholder registry contract address used in registrar test configs.
 pub const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
+
+/// Tx manager stub for tests that only need to satisfy generic bounds.
+#[derive(Debug, Clone, Copy)]
+pub struct NoopTxManager;
+
+impl TxManager for NoopTxManager {
+    async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
+        unreachable!("NoopTxManager does not submit transactions")
+    }
+
+    async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+        unreachable!("NoopTxManager does not submit async transactions")
+    }
+
+    fn sender_address(&self) -> Address {
+        Address::ZERO
+    }
+}
+
+/// Nitro verifier stub for tests that do not exercise revocation checks.
+#[derive(Debug)]
+pub struct NoopNitroVerifier;
+
+#[async_trait]
+impl NitroVerifierClient for NoopNitroVerifier {
+    fn address(&self) -> Address {
+        Address::ZERO
+    }
+
+    async fn is_revoked(&self, _cert_hash: B256) -> Result<bool> {
+        Ok(false)
+    }
+}
 
 /// Derives the uncompressed 65-byte public key from a private key.
 pub fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {

--- a/crates/proof/tee/registrar/src/test_utils.rs
+++ b/crates/proof/tee/registrar/src/test_utils.rs
@@ -1,7 +1,77 @@
 //! Shared test fixtures for the registrar crate.
 //!
-//! Real AWS Nitro certificate DER hex strings, captured from a production
-//! attestation document and shared between `crl::tests` and `driver::tests`.
+//! Includes common registrar test keys, instances, addresses, and real AWS
+//! Nitro certificate DER hex strings captured from a production attestation
+//! document.
+
+use std::time::SystemTime;
+
+use alloy_primitives::Address;
+use hex_literal::hex;
+use k256::ecdsa::SigningKey;
+
+use crate::{InstanceHealthStatus, ProverClient, ProverInstance};
+
+/// Well-known Hardhat / Anvil account #0 private key.
+pub const HARDHAT_KEY_0: [u8; 32] =
+    hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+
+/// Hardhat / Anvil account #1 private key.
+pub const HARDHAT_KEY_1: [u8; 32] =
+    hex!("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+
+/// Hardhat / Anvil account #2 private key.
+pub const HARDHAT_KEY_2: [u8; 32] =
+    hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
+
+/// Hardhat / Anvil account #3 private key.
+pub const HARDHAT_KEY_3: [u8; 32] =
+    hex!("7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6");
+
+/// Prover instance endpoint #1 used in registrar tests.
+pub const EP1: &str = "10.0.0.1:8000";
+
+/// Prover instance endpoint #2 used in registrar tests.
+pub const EP2: &str = "10.0.0.2:8000";
+
+/// Prover instance endpoint #3 used in registrar tests.
+pub const EP3: &str = "10.0.0.3:8000";
+
+/// Prover instance endpoint #4 used in registrar tests.
+pub const EP4: &str = "10.0.0.4:8000";
+
+/// Placeholder registry contract address used in registrar test configs.
+pub const TEST_REGISTRY_ADDRESS: Address = Address::repeat_byte(0x01);
+
+/// Derives the uncompressed 65-byte public key from a private key.
+pub fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
+    let signing_key = SigningKey::from_slice(private_key).unwrap();
+    signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
+}
+
+/// Derives the signer address for a private key.
+pub fn signer_from_private_key(private_key: &[u8; 32]) -> Address {
+    ProverClient::derive_address(&public_key_from_private(private_key)).unwrap()
+}
+
+/// Builds a test [`ProverInstance`] with a deterministic instance id.
+pub fn prover_instance(
+    host_port: &str,
+    health_status: InstanceHealthStatus,
+    launch_time: Option<SystemTime>,
+) -> ProverInstance {
+    ProverInstance {
+        instance_id: format!("i-{host_port}"),
+        endpoint: url::Url::parse(&format!("http://{host_port}")).unwrap(),
+        health_status,
+        launch_time,
+    }
+}
+
+/// Builds a healthy test [`ProverInstance`] with no launch time.
+pub fn healthy_prover_instance(host_port: &str) -> ProverInstance {
+    prover_instance(host_port, InstanceHealthStatus::Healthy, None)
+}
 
 /// Real AWS Nitro root CA (self-signed, P384). Validity: 2019-10-28 to
 /// 2049-10-28.


### PR DESCRIPTION
### What changed? Why?

Extracts the signer manager unit tests into `signer_manager.rs` on top of #3523, so the driver tests stay focused on discovery and run-loop orchestration while signer lifecycle behavior is covered at the signer manager boundary.

### Notes to reviewers

This PR is stacked on #3523 and should be reviewed as a test-only follow-up. The driver test simplifications from #3523 are already present; this branch only adds the missing signer manager coverage and test-only `ProofTaskSet` accessors.

### How has it been tested?

- `cargo test -p base-proof-tee-registrar signer_manager`
- `cargo test -p base-proof-tee-registrar`
- `cargo test -p base-proof-tee-registrar --features metrics drain_counts_only_tasks_not_already_cancelled_by_reconcile`