### PR TITLE
fix(follow): recover from safe-head divergence by resetting to common ancestor

### DIFF
--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -1,6 +1,9 @@
 //! Mock implementations for testing engine client functionality.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
 use alloy_json_rpc::ErrorPayload;
@@ -10,6 +13,7 @@ use alloy_provider::{EthGetBlock, ProviderCall, RpcWithBlock};
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
+    PayloadStatusEnum,
 };
 use alloy_rpc_types_eth::{Block, EIP1186AccountProofResponse, Transaction as EthTransaction};
 use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
@@ -46,12 +50,30 @@ pub enum MockL2BlockError {
     Custom(String),
 }
 
+/// Opt-in stateful execution-layer model for recovery tests.
+///
+/// When set, `new_payload_v2` and `fork_choice_updated_v3` answer based on which blocks the EL
+/// "has" rather than from static responses: a forkchoice update to a known block is `Valid` (and
+/// advances the head); to an unknown block it is `Syncing`. A new payload whose parent is known is
+/// `Valid` (and the block becomes known); otherwise `Syncing`. This models the real distinction the
+/// follow-mode recovery relies on (reset to a block the EL has vs. the canonical tip it lacks).
+#[derive(Debug, Clone, Default)]
+pub struct StatefulEl {
+    /// Hashes of blocks the EL currently has.
+    pub known: HashSet<B256>,
+    /// The EL's current head.
+    pub head: B256,
+}
+
 /// Mock storage for engine client responses.
 ///
 /// Each API method has version-specific storage to allow tests to verify
 /// which specific version was called and return different responses per version.
 #[derive(Debug, Clone, Default)]
 pub struct MockEngineStorage {
+    /// Optional stateful EL model (see [`StatefulEl`]); when `Some`, overrides the static
+    /// `new_payload_v2` / `fork_choice_updated_v3` responses.
+    pub stateful: Option<StatefulEl>,
     /// Storage for block responses by tag.
     pub l2_blocks_by_label: HashMap<BlockNumberOrTag, L2RpcBlock>,
     /// Storage for block info responses by tag.
@@ -201,6 +223,14 @@ impl MockEngineClientBuilder {
     /// Sets the `fork_choice_updated_v3` response.
     pub fn with_fork_choice_updated_v3_response(mut self, response: ForkchoiceUpdated) -> Self {
         self.storage.fork_choice_updated_v3_response = Some(response);
+        self
+    }
+
+    /// Enables the stateful EL model (see [`StatefulEl`]), seeded with the given known block hashes
+    /// and head. While enabled, `new_payload_v2` and `fork_choice_updated_v3` answer based on block
+    /// presence instead of the static responses.
+    pub fn with_stateful_el(mut self, known: impl IntoIterator<Item = B256>, head: B256) -> Self {
+        self.storage.stateful = Some(StatefulEl { known: known.into_iter().collect(), head });
         self
     }
 
@@ -372,6 +402,11 @@ impl MockEngineClient {
     /// Returns the most recent `new_payload_v2` request, if any.
     pub async fn last_new_payload_v2(&self) -> Option<ExecutionPayloadInputV2> {
         self.storage.read().await.last_new_payload_v2_request.clone()
+    }
+
+    /// Returns the stateful EL head, if the stateful model is enabled.
+    pub async fn stateful_head(&self) -> Option<B256> {
+        self.storage.read().await.stateful.as_ref().map(|s| s.head)
     }
 
     /// Sets the `new_payload_v3` response.
@@ -566,8 +601,22 @@ impl BaseEngineApi for MockEngineClient {
         &self,
         payload: ExecutionPayloadInputV2,
     ) -> TransportResult<PayloadStatus> {
+        let block_hash = payload.execution_payload.block_hash;
+        let parent_hash = payload.execution_payload.parent_hash;
         let mut storage = self.storage.write().await;
         storage.last_new_payload_v2_request = Some(payload);
+        if let Some(st) = storage.stateful.as_mut() {
+            // A payload whose parent the EL has is Valid (and becomes known); otherwise Syncing.
+            return Ok(if st.known.contains(&parent_hash) {
+                st.known.insert(block_hash);
+                PayloadStatus {
+                    status: PayloadStatusEnum::Valid,
+                    latest_valid_hash: Some(block_hash),
+                }
+            } else {
+                PayloadStatus { status: PayloadStatusEnum::Syncing, latest_valid_hash: None }
+            });
+        }
         storage.new_payload_v2_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "new_payload_v2 was called but no v2 response configured. \
@@ -635,6 +684,28 @@ impl BaseEngineApi for MockEngineClient {
             .push((fork_choice_state, payload_attributes.is_some()));
         if let Some(error) = storage.fork_choice_updated_v3_error.clone() {
             return Err(TransportError::ErrorResp(error));
+        }
+        if let Some(st) = storage.stateful.as_mut() {
+            // A forkchoice update to a block the EL has is Valid (and advances head); else Syncing.
+            let head = fork_choice_state.head_block_hash;
+            return Ok(if st.known.contains(&head) {
+                st.head = head;
+                ForkchoiceUpdated {
+                    payload_status: PayloadStatus {
+                        status: PayloadStatusEnum::Valid,
+                        latest_valid_hash: Some(head),
+                    },
+                    payload_id: None,
+                }
+            } else {
+                ForkchoiceUpdated {
+                    payload_status: PayloadStatus {
+                        status: PayloadStatusEnum::Syncing,
+                        latest_valid_hash: None,
+                    },
+                    payload_id: None,
+                }
+            });
         }
         storage.fork_choice_updated_v3_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(

--- a/crates/consensus/engine/src/test_utils/mod.rs
+++ b/crates/consensus/engine/src/test_utils/mod.rs
@@ -6,7 +6,7 @@ pub use attributes::TestAttributesBuilder;
 mod engine_client;
 pub use engine_client::{
     MockEngineClient, MockEngineClientBuilder, MockEngineStorage, MockL2BlockError,
-    test_engine_client_builder,
+    StatefulEl, test_engine_client_builder,
 };
 
 mod engine_state;

--- a/crates/consensus/engine/src/test_utils/mod.rs
+++ b/crates/consensus/engine/src/test_utils/mod.rs
@@ -5,8 +5,8 @@ pub use attributes::TestAttributesBuilder;
 
 mod engine_client;
 pub use engine_client::{
-    MockEngineClient, MockEngineClientBuilder, MockEngineStorage, MockL2BlockError,
-    StatefulEl, test_engine_client_builder,
+    MockEngineClient, MockEngineClientBuilder, MockEngineStorage, MockL2BlockError, StatefulEl,
+    test_engine_client_builder,
 };
 
 mod engine_state;

--- a/crates/consensus/service/src/follow/engine.rs
+++ b/crates/consensus/service/src/follow/engine.rs
@@ -1,27 +1,16 @@
-use std::{fmt::Debug, sync::Arc, time::Duration};
+use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_engine::{
-    EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, EngineTaskExt, InsertTask, SynchronizeTask,
+    EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskExt, InsertTask,
+    SynchronizeTask,
 };
 use base_protocol::L2BlockInfo;
-use tokio::{sync::Mutex, time};
-use tokio_util::sync::CancellationToken;
+use tokio::sync::Mutex;
 
 use crate::follow::error::FollowError;
-
-const RESET_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
-const RESET_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
-
-/// Statistics collected while resetting the execution engine to a recovery ancestor.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(super) struct ResetStats {
-    /// Number of temporary Engine API failures retried.
-    pub(super) retries: u64,
-}
 
 #[async_trait]
 pub(super) trait FollowEngine: Debug + Send + Sync {
@@ -39,11 +28,7 @@ pub(super) trait FollowEngine: Debug + Send + Sync {
     /// Reorg the local unsafe and safe heads down to `ancestor` — a block the EL already has, so
     /// the forkchoice update returns Valid and the head reorgs immediately (no EL sync). Refuses to
     /// reorg below the finalized head.
-    async fn reset_to_ancestor(
-        &self,
-        ancestor: L2BlockInfo,
-        cancellation: CancellationToken,
-    ) -> Result<ResetStats, FollowError>;
+    async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError>;
 }
 
 #[derive(Debug)]
@@ -113,11 +98,7 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
         task.execute(&mut *self.state.lock().await).await.map_err(FollowError::engine_task)
     }
 
-    async fn reset_to_ancestor(
-        &self,
-        ancestor: L2BlockInfo,
-        cancellation: CancellationToken,
-    ) -> Result<ResetStats, FollowError> {
+    async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError> {
         let mut state = self.state.lock().await;
 
         // Never rewind below finality. `apply_update` does not enforce this, so guard here.
@@ -142,25 +123,7 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
                 ..Default::default()
             },
         );
-        let mut retry_backoff = RESET_RETRY_INITIAL_BACKOFF;
-        let mut retries = 0_u64;
-        loop {
-            match task.execute(&mut state).await {
-                Ok(()) => break,
-                Err(error) if error.severity() == EngineTaskErrorSeverity::Temporary => {
-                    retries = retries.saturating_add(1);
-                    // A transport error may mean the EL applied the FCU but the response was
-                    // lost. Repeating the same FCU reconciles the in-memory state once the EL
-                    // responds again.
-                    tokio::select! {
-                        _ = cancellation.cancelled() => return Ok(ResetStats { retries }),
-                        _ = time::sleep(retry_backoff) => {}
-                    }
-                    retry_backoff = retry_backoff.saturating_mul(2).min(RESET_RETRY_MAX_BACKOFF);
-                }
-                Err(error) => return Err(FollowError::engine_task(error)),
-            }
-        }
+        task.execute(&mut state).await.map_err(FollowError::engine_task)?;
 
         if state.sync_state.unsafe_head().block_info.hash != ancestor.block_info.hash {
             return Err(FollowError::ResetToAncestorUnconfirmed {
@@ -169,7 +132,7 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
             });
         }
 
-        Ok(ResetStats { retries })
+        Ok(())
     }
 }
 
@@ -188,7 +151,6 @@ mod tests {
     use base_consensus_engine::test_utils::test_engine_client_builder;
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
     use tokio::time::{self, Instant};
-    use tokio_util::sync::CancellationToken;
 
     use super::{EngineApiFollowEngine, FollowEngine};
     use crate::follow::error::FollowError;
@@ -315,7 +277,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reset_to_ancestor_retries_temporary_forkchoice_errors() {
+    async fn reset_to_ancestor_returns_temporary_forkchoice_errors() {
         let rollup_config = Arc::new(RollupConfig::default());
         let client =
             Arc::new(test_engine_client_builder().with_config(Arc::clone(&rollup_config)).build());
@@ -328,19 +290,11 @@ mod tests {
             ancestor,
         ));
 
-        let reset_engine = Arc::clone(&engine);
-        let reset = tokio::spawn(async move {
-            reset_engine.reset_to_ancestor(ancestor, CancellationToken::new()).await
-        });
-        time::sleep(Duration::from_millis(10)).await;
-        client.set_fork_choice_updated_v3_response(valid_forkchoice_updated()).await;
-
-        let stats = time::timeout(Duration::from_secs(1), reset)
+        let result = engine
+            .reset_to_ancestor(ancestor)
             .await
-            .expect("reset should finish after temporary error clears")
-            .expect("reset task should not panic")
-            .expect("temporary forkchoice error should be retried");
-        assert!(stats.retries >= 1);
+            .expect_err("temporary forkchoice error should be returned to the safety loop");
+        assert!(matches!(result, FollowError::EngineTask { .. }));
     }
 
     #[tokio::test]
@@ -369,10 +323,7 @@ mod tests {
 
         // Reset to the common ancestor (canonical block 1), a block the EL already has, so the
         // forkchoice update is Valid and the head reorgs down to it without EL sync.
-        engine
-            .reset_to_ancestor(block1, CancellationToken::new())
-            .await
-            .expect("reset to ancestor");
+        engine.reset_to_ancestor(block1).await.expect("reset to ancestor");
         assert_eq!(
             client.stateful_head().await,
             Some(block1.block_info.hash),
@@ -415,7 +366,7 @@ mod tests {
         // unchanged.
         let tip = l2_block(5, B256::with_last_byte(205));
         let error = engine
-            .reset_to_ancestor(tip, CancellationToken::new())
+            .reset_to_ancestor(tip)
             .await
             .expect_err("syncing must be surfaced as a failed reset");
         assert!(matches!(error, FollowError::ResetToAncestorUnconfirmed { number: 5, .. }));
@@ -446,7 +397,7 @@ mod tests {
         ));
 
         let error = engine
-            .reset_to_ancestor(l2_block(4, B256::with_last_byte(4)), CancellationToken::new())
+            .reset_to_ancestor(l2_block(4, B256::with_last_byte(4)))
             .await
             .expect_err("must refuse to rewind below finalized");
         assert!(matches!(error, FollowError::ReorgBelowFinalized { number: 4, finalized: 5 }));
@@ -455,35 +406,5 @@ mod tests {
             Some(head),
             "no forkchoice update should be issued on refusal"
         );
-    }
-
-    #[tokio::test]
-    async fn reset_to_ancestor_stops_retrying_when_cancelled() {
-        let rollup_config = Arc::new(RollupConfig::default());
-        let client =
-            Arc::new(test_engine_client_builder().with_config(Arc::clone(&rollup_config)).build());
-        let ancestor = l2_block_info(1);
-        let engine = Arc::new(EngineApiFollowEngine::new(
-            client,
-            rollup_config,
-            l2_block_info(2),
-            ancestor,
-            ancestor,
-        ));
-        let cancellation = CancellationToken::new();
-        let reset_engine = Arc::clone(&engine);
-        let reset_cancellation = cancellation.clone();
-        let reset = tokio::spawn(async move {
-            reset_engine.reset_to_ancestor(ancestor, reset_cancellation).await
-        });
-
-        time::sleep(Duration::from_millis(10)).await;
-        cancellation.cancel();
-
-        time::timeout(Duration::from_secs(1), reset)
-            .await
-            .expect("cancelled reset should finish promptly")
-            .expect("reset task should not panic")
-            .expect("cancellation should be treated as shutdown");
     }
 }

--- a/crates/consensus/service/src/follow/engine.rs
+++ b/crates/consensus/service/src/follow/engine.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
@@ -8,9 +8,20 @@ use base_consensus_engine::{
     EngineTaskErrorSeverity, EngineTaskExt, InsertTask, SynchronizeTask,
 };
 use base_protocol::L2BlockInfo;
-use tokio::{sync::Mutex, task::yield_now};
+use tokio::{sync::Mutex, time};
+use tokio_util::sync::CancellationToken;
 
 use crate::follow::error::FollowError;
+
+const RESET_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const RESET_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Statistics collected while resetting the execution engine to a recovery ancestor.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ResetStats {
+    /// Number of temporary Engine API failures retried.
+    pub(super) retries: u64,
+}
 
 #[async_trait]
 pub(super) trait FollowEngine: Debug + Send + Sync {
@@ -28,7 +39,11 @@ pub(super) trait FollowEngine: Debug + Send + Sync {
     /// Reorg the local unsafe and safe heads down to `ancestor` — a block the EL already has, so
     /// the forkchoice update returns Valid and the head reorgs immediately (no EL sync). Refuses to
     /// reorg below the finalized head.
-    async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError>;
+    async fn reset_to_ancestor(
+        &self,
+        ancestor: L2BlockInfo,
+        cancellation: CancellationToken,
+    ) -> Result<ResetStats, FollowError>;
 }
 
 #[derive(Debug)]
@@ -98,7 +113,11 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
         task.execute(&mut *self.state.lock().await).await.map_err(FollowError::engine_task)
     }
 
-    async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError> {
+    async fn reset_to_ancestor(
+        &self,
+        ancestor: L2BlockInfo,
+        cancellation: CancellationToken,
+    ) -> Result<ResetStats, FollowError> {
         let mut state = self.state.lock().await;
 
         // Never rewind below finality. `apply_update` does not enforce this, so guard here.
@@ -123,14 +142,21 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
                 ..Default::default()
             },
         );
+        let mut retry_backoff = RESET_RETRY_INITIAL_BACKOFF;
+        let mut retries = 0_u64;
         loop {
             match task.execute(&mut state).await {
                 Ok(()) => break,
                 Err(error) if error.severity() == EngineTaskErrorSeverity::Temporary => {
+                    retries = retries.saturating_add(1);
                     // A transport error may mean the EL applied the FCU but the response was
                     // lost. Repeating the same FCU reconciles the in-memory state once the EL
                     // responds again.
-                    yield_now().await;
+                    tokio::select! {
+                        _ = cancellation.cancelled() => return Ok(ResetStats { retries }),
+                        _ = time::sleep(retry_backoff) => {}
+                    }
+                    retry_backoff = retry_backoff.saturating_mul(2).min(RESET_RETRY_MAX_BACKOFF);
                 }
                 Err(error) => return Err(FollowError::engine_task(error)),
             }
@@ -143,7 +169,7 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
             });
         }
 
-        Ok(())
+        Ok(ResetStats { retries })
     }
 }
 
@@ -162,6 +188,7 @@ mod tests {
     use base_consensus_engine::test_utils::test_engine_client_builder;
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
     use tokio::time::{self, Instant};
+    use tokio_util::sync::CancellationToken;
 
     use super::{EngineApiFollowEngine, FollowEngine};
     use crate::follow::error::FollowError;
@@ -302,15 +329,18 @@ mod tests {
         ));
 
         let reset_engine = Arc::clone(&engine);
-        let reset = tokio::spawn(async move { reset_engine.reset_to_ancestor(ancestor).await });
+        let reset = tokio::spawn(async move {
+            reset_engine.reset_to_ancestor(ancestor, CancellationToken::new()).await
+        });
         time::sleep(Duration::from_millis(10)).await;
         client.set_fork_choice_updated_v3_response(valid_forkchoice_updated()).await;
 
-        time::timeout(Duration::from_secs(1), reset)
+        let stats = time::timeout(Duration::from_secs(1), reset)
             .await
             .expect("reset should finish after temporary error clears")
             .expect("reset task should not panic")
             .expect("temporary forkchoice error should be retried");
+        assert!(stats.retries >= 1);
     }
 
     #[tokio::test]
@@ -339,7 +369,10 @@ mod tests {
 
         // Reset to the common ancestor (canonical block 1), a block the EL already has, so the
         // forkchoice update is Valid and the head reorgs down to it without EL sync.
-        engine.reset_to_ancestor(block1).await.expect("reset to ancestor");
+        engine
+            .reset_to_ancestor(block1, CancellationToken::new())
+            .await
+            .expect("reset to ancestor");
         assert_eq!(
             client.stateful_head().await,
             Some(block1.block_info.hash),
@@ -383,7 +416,7 @@ mod tests {
         // common ancestor, not the source tip.
         let tip = l2_block(5, B256::with_last_byte(205));
         let error = engine
-            .reset_to_ancestor(tip)
+            .reset_to_ancestor(tip, CancellationToken::new())
             .await
             .expect_err("syncing must be surfaced as a failed reset");
         assert!(matches!(error, FollowError::ResetToAncestorUnconfirmed { number: 5, .. }));
@@ -414,7 +447,7 @@ mod tests {
         ));
 
         let error = engine
-            .reset_to_ancestor(l2_block(4, B256::with_last_byte(4)))
+            .reset_to_ancestor(l2_block(4, B256::with_last_byte(4)), CancellationToken::new())
             .await
             .expect_err("must refuse to rewind below finalized");
         assert!(matches!(error, FollowError::ReorgBelowFinalized { number: 4, finalized: 5 }));
@@ -423,5 +456,35 @@ mod tests {
             Some(head),
             "no forkchoice update should be issued on refusal"
         );
+    }
+
+    #[tokio::test]
+    async fn reset_to_ancestor_stops_retrying_when_cancelled() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        let client =
+            Arc::new(test_engine_client_builder().with_config(Arc::clone(&rollup_config)).build());
+        let ancestor = l2_block_info(1);
+        let engine = Arc::new(EngineApiFollowEngine::new(
+            client,
+            rollup_config,
+            l2_block_info(2),
+            ancestor,
+            ancestor,
+        ));
+        let cancellation = CancellationToken::new();
+        let reset_engine = Arc::clone(&engine);
+        let reset_cancellation = cancellation.clone();
+        let reset = tokio::spawn(async move {
+            reset_engine.reset_to_ancestor(ancestor, reset_cancellation).await
+        });
+
+        time::sleep(Duration::from_millis(10)).await;
+        cancellation.cancel();
+
+        time::timeout(Duration::from_secs(1), reset)
+            .await
+            .expect("cancelled reset should finish promptly")
+            .expect("reset task should not panic")
+            .expect("cancellation should be treated as shutdown");
     }
 }

--- a/crates/consensus/service/src/follow/engine.rs
+++ b/crates/consensus/service/src/follow/engine.rs
@@ -24,6 +24,11 @@ pub(super) trait FollowEngine: Debug + Send + Sync {
         safe: Option<L2BlockInfo>,
         finalized: Option<L2BlockInfo>,
     ) -> Result<(), FollowError>;
+
+    /// Reorg the local unsafe and safe heads down to `ancestor` — a block the EL already has, so
+    /// the forkchoice update returns Valid and the head reorgs immediately (no EL sync). Refuses to
+    /// reorg below the finalized head.
+    async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError>;
 }
 
 #[derive(Debug)]
@@ -90,6 +95,43 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
         );
         task.execute(&mut *self.state.lock().await).await.map_err(FollowError::engine_task)
     }
+
+    async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError> {
+        let mut state = self.state.lock().await;
+
+        // Never rewind below finality. `apply_update` does not enforce this, so guard here.
+        let finalized = state.sync_state.finalized_head().block_info.number;
+        if ancestor.block_info.number < finalized {
+            return Err(FollowError::ReorgBelowFinalized {
+                number: ancestor.block_info.number,
+                finalized,
+            });
+        }
+
+        // `ancestor` is a block the local EL already has (it is on the local chain), so this
+        // forkchoice update returns Valid and reorgs the unsafe head down to it without EL sync.
+        // Replaying source payloads from ancestor+1 then rebuilds onto the source's chain.
+        let task = SynchronizeTask::new(
+            Arc::clone(&self.client),
+            Arc::clone(&self.rollup_config),
+            EngineSyncStateUpdate {
+                unsafe_head: Some(ancestor),
+                local_safe_head: Some(ancestor),
+                safe_head: Some(ancestor),
+                ..Default::default()
+            },
+        );
+        task.execute(&mut state).await.map_err(FollowError::engine_task)?;
+
+        if state.sync_state.unsafe_head().block_info.hash != ancestor.block_info.hash {
+            return Err(FollowError::ResetToAncestorUnconfirmed {
+                number: ancestor.block_info.number,
+                hash: ancestor.block_info.hash,
+            });
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -101,7 +143,7 @@ mod tests {
     use alloy_rpc_types_engine::{
         ExecutionPayloadV1, ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum,
     };
-    use base_common_consensus::{BaseTxEnvelope, TxDeposit};
+    use base_common_consensus::{BaseBlock, BaseTxEnvelope, TxDeposit};
     use base_common_genesis::RollupConfig;
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
     use base_consensus_engine::test_utils::test_engine_client_builder;
@@ -109,6 +151,7 @@ mod tests {
     use tokio::time::{self, Instant};
 
     use super::{EngineApiFollowEngine, FollowEngine};
+    use crate::follow::error::FollowError;
 
     fn valid_payload_status() -> PayloadStatus {
         PayloadStatus { status: PayloadStatusEnum::Valid, latest_valid_hash: Some(B256::ZERO) }
@@ -135,6 +178,39 @@ mod tests {
             },
             ..Default::default()
         }
+    }
+
+    fn l2_block(number: u64, hash: B256) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo { hash, number, ..Default::default() },
+            ..Default::default()
+        }
+    }
+
+    /// Builds a canonical chain of `len` blocks (numbered `1..=len`) where each block's parent is the
+    /// previous block's *computed* hash and the declared `block_hash` equals the computed hash — as a
+    /// real EL would have it. This keeps the stateful mock (which keys off the declared `block_hash`)
+    /// consistent with `InsertTask`, which recomputes the hash from the block body for its forkchoice
+    /// update. Returns each payload paired with its computed [`L2BlockInfo`].
+    fn canonical_chain(
+        rollup_config: &RollupConfig,
+        len: u64,
+    ) -> Vec<(BaseExecutionPayloadEnvelope, L2BlockInfo)> {
+        let mut chain = Vec::new();
+        let mut parent = B256::ZERO;
+        for number in 1..=len {
+            let mut env = payload(number);
+            let BaseExecutionPayload::V1(p) = &mut env.execution_payload else { unreachable!() };
+            p.parent_hash = parent;
+            let block: BaseBlock = env.execution_payload.clone().try_into_block().expect("block");
+            let info = L2BlockInfo::from_block_and_genesis(&block, &rollup_config.genesis)
+                .expect("block info");
+            let BaseExecutionPayload::V1(p) = &mut env.execution_payload else { unreachable!() };
+            p.block_hash = info.block_info.hash;
+            parent = info.block_info.hash;
+            chain.push((env, info));
+        }
+        chain
     }
 
     fn payload(number: u64) -> BaseExecutionPayloadEnvelope {
@@ -196,5 +272,117 @@ mod tests {
             .expect("insert should finish after temporary error clears")
             .expect("insert task should not panic")
             .expect("temporary engine error should be retried");
+    }
+
+    #[tokio::test]
+    async fn reset_to_ancestor_then_replay_rebuilds_onto_source() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        // Canonical source chain, blocks 1..=3, with consistent computed hashes.
+        let chain = canonical_chain(&rollup_config, 3);
+        let block1 = chain[0].1;
+        let bad2 = B256::with_last_byte(102);
+
+        // The EL is on a bad fork: it has the shared prefix up to canonical block 1 plus a bad block
+        // 2, with its head on the bad tip.
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_config(Arc::clone(&rollup_config))
+                .with_stateful_el([block1.block_info.hash, bad2], bad2)
+                .build(),
+        );
+        let engine = Arc::new(EngineApiFollowEngine::new(
+            Arc::clone(&client),
+            Arc::clone(&rollup_config),
+            l2_block(2, bad2), // latest (bad tip)
+            block1,            // safe
+            block1,            // finalized at block 1
+        ));
+
+        // Reset to the common ancestor (canonical block 1), a block the EL already has, so the
+        // forkchoice update is Valid and the head reorgs down to it without EL sync.
+        engine.reset_to_ancestor(block1).await.expect("reset to ancestor");
+        assert_eq!(
+            client.stateful_head().await,
+            Some(block1.block_info.hash),
+            "head should reorg down to the ancestor"
+        );
+
+        // Replay the canonical chain from ancestor+1. Each payload's parent is already known, so the
+        // EL accepts it (Valid) and the head advances onto the source chain.
+        engine.insert_payload(chain[1].0.clone()).await.expect("replay block 2");
+        engine.insert_payload(chain[2].0.clone()).await.expect("replay block 3");
+
+        assert_eq!(
+            client.stateful_head().await,
+            Some(chain[2].1.block_info.hash),
+            "head should be rebuilt onto the canonical chain"
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_to_unknown_tip_returns_syncing_and_does_not_recover() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        let h0 = B256::with_last_byte(0);
+        let h1 = B256::with_last_byte(1);
+        let bad2 = B256::with_last_byte(102);
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_config(Arc::clone(&rollup_config))
+                .with_stateful_el([h0, h1, bad2], bad2)
+                .build(),
+        );
+        let engine = Arc::new(EngineApiFollowEngine::new(
+            Arc::clone(&client),
+            Arc::clone(&rollup_config),
+            l2_block(2, bad2),
+            l2_block(1, h1),
+            l2_block(0, h0),
+        ));
+
+        // Pointing the EL at the canonical *tip* (a block it does not have) returns Syncing: the
+        // head does not move and nothing is recovered. This is exactly why recovery must target the
+        // common ancestor, not the source tip.
+        let tip = l2_block(5, B256::with_last_byte(205));
+        let error = engine
+            .reset_to_ancestor(tip)
+            .await
+            .expect_err("syncing must be surfaced as a failed reset");
+        assert!(matches!(error, FollowError::ResetToAncestorUnconfirmed { number: 5, .. }));
+        assert_eq!(
+            client.stateful_head().await,
+            Some(bad2),
+            "head must not advance to a block the EL lacks"
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_below_finalized_is_refused() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        let h5 = B256::with_last_byte(5);
+        let head = B256::with_last_byte(8);
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_config(Arc::clone(&rollup_config))
+                .with_stateful_el([head], head)
+                .build(),
+        );
+        let engine = Arc::new(EngineApiFollowEngine::new(
+            Arc::clone(&client),
+            Arc::clone(&rollup_config),
+            l2_block(8, head),
+            l2_block(5, h5),
+            l2_block(5, h5), // finalized at block 5
+        ));
+
+        let error = engine
+            .reset_to_ancestor(l2_block(4, B256::with_last_byte(4)))
+            .await
+            .expect_err("must refuse to rewind below finalized");
+        assert!(matches!(error, FollowError::ReorgBelowFinalized { number: 4, finalized: 5 }));
+        assert_eq!(
+            client.stateful_head().await,
+            Some(head),
+            "no forkchoice update should be issued on refusal"
+        );
     }
 }

--- a/crates/consensus/service/src/follow/engine.rs
+++ b/crates/consensus/service/src/follow/engine.rs
@@ -411,9 +411,8 @@ mod tests {
             l2_block(0, h0),
         ));
 
-        // Pointing the EL at the canonical *tip* (a block it does not have) returns Syncing: the
-        // head does not move and nothing is recovered. This is exactly why recovery must target the
-        // common ancestor, not the source tip.
+        // A forkchoice update to a tip the EL does not have returns Syncing and leaves the head
+        // unchanged.
         let tip = l2_block(5, B256::with_last_byte(205));
         let error = engine
             .reset_to_ancestor(tip, CancellationToken::new())

--- a/crates/consensus/service/src/follow/engine.rs
+++ b/crates/consensus/service/src/follow/engine.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_engine::{
-    EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskExt, InsertTask,
-    SynchronizeTask,
+    EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
+    EngineTaskErrorSeverity, EngineTaskExt, InsertTask, SynchronizeTask,
 };
 use base_protocol::L2BlockInfo;
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, task::yield_now};
 
 use crate::follow::error::FollowError;
 
@@ -17,7 +17,7 @@ pub(super) trait FollowEngine: Debug + Send + Sync {
     async fn insert_payload(
         &self,
         envelope: BaseExecutionPayloadEnvelope,
-    ) -> Result<(), FollowError>;
+    ) -> Result<L2BlockInfo, FollowError>;
 
     async fn update_safe_finalized_blocks(
         &self,
@@ -62,16 +62,18 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
     async fn insert_payload(
         &self,
         envelope: BaseExecutionPayloadEnvelope,
-    ) -> Result<(), FollowError> {
+    ) -> Result<L2BlockInfo, FollowError> {
         let task = InsertTask::unsafe_payload(
             Arc::clone(&self.client),
             Arc::clone(&self.rollup_config),
             envelope,
         );
+        let mut state = self.state.lock().await;
         EngineTask::Insert(Box::new(task))
-            .execute(&mut *self.state.lock().await)
+            .execute(&mut state)
             .await
-            .map_err(FollowError::engine_task)
+            .map_err(FollowError::engine_task)?;
+        Ok(state.sync_state.unsafe_head())
     }
 
     async fn update_safe_finalized_blocks(
@@ -121,7 +123,18 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
                 ..Default::default()
             },
         );
-        task.execute(&mut state).await.map_err(FollowError::engine_task)?;
+        loop {
+            match task.execute(&mut state).await {
+                Ok(()) => break,
+                Err(error) if error.severity() == EngineTaskErrorSeverity::Temporary => {
+                    // A transport error may mean the EL applied the FCU but the response was
+                    // lost. Repeating the same FCU reconciles the in-memory state once the EL
+                    // responds again.
+                    yield_now().await;
+                }
+                Err(error) => return Err(FollowError::engine_task(error)),
+            }
+        }
 
         if state.sync_state.unsafe_head().block_info.hash != ancestor.block_info.hash {
             return Err(FollowError::ResetToAncestorUnconfirmed {
@@ -272,6 +285,32 @@ mod tests {
             .expect("insert should finish after temporary error clears")
             .expect("insert task should not panic")
             .expect("temporary engine error should be retried");
+    }
+
+    #[tokio::test]
+    async fn reset_to_ancestor_retries_temporary_forkchoice_errors() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        let client =
+            Arc::new(test_engine_client_builder().with_config(Arc::clone(&rollup_config)).build());
+        let ancestor = l2_block_info(1);
+        let engine = Arc::new(EngineApiFollowEngine::new(
+            Arc::clone(&client),
+            rollup_config,
+            l2_block_info(2),
+            ancestor,
+            ancestor,
+        ));
+
+        let reset_engine = Arc::clone(&engine);
+        let reset = tokio::spawn(async move { reset_engine.reset_to_ancestor(ancestor).await });
+        time::sleep(Duration::from_millis(10)).await;
+        client.set_fork_choice_updated_v3_response(valid_forkchoice_updated()).await;
+
+        time::timeout(Duration::from_secs(1), reset)
+            .await
+            .expect("reset should finish after temporary error clears")
+            .expect("reset task should not panic")
+            .expect("temporary forkchoice error should be retried");
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -95,6 +95,15 @@ pub enum FollowError {
         parent_number: u64,
     },
 
+    /// Recovery exceeded its shared lookup or time budget.
+    #[error("follow recovery budget exceeded during {phase} after {lookups} lookups")]
+    RecoveryBudgetExceeded {
+        /// Recovery phase that exhausted the budget.
+        phase: &'static str,
+        /// Number of lookups attempted before the budget was exhausted.
+        lookups: u64,
+    },
+
     /// A recovery reorg was refused because it would rewind below the finalized head.
     #[error("refusing to reorg to block {number} below the finalized head {finalized}")]
     ReorgBelowFinalized {

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -176,6 +176,9 @@ pub enum FollowError {
     },
 
     /// The execution engine did not advance to the source payload that was inserted.
+    ///
+    /// The follow runtime treats this as an insertion stall and awaits safety reconciliation so a
+    /// recoverable divergence can reset and replay.
     #[error(
         "engine did not advance to source payload {expected_hash} at block {expected_number}; \
          current head is {actual_hash} at block {actual_number}"

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -73,6 +73,25 @@ pub enum FollowError {
         remote: B256,
     },
 
+    /// A recovery reorg was refused because it would rewind below the finalized head.
+    #[error("refusing to reorg to block {number} below the finalized head {finalized}")]
+    ReorgBelowFinalized {
+        /// Block number we were asked to reorg to.
+        number: u64,
+        /// Current local finalized head number.
+        finalized: u64,
+    },
+
+    /// The engine did not confirm the forkchoice reset to the common ancestor. This usually means
+    /// the EL returned `Syncing`, so recovery cannot safely replay payloads yet.
+    #[error("engine did not confirm reset to ancestor block {number} ({hash})")]
+    ResetToAncestorUnconfirmed {
+        /// Ancestor block number.
+        number: u64,
+        /// Ancestor block hash.
+        hash: B256,
+    },
+
     /// The local engine rejected a follow-mode task.
     #[error("engine task failed with {severity} severity: {error}")]
     EngineTask {

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -73,6 +73,17 @@ pub enum FollowError {
         remote: B256,
     },
 
+    /// Two source reads for the same block number described different source branches.
+    #[error("source branch mismatch at block {number}: expected {expected}, got {actual}")]
+    SourceBranchMismatch {
+        /// Block number compared across source reads.
+        number: u64,
+        /// Hash from the source branch captured earlier.
+        expected: B256,
+        /// Hash returned by the later source read.
+        actual: B256,
+    },
+
     /// A source block's parent lookup did not return its direct parent.
     #[error(
         "source chain is discontinuous between child block {child_number} and parent block {parent_number}"
@@ -139,6 +150,22 @@ pub enum FollowError {
         actual: u64,
         /// Block number the insert loop expected next.
         expected: u64,
+    },
+
+    /// The execution engine did not advance to the source payload that was inserted.
+    #[error(
+        "engine did not advance to source payload {expected_hash} at block {expected_number}; \
+         current head is {actual_hash} at block {actual_number}"
+    )]
+    PayloadNotApplied {
+        /// Source payload block number.
+        expected_number: u64,
+        /// Source payload block hash.
+        expected_hash: B256,
+        /// Engine head block number after insertion.
+        actual_number: u64,
+        /// Engine head block hash after insertion.
+        actual_hash: B256,
     },
 
     /// Joining a follow-mode task failed.

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -73,6 +73,20 @@ pub enum FollowError {
         remote: B256,
     },
 
+    /// The local and source finalized heads disagree. Follow-mode recovery cannot rewind past
+    /// the local finalized head, so this requires operator intervention.
+    #[error(
+        "source finalized block hash {remote} does not match local finalized block hash {local} at block {number}"
+    )]
+    FinalizedDivergence {
+        /// Finalized block number compared across the source and local nodes.
+        number: u64,
+        /// Hash returned by the local node.
+        local: B256,
+        /// Hash returned by the source node.
+        remote: B256,
+    },
+
     /// Two source reads for the same block number described different source branches.
     #[error("source branch mismatch at block {number}: expected {expected}, got {actual}")]
     SourceBranchMismatch {

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -73,6 +73,17 @@ pub enum FollowError {
         remote: B256,
     },
 
+    /// A source block's parent lookup did not return its direct parent.
+    #[error(
+        "source chain is discontinuous between child block {child_number} and parent block {parent_number}"
+    )]
+    SourceChainDiscontinuity {
+        /// Child block number.
+        child_number: u64,
+        /// Number reported by the block fetched using the child's parent hash.
+        parent_number: u64,
+    },
+
     /// A recovery reorg was refused because it would rewind below the finalized head.
     #[error("refusing to reorg to block {number} below the finalized head {finalized}")]
     ReorgBelowFinalized {

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -87,15 +87,21 @@ pub enum FollowError {
         remote: B256,
     },
 
-    /// Two source reads for the same block number described different source branches.
-    #[error("source branch mismatch at block {number}: expected {expected}, got {actual}")]
-    SourceBranchMismatch {
-        /// Block number compared across source reads.
-        number: u64,
-        /// Hash from the source branch captured earlier.
-        expected: B256,
-        /// Hash returned by the later source read.
-        actual: B256,
+    /// The local finalized head changed while recovery was being prepared. The safety loop should
+    /// retry the recovery against the newer finality fence.
+    #[error(
+        "local finalized head changed during recovery from {previous_hash} at block {previous_number} \
+         to {current_hash} at block {current_number}"
+    )]
+    FinalizedHeadChanged {
+        /// Finalized block number observed before recovery planning.
+        previous_number: u64,
+        /// Finalized block hash observed before recovery planning.
+        previous_hash: B256,
+        /// Finalized block number observed immediately before reset.
+        current_number: u64,
+        /// Finalized block hash observed immediately before reset.
+        current_hash: B256,
     },
 
     /// A source block's parent lookup did not return its direct parent.
@@ -173,25 +179,6 @@ pub enum FollowError {
         actual: u64,
         /// Block number the insert loop expected next.
         expected: u64,
-    },
-
-    /// The execution engine did not advance to the source payload that was inserted.
-    ///
-    /// The follow runtime treats this as an insertion stall and awaits safety reconciliation so a
-    /// recoverable divergence can reset and replay.
-    #[error(
-        "engine did not advance to source payload {expected_hash} at block {expected_number}; \
-         current head is {actual_hash} at block {actual_number}"
-    )]
-    PayloadNotApplied {
-        /// Source payload block number.
-        expected_number: u64,
-        /// Source payload block hash.
-        expected_hash: B256,
-        /// Engine head block number after insertion.
-        actual_number: u64,
-        /// Engine head block hash after insertion.
-        actual_hash: B256,
     },
 
     /// Joining a follow-mode task failed.

--- a/crates/consensus/service/src/follow/mod.rs
+++ b/crates/consensus/service/src/follow/mod.rs
@@ -10,6 +10,7 @@ pub use node::{FollowNode, FollowNodeConfig};
 
 mod prefetcher;
 mod proof_gate;
+mod recovery;
 mod rpc;
 mod runtime;
 mod source;

--- a/crates/consensus/service/src/follow/prefetcher.rs
+++ b/crates/consensus/service/src/follow/prefetcher.rs
@@ -47,8 +47,70 @@ where
         start_from_local_head: u64,
         replay: Vec<ReplayBlock>,
     ) -> Result<(), FollowError> {
+        let Some(mut next_fetch) = self.prefetch_replay(start_from_local_head, replay).await?
+        else {
+            return Ok(());
+        };
+        let mut source_latest = next_fetch.saturating_sub(1);
+        let mut consecutive_payload_failures = 0;
+
+        loop {
+            if self.cancellation.is_cancelled() {
+                return Ok(());
+            }
+
+            if next_fetch > source_latest {
+                source_latest = self.refresh_source_latest(source_latest).await;
+                if next_fetch > source_latest {
+                    self.backoff_at_source_head().await;
+                    continue;
+                }
+            }
+
+            let payload = self.source.get_payload_by_number(next_fetch).await;
+
+            match payload {
+                Ok(payload) => {
+                    if self.blocks_to_insert_tx.send(payload).await.is_err() {
+                        return Ok(());
+                    }
+                    consecutive_payload_failures = 0;
+                    next_fetch = next_fetch.saturating_add(1);
+                }
+                Err(e) => {
+                    consecutive_payload_failures += 1;
+                    if consecutive_payload_failures % PREFETCH_FAILURE_WARN_INTERVAL == 0 {
+                        warn!(
+                            target: "follow",
+                            block = next_fetch,
+                            attempts = consecutive_payload_failures,
+                            error = %e,
+                            "Repeatedly failed to prefetch source payload"
+                        );
+                    } else {
+                        debug!(
+                            target: "follow",
+                            block = next_fetch,
+                            attempts = consecutive_payload_failures,
+                            error = %e,
+                            "Failed to prefetch source payload"
+                        );
+                    }
+                    self.backoff_at_source_head().await;
+                }
+            }
+        }
+    }
+
+    /// Fetches the captured recovery branch and returns the first live source block to fetch.
+    ///
+    /// Returns `None` when cancellation or channel closure ends follow mode.
+    async fn prefetch_replay(
+        &self,
+        start_from_local_head: u64,
+        replay: Vec<ReplayBlock>,
+    ) -> Result<Option<u64>, FollowError> {
         let mut next_fetch = start_from_local_head.saturating_add(1);
-        let mut source_latest = start_from_local_head;
         let mut consecutive_payload_failures = 0;
 
         for replay_block in replay {
@@ -61,7 +123,7 @@ where
 
             loop {
                 if self.cancellation.is_cancelled() {
-                    return Ok(());
+                    return Ok(None);
                 }
 
                 match self.source.get_payload_by_hash(replay_block.hash).await {
@@ -72,7 +134,7 @@ where
                                 == replay_block.parent_hash =>
                     {
                         if self.blocks_to_insert_tx.send(payload).await.is_err() {
-                            return Ok(());
+                            return Ok(None);
                         }
                         consecutive_payload_failures = 0;
                         next_fetch = next_fetch.saturating_add(1);
@@ -133,56 +195,7 @@ where
             }
         }
 
-        if next_fetch > start_from_local_head.saturating_add(1) {
-            source_latest = next_fetch.saturating_sub(1);
-        }
-
-        loop {
-            if self.cancellation.is_cancelled() {
-                return Ok(());
-            }
-
-            if next_fetch > source_latest {
-                source_latest = self.refresh_source_latest(source_latest).await;
-                if next_fetch > source_latest {
-                    self.backoff_at_source_head().await;
-                    continue;
-                }
-            }
-
-            let payload = self.source.get_payload_by_number(next_fetch).await;
-
-            match payload {
-                Ok(payload) => {
-                    if self.blocks_to_insert_tx.send(payload).await.is_err() {
-                        return Ok(());
-                    }
-                    consecutive_payload_failures = 0;
-                    next_fetch = next_fetch.saturating_add(1);
-                }
-                Err(e) => {
-                    consecutive_payload_failures += 1;
-                    if consecutive_payload_failures % PREFETCH_FAILURE_WARN_INTERVAL == 0 {
-                        warn!(
-                            target: "follow",
-                            block = next_fetch,
-                            attempts = consecutive_payload_failures,
-                            error = %e,
-                            "Repeatedly failed to prefetch source payload"
-                        );
-                    } else {
-                        debug!(
-                            target: "follow",
-                            block = next_fetch,
-                            attempts = consecutive_payload_failures,
-                            error = %e,
-                            "Failed to prefetch source payload"
-                        );
-                    }
-                    self.backoff_at_source_head().await;
-                }
-            }
-        }
+        Ok(Some(next_fetch))
     }
 
     async fn refresh_source_latest(&self, current: u64) -> u64 {

--- a/crates/consensus/service/src/follow/prefetcher.rs
+++ b/crates/consensus/service/src/follow/prefetcher.rs
@@ -6,7 +6,7 @@ use tokio::{sync::mpsc, time};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use crate::follow::{error::FollowError, source::RemoteClient};
+use crate::follow::{error::FollowError, recovery::ReplayBlock, source::RemoteClient};
 
 /// Number of source L2 payloads to keep prefetched ahead of the insert loop.
 pub(super) const PREFETCH_WINDOW: usize = 50;
@@ -37,12 +37,105 @@ where
         Self { source, cancellation, blocks_to_insert_tx }
     }
 
-    /// Starts fetching from the local node head and pushes payloads through a
-    /// bounded channel.
-    pub(super) async fn run(self, start_from_local_head: u64) -> Result<(), FollowError> {
+    /// Starts fetching from the local node head and pushes payloads through a bounded channel.
+    ///
+    /// Recovery payloads are fetched by hash so every replay request stays on the source branch
+    /// captured during ancestor discovery. Once the captured path is exhausted, live follow mode
+    /// resumes with the normal latest/by-number polling.
+    pub(super) async fn run(
+        self,
+        start_from_local_head: u64,
+        replay: Vec<ReplayBlock>,
+    ) -> Result<(), FollowError> {
         let mut next_fetch = start_from_local_head.saturating_add(1);
         let mut source_latest = start_from_local_head;
         let mut consecutive_payload_failures = 0;
+
+        for replay_block in replay {
+            if replay_block.number != next_fetch {
+                return Err(FollowError::OutOfOrderPayload {
+                    actual: replay_block.number,
+                    expected: next_fetch,
+                });
+            }
+
+            loop {
+                if self.cancellation.is_cancelled() {
+                    return Ok(());
+                }
+
+                match self.source.get_payload_by_hash(replay_block.hash).await {
+                    Ok(payload)
+                        if payload.execution_payload.block_number() == replay_block.number
+                            && payload.execution_payload.block_hash() == replay_block.hash
+                            && payload.execution_payload.parent_hash()
+                                == replay_block.parent_hash =>
+                    {
+                        if self.blocks_to_insert_tx.send(payload).await.is_err() {
+                            return Ok(());
+                        }
+                        consecutive_payload_failures = 0;
+                        next_fetch = next_fetch.saturating_add(1);
+                        break;
+                    }
+                    Ok(payload) => {
+                        consecutive_payload_failures += 1;
+                        let actual_number = payload.execution_payload.block_number();
+                        let actual_hash = payload.execution_payload.block_hash();
+                        let actual_parent = payload.execution_payload.parent_hash();
+                        if consecutive_payload_failures % PREFETCH_FAILURE_WARN_INTERVAL == 0 {
+                            warn!(
+                                target: "follow",
+                                block = replay_block.number,
+                                attempts = consecutive_payload_failures,
+                                expected_hash = %replay_block.hash,
+                                actual_number,
+                                actual_hash = %actual_hash,
+                                actual_parent = %actual_parent,
+                                "Repeatedly received a source payload outside the captured replay branch"
+                            );
+                        } else {
+                            debug!(
+                                target: "follow",
+                                block = replay_block.number,
+                                attempts = consecutive_payload_failures,
+                                expected_hash = %replay_block.hash,
+                                actual_number,
+                                actual_hash = %actual_hash,
+                                actual_parent = %actual_parent,
+                                "Received a source payload outside the captured replay branch"
+                            );
+                        }
+                        self.backoff_at_source_head().await;
+                    }
+                    Err(e) => {
+                        consecutive_payload_failures += 1;
+                        if consecutive_payload_failures % PREFETCH_FAILURE_WARN_INTERVAL == 0 {
+                            warn!(
+                                target: "follow",
+                                block = replay_block.number,
+                                attempts = consecutive_payload_failures,
+                                error = %e,
+                                "Repeatedly failed to prefetch captured source payload"
+                            );
+                        } else {
+                            debug!(
+                                target: "follow",
+                                block = replay_block.number,
+                                attempts = consecutive_payload_failures,
+                                error = %e,
+                                "Failed to prefetch captured source payload"
+                            );
+                        }
+                        self.backoff_at_source_head().await;
+                    }
+                }
+            }
+        }
+
+        if next_fetch > start_from_local_head.saturating_add(1) {
+            source_latest = next_fetch.saturating_sub(1);
+        }
 
         loop {
             if self.cancellation.is_cancelled() {

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -4,15 +4,28 @@
 //! so its forkchoice update is `Valid` (no EL sync) — unlike pointing the EL at the canonical tip,
 //! which it lacks and would answer `Syncing`.
 
-use std::sync::Arc;
+use std::{
+    future::Future,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use base_protocol::{BlockInfo, L2BlockInfo};
+use tokio::time;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 use crate::follow::{
-    engine::FollowEngine, error::FollowError, local::FollowLocalClient, source::RemoteClient,
+    engine::{FollowEngine, ResetStats},
+    error::FollowError,
+    local::FollowLocalClient,
+    source::RemoteClient,
 };
+
+const RECOVERY_DEADLINE: Duration = Duration::from_secs(30);
+const MAX_RECOVERY_LOOKUPS: u64 = 4096;
 
 /// A source block to replay after resetting to a common ancestor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,6 +47,57 @@ pub(super) struct RecoveryPlan {
     pub(super) replay: Vec<ReplayBlock>,
 }
 
+#[derive(Debug)]
+struct RecoveryBudget {
+    deadline: Instant,
+    lookups: u64,
+    max_lookups: u64,
+    ancestor_walk_depth: u64,
+    replay_walk_depth: u64,
+}
+
+impl RecoveryBudget {
+    fn new() -> Self {
+        Self::with_limits(RECOVERY_DEADLINE, MAX_RECOVERY_LOOKUPS)
+    }
+
+    fn with_limits(deadline: Duration, max_lookups: u64) -> Self {
+        Self {
+            deadline: Instant::now() + deadline,
+            lookups: 0,
+            max_lookups,
+            ancestor_walk_depth: 0,
+            replay_walk_depth: 0,
+        }
+    }
+
+    fn next_timeout(&mut self, phase: &'static str) -> Result<Duration, FollowError> {
+        if self.lookups >= self.max_lookups {
+            return Err(FollowError::RecoveryBudgetExceeded { phase, lookups: self.lookups });
+        }
+        self.lookups += 1;
+        let remaining = self.deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(FollowError::RecoveryBudgetExceeded { phase, lookups: self.lookups });
+        }
+        Ok(remaining)
+    }
+
+    async fn run<T, Operation>(
+        &mut self,
+        phase: &'static str,
+        operation: Operation,
+    ) -> Result<T, FollowError>
+    where
+        Operation: Future<Output = Result<T, FollowError>>,
+    {
+        let timeout = self.next_timeout(phase)?;
+        time::timeout(timeout, operation)
+            .await
+            .map_err(|_| FollowError::RecoveryBudgetExceeded { phase, lookups: self.lookups })?
+    }
+}
+
 /// Resets the local engine onto the common ancestor of the local and source chains and returns the
 /// source branch to replay. `source_safe` is the coherent source label block where the two chains
 /// are known to disagree.
@@ -43,16 +107,75 @@ pub(super) async fn recover<Local, Remote>(
     engine: &Arc<dyn FollowEngine>,
     finalized: &L2BlockInfo,
     source_safe: &BlockInfo,
+    divergence_local_hash: B256,
+    cancellation: CancellationToken,
 ) -> Result<RecoveryPlan, FollowError>
 where
     Local: FollowLocalClient,
     Remote: RemoteClient,
 {
-    let ancestor = find_common_ancestor(local, source, finalized, source_safe).await?;
-    let source_latest = source.get_block_info(BlockNumberOrTag::Latest).await?;
-    let replay = find_replay_path(source, source_latest, source_safe, &ancestor).await?;
-    engine.reset_to_ancestor(ancestor).await?;
+    let started_at = Instant::now();
+    let mut budget = RecoveryBudget::new();
+    let (mut ancestor, mut source_latest, mut replay) =
+        build_recovery_path(local, source, finalized, source_safe, &mut budget).await?;
+
+    let fresh_finalized = budget
+        .run("fresh finalized fence", local.block_info(BlockNumberOrTag::Finalized))
+        .await?
+        .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
+    if fresh_finalized.block_info.number != finalized.block_info.number
+        || fresh_finalized.block_info.hash != finalized.block_info.hash
+    {
+        (ancestor, source_latest, replay) =
+            build_recovery_path(local, source, &fresh_finalized, source_safe, &mut budget).await?;
+    }
+
+    let reset_stats: ResetStats = engine.reset_to_ancestor(ancestor, cancellation.clone()).await?;
+    if !cancellation.is_cancelled() {
+        info!(
+            target: "follow",
+            divergence_number = source_safe.number,
+            divergence_local = %divergence_local_hash,
+            divergence_source = %source_safe.hash,
+            ancestor_number = ancestor.block_info.number,
+            ancestor_hash = %ancestor.block_info.hash,
+            source_safe_number = source_safe.number,
+            source_safe_hash = %source_safe.hash,
+            source_latest_number = source_latest.number,
+            source_latest_hash = %source_latest.hash,
+            walk_depth = budget.ancestor_walk_depth + budget.replay_walk_depth,
+            ancestor_walk_depth = budget.ancestor_walk_depth,
+            replay_walk_depth = budget.replay_walk_depth,
+            replay_blocks = replay.len(),
+            recovery_lookups = budget.lookups,
+            reset_retries = reset_stats.retries,
+            duration = ?started_at.elapsed(),
+            "Prepared source-coherent follow recovery",
+        );
+    }
     Ok(RecoveryPlan { ancestor, replay })
+}
+
+async fn build_recovery_path<Local, Remote>(
+    local: &Local,
+    source: &Remote,
+    finalized: &L2BlockInfo,
+    source_safe: &BlockInfo,
+    budget: &mut RecoveryBudget,
+) -> Result<(L2BlockInfo, BlockInfo, Vec<ReplayBlock>), FollowError>
+where
+    Local: FollowLocalClient,
+    Remote: RemoteClient,
+{
+    let ancestor =
+        find_common_ancestor_with_budget(local, source, finalized, source_safe, budget).await?;
+    let source_latest = budget
+        .run("source latest lookup", async {
+            source.get_block_info(BlockNumberOrTag::Latest).await.map_err(FollowError::from)
+        })
+        .await?;
+    let replay = find_replay_path(source, source_latest, source_safe, &ancestor, budget).await?;
+    Ok((ancestor, source_latest, replay))
 }
 
 /// Walks the captured source-latest branch backward to the common ancestor and returns it in
@@ -63,6 +186,7 @@ async fn find_replay_path<Remote>(
     source_latest: BlockInfo,
     source_safe: &BlockInfo,
     ancestor: &L2BlockInfo,
+    budget: &mut RecoveryBudget,
 ) -> Result<Vec<ReplayBlock>, FollowError>
 where
     Remote: RemoteClient,
@@ -108,13 +232,21 @@ where
             parent_hash: source_block.parent_hash,
         });
 
-        let parent = source.get_block_info_by_hash(source_block.parent_hash).await?;
+        let parent = budget
+            .run("replay path parent lookup", async {
+                source
+                    .get_block_info_by_hash(source_block.parent_hash)
+                    .await
+                    .map_err(FollowError::from)
+            })
+            .await?;
         if !parent.is_parent_of(&source_block) {
             return Err(FollowError::SourceChainDiscontinuity {
                 child_number: source_block.number,
                 parent_number: parent.number,
             });
         }
+        budget.replay_walk_depth = budget.replay_walk_depth.saturating_add(1);
         source_block = parent;
     }
 
@@ -135,11 +267,27 @@ where
 /// Parent-hash traversal pins every lookup to the branch containing `source_safe`. Independent
 /// by-number lookups are unsafe here because a load-balanced source can route them to replicas on
 /// different branches and violate the monotonicity required by a binary search.
+#[cfg(test)]
 pub(super) async fn find_common_ancestor<Local, Remote>(
     local: &Local,
     source: &Remote,
     finalized: &L2BlockInfo,
     source_safe: &BlockInfo,
+) -> Result<L2BlockInfo, FollowError>
+where
+    Local: FollowLocalClient,
+    Remote: RemoteClient,
+{
+    let mut budget = RecoveryBudget::new();
+    find_common_ancestor_with_budget(local, source, finalized, source_safe, &mut budget).await
+}
+
+async fn find_common_ancestor_with_budget<Local, Remote>(
+    local: &Local,
+    source: &Remote,
+    finalized: &L2BlockInfo,
+    source_safe: &BlockInfo,
+    budget: &mut RecoveryBudget,
 ) -> Result<L2BlockInfo, FollowError>
 where
     Local: FollowLocalClient,
@@ -168,19 +316,58 @@ where
             });
         }
 
-        if let Some(local_block) = local.block_info(number.into()).await?
+        if let Some(local_block) =
+            budget.run("ancestor local lookup", local.block_info(number.into())).await?
             && local_block.block_info.hash == source_block.hash
         {
             return Ok(local_block);
         }
 
-        let parent = source.get_block_info_by_hash(source_block.parent_hash).await?;
+        let parent = budget
+            .run("ancestor parent lookup", async {
+                source
+                    .get_block_info_by_hash(source_block.parent_hash)
+                    .await
+                    .map_err(FollowError::from)
+            })
+            .await?;
         if !parent.is_parent_of(&source_block) {
             return Err(FollowError::SourceChainDiscontinuity {
                 child_number: number,
                 parent_number: parent.number,
             });
         }
+        budget.ancestor_walk_depth = budget.ancestor_walk_depth.saturating_add(1);
         source_block = parent;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{FollowError, RecoveryBudget};
+
+    #[tokio::test]
+    async fn recovery_budget_is_shared_across_phases() {
+        let mut budget = RecoveryBudget::with_limits(Duration::from_secs(1), 2);
+
+        budget
+            .run("ancestor", async { Ok::<_, FollowError>(()) })
+            .await
+            .expect("ancestor lookup should fit within budget");
+        budget
+            .run("replay", async { Ok::<_, FollowError>(()) })
+            .await
+            .expect("replay lookup should fit within budget");
+
+        let error = budget
+            .run("replay", async { Ok::<_, FollowError>(()) })
+            .await
+            .expect_err("shared lookup budget should be exhausted");
+        assert!(matches!(
+            error,
+            FollowError::RecoveryBudgetExceeded { phase: "replay", lookups: 2 }
+        ));
     }
 }

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -13,14 +13,10 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use base_protocol::{BlockInfo, L2BlockInfo};
 use tokio::time;
-use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::follow::{
-    engine::{FollowEngine, ResetStats},
-    error::FollowError,
-    local::FollowLocalClient,
-    source::RemoteClient,
+    engine::FollowEngine, error::FollowError, local::FollowLocalClient, source::RemoteClient,
 };
 
 const RECOVERY_DEADLINE: Duration = Duration::from_secs(30);
@@ -37,12 +33,12 @@ pub(super) struct ReplayBlock {
     pub(super) parent_hash: B256,
 }
 
-/// The local reset point and the source branch to replay from it.
+/// The local reset point and the captured source-safe branch to replay from it.
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct RecoveryPlan {
     /// Highest block shared by the local and source chains.
     pub(super) ancestor: L2BlockInfo,
-    /// Source blocks after `ancestor`, ordered from oldest to newest.
+    /// Source blocks after `ancestor` through the captured safe head, ordered from oldest to newest.
     pub(super) replay: Vec<ReplayBlock>,
 }
 
@@ -51,8 +47,7 @@ struct RecoveryBudget {
     deadline: Instant,
     lookups: u64,
     max_lookups: u64,
-    ancestor_walk_depth: u64,
-    replay_walk_depth: u64,
+    walk_depth: u64,
 }
 
 impl RecoveryBudget {
@@ -61,13 +56,7 @@ impl RecoveryBudget {
     }
 
     fn with_limits(deadline: Duration, max_lookups: u64) -> Self {
-        Self {
-            deadline: Instant::now() + deadline,
-            lookups: 0,
-            max_lookups,
-            ancestor_walk_depth: 0,
-            replay_walk_depth: 0,
-        }
+        Self { deadline: Instant::now() + deadline, lookups: 0, max_lookups, walk_depth: 0 }
     }
 
     fn next_timeout(&mut self, phase: &'static str) -> Result<Duration, FollowError> {
@@ -104,10 +93,8 @@ pub(super) async fn recover<Local, Remote>(
     local: &Local,
     source: &Remote,
     engine: &Arc<dyn FollowEngine>,
-    finalized: &L2BlockInfo,
     source_safe: &BlockInfo,
     divergence_local_hash: B256,
-    cancellation: CancellationToken,
 ) -> Result<RecoveryPlan, FollowError>
 where
     Local: FollowLocalClient,
@@ -115,8 +102,11 @@ where
 {
     let started_at = Instant::now();
     let mut budget = RecoveryBudget::new();
-    let (mut ancestor, mut source_latest, mut replay) =
-        build_recovery_path(local, source, finalized, source_safe, &mut budget).await?;
+    let finalized = budget
+        .run("finalized fence", local.block_info(BlockNumberOrTag::Finalized))
+        .await?
+        .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
+    let plan = build_recovery_plan(local, source, &finalized, source_safe, &mut budget).await?;
 
     let fresh_finalized = budget
         .run("fresh finalized fence", local.block_info(BlockNumberOrTag::Finalized))
@@ -125,142 +115,34 @@ where
     if fresh_finalized.block_info.number != finalized.block_info.number
         || fresh_finalized.block_info.hash != finalized.block_info.hash
     {
-        (ancestor, source_latest, replay) =
-            build_recovery_path(local, source, &fresh_finalized, source_safe, &mut budget).await?;
-    }
-
-    let reset_stats: ResetStats = engine.reset_to_ancestor(ancestor, cancellation.clone()).await?;
-    if !cancellation.is_cancelled() {
-        info!(
-            target: "follow",
-            divergence_number = source_safe.number,
-            divergence_local = %divergence_local_hash,
-            divergence_source = %source_safe.hash,
-            ancestor_number = ancestor.block_info.number,
-            ancestor_hash = %ancestor.block_info.hash,
-            source_safe_number = source_safe.number,
-            source_safe_hash = %source_safe.hash,
-            source_latest_number = source_latest.number,
-            source_latest_hash = %source_latest.hash,
-            walk_depth = budget.ancestor_walk_depth + budget.replay_walk_depth,
-            ancestor_walk_depth = budget.ancestor_walk_depth,
-            replay_walk_depth = budget.replay_walk_depth,
-            replay_blocks = replay.len(),
-            recovery_lookups = budget.lookups,
-            reset_retries = reset_stats.retries,
-            duration = ?started_at.elapsed(),
-            "Prepared source-coherent follow recovery",
-        );
-    }
-    Ok(RecoveryPlan { ancestor, replay })
-}
-
-async fn build_recovery_path<Local, Remote>(
-    local: &Local,
-    source: &Remote,
-    finalized: &L2BlockInfo,
-    source_safe: &BlockInfo,
-    budget: &mut RecoveryBudget,
-) -> Result<(L2BlockInfo, BlockInfo, Vec<ReplayBlock>), FollowError>
-where
-    Local: FollowLocalClient,
-    Remote: RemoteClient,
-{
-    let ancestor =
-        find_common_ancestor_with_budget(local, source, finalized, source_safe, budget).await?;
-    let source_latest = budget
-        .run("source latest lookup", async {
-            source.get_block_info(BlockNumberOrTag::Latest).await.map_err(FollowError::from)
-        })
-        .await?;
-    let replay = find_replay_path(source, source_latest, source_safe, &ancestor, budget).await?;
-    Ok((ancestor, source_latest, replay))
-}
-
-/// Walks the captured source-latest branch backward to the common ancestor and returns it in
-/// replay order. The source-safe block must occur on this branch; otherwise the source reads were
-/// not coherent and replay must not begin.
-async fn find_replay_path<Remote>(
-    source: &Remote,
-    source_latest: BlockInfo,
-    source_safe: &BlockInfo,
-    ancestor: &L2BlockInfo,
-    budget: &mut RecoveryBudget,
-) -> Result<Vec<ReplayBlock>, FollowError>
-where
-    Remote: RemoteClient,
-{
-    let mut source_block = source_latest;
-    let mut reverse_path = Vec::new();
-    let mut saw_source_safe = source_safe.number == ancestor.block_info.number
-        && source_safe.hash == ancestor.block_info.hash;
-
-    loop {
-        if source_block.number < ancestor.block_info.number {
-            return Err(FollowError::SourceChainDiscontinuity {
-                child_number: source_latest.number,
-                parent_number: source_block.number,
-            });
-        }
-
-        if source_block.number == source_safe.number {
-            if source_block.hash != source_safe.hash {
-                return Err(FollowError::SourceBranchMismatch {
-                    number: source_block.number,
-                    expected: source_safe.hash,
-                    actual: source_block.hash,
-                });
-            }
-            saw_source_safe = true;
-        }
-
-        if source_block.number == ancestor.block_info.number {
-            if source_block.hash != ancestor.block_info.hash {
-                return Err(FollowError::SourceBranchMismatch {
-                    number: source_block.number,
-                    expected: ancestor.block_info.hash,
-                    actual: source_block.hash,
-                });
-            }
-            break;
-        }
-
-        reverse_path.push(ReplayBlock {
-            number: source_block.number,
-            hash: source_block.hash,
-            parent_hash: source_block.parent_hash,
-        });
-
-        let parent = budget
-            .run("replay path parent lookup", async {
-                source
-                    .get_block_info_by_hash(source_block.parent_hash)
-                    .await
-                    .map_err(FollowError::from)
-            })
-            .await?;
-        if !parent.is_parent_of(&source_block) {
-            return Err(FollowError::SourceChainDiscontinuity {
-                child_number: source_block.number,
-                parent_number: parent.number,
-            });
-        }
-        budget.replay_walk_depth = budget.replay_walk_depth.saturating_add(1);
-        source_block = parent;
-    }
-
-    if !saw_source_safe {
-        return Err(FollowError::SourceChainDiscontinuity {
-            child_number: source_latest.number,
-            parent_number: source_safe.number,
+        return Err(FollowError::FinalizedHeadChanged {
+            previous_number: finalized.block_info.number,
+            previous_hash: finalized.block_info.hash,
+            current_number: fresh_finalized.block_info.number,
+            current_hash: fresh_finalized.block_info.hash,
         });
     }
 
-    reverse_path.reverse();
-    Ok(reverse_path)
+    engine.reset_to_ancestor(plan.ancestor).await?;
+    info!(
+        target: "follow",
+        divergence_number = source_safe.number,
+        divergence_local = %divergence_local_hash,
+        divergence_source = %source_safe.hash,
+        ancestor_number = plan.ancestor.block_info.number,
+        ancestor_hash = %plan.ancestor.block_info.hash,
+        source_safe_number = source_safe.number,
+        source_safe_hash = %source_safe.hash,
+        walk_depth = budget.walk_depth,
+        replay_blocks = plan.replay.len(),
+        recovery_lookups = budget.lookups,
+        duration = ?started_at.elapsed(),
+        "Prepared source-safe follow recovery",
+    );
+    Ok(plan)
 }
 
-/// Test helper for [`find_common_ancestor_with_budget`] with a fresh recovery budget.
+/// Walks the captured source-safe branch backward and returns the highest matching local ancestor.
 #[cfg(test)]
 pub(super) async fn find_common_ancestor<Local, Remote>(
     local: &Local,
@@ -273,24 +155,26 @@ where
     Remote: RemoteClient,
 {
     let mut budget = RecoveryBudget::new();
-    find_common_ancestor_with_budget(local, source, finalized, source_safe, &mut budget).await
+    Ok(build_recovery_plan(local, source, finalized, source_safe, &mut budget).await?.ancestor)
 }
 
-/// Walks the source-safe branch backward by parent hash and returns its highest block that matches
-/// the local chain. The finalized head must be common; recovery cannot reorg below it.
-async fn find_common_ancestor_with_budget<Local, Remote>(
+/// Walks the source-safe branch backward by parent hash, collecting the source-safe replay path,
+/// and returns its highest block that matches the local chain. The finalized head must be common;
+/// recovery cannot reorg below it.
+async fn build_recovery_plan<Local, Remote>(
     local: &Local,
     source: &Remote,
     finalized: &L2BlockInfo,
     source_safe: &BlockInfo,
     budget: &mut RecoveryBudget,
-) -> Result<L2BlockInfo, FollowError>
+) -> Result<RecoveryPlan, FollowError>
 where
     Local: FollowLocalClient,
     Remote: RemoteClient,
 {
     let finalized_number = finalized.block_info.number;
     let mut source_block = *source_safe;
+    let mut reverse_replay = Vec::new();
 
     loop {
         let number = source_block.number;
@@ -303,7 +187,8 @@ where
 
         if number == finalized_number {
             if source_block.hash == finalized.block_info.hash {
-                return Ok(*finalized);
+                reverse_replay.reverse();
+                return Ok(RecoveryPlan { ancestor: *finalized, replay: reverse_replay });
             }
             return Err(FollowError::FinalizedDivergence {
                 number,
@@ -316,11 +201,17 @@ where
             budget.run("ancestor local lookup", local.block_info(number.into())).await?
             && local_block.block_info.hash == source_block.hash
         {
-            return Ok(local_block);
+            reverse_replay.reverse();
+            return Ok(RecoveryPlan { ancestor: local_block, replay: reverse_replay });
         }
 
+        reverse_replay.push(ReplayBlock {
+            number: source_block.number,
+            hash: source_block.hash,
+            parent_hash: source_block.parent_hash,
+        });
         let parent = budget
-            .run("ancestor parent lookup", async {
+            .run("recovery parent lookup", async {
                 source
                     .get_block_info_by_hash(source_block.parent_hash)
                     .await
@@ -333,7 +224,7 @@ where
                 parent_number: parent.number,
             });
         }
-        budget.ancestor_walk_depth = budget.ancestor_walk_depth.saturating_add(1);
+        budget.walk_depth = budget.walk_depth.saturating_add(1);
         source_block = parent;
     }
 }
@@ -345,25 +236,25 @@ mod tests {
     use super::{FollowError, RecoveryBudget};
 
     #[tokio::test]
-    async fn recovery_budget_is_shared_across_phases() {
+    async fn recovery_budget_bounds_one_walk() {
         let mut budget = RecoveryBudget::with_limits(Duration::from_secs(1), 2);
 
         budget
-            .run("ancestor", async { Ok::<_, FollowError>(()) })
+            .run("recovery", async { Ok::<_, FollowError>(()) })
             .await
-            .expect("ancestor lookup should fit within budget");
+            .expect("first lookup should fit within budget");
         budget
-            .run("replay", async { Ok::<_, FollowError>(()) })
+            .run("recovery", async { Ok::<_, FollowError>(()) })
             .await
-            .expect("replay lookup should fit within budget");
+            .expect("second lookup should fit within budget");
 
         let error = budget
-            .run("replay", async { Ok::<_, FollowError>(()) })
+            .run("recovery", async { Ok::<_, FollowError>(()) })
             .await
-            .expect_err("shared lookup budget should be exhausted");
+            .expect_err("lookup budget should be exhausted");
         assert!(matches!(
             error,
-            FollowError::RecoveryBudgetExceeded { phase: "replay", lookups: 2 }
+            FollowError::RecoveryBudgetExceeded { phase: "recovery", lookups: 2 }
         ));
     }
 }

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -1,8 +1,7 @@
 //! Follow-mode recovery: when the local chain diverges from the source, reset the local engine to
 //! the highest block both nodes agree on (the common ancestor) and let the normal insert loop
 //! replay source payloads forward from there. The reset targets a block the local EL already has,
-//! so its forkchoice update is `Valid` (no EL sync) — unlike pointing the EL at the canonical tip,
-//! which it lacks and would answer `Syncing`.
+//! so the forkchoice update is `Valid` and the head reorgs without EL sync.
 
 use std::{
     future::Future,
@@ -261,12 +260,7 @@ where
     Ok(reverse_path)
 }
 
-/// Walks the captured source-safe branch backward by parent hash and returns its highest block that
-/// matches the local chain. The finalized head must be common; recovery cannot reorg below it.
-///
-/// Parent-hash traversal pins every lookup to the branch containing `source_safe`. Independent
-/// by-number lookups are unsafe here because a load-balanced source can route them to replicas on
-/// different branches and violate the monotonicity required by a binary search.
+/// Test helper for [`find_common_ancestor_with_budget`] with a fresh recovery budget.
 #[cfg(test)]
 pub(super) async fn find_common_ancestor<Local, Remote>(
     local: &Local,
@@ -282,6 +276,8 @@ where
     find_common_ancestor_with_budget(local, source, finalized, source_safe, &mut budget).await
 }
 
+/// Walks the source-safe branch backward by parent hash and returns its highest block that matches
+/// the local chain. The finalized head must be common; recovery cannot reorg below it.
 async fn find_common_ancestor_with_budget<Local, Remote>(
     local: &Local,
     source: &Remote,

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -6,87 +6,83 @@
 
 use std::sync::Arc;
 
-use base_protocol::L2BlockInfo;
+use base_protocol::{BlockInfo, L2BlockInfo};
 
 use crate::follow::{
     engine::FollowEngine, error::FollowError, local::FollowLocalClient, source::RemoteClient,
 };
 
 /// Resets the local engine onto the common ancestor of the local and source chains and returns the
-/// ancestor block number, from which fetch/insert should restart. `divergent_number` is a block
-/// number (at or below the local latest) where the two chains are known to disagree.
+/// ancestor block number, from which fetch/insert should restart. `source_safe` is the coherent
+/// source label block where the two chains are known to disagree.
 pub(super) async fn recover<Local, Remote>(
     local: &Local,
     source: &Remote,
     engine: &Arc<dyn FollowEngine>,
     finalized: &L2BlockInfo,
-    divergent_number: u64,
+    source_safe: &BlockInfo,
 ) -> Result<u64, FollowError>
 where
     Local: FollowLocalClient,
     Remote: RemoteClient,
 {
-    let ancestor = find_common_ancestor(local, source, finalized, divergent_number).await?;
+    let ancestor = find_common_ancestor(local, source, finalized, source_safe).await?;
     engine.reset_to_ancestor(ancestor).await?;
     Ok(ancestor.block_info.number)
 }
 
-/// Returns the highest L2 block in `[finalized, divergent_number)` whose hash is the same on the
-/// local and source nodes. The finalized head must itself be common; if it is not, recovery cannot
-/// safely reorg below it.
+/// Walks the captured source-safe branch backward by parent hash and returns its highest block that
+/// matches the local chain. The finalized head must be common; recovery cannot reorg below it.
 ///
-/// Forks are contiguous (the chains share a prefix and then diverge), so "agrees with source" is
-/// monotonic in the block number, which makes a binary search correct.
+/// Parent-hash traversal pins every lookup to the branch containing `source_safe`. Independent
+/// by-number lookups are unsafe here because a load-balanced source can route them to replicas on
+/// different branches and violate the monotonicity required by a binary search.
 pub(super) async fn find_common_ancestor<Local, Remote>(
     local: &Local,
     source: &Remote,
     finalized: &L2BlockInfo,
-    divergent_number: u64,
+    source_safe: &BlockInfo,
 ) -> Result<L2BlockInfo, FollowError>
 where
     Local: FollowLocalClient,
     Remote: RemoteClient,
 {
-    // The search floor must be common. Finality is never reorged, so stop before resetting.
     let finalized_number = finalized.block_info.number;
-    let source_finalized = source.get_block_info(finalized_number.into()).await?;
-    if source_finalized.hash != finalized.block_info.hash {
-        return Err(FollowError::SourceBlockHashMismatch {
-            number: finalized_number,
-            local: finalized.block_info.hash,
-            remote: source_finalized.hash,
-        });
-    }
+    let mut source_block = *source_safe;
 
-    // Invariant: blocks agree at `lo`, disagree at `hi`. Converge to the highest agreeing block.
-    let mut lo = finalized_number;
-    let mut hi = divergent_number.max(finalized_number + 1);
-    while hi - lo > 1 {
-        let mid = lo + (hi - lo) / 2;
-        if blocks_match(local, source, mid).await? {
-            lo = mid;
-        } else {
-            hi = mid;
+    loop {
+        let number = source_block.number;
+        if number < finalized_number {
+            return Err(FollowError::SourceChainDiscontinuity {
+                child_number: source_safe.number,
+                parent_number: number,
+            });
         }
+
+        if number == finalized_number {
+            if source_block.hash == finalized.block_info.hash {
+                return Ok(*finalized);
+            }
+            return Err(FollowError::SourceBlockHashMismatch {
+                number,
+                local: finalized.block_info.hash,
+                remote: source_block.hash,
+            });
+        }
+
+        if let Some(local_block) = local.block_info(number.into()).await?
+            && local_block.block_info.hash == source_block.hash
+        {
+            return Ok(local_block);
+        }
+
+        let parent = source.get_block_info_by_hash(source_block.parent_hash).await?;
+        if !parent.is_parent_of(&source_block) {
+            return Err(FollowError::SourceChainDiscontinuity {
+                child_number: number,
+                parent_number: parent.number,
+            });
+        }
+        source_block = parent;
     }
-
-    local.block_info(lo.into()).await?.ok_or(FollowError::LocalBlockUnavailable(lo.into()))
-}
-
-/// Whether the local and source nodes report the same hash for the block at `number`. A missing
-/// local block counts as a mismatch (the search moves below it).
-async fn blocks_match<Local, Remote>(
-    local: &Local,
-    source: &Remote,
-    number: u64,
-) -> Result<bool, FollowError>
-where
-    Local: FollowLocalClient,
-    Remote: RemoteClient,
-{
-    let Some(local_block) = local.block_info(number.into()).await? else {
-        return Ok(false);
-    };
-    let source_block = source.get_block_info(number.into()).await?;
-    Ok(local_block.block_info.hash == source_block.hash)
 }

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -309,7 +309,7 @@ where
             if source_block.hash == finalized.block_info.hash {
                 return Ok(*finalized);
             }
-            return Err(FollowError::SourceBlockHashMismatch {
+            return Err(FollowError::FinalizedDivergence {
                 number,
                 local: finalized.block_info.hash,
                 remote: source_block.hash,

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -6,29 +6,127 @@
 
 use std::sync::Arc;
 
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
 use base_protocol::{BlockInfo, L2BlockInfo};
 
 use crate::follow::{
     engine::FollowEngine, error::FollowError, local::FollowLocalClient, source::RemoteClient,
 };
 
+/// A source block to replay after resetting to a common ancestor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ReplayBlock {
+    /// Source block number.
+    pub(super) number: u64,
+    /// Source block hash.
+    pub(super) hash: B256,
+    /// Source block parent hash.
+    pub(super) parent_hash: B256,
+}
+
+/// The local reset point and the source branch to replay from it.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct RecoveryPlan {
+    /// Highest block shared by the local and source chains.
+    pub(super) ancestor: L2BlockInfo,
+    /// Source blocks after `ancestor`, ordered from oldest to newest.
+    pub(super) replay: Vec<ReplayBlock>,
+}
+
 /// Resets the local engine onto the common ancestor of the local and source chains and returns the
-/// ancestor block number, from which fetch/insert should restart. `source_safe` is the coherent
-/// source label block where the two chains are known to disagree.
+/// source branch to replay. `source_safe` is the coherent source label block where the two chains
+/// are known to disagree.
 pub(super) async fn recover<Local, Remote>(
     local: &Local,
     source: &Remote,
     engine: &Arc<dyn FollowEngine>,
     finalized: &L2BlockInfo,
     source_safe: &BlockInfo,
-) -> Result<u64, FollowError>
+) -> Result<RecoveryPlan, FollowError>
 where
     Local: FollowLocalClient,
     Remote: RemoteClient,
 {
     let ancestor = find_common_ancestor(local, source, finalized, source_safe).await?;
+    let source_latest = source.get_block_info(BlockNumberOrTag::Latest).await?;
+    let replay = find_replay_path(source, source_latest, source_safe, &ancestor).await?;
     engine.reset_to_ancestor(ancestor).await?;
-    Ok(ancestor.block_info.number)
+    Ok(RecoveryPlan { ancestor, replay })
+}
+
+/// Walks the captured source-latest branch backward to the common ancestor and returns it in
+/// replay order. The source-safe block must occur on this branch; otherwise the source reads were
+/// not coherent and replay must not begin.
+async fn find_replay_path<Remote>(
+    source: &Remote,
+    source_latest: BlockInfo,
+    source_safe: &BlockInfo,
+    ancestor: &L2BlockInfo,
+) -> Result<Vec<ReplayBlock>, FollowError>
+where
+    Remote: RemoteClient,
+{
+    let mut source_block = source_latest;
+    let mut reverse_path = Vec::new();
+    let mut saw_source_safe = source_safe.number == ancestor.block_info.number
+        && source_safe.hash == ancestor.block_info.hash;
+
+    loop {
+        if source_block.number < ancestor.block_info.number {
+            return Err(FollowError::SourceChainDiscontinuity {
+                child_number: source_latest.number,
+                parent_number: source_block.number,
+            });
+        }
+
+        if source_block.number == source_safe.number {
+            if source_block.hash != source_safe.hash {
+                return Err(FollowError::SourceBranchMismatch {
+                    number: source_block.number,
+                    expected: source_safe.hash,
+                    actual: source_block.hash,
+                });
+            }
+            saw_source_safe = true;
+        }
+
+        if source_block.number == ancestor.block_info.number {
+            if source_block.hash != ancestor.block_info.hash {
+                return Err(FollowError::SourceBranchMismatch {
+                    number: source_block.number,
+                    expected: ancestor.block_info.hash,
+                    actual: source_block.hash,
+                });
+            }
+            break;
+        }
+
+        reverse_path.push(ReplayBlock {
+            number: source_block.number,
+            hash: source_block.hash,
+            parent_hash: source_block.parent_hash,
+        });
+
+        let parent = source.get_block_info_by_hash(source_block.parent_hash).await?;
+        if !parent.is_parent_of(&source_block) {
+            return Err(FollowError::SourceChainDiscontinuity {
+                child_number: source_block.number,
+                parent_number: parent.number,
+            });
+        }
+        source_block = parent;
+    }
+
+    if !saw_source_safe {
+        return Err(FollowError::SourceChainDiscontinuity {
+            child_number: source_latest.number,
+            parent_number: source_safe.number,
+        });
+    }
+
+    reverse_path.reverse();
+    Ok(reverse_path)
 }
 
 /// Walks the captured source-safe branch backward by parent hash and returns its highest block that

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -1,0 +1,92 @@
+//! Follow-mode recovery: when the local chain diverges from the source, reset the local engine to
+//! the highest block both nodes agree on (the common ancestor) and let the normal insert loop
+//! replay source payloads forward from there. The reset targets a block the local EL already has,
+//! so its forkchoice update is `Valid` (no EL sync) — unlike pointing the EL at the canonical tip,
+//! which it lacks and would answer `Syncing`.
+
+use std::sync::Arc;
+
+use base_protocol::L2BlockInfo;
+
+use crate::follow::{
+    engine::FollowEngine, error::FollowError, local::FollowLocalClient, source::RemoteClient,
+};
+
+/// Resets the local engine onto the common ancestor of the local and source chains and returns the
+/// ancestor block number, from which fetch/insert should restart. `divergent_number` is a block
+/// number (at or below the local latest) where the two chains are known to disagree.
+pub(super) async fn recover<Local, Remote>(
+    local: &Local,
+    source: &Remote,
+    engine: &Arc<dyn FollowEngine>,
+    finalized: &L2BlockInfo,
+    divergent_number: u64,
+) -> Result<u64, FollowError>
+where
+    Local: FollowLocalClient,
+    Remote: RemoteClient,
+{
+    let ancestor = find_common_ancestor(local, source, finalized, divergent_number).await?;
+    engine.reset_to_ancestor(ancestor).await?;
+    Ok(ancestor.block_info.number)
+}
+
+/// Returns the highest L2 block in `[finalized, divergent_number)` whose hash is the same on the
+/// local and source nodes. The finalized head must itself be common; if it is not, recovery cannot
+/// safely reorg below it.
+///
+/// Forks are contiguous (the chains share a prefix and then diverge), so "agrees with source" is
+/// monotonic in the block number, which makes a binary search correct.
+pub(super) async fn find_common_ancestor<Local, Remote>(
+    local: &Local,
+    source: &Remote,
+    finalized: &L2BlockInfo,
+    divergent_number: u64,
+) -> Result<L2BlockInfo, FollowError>
+where
+    Local: FollowLocalClient,
+    Remote: RemoteClient,
+{
+    // The search floor must be common. Finality is never reorged, so stop before resetting.
+    let finalized_number = finalized.block_info.number;
+    let source_finalized = source.get_block_info(finalized_number.into()).await?;
+    if source_finalized.hash != finalized.block_info.hash {
+        return Err(FollowError::SourceBlockHashMismatch {
+            number: finalized_number,
+            local: finalized.block_info.hash,
+            remote: source_finalized.hash,
+        });
+    }
+
+    // Invariant: blocks agree at `lo`, disagree at `hi`. Converge to the highest agreeing block.
+    let mut lo = finalized_number;
+    let mut hi = divergent_number.max(finalized_number + 1);
+    while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2;
+        if blocks_match(local, source, mid).await? {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    local.block_info(lo.into()).await?.ok_or(FollowError::LocalBlockUnavailable(lo.into()))
+}
+
+/// Whether the local and source nodes report the same hash for the block at `number`. A missing
+/// local block counts as a mismatch (the search moves below it).
+async fn blocks_match<Local, Remote>(
+    local: &Local,
+    source: &Remote,
+    number: u64,
+) -> Result<bool, FollowError>
+where
+    Local: FollowLocalClient,
+    Remote: RemoteClient,
+{
+    let Some(local_block) = local.block_info(number.into()).await? else {
+        return Ok(false);
+    };
+    let source_block = source.get_block_info(number.into()).await?;
+    Ok(local_block.block_info.hash == source_block.hash)
+}

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -22,15 +22,15 @@ use crate::follow::{
 const SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Outcome of the safety loop / a single safe-finalized update pass.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum SafetyOutcome {
     /// Safe/finalized labels were updated, intentionally skipped, or the loop was cancelled.
     Updated,
     /// The local chain diverged from the source and was reset to the common ancestor; fetch/insert
-    /// must restart from `ancestor` to replay the source chain forward.
+    /// must restart from the recovery plan's ancestor to replay the captured source branch.
     Reorged {
-        /// Common-ancestor block number to restart fetch/insert from.
-        ancestor: u64,
+        /// Common ancestor and source branch to replay.
+        plan: recovery::RecoveryPlan,
     },
 }
 
@@ -108,8 +108,19 @@ where
                 });
             }
 
+            let expected_hash = payload.execution_payload.block_hash();
             info!(target: "follow", block = current_block, "Inserting source payload");
-            engine.insert_payload(payload).await?;
+            let inserted = engine.insert_payload(payload).await?;
+            if inserted.block_info.number != current_block
+                || inserted.block_info.hash != expected_hash
+            {
+                return Err(FollowError::PayloadNotApplied {
+                    expected_number: current_block,
+                    expected_hash,
+                    actual_number: inserted.block_info.number,
+                    actual_hash: inserted.block_info.hash,
+                });
+            }
             if !insert_delay.is_zero() {
                 debug!(
                     target: "follow",
@@ -204,7 +215,7 @@ where
                 let finalized = local_finalized
                     .as_ref()
                     .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
-                let ancestor = recovery::recover(
+                let plan = recovery::recover(
                     local.as_ref(),
                     source.as_ref(),
                     &engine,
@@ -216,7 +227,7 @@ where
                 // first and causes the outer select to shut down follow mode before recovery can
                 // return its restart point.
                 generation.cancel();
-                return Ok(SafetyOutcome::Reorged { ancestor });
+                return Ok(SafetyOutcome::Reorged { plan });
             }
         };
 
@@ -317,6 +328,7 @@ where
 {
     pub(super) async fn start(mut self) -> Result<(), FollowError> {
         let mut head_number = self.follow_from_block.block_info.number;
+        let mut replay = Vec::new();
 
         loop {
             if self.cancellation.is_cancelled() {
@@ -334,7 +346,7 @@ where
                 generation.clone(),
                 blocks_to_insert_tx,
             );
-            let fetch_loop = prefetcher.run(head_number);
+            let fetch_loop = prefetcher.run(head_number, replay);
             let insert_loop = Self::run_ordered_insert_loop(
                 Arc::clone(&self.engine),
                 generation.clone(),
@@ -358,16 +370,18 @@ where
             }?;
 
             match outcome {
-                SafetyOutcome::Reorged { ancestor } => {
-                    // The engine reset the unsafe head down to `ancestor` (a block it has, so the
-                    // forkchoice update was Valid). Restart fetch/insert from there to replay the
-                    // source chain forward.
+                SafetyOutcome::Reorged { plan } => {
+                    // The engine reset the unsafe head down to the common ancestor (a block it
+                    // has, so the forkchoice update was Valid). Restart from there and replay the
+                    // captured source branch by hash.
+                    let ancestor = plan.ancestor.block_info.number;
                     info!(
                         target: "follow",
                         ancestor,
                         "Reset to common ancestor; restarting follow fetch/insert",
                     );
                     head_number = ancestor;
+                    replay = plan.replay;
                 }
                 SafetyOutcome::Updated => return Ok(()),
             }
@@ -412,6 +426,7 @@ mod tests {
         labels: Mutex<Vec<(Option<u64>, Option<u64>)>>,
         reset: Mutex<Vec<u64>>,
         delay: Duration,
+        advance: bool,
     }
 
     impl RecordingEngine {
@@ -421,7 +436,12 @@ mod tests {
                 labels: Mutex::new(Vec::new()),
                 reset: Mutex::new(Vec::new()),
                 delay,
+                advance: true,
             }
+        }
+
+        fn non_advancing(delay: Duration) -> Self {
+            Self { advance: false, ..Self::new(delay) }
         }
     }
 
@@ -469,6 +489,14 @@ mod tests {
             time::sleep(self.fetch_delay).await;
             Ok(payload(number))
         }
+
+        async fn get_payload_by_hash(
+            &self,
+            hash: B256,
+        ) -> Result<BaseExecutionPayloadEnvelope, crate::RemoteL2ClientError> {
+            time::sleep(self.fetch_delay).await;
+            Ok(payload(hash[31] as u64))
+        }
     }
 
     #[async_trait]
@@ -476,10 +504,12 @@ mod tests {
         async fn insert_payload(
             &self,
             envelope: BaseExecutionPayloadEnvelope,
-        ) -> Result<(), FollowError> {
+        ) -> Result<L2BlockInfo, FollowError> {
             time::sleep(self.delay).await;
-            self.inserted.lock().await.push(envelope.execution_payload.block_number());
-            Ok(())
+            let number = envelope.execution_payload.block_number();
+            self.inserted.lock().await.push(number);
+            let reported_number = if self.advance { number } else { number.saturating_sub(1) };
+            Ok(block_info(reported_number))
         }
 
         async fn update_safe_finalized_blocks(
@@ -625,6 +655,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ordered_insertion_rejects_engine_noop_without_advancing_cursor() {
+        let engine = Arc::new(RecordingEngine::non_advancing(Duration::ZERO));
+        let mut proof_gate = NoopProofGate;
+        let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
+        blocks_to_insert_tx.send(payload(1)).await.expect("send 1");
+        drop(blocks_to_insert_tx);
+
+        let engine_for_loop: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let error =
+            FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::run_ordered_insert_loop(
+                engine_for_loop,
+                CancellationToken::new(),
+                blocks_to_insert_rx,
+                1,
+                &mut proof_gate,
+                Duration::ZERO,
+            )
+            .await
+            .expect_err("non-advancing insert must fail");
+
+        assert!(matches!(
+            error,
+            FollowError::PayloadNotApplied { expected_number: 1, actual_number: 0, .. }
+        ));
+        assert_eq!(*engine.inserted.lock().await, vec![1]);
+    }
+
+    #[tokio::test]
     async fn ordered_insertion_applies_configured_insert_delay() {
         let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let mut proof_gate = NoopProofGate;
@@ -665,7 +723,7 @@ mod tests {
         let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
         let prefetcher =
             PayloadPrefetcher::new(Arc::new(source), cancellation.clone(), blocks_to_insert_tx);
-        let handle = tokio::spawn(async move { prefetcher.run(0).await });
+        let handle = tokio::spawn(async move { prefetcher.run(0, Vec::new()).await });
 
         let deadline = Instant::now() + Duration::from_secs(1);
         while blocks_to_insert_rx.len() < PREFETCH_WINDOW && Instant::now() < deadline {
@@ -678,6 +736,34 @@ mod tests {
 
         assert_eq!(fetched, PREFETCH_WINDOW);
         assert!(requests.load(Ordering::SeqCst) <= PREFETCH_WINDOW as u64 + 1);
+    }
+
+    #[tokio::test]
+    async fn prefetch_replays_captured_branch_by_hash() {
+        let hash = B256::from([1; 32]);
+        let mut source = MockRemoteClient::new();
+        source.expect_get_payload_by_hash().with(eq(hash)).times(1).returning(|_| Ok(payload(1)));
+        source.expect_get_block_number().with(eq(BlockNumberOrTag::Latest)).returning(|_| Ok(1));
+
+        let cancellation = CancellationToken::new();
+        let (blocks_to_insert_tx, mut blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
+        let prefetcher =
+            PayloadPrefetcher::new(Arc::new(source), cancellation.clone(), blocks_to_insert_tx);
+        let handle = tokio::spawn(async move {
+            prefetcher
+                .run(0, vec![recovery::ReplayBlock { number: 1, hash, parent_hash: B256::ZERO }])
+                .await
+        });
+
+        let replayed = time::timeout(Duration::from_secs(1), blocks_to_insert_rx.recv())
+            .await
+            .expect("replay payload timeout")
+            .expect("replay payload");
+        assert_eq!(replayed.execution_payload.block_hash(), hash);
+
+        cancellation.cancel();
+        drop(blocks_to_insert_rx);
+        handle.await.expect("join").expect("prefetcher");
     }
 
     #[tokio::test]
@@ -858,12 +944,19 @@ mod tests {
     async fn safe_divergence_recovers_to_ancestor() {
         // A coherent read of the safe label (number + hash together) disagrees with the local block
         // at that height (number 10). Rather than wedge, recovery finds the common ancestor and
-        // resets to it. Here by-number reads agree everywhere below 10, so the highest common block
-        // is 9: recovery resets to 9 and the pass returns Reorged { ancestor: 9 } so the caller
-        // restarts fetch/insert from there.
+        // resets to it. The source latest read is on the same branch as source safe, so the
+        // recovery plan contains block 10 for hash-pinned replay.
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
+            Ok(BlockInfo {
+                number: 10,
+                hash: B256::from([99; 32]),
+                parent_hash: B256::from([9; 32]),
+                ..Default::default()
+            })
+        });
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Latest)).returning(|_| {
             Ok(BlockInfo {
                 number: 10,
                 hash: B256::from([99; 32]),
@@ -889,7 +982,13 @@ mod tests {
             .await
             .expect("recover from divergence");
 
-        assert_eq!(outcome, SafetyOutcome::Reorged { ancestor: 9 });
+        let SafetyOutcome::Reorged { plan } = outcome else {
+            panic!("expected recovery outcome");
+        };
+        assert_eq!(plan.ancestor.block_info.number, 9);
+        assert_eq!(plan.replay.len(), 1);
+        assert_eq!(plan.replay[0].number, 10);
+        assert_eq!(plan.replay[0].hash, B256::from([99; 32]));
         assert!(generation.is_cancelled());
         assert_eq!(*engine.reset.lock().await, vec![9]);
         assert!(engine.labels.lock().await.is_empty());
@@ -942,6 +1041,49 @@ mod tests {
             FollowError::SourceL1OriginMismatch { l2_number: 9, l1_number: 0, .. }
         ));
         assert!(engine.labels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_source_latest_from_different_branch() {
+        let local = Arc::new(local_client(10, 8, 7, 100));
+        let mut source = MockRemoteClient::new();
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
+            Ok(BlockInfo {
+                number: 10,
+                hash: B256::from([99; 32]),
+                parent_hash: B256::from([9; 32]),
+                ..Default::default()
+            })
+        });
+        source
+            .expect_get_block_info_by_hash()
+            .with(eq(B256::from([9; 32])))
+            .returning(|_| Ok(source_block_info(9)));
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Latest)).returning(|_| {
+            Ok(BlockInfo {
+                number: 10,
+                hash: B256::from([100; 32]),
+                parent_hash: B256::from([9; 32]),
+                ..Default::default()
+            })
+        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
+        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let generation = CancellationToken::new();
+
+        let error =
+            FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
+                local,
+                Arc::new(source),
+                engine_for_update,
+                generation.clone(),
+            )
+            .await
+            .expect_err("incoherent source branch");
+
+        assert!(matches!(error, FollowError::SourceBranchMismatch { number: 10, .. }));
+        assert!(!generation.is_cancelled());
+        assert!(engine.reset.lock().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -194,9 +194,8 @@ where
         };
         let local_finalized = local.block_info(BlockNumberOrTag::Finalized).await?;
 
-        // One coherent read per label: the number and hash come from the same response, so a
-        // load-balanced multi-replica source can no longer supply a safe height from one backend
-        // and a by-number hash from another (mirrors op-node `L2BlockRefByLabel`).
+        // Coherent label read: number and hash from one response (mirrors op-node
+        // `L2BlockRefByLabel`).
         let source_safe = source.get_block_info(BlockNumberOrTag::Safe).await?;
         let safe = match Self::evaluate_label(
             &local,
@@ -212,8 +211,7 @@ where
             }
             LabelOutcome::Skip => None,
             LabelOutcome::Diverged { number, local: local_hash, remote } => {
-                // Rather than wedge forever, reset to the common ancestor and replay the source
-                // branch forward.
+                // Reset to the common ancestor and replay the source branch forward.
                 warn!(
                     target: "follow",
                     number,
@@ -237,9 +235,8 @@ where
                 if generation.is_cancelled() {
                     return Ok(SafetyOutcome::Updated);
                 }
-                // Cancel only after a confirmed reset. Cancelling earlier lets fetch/insert finish
-                // first and causes the outer select to shut down follow mode before recovery can
-                // return its restart point.
+                // Cancel fetch/insert after the reset so this generation can return the restart
+                // point.
                 generation.cancel();
                 return Ok(SafetyOutcome::Reorged { plan });
             }
@@ -356,28 +353,72 @@ where
                 generation.clone(),
                 blocks_to_insert_tx,
             );
-            let fetch_loop = prefetcher.run(head_number, replay);
-            let insert_loop = Self::run_ordered_insert_loop(
-                Arc::clone(&self.engine),
-                generation.clone(),
-                blocks_to_insert_rx,
-                next_insert,
-                &mut self.proof_gate,
-                self.insert_delay,
-            );
-            let safety_loop = Self::run_update_safe_finalized_heads_loop(
+            // Pin the safety future so an insert stall can await the same in-flight reconciliation
+            // after catch-up futures are dropped.
+            let mut safety_loop = Box::pin(Self::run_update_safe_finalized_heads_loop(
                 Arc::clone(&self.local),
                 Arc::clone(&self.source),
                 Arc::clone(&self.engine),
                 generation.clone(),
                 self.cancellation.clone(),
-            );
+            ));
 
-            let outcome = tokio::select! {
-                result = fetch_loop => result.map(|()| SafetyOutcome::Updated),
-                result = insert_loop => result.map(|()| SafetyOutcome::Updated),
-                result = safety_loop => result,
-            }?;
+            let selected = {
+                let fetch_loop = prefetcher.run(head_number, replay);
+                let insert_loop = Self::run_ordered_insert_loop(
+                    Arc::clone(&self.engine),
+                    generation.clone(),
+                    blocks_to_insert_rx,
+                    next_insert,
+                    &mut self.proof_gate,
+                    self.insert_delay,
+                );
+                tokio::pin!(fetch_loop);
+                tokio::pin!(insert_loop);
+
+                tokio::select! {
+                    result = &mut fetch_loop => GenerationSelect::Finished(
+                        result.map(|()| SafetyOutcome::Updated),
+                    ),
+                    result = &mut insert_loop => match result {
+                        Ok(()) => GenerationSelect::Finished(Ok(SafetyOutcome::Updated)),
+                        Err(FollowError::PayloadNotApplied {
+                            expected_number,
+                            expected_hash,
+                            actual_number,
+                            actual_hash,
+                        }) => GenerationSelect::InsertionStalled {
+                            expected_number,
+                            expected_hash,
+                            actual_number,
+                            actual_hash,
+                        },
+                        Err(error) => GenerationSelect::Finished(Err(error)),
+                    },
+                    result = &mut safety_loop => GenerationSelect::Finished(result),
+                }
+            };
+
+            let outcome = match selected {
+                GenerationSelect::Finished(result) => result?,
+                GenerationSelect::InsertionStalled {
+                    expected_number,
+                    expected_hash,
+                    actual_number,
+                    actual_hash,
+                } => {
+                    // Pause catch-up and finish reconciliation on the in-flight safety loop.
+                    warn!(
+                        target: "follow",
+                        expected_number,
+                        expected_hash = %expected_hash,
+                        actual_number,
+                        actual_hash = %actual_hash,
+                        "Source payload was not applied; pausing insertion until safety reconciliation completes",
+                    );
+                    safety_loop.await?
+                }
+            };
 
             match outcome {
                 SafetyOutcome::Reorged { plan } => {
@@ -397,6 +438,23 @@ where
             }
         }
     }
+}
+
+/// Result of selecting among fetch, insert, and safety work for one follow generation.
+enum GenerationSelect {
+    /// Fetch, insert, or safety finished with a definitive generation outcome.
+    Finished(Result<SafetyOutcome, FollowError>),
+    /// Insert could not apply a source payload; await the in-flight safety loop for reconciliation.
+    InsertionStalled {
+        /// Source payload block number that was not applied.
+        expected_number: u64,
+        /// Source payload block hash that was not applied.
+        expected_hash: B256,
+        /// Engine head block number after the rejected insert.
+        actual_number: u64,
+        /// Engine head block hash after the rejected insert.
+        actual_hash: B256,
+    },
 }
 
 #[cfg(test)]
@@ -437,6 +495,8 @@ mod tests {
         reset: Mutex<Vec<u64>>,
         delay: Duration,
         advance: bool,
+        /// When set, inserts report a non-advancing head until [`FollowEngine::reset_to_ancestor`].
+        stall_until_reset: bool,
     }
 
     impl RecordingEngine {
@@ -447,11 +507,16 @@ mod tests {
                 reset: Mutex::new(Vec::new()),
                 delay,
                 advance: true,
+                stall_until_reset: false,
             }
         }
 
         fn non_advancing(delay: Duration) -> Self {
             Self { advance: false, ..Self::new(delay) }
+        }
+
+        fn stall_inserts_until_reset(delay: Duration) -> Self {
+            Self { stall_until_reset: true, ..Self::new(delay) }
         }
     }
 
@@ -517,9 +582,17 @@ mod tests {
         ) -> Result<L2BlockInfo, FollowError> {
             time::sleep(self.delay).await;
             let number = envelope.execution_payload.block_number();
+            let hash = envelope.execution_payload.block_hash();
             self.inserted.lock().await.push(number);
-            let reported_number = if self.advance { number } else { number.saturating_sub(1) };
-            Ok(block_info(reported_number))
+            let advance =
+                self.advance && (!self.stall_until_reset || !self.reset.lock().await.is_empty());
+            if advance {
+                return Ok(L2BlockInfo {
+                    block_info: BlockInfo { number, hash, ..Default::default() },
+                    ..Default::default()
+                });
+            }
+            Ok(block_info(number.saturating_sub(1)))
         }
 
         async fn update_safe_finalized_blocks(
@@ -694,6 +767,158 @@ mod tests {
             FollowError::PayloadNotApplied { expected_number: 1, actual_number: 0, .. }
         ));
         assert_eq!(*engine.inserted.lock().await, vec![1]);
+    }
+
+    /// Source whose safe label is delayed and disagrees with the local tip at that height.
+    #[derive(Debug)]
+    struct DivergentRestartSource {
+        safe_delay: Duration,
+    }
+
+    #[async_trait]
+    impl RemoteClient for DivergentRestartSource {
+        async fn get_block_number(
+            &self,
+            tag: BlockNumberOrTag,
+        ) -> Result<u64, crate::RemoteL2ClientError> {
+            match tag {
+                BlockNumberOrTag::Latest => Ok(2),
+                BlockNumberOrTag::Number(number) => Ok(number),
+                BlockNumberOrTag::Safe => Ok(1),
+                _ => Ok(0),
+            }
+        }
+
+        async fn get_block_info(
+            &self,
+            tag: BlockNumberOrTag,
+        ) -> Result<BlockInfo, crate::RemoteL2ClientError> {
+            match tag {
+                BlockNumberOrTag::Safe => {
+                    time::sleep(self.safe_delay).await;
+                    Ok(BlockInfo {
+                        number: 1,
+                        hash: B256::from([99; 32]),
+                        parent_hash: B256::from([0; 32]),
+                        ..Default::default()
+                    })
+                }
+                BlockNumberOrTag::Latest => Ok(BlockInfo {
+                    number: 2,
+                    hash: B256::from([2; 32]),
+                    parent_hash: B256::from([99; 32]),
+                    ..Default::default()
+                }),
+                BlockNumberOrTag::Number(number) => Ok(source_block_info(number)),
+                _ => Ok(source_block_info(0)),
+            }
+        }
+
+        async fn get_block_info_by_hash(
+            &self,
+            hash: B256,
+        ) -> Result<BlockInfo, crate::RemoteL2ClientError> {
+            if hash == B256::from([99; 32]) {
+                return Ok(BlockInfo {
+                    number: 1,
+                    hash,
+                    parent_hash: B256::from([0; 32]),
+                    ..Default::default()
+                });
+            }
+            if hash == B256::from([2; 32]) {
+                return Ok(BlockInfo {
+                    number: 2,
+                    hash,
+                    parent_hash: B256::from([99; 32]),
+                    ..Default::default()
+                });
+            }
+            Ok(source_block_info(hash[31] as u64))
+        }
+
+        async fn get_payload_by_number(
+            &self,
+            number: u64,
+        ) -> Result<BaseExecutionPayloadEnvelope, crate::RemoteL2ClientError> {
+            Ok(payload(number))
+        }
+
+        async fn get_payload_by_hash(
+            &self,
+            hash: B256,
+        ) -> Result<BaseExecutionPayloadEnvelope, crate::RemoteL2ClientError> {
+            let mut envelope = if hash == B256::from([99; 32]) {
+                payload(1)
+            } else if hash == B256::from([2; 32]) {
+                payload(2)
+            } else {
+                payload(hash[31] as u64)
+            };
+            if let BaseExecutionPayload::V1(payload) = &mut envelope.execution_payload {
+                payload.block_hash = hash;
+                payload.parent_hash = if hash == B256::from([2; 32]) {
+                    B256::from([99; 32])
+                } else if hash == B256::from([99; 32]) {
+                    B256::from([0; 32])
+                } else {
+                    B256::from([hash[31].saturating_sub(1); 32])
+                };
+            }
+            Ok(envelope)
+        }
+    }
+
+    #[tokio::test]
+    async fn payload_not_applied_awaits_safety_recovery() {
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Latest => block_info(1),
+                BlockNumberOrTag::Number(number) => block_info(number),
+                _ => block_info(0),
+            }))
+        });
+        local.expect_proofs_latest().returning(|| Ok(Some(100)));
+
+        let engine = Arc::new(RecordingEngine::stall_inserts_until_reset(Duration::ZERO));
+        let cancellation = CancellationToken::new();
+        let engine_for_runtime: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let runtime = FollowRuntime::new(
+            Arc::new(local),
+            Arc::new(DivergentRestartSource { safe_delay: Duration::from_millis(50) }),
+            engine_for_runtime,
+            cancellation.clone(),
+            block_info(1),
+            NoopProofGate,
+            Duration::ZERO,
+        );
+        let handle = tokio::spawn(async move { runtime.start().await });
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if !engine.reset.lock().await.is_empty()
+                && engine.inserted.lock().await.iter().any(|number| *number >= 2)
+            {
+                break;
+            }
+            time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(*engine.reset.lock().await, vec![0]);
+        assert!(
+            engine.inserted.lock().await.contains(&1),
+            "recovery must replay the source branch after reset: {:?}",
+            engine.inserted.lock().await
+        );
+        assert!(
+            engine.inserted.lock().await.iter().any(|number| *number >= 2),
+            "follow must resume catch-up after recovery: {:?}",
+            engine.inserted.lock().await
+        );
+
+        cancellation.cancel();
+        handle.await.expect("join").expect("follow recovered after PayloadNotApplied");
     }
 
     #[tokio::test]
@@ -956,10 +1181,9 @@ mod tests {
 
     #[tokio::test]
     async fn safe_divergence_recovers_to_ancestor() {
-        // A coherent read of the safe label (number + hash together) disagrees with the local block
-        // at that height (number 10). Rather than wedge, recovery finds the common ancestor and
-        // resets to it. The source latest read is on the same branch as source safe, so the
-        // recovery plan contains block 10 for hash-pinned replay.
+        // Safe label (number + hash) disagrees with the local block at height 10. Recovery resets
+        // to the common ancestor. Source latest is on the same branch as source safe, so the plan
+        // includes block 10 for hash-pinned replay.
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
@@ -1133,9 +1357,8 @@ mod tests {
 
     #[tokio::test]
     async fn finalized_label_rejects_source_hash_mismatch() {
-        // The safe label is consistent (so evaluation reaches the finalized read), but the in-range
-        // finalized block's hash disagrees with the local block: surface the existing mismatch
-        // error and never reset.
+        // Safe label is consistent so evaluation reaches finalized; the in-range finalized hash
+        // disagrees with local, which returns FinalizedDivergence without resetting.
         let local = Arc::new(local_client(10, 9, 7, 100));
         let mut source = MockRemoteClient::new();
         source
@@ -1201,9 +1424,8 @@ mod tests {
 
     #[tokio::test]
     async fn recover_rejects_finalized_hash_mismatch() {
-        // If the source disagrees with the local node even at the finalized height, finality has
-        // diverged. Recovery cannot safely reset below finalized, so surface the existing mismatch
-        // error and never reset.
+        // Source disagrees with local at the finalized height. Recovery must not reset below
+        // finalized, so this returns FinalizedDivergence.
         let mut local = MockFollowLocalClient::new();
         local.expect_block_info().returning(|tag| {
             Ok(Some(match tag {

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -20,6 +20,8 @@ use crate::follow::{
 };
 
 const SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const INSERT_STALL_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const INSERT_STALL_WARN_INTERVAL: u64 = 5;
 
 /// Outcome of the safety loop / a single safe-finalized update pass.
 #[derive(Debug, PartialEq, Eq)]
@@ -27,7 +29,7 @@ enum SafetyOutcome {
     /// Safe/finalized labels were updated, intentionally skipped, or the loop was cancelled.
     Updated,
     /// The local chain diverged from the source and was reset to the common ancestor; fetch/insert
-    /// must restart from the recovery plan's ancestor to replay the captured source branch.
+    /// must restart from the recovery plan's ancestor to replay through the captured source safe.
     Reorged {
         /// Common ancestor and source branch to replay.
         plan: recovery::RecoveryPlan,
@@ -108,18 +110,56 @@ where
                 });
             }
 
-            let expected_hash = payload.execution_payload.block_hash();
-            info!(target: "follow", block = current_block, "Inserting source payload");
-            let inserted = engine.insert_payload(payload).await?;
-            if inserted.block_info.number != current_block
-                || inserted.block_info.hash != expected_hash
-            {
-                return Err(FollowError::PayloadNotApplied {
-                    expected_number: current_block,
-                    expected_hash,
-                    actual_number: inserted.block_info.number,
-                    actual_hash: inserted.block_info.hash,
-                });
+            let mut stall_attempts = 0;
+            loop {
+                if cancellation.is_cancelled() {
+                    return Ok(());
+                }
+
+                let expected_hash = payload.execution_payload.block_hash();
+                if stall_attempts == 0 {
+                    info!(target: "follow", block = current_block, "Inserting source payload");
+                } else {
+                    debug!(
+                        target: "follow",
+                        block = current_block,
+                        attempt = stall_attempts + 1,
+                        "Retrying source payload insert after a deferred application",
+                    );
+                }
+                let inserted = engine.insert_payload(payload.clone()).await?;
+                if inserted.block_info.number == current_block
+                    && inserted.block_info.hash == expected_hash
+                {
+                    break;
+                }
+
+                stall_attempts += 1;
+                if stall_attempts % INSERT_STALL_WARN_INTERVAL == 0 {
+                    warn!(
+                        target: "follow",
+                        block = current_block,
+                        attempts = stall_attempts,
+                        expected_hash = %expected_hash,
+                        actual_number = inserted.block_info.number,
+                        actual_hash = %inserted.block_info.hash,
+                        "Source payload was not applied; deferring retry while safety reconciles",
+                    );
+                } else {
+                    debug!(
+                        target: "follow",
+                        block = current_block,
+                        attempts = stall_attempts,
+                        expected_hash = %expected_hash,
+                        actual_number = inserted.block_info.number,
+                        actual_hash = %inserted.block_info.hash,
+                        "Source payload was not applied; deferring retry while safety reconciles",
+                    );
+                }
+                tokio::select! {
+                    _ = cancellation.cancelled() => return Ok(()),
+                    _ = time::sleep(INSERT_STALL_RETRY_INTERVAL) => {}
+                }
             }
             if !insert_delay.is_zero() {
                 debug!(
@@ -219,22 +259,14 @@ where
                     source = %remote,
                     "Local chain diverged from source safe head; recovering to common ancestor",
                 );
-                let finalized = local_finalized
-                    .as_ref()
-                    .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
                 let plan = recovery::recover(
                     local.as_ref(),
                     source.as_ref(),
                     &engine,
-                    finalized,
                     &source_safe,
                     local_hash,
-                    generation.clone(),
                 )
                 .await?;
-                if generation.is_cancelled() {
-                    return Ok(SafetyOutcome::Updated);
-                }
                 // Cancel fetch/insert after the reset so this generation can return the restart
                 // point.
                 generation.cancel();
@@ -353,78 +385,38 @@ where
                 generation.clone(),
                 blocks_to_insert_tx,
             );
-            // Pin the safety future so an insert stall can await the same in-flight reconciliation
-            // after catch-up futures are dropped.
-            let mut safety_loop = Box::pin(Self::run_update_safe_finalized_heads_loop(
+            let safety_loop = Self::run_update_safe_finalized_heads_loop(
                 Arc::clone(&self.local),
                 Arc::clone(&self.source),
                 Arc::clone(&self.engine),
                 generation.clone(),
                 self.cancellation.clone(),
-            ));
+            );
 
-            let selected = {
-                let fetch_loop = prefetcher.run(head_number, replay);
-                let insert_loop = Self::run_ordered_insert_loop(
-                    Arc::clone(&self.engine),
-                    generation.clone(),
-                    blocks_to_insert_rx,
-                    next_insert,
-                    &mut self.proof_gate,
-                    self.insert_delay,
-                );
-                tokio::pin!(fetch_loop);
-                tokio::pin!(insert_loop);
+            let fetch_loop = prefetcher.run(head_number, replay);
+            let insert_loop = Self::run_ordered_insert_loop(
+                Arc::clone(&self.engine),
+                generation.clone(),
+                blocks_to_insert_rx,
+                next_insert,
+                &mut self.proof_gate,
+                self.insert_delay,
+            );
+            tokio::pin!(fetch_loop);
+            tokio::pin!(insert_loop);
+            tokio::pin!(safety_loop);
 
-                tokio::select! {
-                    result = &mut fetch_loop => GenerationSelect::Finished(
-                        result.map(|()| SafetyOutcome::Updated),
-                    ),
-                    result = &mut insert_loop => match result {
-                        Ok(()) => GenerationSelect::Finished(Ok(SafetyOutcome::Updated)),
-                        Err(FollowError::PayloadNotApplied {
-                            expected_number,
-                            expected_hash,
-                            actual_number,
-                            actual_hash,
-                        }) => GenerationSelect::InsertionStalled {
-                            expected_number,
-                            expected_hash,
-                            actual_number,
-                            actual_hash,
-                        },
-                        Err(error) => GenerationSelect::Finished(Err(error)),
-                    },
-                    result = &mut safety_loop => GenerationSelect::Finished(result),
-                }
-            };
-
-            let outcome = match selected {
-                GenerationSelect::Finished(result) => result?,
-                GenerationSelect::InsertionStalled {
-                    expected_number,
-                    expected_hash,
-                    actual_number,
-                    actual_hash,
-                } => {
-                    // Pause catch-up and finish reconciliation on the in-flight safety loop.
-                    warn!(
-                        target: "follow",
-                        expected_number,
-                        expected_hash = %expected_hash,
-                        actual_number,
-                        actual_hash = %actual_hash,
-                        "Source payload was not applied; pausing insertion until safety reconciliation completes",
-                    );
-                    safety_loop.await?
-                }
-            };
+            let outcome = tokio::select! {
+                result = &mut fetch_loop => result.map(|()| SafetyOutcome::Updated),
+                result = &mut insert_loop => result.map(|()| SafetyOutcome::Updated),
+                result = &mut safety_loop => result,
+            }?;
 
             match outcome {
                 SafetyOutcome::Reorged { plan } => {
                     // The engine reset the unsafe head down to the common ancestor (a block it
                     // has, so the forkchoice update was Valid). Restart from there and replay the
-                    // captured source branch by hash.
+                    // captured source-safe branch by hash.
                     let ancestor = plan.ancestor.block_info.number;
                     info!(
                         target: "follow",
@@ -438,23 +430,6 @@ where
             }
         }
     }
-}
-
-/// Result of selecting among fetch, insert, and safety work for one follow generation.
-enum GenerationSelect {
-    /// Fetch, insert, or safety finished with a definitive generation outcome.
-    Finished(Result<SafetyOutcome, FollowError>),
-    /// Insert could not apply a source payload; await the in-flight safety loop for reconciliation.
-    InsertionStalled {
-        /// Source payload block number that was not applied.
-        expected_number: u64,
-        /// Source payload block hash that was not applied.
-        expected_hash: B256,
-        /// Engine head block number after the rejected insert.
-        actual_number: u64,
-        /// Engine head block hash after the rejected insert.
-        actual_hash: B256,
-    },
 }
 
 #[cfg(test)]
@@ -480,7 +455,7 @@ mod tests {
     use crate::{
         MockRemoteClient,
         follow::{
-            engine::{FollowEngine, ResetStats},
+            engine::FollowEngine,
             local::MockFollowLocalClient,
             proof_gate::{ActiveProofGate, NoopProofGate},
         },
@@ -611,13 +586,9 @@ mod tests {
             Ok(())
         }
 
-        async fn reset_to_ancestor(
-            &self,
-            ancestor: L2BlockInfo,
-            _cancellation: CancellationToken,
-        ) -> Result<ResetStats, FollowError> {
+        async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError> {
             self.reset.lock().await.push(ancestor.block_info.number);
-            Ok(ResetStats::default())
+            Ok(())
         }
     }
 
@@ -742,7 +713,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ordered_insertion_rejects_engine_noop_without_advancing_cursor() {
+    async fn ordered_insertion_defers_engine_noop_without_advancing_cursor() {
         let engine = Arc::new(RecordingEngine::non_advancing(Duration::ZERO));
         let mut proof_gate = NoopProofGate;
         let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
@@ -750,22 +721,23 @@ mod tests {
         drop(blocks_to_insert_tx);
 
         let engine_for_loop: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
-        let error =
+        let cancellation = CancellationToken::new();
+        let loop_cancellation = cancellation.clone();
+        let handle = tokio::spawn(async move {
             FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::run_ordered_insert_loop(
-                engine_for_loop,
-                CancellationToken::new(),
-                blocks_to_insert_rx,
-                1,
-                &mut proof_gate,
-                Duration::ZERO,
-            )
-            .await
-            .expect_err("non-advancing insert must fail");
+                    engine_for_loop,
+                    loop_cancellation,
+                    blocks_to_insert_rx,
+                    1,
+                    &mut proof_gate,
+                    Duration::ZERO,
+                )
+                .await
+        });
+        time::sleep(Duration::from_millis(10)).await;
+        cancellation.cancel();
+        handle.await.expect("insert loop should not panic").expect("cancellation");
 
-        assert!(matches!(
-            error,
-            FollowError::PayloadNotApplied { expected_number: 1, actual_number: 0, .. }
-        ));
         assert_eq!(*engine.inserted.lock().await, vec![1]);
     }
 
@@ -870,7 +842,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn payload_not_applied_awaits_safety_recovery() {
+    async fn stalled_insert_allows_safety_recovery() {
         let mut local = MockFollowLocalClient::new();
         local.expect_block_info().returning(|tag| {
             Ok(Some(match tag {
@@ -918,7 +890,7 @@ mod tests {
         );
 
         cancellation.cancel();
-        handle.await.expect("join").expect("follow recovered after PayloadNotApplied");
+        handle.await.expect("join").expect("follow recovered after stalled insert");
     }
 
     #[tokio::test]
@@ -1191,14 +1163,6 @@ mod tests {
                 ..Default::default()
             })
         });
-        source.expect_get_block_info().with(eq(BlockNumberOrTag::Latest)).returning(|_| {
-            Ok(BlockInfo {
-                number: 10,
-                hash: B256::from([99; 32]),
-                parent_hash: B256::from([9; 32]),
-                ..Default::default()
-            })
-        });
         source
             .expect_get_block_info_by_hash()
             .with(eq(B256::from([9; 32])))
@@ -1272,49 +1236,6 @@ mod tests {
             FollowError::SourceL1OriginMismatch { l2_number: 9, l1_number: 0, .. }
         ));
         assert!(engine.labels.lock().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn recovery_rejects_source_latest_from_different_branch() {
-        let local = Arc::new(local_client(10, 8, 7, 100));
-        let mut source = MockRemoteClient::new();
-        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
-            Ok(BlockInfo {
-                number: 10,
-                hash: B256::from([99; 32]),
-                parent_hash: B256::from([9; 32]),
-                ..Default::default()
-            })
-        });
-        source
-            .expect_get_block_info_by_hash()
-            .with(eq(B256::from([9; 32])))
-            .returning(|_| Ok(source_block_info(9)));
-        source.expect_get_block_info().with(eq(BlockNumberOrTag::Latest)).returning(|_| {
-            Ok(BlockInfo {
-                number: 10,
-                hash: B256::from([100; 32]),
-                parent_hash: B256::from([9; 32]),
-                ..Default::default()
-            })
-        });
-        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
-        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
-        let generation = CancellationToken::new();
-
-        let error =
-            FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
-                local,
-                Arc::new(source),
-                engine_for_update,
-                generation.clone(),
-            )
-            .await
-            .expect_err("incoherent source branch");
-
-        assert!(matches!(error, FollowError::SourceBranchMismatch { number: 10, .. }));
-        assert!(!generation.is_cancelled());
-        assert!(engine.reset.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -1438,7 +1359,6 @@ mod tests {
             })
         });
         let engine: Arc<dyn FollowEngine> = Arc::new(RecordingEngine::new(Duration::ZERO));
-        let finalized = block_info(7);
         let source_safe = BlockInfo {
             number: 10,
             hash: B256::from([110; 32]),
@@ -1446,17 +1366,9 @@ mod tests {
             ..Default::default()
         };
 
-        let error = recovery::recover(
-            &local,
-            &source,
-            &engine,
-            &finalized,
-            &source_safe,
-            B256::from([7; 32]),
-            CancellationToken::new(),
-        )
-        .await
-        .expect_err("finalized divergence");
+        let error = recovery::recover(&local, &source, &engine, &source_safe, B256::from([7; 32]))
+            .await
+            .expect_err("finalized divergence");
 
         assert!(matches!(error, FollowError::FinalizedDivergence { number: 7, .. }));
     }
@@ -1469,8 +1381,8 @@ mod tests {
         local.expect_block_info().returning(move |tag| {
             Ok(Some(match tag {
                 BlockNumberOrTag::Finalized => {
-                    finalized_reads_for_local.fetch_add(1, Ordering::SeqCst);
-                    block_info(10)
+                    let read = finalized_reads_for_local.fetch_add(1, Ordering::SeqCst);
+                    block_info(if read == 0 { 7 } else { 8 })
                 }
                 BlockNumberOrTag::Number(number) => block_info(number),
                 _ => block_info(0),
@@ -1478,14 +1390,6 @@ mod tests {
         });
 
         let mut source = MockRemoteClient::new();
-        source.expect_get_block_info().with(eq(BlockNumberOrTag::Latest)).returning(|_| {
-            Ok(BlockInfo {
-                number: 10,
-                hash: B256::from([99; 32]),
-                parent_hash: B256::from([9; 32]),
-                ..Default::default()
-            })
-        });
         source
             .expect_get_block_info_by_hash()
             .with(eq(B256::from([9; 32])))
@@ -1497,7 +1401,6 @@ mod tests {
             &local,
             &source,
             &engine_for_recovery,
-            &block_info(7),
             &BlockInfo {
                 number: 10,
                 hash: B256::from([99; 32]),
@@ -1505,13 +1408,12 @@ mod tests {
                 ..Default::default()
             },
             B256::from([10; 32]),
-            CancellationToken::new(),
         )
         .await
         .expect_err("fresh finalized divergence must prevent reset");
 
-        assert!(matches!(error, FollowError::FinalizedDivergence { number: 10, .. }));
-        assert_eq!(finalized_reads.load(Ordering::SeqCst), 1);
+        assert!(matches!(error, FollowError::FinalizedHeadChanged { .. }));
+        assert_eq!(finalized_reads.load(Ordering::SeqCst), 2);
         assert!(engine.reset.lock().await.is_empty());
     }
 

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
 use base_protocol::{BlockInfo, L2BlockInfo};
 use tokio::{
     sync::mpsc,
@@ -14,10 +15,41 @@ use crate::follow::{
     local::FollowLocalClient,
     prefetcher::{PREFETCH_WINDOW, PayloadPrefetcher, PrefetchedPayload},
     proof_gate::ProofGate,
+    recovery,
     source::RemoteClient,
 };
 
 const SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Outcome of the safety loop / a single safe-finalized update pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SafetyOutcome {
+    /// Safe/finalized labels were updated, intentionally skipped, or the loop was cancelled.
+    Updated,
+    /// The local chain diverged from the source and was reset to the common ancestor; fetch/insert
+    /// must restart from `ancestor` to replay the source chain forward.
+    Reorged {
+        /// Common-ancestor block number to restart fetch/insert from.
+        ancestor: u64,
+    },
+}
+
+/// Result of evaluating one coherent source label block against the local chain at that height.
+enum LabelOutcome {
+    /// Promote the local block as the new label.
+    Promote(L2BlockInfo),
+    /// Skip promotion this round (label out of range, or local block missing).
+    Skip,
+    /// The local block at the label's height has a different hash than the source.
+    Diverged {
+        /// Block number that diverged.
+        number: u64,
+        /// Hash on the local node.
+        local: B256,
+        /// Hash on the source node.
+        remote: B256,
+    },
+}
 
 #[derive(Debug)]
 pub(super) struct FollowRuntime<Local, Remote, Gate> {
@@ -95,25 +127,33 @@ where
         local: Arc<Local>,
         source: Arc<Remote>,
         engine: Arc<dyn FollowEngine>,
+        generation: CancellationToken,
         cancellation: CancellationToken,
-    ) -> Result<(), FollowError> {
+    ) -> Result<SafetyOutcome, FollowError> {
         let mut ticker = time::interval(SAFETY_POLL_INTERVAL);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
             if cancellation.is_cancelled() {
-                return Ok(());
+                return Ok(SafetyOutcome::Updated);
             }
 
             ticker.tick().await;
-            if let Err(e) = Self::update_safe_and_finalized(
+            match Self::update_safe_and_finalized(
                 Arc::clone(&local),
                 Arc::clone(&source),
                 Arc::clone(&engine),
+                generation.clone(),
             )
             .await
             {
-                warn!(target: "follow", error = %e, "Failed to update safe/finalized labels");
+                Ok(SafetyOutcome::Updated) => {}
+                // A recovery reorg ends the loop so the caller restarts fetch/insert from the
+                // common ancestor.
+                Ok(outcome @ SafetyOutcome::Reorged { .. }) => return Ok(outcome),
+                Err(e) => {
+                    warn!(target: "follow", error = %e, "Failed to update safe/finalized labels");
+                }
             }
         }
     }
@@ -122,60 +162,98 @@ where
         local: Arc<Local>,
         source: Arc<Remote>,
         engine: Arc<dyn FollowEngine>,
-    ) -> Result<(), FollowError> {
+        generation: CancellationToken,
+    ) -> Result<SafetyOutcome, FollowError> {
         let latest = local
             .block_info(BlockNumberOrTag::Latest)
             .await?
             .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Latest))?;
         let Some(local_safe) = local.block_info(BlockNumberOrTag::Safe).await? else {
             debug!(target: "follow", "Skipping safe/finalized update because local safe label is unavailable");
-            return Ok(());
+            return Ok(SafetyOutcome::Updated);
         };
         let local_finalized = local.block_info(BlockNumberOrTag::Finalized).await?;
 
-        // Read number and hash from the same response, matching op-node's `L2BlockRefByLabel`.
+        // One coherent read per label: the number and hash come from the same response, so a
+        // load-balanced multi-replica source can no longer supply a safe height from one backend
+        // and a by-number hash from another (mirrors op-node `L2BlockRefByLabel`).
         let source_safe = source.get_block_info(BlockNumberOrTag::Safe).await?;
-        let safe = Self::verified_local_block(
+        let safe = match Self::evaluate_label(
             &local,
             &source_safe,
             local_safe.block_info.number,
             latest.block_info.number,
         )
-        .await?;
-        if let Some(safe_block) = safe.as_ref() {
-            Self::validate_source_l1_origin(local.as_ref(), safe_block).await?;
-        }
+        .await?
+        {
+            LabelOutcome::Promote(block) => {
+                Self::validate_source_l1_origin(local.as_ref(), &block).await?;
+                Some(block)
+            }
+            LabelOutcome::Skip => None,
+            LabelOutcome::Diverged { number, local: local_hash, remote } => {
+                // The source is authoritative for the L2 chain in follow mode. Rather than wedge
+                // forever, reset to the common ancestor and replay the source chain forward.
+                warn!(
+                    target: "follow",
+                    number,
+                    local = %local_hash,
+                    source = %remote,
+                    "Local chain diverged from source safe head; recovering to common ancestor",
+                );
+                generation.cancel();
+                let finalized = local_finalized
+                    .as_ref()
+                    .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
+                let ancestor =
+                    recovery::recover(local.as_ref(), source.as_ref(), &engine, finalized, number)
+                        .await?;
+                return Ok(SafetyOutcome::Reorged { ancestor });
+            }
+        };
 
         let safe_limit = safe.as_ref().unwrap_or(&local_safe).block_info.number;
 
         // Finalized floor at the local finalized head (never unwind), ceiling at the safe head.
         let source_finalized = source.get_block_info(BlockNumberOrTag::Finalized).await?;
         let local_finalized_number =
-            local_finalized.map(|block| block.block_info.number).unwrap_or_default();
-        let finalized = Self::verified_local_block(
+            local_finalized.as_ref().map(|block| block.block_info.number).unwrap_or_default();
+        let finalized = match Self::evaluate_label(
             &local,
             &source_finalized,
             local_finalized_number,
             latest.block_info.number.min(safe_limit),
         )
-        .await?;
-        if let Some(finalized_block) = finalized.as_ref() {
-            Self::validate_source_l1_origin(local.as_ref(), finalized_block).await?;
-        }
+        .await?
+        {
+            LabelOutcome::Promote(block) => {
+                Self::validate_source_l1_origin(local.as_ref(), &block).await?;
+                Some(block)
+            }
+            LabelOutcome::Skip => None,
+            LabelOutcome::Diverged { number, local: local_hash, remote } => {
+                return Err(FollowError::SourceBlockHashMismatch {
+                    number,
+                    local: local_hash,
+                    remote,
+                });
+            }
+        };
 
-        engine.update_safe_finalized_blocks(safe, finalized).await
+        engine.update_safe_finalized_blocks(safe, finalized).await?;
+        Ok(SafetyOutcome::Updated)
     }
 
-    /// Returns the local block at a coherent source label's height (`{number, hash}` from a single
-    /// read) when the number is within `[floor, ceiling]` and the local hash matches the source
-    /// hash. Labels outside the local range, or missing locally, are skipped. In-range hash
-    /// divergence returns `SourceBlockHashMismatch`.
-    async fn verified_local_block(
+    /// Evaluates a coherent source label block (`{number, hash}` from a single read) against the
+    /// local chain at the same height. Returns [`LabelOutcome::Skip`] when the label is out of
+    /// `[floor, ceiling]` or the local block is missing, [`LabelOutcome::Promote`] when the hashes
+    /// match, and [`LabelOutcome::Diverged`] when the local block at that height differs.
+    async fn evaluate_label(
         local: &Local,
         source_block: &BlockInfo,
         floor: u64,
         ceiling: u64,
-    ) -> Result<Option<L2BlockInfo>, FollowError> {
+    ) -> Result<LabelOutcome, FollowError> {
         let number = source_block.number;
         if number < floor || number > ceiling {
             debug!(
@@ -186,19 +264,19 @@ where
                 hash = %source_block.hash,
                 "Skipping source label outside local range"
             );
-            return Ok(None);
+            return Ok(LabelOutcome::Skip);
         }
         let Some(local_block) = local.block_info(number.into()).await? else {
-            return Ok(None);
+            return Ok(LabelOutcome::Skip);
         };
         if local_block.block_info.hash != source_block.hash {
-            return Err(FollowError::SourceBlockHashMismatch {
+            return Ok(LabelOutcome::Diverged {
                 number,
                 local: local_block.block_info.hash,
                 remote: source_block.hash,
             });
         }
-        Ok(Some(local_block))
+        Ok(LabelOutcome::Promote(local_block))
     }
 
     /// Verifies that a hash-verified local block's L1 origin is canonical in the local L1 view.
@@ -230,33 +308,61 @@ where
     Gate: ProofGate + 'static,
 {
     pub(super) async fn start(mut self) -> Result<(), FollowError> {
-        let next_insert = self.follow_from_block.block_info.number.saturating_add(1);
-        let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
-        let prefetcher = PayloadPrefetcher::new(
-            Arc::clone(&self.source),
-            self.cancellation.clone(),
-            blocks_to_insert_tx,
-        );
-        let fetch_loop = prefetcher.run(self.follow_from_block.block_info.number);
-        let insert_loop = Self::run_ordered_insert_loop(
-            Arc::clone(&self.engine),
-            self.cancellation.clone(),
-            blocks_to_insert_rx,
-            next_insert,
-            &mut self.proof_gate,
-            self.insert_delay,
-        );
-        let safety_loop = Self::run_update_safe_finalized_heads_loop(
-            Arc::clone(&self.local),
-            Arc::clone(&self.source),
-            Arc::clone(&self.engine),
-            self.cancellation.clone(),
-        );
+        let mut head_number = self.follow_from_block.block_info.number;
 
-        tokio::select! {
-            result = fetch_loop => result,
-            result = insert_loop => result,
-            result = safety_loop => result,
+        loop {
+            if self.cancellation.is_cancelled() {
+                return Ok(());
+            }
+
+            let next_insert = head_number.saturating_add(1);
+
+            // Fetch + insert share a child token so a recovery reorg can restart just those loops
+            // from the new head while the parent cancellation still drives full shutdown.
+            let generation = self.cancellation.child_token();
+            let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
+            let prefetcher = PayloadPrefetcher::new(
+                Arc::clone(&self.source),
+                generation.clone(),
+                blocks_to_insert_tx,
+            );
+            let fetch_loop = prefetcher.run(head_number);
+            let insert_loop = Self::run_ordered_insert_loop(
+                Arc::clone(&self.engine),
+                generation.clone(),
+                blocks_to_insert_rx,
+                next_insert,
+                &mut self.proof_gate,
+                self.insert_delay,
+            );
+            let safety_loop = Self::run_update_safe_finalized_heads_loop(
+                Arc::clone(&self.local),
+                Arc::clone(&self.source),
+                Arc::clone(&self.engine),
+                generation.clone(),
+                self.cancellation.clone(),
+            );
+
+            let outcome = tokio::select! {
+                result = fetch_loop => result.map(|()| SafetyOutcome::Updated),
+                result = insert_loop => result.map(|()| SafetyOutcome::Updated),
+                result = safety_loop => result,
+            }?;
+
+            match outcome {
+                SafetyOutcome::Reorged { ancestor } => {
+                    // The engine reset the unsafe head down to `ancestor` (a block it has, so the
+                    // forkchoice update was Valid). Restart fetch/insert from there to replay the
+                    // source chain forward.
+                    info!(
+                        target: "follow",
+                        ancestor,
+                        "Reset to common ancestor; restarting follow fetch/insert",
+                    );
+                    head_number = ancestor;
+                }
+                SafetyOutcome::Updated => return Ok(()),
+            }
         }
     }
 }
@@ -296,7 +402,19 @@ mod tests {
     struct RecordingEngine {
         inserted: Mutex<Vec<u64>>,
         labels: Mutex<Vec<(Option<u64>, Option<u64>)>>,
+        reset: Mutex<Vec<u64>>,
         delay: Duration,
+    }
+
+    impl RecordingEngine {
+        fn new(delay: Duration) -> Self {
+            Self {
+                inserted: Mutex::new(Vec::new()),
+                labels: Mutex::new(Vec::new()),
+                reset: Mutex::new(Vec::new()),
+                delay,
+            }
+        }
     }
 
     #[derive(Debug)]
@@ -364,6 +482,11 @@ mod tests {
                 .push((safe.map(|v| v.block_info.number), finalized.map(|v| v.block_info.number)));
             Ok(())
         }
+
+        async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError> {
+            self.reset.lock().await.push(ancestor.block_info.number);
+            Ok(())
+        }
     }
 
     fn block_info(number: u64) -> L2BlockInfo {
@@ -426,11 +549,7 @@ mod tests {
 
     #[tokio::test]
     async fn ordered_insertion_consumes_channel_order() {
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let mut proof_gate = NoopProofGate;
         let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
         blocks_to_insert_tx.send(payload(1)).await.expect("send 1");
@@ -456,11 +575,7 @@ mod tests {
 
     #[tokio::test]
     async fn ordered_insertion_rejects_out_of_order_channel_input() {
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let mut proof_gate = NoopProofGate;
         let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
         blocks_to_insert_tx.send(payload(2)).await.expect("send 2");
@@ -482,11 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn ordered_insertion_applies_configured_insert_delay() {
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let mut proof_gate = NoopProofGate;
         let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
         blocks_to_insert_tx.send(payload(1)).await.expect("send 1");
@@ -566,11 +677,7 @@ mod tests {
             })
         });
         source.expect_get_payload_by_number().returning(|number| Ok(payload(number)));
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let cancellation = CancellationToken::new();
         let proof_gate = ActiveProofGate::new(Arc::clone(&local), DEFAULT_PROOFS_MAX_BLOCKS_AHEAD)
             .await
@@ -612,16 +719,13 @@ mod tests {
             .expect_get_block_info()
             .with(eq(BlockNumberOrTag::Finalized))
             .returning(|_| Ok(source_block_info(6)));
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
         FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
             local,
             Arc::new(source),
             engine_for_update,
+            CancellationToken::new(),
         )
         .await
         .expect("labels");
@@ -643,16 +747,13 @@ mod tests {
             .expect_get_block_info()
             .with(eq(BlockNumberOrTag::Finalized))
             .returning(|_| Ok(source_block_info(6)));
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
         FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
             local,
             Arc::new(source),
             engine_for_update,
+            CancellationToken::new(),
         )
         .await
         .expect("labels");
@@ -710,16 +811,13 @@ mod tests {
                 _ => panic!("unexpected local block lookup: {tag:?}"),
             })
         });
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
         FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
             Arc::new(local),
             Arc::new(MockRemoteClient::new()),
             engine_for_update,
+            CancellationToken::new(),
         )
         .await
         .expect("skip update");
@@ -728,31 +826,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn safe_label_rejects_source_hash_mismatch() {
-        // Safe label hash disagrees with the local block at that height; returns
-        // SourceBlockHashMismatch and does not promote labels.
+    async fn safe_divergence_recovers_to_ancestor() {
+        // A coherent read of the safe label (number + hash together) disagrees with the local block
+        // at that height (number 10). Rather than wedge, recovery finds the common ancestor and
+        // resets to it. Here by-number reads agree everywhere below 10, so the highest common block
+        // is 9: recovery resets to 9 and the pass returns Reorged { ancestor: 9 } so the caller
+        // restarts fetch/insert from there.
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
-        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).times(1).returning(|_| {
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
             Ok(BlockInfo { number: 10, hash: B256::from([99; 32]), ..Default::default() })
         });
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        source
+            .expect_get_block_info()
+            .withf(|tag| matches!(tag, BlockNumberOrTag::Number(_)))
+            .returning(|tag| {
+                let BlockNumberOrTag::Number(number) = tag else { unreachable!() };
+                Ok(source_block_info(number))
+            });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let generation = CancellationToken::new();
 
-        let error =
+        let outcome =
             FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
                 local,
                 Arc::new(source),
                 engine_for_update,
+                generation.clone(),
             )
             .await
-            .expect_err("mismatched source hash");
+            .expect("recover from divergence");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 10, .. }));
+        assert_eq!(outcome, SafetyOutcome::Reorged { ancestor: 9 });
+        assert!(generation.is_cancelled());
+        assert_eq!(*engine.reset.lock().await, vec![9]);
         assert!(engine.labels.lock().await.is_empty());
     }
 
@@ -792,6 +900,7 @@ mod tests {
                 Arc::new(local),
                 Arc::new(source),
                 engine_for_update,
+                CancellationToken::new(),
             )
             .await
             .expect_err("verified local L1 origin must match local canonical L1");
@@ -805,8 +914,9 @@ mod tests {
 
     #[tokio::test]
     async fn finalized_label_rejects_source_hash_mismatch() {
-        // Safe label is consistent so evaluation reaches finalized; the in-range finalized hash
-        // disagrees with local, which returns SourceBlockHashMismatch.
+        // The safe label is consistent (so evaluation reaches the finalized read), but the in-range
+        // finalized block's hash disagrees with the local block: surface the existing mismatch
+        // error and never reset.
         let local = Arc::new(local_client(10, 9, 7, 100));
         let mut source = MockRemoteClient::new();
         source
@@ -816,11 +926,7 @@ mod tests {
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Finalized)).times(1).returning(
             |_| Ok(BlockInfo { number: 8, hash: B256::from([99; 32]), ..Default::default() }),
         );
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
 
         let error =
@@ -828,23 +934,95 @@ mod tests {
                 local,
                 Arc::new(source),
                 engine_for_update,
+                CancellationToken::new(),
             )
             .await
             .expect_err("mismatched finalized hash");
 
         assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 8, .. }));
         assert!(engine.labels.lock().await.is_empty());
+        assert!(engine.reset.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_common_ancestor_binary_search() {
+        // Local and source agree at and below block 5 and disagree above it. A divergence detected
+        // at block 10 must converge to block 5 as the highest common ancestor.
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            let number = match tag {
+                BlockNumberOrTag::Number(n) => n,
+                BlockNumberOrTag::Finalized => 2,
+                _ => 0,
+            };
+            // Above the agreement boundary the local chain is on a different fork.
+            let hash = if number <= 5 {
+                B256::from([number as u8; 32])
+            } else {
+                B256::from([number as u8 + 100; 32])
+            };
+            Ok(Some(L2BlockInfo {
+                block_info: base_protocol::BlockInfo { number, hash, ..Default::default() },
+                ..Default::default()
+            }))
+        });
+        let mut source = MockRemoteClient::new();
+        source.expect_get_block_info().returning(|tag| {
+            let number = match tag {
+                BlockNumberOrTag::Number(n) => n,
+                _ => 0,
+            };
+            Ok(source_block_info(number))
+        });
+
+        let finalized = block_info(2);
+        let ancestor = recovery::find_common_ancestor(&local, &source, &finalized, 10)
+            .await
+            .expect("common ancestor");
+
+        assert_eq!(ancestor.block_info.number, 5);
+    }
+
+    #[tokio::test]
+    async fn recover_rejects_finalized_hash_mismatch() {
+        // If the source disagrees with the local node even at the finalized height, finality has
+        // diverged. Recovery cannot safely reset below finalized, so surface the existing mismatch
+        // error and never reset.
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Finalized => block_info(7),
+                BlockNumberOrTag::Number(number) => block_info(number),
+                _ => block_info(0),
+            }))
+        });
+        let mut source = MockRemoteClient::new();
+        source.expect_get_block_info().returning(|tag| {
+            let number = match tag {
+                BlockNumberOrTag::Number(n) => n,
+                _ => 0,
+            };
+            Ok(BlockInfo {
+                number,
+                hash: B256::from([number as u8 + 100; 32]),
+                ..Default::default()
+            })
+        });
+        let engine: Arc<dyn FollowEngine> = Arc::new(RecordingEngine::new(Duration::ZERO));
+        let finalized = block_info(7);
+
+        let error = recovery::recover(&local, &source, &engine, &finalized, 10)
+            .await
+            .expect_err("finalized divergence");
+
+        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 7, .. }));
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn insert_loop_benchmark_prefetches_source_fetch_latency() {
         let local = Arc::new(local_client(0, 0, 0, 100));
         let source = DelayedSource { latest: 25, fetch_delay: Duration::from_millis(30) };
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::from_millis(50),
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::from_millis(50)));
         let cancellation = CancellationToken::new();
         let engine_for_runtime: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
         let runtime = FollowRuntime::new(

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -221,8 +221,13 @@ where
                     &engine,
                     finalized,
                     &source_safe,
+                    local_hash,
+                    generation.clone(),
                 )
                 .await?;
+                if generation.is_cancelled() {
+                    return Ok(SafetyOutcome::Updated);
+                }
                 // Cancel only after a confirmed reset. Cancelling earlier lets fetch/insert finish
                 // first and causes the outer select to shut down follow mode before recovery can
                 // return its restart point.
@@ -412,7 +417,7 @@ mod tests {
     use crate::{
         MockRemoteClient,
         follow::{
-            engine::FollowEngine,
+            engine::{FollowEngine, ResetStats},
             local::MockFollowLocalClient,
             proof_gate::{ActiveProofGate, NoopProofGate},
         },
@@ -528,9 +533,13 @@ mod tests {
             Ok(())
         }
 
-        async fn reset_to_ancestor(&self, ancestor: L2BlockInfo) -> Result<(), FollowError> {
+        async fn reset_to_ancestor(
+            &self,
+            ancestor: L2BlockInfo,
+            _cancellation: CancellationToken,
+        ) -> Result<ResetStats, FollowError> {
             self.reset.lock().await.push(ancestor.block_info.number);
-            Ok(())
+            Ok(ResetStats::default())
         }
     }
 
@@ -1217,11 +1226,73 @@ mod tests {
             ..Default::default()
         };
 
-        let error = recovery::recover(&local, &source, &engine, &finalized, &source_safe)
-            .await
-            .expect_err("finalized divergence");
+        let error = recovery::recover(
+            &local,
+            &source,
+            &engine,
+            &finalized,
+            &source_safe,
+            B256::from([7; 32]),
+            CancellationToken::new(),
+        )
+        .await
+        .expect_err("finalized divergence");
 
         assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 7, .. }));
+    }
+
+    #[tokio::test]
+    async fn recovery_rechecks_fresh_finalized_head_before_reset() {
+        let finalized_reads = Arc::new(AtomicU64::new(0));
+        let finalized_reads_for_local = Arc::clone(&finalized_reads);
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(move |tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Finalized => {
+                    finalized_reads_for_local.fetch_add(1, Ordering::SeqCst);
+                    block_info(10)
+                }
+                BlockNumberOrTag::Number(number) => block_info(number),
+                _ => block_info(0),
+            }))
+        });
+
+        let mut source = MockRemoteClient::new();
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Latest)).returning(|_| {
+            Ok(BlockInfo {
+                number: 10,
+                hash: B256::from([99; 32]),
+                parent_hash: B256::from([9; 32]),
+                ..Default::default()
+            })
+        });
+        source
+            .expect_get_block_info_by_hash()
+            .with(eq(B256::from([9; 32])))
+            .returning(|_| Ok(source_block_info(9)));
+
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
+        let engine_for_recovery: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let error = recovery::recover(
+            &local,
+            &source,
+            &engine_for_recovery,
+            &block_info(7),
+            &BlockInfo {
+                number: 10,
+                hash: B256::from([99; 32]),
+                parent_hash: B256::from([9; 32]),
+                ..Default::default()
+            },
+            B256::from([10; 32]),
+            CancellationToken::new(),
+        )
+        .await
+        .expect_err("fresh finalized divergence must prevent reset");
+
+        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 10, .. }));
+        assert_eq!(finalized_reads.load(Ordering::SeqCst), 1);
+        assert!(engine.reset.lock().await.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -162,8 +162,17 @@ where
                 // A recovery reorg ends the loop so the caller restarts fetch/insert from the
                 // common ancestor.
                 Ok(outcome @ SafetyOutcome::Reorged { .. }) => return Ok(outcome),
-                Err(e) => {
-                    warn!(target: "follow", error = %e, "Failed to update safe/finalized labels");
+                Err(FollowError::FinalizedDivergence { number, local, remote }) => {
+                    error!(
+                        target: "follow",
+                        number,
+                        local = %local,
+                        source = %remote,
+                        "Local finalized head diverged from source; follow mode requires operator intervention",
+                    );
+                }
+                Err(error) => {
+                    warn!(target: "follow", error = %error, "Failed to update safe/finalized labels");
                 }
             }
         }
@@ -256,11 +265,7 @@ where
             }
             LabelOutcome::Skip => None,
             LabelOutcome::Diverged { number, local: local_hash, remote } => {
-                return Err(FollowError::SourceBlockHashMismatch {
-                    number,
-                    local: local_hash,
-                    remote,
-                });
+                return Err(FollowError::FinalizedDivergence { number, local: local_hash, remote });
             }
         };
 
@@ -1121,7 +1126,7 @@ mod tests {
             .await
             .expect_err("source branch diverges at finalized");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 7, .. }));
+        assert!(matches!(error, FollowError::FinalizedDivergence { number: 7, .. }));
         assert!(!generation.is_cancelled());
         assert!(engine.reset.lock().await.is_empty());
     }
@@ -1153,7 +1158,7 @@ mod tests {
             .await
             .expect_err("mismatched finalized hash");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 8, .. }));
+        assert!(matches!(error, FollowError::FinalizedDivergence { number: 8, .. }));
         assert!(engine.labels.lock().await.is_empty());
         assert!(engine.reset.lock().await.is_empty());
     }
@@ -1238,7 +1243,7 @@ mod tests {
         .await
         .expect_err("finalized divergence");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 7, .. }));
+        assert!(matches!(error, FollowError::FinalizedDivergence { number: 7, .. }));
     }
 
     #[tokio::test]
@@ -1290,7 +1295,7 @@ mod tests {
         .await
         .expect_err("fresh finalized divergence must prevent reset");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 10, .. }));
+        assert!(matches!(error, FollowError::FinalizedDivergence { number: 10, .. }));
         assert_eq!(finalized_reads.load(Ordering::SeqCst), 1);
         assert!(engine.reset.lock().await.is_empty());
     }

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -1137,17 +1137,14 @@ mod tests {
             .expect_get_block_info()
             .with(eq(BlockNumberOrTag::Finalized))
             .returning(|_| Ok(source_block_info(6)));
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
 
         FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
             Arc::new(local),
             Arc::new(source),
             engine_for_update,
+            CancellationToken::new(),
         )
         .await
         .expect("labels");
@@ -1257,11 +1254,7 @@ mod tests {
             .expect_get_block_info()
             .with(eq(BlockNumberOrTag::Safe))
             .returning(|_| Ok(source_block_info(9)));
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
 
         let error =

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -192,8 +192,8 @@ where
             }
             LabelOutcome::Skip => None,
             LabelOutcome::Diverged { number, local: local_hash, remote } => {
-                // The source is authoritative for the L2 chain in follow mode. Rather than wedge
-                // forever, reset to the common ancestor and replay the source chain forward.
+                // Rather than wedge forever, reset to the common ancestor and replay the source
+                // branch forward.
                 warn!(
                     target: "follow",
                     number,
@@ -201,13 +201,21 @@ where
                     source = %remote,
                     "Local chain diverged from source safe head; recovering to common ancestor",
                 );
-                generation.cancel();
                 let finalized = local_finalized
                     .as_ref()
                     .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
-                let ancestor =
-                    recovery::recover(local.as_ref(), source.as_ref(), &engine, finalized, number)
-                        .await?;
+                let ancestor = recovery::recover(
+                    local.as_ref(),
+                    source.as_ref(),
+                    &engine,
+                    finalized,
+                    &source_safe,
+                )
+                .await?;
+                // Cancel only after a confirmed reset. Cancelling earlier lets fetch/insert finish
+                // first and causes the outer select to shut down follow mode before recovery can
+                // return its restart point.
+                generation.cancel();
                 return Ok(SafetyOutcome::Reorged { ancestor });
             }
         };
@@ -447,6 +455,13 @@ mod tests {
             })
         }
 
+        async fn get_block_info_by_hash(
+            &self,
+            hash: B256,
+        ) -> Result<BlockInfo, crate::RemoteL2ClientError> {
+            Ok(source_block_info(hash[31] as u64))
+        }
+
         async fn get_payload_by_number(
             &self,
             number: u64,
@@ -501,7 +516,21 @@ mod tests {
     }
 
     fn source_block_info(number: u64) -> BlockInfo {
-        BlockInfo { number, hash: B256::from([number as u8; 32]), ..Default::default() }
+        BlockInfo {
+            number,
+            hash: B256::from([number as u8; 32]),
+            parent_hash: B256::from([number.saturating_sub(1) as u8; 32]),
+            ..Default::default()
+        }
+    }
+
+    fn fork_source_block_info(number: u64, offset: u8) -> BlockInfo {
+        BlockInfo {
+            number,
+            hash: B256::from([number as u8 + offset; 32]),
+            parent_hash: B256::from([number.saturating_sub(1) as u8 + offset; 32]),
+            ..Default::default()
+        }
     }
 
     fn payload(number: u64) -> BaseExecutionPayloadEnvelope {
@@ -835,15 +864,17 @@ mod tests {
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
-            Ok(BlockInfo { number: 10, hash: B256::from([99; 32]), ..Default::default() })
+            Ok(BlockInfo {
+                number: 10,
+                hash: B256::from([99; 32]),
+                parent_hash: B256::from([9; 32]),
+                ..Default::default()
+            })
         });
         source
-            .expect_get_block_info()
-            .withf(|tag| matches!(tag, BlockNumberOrTag::Number(_)))
-            .returning(|tag| {
-                let BlockNumberOrTag::Number(number) = tag else { unreachable!() };
-                Ok(source_block_info(number))
-            });
+            .expect_get_block_info_by_hash()
+            .with(eq(B256::from([9; 32])))
+            .returning(|_| Ok(source_block_info(9)));
         let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
         let generation = CancellationToken::new();
@@ -883,6 +914,7 @@ mod tests {
             }))
         });
         local.expect_l1_block_hash().returning(|_| Ok(Some(B256::ZERO)));
+
         let mut source = MockRemoteClient::new();
         source
             .expect_get_block_info()
@@ -910,6 +942,37 @@ mod tests {
             FollowError::SourceL1OriginMismatch { l2_number: 9, l1_number: 0, .. }
         ));
         assert!(engine.labels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_safe_recovery_keeps_fetch_generation_running() {
+        let local = Arc::new(local_client(10, 8, 7, 100));
+        let mut source = MockRemoteClient::new();
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Safe))
+            .returning(|_| Ok(fork_source_block_info(10, 100)));
+        source.expect_get_block_info_by_hash().returning(|hash| {
+            let number = hash[31].saturating_sub(100) as u64;
+            Ok(fork_source_block_info(number, 100))
+        });
+        let engine = Arc::new(RecordingEngine::new(Duration::ZERO));
+        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let generation = CancellationToken::new();
+
+        let error =
+            FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
+                local,
+                Arc::new(source),
+                engine_for_update,
+                generation.clone(),
+            )
+            .await
+            .expect_err("source branch diverges at finalized");
+
+        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 7, .. }));
+        assert!(!generation.is_cancelled());
+        assert!(engine.reset.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -945,7 +1008,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_common_ancestor_binary_search() {
+    async fn find_common_ancestor_follows_captured_source_branch() {
         // Local and source agree at and below block 5 and disagree above it. A divergence detected
         // at block 10 must converge to block 5 as the highest common ancestor.
         let mut local = MockFollowLocalClient::new();
@@ -967,16 +1030,13 @@ mod tests {
             }))
         });
         let mut source = MockRemoteClient::new();
-        source.expect_get_block_info().returning(|tag| {
-            let number = match tag {
-                BlockNumberOrTag::Number(n) => n,
-                _ => 0,
-            };
-            Ok(source_block_info(number))
-        });
+        source
+            .expect_get_block_info_by_hash()
+            .returning(|hash| Ok(source_block_info(hash[31] as u64)));
 
         let finalized = block_info(2);
-        let ancestor = recovery::find_common_ancestor(&local, &source, &finalized, 10)
+        let source_safe = source_block_info(10);
+        let ancestor = recovery::find_common_ancestor(&local, &source, &finalized, &source_safe)
             .await
             .expect("common ancestor");
 
@@ -997,21 +1057,25 @@ mod tests {
             }))
         });
         let mut source = MockRemoteClient::new();
-        source.expect_get_block_info().returning(|tag| {
-            let number = match tag {
-                BlockNumberOrTag::Number(n) => n,
-                _ => 0,
-            };
+        source.expect_get_block_info_by_hash().returning(|hash| {
+            let number = hash[31].saturating_sub(100) as u64;
             Ok(BlockInfo {
                 number,
-                hash: B256::from([number as u8 + 100; 32]),
+                hash,
+                parent_hash: B256::from([number.saturating_sub(1) as u8 + 100; 32]),
                 ..Default::default()
             })
         });
         let engine: Arc<dyn FollowEngine> = Arc::new(RecordingEngine::new(Duration::ZERO));
         let finalized = block_info(7);
+        let source_safe = BlockInfo {
+            number: 10,
+            hash: B256::from([110; 32]),
+            parent_hash: B256::from([109; 32]),
+            ..Default::default()
+        };
 
-        let error = recovery::recover(&local, &source, &engine, &finalized, 10)
+        let error = recovery::recover(&local, &source, &engine, &finalized, &source_safe)
             .await
             .expect_err("finalized divergence");
 

--- a/crates/consensus/service/src/follow/source.rs
+++ b/crates/consensus/service/src/follow/source.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use alloy_consensus::Block;
 use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
 use base_common_consensus::BaseTxEnvelope;
@@ -38,6 +39,9 @@ pub trait RemoteClient: Debug + Send + Sync {
     /// Fetches the block info at the given tag.
     async fn get_block_info(&self, tag: BlockNumberOrTag)
     -> Result<BlockInfo, RemoteL2ClientError>;
+
+    /// Fetches block info by hash, pinning the lookup to one source-chain branch.
+    async fn get_block_info_by_hash(&self, hash: B256) -> Result<BlockInfo, RemoteL2ClientError>;
 
     /// Fetches a block by number and converts it to an [`BaseExecutionPayloadEnvelope`].
     async fn get_payload_by_number(
@@ -84,6 +88,17 @@ impl RemoteClient for RemoteL2Client {
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{tag:?}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{tag:?}")))?;
         let block = block.map_header(|header| header.into_inner());
+
+        Ok(BlockInfo::from(&block))
+    }
+
+    async fn get_block_info_by_hash(&self, hash: B256) -> Result<BlockInfo, RemoteL2ClientError> {
+        let block = self
+            .provider
+            .get_block_by_hash(hash)
+            .await
+            .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{hash}"), source: e })?
+            .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{hash}")))?;
 
         Ok(BlockInfo::from(&block))
     }

--- a/crates/consensus/service/src/follow/source.rs
+++ b/crates/consensus/service/src/follow/source.rs
@@ -105,6 +105,7 @@ impl RemoteClient for RemoteL2Client {
             .await
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{hash}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{hash}")))?;
+        let block = block.map_header(|header| header.into_inner());
 
         Ok(BlockInfo::from(&block))
     }
@@ -157,6 +158,7 @@ impl RemoteClient for RemoteL2Client {
             .await
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{hash}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{hash}")))?;
+        let rpc_block = rpc_block.map_header(|header| header.into_inner());
 
         let block_hash = rpc_block.header.hash;
         let parent_beacon_block_root = rpc_block.header.parent_beacon_block_root;

--- a/crates/consensus/service/src/follow/source.rs
+++ b/crates/consensus/service/src/follow/source.rs
@@ -48,6 +48,12 @@ pub trait RemoteClient: Debug + Send + Sync {
         &self,
         number: u64,
     ) -> Result<BaseExecutionPayloadEnvelope, RemoteL2ClientError>;
+
+    /// Fetches a block by hash and converts it to an [`BaseExecutionPayloadEnvelope`].
+    async fn get_payload_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<BaseExecutionPayloadEnvelope, RemoteL2ClientError>;
 }
 
 /// Client that polls a source L2 execution layer node for block data and
@@ -115,6 +121,42 @@ impl RemoteClient for RemoteL2Client {
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{number}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{number}")))?;
         let rpc_block = rpc_block.map_header(|header| header.into_inner());
+
+        let block_hash = rpc_block.header.hash;
+        let parent_beacon_block_root = rpc_block.header.parent_beacon_block_root;
+
+        let txs: Vec<BaseTxEnvelope> = rpc_block
+            .transactions
+            .into_transactions()
+            .map(|tx| tx.inner.inner.into_inner())
+            .collect();
+
+        let consensus_block: Block<BaseTxEnvelope> = Block {
+            header: rpc_block.header.inner,
+            body: alloy_consensus::BlockBody {
+                transactions: txs,
+                ommers: vec![],
+                withdrawals: rpc_block.withdrawals,
+            },
+        };
+
+        let (execution_payload, _sidecar) =
+            BaseExecutionPayload::from_block_unchecked(block_hash, &consensus_block);
+
+        Ok(BaseExecutionPayloadEnvelope { parent_beacon_block_root, execution_payload })
+    }
+
+    async fn get_payload_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<BaseExecutionPayloadEnvelope, RemoteL2ClientError> {
+        let rpc_block = self
+            .provider
+            .get_block_by_hash(hash)
+            .full()
+            .await
+            .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{hash}"), source: e })?
+            .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{hash}")))?;
 
         let block_hash = rpc_block.header.hash;
         let parent_beacon_block_root = rpc_block.header.parent_beacon_block_root;


### PR DESCRIPTION
#3527 prevents follow mode from promoting a non-canonical block to `safe`, but a node that has already diverged still needs to recover. This PR finds the highest block local and source agree on, resets the engine forkchoice to that common ancestor, then replays source payloads so the EL rebuilds onto the canonical source branch.

Recovery is intentionally small:

- Capture source sync labels once, then walk only from that source `safe` head down to the common ancestor (or local finalized fence).
- Collect the hash-pinned replay path during that single walk; there is no separate source-latest dual walk or generation accounting.
- Reset once to the ancestor. Temporary Engine API reset failures retry on the next safety cycle instead of inline backoff.
- Replay hash-pinned payloads through the captured source `safe`, then continue live by-number catch-up.
- Non-applied inserts stay in the ordered insert loop: wait briefly and retry the same payload rather than escalating through a `PayloadNotApplied` generation select.

Finality remains a hard fence: recovery refuses resets below finalized, and finalized-head disagreement exits as `FinalizedHeadChanged`.

## Validation

- `cargo fmt --check`
- `cargo test -p base-consensus-node follow:: --lib` (26 passed)
- `cargo clippy -p base-consensus-node --all-targets -- -D warnings`

Controlled divergent-follow Podman QA on the simplified image:

1. Forced a local/source fork after common ancestor `0x45`.
2. Forced source `safe` to canonical `0x80` via a temporary source-safe shim.
3. Observed recovery prepare a one-walk plan (ancestor ~69 / `0x45` family, replay through 128).
4. Observed reset + catch-up converge; tip parity at `0xd5c` with matching hashes.
5. Restored direct builder RPC and verified 10/10 tip parity samples while sync labels advanced (unsafe 3420 / safe 128 / finalized 0).
6. Follow CL stayed healthy with zero restarts through recovery and stability sampling.

Proofs-gated validation was not run; this covers the follow runtime and Engine API recovery path.

type=routine
risk=medium
impact=sev3