### PR TITLE
feat(PRIV-1967): add nitro-host-local docker image for l3

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -77,9 +77,6 @@ jobs:
             ${{ env.REGISTRY_IMAGE }}:${{ matrix.target }}-sha-${{ github.sha }}
 
   build-nitro-host-local:
-    if: >-
-      github.event_name != 'workflow_dispatch' ||
-      inputs.skip_rust_services != true
     runs-on: ubuntu-24.04
 
     permissions:

--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -76,6 +76,53 @@ jobs:
             --tag ${{ env.REGISTRY_IMAGE }}:${{ matrix.target }}-l3 \
             ${{ env.REGISTRY_IMAGE }}:${{ matrix.target }}-sha-${{ github.sha }}
 
+  build-nitro-host-local:
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.skip_rust_services != true
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push nitro-host-local
+        run: |
+          docker buildx build \
+            -f etc/docker/Dockerfile.nitro-host-local \
+            -t ${{ env.REGISTRY_IMAGE }}:nitro-host-local-sha-${{ github.sha }} \
+            --platform linux/amd64 \
+            --push \
+            --cache-from type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-nitro-host-local-linux-amd64 \
+            --cache-to type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-l3-nitro-host-local-linux-amd64,mode=max \
+            .
+
+      - name: Tag as latest l3
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY_IMAGE }}:nitro-host-local-l3 \
+            ${{ env.REGISTRY_IMAGE }}:nitro-host-local-sha-${{ github.sha }}
+
   build-devnet-setup:
     runs-on: ubuntu-24.04
 

--- a/etc/docker/Dockerfile.nitro-host-local
+++ b/etc/docker/Dockerfile.nitro-host-local
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# Builds base-prover-nitro-host with --features local — runs the enclave
+# in-process for local/L3 proving without Nitro Enclave hardware.
+
+# --- Builder ---
+FROM --platform=linux/amd64 rust:1.93-trixie@sha256:51c04d7a2b38418ba23ecbfb373c40d3bd493dec1ddfae00ab5669527320195e AS builder
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git libclang-dev pkg-config curl build-essential mold protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=prover-nitro-host-local-target,sharing=locked \
+    cargo build --profile $PROFILE --locked --package base-prover-nitro-host --features local --bin base-prover-nitro-host && \
+    cp target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-prover-nitro-host ./base-prover-nitro-host
+
+# --- Runtime ---
+FROM --platform=linux/amd64 debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -m -s /sbin/nologin base
+
+WORKDIR /app
+COPY --from=builder /app/base-prover-nitro-host ./
+COPY etc/docker/nitro-host/entrypoint-local.sh ./entrypoint.sh
+
+USER base
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/etc/docker/nitro-host/entrypoint-local.sh
+++ b/etc/docker/nitro-host/entrypoint-local.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eux
+
+: "${LISTEN_ADDR:?required}"
+: "${L1_ETH_URL:?required}"
+: "${L2_ETH_URL:?required}"
+: "${L2_CHAIN_ID:?required}"
+
+ADDITIONAL_ARGS=()
+
+# Default to calldata-only mode for appchain (L3) use.
+# Set L1_BEACON_URL to override with blob-backed proving instead.
+if [ -n "${L1_BEACON_URL:-}" ]; then
+    ADDITIONAL_ARGS+=(--l1-beacon-url="$L1_BEACON_URL")
+else
+    ADDITIONAL_ARGS+=(--l1-calldata-only)
+fi
+
+if [ -n "${TEE_PROVER_REGISTRY_ADDRESS:-}" ]; then
+    ADDITIONAL_ARGS+=(--tee-prover-registry-address="$TEE_PROVER_REGISTRY_ADDRESS")
+fi
+
+if [ -n "${LOCAL_ENCLAVE_COUNT:-}" ]; then
+    ADDITIONAL_ARGS+=(--local-enclave-count="$LOCAL_ENCLAVE_COUNT")
+fi
+
+exec ./base-prover-nitro-host \
+    local \
+    --l1-eth-url "$L1_ETH_URL" \
+    --l2-eth-url "$L2_ETH_URL" \
+    --l2-chain-id "$L2_CHAIN_ID" \
+    --listen-addr "$LISTEN_ADDR" \
+    --enable-experimental-witness-endpoint \
+    "${ADDITIONAL_ARGS[@]}"


### PR DESCRIPTION
### Summary

Adds a Docker image and GHA workflow job to build `base-prover-nitro-host` with `--features local` for the L3 branch, enabling local (in-process, non-enclave) TEE proof generation on EC2 without Nitro Enclave hardware.

Linked issue: https://linear.app/coinbase/issue/PRIV-1967/bring-up-the-proposer-for-the-l3

### Changes

- **`etc/docker/Dockerfile.nitro-host-local`** — New Dockerfile mirroring `Dockerfile.nitro-host` with `--features local` in the cargo build, `release` profile (instead of `maxperf`), and a separate build cache ID
- **`etc/docker/nitro-host/entrypoint-local.sh`** — Entrypoint script using the `local` subcommand instead of `server`, defaulting to `--l1-calldata-only` for appchain mode, dropping `VSOCK_CID` and `L1_BEACON_URL` as required env vars
- **`.github/workflows/docker-l3.yml`** — New `build-nitro-host-local` job using `docker buildx build` (separate from the bake matrix since it has its own Dockerfile), pushing to `nitro-host-local-sha-<sha>` and `nitro-host-local-l3` tags

### Testing

Shell script syntax validated with `bash -n`. Dockerfile structure matches the existing `Dockerfile.nitro-host` with minimal diff (4 line changes). GHA workflow job follows the same pattern as `build-devnet-setup`. Full build validation will occur on CI when merged to `l3`.

### Risk
type=routine
risk=low
impact=sev5

### Notes for Reviewers

- The `rollup_config!(chain_id)` macro in `cli.rs` only recognizes chain IDs 8453, 84532, 1337, and 763360 — if the L3 uses a different chain ID, the prover will fail at startup and a chain config entry will need to be added to `crates/common/chains/src/config.rs`
- Image defaults to calldata-only mode (no beacon API needed for L3→Base appchain), but `L1_BEACON_URL` can be set to override