### PR TITLE
fix(flashblocks): wire up FlashblockAccessList from builder to consumer to eliminate re execution divergence

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -484,6 +484,7 @@ where
             None,
             latest_block_l1_block_info.clone(),
             state_overrides,
+            flashblock.metadata.access_list.clone(),
         );
         pending_state_builder.set_execution_offsets(
             prev_pending_blocks.latest_block_cumulative_gas_used(),
@@ -615,6 +616,7 @@ where
             None,
             l1_block_info.clone(),
             state_overrides,
+            flashblock.metadata.access_list.clone(),
         );
         pending_state_builder.apply_pre_execution_changes(
             previous_header.hash_slow(),
@@ -767,6 +769,7 @@ where
                 prev_pending_blocks.clone(),
                 l1_block_info,
                 state_overrides,
+                flashblock.metadata.access_list.clone(),
             );
 
             pending_state_builder


### PR DESCRIPTION
Problem
Issue https://github.com/base/base/issues/3274 describes a divergence between builder execution and consumer re-execution of flashblocks. Per ron137's analysis:

~23% of flashblocks diverge despite identical tx set, ordering, parent hash, basefee, timestamp, and spec ID
Gas-only divergence (~8-14k extra gas on refund-heavy txs like ERC-4337 EntryPoint handleOps) — logs are byte-identical, only the checksum breaks
Content-drift on swaps — same pool address and topics but different sqrtPrice/amounts in logs
The dev team has confirmed (in https://github.com/base/base/issues/2265) that receipts will not return to the flashblock payload, so the fix must come from aligning the re-execution path with the builder's execution.

Root Cause
In crates/builder/core/src/flashblocks/payload.rs, the builder's build_block function already computes a FlashblockAccessList via FBALBuilderDb during execution. This access list tracks every account touched (balance/nonce/code/storage reads and writes) across the flashblock's transactions:

rust
let fal_builder = std::mem::take(&mut info.extra.access_list_builder);
let _access_list = fal_builder.build(min_tx_index, max_tx_index); // computed but discarded!

The FlashblocksMetadata struct already has an access_list: Option<FlashblockAccessList> field, but it was always set to None — the computed access list was thrown away.

On the consumer side, PendingStateBuilder re-executes transactions from scratch against canonical parent state, without any knowledge of which accounts the builder had already accessed. This causes warm/cold address accounting differences that cascade into:

Different gas costs on refund-heavy transactions (the EntryPoint case)
Different intermediate state → different swap outputs (the content-drift case)
Fix
Three changes across the builder-consumer boundary:

1. Builder: Include the access list in flashblock metadata (payload.rs)
Instead of discarding the built access list, pass it through the metadata:
rust
let access_list = fal_builder.build(min_tx_index, max_tx_index);
// ...
FlashblocksMetadata {
access_list: Some(access_list),
// ...
}

2. Consumer Metadata: Add access_list field (metadata.rs)
The consumer's Metadata struct now accepts the optional access list:
rust
pub struct Metadata {
pub block_number: u64,
pub access_list: Option,
}

3. Consumer PendingStateBuilder: Pre-load addresses before execution (state_builder.rs)
Before calling evm.transact(), pre-load all accounts from the access list into the EVM database:
rust
if let Some(ref access_list) = self.access_list {
for account_change in &access_list.account_changes {
self.evm.db_mut().basic(account_change.address)?;
}
}

This ensures the consumer's DB cache matches the builder's state, producing identical execution results.

Files Changed
crates/common/flashblocks/src/metadata.rs added access_list field
crates/common/flashblocks/Cargo.toml added base-access-lists dependency
crates/builder/core/src/flashblocks/payload.rs wire up access list in metadata
crates/execution/flashblocks/src/state_builder.rs pre-load accounts from access list
crates/execution/flashblocks/Cargo.toml added base-access-lists dependency
crates/execution/flashblocks/src/processor.rs pass metadata access_list to PendingStateBuilder
Status
Implementation is complete on branch fix/3274-access-list-warm. Opened as a draft to gather feedback before formal PR.

Closes https://github.com/base/base/issues/3274
Ref: https://github.com/base/base/issues/2265, https://github.com/base/base/pull/300, https://github.com/base/base/issues/2790