### PR TITLE
fix(consensus): realign EIP-8130 account-change wire types with the spec

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -73,17 +73,24 @@ impl Scope {
 }
 
 /// Initial actor installed on a newly-created account.
+///
+/// Per [EIP-8130], a create entry's initial actors are `[actorId, authenticator]`
+/// tuples, always registered as unrestricted owners (`scope = 0x00`, no expiry,
+/// no policy). Scope, expiry, and policy are deliberately not expressible here
+/// and default to their zero values; restricted keys are added afterwards via a
+/// [`ConfigChange`]. The field order matches the wire encoding and the
+/// address-derivation commitment (`actorId || authenticator`).
+///
+/// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct InitialActor {
+    /// Actor identifier (the authenticator-derived `actorId`).
+    pub actor_id: B256,
     /// Address of the authenticator contract (e.g. an ERC-1271 authenticator).
     pub authenticator: Address,
-    /// Actor identifier passed to the authenticator.
-    pub actor_id: B256,
-    /// Scope bitmask granted to this actor.
-    pub scope: Scope,
 }
 
 /// Operation performed by an [`ActorChange`] inside a [`ConfigChange`].
@@ -117,6 +124,16 @@ impl ActorChangeType {
 }
 
 /// A single actor authorization or revocation inside a [`ConfigChange`].
+///
+/// Per [EIP-8130], `data` is the operation-specific, contract-ABI-encoded blob:
+/// `abi.encode(ActorConfig, bytes policyData)` for an `Authorize` (carrying the
+/// new actor's authenticator, scope, expiry, policy type, and policy data), and
+/// empty for a `Revoke`. It is opaque at this layer — decoded only where the
+/// change is applied (native authorization or `applySignedActorChanges`) — and
+/// is the value hashed (`keccak256(data)`) in the config-change signature
+/// payload, so the same blob is interpreted identically on every path.
+///
+/// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,20 +141,15 @@ impl ActorChangeType {
 pub struct ActorChange {
     /// Operation (authorize / revoke).
     pub change_type: ActorChangeType,
-    /// Authenticator contract address.
-    pub authenticator: Address,
     /// Actor identifier.
     pub actor_id: B256,
-    /// Scope bitmask (relevant for `Authorize`; ignored on `Revoke`).
-    pub scope: Scope,
+    /// Operation-specific ABI-encoded data (opaque at this layer).
+    pub data: Bytes,
 }
 
 impl ActorChange {
     fn rlp_fields_len(&self) -> usize {
-        self.change_type.op_byte().length()
-            + self.authenticator.length()
-            + self.actor_id.length()
-            + self.scope.length()
+        self.change_type.op_byte().length() + self.actor_id.length() + self.data.length()
     }
 }
 
@@ -147,9 +159,8 @@ impl Encodable for ActorChange {
         let header = Header { list: true, payload_length: fields_len };
         header.encode(out);
         self.change_type.op_byte().encode(out);
-        self.authenticator.encode(out);
         self.actor_id.encode(out);
-        self.scope.encode(out);
+        self.data.encode(out);
     }
 
     fn length(&self) -> usize {
@@ -168,9 +179,8 @@ impl Decodable for ActorChange {
         let op = u8::decode(buf)?;
         let change_type = ActorChangeType::from_op_byte(op)
             .ok_or(alloy_rlp::Error::Custom("invalid ActorChange op byte"))?;
-        let authenticator = Address::decode(buf)?;
         let actor_id = B256::decode(buf)?;
-        let scope = Scope::decode(buf)?;
+        let data = Bytes::decode(buf)?;
         let consumed = started_len - buf.len();
         if consumed != header.payload_length {
             return Err(alloy_rlp::Error::ListLengthMismatch {
@@ -178,7 +188,7 @@ impl Decodable for ActorChange {
                 got: consumed,
             });
         }
-        Ok(Self { change_type, authenticator, actor_id, scope })
+        Ok(Self { change_type, actor_id, data })
     }
 }
 
@@ -333,9 +343,8 @@ mod tests {
     fn actor_change_rlp_roundtrip() {
         let oc = ActorChange {
             change_type: ActorChangeType::Authorize,
-            authenticator: address!("0x00000000000000000000000000000000000000aa"),
             actor_id: b256!("0x1111111111111111111111111111111111111111111111111111111111111111"),
-            scope: Scope(Eip8130Constants::SCOPE_SIGNATURE | Eip8130Constants::SCOPE_SENDER),
+            data: bytes!("00000000000000000000000000000000000000000000000000000000000000aa"),
         };
         let mut buf = Vec::new();
         oc.encode(&mut buf);
@@ -350,11 +359,10 @@ mod tests {
             user_salt: b256!("0x2222222222222222222222222222222222222222222222222222222222222222"),
             code: bytes!("6080604052"),
             initial_actors: vec![InitialActor {
-                authenticator: address!("0x00000000000000000000000000000000000000bb"),
                 actor_id: b256!(
                     "0x3333333333333333333333333333333333333333333333333333333333333333"
                 ),
-                scope: Scope(Eip8130Constants::SCOPE_SIGNATURE),
+                authenticator: address!("0x00000000000000000000000000000000000000bb"),
             }],
         });
         let mut buf = Vec::new();
@@ -372,11 +380,10 @@ mod tests {
             sequence: 7,
             actor_changes: vec![ActorChange {
                 change_type: ActorChangeType::Revoke,
-                authenticator: address!("0x00000000000000000000000000000000000000cc"),
                 actor_id: b256!(
                     "0x4444444444444444444444444444444444444444444444444444444444444444"
                 ),
-                scope: Scope::UNRESTRICTED,
+                data: Bytes::new(),
             }],
             auth: bytes!("aabbcc"),
         });

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -492,6 +492,7 @@ mod tests {
                 to: address!("0x00000000000000000000000000000000000000bb"),
                 data: bytes!("01020304"),
             }]],
+            metadata: Bytes::new(),
             payer: if payer_present {
                 Some(address!("0x00000000000000000000000000000000000000cc"))
             } else {

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -66,6 +66,10 @@ pub struct TxEip8130 {
     /// Calls dispatched by the protocol after account changes apply, grouped
     /// into phases (`Vec<Vec<Call>>`).
     pub calls: Vec<Vec<Call>>,
+    /// Opaque attribution/annotation bytes; empty when unused. Carried in the
+    /// wire body between `calls` and `payer` and committed to by both the
+    /// sender and payer signatures, but otherwise uninterpreted by the protocol.
+    pub metadata: Bytes,
     /// Optional explicit payer; `None` means the resolved sender pays gas.
     pub payer: Option<Address>,
 }
@@ -139,8 +143,10 @@ impl TxEip8130 {
         Ok(phases)
     }
 
-    /// Length of all RLP fields (no list header).
-    pub fn rlp_encoded_fields_length(&self) -> usize {
+    /// Length of the RLP body fields up to and including `metadata` — every
+    /// field except the trailing `payer`. This is exactly the payload covered
+    /// by the payer signature (see [`Self::payer_signature_hash`]).
+    fn fields_through_metadata_length(&self) -> usize {
         self.chain_id.length()
             + Self::address_opt_encoded_length(&self.sender)
             + self.nonce_key.length()
@@ -151,11 +157,12 @@ impl TxEip8130 {
             + self.gas_limit.length()
             + self.account_changes.length()
             + Self::calls_encoded_length(&self.calls)
-            + Self::address_opt_encoded_length(&self.payer)
+            + self.metadata.length()
     }
 
-    /// Encodes the RLP fields (no list header) in canonical order.
-    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
+    /// Encodes the RLP body fields up to and including `metadata` (no `payer`,
+    /// no list header), in canonical order.
+    fn rlp_encode_fields_through_metadata(&self, out: &mut dyn BufMut) {
         self.chain_id.encode(out);
         Self::encode_address_opt(&self.sender, out);
         self.nonce_key.encode(out);
@@ -166,6 +173,17 @@ impl TxEip8130 {
         self.gas_limit.encode(out);
         self.account_changes.encode(out);
         Self::encode_calls(&self.calls, out);
+        self.metadata.encode(out);
+    }
+
+    /// Length of all RLP fields (no list header).
+    pub fn rlp_encoded_fields_length(&self) -> usize {
+        self.fields_through_metadata_length() + Self::address_opt_encoded_length(&self.payer)
+    }
+
+    /// Encodes the RLP fields (no list header) in canonical order.
+    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
+        self.rlp_encode_fields_through_metadata(out);
         Self::encode_address_opt(&self.payer, out);
     }
 
@@ -182,6 +200,7 @@ impl TxEip8130 {
             gas_limit: Decodable::decode(buf)?,
             account_changes: Decodable::decode(buf)?,
             calls: Self::decode_calls(buf)?,
+            metadata: Decodable::decode(buf)?,
             payer: Self::decode_address_opt(buf)?,
         })
     }
@@ -215,15 +234,21 @@ impl TxEip8130 {
 
     /// Signing-hash preimage for the payer, per [EIP-8130].
     ///
-    /// `keccak256(EIP8130_PAYER_TYPE || rlp(unsigned body fields with the
-    /// `sender` slot replaced by the recovered sender address))`.
+    /// `keccak256(EIP8130_PAYER_TYPE || rlp([body fields through `metadata`]))`
+    /// with the `sender` slot replaced by the recovered sender address. The
+    /// payer commits to the transaction body but deliberately *not* to the
+    /// trailing `payer` field itself (nor the `sender_auth` / `payer_auth`
+    /// slots, which live in the signed wrapper).
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     pub fn payer_signature_hash(&self, resolved_sender: Address) -> B256 {
         let with_resolved = Self { sender: Some(resolved_sender), ..self.clone() };
-        let mut buf = Vec::with_capacity(with_resolved.rlp_encoded_length() + 1);
+        let header =
+            Header { list: true, payload_length: with_resolved.fields_through_metadata_length() };
+        let mut buf = Vec::with_capacity(1 + header.length_with_payload());
         buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
-        with_resolved.rlp_encode(&mut buf);
+        header.encode(&mut buf);
+        with_resolved.rlp_encode_fields_through_metadata(&mut buf);
         keccak256(&buf)
     }
 
@@ -239,6 +264,7 @@ impl TxEip8130 {
             + mem::size_of::<u64>()
             + self.account_changes.capacity() * mem::size_of::<AccountChange>()
             + self.calls.iter().map(|p| p.capacity() * mem::size_of::<Call>()).sum::<usize>()
+            + self.metadata.len()
             + mem::size_of::<Option<Address>>()
     }
 }
@@ -402,6 +428,7 @@ mod tests {
                 to: address!("0x00000000000000000000000000000000000000cc"),
                 data: bytes!("deadbeef"),
             }]],
+            metadata: bytes!("c0ffee"),
             payer: None,
         }
     }
@@ -533,12 +560,51 @@ mod tests {
         let resolved = address!("0x00000000000000000000000000000000000000dd");
         let payer_hash_v1 = tx.payer_signature_hash(resolved);
 
+        // Reconstruct the preimage: `PAYER_TYPE || rlp([fields through metadata])`
+        // with the resolved sender substituted and `payer` excluded.
         let tx2 = TxEip8130 { sender: Some(resolved), ..tx };
-        let mut buf = Vec::with_capacity(tx2.rlp_encoded_length() + 1);
+        let header = Header { list: true, payload_length: tx2.fields_through_metadata_length() };
+        let mut buf = Vec::with_capacity(1 + header.length_with_payload());
         buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
-        tx2.rlp_encode(&mut buf);
+        header.encode(&mut buf);
+        tx2.rlp_encode_fields_through_metadata(&mut buf);
         let payer_hash_v2 = keccak256(&buf);
         assert_eq!(payer_hash_v1, payer_hash_v2);
+    }
+
+    // `metadata` is committed to by both signatures.
+    #[test]
+    fn metadata_is_covered_by_both_signature_hashes() {
+        let tx = sample_tx();
+        let resolved = address!("0x00000000000000000000000000000000000000dd");
+        let mut other = tx.clone();
+        other.metadata = bytes!("beef");
+
+        assert_ne!(tx.sender_signature_hash(), other.sender_signature_hash());
+        assert_ne!(
+            tx.payer_signature_hash(resolved),
+            other.payer_signature_hash(resolved)
+        );
+    }
+
+    // The payer signature commits to the body but not to the `payer` slot, so
+    // changing `payer` leaves the payer hash unchanged while the sender hash
+    // (which covers the full body) does change.
+    #[test]
+    fn payer_signature_hash_excludes_payer_field() {
+        let resolved = address!("0x00000000000000000000000000000000000000dd");
+        let mut self_pay = sample_tx();
+        self_pay.payer = None;
+        let sponsored = TxEip8130 {
+            payer: Some(address!("0x00000000000000000000000000000000000000ee")),
+            ..self_pay.clone()
+        };
+
+        assert_eq!(
+            self_pay.payer_signature_hash(resolved),
+            sponsored.payer_signature_hash(resolved)
+        );
+        assert_ne!(self_pay.sender_signature_hash(), sponsored.sender_signature_hash());
     }
 
     /// Proves that EIP-8130 transactions can be deserialized through the
@@ -569,6 +635,7 @@ mod tests {
                 "gasLimit": 21000,
                 "accountChanges": [],
                 "calls": [],
+                "metadata": "0x",
                 "payer": null
             },
             "senderAuth": "0x",

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -562,10 +562,7 @@ mod tests {
         other.metadata = bytes!("beef");
 
         assert_ne!(tx.sender_signature_hash(), other.sender_signature_hash());
-        assert_ne!(
-            tx.payer_signature_hash(resolved),
-            other.payer_signature_hash(resolved)
-        );
+        assert_ne!(tx.payer_signature_hash(resolved), other.payer_signature_hash(resolved));
     }
 
     // Both signatures commit to the full body through `payer`, so changing the

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -143,10 +143,8 @@ impl TxEip8130 {
         Ok(phases)
     }
 
-    /// Length of the RLP body fields up to and including `metadata` — every
-    /// field except the trailing `payer`. This is exactly the payload covered
-    /// by the payer signature (see [`Self::payer_signature_hash`]).
-    fn fields_through_metadata_length(&self) -> usize {
+    /// Length of all RLP fields (no list header).
+    pub fn rlp_encoded_fields_length(&self) -> usize {
         self.chain_id.length()
             + Self::address_opt_encoded_length(&self.sender)
             + self.nonce_key.length()
@@ -158,11 +156,11 @@ impl TxEip8130 {
             + self.account_changes.length()
             + Self::calls_encoded_length(&self.calls)
             + self.metadata.length()
+            + Self::address_opt_encoded_length(&self.payer)
     }
 
-    /// Encodes the RLP body fields up to and including `metadata` (no `payer`,
-    /// no list header), in canonical order.
-    fn rlp_encode_fields_through_metadata(&self, out: &mut dyn BufMut) {
+    /// Encodes the RLP fields (no list header) in canonical order.
+    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
         self.chain_id.encode(out);
         Self::encode_address_opt(&self.sender, out);
         self.nonce_key.encode(out);
@@ -174,16 +172,6 @@ impl TxEip8130 {
         self.account_changes.encode(out);
         Self::encode_calls(&self.calls, out);
         self.metadata.encode(out);
-    }
-
-    /// Length of all RLP fields (no list header).
-    pub fn rlp_encoded_fields_length(&self) -> usize {
-        self.fields_through_metadata_length() + Self::address_opt_encoded_length(&self.payer)
-    }
-
-    /// Encodes the RLP fields (no list header) in canonical order.
-    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
-        self.rlp_encode_fields_through_metadata(out);
         Self::encode_address_opt(&self.payer, out);
     }
 
@@ -234,21 +222,18 @@ impl TxEip8130 {
 
     /// Signing-hash preimage for the payer, per [EIP-8130].
     ///
-    /// `keccak256(EIP8130_PAYER_TYPE || rlp([body fields through `metadata`]))`
+    /// `keccak256(EIP8130_PAYER_TYPE || rlp([all body fields through `payer`]))`
     /// with the `sender` slot replaced by the recovered sender address. The
-    /// payer commits to the transaction body but deliberately *not* to the
-    /// trailing `payer` field itself (nor the `sender_auth` / `payer_auth`
-    /// slots, which live in the signed wrapper).
+    /// payer commits to the full transaction body — including the `payer` slot
+    /// itself — and only the `sender_auth` / `payer_auth` slots (which live in
+    /// the signed wrapper) are excluded.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     pub fn payer_signature_hash(&self, resolved_sender: Address) -> B256 {
         let with_resolved = Self { sender: Some(resolved_sender), ..self.clone() };
-        let header =
-            Header { list: true, payload_length: with_resolved.fields_through_metadata_length() };
-        let mut buf = Vec::with_capacity(1 + header.length_with_payload());
+        let mut buf = Vec::with_capacity(with_resolved.rlp_encoded_length() + 1);
         buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
-        header.encode(&mut buf);
-        with_resolved.rlp_encode_fields_through_metadata(&mut buf);
+        with_resolved.rlp_encode(&mut buf);
         keccak256(&buf)
     }
 
@@ -560,14 +545,10 @@ mod tests {
         let resolved = address!("0x00000000000000000000000000000000000000dd");
         let payer_hash_v1 = tx.payer_signature_hash(resolved);
 
-        // Reconstruct the preimage: `PAYER_TYPE || rlp([fields through metadata])`
-        // with the resolved sender substituted and `payer` excluded.
         let tx2 = TxEip8130 { sender: Some(resolved), ..tx };
-        let header = Header { list: true, payload_length: tx2.fields_through_metadata_length() };
-        let mut buf = Vec::with_capacity(1 + header.length_with_payload());
+        let mut buf = Vec::with_capacity(tx2.rlp_encoded_length() + 1);
         buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
-        header.encode(&mut buf);
-        tx2.rlp_encode_fields_through_metadata(&mut buf);
+        tx2.rlp_encode(&mut buf);
         let payer_hash_v2 = keccak256(&buf);
         assert_eq!(payer_hash_v1, payer_hash_v2);
     }
@@ -587,11 +568,10 @@ mod tests {
         );
     }
 
-    // The payer signature commits to the body but not to the `payer` slot, so
-    // changing `payer` leaves the payer hash unchanged while the sender hash
-    // (which covers the full body) does change.
+    // Both signatures commit to the full body through `payer`, so changing the
+    // `payer` slot changes both the sender and payer hashes.
     #[test]
-    fn payer_signature_hash_excludes_payer_field() {
+    fn payer_field_is_covered_by_both_signature_hashes() {
         let resolved = address!("0x00000000000000000000000000000000000000dd");
         let mut self_pay = sample_tx();
         self_pay.payer = None;
@@ -600,7 +580,7 @@ mod tests {
             ..self_pay.clone()
         };
 
-        assert_eq!(
+        assert_ne!(
             self_pay.payer_signature_hash(resolved),
             sponsored.payer_signature_hash(resolved)
         );

--- a/crates/common/rpc-types/src/transaction.rs
+++ b/crates/common/rpc-types/src/transaction.rs
@@ -383,6 +383,7 @@ mod tests {
             gas_limit: 1_000_000,
             account_changes: vec![],
             calls: vec![],
+            metadata: Bytes::new(),
             payer: None,
         };
         let sender_auth = Bytes::from_static(&[0xAB; 32]);

--- a/crates/execution/txpool/src/best.rs
+++ b/crates/execution/txpool/src/best.rs
@@ -227,6 +227,7 @@ mod tests {
             gas_limit: 50_000,
             account_changes: Vec::new(),
             calls: Vec::new(),
+            metadata: Bytes::new(),
             payer: None,
         };
         let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -1159,6 +1159,7 @@ mod tests {
             gas_limit: 50_000,
             account_changes: Vec::new(),
             calls: Vec::new(),
+            metadata: Bytes::new(),
             payer: None,
         };
         let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -494,6 +494,7 @@ mod tests {
             gas_limit: 50_000,
             account_changes: Vec::new(),
             calls: Vec::new(),
+            metadata: Bytes::new(),
             payer: None,
         };
         let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();

--- a/crates/execution/txpool/src/two_d_nonce_pool.rs
+++ b/crates/execution/txpool/src/two_d_nonce_pool.rs
@@ -582,6 +582,7 @@ mod tests {
             gas_limit: 50_000,
             account_changes: Vec::new(),
             calls: Vec::new(),
+            metadata: Bytes::new(),
             payer: None,
         };
         let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -8,9 +8,11 @@ use std::{
 };
 
 use alloy_consensus::{BlockHeader, Transaction};
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, U256};
 use base_common_chains::Upgrades;
-use base_common_consensus::{AccountChange, Eip8130Constants, Eip8130Signed};
+use base_common_consensus::{
+    AccountChange, ActorChange, ActorChangeType, Eip8130Constants, Eip8130Signed, InitialActor,
+};
 use base_common_evm::{BaseSpecId, L1BlockInfo};
 use base_common_genesis::DaFootprintGasScalarUpdate;
 use parking_lot::RwLock;
@@ -330,9 +332,7 @@ where
                     if create.code.is_empty() || create.initial_actors.is_empty() {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
-                    Self::validate_actor_iter(&create.initial_actors, |o| {
-                        (&o.authenticator, &o.actor_id)
-                    })?;
+                    Self::validate_initial_actors(&create.initial_actors)?;
                 }
                 AccountChange::ConfigChange(cfg) => {
                     config_count += 1;
@@ -349,9 +349,7 @@ where
                     if Self::authenticator_out_of_range(&cfg_authenticator) {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
-                    Self::validate_actor_iter(&cfg.actor_changes, |o| {
-                        (&o.authenticator, &o.actor_id)
-                    })?;
+                    Self::validate_actor_changes(&cfg.actor_changes)?;
                 }
                 AccountChange::Delegation(_) => {
                     delegation_count += 1;
@@ -364,27 +362,57 @@ where
         Ok(())
     }
 
-    /// Shared validation for any actor-bearing slice (`initial_actors` on
-    /// `Create`, `actor_changes` on `ConfigChange`). Enforces that the slice
-    /// length is bounded by [`Eip8130Constants::MAX_ACTORS_PER_ENTRY`] (anti-DoS
-    /// cap on memory + work spent on duplicate detection), that every authenticator
-    /// address is at or above the `ECRECOVER_AUTHENTICATOR` floor, never equals the
-    /// `REVOKED_AUTHENTICATOR` sentinel, and that no two entries share the same
-    /// `actor_id`.
-    fn validate_actor_iter<T>(
-        actors: &[T],
-        project: impl Fn(&T) -> (&Address, &B256),
-    ) -> Result<(), InvalidPoolTransactionError> {
+    /// Validates `Create.initial_actors`: the slice length is bounded by
+    /// [`Eip8130Constants::MAX_ACTORS_PER_ENTRY`] (anti-DoS cap on memory + work
+    /// spent on duplicate detection), every `authenticator` is at or above the
+    /// `ECRECOVER_AUTHENTICATOR` floor and never the `REVOKED_AUTHENTICATOR`
+    /// sentinel, and no two entries share the same `actor_id`.
+    fn validate_initial_actors(actors: &[InitialActor]) -> Result<(), InvalidPoolTransactionError> {
         if actors.len() > Eip8130Constants::MAX_ACTORS_PER_ENTRY {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
         let mut seen = BTreeSet::new();
-        for entry in actors {
-            let (authenticator, actor_id) = project(entry);
-            if Self::authenticator_out_of_range(authenticator) {
+        for actor in actors {
+            if Self::authenticator_out_of_range(&actor.authenticator) {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
-            if !seen.insert(*actor_id) {
+            if !seen.insert(actor.actor_id) {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Validates `ConfigChange.actor_changes`: the same length cap and
+    /// `actor_id`-uniqueness rules as [`Self::validate_initial_actors`], plus the
+    /// reserved/`REVOKED` authenticator bound for the *new* actor of each
+    /// `Authorize`. The authenticator lives in the ABI-encoded `data`
+    /// (`abi.encode(ActorConfig, bytes)`), where `ActorConfig.authenticator` is
+    /// the right-aligned address in the first 32-byte word, so it is read from
+    /// `data[12..32]` without a full decode; the remaining structure is validated
+    /// where the change is applied. A `Revoke` carries empty `data` and names no
+    /// authenticator, so only the cap and uniqueness apply.
+    ///
+    /// Per EIP-8130 a config change MAY authorize a non-canonical authenticator
+    /// (for in-EVM use such as recovery keys); only the reserved window
+    /// (`< ECRECOVER_AUTHENTICATOR`) and the `REVOKED_AUTHENTICATOR` sentinel are
+    /// rejected here, matching the bound applied to the other auth surfaces.
+    fn validate_actor_changes(changes: &[ActorChange]) -> Result<(), InvalidPoolTransactionError> {
+        if changes.len() > Eip8130Constants::MAX_ACTORS_PER_ENTRY {
+            return Err(InvalidTransactionError::TxTypeNotSupported.into());
+        }
+        let mut seen = BTreeSet::new();
+        for change in changes {
+            if change.change_type == ActorChangeType::Authorize {
+                if change.data.len() < 32 {
+                    return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                }
+                let authenticator = Address::from_slice(&change.data[12..32]);
+                if Self::authenticator_out_of_range(&authenticator) {
+                    return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                }
+            }
+            if !seen.insert(change.actor_id) {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
         }
@@ -507,7 +535,7 @@ mod tests {
     use base_common_consensus::{
         AccountChange, ActorChange, ActorChangeType, BasePrimitives, BaseTransactionSigned,
         BaseTxEnvelope, ConfigChange, CreateEntry, Delegation, Eip8130Constants, Eip8130Signed,
-        InitialActor, Scope, TxDeposit, TxEip8130,
+        InitialActor, TxDeposit, TxEip8130,
     };
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
     use base_execution_evm::BaseEvmConfig;
@@ -858,10 +886,18 @@ mod tests {
 
     fn make_initial_actor(actor_id_byte: u8) -> InitialActor {
         InitialActor {
-            authenticator: ok_authenticator(),
             actor_id: B256::repeat_byte(actor_id_byte),
-            scope: Scope::UNRESTRICTED,
+            authenticator: ok_authenticator(),
         }
+    }
+
+    /// Builds an `Authorize` actor-change whose ABI-encoded `data` carries
+    /// `authenticator` in the first word (`ActorConfig.authenticator`), matching
+    /// the layout the validator reads from `data[12..32]`.
+    fn make_authorize_change(actor_id: B256, authenticator: Address) -> ActorChange {
+        let mut data = vec![0u8; 160];
+        data[12..32].copy_from_slice(authenticator.as_slice());
+        ActorChange { change_type: ActorChangeType::Authorize, actor_id, data: Bytes::from(data) }
     }
 
     fn make_valid_create_entry() -> CreateEntry {
@@ -1064,15 +1100,16 @@ mod tests {
         ));
     }
 
+    // An `Authorize` change must not register a new actor against the
+    // `REVOKED_AUTHENTICATOR` sentinel; the authenticator is read from the
+    // leading word of the ABI-encoded `data`.
     #[test]
     fn rejects_eip8130_config_change_with_revoked_authenticator_in_actor_changes() {
         let cfg = ConfigChange {
-            actor_changes: vec![ActorChange {
-                change_type: ActorChangeType::Revoke,
-                authenticator: Eip8130Constants::REVOKED_AUTHENTICATOR,
-                actor_id: B256::repeat_byte(0x01),
-                scope: Scope::UNRESTRICTED,
-            }],
+            actor_changes: vec![make_authorize_change(
+                B256::repeat_byte(0x01),
+                Eip8130Constants::REVOKED_AUTHENTICATOR,
+            )],
             ..make_valid_config_change()
         };
         let tx = TxEip8130 {
@@ -1088,14 +1125,11 @@ mod tests {
     #[test]
     fn rejects_eip8130_config_change_with_duplicate_actor_ids() {
         let dup_id = B256::repeat_byte(0x07);
-        let mk = |id| ActorChange {
-            change_type: ActorChangeType::Authorize,
-            authenticator: ok_authenticator(),
-            actor_id: id,
-            scope: Scope::UNRESTRICTED,
-        };
         let cfg = ConfigChange {
-            actor_changes: vec![mk(dup_id), mk(dup_id)],
+            actor_changes: vec![
+                make_authorize_change(dup_id, ok_authenticator()),
+                make_authorize_change(dup_id, ok_authenticator()),
+            ],
             ..make_valid_config_change()
         };
         let tx = TxEip8130 {
@@ -1111,12 +1145,7 @@ mod tests {
     #[test]
     fn rejects_eip8130_config_change_with_too_many_actor_changes() {
         let actor_changes = (0..(Eip8130Constants::MAX_ACTORS_PER_ENTRY + 1))
-            .map(|i| ActorChange {
-                change_type: ActorChangeType::Authorize,
-                authenticator: ok_authenticator(),
-                actor_id: B256::repeat_byte(i as u8),
-                scope: Scope::UNRESTRICTED,
-            })
+            .map(|i| make_authorize_change(B256::repeat_byte(i as u8), ok_authenticator()))
             .collect();
         let cfg = ConfigChange { actor_changes, ..make_valid_config_change() };
         let tx = TxEip8130 {

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1230,10 +1230,7 @@ mod tests {
         let mut data = change.data.to_vec();
         data[0] = 0x01;
         change.data = Bytes::from(data);
-        let cfg = ConfigChange {
-            actor_changes: vec![change],
-            ..make_valid_config_change()
-        };
+        let cfg = ConfigChange { actor_changes: vec![change], ..make_valid_config_change() };
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::ConfigChange(cfg)],
             ..minimal_valid_eoa_tx()

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -298,10 +298,11 @@ where
     }
 
     /// Returns `true` when `authenticator` falls outside the live mempool policy
-    /// range. Mirrors the check in [`Self::validate_actor_iter`] so all three
-    /// auth surfaces (`sender_auth`, `payer_auth`, `cfg.auth`, and per-actor
-    /// authenticators) reject the reserved `< ECRECOVER_AUTHENTICATOR` window and the
-    /// `REVOKED_AUTHENTICATOR` sentinel identically.
+    /// range. Mirrors the check in [`Self::validate_initial_actors`] and
+    /// [`Self::validate_actor_changes`] so all auth surfaces (`sender_auth`,
+    /// `payer_auth`, `cfg.auth`, and per-actor authenticators) reject the reserved
+    /// `< ECRECOVER_AUTHENTICATOR` window and the `REVOKED_AUTHENTICATOR` sentinel
+    /// identically.
     fn authenticator_out_of_range(authenticator: &Address) -> bool {
         *authenticator < Eip8130Constants::ECRECOVER_AUTHENTICATOR
             || *authenticator == Eip8130Constants::REVOKED_AUTHENTICATOR
@@ -313,8 +314,8 @@ where
     /// [`Eip8130Constants::MAX_CONFIG_CHANGES_PER_TX`], chain-binding on
     /// config changes, and per-entry well-formedness. Authenticator-address bounds
     /// and actor-id uniqueness are enforced on both `Create.initial_actors`
-    /// and `ConfigChange.actor_changes` via
-    /// [`Self::validate_actor_iter`].
+    /// and `ConfigChange.actor_changes` via [`Self::validate_initial_actors`]
+    /// and [`Self::validate_actor_changes`] respectively.
     fn validate_account_changes(
         signed: &Eip8130Signed,
         local_chain_id: u64,
@@ -389,8 +390,9 @@ where
     /// `Authorize`. The authenticator lives in the ABI-encoded `data`
     /// (`abi.encode(ActorConfig, bytes)`), where `ActorConfig.authenticator` is
     /// the right-aligned address in the first 32-byte word, so it is read from
-    /// `data[12..32]` without a full decode; the remaining structure is validated
-    /// where the change is applied. A `Revoke` carries empty `data` and names no
+    /// `data[12..32]` without a full decode (the leading 12 padding bytes must be
+    /// zero, matching ABI encoding); the remaining structure is validated where
+    /// the change is applied. A `Revoke` carries empty `data` and names no
     /// authenticator, so only the cap and uniqueness apply.
     ///
     /// Per EIP-8130 a config change MAY authorize a non-canonical authenticator
@@ -410,6 +412,12 @@ where
                     // `data` = `abi.encode(ActorConfig, bytes)`; the new actor's
                     // authenticator is the right-aligned address in the first word.
                     if change.data.len() < 32 {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    // The first word is an ABI-encoded `address`: the leading 12
+                    // bytes are zero padding. Reject dirty upper bits so the gate
+                    // and a strict ABI decoder downstream agree on validity.
+                    if change.data[..12].iter().any(|&b| b != 0) {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                     let authenticator = Address::from_slice(&change.data[12..32]);
@@ -835,7 +843,7 @@ mod tests {
     }
 
     // Regression: configured-actor path must reject the reserved authenticator
-    // range below `ECRECOVER_AUTHENTICATOR`, matching `validate_actor_iter`.
+    // range below `ECRECOVER_AUTHENTICATOR`, matching `validate_actor_changes`.
     // `address(0)` is the canonical reserved value.
     #[test]
     fn rejects_eip8130_configured_actor_with_reserved_authenticator() {
@@ -1201,6 +1209,28 @@ mod tests {
                 actor_id: B256::repeat_byte(0x01),
                 data: Bytes::from_static(&[0xaa]),
             }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    // The first `data` word is an ABI-encoded `address`; non-zero padding in the
+    // leading 12 bytes is malformed and rejected at the gate.
+    #[test]
+    fn rejects_eip8130_config_change_with_dirty_authenticator_padding() {
+        let mut change = make_authorize_change(B256::repeat_byte(0x01), ok_authenticator());
+        let mut data = change.data.to_vec();
+        data[0] = 0x01;
+        change.data = Bytes::from(data);
+        let cfg = ConfigChange {
+            actor_changes: vec![change],
             ..make_valid_config_change()
         };
         let tx = TxEip8130 {

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -396,20 +396,31 @@ where
     /// Per EIP-8130 a config change MAY authorize a non-canonical authenticator
     /// (for in-EVM use such as recovery keys); only the reserved window
     /// (`< ECRECOVER_AUTHENTICATOR`) and the `REVOKED_AUTHENTICATOR` sentinel are
-    /// rejected here, matching the bound applied to the other auth surfaces.
+    /// rejected here, matching the bound applied to the other auth surfaces. A
+    /// `Revoke` names no authenticator and MUST carry empty `data`; a non-empty
+    /// `data` is malformed and rejected at the gate.
     fn validate_actor_changes(changes: &[ActorChange]) -> Result<(), InvalidPoolTransactionError> {
         if changes.len() > Eip8130Constants::MAX_ACTORS_PER_ENTRY {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
         let mut seen = BTreeSet::new();
         for change in changes {
-            if change.change_type == ActorChangeType::Authorize {
-                if change.data.len() < 32 {
-                    return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            match change.change_type {
+                ActorChangeType::Authorize => {
+                    // `data` = `abi.encode(ActorConfig, bytes)`; the new actor's
+                    // authenticator is the right-aligned address in the first word.
+                    if change.data.len() < 32 {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    let authenticator = Address::from_slice(&change.data[12..32]);
+                    if Self::authenticator_out_of_range(&authenticator) {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
                 }
-                let authenticator = Address::from_slice(&change.data[12..32]);
-                if Self::authenticator_out_of_range(&authenticator) {
-                    return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                ActorChangeType::Revoke => {
+                    if !change.data.is_empty() {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
                 }
             }
             if !seen.insert(change.actor_id) {
@@ -900,6 +911,12 @@ mod tests {
         ActorChange { change_type: ActorChangeType::Authorize, actor_id, data: Bytes::from(data) }
     }
 
+    /// Builds a `Revoke` actor-change. Per EIP-8130 a revoke names no
+    /// authenticator and carries empty `data`.
+    fn make_revoke_change(actor_id: B256) -> ActorChange {
+        ActorChange { change_type: ActorChangeType::Revoke, actor_id, data: Bytes::new() }
+    }
+
     fn make_valid_create_entry() -> CreateEntry {
         CreateEntry {
             user_salt: B256::ZERO,
@@ -1148,6 +1165,65 @@ mod tests {
             .map(|i| make_authorize_change(B256::repeat_byte(i as u8), ok_authenticator()))
             .collect();
         let cfg = ConfigChange { actor_changes, ..make_valid_config_change() };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    // A `Revoke` carries empty `data` and names no authenticator, so it must
+    // pass `validate_actor_changes` (no authenticator bound is applied).
+    #[test]
+    fn accepts_eip8130_config_change_with_valid_revoke() {
+        let cfg = ConfigChange {
+            actor_changes: vec![make_revoke_change(B256::repeat_byte(0x01))],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id()).is_ok()
+        );
+    }
+
+    // A `Revoke` with non-empty `data` is malformed and rejected at the gate.
+    #[test]
+    fn rejects_eip8130_config_change_with_nonempty_revoke_data() {
+        let cfg = ConfigChange {
+            actor_changes: vec![ActorChange {
+                change_type: ActorChangeType::Revoke,
+                actor_id: B256::repeat_byte(0x01),
+                data: Bytes::from_static(&[0xaa]),
+            }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    // Duplicate `actor_id` detection spans mixed `Authorize`/`Revoke` entries.
+    #[test]
+    fn rejects_eip8130_config_change_with_duplicate_actor_ids_mixed() {
+        let dup_id = B256::repeat_byte(0x07);
+        let cfg = ConfigChange {
+            actor_changes: vec![
+                make_authorize_change(dup_id, ok_authenticator()),
+                make_revoke_change(dup_id),
+            ],
+            ..make_valid_config_change()
+        };
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::ConfigChange(cfg)],
             ..minimal_valid_eoa_tx()

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -624,6 +624,7 @@ mod tests {
             gas_limit: 50_000,
             account_changes: Vec::new(),
             calls: Vec::new(),
+            metadata: Bytes::new(),
             payer: None,
         }
     }

--- a/crates/utilities/test-utils/contracts/out
+++ b/crates/utilities/test-utils/contracts/out
@@ -1,1 +1,0 @@
-/Users/chrishunter/Coinbase/Github/base/crates/utilities/test-utils/contracts/out

--- a/crates/utilities/test-utils/contracts/out
+++ b/crates/utilities/test-utils/contracts/out
@@ -1,0 +1,1 @@
+/Users/chrishunter/Coinbase/Github/base/crates/utilities/test-utils/contracts/out


### PR DESCRIPTION
## Summary

The `account_changes` consensus types had drifted from the EIP-8130 wire format, and the transaction body was missing the newly-added top-level `metadata` field. This PR realigns both with the spec.

### Account-change wire types

Two fields were spec-conformance bugs that would otherwise propagate into the config-change authorization layer:

- **`InitialActor`** carried a spurious `scope` field, in the wrong field order. Per the EIP, a create entry's `initial_actors` are `[actorId, authenticator]` tuples, **always** registered as unrestricted owners (`scope = 0x00`, no expiry, no policy) — scope/expiry/policy are deliberately not expressible there. The contract agrees (`createAccount` NatSpec), and the address-derivation commitment is exactly `actorId || authenticator`.
- **`ActorChange`** invented typed `authenticator` + `scope` fields instead of the spec's opaque ABI `data` blob, making it **lossy**: it could not express `expiry`, `policyType`, or `policyData`, and could not reproduce the `keccak256(data)` used in the config-change signature payload.

| Type | Before | After (EIP-8130) |
|------|--------|------------------|
| `InitialActor` | `{authenticator, actor_id, scope}` | `{actor_id, authenticator}` |
| `ActorChange` | `{change_type, authenticator, actor_id, scope}` | `{change_type, actor_id, data: Bytes}` |

`data` is the `abi.encode(ActorConfig, bytes policyData)` blob for an `Authorize` (empty for a `Revoke`), opaque at this layer and decoded only where the change is applied (native authorization or `applySignedActorChanges`).

This is the prerequisite for the config-change (`SCOPE_CONFIG`) authorization PR, which needs the `data` field to compute the `SignedActorChanges` digest and to authorize scoped/expiring/policy-gated actor grants.

### Top-level `metadata` field

EIP-8130 added an opaque `metadata` bytes field to the transaction body, between `calls` and `payer`:

```
AA_TX_TYPE || rlp([ chain_id, sender, nonce_key, nonce_sequence, expiry,
  max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
  account_changes, calls, metadata, payer, sender_auth, payer_auth ])
```

- The field is uninterpreted by the protocol (attribution/annotation bytes; the legacy "data suffix" replacement) but is committed to by **both** signatures, making it tamper-evident.
- **Sender signature hash** — all body fields through `payer` (now includes `metadata`), `AA_TX_TYPE` prefix.
- **Payer signature hash** — all body fields through `payer` (now includes `metadata`), `AA_PAYER_TYPE` prefix; only `sender_auth` / `payer_auth` are excluded. (see https://github.com/ethereum/EIPs/pull/11808) 

## Security control preserved (no downgrade)

The txpool validator's reserved/`REVOKED` authenticator bound on actor changes is **kept**. Since the authenticator now lives inside `data`, for `Authorize` entries the validator reads `ActorConfig.authenticator` from the leading word (`data[12..32]`) and applies the same `authenticator_out_of_range` check; a `Revoke` carries no authenticator (empty `data`), so only the cap + `actor_id`-uniqueness rules apply. Per EIP-8130 a config change MAY authorize a *non-canonical* authenticator (for in-EVM use such as recovery keys), so only the reserved window (`< ECRECOVER_AUTHENTICATOR`) and the `REVOKED_AUTHENTICATOR` sentinel are rejected — matching the bound on the other auth surfaces.

## Review-comment fixes

- The `Authorize` `data` leading word is an ABI `address`; non-zero bytes in the 12-byte padding are now rejected at the mempool gate so it agrees with a strict downstream ABI decoder.
- `Revoke` entries must carry empty `data` (enforced + tested).
- Repointed stale intra-doc links from the removed `validate_actor_iter` to `validate_initial_actors` / `validate_actor_changes`.

## Test plan

- [x] `cargo test -p base-common-consensus --features serde,arbitrary` — RLP round-trips for both new shapes; new tests assert `metadata` and `payer` are covered by both signature hashes
- [x] `cargo test -p base-execution-txpool --lib` (110 passed) — actor-change validation; new dirty-padding + `Revoke` tests
- [x] `cargo clippy` clean on consensus + txpool
- [x] `cargo fmt`