### PR TITLE
feat: add --fetch-rollup-config flag to nitro-host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,6 +5953,7 @@ dependencies = [
  "alloy-provider 2.0.5",
  "base-cli-utils",
  "base-common-chains",
+ "base-common-genesis",
  "base-proof-host",
  "base-proof-tee-nitro-enclave",
  "base-proof-tee-nitro-host",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5950,6 +5950,7 @@ name = "base-prover-nitro-host"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-provider 2.0.5",
  "base-cli-utils",
  "base-common-chains",
  "base-proof-host",

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
 base-proof-host = { workspace = true, features = ["metrics"] }
 uuid = { workspace = true, features = ["v4"], optional = true }
 base-prover-service-client = { workspace = true, optional = true }

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 base-cli-utils.workspace = true
 alloy-primitives.workspace = true
 base-common-chains.workspace = true
+base-common-genesis.workspace = true
 base-proof-tee-nitro-host.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, optional = true }

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -602,23 +602,18 @@ struct SystemConfigRpcResponse {
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
-async fn fetch_rollup_config_from_rpc(
-    l2_eth_url: &str,
-) -> eyre::Result<RollupConfigRpcResponse> {
+async fn fetch_rollup_config_from_rpc(l2_eth_url: &str) -> eyre::Result<RollupConfigRpcResponse> {
     let provider = ProviderBuilder::new()
         .connect(l2_eth_url)
         .await
         .map_err(|e| eyre!("failed to connect to L2 node at {l2_eth_url}: {e}"))?;
 
-    provider
-        .raw_request("optimism_rollupConfig".into(), ())
-        .await
-        .map_err(|e| {
-            eyre!(
-                "optimism_rollupConfig RPC failed on {l2_eth_url}: {e}. \
+    provider.raw_request("optimism_rollupConfig".into(), ()).await.map_err(|e| {
+        eyre!(
+            "optimism_rollupConfig RPC failed on {l2_eth_url}: {e}. \
                  Ensure the L2 node supports this method"
-            )
-        })
+        )
+    })
 }
 
 #[cfg(all(test, feature = "local"))]

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -181,6 +181,7 @@ impl ProverRuntimeArgs {
                 genesis_l1_hash = %rpc.genesis.l1.hash,
                 genesis_l1_number = rpc.genesis.l1.number,
                 genesis_l2_hash = %rpc.genesis.l2.hash,
+                genesis_l2_number = rpc.genesis.l2.number,
                 genesis_l2_time = rpc.genesis.l2_time,
                 deposit_contract = %rpc.deposit_contract_address,
                 system_config_address = %rpc.l1_system_config_address,

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -131,6 +131,7 @@ struct ProverRuntimeArgs {
     /// hardcoded chain config. Requires `--l2-cl-url`. Use for
     /// devnet/ephemeral chains where genesis changes on every deployment.
     #[arg(long, env = "FETCH_ROLLUP_CONFIG")]
+    #[arg(long, env = "FETCH_ROLLUP_CONFIG", requires = "l2_cl_url")]
     fetch_rollup_config: bool,
 
     /// L2 consensus-layer (op-node) RPC URL. Required when

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -615,13 +615,13 @@ struct SystemConfigRpcResponse {
 #[cfg(any(target_os = "linux", feature = "local"))]
 async fn fetch_rollup_config_from_rpc(cl_url: &str) -> eyre::Result<RollupConfigRpcResponse> {
     let provider = ProviderBuilder::new()
-        .connect(l2_eth_url)
+        .connect(cl_url)
         .await
-        .map_err(|e| eyre!("failed to connect to L2 node at {l2_eth_url}: {e}"))?;
+        .map_err(|e| eyre!("failed to connect to L2 CL node at {cl_url}: {e}"))?;
 
     provider.raw_request("optimism_rollupConfig".into(), ()).await.map_err(|e| {
         eyre!(
-            "optimism_rollupConfig RPC failed on {l2_eth_url}: {e}. \
+            "optimism_rollupConfig RPC failed on {cl_url}: {e}. \
                  Ensure the L2 node supports this method"
         )
     })

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -124,10 +124,10 @@ struct ProverRuntimeArgs {
     #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Option<Address>,
 
-    /// Fetch genesis config via `optimism_rollupConfig` RPC at startup,
-    /// overriding placeholder genesis anchors and contract addresses in the
-    /// hardcoded chain config. Requires `--l2-cl-url`. Use for
-    /// devnet/ephemeral chains where genesis changes on every deployment.
+    /// Fetch the full rollup config via `optimism_rollupConfig` RPC at startup.
+    /// Requires `--l2-cl-url`. Intended for devnet/ephemeral chains whose
+    /// chain ID is not in the built-in config table. For built-in chain IDs,
+    /// the enclave's `BootInfo::load` will use the hardcoded config regardless.
     #[arg(long, env = "FETCH_ROLLUP_CONFIG", requires = "l2_cl_url")]
     fetch_rollup_config: bool,
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -613,7 +613,7 @@ struct SystemConfigRpcResponse {
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
-async fn fetch_rollup_config_from_rpc(l2_eth_url: &str) -> eyre::Result<RollupConfigRpcResponse> {
+async fn fetch_rollup_config_from_rpc(cl_url: &str) -> eyre::Result<RollupConfigRpcResponse> {
     let provider = ProviderBuilder::new()
         .connect(l2_eth_url)
         .await

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -130,7 +130,6 @@ struct ProverRuntimeArgs {
     /// overriding placeholder genesis anchors and contract addresses in the
     /// hardcoded chain config. Requires `--l2-cl-url`. Use for
     /// devnet/ephemeral chains where genesis changes on every deployment.
-    #[arg(long, env = "FETCH_ROLLUP_CONFIG")]
     #[arg(long, env = "FETCH_ROLLUP_CONFIG", requires = "l2_cl_url")]
     fetch_rollup_config: bool,
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use alloy_primitives::Address;
 #[cfg(any(target_os = "linux", feature = "local"))]
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use alloy_provider::{Provider, ProviderBuilder};
 use base_cli_utils::{LogConfig, RuntimeManager};
@@ -195,6 +195,8 @@ impl ProverRuntimeArgs {
                 deposit_contract = %rpc.deposit_contract_address,
                 system_config_address = %rpc.l1_system_config_address,
                 batcher_address = %rpc.genesis.system_config.batcher_addr,
+                gas_limit = rpc.genesis.system_config.gas_limit,
+                scalar = %rpc.genesis.system_config.scalar,
                 "overriding genesis config from L2 node RPC"
             );
 
@@ -206,8 +208,10 @@ impl ProverRuntimeArgs {
             rollup_config.deposit_contract_address = rpc.deposit_contract_address;
             rollup_config.l1_system_config_address = rpc.l1_system_config_address;
 
-            rollup_config.genesis.system_config.get_or_insert_default().batcher_address =
-                rpc.genesis.system_config.batcher_addr;
+            let sc = rollup_config.genesis.system_config.get_or_insert_default();
+            sc.batcher_address = rpc.genesis.system_config.batcher_addr;
+            sc.gas_limit = rpc.genesis.system_config.gas_limit;
+            sc.scalar = rpc.genesis.system_config.scalar;
         }
 
         let l1_config = base_common_chains::L1_CONFIGS
@@ -609,6 +613,9 @@ struct BlockRefRpcResponse {
 struct SystemConfigRpcResponse {
     #[serde(alias = "batcherAddr")]
     batcher_addr: Address,
+    #[serde(alias = "gasLimit")]
+    gas_limit: u64,
+    scalar: U256,
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -126,12 +126,18 @@ struct ProverRuntimeArgs {
     #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Option<Address>,
 
-    /// Fetch genesis config from the L2 node via `optimism_rollupConfig` RPC at
-    /// startup. Overrides placeholder genesis anchors and contract addresses in
-    /// the hardcoded chain config. Use for devnet/ephemeral chains where genesis
-    /// changes on every deployment.
+    /// Fetch genesis config via `optimism_rollupConfig` RPC at startup,
+    /// overriding placeholder genesis anchors and contract addresses in the
+    /// hardcoded chain config. Requires `--l2-cl-url`. Use for
+    /// devnet/ephemeral chains where genesis changes on every deployment.
     #[arg(long, env = "FETCH_ROLLUP_CONFIG")]
     fetch_rollup_config: bool,
+
+    /// L2 consensus-layer (op-node) RPC URL. Required when
+    /// `--fetch-rollup-config` is set — `optimism_rollupConfig` is served by
+    /// op-node, not the execution-layer endpoint.
+    #[arg(long, env = "L2_CL_URL")]
+    l2_cl_url: Option<String>,
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -167,7 +173,10 @@ impl ProverRuntimeArgs {
             .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?;
 
         if self.fetch_rollup_config {
-            let rpc = fetch_rollup_config_from_rpc(&self.l2_eth_url).await?;
+            let cl_url = self.l2_cl_url.as_deref().ok_or_else(|| {
+                eyre!("--l2-cl-url is required when --fetch-rollup-config is set")
+            })?;
+            let rpc = fetch_rollup_config_from_rpc(cl_url).await?;
 
             if rpc.l2_chain_id != self.l2_chain_id {
                 return Err(eyre!(
@@ -631,6 +640,7 @@ mod tests {
             enable_experimental_witness_endpoint: false,
             tee_prover_registry_address: None,
             fetch_rollup_config: false,
+            l2_cl_url: None,
         }
     }
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -11,6 +11,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::Address;
+#[cfg(any(target_os = "linux", feature = "local"))]
+use alloy_primitives::B256;
+#[cfg(any(target_os = "linux", feature = "local"))]
+use alloy_provider::{Provider, ProviderBuilder};
 use base_cli_utils::{LogConfig, RuntimeManager};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_common_chains::rollup_config;
@@ -121,6 +125,13 @@ struct ProverRuntimeArgs {
     /// by on-chain signer validity and server `/healthz` is registration-gated.
     #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Option<Address>,
+
+    /// Fetch genesis config from the L2 node via `optimism_rollupConfig` RPC at
+    /// startup. Overrides placeholder genesis anchors and contract addresses in
+    /// the hardcoded chain config. Use for devnet/ephemeral chains where genesis
+    /// changes on every deployment.
+    #[arg(long, env = "FETCH_ROLLUP_CONFIG")]
+    fetch_rollup_config: bool,
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -150,10 +161,45 @@ impl ProverRuntimeArgs {
         })
     }
 
-    fn prover_config(self) -> eyre::Result<ProverConfig> {
+    async fn prover_config(self) -> eyre::Result<ProverConfig> {
         let l1_beacon_url = self.l1_beacon_url()?;
-        let rollup_config = rollup_config!(self.l2_chain_id)
+        let mut rollup_config = rollup_config!(self.l2_chain_id)
             .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?;
+
+        if self.fetch_rollup_config {
+            let rpc = fetch_rollup_config_from_rpc(&self.l2_eth_url).await?;
+
+            if rpc.l2_chain_id != self.l2_chain_id {
+                return Err(eyre!(
+                    "chain ID mismatch: --l2-chain-id is {} but the L2 node returned {}",
+                    self.l2_chain_id,
+                    rpc.l2_chain_id,
+                ));
+            }
+
+            info!(
+                genesis_l1_hash = %rpc.genesis.l1.hash,
+                genesis_l1_number = rpc.genesis.l1.number,
+                genesis_l2_hash = %rpc.genesis.l2.hash,
+                genesis_l2_time = rpc.genesis.l2_time,
+                deposit_contract = %rpc.deposit_contract_address,
+                system_config_address = %rpc.l1_system_config_address,
+                batcher_address = %rpc.genesis.system_config.batcher_addr,
+                "overriding genesis config from L2 node RPC"
+            );
+
+            rollup_config.genesis.l1.hash = rpc.genesis.l1.hash;
+            rollup_config.genesis.l1.number = rpc.genesis.l1.number;
+            rollup_config.genesis.l2.hash = rpc.genesis.l2.hash;
+            rollup_config.genesis.l2.number = rpc.genesis.l2.number;
+            rollup_config.genesis.l2_time = rpc.genesis.l2_time;
+            rollup_config.deposit_contract_address = rpc.deposit_contract_address;
+            rollup_config.l1_system_config_address = rpc.l1_system_config_address;
+
+            if let Some(ref mut sys) = rollup_config.genesis.system_config {
+                sys.batcher_address = rpc.genesis.system_config.batcher_addr;
+            }
+        }
 
         let l1_config = base_common_chains::L1_CONFIGS
             .get(&rollup_config.l1_chain_id)
@@ -300,7 +346,7 @@ impl ServerArgs {
     async fn run(self) -> eyre::Result<()> {
         let registration_health = self.runtime.registration_health_config();
         let registry_configured = registration_health.is_some();
-        let config = self.runtime.prover_config()?;
+        let config = self.runtime.prover_config().await?;
 
         if self.vsock_cid.is_empty() {
             return Err(eyre!("at least one --vsock-cid is required"));
@@ -358,7 +404,7 @@ impl LocalArgs {
     async fn run(self) -> eyre::Result<()> {
         let registration_health = self.runtime.registration_health_config();
         let registry_configured = registration_health.is_some();
-        let prover_config = self.runtime.prover_config()?;
+        let prover_config = self.runtime.prover_config().await?;
 
         if self.local_enclave_count == 0 {
             return Err(eyre!("--local-enclave-count must be at least 1"));
@@ -434,7 +480,7 @@ async fn run_worker(
 ) -> eyre::Result<()> {
     let registration_health = runtime.registration_health_config();
     let registry_configured = registration_health.is_some();
-    let config = runtime.prover_config()?;
+    let config = runtime.prover_config().await?;
 
     if transports.is_empty() {
         return Err(eyre!("at least one enclave transport is required"));
@@ -524,6 +570,58 @@ impl WorkerTransportMode {
     }
 }
 
+#[cfg(any(target_os = "linux", feature = "local"))]
+#[derive(Debug, serde::Deserialize)]
+struct RollupConfigRpcResponse {
+    genesis: GenesisRpcResponse,
+    deposit_contract_address: Address,
+    l1_system_config_address: Address,
+    l2_chain_id: u64,
+}
+
+#[cfg(any(target_os = "linux", feature = "local"))]
+#[derive(Debug, serde::Deserialize)]
+struct GenesisRpcResponse {
+    l1: BlockRefRpcResponse,
+    l2: BlockRefRpcResponse,
+    l2_time: u64,
+    system_config: SystemConfigRpcResponse,
+}
+
+#[cfg(any(target_os = "linux", feature = "local"))]
+#[derive(Debug, serde::Deserialize)]
+struct BlockRefRpcResponse {
+    hash: B256,
+    number: u64,
+}
+
+#[cfg(any(target_os = "linux", feature = "local"))]
+#[derive(Debug, serde::Deserialize)]
+struct SystemConfigRpcResponse {
+    #[serde(alias = "batcherAddr")]
+    batcher_addr: Address,
+}
+
+#[cfg(any(target_os = "linux", feature = "local"))]
+async fn fetch_rollup_config_from_rpc(
+    l2_eth_url: &str,
+) -> eyre::Result<RollupConfigRpcResponse> {
+    let provider = ProviderBuilder::new()
+        .connect(l2_eth_url)
+        .await
+        .map_err(|e| eyre!("failed to connect to L2 node at {l2_eth_url}: {e}"))?;
+
+    provider
+        .raw_request("optimism_rollupConfig".into(), ())
+        .await
+        .map_err(|e| {
+            eyre!(
+                "optimism_rollupConfig RPC failed on {l2_eth_url}: {e}. \
+                 Ensure the L2 node supports this method"
+            )
+        })
+}
+
 #[cfg(all(test, feature = "local"))]
 mod tests {
     use super::ProverRuntimeArgs;
@@ -537,6 +635,7 @@ mod tests {
             l2_chain_id: 8453,
             enable_experimental_witness_endpoint: false,
             tee_prover_registry_address: None,
+            fetch_rollup_config: false,
         }
     }
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -12,8 +12,6 @@ use std::time::Duration;
 
 use alloy_primitives::Address;
 #[cfg(any(target_os = "linux", feature = "local"))]
-use alloy_primitives::{B256, U256};
-#[cfg(any(target_os = "linux", feature = "local"))]
 use alloy_provider::{Provider, ProviderBuilder};
 use base_cli_utils::{LogConfig, RuntimeManager};
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -173,19 +171,21 @@ impl ProverRuntimeArgs {
             .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?;
 
         if self.fetch_rollup_config {
-            let cl_url = self.l2_cl_url.as_deref().ok_or_else(|| {
-                eyre!("--l2-cl-url is required when --fetch-rollup-config is set")
-            })?;
+            let cl_url = self
+                .l2_cl_url
+                .as_deref()
+                .expect("clap `requires` guarantees --l2-cl-url is present");
             let rpc = fetch_rollup_config_from_rpc(cl_url).await?;
 
-            if rpc.l2_chain_id != self.l2_chain_id {
+            if rpc.l2_chain_id.id() != self.l2_chain_id {
                 return Err(eyre!(
                     "chain ID mismatch: --l2-chain-id is {} but the L2 node returned {}",
                     self.l2_chain_id,
-                    rpc.l2_chain_id,
+                    rpc.l2_chain_id.id(),
                 ));
             }
 
+            let rpc_sc = rpc.genesis.system_config.as_ref();
             info!(
                 genesis_l1_hash = %rpc.genesis.l1.hash,
                 genesis_l1_number = rpc.genesis.l1.number,
@@ -195,25 +195,16 @@ impl ProverRuntimeArgs {
                 block_time = rpc.block_time,
                 deposit_contract = %rpc.deposit_contract_address,
                 system_config_address = %rpc.l1_system_config_address,
-                batcher_address = %rpc.genesis.system_config.batcher_addr,
-                gas_limit = rpc.genesis.system_config.gas_limit,
-                scalar = %rpc.genesis.system_config.scalar,
+                batcher_address = %rpc_sc.map(|sc| sc.batcher_address.to_string()).unwrap_or_default(),
+                gas_limit = rpc_sc.map(|sc| sc.gas_limit).unwrap_or_default(),
+                scalar = %rpc_sc.map(|sc| sc.scalar).unwrap_or_default(),
                 "overriding rollup config from L2 node RPC"
             );
 
-            rollup_config.genesis.l1.hash = rpc.genesis.l1.hash;
-            rollup_config.genesis.l1.number = rpc.genesis.l1.number;
-            rollup_config.genesis.l2.hash = rpc.genesis.l2.hash;
-            rollup_config.genesis.l2.number = rpc.genesis.l2.number;
-            rollup_config.genesis.l2_time = rpc.genesis.l2_time;
+            rollup_config.genesis = rpc.genesis;
             rollup_config.block_time = rpc.block_time;
             rollup_config.deposit_contract_address = rpc.deposit_contract_address;
             rollup_config.l1_system_config_address = rpc.l1_system_config_address;
-
-            let sc = rollup_config.genesis.system_config.get_or_insert_default();
-            sc.batcher_address = rpc.genesis.system_config.batcher_addr;
-            sc.gas_limit = rpc.genesis.system_config.gas_limit;
-            sc.scalar = rpc.genesis.system_config.scalar;
         }
 
         let l1_config = base_common_chains::L1_CONFIGS
@@ -586,43 +577,9 @@ impl WorkerTransportMode {
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
-#[derive(Debug, serde::Deserialize)]
-struct RollupConfigRpcResponse {
-    genesis: GenesisRpcResponse,
-    block_time: u64,
-    deposit_contract_address: Address,
-    l1_system_config_address: Address,
-    l2_chain_id: u64,
-}
-
-#[cfg(any(target_os = "linux", feature = "local"))]
-#[derive(Debug, serde::Deserialize)]
-struct GenesisRpcResponse {
-    l1: BlockRefRpcResponse,
-    l2: BlockRefRpcResponse,
-    l2_time: u64,
-    system_config: SystemConfigRpcResponse,
-}
-
-#[cfg(any(target_os = "linux", feature = "local"))]
-#[derive(Debug, serde::Deserialize)]
-struct BlockRefRpcResponse {
-    hash: B256,
-    number: u64,
-}
-
-#[cfg(any(target_os = "linux", feature = "local"))]
-#[derive(Debug, serde::Deserialize)]
-struct SystemConfigRpcResponse {
-    #[serde(alias = "batcherAddr")]
-    batcher_addr: Address,
-    #[serde(alias = "gasLimit")]
-    gas_limit: u64,
-    scalar: U256,
-}
-
-#[cfg(any(target_os = "linux", feature = "local"))]
-async fn fetch_rollup_config_from_rpc(cl_url: &str) -> eyre::Result<RollupConfigRpcResponse> {
+async fn fetch_rollup_config_from_rpc(
+    cl_url: &str,
+) -> eyre::Result<base_common_genesis::RollupConfig> {
     let provider = ProviderBuilder::new()
         .connect(cl_url)
         .await

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -192,12 +192,13 @@ impl ProverRuntimeArgs {
                 genesis_l2_hash = %rpc.genesis.l2.hash,
                 genesis_l2_number = rpc.genesis.l2.number,
                 genesis_l2_time = rpc.genesis.l2_time,
+                block_time = rpc.block_time,
                 deposit_contract = %rpc.deposit_contract_address,
                 system_config_address = %rpc.l1_system_config_address,
                 batcher_address = %rpc.genesis.system_config.batcher_addr,
                 gas_limit = rpc.genesis.system_config.gas_limit,
                 scalar = %rpc.genesis.system_config.scalar,
-                "overriding genesis config from L2 node RPC"
+                "overriding rollup config from L2 node RPC"
             );
 
             rollup_config.genesis.l1.hash = rpc.genesis.l1.hash;
@@ -205,6 +206,7 @@ impl ProverRuntimeArgs {
             rollup_config.genesis.l2.hash = rpc.genesis.l2.hash;
             rollup_config.genesis.l2.number = rpc.genesis.l2.number;
             rollup_config.genesis.l2_time = rpc.genesis.l2_time;
+            rollup_config.block_time = rpc.block_time;
             rollup_config.deposit_contract_address = rpc.deposit_contract_address;
             rollup_config.l1_system_config_address = rpc.l1_system_config_address;
 
@@ -587,6 +589,7 @@ impl WorkerTransportMode {
 #[derive(Debug, serde::Deserialize)]
 struct RollupConfigRpcResponse {
     genesis: GenesisRpcResponse,
+    block_time: u64,
     deposit_contract_address: Address,
     l1_system_config_address: Address,
     l2_chain_id: u64,

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -196,9 +196,8 @@ impl ProverRuntimeArgs {
             rollup_config.deposit_contract_address = rpc.deposit_contract_address;
             rollup_config.l1_system_config_address = rpc.l1_system_config_address;
 
-            if let Some(ref mut sys) = rollup_config.genesis.system_config {
-                sys.batcher_address = rpc.genesis.system_config.batcher_addr;
-            }
+            rollup_config.genesis.system_config.get_or_insert_default().batcher_address =
+                rpc.genesis.system_config.batcher_addr;
         }
 
         let l1_config = base_common_chains::L1_CONFIGS

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -167,10 +167,8 @@ impl ProverRuntimeArgs {
 
     async fn prover_config(self) -> eyre::Result<ProverConfig> {
         let l1_beacon_url = self.l1_beacon_url()?;
-        let mut rollup_config = rollup_config!(self.l2_chain_id)
-            .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?;
 
-        if self.fetch_rollup_config {
+        let rollup_config = if self.fetch_rollup_config {
             let cl_url = self
                 .l2_cl_url
                 .as_deref()
@@ -198,14 +196,14 @@ impl ProverRuntimeArgs {
                 batcher_address = %rpc_sc.map(|sc| sc.batcher_address.to_string()).unwrap_or_default(),
                 gas_limit = rpc_sc.map(|sc| sc.gas_limit).unwrap_or_default(),
                 scalar = %rpc_sc.map(|sc| sc.scalar).unwrap_or_default(),
-                "overriding rollup config from L2 node RPC"
+                "using rollup config from L2 node RPC"
             );
 
-            rollup_config.genesis = rpc.genesis;
-            rollup_config.block_time = rpc.block_time;
-            rollup_config.deposit_contract_address = rpc.deposit_contract_address;
-            rollup_config.l1_system_config_address = rpc.l1_system_config_address;
-        }
+            rpc
+        } else {
+            rollup_config!(self.l2_chain_id)
+                .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?
+        };
 
         let l1_config = base_common_chains::L1_CONFIGS
             .get(&rollup_config.l1_chain_id)

--- a/bin/prover/nitro-host/src/main.rs
+++ b/bin/prover/nitro-host/src/main.rs
@@ -8,6 +8,8 @@ use alloy_provider as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_common_chains as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
+use base_common_genesis as _;
+#[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_proof_host as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_proof_tee_nitro_host as _;

--- a/bin/prover/nitro-host/src/main.rs
+++ b/bin/prover/nitro-host/src/main.rs
@@ -4,6 +4,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 #[cfg(not(any(target_os = "linux", feature = "local")))]
+use alloy_provider as _;
+#[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_common_chains as _;
 #[cfg(not(any(target_os = "linux", feature = "local")))]
 use base_proof_host as _;

--- a/crates/proof/tee/nitro-enclave/src/error.rs
+++ b/crates/proof/tee/nitro-enclave/src/error.rs
@@ -108,9 +108,6 @@ pub enum NitroError {
     /// Internal error.
     #[error("internal error: {0}")]
     Internal(String),
-    /// Unsupported chain ID.
-    #[error("unsupported chain ID: {0}")]
-    UnsupportedChain(u64),
     /// Rollup config is missing `genesis.system_config`.
     #[error("rollup config for chain {0} is missing genesis.system_config")]
     MissingSystemConfig(u64),

--- a/crates/proof/tee/nitro-enclave/src/error.rs
+++ b/crates/proof/tee/nitro-enclave/src/error.rs
@@ -111,6 +111,9 @@ pub enum NitroError {
     /// Unsupported chain ID.
     #[error("unsupported chain ID: {0}")]
     UnsupportedChain(u64),
+    /// Rollup config is missing `genesis.system_config`.
+    #[error("rollup config for chain {0} is missing genesis.system_config")]
+    MissingSystemConfig(u64),
     /// A preimage's content does not match its hash-based key.
     #[error("preimage hash mismatch for key {0}")]
     InvalidPreimage(PreimageKey),

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -1,9 +1,6 @@
 /// Enclave server — manages keys, attestation, signing, and proof execution.
-use std::sync::LazyLock;
-
-use alloy_primitives::{Address, B256, Bytes, keccak256, map::HashMap};
+use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_signer_local::PrivateKeySigner;
-use base_common_chains::ChainConfig;
 use base_common_evm::BaseEvmFactory;
 use base_common_genesis::RollupConfig;
 use base_proof::BootInfo;
@@ -23,25 +20,19 @@ const SIGNER_KEY_ENV_VAR: &str = "BASE_ENCLAVE_SIGNER_KEY";
 /// PCR0 is a SHA-384 hash (48 bytes) per the AWS Nitro Enclaves specification.
 const PCR0_LENGTH: usize = 48;
 
-/// Per-chain config hashes derived from [`ChainConfig::all`] at first access.
+/// Compute the config hash from a [`RollupConfig`].
 ///
-/// Each entry is `keccak256(PerChainConfig::marshal_binary())` with defaults applied.
-/// Chains that lack a `system_config` in their rollup config are skipped.
-static CONFIG_HASHES: LazyLock<HashMap<u64, B256>> = LazyLock::new(|| {
-    let mut map = HashMap::default();
-    for cfg in ChainConfig::all() {
-        let rollup = RollupConfig::from(cfg);
-        if let Some(mut per_chain) = PerChainConfig::from_rollup_config(&rollup) {
-            per_chain.force_defaults();
-            map.insert(cfg.chain_id, per_chain.hash());
-        }
-    }
-    map
-});
-
-/// Look up the config hash for a supported chain.
-fn config_hash_for_chain(chain_id: u64) -> Result<B256> {
-    CONFIG_HASHES.get(&chain_id).copied().ok_or(NitroError::UnsupportedChain(chain_id))
+/// Builds a [`PerChainConfig`] from the rollup config, applies forced defaults,
+/// and returns the `keccak256` hash of its canonical binary encoding.
+///
+/// This replaces the previous hardcoded `CONFIG_HASHES` table so that chains
+/// not compiled into `ChainConfig::all()` (e.g. devnets) are supported.
+fn config_hash(rollup_config: &RollupConfig) -> Result<B256> {
+    let chain_id = rollup_config.l2_chain_id.id();
+    let mut per_chain = PerChainConfig::from_rollup_config(rollup_config)
+        .ok_or(NitroError::UnsupportedChain(chain_id))?;
+    per_chain.force_defaults();
+    Ok(per_chain.hash())
 }
 
 /// The enclave server.
@@ -148,7 +139,7 @@ impl Server {
 
         let boot_info =
             BootInfo::load(&oracle).await.map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
-        let config_hash = config_hash_for_chain(boot_info.chain_id)?;
+        let config_hash = config_hash(&boot_info.rollup_config)?;
         let agreed_l2_output_root = boot_info.agreed_l2_output_root;
 
         let prologue = Prologue::new(oracle.clone(), oracle, BaseEvmFactory::default());
@@ -288,64 +279,53 @@ mod tests {
     }
 
     #[test]
-    fn config_hash_unknown_chain() {
-        assert!(config_hash_for_chain(999999).is_err());
+    fn config_hash_missing_system_config() {
+        let rollup = RollupConfig {
+            genesis: base_common_genesis::ChainGenesis {
+                system_config: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(config_hash(&rollup).is_err());
     }
 
     #[test]
-    fn config_hashes_match_chain_configs() {
+    fn config_hash_matches_known_chains() {
+        use base_common_chains::ChainConfig;
+
         for cfg in ChainConfig::all() {
-            let chain_id = cfg.chain_id;
             let rollup = base_common_chains::rollup_config!(cfg);
             let Some(mut per_chain) = PerChainConfig::from_rollup_config(&rollup) else {
                 continue;
             };
             per_chain.force_defaults();
 
-            let cached = config_hash_for_chain(chain_id)
-                .unwrap_or_else(|_| panic!("missing config hash for chain {chain_id}"));
-            assert_eq!(per_chain.hash(), cached, "config hash mismatch for chain {chain_id}");
-        }
-    }
-
-    /// Print config hashes for supported chains so they can be hardcoded in the
-    /// enclave server. Run with:
-    /// `cargo test -p base-proof-tee-nitro-enclave print_real_config_hashes -- --nocapture --ignored`
-    #[test]
-    #[ignore]
-    fn print_real_config_hashes() {
-        for cfg in ChainConfig::all() {
-            let chain_id = cfg.chain_id;
-            let rollup = base_common_chains::rollup_config!(cfg);
-            let mut per_chain = match PerChainConfig::from_rollup_config(&rollup) {
-                Some(pc) => pc,
-                None => {
-                    println!("chain {chain_id}: skipped (no system_config)");
-                    continue;
-                }
-            };
-            per_chain.force_defaults();
-            println!("chain {chain_id}: {:?}", per_chain.hash());
+            let computed = config_hash(&rollup)
+                .unwrap_or_else(|_| panic!("config_hash failed for chain {}", cfg.chain_id));
+            assert_eq!(
+                per_chain.hash(),
+                computed,
+                "config hash mismatch for chain {}",
+                cfg.chain_id
+            );
         }
     }
 
     #[test]
     fn config_hash_known_values() {
-        assert_eq!(
-            config_hash_for_chain(8453).unwrap(),
-            b256!("1607709d90d40904f790574404e2ad614eac858f6162faa0ec34c6bf5e5f3c57"),
-        );
-        assert_eq!(
-            config_hash_for_chain(84532).unwrap(),
-            b256!("12e9c45f19f9817c6d4385fad29e7a70c355502cf0883e76a9a7e478a85d1360"),
-        );
-        assert_eq!(
-            config_hash_for_chain(1337).unwrap(),
-            b256!("1bb15c380e7cf5cfd303807cc1dff6cd5275a6facc7628091d8b3a7ab6d631b1"),
-        );
-        assert_eq!(
-            config_hash_for_chain(763360).unwrap(),
-            b256!("ab64b3118d2d030a3fd3fe3005239a2f332e48848bbedddca9e10df77ac7303e"),
-        );
+        use base_common_chains::ChainConfig;
+
+        let check = |chain_id: u64, expected: B256| {
+            let cfg = ChainConfig::by_chain_id(chain_id)
+                .unwrap_or_else(|| panic!("unknown chain {chain_id}"));
+            let rollup = cfg.rollup_config();
+            assert_eq!(config_hash(&rollup).unwrap(), expected, "chain {chain_id}");
+        };
+
+        check(8453, b256!("1607709d90d40904f790574404e2ad614eac858f6162faa0ec34c6bf5e5f3c57"));
+        check(84532, b256!("12e9c45f19f9817c6d4385fad29e7a70c355502cf0883e76a9a7e478a85d1360"));
+        check(1337, b256!("1bb15c380e7cf5cfd303807cc1dff6cd5275a6facc7628091d8b3a7ab6d631b1"));
+        check(763360, b256!("ab64b3118d2d030a3fd3fe3005239a2f332e48848bbedddca9e10df77ac7303e"));
     }
 }

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -30,7 +30,7 @@ const PCR0_LENGTH: usize = 48;
 fn config_hash(rollup_config: &RollupConfig) -> Result<B256> {
     let chain_id = rollup_config.l2_chain_id.id();
     let mut per_chain = PerChainConfig::from_rollup_config(rollup_config)
-        .ok_or(NitroError::UnsupportedChain(chain_id))?;
+        .ok_or(NitroError::MissingSystemConfig(chain_id))?;
     per_chain.force_defaults();
     Ok(per_chain.hash())
 }


### PR DESCRIPTION
## Summary

Adds `--fetch-rollup-config` / `--l2-cl-url` CLI flags to `base-prover-nitro-host` for fetching genesis config from an L2 CL node via `optimism_rollupConfig` RPC. Also fixes the enclave to compute `config_hash` dynamically from the rollup config instead of a hardcoded table, so non-built-in chains (e.g. devnet 84534) can produce valid signed proofs.

## Host changes (`bin/prover/nitro-host/`)

- **`cli.rs`**: `--fetch-rollup-config` bool flag, `--l2-cl-url` CL endpoint, RPC response structs, `fetch_rollup_config_from_rpc()`, async `prover_config()` with override logic, all 3 call sites updated.
- **`Cargo.toml`**: Added `alloy-provider` with `reqwest` feature.
- **`main.rs`**: `use alloy_provider as _;` unused dep guard.

When `--fetch-rollup-config` is set: fetches config from CL, validates chain ID, overrides genesis fields on the resolved `RollupConfig`. Hard error if RPC fails or `--l2-cl-url` missing.

## Enclave change (`crates/proof/tee/nitro-enclave/`)

- **`server.rs`**: Replaced `CONFIG_HASHES` `LazyLock` table (hardcoded from `ChainConfig::all()`) with `config_hash()` that computes `PerChainConfig` from `boot_info.rollup_config`. The rollup config already flows through preimage oracle key 6 — we just weren't using it for `config_hash`. Known chain hashes unchanged (verified by golden-value tests). Matches ZK pipeline's `hash_rollup_config()`.

## Why `--l2-cl-url`?

`optimism_rollupConfig` is a CL method (op-node), not EL (reth/geth). Verified on devnet: EL returns "Method not found", CL works.

## Usage

```bash
base-prover-nitro-host local \
  --l2-eth-url http://base-rpc:8645 \
  --l2-cl-url http://base-builder-cl:7549 \
  --l2-chain-id 84534 \
  --fetch-rollup-config
```