### PR TITLE
docs: add Turkish translation of contributing guidelines

### DIFF
--- a/CONTRIBUTING.tr.md
+++ b/CONTRIBUTING.tr.md
@@ -1,0 +1,35 @@
+Base Dökümantasyonuna Katkıda Bulunma Rehberi
+
+Base dökümantasyonunu geliştirmemize yardımcı olmak istediğiniz için teşekkür ederiz! Base, herkes için erişilebilir, güvenli ve düşük maliyetli bir Ethereum L2 ağıdır. Bu dökümantasyonun güncel ve anlaşılır kalması, geliştirici topluluğumuz için hayati önem taşımaktadır.
+
+Bu kılavuz, katkı sürecinizi olabildiğince kolaylaştırmak için hazırlanmıştır.
+
+Nasıl Katkıda Bulunabilirsiniz?
+
+Her türlü katkıya açığız! Katkıda bulunabileceğiniz bazı alanlar:
+
+Yazım Hatalarını Düzeltme: Metinlerdeki veya kod bloklarındaki küçük hataları düzeltmek.
+
+Kırık Linkleri Bildirmek: Çalışmayan veya güncelliğini yitirmiş bağlantıları güncellemek.
+
+Yerelleştirme ve Çeviri: Dökümanları Türkçe gibi yerel dillere çevirerek erişilebilirliği artırmak.
+
+Yeni Eğitim İçerikleri (Tutorials): Base üzerinde uygulama geliştirmeyi anlatan yeni adım adım rehberler eklemek.
+
+Katkı Süreci (GitHub Akışı)
+
+Fork Yapın: Bu depoyu kendi GitHub hesabınıza forklayın.
+
+Dal (Branch) Oluşturun: Yapacağınız değişiklik için anlamlı bir branch oluşturun (örn: feat/turkish-translation veya fix/broken-links).
+
+Değişiklikleri Yapın: Dosyalarınızı düzenleyin ve yerel olarak test edin.
+
+Değişiklikleri Kaydedin (Commit): Commit mesajlarınızı kısa ve açıklayıcı tutun (örn: docs: translate getting started to Turkish).
+
+Pull Request Açın: Değişikliklerinizi ana depoya gönderin ve neyi, neden değiştirdiğinizi açıklayan profesyonel bir PR açıklaması yazın.
+
+Davranış Kuralları (Code of Conduct)
+
+Bu projeye katkıda bulunarak, topluluk kurallarımıza ve herkese saygılı davranma ilkemize uymayı kabul etmiş olursunuz. Lütfen tüm iletişimlerinizde nazik, profesyonel ve yapıcı olun.
+
+Base ekosistemini birlikte büyütmek için sabırsızlanıyoruz!


### PR DESCRIPTION
## Description
This PR adds the Turkish translation of the main contributing guidelines (`CONTRIBUTING.tr.md`). Turkey has a massive and highly active Web3 developer community. Having local contributing guidelines will significantly lower the barrier to entry for Turkish-speaking contributors and developers who want to help build on Base.

## Changes
- Added `CONTRIBUTING.tr.md` (full Turkish translation of `CONTRIBUTING.md`).

## Checklist
- [x] Translation matches the structure and formatting of the original English version.
- [x] Followed the existing document standards.