### PR TITLE
feat(eip8130): transaction actor authorization (sender + payer scope gating)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,6 +4539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-execution-eip8130-tx"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "base-common-consensus",
+ "base-execution-eip8130-authorize",
+ "base-execution-eip8130-state",
+ "base-precompile-storage",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "base-execution-evm"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ base-flashblocks-node = { path = "crates/execution/flashblocks-node" }
 base-execution-eip8130 = { path = "crates/execution/eip8130", default-features = false }
 base-execution-eip8130-state = { path = "crates/execution/eip8130-state", default-features = false }
 base-execution-eip8130-authorize = { path = "crates/execution/eip8130-authorize", default-features = false }
+base-execution-eip8130-tx = { path = "crates/execution/eip8130-tx", default-features = false }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }

--- a/crates/execution/eip8130-tx/Cargo.toml
+++ b/crates/execution/eip8130-tx/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "base-execution-eip8130-tx"
+description = "EIP-8130 transaction actor authorization (sender + payer scope gating)"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-primitives.workspace = true
+
+# base
+base-execution-eip8130-state.workspace = true
+base-execution-eip8130-authorize.workspace = true
+base-common-consensus = { workspace = true, default-features = false, features = ["k256"] }
+
+# misc
+thiserror.workspace = true
+
+[dev-dependencies]
+k256 = { workspace = true, features = ["ecdsa"] }
+base-precompile-storage = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/eip8130-tx/README.md
+++ b/crates/execution/eip8130-tx/README.md
@@ -1,0 +1,42 @@
+# base-execution-eip8130-tx
+
+Transaction-level actor authorization for EIP-8130 — the first transaction-aware
+layer of the validation pipeline, shared by mempool admission and block
+inclusion. It turns the single-actor [`ActorAuthorizer`](../eip8130-authorize)
+into "authorize *this transaction's* actors".
+
+For an [`Eip8130Signed`] it resolves and authorizes the two transaction actors
+against the [`AccountConfiguration`](../eip8130-state) storage, then enforces the
+per-operation **scope** gate:
+
+1. **Sender** — resolve the sender account (`tx.sender` for a configured account,
+   or the checked-recovered signer on the EOA path), authorize its `sender_auth`
+   against `sender_signature_hash`, and require **`SCOPE_SENDER`**.
+2. **Payer** — when `tx.payer` is set, authorize its `payer_auth` against
+   `payer_signature_hash(resolved_sender)` and require **`SCOPE_PAYER`**. A `None`
+   payer means the sender pays; no payer authorization is performed.
+
+An actor with `scope == 0` (unrestricted) satisfies every context; otherwise the
+relevant scope bit must be set, matching `AccountConfiguration`'s
+`scope == 0 || scope & REQUIRED != 0` rule.
+
+## Sender auth formats
+
+The sender auth blob differs by path, mirroring the wire format:
+
+- **Configured account** (`tx.sender == Some`): `sender_auth` is already
+  `authenticator(20) || data` and is passed through unchanged.
+- **EOA** (`tx.sender == None`): `sender_auth` is a bare 65-byte `r‖s‖v`
+  signature. The sender is recovered with the **checked** (EIP-2) recovery, and
+  an `address(0)` authenticator prefix is synthesized so the unified
+  `authenticate_actor` runs the implicit-EOA path (self-slot empty + recovered ==
+  account, unrestricted owner).
+
+## Scope (what this is and is not)
+
+This layer covers **sender + payer** authorization and scope gating only. It does
+**not** validate account changes (the `SCOPE_CONFIG` owner-changes path, layered
+next), 2D nonces, gas/payment amounts, account locking, or call execution — those
+consume the [`TxActors`] this returns.
+
+[`Eip8130Signed`]: base_common_consensus::Eip8130Signed

--- a/crates/execution/eip8130-tx/src/error.rs
+++ b/crates/execution/eip8130-tx/src/error.rs
@@ -1,0 +1,30 @@
+//! Errors returned by transaction actor authorization.
+
+use base_execution_eip8130_authorize::AuthorizeError;
+
+use crate::Operation;
+
+/// Reason a transaction's actors could not be authorized.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TxAuthError {
+    /// The sender or payer actor failed the stateful authorize step (dispatch,
+    /// binding, expiry, implicit-EOA rule, or a storage read).
+    #[error("actor authorization failed: {0}")]
+    Authorize(#[from] AuthorizeError),
+
+    /// The EOA-path sender signature was malformed or did not recover (wrong
+    /// length, or a non-canonical upper-half `s` rejected by the checked
+    /// recovery). Applies only when `tx.sender` is `None`.
+    #[error("EOA sender signature could not be recovered")]
+    SenderRecovery,
+
+    /// The resolved actor is valid but its scope does not grant the operation it
+    /// was authorized for. Mirrors the contract's scope requirement.
+    #[error("{operation:?} actor scope {scope:#04x} does not grant the required context")]
+    Scope {
+        /// The operation whose scope requirement was not met.
+        operation: Operation,
+        /// The resolved actor's scope bitfield.
+        scope: u8,
+    },
+}

--- a/crates/execution/eip8130-tx/src/lib.rs
+++ b/crates/execution/eip8130-tx/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod error;
+pub use error::TxAuthError;
+
+mod scope;
+pub use scope::Operation;
+
+mod verify;
+pub use verify::{ActorTxVerifier, AuthorizedActor, TxActors};

--- a/crates/execution/eip8130-tx/src/scope.rs
+++ b/crates/execution/eip8130-tx/src/scope.rs
@@ -1,0 +1,47 @@
+//! Per-operation scope gating for resolved actors.
+
+use base_common_consensus::Eip8130Constants;
+use base_execution_eip8130_authorize::ResolvedActor;
+
+/// The transaction context an actor is being authorized for. Each maps to the
+/// EIP-8130 scope bit that gates it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Operation {
+    /// Authorizing the transaction sender (`SCOPE_SENDER`).
+    Sender,
+    /// Authorizing a gas payer (`SCOPE_PAYER`).
+    Payer,
+    /// Authorizing an account-configuration change (`SCOPE_CONFIG`).
+    Config,
+    /// Authorizing a message signature, ERC-1271 style (`SCOPE_SIGNATURE`).
+    Signature,
+}
+
+impl Operation {
+    /// The scope bit that grants this operation.
+    #[must_use]
+    pub const fn required_bit(self) -> u8 {
+        match self {
+            Self::Sender => Eip8130Constants::SCOPE_SENDER,
+            Self::Payer => Eip8130Constants::SCOPE_PAYER,
+            Self::Config => Eip8130Constants::SCOPE_CONFIG,
+            Self::Signature => Eip8130Constants::SCOPE_SIGNATURE,
+        }
+    }
+
+    /// Whether `scope` grants this operation. An unrestricted actor
+    /// (`scope == 0`) is valid in every context; otherwise the operation's bit
+    /// must be set. Mirrors `AccountConfiguration`'s
+    /// `scope == 0 || scope & REQUIRED != 0`.
+    #[must_use]
+    pub const fn is_granted_by(self, scope: u8) -> bool {
+        scope == Eip8130Constants::SCOPE_UNRESTRICTED || scope & self.required_bit() != 0
+    }
+
+    /// Whether the resolved actor's scope grants this operation.
+    #[must_use]
+    pub const fn is_granted(self, actor: &ResolvedActor) -> bool {
+        self.is_granted_by(actor.scope)
+    }
+}

--- a/crates/execution/eip8130-tx/src/verify.rs
+++ b/crates/execution/eip8130-tx/src/verify.rs
@@ -1,0 +1,367 @@
+//! Transaction-level actor authorization: resolve and scope-gate the sender and
+//! payer actors of an [`Eip8130Signed`].
+
+use alloy_primitives::Address;
+use base_common_consensus::Eip8130Signed;
+use base_execution_eip8130_authorize::{ActorAuthorizer, ResolvedActor};
+use base_execution_eip8130_state::AccountConfigurationStorage;
+
+use crate::{Operation, TxAuthError};
+
+/// A resolved transaction actor together with the account it was authorized
+/// against (the sender or payer account, not the actor id).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AuthorizedActor {
+    /// The account the actor was authorized against.
+    pub account: Address,
+    /// The resolved actor and its authorization surface.
+    pub resolved: ResolvedActor,
+}
+
+/// The authorized actors of an EIP-8130 transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TxActors {
+    /// The transaction sender, scope-gated for [`Operation::Sender`].
+    pub sender: AuthorizedActor,
+    /// The gas payer, scope-gated for [`Operation::Payer`], or `None` when the
+    /// sender pays (`tx.payer == None`).
+    pub payer: Option<AuthorizedActor>,
+}
+
+/// Authorizes the sender and payer actors of an [`Eip8130Signed`] against the
+/// [`AccountConfigurationStorage`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ActorTxVerifier;
+
+impl ActorTxVerifier {
+    /// Resolves and scope-gates the transaction's sender and (optional) payer.
+    ///
+    /// `now` is the timestamp used for actor expiry (block timestamp at
+    /// inclusion, wall-clock in the pool). Returns the authorized [`TxActors`],
+    /// or the first [`TxAuthError`] encountered (sender checked before payer).
+    pub fn verify(
+        signed: &Eip8130Signed,
+        storage: &AccountConfigurationStorage<'_>,
+        now: u64,
+    ) -> Result<TxActors, TxAuthError> {
+        let tx = signed.tx();
+        let sender = Self::verify_sender(signed, storage, now)?;
+
+        let payer = match tx.payer {
+            None => None,
+            Some(account) => {
+                // The payer digest binds to the resolved sender account.
+                let hash = tx.payer_signature_hash(sender.account);
+                let resolved = Self::authorize_scoped(
+                    storage,
+                    account,
+                    hash,
+                    signed.payer_auth(),
+                    Operation::Payer,
+                    now,
+                )?;
+                Some(AuthorizedActor { account, resolved })
+            }
+        };
+
+        Ok(TxActors { sender, payer })
+    }
+
+    /// Resolves and scope-gates the sender, handling both the configured-account
+    /// path (`tx.sender == Some`) and the EOA path (`tx.sender == None`).
+    fn verify_sender(
+        signed: &Eip8130Signed,
+        storage: &AccountConfigurationStorage<'_>,
+        now: u64,
+    ) -> Result<AuthorizedActor, TxAuthError> {
+        let hash = signed.tx().sender_signature_hash();
+
+        if let Some(account) = signed.explicit_sender() {
+            // Configured account: `sender_auth` is already `authenticator(20) || data`.
+            let resolved = Self::authorize_scoped(
+                storage,
+                account,
+                hash,
+                signed.sender_auth(),
+                Operation::Sender,
+                now,
+            )?;
+            return Ok(AuthorizedActor { account, resolved });
+        }
+
+        // EOA path: recover the sender with the checked (EIP-2) recovery, then
+        // authorize the implicit-EOA owner. `sender_auth` is a bare 65-byte
+        // signature, so synthesize the `address(0)` authenticator prefix that the
+        // unified authorize step expects.
+        let account = signed
+            .recover_eoa_sender()
+            .map_err(|_| TxAuthError::SenderRecovery)?
+            .ok_or(TxAuthError::SenderRecovery)?;
+
+        let mut auth = Vec::with_capacity(Address::len_bytes() + signed.sender_auth().len());
+        auth.extend_from_slice(Address::ZERO.as_slice());
+        auth.extend_from_slice(signed.sender_auth());
+
+        let resolved =
+            Self::authorize_scoped(storage, account, hash, &auth, Operation::Sender, now)?;
+        Ok(AuthorizedActor { account, resolved })
+    }
+
+    /// Authorizes `auth` against `account`/`hash`, then enforces that the
+    /// resolved actor's scope grants `operation`.
+    fn authorize_scoped(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        hash: alloy_primitives::B256,
+        auth: &[u8],
+        operation: Operation,
+        now: u64,
+    ) -> Result<ResolvedActor, TxAuthError> {
+        let resolved = ActorAuthorizer::authenticate_actor(storage, account, hash, auth, now)?;
+        if !operation.is_granted(&resolved) {
+            return Err(TxAuthError::Scope { operation, scope: resolved.scope });
+        }
+        Ok(resolved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{B256, Bytes, U256, address, keccak256};
+    use base_common_consensus::{Eip8130Constants, TxEip8130};
+    use base_execution_eip8130_authorize::AuthorizeError;
+    use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
+    use k256::ecdsa::SigningKey as K256SigningKey;
+
+    use super::*;
+
+    const NOW: u64 = 1_000;
+    const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+
+    fn key(byte: u8) -> K256SigningKey {
+        K256SigningKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn addr(key: &K256SigningKey) -> Address {
+        let point = key.verifying_key().to_encoded_point(false);
+        Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+    }
+
+    fn actor_id(account: Address) -> B256 {
+        AccountConfigurationStorage::self_actor_id(account)
+    }
+
+    /// 65-byte `r || s || v` signature over `hash`, `v` in `{27, 28}`, low-s.
+    fn sig(key: &K256SigningKey, hash: B256) -> Vec<u8> {
+        let (signature, recid) = key.sign_prehash_recoverable(hash.as_slice()).unwrap();
+        let mut out = vec![0u8; 65];
+        out[..64].copy_from_slice(&signature.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    /// `authenticator(20) || data`.
+    fn auth_blob(authenticator: Address, data: &[u8]) -> Bytes {
+        let mut out = Vec::with_capacity(20 + data.len());
+        out.extend_from_slice(authenticator.as_slice());
+        out.extend_from_slice(data);
+        Bytes::from(out)
+    }
+
+    /// Canonical Solidity packing of `ActorConfig`.
+    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+        U256::from_be_slice(authenticator.as_slice())
+            | (U256::from(scope) << 160)
+            | (U256::from(expiry) << 168)
+            | (U256::from(policy_type) << 216)
+    }
+
+    fn base_tx(sender: Option<Address>, payer: Option<Address>) -> TxEip8130 {
+        TxEip8130 {
+            chain_id: 8453,
+            sender,
+            nonce_key: U256::ZERO,
+            nonce_sequence: 0,
+            expiry: 0,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 5_000_000_000,
+            gas_limit: 250_000,
+            account_changes: Vec::new(),
+            calls: Vec::new(),
+            metadata: Bytes::new(),
+            payer,
+        }
+    }
+
+    fn with_storage<R>(body: impl FnOnce(&mut AccountConfigurationStorage<'_>) -> R) -> R {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| body(&mut AccountConfigurationStorage::new(ctx)))
+    }
+
+    #[test]
+    fn eoa_sender_authorizes_as_unrestricted_owner() {
+        let k = key(0x11);
+        let account = addr(&k);
+        let tx = base_tx(None, None);
+        let hash = tx.sender_signature_hash();
+        let signed = Eip8130Signed::new(tx, Bytes::from(sig(&k, hash)), Bytes::new());
+        with_storage(|acc| {
+            let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
+            assert_eq!(actors.sender.account, account);
+            assert!(actors.sender.resolved.is_unrestricted());
+            assert!(actors.payer.is_none());
+        });
+    }
+
+    #[test]
+    fn configured_sender_resolves_with_scope() {
+        let k = key(0x22);
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let id = actor_id(addr(&k));
+        let tx = base_tx(Some(account), None);
+        let hash = tx.sender_signature_hash();
+        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&k, hash)), Bytes::new());
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&id)
+                .at_mut(&account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .unwrap();
+            let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
+            assert_eq!(actors.sender.account, account);
+            assert_eq!(actors.sender.resolved.scope, Eip8130Constants::SCOPE_SENDER);
+            assert!(actors.payer.is_none());
+        });
+    }
+
+    #[test]
+    fn sender_without_sender_scope_is_rejected() {
+        let k = key(0x22);
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let id = actor_id(addr(&k));
+        let tx = base_tx(Some(account), None);
+        let hash = tx.sender_signature_hash();
+        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&k, hash)), Bytes::new());
+        with_storage(|acc| {
+            // Bound, non-zero scope that lacks SCOPE_SENDER.
+            acc.actor_config
+                .at_mut(&id)
+                .at_mut(&account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .unwrap();
+            assert_eq!(
+                ActorTxVerifier::verify(&signed, acc, NOW),
+                Err(TxAuthError::Scope {
+                    operation: Operation::Sender,
+                    scope: Eip8130Constants::SCOPE_PAYER,
+                }),
+            );
+        });
+    }
+
+    #[test]
+    fn sponsored_payer_resolves_against_payer_hash() {
+        let sk = key(0x22);
+        let sender_account = address!("0x00000000000000000000000000000000000000aa");
+        let sid = actor_id(addr(&sk));
+        let pk = key(0x33);
+        let payer_account = address!("0x00000000000000000000000000000000000000cc");
+        let pid = actor_id(addr(&pk));
+
+        let tx = base_tx(Some(sender_account), Some(payer_account));
+        let sender_hash = tx.sender_signature_hash();
+        let payer_hash = tx.payer_signature_hash(sender_account);
+        let signed = Eip8130Signed::new(
+            tx,
+            auth_blob(ECRECOVER, &sig(&sk, sender_hash)),
+            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+        );
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&sid)
+                .at_mut(&sender_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .unwrap();
+            acc.actor_config
+                .at_mut(&pid)
+                .at_mut(&payer_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .unwrap();
+            let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
+            let payer = actors.payer.expect("payer present");
+            assert_eq!(payer.account, payer_account);
+            assert_eq!(payer.resolved.scope, Eip8130Constants::SCOPE_PAYER);
+        });
+    }
+
+    #[test]
+    fn payer_without_payer_scope_is_rejected() {
+        let sk = key(0x22);
+        let sender_account = address!("0x00000000000000000000000000000000000000aa");
+        let sid = actor_id(addr(&sk));
+        let pk = key(0x33);
+        let payer_account = address!("0x00000000000000000000000000000000000000cc");
+        let pid = actor_id(addr(&pk));
+
+        let tx = base_tx(Some(sender_account), Some(payer_account));
+        let sender_hash = tx.sender_signature_hash();
+        let payer_hash = tx.payer_signature_hash(sender_account);
+        let signed = Eip8130Signed::new(
+            tx,
+            auth_blob(ECRECOVER, &sig(&sk, sender_hash)),
+            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+        );
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&sid)
+                .at_mut(&sender_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .unwrap();
+            // Payer actor bound but lacking SCOPE_PAYER.
+            acc.actor_config
+                .at_mut(&pid)
+                .at_mut(&payer_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .unwrap();
+            assert_eq!(
+                ActorTxVerifier::verify(&signed, acc, NOW),
+                Err(TxAuthError::Scope {
+                    operation: Operation::Payer,
+                    scope: Eip8130Constants::SCOPE_SENDER,
+                }),
+            );
+        });
+    }
+
+    #[test]
+    fn malformed_eoa_sender_signature_is_rejected() {
+        let tx = base_tx(None, None);
+        // 64 bytes is one short of a valid r||s||v payload.
+        let signed = Eip8130Signed::new(tx, Bytes::from(vec![0u8; 64]), Bytes::new());
+        with_storage(|acc| {
+            assert_eq!(
+                ActorTxVerifier::verify(&signed, acc, NOW),
+                Err(TxAuthError::SenderRecovery),
+            );
+        });
+    }
+
+    #[test]
+    fn unbound_configured_sender_propagates_authorize_error() {
+        let k = key(0x22);
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let tx = base_tx(Some(account), None);
+        let hash = tx.sender_signature_hash();
+        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&k, hash)), Bytes::new());
+        with_storage(|acc| {
+            // No actor seeded: the sender actor is not bound on the account.
+            assert!(matches!(
+                ActorTxVerifier::verify(&signed, acc, NOW),
+                Err(TxAuthError::Authorize(AuthorizeError::NotBound { .. })),
+            ));
+        });
+    }
+}

--- a/crates/execution/eip8130-tx/src/verify.rs
+++ b/crates/execution/eip8130-tx/src/verify.rs
@@ -298,6 +298,76 @@ mod tests {
     }
 
     #[test]
+    fn eoa_sender_with_sponsored_payer_binds_recovered_address() {
+        // The sender is wire-invisible (tx.sender == None): it must be recovered
+        // before the payer digest can be computed, since `payer_signature_hash`
+        // binds to the recovered sender account.
+        let sk = key(0x44);
+        let sender_account = addr(&sk);
+        let pk = key(0x55);
+        let payer_account = address!("0x00000000000000000000000000000000000000cc");
+        let pid = actor_id(addr(&pk));
+
+        let tx = base_tx(None, Some(payer_account));
+        let sender_hash = tx.sender_signature_hash();
+        let payer_hash = tx.payer_signature_hash(sender_account);
+        let signed = Eip8130Signed::new(
+            tx,
+            Bytes::from(sig(&sk, sender_hash)),
+            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+        );
+        with_storage(|acc| {
+            // Sender is an implicit-EOA owner (self-slot empty); only the payer
+            // actor needs seeding.
+            acc.actor_config
+                .at_mut(&pid)
+                .at_mut(&payer_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .unwrap();
+            let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
+            assert_eq!(actors.sender.account, sender_account);
+            assert!(actors.sender.resolved.is_unrestricted());
+            let payer = actors.payer.expect("payer present");
+            assert_eq!(payer.account, payer_account);
+            assert_eq!(payer.resolved.scope, Eip8130Constants::SCOPE_PAYER);
+        });
+    }
+
+    #[test]
+    fn payer_signature_bound_to_wrong_sender_is_rejected() {
+        // Same as above, but the payer signs over a digest bound to a *different*
+        // sender than the one recovered from the wire. The payer signature must
+        // not authenticate, proving the binding is enforced.
+        let sk = key(0x44);
+        let pk = key(0x55);
+        let payer_account = address!("0x00000000000000000000000000000000000000cc");
+        let pid = actor_id(addr(&pk));
+        let wrong_sender = address!("0x00000000000000000000000000000000000000ee");
+
+        let tx = base_tx(None, Some(payer_account));
+        let sender_hash = tx.sender_signature_hash();
+        let wrong_payer_hash = tx.payer_signature_hash(wrong_sender);
+        let signed = Eip8130Signed::new(
+            tx,
+            Bytes::from(sig(&sk, sender_hash)),
+            auth_blob(ECRECOVER, &sig(&pk, wrong_payer_hash)),
+        );
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&pid)
+                .at_mut(&payer_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .unwrap();
+            // The payer signs the wrong digest, so it recovers a different actor
+            // that is not bound on the payer account.
+            assert!(matches!(
+                ActorTxVerifier::verify(&signed, acc, NOW),
+                Err(TxAuthError::Authorize(AuthorizeError::NotBound { .. })),
+            ));
+        });
+    }
+
+    #[test]
     fn payer_without_payer_scope_is_rejected() {
         let sk = key(0x22);
         let sender_account = address!("0x00000000000000000000000000000000000000aa");


### PR DESCRIPTION
## Summary

Adds `base-execution-eip8130-tx`, the first **transaction-aware** layer of the EIP-8130 validation pipeline, shared by mempool admission and block inclusion. It turns the single-actor `ActorAuthorizer` from #3535 into "authorize *this transaction's* actors", resolving and scope-gating the sender and payer of an `Eip8130Signed`.

### What it does

For an `Eip8130Signed`, `ActorTxVerifier::verify(signed, storage, now)`:

1. **Sender** — resolves the sender account and authorizes its `sender_auth` against `sender_signature_hash`, requiring `SCOPE_SENDER`.
   - **Configured account** (`tx.sender == Some`): `sender_auth` is already `authenticator(20) || data` and passed through unchanged.
   - **EOA** (`tx.sender == None`): `sender_auth` is a bare 65-byte `r‖s‖v`. The signer is recovered with the **checked (EIP-2)** recovery, and an `address(0)` authenticator prefix is synthesized so the unified `authenticate_actor` runs the implicit-EOA path (self-slot empty + `recovered == account`, unrestricted owner).
2. **Payer** — when `tx.payer` is set, authorizes its `payer_auth` against `payer_signature_hash(resolved_sender)`, requiring `SCOPE_PAYER`. A `None` payer means the sender pays and skips payer authorization.

`Operation` maps each context to its scope bit and applies the contract's rule `scope == 0 || scope & REQUIRED != 0` (an unrestricted `scope == 0` actor is valid everywhere). The result `TxActors` carries the resolved sender/payer actors plus their **account** addresses for the downstream nonce/gas layers.

### Scope (what this is not)

Sender + payer authorization and scope gating only. It does **not** validate account changes (the `SCOPE_CONFIG` owner-changes path, layered next), 2D nonces, gas/payment amounts, account locking, or call execution — those consume the `TxActors` this returns.

## Test plan

- [x] `cargo test -p base-execution-eip8130-tx` — 7 tests: EOA implicit-owner sender, configured sender with scope, sender missing `SCOPE_SENDER`, sponsored payer resolved against the payer hash, payer missing `SCOPE_PAYER`, malformed EOA signature, unbound configured sender propagating the authorize error.
- [x] `cargo clippy -p base-execution-eip8130-tx --all-targets -- -D warnings`
- [x] `cargo fmt -p base-execution-eip8130-tx -- --check`