### PR TITLE
feat: build proposer image for the L3

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [client, base, builder, consensus, batcher, zk-prover]
+        target: [client, base, builder, consensus, proposer, batcher, zk-prover]
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
Add proposer to the build-rust-services matrix in docker-l3.yml so the L3 CI builds and pushes the proposer image alongside the other services.