### PR TITLE
refactor(registrar): clean up driver

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -632,9 +632,9 @@ impl Cli {
             config.l1_rpc_url.clone(),
         );
 
-        // The driver always carries a certificate manager, but only calls it
-        // when CRL checking is enabled. When disabled and no verifier address
-        // is configured, bind the unused client to the zero address.
+        // The driver always carries a certificate manager. When CRL checking is
+        // disabled and no verifier address is configured, bind the unused
+        // client to the zero address.
         let nitro_verifier_address = config.crl.nitro_verifier_address.unwrap_or(Address::ZERO);
         let nitro_verifier: Arc<dyn NitroVerifierClient> = Arc::new(
             NitroVerifierContractClient::new(nitro_verifier_address, config.l1_rpc_url.clone()),
@@ -685,14 +685,14 @@ impl Cli {
         let driver_config = DriverConfig {
             poll_interval: config.poll_interval,
             cancel: cancel.clone(),
-            signer_manager: SignerManagerConfig {
-                registry_address: config.tee_prover_registry_address,
-                max_concurrency: config.max_concurrency,
-                max_tx_retries: config.max_tx_retries,
-                tx_retry_delay: config.tx_retry_delay,
-            },
+            max_concurrency: config.max_concurrency,
             unhealthy_registration_window: config.unhealthy_registration_window,
-            crl: config.crl,
+        };
+        let signer_manager_config = SignerManagerConfig {
+            registry_address: config.tee_prover_registry_address,
+            max_concurrency: config.max_concurrency,
+            max_tx_retries: config.max_tx_retries,
+            tx_retry_delay: config.tx_retry_delay,
         };
 
         // Mark the service as ready. This signals "initialised and running", not
@@ -705,9 +705,9 @@ impl Cli {
             proof_provider,
             registry,
             tx_manager.clone(),
-            driver_config.signer_manager.clone(),
+            signer_manager_config,
         ));
-        let cert_manager = CertManager::new(&driver_config.crl, nitro_verifier, tx_manager)?;
+        let cert_manager = CertManager::new(&config.crl, nitro_verifier, tx_manager)?;
         let cancel_guard = cancel.clone().drop_guard();
         let driver = RegistrationDriver::new(
             discovery,

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -362,8 +362,12 @@ mod tests {
         let mut config = crl_config();
         config.enabled = false;
         let verifier = Arc::new(MockNitroVerifier::default());
-        let cert_manager = CertManager::new(&config, verifier.clone(), MockTxManager::default())
-            .expect("disabled cert manager still builds");
+        let cert_manager = CertManager::new(
+            &config,
+            Arc::<MockNitroVerifier>::clone(&verifier),
+            MockTxManager::default(),
+        )
+        .expect("disabled cert manager still builds");
 
         let result =
             cert_manager.check_and_revoke_crls(b"not-an-attestation", &test_instance()).await;

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -17,6 +17,7 @@ use crate::{
 
 /// Manages Nitro certificate revocation checks and revocation transaction submission.
 pub struct CertManager<T> {
+    enabled: bool,
     http_client: reqwest::Client,
     nitro_verifier: Arc<dyn NitroVerifierClient>,
     tx_manager: T,
@@ -51,7 +52,7 @@ where
                 "failed to build CRL HTTP client (Layer 2 / AWS CRL fetch): {e}"
             ))
         })?;
-        Ok(Self { http_client, nitro_verifier, tx_manager })
+        Ok(Self { enabled: config.enabled, http_client, nitro_verifier, tx_manager })
     }
 
     /// Checks an attestation's intermediate certificates and submits revocations.
@@ -69,6 +70,10 @@ where
         attestation_bytes: &[u8],
         instance: &ProverInstance,
     ) -> Result<bool> {
+        if !self.enabled {
+            return Ok(false);
+        }
+
         let cert_infos = {
             let report = AttestationReport::parse(attestation_bytes).map_err(|e| {
                 RegistrarError::ProverClient {
@@ -321,6 +326,7 @@ mod tests {
 
     fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
         CertManager {
+            enabled: true,
             http_client: reqwest::Client::new(),
             nitro_verifier: verifier,
             tx_manager: MockTxManager::default(),
@@ -349,6 +355,25 @@ mod tests {
         let verifier = Arc::new(MockNitroVerifier::default());
         let result = CertManager::new(&crl_config(), verifier, MockTxManager::default());
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn check_and_revoke_crls_noops_when_disabled() {
+        let mut config = crl_config();
+        config.enabled = false;
+        let verifier = Arc::new(MockNitroVerifier::default());
+        let cert_manager = CertManager::new(&config, verifier.clone(), MockTxManager::default())
+            .expect("disabled cert manager still builds");
+
+        let result =
+            cert_manager.check_and_revoke_crls(b"not-an-attestation", &test_instance()).await;
+
+        assert!(!result.expect("disabled CRL checks must no-op"));
+        assert_eq!(
+            verifier.call_count.load(Ordering::SeqCst),
+            0,
+            "disabled CRL checks must not query the verifier",
+        );
     }
 
     fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -164,24 +164,13 @@ where
         let mut proof_tasks = ProofTaskSet::new();
 
         loop {
-            // Reap before discovery so finished tasks don't linger in
-            // `pending` for an entire cycle and (incorrectly) cause
-            // reconcile to skip spawning a replacement on transient
-            // failure (audit finding #9).
+            // Keep task state current before reconcile decisions each cycle.
             proof_tasks.reap_finished_tasks();
 
             match self.discover_and_resolve().await {
                 Ok(resolution) => {
-                    // Reap again: a task that finished during the
-                    // (potentially slow) discovery RPCs would otherwise
-                    // look in-flight to reconcile and get spuriously
-                    // re-cancelled or have its respawn deferred a cycle.
                     proof_tasks.reap_finished_tasks();
 
-                    // Spawning new proof tasks during a shutdown would
-                    // acquire L1 nonces we have no intention of
-                    // broadcasting. Skip reconcile (and the orphan
-                    // dereg pass) entirely when cancellation is set.
                     if !self.config.cancel.is_cancelled() {
                         self.signer_manager.reconcile_proof_tasks(
                             &resolution,
@@ -191,8 +180,6 @@ where
                     }
 
                     if resolution.ok_to_dereg && !self.config.cancel.is_cancelled() {
-                        // Pending proof tasks can register while orphan cleanup
-                        // is running, so protect those signers too.
                         let protected = proof_tasks.protected_signers(&resolution);
                         if let Err(e) = self
                             .signer_manager
@@ -216,8 +203,6 @@ where
                 }
             }
 
-            // Publish gauge once per cycle, after every path that could
-            // mutate `pending` (reconcile, reap) has run.
             RegistrarMetrics::proof_tasks_pending().set(proof_tasks.pending_len() as f64);
 
             tokio::select! {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -5,7 +5,7 @@
 //! to L1 via the [`TxManager`]. Also detects orphaned onchain signers (those
 //! no longer backed by a healthy instance) and deregisters them.
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, hex};
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
@@ -17,7 +17,8 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
-    ProverInstance, RegistrarMetrics, RegistryClient, Result, SignerClient, SignerManager,
+    ProverInstance, RegistrarError, RegistrarMetrics, RegistryClient, Result, SignerClient,
+    SignerManager,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -77,15 +78,14 @@ pub struct DiscoveryResolution {
     pub registerable: Vec<RegisterableSigner>,
     /// Signers contributed by reachable instances.
     pub active_signers: HashSet<Address>,
-    /// Whether any instance had inconclusive resolution this cycle.
-    pub has_unresolved_instances: bool,
+    /// Instance IDs whose resolution was inconclusive this cycle.
+    pub unresolved_instance_ids: HashSet<String>,
 }
 
 /// Core registration loop tying together discovery, attestation polling, signer
 /// lifecycle reconciliation, and orphan cleanup.
 ///
 /// Generic over discovery and RPC backends.
-#[derive(Debug)]
 pub struct RegistrationDriver<D, S, P, R, T> {
     discovery: D,
     signer_client: S,
@@ -94,6 +94,12 @@ pub struct RegistrationDriver<D, S, P, R, T> {
     cert_manager: CertManager<T>,
     /// Signer lifecycle manager for registration tasks and orphan cleanup.
     signer_manager: Arc<SignerManager<P, R, T>>,
+}
+
+impl<D, S, P, R, T> fmt::Debug for RegistrationDriver<D, S, P, R, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RegistrationDriver").field("config", &self.config).finish_non_exhaustive()
+    }
 }
 
 impl<D, S, P, R, T> RegistrationDriver<D, S, P, R, T>
@@ -249,7 +255,7 @@ where
                     "failed to fetch signer attestations after resolving signer addresses"
                 );
                 RegistrarMetrics::processing_errors_total().increment(1);
-                outcome.has_unresolved_instances = true;
+                outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
                 return Ok(outcome);
             }
         };
@@ -262,14 +268,19 @@ where
                 "signer attestation count was lower than signer public key count"
             );
             RegistrarMetrics::processing_errors_total().increment(1);
-            outcome.has_unresolved_instances = true;
+            outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
             return Ok(outcome);
         }
 
         if self.config.cancel.is_cancelled() {
             return Ok(outcome);
         }
-        match self.cert_manager.check_and_revoke_crls(&all_attestations[0], instance).await {
+        let first_attestation =
+            all_attestations.first().ok_or_else(|| RegistrarError::ProverClient {
+                instance: instance.endpoint.to_string(),
+                source: "no attestations available for CRL check".into(),
+            })?;
+        match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
             Ok(true) => {
                 warn!(
                     instance = %instance.instance_id,
@@ -342,7 +353,7 @@ where
                     reachable_count += 1;
                     resolution.registerable.extend(outcome.registerable);
                     resolution.active_signers.extend(outcome.active_signers);
-                    resolution.has_unresolved_instances |= outcome.has_unresolved_instances;
+                    resolution.unresolved_instance_ids.extend(outcome.unresolved_instance_ids);
                 }
                 Err(e) => {
                     warn!(
@@ -352,13 +363,13 @@ where
                         "failed to resolve instance"
                     );
                     RegistrarMetrics::processing_errors_total().increment(1);
-                    resolution.has_unresolved_instances = true;
+                    resolution.unresolved_instance_ids.insert(instance.instance_id);
                 }
             }
         }
 
         let ok_to_dereg = !self.config.cancel.is_cancelled()
-            && !resolution.has_unresolved_instances
+            && resolution.unresolved_instance_ids.is_empty()
             && (total_count == 0 || reachable_count * 2 > total_count);
 
         if !ok_to_dereg {
@@ -633,7 +644,7 @@ mod tests {
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert_eq!(resolution.registerable.len(), reachable.len());
-        assert!(resolution.has_unresolved_instances);
+        assert_eq!(resolution.unresolved_instance_ids, HashSet::from([unreachable.instance_id]));
         assert!(!ok_to_dereg);
     }
 
@@ -693,7 +704,10 @@ mod tests {
 
             assert!(resolution.active_signers.contains(&signer_addr));
             assert!(resolution.registerable.is_empty());
-            assert!(resolution.has_unresolved_instances);
+            assert_eq!(
+                resolution.unresolved_instance_ids,
+                HashSet::from([inst.instance_id.clone()])
+            );
             assert!(!ok_to_dereg);
         }
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -92,12 +92,6 @@ pub struct DiscoveryResolution {
     pub registerable: Vec<RegisterableSigner>,
     /// Signers contributed by reachable instances.
     pub active_signers: HashSet<Address>,
-    /// Number of discovered instances that responded to discovery RPCs.
-    pub reachable_count: usize,
-    /// Total instances returned by discovery (reachable + unreachable).
-    pub total_count: usize,
-    /// Whether orphan deregistration is safe to run this cycle.
-    pub ok_to_dereg: bool,
     /// Instance IDs with inconclusive resolution this cycle.
     pub unresolved_instance_ids: HashSet<String>,
 }
@@ -166,7 +160,7 @@ where
             proof_tasks.reap_finished_tasks();
 
             match self.discover_and_resolve().await {
-                Ok(resolution) => {
+                Ok((resolution, ok_to_dereg)) => {
                     proof_tasks.reap_finished_tasks();
 
                     if !self.config.cancel.is_cancelled() {
@@ -177,7 +171,7 @@ where
                         );
                     }
 
-                    if resolution.ok_to_dereg && !self.config.cancel.is_cancelled() {
+                    if ok_to_dereg && !self.config.cancel.is_cancelled() {
                         let protected = proof_tasks.protected_signers(&resolution);
                         if let Err(e) = self
                             .signer_manager
@@ -187,12 +181,6 @@ where
                             warn!(error = %e, "orphan deregistration pass failed");
                             RegistrarMetrics::processing_errors_total().increment(1);
                         }
-                    } else if !resolution.ok_to_dereg {
-                        debug!(
-                            reachable = resolution.reachable_count,
-                            total = resolution.total_count,
-                            "skipping orphan deregistration this cycle"
-                        );
                     }
                 }
                 Err(e) => {
@@ -338,7 +326,7 @@ where
     }
 
     /// Runs one discovery cycle and resolves every instance into a [`DiscoveryResolution`].
-    async fn discover_and_resolve(&self) -> Result<DiscoveryResolution> {
+    async fn discover_and_resolve(&self) -> Result<(DiscoveryResolution, bool)> {
         let instances = self.discovery.discover_instances().await?;
         RegistrarMetrics::discovery_success_total().increment(1);
 
@@ -422,14 +410,18 @@ where
             && unresolved_instance_ids.is_empty()
             && (total_count == 0 || reachable_count * 2 > total_count);
 
-        Ok(DiscoveryResolution {
-            registerable,
-            active_signers,
-            reachable_count,
-            total_count,
+        if !ok_to_dereg {
+            debug!(
+                reachable = reachable_count,
+                total = total_count,
+                "skipping orphan deregistration this cycle"
+            );
+        }
+
+        Ok((
+            DiscoveryResolution { registerable, active_signers, unresolved_instance_ids },
             ok_to_dereg,
-            unresolved_instance_ids,
-        })
+        ))
     }
 }
 
@@ -697,7 +689,7 @@ mod tests {
             CancellationToken::new(),
         );
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert_eq!(
             resolution.registerable.len(),
             1,
@@ -708,7 +700,7 @@ mod tests {
             resolution.active_signers.contains(&addr),
             "recently-launched unhealthy signer should be in active_signers"
         );
-        assert!(resolution.ok_to_dereg, "resolved instance permits orphan cleanup");
+        assert!(ok_to_dereg, "resolved instance permits orphan cleanup");
     }
 
     #[tokio::test]
@@ -716,12 +708,9 @@ mod tests {
         let driver =
             cycle_driver(vec![], MockSignerClient::from_keys(&[]), CancellationToken::new());
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert!(resolution.active_signers.is_empty(), "no instances → no active signers");
-        assert!(
-            resolution.ok_to_dereg,
-            "zero-instance fleet drain is a legitimate empty active set",
-        );
+        assert!(ok_to_dereg, "zero-instance fleet drain is a legitimate empty active set",);
     }
 
     #[tokio::test]
@@ -735,9 +724,9 @@ mod tests {
         let driver = cycle_driver(instances, signer_client, cancel.clone());
 
         cancel.cancel();
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (_, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
-        assert!(!resolution.ok_to_dereg, "cancellation must clear ok_to_dereg",);
+        assert!(!ok_to_dereg, "cancellation must clear ok_to_dereg",);
     }
 
     #[tokio::test]
@@ -747,12 +736,9 @@ mod tests {
             .with_cancel_after_public_key_success(cancel.clone());
         let driver = cycle_driver(vec![healthy_prover_instance(EP1)], signer_client, cancel);
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (_, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
-        assert!(
-            !resolution.ok_to_dereg,
-            "cancellation observed during resolution must clear ok_to_dereg",
-        );
+        assert!(!ok_to_dereg, "cancellation observed during resolution must clear ok_to_dereg",);
     }
 
     #[tokio::test]
@@ -765,11 +751,9 @@ mod tests {
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (_, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
-        assert_eq!(resolution.reachable_count, 1);
-        assert_eq!(resolution.total_count, 3);
-        assert!(!resolution.ok_to_dereg, "1/3 reachable must block orphan-deregistration",);
+        assert!(!ok_to_dereg, "1/3 reachable must block orphan-deregistration",);
     }
 
     #[tokio::test]
@@ -792,7 +776,7 @@ mod tests {
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert_eq!(
             resolution.registerable.len(),
             reachable.len(),
@@ -802,7 +786,7 @@ mod tests {
             resolution.unresolved_instance_ids.contains(&unreachable.instance_id),
             "unreachable instance must be marked as unresolved so reconcile skips its cancel-pass",
         );
-        assert!(!resolution.ok_to_dereg, "unresolved instance must block orphan-dereg",);
+        assert!(!ok_to_dereg, "unresolved instance must block orphan-dereg",);
     }
 
     #[tokio::test]
@@ -816,14 +800,14 @@ mod tests {
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert!(
             resolution.registerable.is_empty(),
             "draining instance must not appear in the registerable set",
         );
         assert!(resolution.active_signers.contains(&addr0));
         assert!(resolution.active_signers.contains(&addr1));
-        assert!(resolution.ok_to_dereg);
+        assert!(ok_to_dereg);
     }
 
     #[tokio::test]
@@ -841,7 +825,7 @@ mod tests {
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert_eq!(
             resolution.registerable.len(),
             1,
@@ -852,7 +836,7 @@ mod tests {
             resolution.active_signers.contains(&addr_unhealthy),
             "unhealthy signer must remain in active_signers to block dereg",
         );
-        assert!(resolution.ok_to_dereg);
+        assert!(ok_to_dereg);
     }
 
     #[rstest]
@@ -872,7 +856,7 @@ mod tests {
 
         let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
         assert!(
             resolution.active_signers.contains(&signer_addr),
@@ -886,7 +870,7 @@ mod tests {
             resolution.unresolved_instance_ids.contains(&inst.instance_id),
             "partial resolution must preserve in-flight tasks for the instance",
         );
-        assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
+        assert!(!ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
     }
 
     #[tokio::test]
@@ -914,7 +898,7 @@ mod tests {
             signer_manager,
         );
 
-        let resolution = driver.discover_and_resolve().await.unwrap();
+        let (resolution, _) = driver.discover_and_resolve().await.unwrap();
 
         let observed_peak = peak.load(Ordering::SeqCst);
         assert!(

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -454,10 +454,6 @@ where
             } else if total_count == 0 {
                 true
             } else {
-                // Plain `* 2` (rather than `saturating_mul`) — `reachable_count`
-                // is bounded above by `total_count = instances.len()`, so the
-                // doubling can only overflow on a list with `usize::MAX / 2`
-                // entries, which is physically impossible.
                 reachable_count * 2 > total_count
             };
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
-    CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
+    CertManager, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
     ProverInstance, RegistrarMetrics, RegistryClient, Result, SignerClient, SignerManager,
 };
 
@@ -62,9 +62,6 @@ pub struct DriverConfig {
     /// while the application is still initializing. Set to zero to disable.
     /// Defaults to [`DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS`] seconds.
     pub unhealthy_registration_window: Duration,
-    /// CRL checking configuration. When enabled, intermediate certificates
-    /// are checked against CRL distribution points before registration.
-    pub crl: CrlConfig,
 }
 
 /// A signer and attestation ready to be spawned as a proof task.
@@ -100,8 +97,7 @@ pub struct RegistrationDriver<D, S, P, R, T> {
     discovery: D,
     signer_client: S,
     config: DriverConfig,
-    /// Certificate revocation manager. The driver only calls it when CRL
-    /// checking is enabled.
+    /// Certificate revocation manager.
     cert_manager: CertManager<T>,
     /// Signer lifecycle manager for registration tasks and orphan cleanup.
     signer_manager: Arc<SignerManager<P, R, T>>,
@@ -282,28 +278,25 @@ where
             return Ok(outcome);
         }
 
-        if self.config.crl.enabled {
-            // skip CRL work after cancellation
-            if self.config.cancel.is_cancelled() {
+        if self.config.cancel.is_cancelled() {
+            return Ok(outcome);
+        }
+        let first_attestation = &all_attestations[0];
+        match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
+            Ok(true) => {
+                warn!(
+                    instance = %instance.instance_id,
+                    "certificate revoked, skipping registration for this instance"
+                );
                 return Ok(outcome);
             }
-            let first_attestation = &all_attestations[0];
-            match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
-                Ok(true) => {
-                    warn!(
-                        instance = %instance.instance_id,
-                        "certificate revoked, skipping registration for this instance"
-                    );
-                    return Ok(outcome);
-                }
-                Ok(false) => {}
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        instance = %instance.instance_id,
-                        "CRL check failed (fail-open, proceeding with registration)"
-                    );
-                }
+            Ok(false) => {}
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    instance = %instance.instance_id,
+                    "CRL check failed (fail-open, proceeding with registration)"
+                );
             }
         }
 
@@ -418,7 +411,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        InstanceHealthStatus, RegistrarError, RegistryClient, Result, SignerClient,
+        CrlConfig, InstanceHealthStatus, RegistrarError, RegistryClient, Result, SignerClient,
         SignerManagerConfig,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
@@ -586,12 +579,17 @@ mod tests {
         Url::parse(&format!("http://{host_port}")).unwrap()
     }
 
-    fn mock_cert_manager<T: TxManager + 'static>(
-        config: &DriverConfig,
-        tx_manager: T,
-    ) -> CertManager<T> {
-        CertManager::new(&config.crl, Arc::new(NoopNitroVerifier), tx_manager)
+    fn mock_cert_manager<T: TxManager + 'static>(tx_manager: T) -> CertManager<T> {
+        CertManager::new(&crl_config(false), Arc::new(NoopNitroVerifier), tx_manager)
             .expect("test cert manager builds")
+    }
+
+    fn crl_config(enabled: bool) -> CrlConfig {
+        CrlConfig {
+            enabled,
+            nitro_verifier_address: None,
+            fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
+        }
     }
 
     fn noop_signer_manager(
@@ -608,11 +606,6 @@ mod tests {
             unhealthy_registration_window: Duration::from_secs(
                 DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
             ),
-            crl: CrlConfig {
-                enabled: false,
-                nitro_verifier_address: None,
-                fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
-            },
         }
     }
 
@@ -634,7 +627,7 @@ mod tests {
         S: SignerClient + 'static,
     {
         let config = default_config(cancel);
-        let cert_manager = mock_cert_manager(&config, NoopTxManager);
+        let cert_manager = mock_cert_manager(NoopTxManager);
         let signer_manager = noop_signer_manager(signer_manager_config());
         RegistrationDriver::new(
             MockDiscovery { instances },
@@ -860,7 +853,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut config = default_config(cancel);
         config.max_concurrency = max_concurrency;
-        let cert_manager = mock_cert_manager(&config, NoopTxManager);
+        let cert_manager = mock_cert_manager(NoopTxManager);
         let signer_manager = noop_signer_manager(signer_manager_config());
 
         let driver = RegistrationDriver::new(

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -336,28 +336,10 @@ where
         }
 
         if self.config.crl.enabled {
-            // Skip the CRL check and any `revokeCert` submission on shutdown
-            // so we do not start new onchain work.
-            //
-            // Return `attestations: None` so the safety invariant —
-            // `Some(..)` ↔ "passed every eligibility + security gate,
-            // including CRL" — is enforced locally. Today the outer
-            // run loop re-checks `cancel.is_cancelled()` before
-            // calling `reconcile_proof_tasks`, so a `Some(..)` here
-            // would still be discarded; keeping it `None` removes the
-            // non-local dependence on that re-check and matches the
-            // CRL-revoked branch below.
+            // skip CRL work after cancellation
             if self.config.cancel.is_cancelled() {
                 return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
             }
-            // Use `.first()` rather than `[0]` so the non-empty
-            // invariant is locally visible: the `addresses.is_empty()`
-            // early-return and the
-            // `all_attestations.len() < addresses.len()` length check
-            // above already guarantee at least one element, but those
-            // sites are 65+ lines upstream. Surfacing the `Option`
-            // here keeps `resolve_instance` indexing-panic-free even
-            // if a future refactor relaxes either upstream guard.
             let first_attestation =
                 all_attestations.first().ok_or_else(|| RegistrarError::ProverClient {
                     instance: instance.endpoint.to_string(),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -224,20 +224,7 @@ where
         Ok(())
     }
 
-    /// Returns `true` if the instance is [`InstanceHealthStatus::Unhealthy`]
-    /// and was launched within the configured
-    /// [`DriverConfig::unhealthy_registration_window`].
-    ///
-    /// New EC2 instances may fail ALB health checks while the application is
-    /// still initializing. This predicate lets the registrar attempt
-    /// registration during that warm-up period rather than waiting for the
-    /// instance to become healthy.
-    ///
-    /// Returns `false` if:
-    /// - The instance is not `Unhealthy` (other statuses have their own rules).
-    /// - The window is zero (feature disabled).
-    /// - The instance has no launch time (e.g. discovery didn't return one).
-    /// - The launch time is in the future (clock skew — treated as unknown).
+    /// Recently launched unhealthy instances may still register.
     fn is_recently_launched_unhealthy(&self, instance: &ProverInstance) -> bool {
         if instance.health_status != InstanceHealthStatus::Unhealthy {
             return false;

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -222,15 +222,12 @@ where
 
     /// Recently launched unhealthy instances may still register.
     fn is_recently_launched_unhealthy(&self, instance: &ProverInstance) -> bool {
-        if instance.health_status != InstanceHealthStatus::Unhealthy {
-            return false;
-        }
-        if self.config.unhealthy_registration_window.is_zero() {
-            return false;
-        }
-        instance.launch_time.is_some_and(|lt| {
-            lt.elapsed().is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
-        })
+        instance.health_status == InstanceHealthStatus::Unhealthy
+            && !self.config.unhealthy_registration_window.is_zero()
+            && instance.launch_time.is_some_and(|lt| {
+                lt.elapsed()
+                    .is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
+            })
     }
 
     /// Returns addresses always for active signer tracking.

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -237,30 +237,8 @@ where
         })
     }
 
-    /// Resolves the signer addresses for a single instance and decides
-    /// whether registration should be attempted this cycle.
-    ///
-    /// Always returns `addresses` so the caller can track the instance's
-    /// signers in the active set (protecting them from orphan
-    /// deregistration even when registration is skipped). The
-    /// `attestations` field is `Some` only when registration should be
-    /// attempted; it is `None` when:
-    ///
-    /// - the instance is not register-eligible (e.g. `Draining`, or
-    ///   `Unhealthy` outside the
-    ///   [`DriverConfig::unhealthy_registration_window`]);
-    /// - the CRL check confirmed revocation for the instance's chain.
-    ///
-    /// This is the shared resolution path used by `discover_and_resolve`.
-    /// It keeps discovery and eligibility checks separate from the
-    /// [`RegistrationManager`] registration path so long proof work can run in
-    /// spawned tasks instead of blocking the next discovery cycle.
-    ///
-    /// **Cancellation contract.** This future checks
-    /// `self.config.cancel.is_cancelled()` before starting new side effects.
-    /// `check_and_revoke_crls` awaits any `revokeCert` transaction
-    /// submissions it triggers, so revocation outcomes are logged before
-    /// the resolution future returns.
+    /// Returns addresses always for active signer tracking.
+    /// Returns attestations only when the instance is registerable.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
         if self.config.cancel.is_cancelled() {
             return Ok(ResolveOutcome {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -5,9 +5,10 @@
 //! to L1 via the [`TxManager`]. Also detects orphaned onchain signers (those
 //! no longer backed by a healthy instance) and deregisters them.
 
-use std::{collections::HashSet, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, hex};
+use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use futures::stream::StreamExt;
 use rand::random;
@@ -16,7 +17,8 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
-    ProverInstance, RegistrarMetrics, Result, SignerClient, SignerLifecycle, SignerManagerConfig,
+    ProverInstance, RegistrarMetrics, RegistryClient, Result, SignerClient, SignerManager,
+    SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -114,10 +116,9 @@ pub struct ResolveOutcome {
 /// Core registration loop tying together discovery, attestation polling, signer
 /// lifecycle reconciliation, and orphan cleanup.
 ///
-/// Generic over discovery, signer client, and signer lifecycle backends so each
-/// can be mocked independently in tests.
+/// Generic over discovery and RPC backends.
 #[derive(Debug)]
-pub struct RegistrationDriver<D, S, M, T> {
+pub struct RegistrationDriver<D, S, P, R, T> {
     discovery: D,
     signer_client: S,
     config: DriverConfig,
@@ -125,14 +126,15 @@ pub struct RegistrationDriver<D, S, M, T> {
     /// checking is enabled.
     cert_manager: CertManager<T>,
     /// Signer lifecycle manager for registration tasks and orphan cleanup.
-    signer_manager: M,
+    signer_manager: Arc<SignerManager<P, R, T>>,
 }
 
-impl<D, S, M, T> RegistrationDriver<D, S, M, T>
+impl<D, S, P, R, T> RegistrationDriver<D, S, P, R, T>
 where
     D: InstanceDiscovery + 'static,
     S: SignerClient + 'static,
-    M: SignerLifecycle + 'static,
+    P: AttestationProofProvider + 'static,
+    R: RegistryClient + 'static,
     T: TxManager + 'static,
 {
     /// Creates a new registration driver.
@@ -144,7 +146,7 @@ where
         signer_client: S,
         config: DriverConfig,
         cert_manager: CertManager<T>,
-        signer_manager: M,
+        signer_manager: Arc<SignerManager<P, R, T>>,
     ) -> Self {
         Self { discovery, signer_client, config, cert_manager, signer_manager }
     }
@@ -436,7 +438,7 @@ mod tests {
     use std::{
         collections::{HashMap, HashSet},
         sync::{
-            Arc, Mutex,
+            Arc,
             atomic::{AtomicUsize, Ordering},
         },
         time::SystemTime,
@@ -444,13 +446,14 @@ mod tests {
 
     use alloy_primitives::Address;
     use async_trait::async_trait;
+    use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
     use crate::{
-        InstanceHealthStatus, RegistrarError, Result, SignerClient,
+        InstanceHealthStatus, RegistrarError, RegistryClient, Result, SignerClient,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
             NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
@@ -585,6 +588,34 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct NoopProofProvider;
+
+    #[async_trait]
+    impl AttestationProofProvider for NoopProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+            _cancel: &CancellationToken,
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            unreachable!("driver discover_and_resolve tests do not spawn proof tasks")
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoopRegistry;
+
+    #[async_trait]
+    impl RegistryClient for NoopRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            unreachable!("driver discover_and_resolve tests do not query registration state")
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            unreachable!("driver discover_and_resolve tests do not run orphan deregistration")
+        }
+    }
+
     fn endpoint_url(host_port: &str) -> Url {
         Url::parse(&format!("http://{host_port}")).unwrap()
     }
@@ -597,43 +628,15 @@ mod tests {
             .expect("test cert manager builds")
     }
 
-    #[derive(Debug)]
-    struct MockSignerManager {
-        reconcile_calls: AtomicUsize,
-        orphan_calls: Mutex<Vec<HashSet<Address>>>,
-        cancel_after_orphan: CancellationToken,
-    }
-
-    impl MockSignerManager {
-        fn new(cancel_after_orphan: CancellationToken) -> Self {
-            Self {
-                reconcile_calls: AtomicUsize::new(0),
-                orphan_calls: Mutex::new(Vec::new()),
-                cancel_after_orphan,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl SignerLifecycle for MockSignerManager {
-        fn reconcile_proof_tasks(
-            &self,
-            _resolution: &DiscoveryResolution,
-            _proof_tasks: &mut ProofTaskSet,
-            _cancel: &CancellationToken,
-        ) {
-            self.reconcile_calls.fetch_add(1, Ordering::SeqCst);
-        }
-
-        async fn run_orphan_dereg(
-            &self,
-            protected_signers: &HashSet<Address>,
-            _cancel: &CancellationToken,
-        ) -> Result<()> {
-            self.orphan_calls.lock().unwrap().push(protected_signers.clone());
-            self.cancel_after_orphan.cancel();
-            Ok(())
-        }
+    fn noop_signer_manager(
+        config: &DriverConfig,
+    ) -> Arc<SignerManager<NoopProofProvider, NoopRegistry, NoopTxManager>> {
+        Arc::new(SignerManager::new(
+            NoopProofProvider,
+            NoopRegistry,
+            NoopTxManager,
+            config.signer_manager.clone(),
+        ))
     }
 
     fn default_config(cancel: CancellationToken) -> DriverConfig {
@@ -661,13 +664,13 @@ mod tests {
         instances: Vec<ProverInstance>,
         signer_client: S,
         cancel: CancellationToken,
-    ) -> RegistrationDriver<MockDiscovery, S, MockSignerManager, NoopTxManager>
+    ) -> RegistrationDriver<MockDiscovery, S, NoopProofProvider, NoopRegistry, NoopTxManager>
     where
         S: SignerClient + 'static,
     {
         let config = default_config(cancel);
-        let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
+        let signer_manager = noop_signer_manager(&config);
         RegistrationDriver::new(
             MockDiscovery { instances },
             signer_client,
@@ -675,41 +678,6 @@ mod tests {
             cert_manager,
             signer_manager,
         )
-    }
-
-    const FAST_POLL_INTERVAL: Duration = Duration::from_millis(25);
-
-    #[tokio::test]
-    async fn run_uses_injected_signer_manager_boundary() {
-        let cancel = CancellationToken::new();
-        let mut config = default_config(cancel.clone());
-        config.poll_interval = FAST_POLL_INTERVAL;
-
-        let signer_manager = MockSignerManager::new(cancel.clone());
-        let signer = signer_from_private_key(&HARDHAT_KEY_0);
-        let cert_manager = mock_cert_manager(&config, NoopTxManager);
-
-        let driver = RegistrationDriver::new(
-            MockDiscovery { instances: vec![healthy_prover_instance(EP1)] },
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
-            config,
-            cert_manager,
-            signer_manager,
-        );
-
-        driver.run().await.expect("driver exits after mock orphan pass cancels");
-
-        assert_eq!(
-            driver.signer_manager.reconcile_calls.load(Ordering::SeqCst),
-            1,
-            "driver should delegate registerable reconciliation to signer manager",
-        );
-        let orphan_inputs = driver.signer_manager.orphan_calls.lock().unwrap();
-        assert_eq!(orphan_inputs.len(), 1, "driver should delegate one orphan pass");
-        assert!(
-            orphan_inputs[0].contains(&signer),
-            "driver passes active signer set into orphan protection",
-        );
     }
 
     #[tokio::test]
@@ -935,8 +903,8 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut config = default_config(cancel);
         config.signer_manager.max_concurrency = max_concurrency;
-        let signer_manager = MockSignerManager::new(CancellationToken::new());
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
+        let signer_manager = noop_signer_manager(&config);
 
         let driver = RegistrationDriver::new(
             MockDiscovery { instances },

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -419,16 +419,6 @@ where
                         unresolved_instance_ids.insert(instance.instance_id.clone());
                     }
                     if let Some(attestations) = outcome.attestations {
-                        // `resolve_instance` already enforced the pairing
-                        // invariants (non-empty addresses,
-                        // `attestations.len() >= addresses.len()`) with
-                        // richer per-instance errors. Flatten one entry
-                        // per (signer, attestation) so the spawn pass in
-                        // `reconcile_proof_tasks` becomes a flat
-                        // iteration. The `zip` truncates at the shorter
-                        // side, which mirrors the upstream invariant —
-                        // any extra trailing attestations are dropped on
-                        // the floor as before.
                         for (enclave_index, (signer, attestation)) in
                             outcome.addresses.into_iter().zip(attestations).enumerate()
                         {

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -116,6 +116,7 @@ pub struct ResolveOutcome {
 ///
 /// Generic over discovery, signer client, and signer lifecycle backends so each
 /// can be mocked independently in tests.
+#[derive(Debug)]
 pub struct RegistrationDriver<D, S, M, T> {
     discovery: D,
     signer_client: S,
@@ -599,28 +600,20 @@ mod tests {
             .expect("test cert manager builds")
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     struct MockSignerManager {
-        reconcile_calls: Arc<AtomicUsize>,
-        orphan_calls: Arc<Mutex<Vec<HashSet<Address>>>>,
+        reconcile_calls: AtomicUsize,
+        orphan_calls: Mutex<Vec<HashSet<Address>>>,
         cancel_after_orphan: CancellationToken,
     }
 
     impl MockSignerManager {
         fn new(cancel_after_orphan: CancellationToken) -> Self {
             Self {
-                reconcile_calls: Arc::new(AtomicUsize::new(0)),
-                orphan_calls: Arc::new(Mutex::new(Vec::new())),
+                reconcile_calls: AtomicUsize::new(0),
+                orphan_calls: Mutex::new(Vec::new()),
                 cancel_after_orphan,
             }
-        }
-
-        fn reconcile_count(&self) -> usize {
-            self.reconcile_calls.load(Ordering::SeqCst)
-        }
-
-        fn orphan_inputs(&self) -> Vec<HashSet<Address>> {
-            self.orphan_calls.lock().unwrap().clone()
         }
     }
 
@@ -696,7 +689,6 @@ mod tests {
         config.poll_interval = FAST_POLL_INTERVAL;
 
         let signer_manager = MockSignerManager::new(cancel.clone());
-        let signer_manager_handle = signer_manager.clone();
         let signer = signer_from_private_key(&HARDHAT_KEY_0);
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
 
@@ -711,11 +703,11 @@ mod tests {
         driver.run().await.expect("driver exits after mock orphan pass cancels");
 
         assert_eq!(
-            signer_manager_handle.reconcile_count(),
+            driver.signer_manager.reconcile_calls.load(Ordering::SeqCst),
             1,
             "driver should delegate registerable reconciliation to signer manager",
         );
-        let orphan_inputs = signer_manager_handle.orphan_inputs();
+        let orphan_inputs = driver.signer_manager.orphan_calls.lock().unwrap();
         assert_eq!(orphan_inputs.len(), 1, "driver should delegate one orphan pass");
         assert!(
             orphan_inputs[0].contains(&signer),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -400,7 +400,7 @@ mod tests {
 
     #[async_trait]
     impl InstanceDiscovery for Vec<ProverInstance> {
-        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
+        async fn discover_instances(&self) -> Result<Self> {
             Ok(self.clone())
         }
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -150,40 +150,6 @@ where
     }
 
     /// Runs the registration loop until cancelled.
-    ///
-    /// # Pipeline
-    ///
-    /// Each cycle is non-blocking with respect to in-flight proof
-    /// generation. Discovery, reconcile, and orphan cleanup all execute
-    /// in the foreground; proofs run in dedicated `JoinSet` tasks owned
-    /// by `pending`:
-    ///
-    /// 1. **Reap** — drain any task that finished since the previous
-    ///    cycle (`reap_finished_tasks`).
-    /// 2. **Discover & resolve** — produce a [`DiscoveryResolution`]
-    ///    snapshot (`discover_and_resolve`).
-    /// 3. **Reconcile** — cancel in-flight tasks for vanished /
-    ///    ineligible signers, spawn new tasks for registerable signers
-    ///    that are not already in-flight (`reconcile_proof_tasks`).
-    /// 4. **Orphan dereg** — when the snapshot's `ok_to_dereg` is set,
-    ///    run a single deregistration pass over signers no longer backed
-    ///    by an active instance (`run_orphan_dereg`). The protected set
-    ///    is the union of `resolution.active_signers` and the keys of
-    ///    `pending` (see [`ProofTaskSet::protected_signers`]) so a signer
-    ///    registered mid-cycle by a preserved task — whose source
-    ///    instance failed `resolve_instance` transiently — cannot be
-    ///    deregistered in the same pass.
-    /// 5. **Sleep** — wait `poll_interval` or until cancelled.
-    ///
-    /// # Cancellation
-    ///
-    /// On shutdown every `PendingRegistration::cancel` is fired cooperatively;
-    /// tasks are then awaited to natural completion via
-    /// `join_next_with_id` so each terminal outcome flows through
-    /// the signer manager join-outcome path, keeping the proof-task metrics
-    /// consistent. `JoinSet::abort_all` is deliberately **not** used — see
-    /// [`ProofTaskSet::drain_proof_tasks`] for the nonce-gap rationale.
-    ///
     pub async fn run(self) -> Result<()> {
         self.run_loop().await
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -77,8 +77,8 @@ pub struct DiscoveryResolution {
     pub registerable: Vec<RegisterableSigner>,
     /// Signers contributed by reachable instances.
     pub active_signers: HashSet<Address>,
-    /// Instance IDs with inconclusive resolution this cycle.
-    pub unresolved_instance_ids: HashSet<String>,
+    /// Whether any instance had inconclusive resolution this cycle.
+    pub has_unresolved_instances: bool,
 }
 
 /// Core registration loop tying together discovery, attestation polling, signer
@@ -142,17 +142,17 @@ where
                             &mut proof_tasks,
                             &self.config.cancel,
                         );
-                    }
 
-                    if ok_to_dereg && !self.config.cancel.is_cancelled() {
-                        let protected = proof_tasks.protected_signers(&resolution);
-                        if let Err(e) = self
-                            .signer_manager
-                            .run_orphan_dereg(&protected, &self.config.cancel)
-                            .await
-                        {
-                            warn!(error = %e, "orphan deregistration pass failed");
-                            RegistrarMetrics::processing_errors_total().increment(1);
+                        if ok_to_dereg {
+                            let protected = proof_tasks.protected_signers(&resolution);
+                            if let Err(e) = self
+                                .signer_manager
+                                .run_orphan_dereg(&protected, &self.config.cancel)
+                                .await
+                            {
+                                warn!(error = %e, "orphan deregistration pass failed");
+                                RegistrarMetrics::processing_errors_total().increment(1);
+                            }
                         }
                     }
                 }
@@ -183,16 +183,6 @@ where
         Ok(())
     }
 
-    /// Recently launched unhealthy instances may still register.
-    fn is_recently_launched_unhealthy(&self, instance: &ProverInstance) -> bool {
-        instance.health_status == InstanceHealthStatus::Unhealthy
-            && !self.config.unhealthy_registration_window.is_zero()
-            && instance.launch_time.is_some_and(|lt| {
-                lt.elapsed()
-                    .is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
-            })
-    }
-
     /// Resolves one instance into active and registerable signers.
     async fn resolve_instance(&self, instance: &ProverInstance) -> Result<DiscoveryResolution> {
         if self.config.cancel.is_cancelled() {
@@ -214,7 +204,14 @@ where
         }
 
         if !instance.health_status.should_register() {
-            if !self.is_recently_launched_unhealthy(instance) {
+            let recently_launched_unhealthy = instance.health_status
+                == InstanceHealthStatus::Unhealthy
+                && !self.config.unhealthy_registration_window.is_zero()
+                && instance.launch_time.is_some_and(|lt| {
+                    lt.elapsed()
+                        .is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
+                });
+            if !recently_launched_unhealthy {
                 debug!(
                     status = ?instance.health_status,
                     instance = %instance.instance_id,
@@ -253,7 +250,7 @@ where
                     "failed to fetch signer attestations after resolving signer addresses"
                 );
                 RegistrarMetrics::processing_errors_total().increment(1);
-                outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
+                outcome.has_unresolved_instances = true;
                 return Ok(outcome);
             }
         };
@@ -266,7 +263,7 @@ where
                 "signer attestation count was lower than signer public key count"
             );
             RegistrarMetrics::processing_errors_total().increment(1);
-            outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
+            outcome.has_unresolved_instances = true;
             return Ok(outcome);
         }
 
@@ -347,7 +344,7 @@ where
                     reachable_count += 1;
                     resolution.registerable.extend(outcome.registerable);
                     resolution.active_signers.extend(outcome.active_signers);
-                    resolution.unresolved_instance_ids.extend(outcome.unresolved_instance_ids);
+                    resolution.has_unresolved_instances |= outcome.has_unresolved_instances;
                 }
                 Err(e) => {
                     warn!(
@@ -357,17 +354,13 @@ where
                         "failed to resolve instance"
                     );
                     RegistrarMetrics::processing_errors_total().increment(1);
-                    // Mark this instance as inconclusive so reconcile
-                    // does NOT cancel in-flight proof tasks tied to it
-                    // (see `DiscoveryResolution::unresolved_instance_ids`
-                    // for the rationale).
-                    resolution.unresolved_instance_ids.insert(instance.instance_id.clone());
+                    resolution.has_unresolved_instances = true;
                 }
             }
         }
 
         let ok_to_dereg = !self.config.cancel.is_cancelled()
-            && resolution.unresolved_instance_ids.is_empty()
+            && !resolution.has_unresolved_instances
             && (total_count == 0 || reachable_count * 2 > total_count);
 
         if !ok_to_dereg {
@@ -414,7 +407,7 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Default)]
+    #[derive(Clone, Debug, Default)]
     struct MockSignerClient {
         keys: HashMap<Url, Vec<Vec<u8>>>,
         attestations: HashMap<Url, Vec<Vec<u8>>>,
@@ -491,11 +484,8 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct NoopProofProvider;
-
     #[async_trait]
-    impl AttestationProofProvider for NoopProofProvider {
+    impl AttestationProofProvider for MockSignerClient {
         async fn generate_proof(
             &self,
             _attestation_bytes: &[u8],
@@ -505,11 +495,8 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct NoopRegistry;
-
     #[async_trait]
-    impl RegistryClient for NoopRegistry {
+    impl RegistryClient for () {
         async fn is_registered(&self, _signer: Address) -> Result<bool> {
             unreachable!("driver discover_and_resolve tests do not query registration state")
         }
@@ -523,14 +510,17 @@ mod tests {
         Url::parse(&format!("http://{host_port}")).unwrap()
     }
 
-    fn cycle_driver<S>(
+    fn cycle_driver(
         instances: Vec<ProverInstance>,
-        signer_client: S,
+        signer_client: MockSignerClient,
         cancel: CancellationToken,
-    ) -> RegistrationDriver<Vec<ProverInstance>, S, NoopProofProvider, NoopRegistry, NoopTxManager>
-    where
-        S: SignerClient + 'static,
-    {
+    ) -> RegistrationDriver<
+        Vec<ProverInstance>,
+        MockSignerClient,
+        MockSignerClient,
+        (),
+        NoopTxManager,
+    > {
         let config = DriverConfig {
             poll_interval: Duration::from_secs(1),
             cancel,
@@ -548,8 +538,8 @@ mod tests {
             CertManager::new(&crl_config, Arc::new(NoopNitroVerifier), NoopTxManager)
                 .expect("test cert manager builds");
         let signer_manager = Arc::new(SignerManager::new(
-            NoopProofProvider,
-            NoopRegistry,
+            signer_client.clone(),
+            (),
             NoopTxManager,
             SignerManagerConfig {
                 registry_address: TEST_REGISTRY_ADDRESS,
@@ -645,7 +635,7 @@ mod tests {
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
         assert_eq!(resolution.registerable.len(), reachable.len());
-        assert!(resolution.unresolved_instance_ids.contains(&unreachable.instance_id));
+        assert!(resolution.has_unresolved_instances);
         assert!(!ok_to_dereg);
     }
 
@@ -705,7 +695,7 @@ mod tests {
 
             assert!(resolution.active_signers.contains(&signer_addr));
             assert!(resolution.registerable.is_empty());
-            assert!(resolution.unresolved_instance_ids.contains(&inst.instance_id));
+            assert!(resolution.has_unresolved_instances);
             assert!(!ok_to_dereg);
         }
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -71,94 +71,44 @@ pub struct DriverConfig {
     pub crl: CrlConfig,
 }
 
-/// A single (signer, attestation) pair from a prover instance that
-/// passed all per-cycle gates and is ready to be spawned as a proof task.
-///
-/// One [`RegisterableSigner`] corresponds to exactly one spawned proof
-/// task. Instances with multiple enclaves are flattened into one entry
-/// per enclave at construction time in `discover_and_resolve`, so the
-/// spawn pass in `reconcile_proof_tasks` is a flat iteration with no
-/// per-entry index correlation between parallel vectors.
-///
-/// Replaces the earlier 3-tuple `(ProverInstance, Vec<Address>,
-/// Vec<Vec<u8>>)` whose unnamed positional fields made the
-/// `attestations[idx]` indexing contract invisible at the call site.
+/// A signer and attestation ready to be spawned as a proof task.
 #[derive(Debug, Clone)]
 pub struct RegisterableSigner {
-    /// Source prover instance, retained so per-signer log lines and
-    /// `PendingRegistration::instance_id` can attribute the spawned
-    /// task. Cloned per enclave on the source instance (typically N=1)
-    /// at flatten time.
+    /// Source prover instance for attribution.
     pub instance: ProverInstance,
-    /// Signer address derived from one of the instance's enclave public
-    /// keys. Each address gets its own spawned proof task.
+    /// Signer address derived from an enclave public key.
     pub signer: Address,
-    /// Pre-fetched attestation blob paired with [`Self::signer`] at
-    /// flatten time.
+    /// Pre-fetched attestation blob for the signer.
     pub attestation: Vec<u8>,
-    /// Zero-based enclave index on the source instance, preserved from
-    /// the original `(addresses, attestations)` enumeration so per-task
-    /// log lines can attribute which enclave on a multi-enclave instance
-    /// the signer came from.
+    /// Zero-based enclave index on the source instance.
     pub enclave_index: usize,
 }
 
-/// Aggregate output of the driver's per-cycle `discover_and_resolve` pass —
-/// the snapshot consumed by the spawn-and-reap loop.
+/// Per-cycle discovery snapshot consumed by signer reconciliation.
 #[derive(Debug, Default)]
 pub struct DiscoveryResolution {
-    /// Instances eligible for registration this cycle, with their derived
-    /// signer addresses and the matching pre-fetched attestation blobs
-    /// (one per enclave on the instance). Instances whose certificates
-    /// were confirmed revoked by the CRL check are filtered out.
+    /// Signers eligible for registration this cycle.
     pub registerable: Vec<RegisterableSigner>,
-    /// All signers contributed by *reachable* instances, regardless of
-    /// register-eligibility. Used to protect draining/unhealthy
-    /// instances from premature orphan deregistration.
+    /// Signers contributed by reachable instances.
     pub active_signers: HashSet<Address>,
     /// Number of discovered instances that responded to discovery RPCs.
     pub reachable_count: usize,
     /// Total instances returned by discovery (reachable + unreachable).
     pub total_count: usize,
-    /// Whether orphan deregistration is safe to run this cycle. `true`
-    /// when the cancellation token has not fired, no discovered instance
-    /// had an inconclusive resolution, **and either** `total_count` is zero
-    /// (legitimate fleet drain) **or** a strict majority of discovered
-    /// instances were reachable (`reachable * 2 > total`). `false` during
-    /// shutdown (to avoid acquiring nonces we don't intend to broadcast),
-    /// when any instance resolution was inconclusive, or when too few
-    /// instances responded for the quorum guard to clear.
+    /// Whether orphan deregistration is safe to run this cycle.
     pub ok_to_dereg: bool,
-    /// Instance IDs whose resolution was inconclusive this cycle, either
-    /// because `resolve_instance` returned `Err` or because it returned
-    /// `Ok` with `unresolved: true`. In-flight proof tasks for these
-    /// instances must be preserved until a later cycle reaches a verdict.
+    /// Instance IDs with inconclusive resolution this cycle.
     pub unresolved_instance_ids: HashSet<String>,
 }
 
-/// Per-instance result of address resolution and registration-eligibility
-/// gating. `attestations` is `Some` only when the instance is registerable
-/// and its CRL check did not flag revocation; otherwise it is `None` and
-/// the caller skips registration but still uses `addresses` for the
-/// active-signer set. `unresolved` distinguishes intentional skips
-/// (draining, old unhealthy, revoked, shutdown) from partial failures after
-/// signer addresses were known (for example, attestation RPC failure).
+/// Per-instance result of address resolution and registration gating.
 #[derive(Debug)]
 pub struct ResolveOutcome {
     /// Signer addresses derived from the instance's enclave public keys.
     pub addresses: Vec<Address>,
-    /// Pre-fetched attestation blobs when the instance is register-eligible
-    /// this cycle; `None` when registration is being skipped (health
-    /// status, CRL revocation, shutdown).
+    /// Pre-fetched attestation blobs when the instance is register-eligible.
     pub attestations: Option<Vec<Vec<u8>>>,
-    /// Whether resolution reached an inconclusive state after signer
-    /// addresses were already known.
-    ///
-    /// The caller should still add [`Self::addresses`] to the active set,
-    /// because the instance proved it is reachable and advertising those
-    /// signers, but should also preserve any in-flight proof task tied to
-    /// the instance because registration eligibility could not be decided
-    /// this cycle.
+    /// Whether resolution ended inconclusively after addresses were known.
     pub unresolved: bool,
 }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -18,7 +18,6 @@ use tracing::{Instrument, debug, info, info_span, warn};
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
     ProverInstance, RegistrarMetrics, RegistryClient, Result, SignerClient, SignerManager,
-    SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -56,12 +55,8 @@ pub struct DriverConfig {
     pub poll_interval: Duration,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
-    /// Signer lifecycle settings.
-    ///
-    /// The registrar currently uses `signer_manager.max_concurrency` for both
-    /// per-cycle instance resolution and spawned proof task concurrency so one
-    /// CLI setting controls total signer lifecycle pressure.
-    pub signer_manager: SignerManagerConfig,
+    /// Maximum number of instances resolved concurrently per discovery cycle.
+    pub max_concurrency: usize,
     /// Duration after launch during which unhealthy instances are still
     /// eligible for registration. New instances may fail ALB health checks
     /// while the application is still initializing. Set to zero to disable.
@@ -149,7 +144,7 @@ where
     pub async fn run(&self) -> Result<()> {
         info!(
             poll_interval = ?self.config.poll_interval,
-            registry = %self.config.signer_manager.registry_address,
+            max_concurrency = self.config.max_concurrency,
             "starting registration driver"
         );
 
@@ -346,7 +341,7 @@ where
         let mut registerable: Vec<RegisterableSigner> = Vec::new();
         let mut unresolved_instance_ids: HashSet<String> = HashSet::new();
 
-        let concurrency = self.config.signer_manager.max_concurrency.max(1);
+        let concurrency = self.config.max_concurrency.max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
             let span = info_span!(
                 "resolve_instance",
@@ -446,6 +441,7 @@ mod tests {
     use super::*;
     use crate::{
         InstanceHealthStatus, RegistrarError, RegistryClient, Result, SignerClient,
+        SignerManagerConfig,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
             NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
@@ -621,26 +617,16 @@ mod tests {
     }
 
     fn noop_signer_manager(
-        config: &DriverConfig,
+        config: SignerManagerConfig,
     ) -> Arc<SignerManager<NoopProofProvider, NoopRegistry, NoopTxManager>> {
-        Arc::new(SignerManager::new(
-            NoopProofProvider,
-            NoopRegistry,
-            NoopTxManager,
-            config.signer_manager.clone(),
-        ))
+        Arc::new(SignerManager::new(NoopProofProvider, NoopRegistry, NoopTxManager, config))
     }
 
     fn default_config(cancel: CancellationToken) -> DriverConfig {
         DriverConfig {
             poll_interval: Duration::from_secs(1),
             cancel,
-            signer_manager: SignerManagerConfig {
-                registry_address: TEST_REGISTRY_ADDRESS,
-                max_concurrency: DEFAULT_MAX_CONCURRENCY,
-                max_tx_retries: DEFAULT_MAX_TX_RETRIES,
-                tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
-            },
+            max_concurrency: DEFAULT_MAX_CONCURRENCY,
             unhealthy_registration_window: Duration::from_secs(
                 DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
             ),
@@ -649,6 +635,15 @@ mod tests {
                 nitro_verifier_address: None,
                 fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
             },
+        }
+    }
+
+    fn signer_manager_config() -> SignerManagerConfig {
+        SignerManagerConfig {
+            registry_address: TEST_REGISTRY_ADDRESS,
+            max_concurrency: DEFAULT_MAX_CONCURRENCY,
+            max_tx_retries: DEFAULT_MAX_TX_RETRIES,
+            tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
         }
     }
 
@@ -662,7 +657,7 @@ mod tests {
     {
         let config = default_config(cancel);
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
-        let signer_manager = noop_signer_manager(&config);
+        let signer_manager = noop_signer_manager(signer_manager_config());
         RegistrationDriver::new(
             MockDiscovery { instances },
             signer_client,
@@ -886,9 +881,9 @@ mod tests {
 
         let cancel = CancellationToken::new();
         let mut config = default_config(cancel);
-        config.signer_manager.max_concurrency = max_concurrency;
+        config.max_concurrency = max_concurrency;
         let cert_manager = mock_cert_manager(&config, NoopTxManager);
-        let signer_manager = noop_signer_manager(&config);
+        let signer_manager = noop_signer_manager(signer_manager_config());
 
         let driver = RegistrationDriver::new(
             MockDiscovery { instances },

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -249,10 +249,11 @@ where
         }
 
         let public_keys = self.signer_client.signer_public_key(&instance.endpoint).await?;
-        let mut addresses = Vec::with_capacity(public_keys.len());
-        for public_key in &public_keys {
-            addresses.push(ProverClient::derive_address(public_key)?);
-        }
+        let addresses = public_keys
+            .iter()
+            .map(Vec::as_slice)
+            .map(ProverClient::derive_address)
+            .collect::<Result<Vec<_>>>()?;
 
         if addresses.is_empty() {
             return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -209,8 +209,7 @@ where
         let public_keys = self.signer_client.signer_public_key(&instance.endpoint).await?;
         let addresses = public_keys
             .iter()
-            .map(Vec::as_slice)
-            .map(ProverClient::derive_address)
+            .map(|key| ProverClient::derive_address(key))
             .collect::<Result<Vec<_>>>()?;
         let mut outcome = DiscoveryResolution {
             active_signers: addresses.iter().copied().collect(),
@@ -281,8 +280,7 @@ where
         if self.config.cancel.is_cancelled() {
             return Ok(outcome);
         }
-        let first_attestation = &all_attestations[0];
-        match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
+        match self.cert_manager.check_and_revoke_crls(&all_attestations[0], instance).await {
             Ok(true) => {
                 warn!(
                     instance = %instance.instance_id,
@@ -395,10 +393,7 @@ where
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
+        sync::Arc,
         time::SystemTime,
     };
 
@@ -414,9 +409,9 @@ mod tests {
         CrlConfig, InstanceHealthStatus, RegistrarError, RegistryClient, Result, SignerClient,
         SignerManagerConfig,
         test_utils::{
-            EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
-            NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
-            prover_instance, public_key_from_private, signer_from_private_key,
+            EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, NoopNitroVerifier,
+            NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance, prover_instance,
+            public_key_from_private, signer_from_private_key,
         },
     };
 
@@ -432,14 +427,12 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct MockSignerClient {
         keys: HashMap<Url, Vec<Vec<u8>>>,
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
         cancel_after_public_key_success: Option<CancellationToken>,
-        in_flight: Option<Arc<AtomicUsize>>,
-        peak: Option<Arc<AtomicUsize>>,
     }
 
     impl MockSignerClient {
@@ -451,26 +444,12 @@ mod tests {
                     (url, vec![public_key_from_private(pk)])
                 })
                 .collect();
-            Self {
-                keys,
-                attestations: HashMap::new(),
-                fail_attestation: HashSet::new(),
-                cancel_after_public_key_success: None,
-                in_flight: None,
-                peak: None,
-            }
+            Self { keys, ..Self::default() }
         }
 
         fn multi_enclave(host_port: &str, private_keys: &[&[u8; 32]]) -> Self {
             let pubs = private_keys.iter().map(|pk| public_key_from_private(pk)).collect();
-            Self {
-                keys: HashMap::from([(endpoint_url(host_port), pubs)]),
-                attestations: HashMap::new(),
-                fail_attestation: HashSet::new(),
-                cancel_after_public_key_success: None,
-                in_flight: None,
-                peak: None,
-            }
+            Self { keys: HashMap::from([(endpoint_url(host_port), pubs)]), ..Self::default() }
         }
 
         fn with_attestations(mut self, host_port: &str, attestations: Vec<Vec<u8>>) -> Self {
@@ -488,23 +467,16 @@ mod tests {
             self
         }
 
-        fn with_concurrency_tracking(mut self) -> (Self, Arc<AtomicUsize>) {
-            let peak = Arc::new(AtomicUsize::new(0));
-            self.in_flight = Some(Arc::new(AtomicUsize::new(0)));
-            self.peak = Some(Arc::clone(&peak));
-            (self, peak)
-        }
-
         fn signer_public_key_result(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
             let result =
                 self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
                     instance: endpoint.to_string(),
                     source: "unreachable".into(),
                 });
-            if result.is_ok() {
-                if let Some(cancel) = &self.cancel_after_public_key_success {
-                    cancel.cancel();
-                }
+            if result.is_ok()
+                && let Some(cancel) = &self.cancel_after_public_key_success
+            {
+                cancel.cancel();
             }
             result
         }
@@ -513,17 +485,6 @@ mod tests {
     #[async_trait]
     impl SignerClient for MockSignerClient {
         async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            if let (Some(in_flight), Some(peak)) = (&self.in_flight, &self.peak) {
-                let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-                peak.fetch_max(current, Ordering::SeqCst);
-
-                tokio::task::yield_now().await;
-
-                let result = self.signer_public_key_result(endpoint);
-                in_flight.fetch_sub(1, Ordering::SeqCst);
-                return result;
-            }
-
             self.signer_public_key_result(endpoint)
         }
 
@@ -680,22 +641,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_before_run() {
-        let instances = vec![healthy_prover_instance(EP1), healthy_prover_instance(EP2)];
-
-        let signer_client =
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
-
-        let cancel = CancellationToken::new();
-        let driver = cycle_driver(instances, signer_client, cancel.clone());
-
-        cancel.cancel();
-        let (_, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
-
-        assert!(!ok_to_dereg, "cancellation must clear ok_to_dereg",);
-    }
-
-    #[tokio::test]
     async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_mid_resolution() {
         let cancel = CancellationToken::new();
         let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)])
@@ -837,44 +782,5 @@ mod tests {
             "partial resolution must preserve in-flight tasks for the instance",
         );
         assert!(!ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
-    }
-
-    #[tokio::test]
-    async fn discover_and_resolve_respects_max_concurrency() {
-        let max_concurrency = 2;
-        let endpoints = [EP1, EP2, EP3, EP4];
-        let private_keys = [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];
-
-        let keys: Vec<(&str, &[u8; 32])> =
-            endpoints.iter().copied().zip(private_keys.iter().copied()).collect();
-        let instances: Vec<_> = endpoints.iter().map(|ep| healthy_prover_instance(ep)).collect();
-        let (signer_client, peak) = MockSignerClient::from_keys(&keys).with_concurrency_tracking();
-
-        let cancel = CancellationToken::new();
-        let mut config = default_config(cancel);
-        config.max_concurrency = max_concurrency;
-        let cert_manager = mock_cert_manager(NoopTxManager);
-        let signer_manager = noop_signer_manager(signer_manager_config());
-
-        let driver = RegistrationDriver::new(
-            MockDiscovery { instances },
-            signer_client,
-            config,
-            cert_manager,
-            signer_manager,
-        );
-
-        let (resolution, _) = driver.discover_and_resolve().await.unwrap();
-
-        let observed_peak = peak.load(Ordering::SeqCst);
-        assert!(
-            observed_peak <= max_concurrency,
-            "peak concurrency {observed_peak} exceeded max_concurrency {max_concurrency}",
-        );
-        assert_eq!(
-            resolution.registerable.len(),
-            endpoints.len(),
-            "all 4 healthy instances should resolve into the registerable set",
-        );
     }
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -479,32 +479,21 @@ mod tests {
         time::SystemTime,
     };
 
-    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom, Bytes};
-    use alloy_rpc_types_eth::TransactionReceipt;
-    use alloy_sol_types::SolCall as _;
+    use alloy_primitives::Address;
     use async_trait::async_trait;
-    use base_proof_contracts::ITEEProverRegistry;
-    use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
-    use base_tx_manager::{SendHandle, TxCandidate};
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
     use crate::{
-        InstanceHealthStatus, RegistryClient, Result, SignerClient, SignerManager,
+        InstanceHealthStatus, Result, SignerClient,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
             NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,
             prover_instance, public_key_from_private, signer_from_private_key,
         },
     };
-
-    const ALL_ENDPOINTS: [&str; 4] = [EP1, EP2, EP3, EP4];
-    const ALL_KEYS: [&[u8; 32]; 4] =
-        [&HARDHAT_KEY_0, &HARDHAT_KEY_1, &HARDHAT_KEY_2, &HARDHAT_KEY_3];
-    const GATED_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
     #[derive(Debug)]
     struct MockDiscovery {
@@ -515,28 +504,6 @@ mod tests {
     impl InstanceDiscovery for MockDiscovery {
         async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
             Ok(self.instances.clone())
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct MutableDiscovery {
-        instances: Arc<Mutex<Vec<ProverInstance>>>,
-    }
-
-    impl MutableDiscovery {
-        fn new(initial: Vec<ProverInstance>) -> Self {
-            Self { instances: Arc::new(Mutex::new(initial)) }
-        }
-
-        fn set(&self, instances: Vec<ProverInstance>) {
-            *self.instances.lock().unwrap() = instances;
-        }
-    }
-
-    #[async_trait]
-    impl InstanceDiscovery for MutableDiscovery {
-        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-            Ok(self.instances.lock().unwrap().clone())
         }
     }
 
@@ -612,261 +579,12 @@ mod tests {
         Url::parse(&format!("http://{host_port}")).unwrap()
     }
 
-    fn stub_receipt() -> TransactionReceipt {
-        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt {
-                status: Eip658Value::Eip658(true),
-                cumulative_gas_used: 21_000,
-                logs: vec![],
-            },
-            logs_bloom: Bloom::ZERO,
-        });
-        TransactionReceipt {
-            inner,
-            transaction_hash: B256::ZERO,
-            transaction_index: Some(0),
-            block_hash: Some(B256::ZERO),
-            block_number: Some(1),
-            gas_used: 21_000,
-            effective_gas_price: 1_000_000_000,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
-    }
-
     fn mock_cert_manager<T: TxManager + 'static>(
         config: &DriverConfig,
         tx_manager: T,
     ) -> CertManager<T> {
         CertManager::new(&config.crl, Arc::new(NoopNitroVerifier), tx_manager)
             .expect("test cert manager builds")
-    }
-
-    #[derive(Debug, Clone)]
-    struct MockRegistry;
-
-    #[async_trait]
-    impl RegistryClient for MockRegistry {
-        async fn is_registered(&self, _signer: Address) -> Result<bool> {
-            Ok(false)
-        }
-
-        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-            Ok(vec![])
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct SharedTxManager {
-        sent: Arc<Mutex<Vec<Bytes>>>,
-    }
-
-    impl SharedTxManager {
-        fn new() -> Self {
-            Self { sent: Arc::new(Mutex::new(vec![])) }
-        }
-
-        fn sent_calldata(&self) -> Vec<Bytes> {
-            self.sent.lock().unwrap().clone()
-        }
-    }
-
-    impl TxManager for SharedTxManager {
-        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            self.sent.lock().unwrap().push(candidate.tx_data);
-            Ok(stub_receipt())
-        }
-
-        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-            unreachable!("driver tests do not submit async transactions")
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
-        }
-    }
-
-    #[derive(Debug)]
-    struct GatedProofState {
-        release: CancellationToken,
-        call_count: AtomicUsize,
-        in_flight: AtomicUsize,
-    }
-
-    impl Default for GatedProofState {
-        fn default() -> Self {
-            Self {
-                release: CancellationToken::new(),
-                call_count: AtomicUsize::new(0),
-                in_flight: AtomicUsize::new(0),
-            }
-        }
-    }
-
-    struct InFlightGuard {
-        state: Arc<GatedProofState>,
-    }
-
-    impl InFlightGuard {
-        fn new(state: Arc<GatedProofState>) -> Self {
-            state.in_flight.fetch_add(1, Ordering::SeqCst);
-            Self { state }
-        }
-    }
-
-    impl Drop for InFlightGuard {
-        fn drop(&mut self) {
-            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct GatedProofProvider {
-        state: Arc<GatedProofState>,
-    }
-
-    impl GatedProofProvider {
-        fn new() -> (Self, GatedProofHandles) {
-            let state = Arc::new(GatedProofState::default());
-            (Self { state: Arc::clone(&state) }, GatedProofHandles { state })
-        }
-    }
-
-    #[async_trait]
-    impl AttestationProofProvider for GatedProofProvider {
-        async fn generate_proof(
-            &self,
-            _attestation_bytes: &[u8],
-            cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            self.state.call_count.fetch_add(1, Ordering::SeqCst);
-            let _guard = InFlightGuard::new(Arc::clone(&self.state));
-
-            tokio::select! {
-                biased;
-                () = cancel.cancelled() => {
-                    Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
-                        "proof cancelled by test harness".into(),
-                    ))
-                }
-                () = self.state.release.cancelled() => {
-                    Ok(AttestationProof {
-                        output: Bytes::new(),
-                        proof_bytes: Bytes::from_static(b"gated-proof"),
-                    })
-                }
-            }
-        }
-
-        async fn generate_proof_for_signer(
-            &self,
-            attestation_bytes: &[u8],
-            signer_address: Address,
-            cancel: &CancellationToken,
-        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
-            let mut proof = self.generate_proof(attestation_bytes, cancel).await?;
-            proof.output = Bytes::copy_from_slice(signer_address.as_slice());
-            Ok(proof)
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct GatedProofHandles {
-        state: Arc<GatedProofState>,
-    }
-
-    impl GatedProofHandles {
-        fn release_all(&self) {
-            self.state.release.cancel();
-        }
-
-        fn call_count(&self) -> usize {
-            self.state.call_count.load(Ordering::SeqCst)
-        }
-
-        fn in_flight(&self) -> usize {
-            self.state.in_flight.load(Ordering::SeqCst)
-        }
-    }
-
-    type RunDriver = RegistrationDriver<
-        MutableDiscovery,
-        MockSignerClient,
-        Arc<SignerManager<GatedProofProvider, MockRegistry, SharedTxManager>>,
-        SharedTxManager,
-    >;
-
-    #[derive(Debug)]
-    struct GatedRunHarness {
-        driver: Arc<RunDriver>,
-        cancel: CancellationToken,
-        discovery: MutableDiscovery,
-        proof: GatedProofHandles,
-        tx: SharedTxManager,
-    }
-
-    impl GatedRunHarness {
-        fn new(
-            initial_instances: Vec<ProverInstance>,
-            endpoints_to_keys: &[(&str, &[u8; 32])],
-        ) -> Self {
-            let discovery = MutableDiscovery::new(initial_instances);
-            let signer_client = MockSignerClient::from_keys(endpoints_to_keys);
-            let cancel = CancellationToken::new();
-            let mut config = default_config(cancel.clone());
-            config.poll_interval = FAST_POLL_INTERVAL;
-            let registry = MockRegistry;
-            let tx = SharedTxManager::new();
-            let (proof_provider, proof_handles) = GatedProofProvider::new();
-            let signer_manager = Arc::new(SignerManager::new(
-                proof_provider,
-                registry,
-                tx.clone(),
-                config.signer_manager.clone(),
-            ));
-            let cert_manager = mock_cert_manager(&config, tx.clone());
-            let driver = Arc::new(RegistrationDriver::new(
-                discovery.clone(),
-                signer_client,
-                config,
-                cert_manager,
-                signer_manager,
-            ));
-
-            Self { driver, cancel, discovery, proof: proof_handles, tx }
-        }
-
-        fn spawn_run(&self) -> tokio::task::JoinHandle<Result<()>> {
-            let driver = Arc::clone(&self.driver);
-            tokio::spawn(async move { driver.run_loop().await })
-        }
-
-        async fn shutdown(&self, handle: tokio::task::JoinHandle<Result<()>>) {
-            self.cancel.cancel();
-            let outcome = tokio::time::timeout(GATED_WAIT_TIMEOUT, handle)
-                .await
-                .expect("run loop should observe cancellation")
-                .expect("run loop task should not panic");
-            outcome.expect("run loop should stop cleanly");
-        }
-    }
-
-    async fn wait_for(label: &str, predicate: impl Fn() -> bool) {
-        let started = std::time::Instant::now();
-        while !predicate() {
-            if started.elapsed() > GATED_WAIT_TIMEOUT {
-                panic!("timed out waiting for: {label}");
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-    }
-
-    fn count_register_calls(sent: &[Bytes]) -> usize {
-        let sel = ITEEProverRegistry::registerSignerCall::SELECTOR;
-        sent.iter().filter(|c| c.starts_with(&sel)).count()
     }
 
     #[derive(Debug, Clone)]
@@ -991,56 +709,6 @@ mod tests {
             orphan_inputs[0].contains(&signer),
             "driver passes active signer set into orphan protection",
         );
-    }
-
-    #[rstest]
-    #[case::one_instance(1)]
-    #[case::two_instances(2)]
-    #[tokio::test]
-    async fn run_loop_registers_each_discovered_enclave(#[case] num_instances: usize) {
-        let keys: Vec<(&str, &[u8; 32])> =
-            ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
-        let instances: Vec<_> =
-            ALL_ENDPOINTS[..num_instances].iter().map(|ep| healthy_prover_instance(ep)).collect();
-        let harness = GatedRunHarness::new(instances, &keys);
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("every proof task parked in gate", || harness.proof.in_flight() == num_instances)
-            .await;
-        harness.proof.release_all();
-        wait_for("every registerSigner transaction submitted", || {
-            count_register_calls(&harness.tx.sent_calldata()) == num_instances
-        })
-        .await;
-        harness.shutdown(run_handle).await;
-
-        assert_eq!(harness.proof.call_count(), num_instances, "exactly one proof per enclave");
-    }
-
-    #[tokio::test]
-    async fn run_loop_continues_discovery_while_proofs_are_in_flight() {
-        let keys: Vec<(&str, &[u8; 32])> =
-            ALL_ENDPOINTS.iter().copied().zip(ALL_KEYS.iter().copied()).collect();
-        let harness = GatedRunHarness::new(vec![healthy_prover_instance(EP1)], &keys);
-
-        let run_handle = harness.spawn_run();
-
-        wait_for("initial proof task parked in gate", || harness.proof.in_flight() == 1).await;
-        harness.discovery.set(vec![healthy_prover_instance(EP1), healthy_prover_instance(EP2)]);
-        wait_for("newly discovered proof task parked while first proof is still in flight", || {
-            harness.proof.in_flight() == 2
-        })
-        .await;
-
-        harness.proof.release_all();
-        wait_for("both registerSigner transactions submitted", || {
-            count_register_calls(&harness.tx.sent_calldata()) == 2
-        })
-        .await;
-        harness.shutdown(run_handle).await;
-
-        assert_eq!(harness.proof.call_count(), 2, "new signer must not wait for old proof");
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -477,6 +477,7 @@ mod tests {
         keys: HashMap<Url, Vec<Vec<u8>>>,
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
+        cancel_after_public_key_success: Option<CancellationToken>,
     }
 
     impl MockSignerClient {
@@ -488,7 +489,12 @@ mod tests {
                     (url, vec![public_key_from_private(pk)])
                 })
                 .collect();
-            Self { keys, attestations: HashMap::new(), fail_attestation: HashSet::new() }
+            Self {
+                keys,
+                attestations: HashMap::new(),
+                fail_attestation: HashSet::new(),
+                cancel_after_public_key_success: None,
+            }
         }
 
         fn multi_enclave(host_port: &str, private_keys: &[&[u8; 32]]) -> Self {
@@ -497,6 +503,7 @@ mod tests {
                 keys: HashMap::from([(endpoint_url(host_port), pubs)]),
                 attestations: HashMap::new(),
                 fail_attestation: HashSet::new(),
+                cancel_after_public_key_success: None,
             }
         }
 
@@ -509,15 +516,27 @@ mod tests {
             self.fail_attestation.insert(endpoint_url(host_port));
             self
         }
+
+        fn with_cancel_after_public_key_success(mut self, cancel: CancellationToken) -> Self {
+            self.cancel_after_public_key_success = Some(cancel);
+            self
+        }
     }
 
     #[async_trait]
     impl SignerClient for MockSignerClient {
         async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
-                instance: endpoint.to_string(),
-                source: "unreachable".into(),
-            })
+            let result =
+                self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
+                    instance: endpoint.to_string(),
+                    source: "unreachable".into(),
+                });
+            if result.is_ok() {
+                if let Some(cancel) = &self.cancel_after_public_key_success {
+                    cancel.cancel();
+                }
+            }
+            result
         }
 
         async fn signer_attestation(
@@ -736,39 +755,11 @@ mod tests {
         assert!(!resolution.ok_to_dereg, "cancellation must clear ok_to_dereg",);
     }
 
-    #[derive(Debug)]
-    struct CancellingSignerClient {
-        inner: MockSignerClient,
-        cancel: CancellationToken,
-    }
-
-    #[async_trait]
-    impl SignerClient for CancellingSignerClient {
-        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            let result = self.inner.signer_public_key(endpoint).await;
-            if result.is_ok() {
-                self.cancel.cancel();
-            }
-            result
-        }
-
-        async fn signer_attestation(
-            &self,
-            endpoint: &Url,
-            user_data: Option<Vec<u8>>,
-            nonce: Option<Vec<u8>>,
-        ) -> Result<Vec<Vec<u8>>> {
-            self.inner.signer_attestation(endpoint, user_data, nonce).await
-        }
-    }
-
     #[tokio::test]
     async fn discover_and_resolve_clears_ok_to_dereg_when_cancelled_mid_resolution() {
         let cancel = CancellationToken::new();
-        let signer_client = CancellingSignerClient {
-            inner: MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]),
-            cancel: cancel.clone(),
-        };
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)])
+            .with_cancel_after_public_key_success(cancel.clone());
         let driver = cycle_driver(vec![healthy_prover_instance(EP1)], signer_client, cancel);
 
         let resolution = driver.discover_and_resolve().await.unwrap();

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -149,11 +149,7 @@ where
     }
 
     /// Runs the registration loop until cancelled.
-    pub async fn run(self) -> Result<()> {
-        self.run_loop().await
-    }
-
-    async fn run_loop(&self) -> Result<()> {
+    pub async fn run(&self) -> Result<()> {
         info!(
             poll_interval = ?self.config.poll_interval,
             registry = %self.config.signer_manager.registry_address,
@@ -647,7 +643,7 @@ mod tests {
     const FAST_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
     #[tokio::test]
-    async fn run_loop_uses_injected_signer_manager_boundary() {
+    async fn run_uses_injected_signer_manager_boundary() {
         let cancel = CancellationToken::new();
         let mut config = default_config(cancel.clone());
         config.poll_interval = FAST_POLL_INTERVAL;
@@ -665,7 +661,7 @@ mod tests {
             signer_manager,
         );
 
-        driver.run_loop().await.expect("driver exits after mock orphan pass cancels");
+        driver.run().await.expect("driver exits after mock orphan pass cancels");
 
         assert_eq!(
             signer_manager_handle.reconcile_count(),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -16,8 +16,7 @@ use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     CertManager, CrlConfig, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
-    ProverInstance, RegistrarError, RegistrarMetrics, Result, SignerClient, SignerLifecycle,
-    SignerManagerConfig,
+    ProverInstance, RegistrarMetrics, Result, SignerClient, SignerLifecycle, SignerManagerConfig,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -319,11 +318,7 @@ where
             if self.config.cancel.is_cancelled() {
                 return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
             }
-            let first_attestation =
-                all_attestations.first().ok_or_else(|| RegistrarError::ProverClient {
-                    instance: instance.endpoint.to_string(),
-                    source: "no attestations available for CRL check".into(),
-                })?;
+            let first_attestation = &all_attestations[0];
             match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
                 Ok(true) => {
                     warn!(
@@ -461,7 +456,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        InstanceHealthStatus, Result, SignerClient,
+        InstanceHealthStatus, RegistrarError, Result, SignerClient,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, HARDHAT_KEY_3,
             NoopNitroVerifier, NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -91,17 +91,6 @@ pub struct DiscoveryResolution {
     pub unresolved_instance_ids: HashSet<String>,
 }
 
-/// Per-instance result of address resolution and registration gating.
-#[derive(Debug)]
-pub struct ResolveOutcome {
-    /// Signer addresses derived from the instance's enclave public keys.
-    pub addresses: Vec<Address>,
-    /// Pre-fetched attestation blobs when the instance is register-eligible.
-    pub attestations: Option<Vec<Vec<u8>>>,
-    /// Whether resolution ended inconclusively after addresses were known.
-    pub unresolved: bool,
-}
-
 /// Core registration loop tying together discovery, attestation polling, signer
 /// lifecycle reconciliation, and orphan cleanup.
 ///
@@ -217,13 +206,12 @@ where
 
     /// Returns addresses always for active signer tracking.
     /// Returns attestations only when the instance is registerable.
-    async fn resolve_instance(&self, instance: &ProverInstance) -> Result<ResolveOutcome> {
+    async fn resolve_instance(
+        &self,
+        instance: &ProverInstance,
+    ) -> Result<(Vec<Address>, Option<Vec<Vec<u8>>>, bool)> {
         if self.config.cancel.is_cancelled() {
-            return Ok(ResolveOutcome {
-                addresses: Vec::new(),
-                attestations: None,
-                unresolved: false,
-            });
+            return Ok((Vec::new(), None, false));
         }
 
         let public_keys = self.signer_client.signer_public_key(&instance.endpoint).await?;
@@ -234,7 +222,7 @@ where
             .collect::<Result<Vec<_>>>()?;
 
         if addresses.is_empty() {
-            return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
+            return Ok((addresses, None, false));
         }
 
         if !instance.health_status.should_register() {
@@ -244,7 +232,7 @@ where
                     instance = %instance.instance_id,
                     "instance not registerable, skipping registration"
                 );
-                return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
+                return Ok((addresses, None, false));
             }
             info!(
                 instance = %instance.instance_id,
@@ -255,7 +243,7 @@ where
         }
 
         if self.config.cancel.is_cancelled() {
-            return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
+            return Ok((addresses, None, false));
         }
 
         let nonce: [u8; 32] = random();
@@ -277,7 +265,7 @@ where
                     "failed to fetch signer attestations after resolving signer addresses"
                 );
                 RegistrarMetrics::processing_errors_total().increment(1);
-                return Ok(ResolveOutcome { addresses, attestations: None, unresolved: true });
+                return Ok((addresses, None, true));
             }
         };
 
@@ -289,13 +277,13 @@ where
                 "signer attestation count was lower than signer public key count"
             );
             RegistrarMetrics::processing_errors_total().increment(1);
-            return Ok(ResolveOutcome { addresses, attestations: None, unresolved: true });
+            return Ok((addresses, None, true));
         }
 
         if self.config.crl.enabled {
             // skip CRL work after cancellation
             if self.config.cancel.is_cancelled() {
-                return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
+                return Ok((addresses, None, false));
             }
             let first_attestation = &all_attestations[0];
             match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
@@ -304,7 +292,7 @@ where
                         instance = %instance.instance_id,
                         "certificate revoked, skipping registration for this instance"
                     );
-                    return Ok(ResolveOutcome { addresses, attestations: None, unresolved: false });
+                    return Ok((addresses, None, false));
                 }
                 Ok(false) => {}
                 Err(e) => {
@@ -317,7 +305,7 @@ where
             }
         }
 
-        Ok(ResolveOutcome { addresses, attestations: Some(all_attestations), unresolved: false })
+        Ok((addresses, Some(all_attestations), false))
     }
 
     /// Runs one discovery cycle and resolves every instance into a [`DiscoveryResolution`].
@@ -363,17 +351,17 @@ where
         // natural boundary.
         while let Some((instance, result)) = futs.next().await {
             match result {
-                Ok(outcome) => {
+                Ok((addresses, attestations, unresolved)) => {
                     reachable_count += 1;
-                    for addr in &outcome.addresses {
+                    for addr in &addresses {
                         active_signers.insert(*addr);
                     }
-                    if outcome.unresolved {
+                    if unresolved {
                         unresolved_instance_ids.insert(instance.instance_id.clone());
                     }
-                    if let Some(attestations) = outcome.attestations {
+                    if let Some(attestations) = attestations {
                         for (enclave_index, (signer, attestation)) in
-                            outcome.addresses.into_iter().zip(attestations).enumerate()
+                            addresses.into_iter().zip(attestations).enumerate()
                         {
                             registerable.push(RegisterableSigner {
                                 instance: instance.clone(),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -478,6 +478,8 @@ mod tests {
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
         cancel_after_public_key_success: Option<CancellationToken>,
+        in_flight: Option<Arc<AtomicUsize>>,
+        peak: Option<Arc<AtomicUsize>>,
     }
 
     impl MockSignerClient {
@@ -494,6 +496,8 @@ mod tests {
                 attestations: HashMap::new(),
                 fail_attestation: HashSet::new(),
                 cancel_after_public_key_success: None,
+                in_flight: None,
+                peak: None,
             }
         }
 
@@ -504,6 +508,8 @@ mod tests {
                 attestations: HashMap::new(),
                 fail_attestation: HashSet::new(),
                 cancel_after_public_key_success: None,
+                in_flight: None,
+                peak: None,
             }
         }
 
@@ -521,11 +527,15 @@ mod tests {
             self.cancel_after_public_key_success = Some(cancel);
             self
         }
-    }
 
-    #[async_trait]
-    impl SignerClient for MockSignerClient {
-        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
+        fn with_concurrency_tracking(mut self) -> (Self, Arc<AtomicUsize>) {
+            let peak = Arc::new(AtomicUsize::new(0));
+            self.in_flight = Some(Arc::new(AtomicUsize::new(0)));
+            self.peak = Some(Arc::clone(&peak));
+            (self, peak)
+        }
+
+        fn signer_public_key_result(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
             let result =
                 self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
                     instance: endpoint.to_string(),
@@ -537,6 +547,24 @@ mod tests {
                 }
             }
             result
+        }
+    }
+
+    #[async_trait]
+    impl SignerClient for MockSignerClient {
+        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
+            if let (Some(in_flight), Some(peak)) = (&self.in_flight, &self.peak) {
+                let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+
+                tokio::task::yield_now().await;
+
+                let result = self.signer_public_key_result(endpoint);
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                return result;
+            }
+
+            self.signer_public_key_result(endpoint)
         }
 
         async fn signer_attestation(
@@ -904,45 +932,6 @@ mod tests {
         assert!(!resolution.ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
     }
 
-    #[derive(Debug)]
-    struct ConcurrencyTrackingSignerClient {
-        inner: MockSignerClient,
-        in_flight: Arc<AtomicUsize>,
-        peak: Arc<AtomicUsize>,
-    }
-
-    impl ConcurrencyTrackingSignerClient {
-        fn new(inner: MockSignerClient) -> (Self, Arc<AtomicUsize>) {
-            let peak = Arc::new(AtomicUsize::new(0));
-            let client =
-                Self { inner, in_flight: Arc::new(AtomicUsize::new(0)), peak: Arc::clone(&peak) };
-            (client, peak)
-        }
-    }
-
-    #[async_trait]
-    impl SignerClient for ConcurrencyTrackingSignerClient {
-        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-            self.peak.fetch_max(current, Ordering::SeqCst);
-
-            tokio::task::yield_now().await;
-
-            let result = self.inner.signer_public_key(endpoint).await;
-            self.in_flight.fetch_sub(1, Ordering::SeqCst);
-            result
-        }
-
-        async fn signer_attestation(
-            &self,
-            endpoint: &Url,
-            user_data: Option<Vec<u8>>,
-            nonce: Option<Vec<u8>>,
-        ) -> Result<Vec<Vec<u8>>> {
-            self.inner.signer_attestation(endpoint, user_data, nonce).await
-        }
-    }
-
     #[tokio::test]
     async fn discover_and_resolve_respects_max_concurrency() {
         let max_concurrency = 2;
@@ -952,8 +941,7 @@ mod tests {
         let keys: Vec<(&str, &[u8; 32])> =
             endpoints.iter().copied().zip(private_keys.iter().copied()).collect();
         let instances: Vec<_> = endpoints.iter().map(|ep| healthy_prover_instance(ep)).collect();
-        let inner = MockSignerClient::from_keys(&keys);
-        let (signer_client, peak) = ConcurrencyTrackingSignerClient::new(inner);
+        let (signer_client, peak) = MockSignerClient::from_keys(&keys).with_concurrency_tracking();
 
         let cancel = CancellationToken::new();
         let mut config = default_config(cancel);

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -427,14 +427,9 @@ where
             }
         }
 
-        let ok_to_dereg =
-            if self.config.cancel.is_cancelled() || !unresolved_instance_ids.is_empty() {
-                false
-            } else if total_count == 0 {
-                true
-            } else {
-                reachable_count * 2 > total_count
-            };
+        let ok_to_dereg = !self.config.cancel.is_cancelled()
+            && unresolved_instance_ids.is_empty()
+            && (total_count == 0 || reachable_count * 2 > total_count);
 
         Ok(DiscoveryResolution {
             registerable,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -206,7 +206,6 @@ where
         if !instance.health_status.should_register() {
             let recently_launched_unhealthy = instance.health_status
                 == InstanceHealthStatus::Unhealthy
-                && !self.config.unhealthy_registration_window.is_zero()
                 && instance.launch_time.is_some_and(|lt| {
                     lt.elapsed()
                         .is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
@@ -318,7 +317,6 @@ where
         let mut resolution = DiscoveryResolution::default();
         let mut reachable_count = 0usize;
 
-        let concurrency = self.config.max_concurrency.max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
             let span = info_span!(
                 "resolve_instance",
@@ -332,7 +330,7 @@ where
             }
             .instrument(span)
         }))
-        .buffer_unordered(concurrency);
+        .buffer_unordered(self.config.max_concurrency.max(1));
 
         // No cancel-select around `futs.next()`: each future checks
         // cancellation cooperatively between awaits, so new work is

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -745,7 +745,7 @@ mod tests {
             self.state.call_count.fetch_add(1, Ordering::SeqCst);
             let _guard = InFlightGuard::new(Arc::clone(&self.state));
 
-            let result = tokio::select! {
+            tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
                     Err(base_proof_tee_nitro_attestation_prover::ProverError::Boundless(
@@ -758,8 +758,7 @@ mod tests {
                         proof_bytes: Bytes::from_static(b"gated-proof"),
                     })
                 }
-            };
-            result
+            }
         }
 
         async fn generate_proof_for_signer(

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -204,14 +204,10 @@ where
             })
     }
 
-    /// Returns addresses always for active signer tracking.
-    /// Returns attestations only when the instance is registerable.
-    async fn resolve_instance(
-        &self,
-        instance: &ProverInstance,
-    ) -> Result<(Vec<Address>, Option<Vec<Vec<u8>>>, bool)> {
+    /// Resolves one instance into active and registerable signers.
+    async fn resolve_instance(&self, instance: &ProverInstance) -> Result<DiscoveryResolution> {
         if self.config.cancel.is_cancelled() {
-            return Ok((Vec::new(), None, false));
+            return Ok(DiscoveryResolution::default());
         }
 
         let public_keys = self.signer_client.signer_public_key(&instance.endpoint).await?;
@@ -220,9 +216,13 @@ where
             .map(Vec::as_slice)
             .map(ProverClient::derive_address)
             .collect::<Result<Vec<_>>>()?;
+        let mut outcome = DiscoveryResolution {
+            active_signers: addresses.iter().copied().collect(),
+            ..Default::default()
+        };
 
         if addresses.is_empty() {
-            return Ok((addresses, None, false));
+            return Ok(outcome);
         }
 
         if !instance.health_status.should_register() {
@@ -232,7 +232,7 @@ where
                     instance = %instance.instance_id,
                     "instance not registerable, skipping registration"
                 );
-                return Ok((addresses, None, false));
+                return Ok(outcome);
             }
             info!(
                 instance = %instance.instance_id,
@@ -243,7 +243,7 @@ where
         }
 
         if self.config.cancel.is_cancelled() {
-            return Ok((addresses, None, false));
+            return Ok(outcome);
         }
 
         let nonce: [u8; 32] = random();
@@ -265,7 +265,8 @@ where
                     "failed to fetch signer attestations after resolving signer addresses"
                 );
                 RegistrarMetrics::processing_errors_total().increment(1);
-                return Ok((addresses, None, true));
+                outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
+                return Ok(outcome);
             }
         };
 
@@ -277,13 +278,14 @@ where
                 "signer attestation count was lower than signer public key count"
             );
             RegistrarMetrics::processing_errors_total().increment(1);
-            return Ok((addresses, None, true));
+            outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
+            return Ok(outcome);
         }
 
         if self.config.crl.enabled {
             // skip CRL work after cancellation
             if self.config.cancel.is_cancelled() {
-                return Ok((addresses, None, false));
+                return Ok(outcome);
             }
             let first_attestation = &all_attestations[0];
             match self.cert_manager.check_and_revoke_crls(first_attestation, instance).await {
@@ -292,7 +294,7 @@ where
                         instance = %instance.instance_id,
                         "certificate revoked, skipping registration for this instance"
                     );
-                    return Ok((addresses, None, false));
+                    return Ok(outcome);
                 }
                 Ok(false) => {}
                 Err(e) => {
@@ -305,7 +307,15 @@ where
             }
         }
 
-        Ok((addresses, Some(all_attestations), false))
+        outcome.registerable.extend(addresses.into_iter().zip(all_attestations).enumerate().map(
+            |(enclave_index, (signer, attestation))| RegisterableSigner {
+                instance: instance.clone(),
+                signer,
+                attestation,
+                enclave_index,
+            },
+        ));
+        Ok(outcome)
     }
 
     /// Runs one discovery cycle and resolves every instance into a [`DiscoveryResolution`].
@@ -324,10 +334,8 @@ where
         }
 
         let total_count = instances.len();
-        let mut active_signers: HashSet<Address> = HashSet::new();
+        let mut resolution = DiscoveryResolution::default();
         let mut reachable_count = 0usize;
-        let mut registerable: Vec<RegisterableSigner> = Vec::new();
-        let mut unresolved_instance_ids: HashSet<String> = HashSet::new();
 
         let concurrency = self.config.max_concurrency.max(1);
         let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
@@ -351,26 +359,11 @@ where
         // natural boundary.
         while let Some((instance, result)) = futs.next().await {
             match result {
-                Ok((addresses, attestations, unresolved)) => {
+                Ok(outcome) => {
                     reachable_count += 1;
-                    for addr in &addresses {
-                        active_signers.insert(*addr);
-                    }
-                    if unresolved {
-                        unresolved_instance_ids.insert(instance.instance_id.clone());
-                    }
-                    if let Some(attestations) = attestations {
-                        for (enclave_index, (signer, attestation)) in
-                            addresses.into_iter().zip(attestations).enumerate()
-                        {
-                            registerable.push(RegisterableSigner {
-                                instance: instance.clone(),
-                                signer,
-                                attestation,
-                                enclave_index,
-                            });
-                        }
-                    }
+                    resolution.registerable.extend(outcome.registerable);
+                    resolution.active_signers.extend(outcome.active_signers);
+                    resolution.unresolved_instance_ids.extend(outcome.unresolved_instance_ids);
                 }
                 Err(e) => {
                     warn!(
@@ -384,13 +377,13 @@ where
                     // does NOT cancel in-flight proof tasks tied to it
                     // (see `DiscoveryResolution::unresolved_instance_ids`
                     // for the rationale).
-                    unresolved_instance_ids.insert(instance.instance_id.clone());
+                    resolution.unresolved_instance_ids.insert(instance.instance_id.clone());
                 }
             }
         }
 
         let ok_to_dereg = !self.config.cancel.is_cancelled()
-            && unresolved_instance_ids.is_empty()
+            && resolution.unresolved_instance_ids.is_empty()
             && (total_count == 0 || reachable_count * 2 > total_count);
 
         if !ok_to_dereg {
@@ -401,10 +394,7 @@ where
             );
         }
 
-        Ok((
-            DiscoveryResolution { registerable, active_signers, unresolved_instance_ids },
-            ok_to_dereg,
-        ))
+        Ok((resolution, ok_to_dereg))
     }
 }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -367,30 +367,7 @@ where
         Ok(ResolveOutcome { addresses, attestations: Some(all_attestations), unresolved: false })
     }
 
-    /// Runs one discovery cycle and resolves every instance into the
-    /// [`DiscoveryResolution`] consumed by the spawn-and-reap loop.
-    ///
-    /// This fans out per-instance resolution work concurrently (bounded by
-    /// [`SignerManagerConfig::max_concurrency`]). No registration transactions are
-    /// submitted here; the [`Self::run`] loop spawns a dedicated task per
-    /// registerable signer instead, so long Boundless proofs do not block the
-    /// next discovery cycle.
-    ///
-    /// **Why no outer cancel-select.** `resolve_instance` performs several
-    /// side effects before deciding whether an instance is registerable. The
-    /// buffered stream is therefore drained to natural completion; each
-    /// `resolve_instance` short-circuits on the configured cancellation token between
-    /// awaits. Shutdown latency is bounded by `max_concurrency` × the slowest
-    /// signer-RPC / CRL-fetch timeout, not by long proof work (which lives in
-    /// the spawned proof tasks).
-    ///
-    /// The returned `ok_to_dereg` flag bakes in the cancellation policy
-    /// (token not cancelled), the inconclusive-resolution guard (no
-    /// `unresolved_instance_ids`), and the majority guard
-    /// (`reachable * 2 > total`). The empty-discovery case sets it to
-    /// `true` so legitimate fleet drains still let orphan cleanup proceed —
-    /// except when the driver is cancelled, in which case the orphan dereg
-    /// pass is skipped so we don't acquire nonces during shutdown.
+    /// Runs one discovery cycle and resolves every instance into a [`DiscoveryResolution`].
     async fn discover_and_resolve(&self) -> Result<DiscoveryResolution> {
         let instances = self.discovery.discover_instances().await?;
         RegistrarMetrics::discovery_success_total().increment(1);

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -5,7 +5,7 @@
 //! to L1 via the [`TxManager`]. Also detects orphaned onchain signers (those
 //! no longer backed by a healthy instance) and deregisters them.
 
-use std::{collections::HashSet, fmt, time::Duration};
+use std::{collections::HashSet, time::Duration};
 
 use alloy_primitives::{Address, hex};
 use base_tx_manager::TxManager;
@@ -126,12 +126,6 @@ pub struct RegistrationDriver<D, S, M, T> {
     cert_manager: CertManager<T>,
     /// Signer lifecycle manager for registration tasks and orphan cleanup.
     signer_manager: M,
-}
-
-impl<D, S, M, T> fmt::Debug for RegistrationDriver<D, S, M, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RegistrationDriver").field("config", &self.config).finish_non_exhaustive()
-    }
 }
 
 impl<D, S, M, T> RegistrationDriver<D, S, M, T>

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -28,13 +28,6 @@ use crate::{
 /// serialization separately.
 pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
-/// Default maximum number of transaction submission retries for transient
-/// errors before giving up.
-pub const DEFAULT_MAX_TX_RETRIES: u32 = 3;
-
-/// Default delay between transaction submission retries.
-pub const DEFAULT_TX_RETRY_DELAY_SECS: u64 = 5;
-
 /// Default duration (in seconds) after launch during which unhealthy
 /// instances are still eligible for registration.
 ///
@@ -400,14 +393,13 @@ mod tests {
     use alloy_primitives::Address;
     use async_trait::async_trait;
     use base_proof_tee_nitro_attestation_prover::{AttestationProof, AttestationProofProvider};
-    use rstest::rstest;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
     use super::*;
     use crate::{
-        CrlConfig, InstanceHealthStatus, RegistrarError, RegistryClient, Result, SignerClient,
-        SignerManagerConfig,
+        CrlConfig, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, InstanceHealthStatus,
+        RegistrarError, RegistryClient, Result, SignerClient, SignerManagerConfig,
         test_utils::{
             EP1, EP2, EP3, EP4, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, NoopNitroVerifier,
             NoopTxManager, TEST_REGISTRY_ADDRESS, healthy_prover_instance, prover_instance,
@@ -415,15 +407,10 @@ mod tests {
         },
     };
 
-    #[derive(Debug)]
-    struct MockDiscovery {
-        instances: Vec<ProverInstance>,
-    }
-
     #[async_trait]
-    impl InstanceDiscovery for MockDiscovery {
+    impl InstanceDiscovery for Vec<ProverInstance> {
         async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-            Ok(self.instances.clone())
+            Ok(self.clone())
         }
     }
 
@@ -466,8 +453,11 @@ mod tests {
             self.cancel_after_public_key_success = Some(cancel);
             self
         }
+    }
 
-        fn signer_public_key_result(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
+    #[async_trait]
+    impl SignerClient for MockSignerClient {
+        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
             let result =
                 self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
                     instance: endpoint.to_string(),
@@ -479,13 +469,6 @@ mod tests {
                 cancel.cancel();
             }
             result
-        }
-    }
-
-    #[async_trait]
-    impl SignerClient for MockSignerClient {
-        async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
-            self.signer_public_key_result(endpoint)
         }
 
         async fn signer_attestation(
@@ -540,63 +523,43 @@ mod tests {
         Url::parse(&format!("http://{host_port}")).unwrap()
     }
 
-    fn mock_cert_manager<T: TxManager + 'static>(tx_manager: T) -> CertManager<T> {
-        CertManager::new(&crl_config(false), Arc::new(NoopNitroVerifier), tx_manager)
-            .expect("test cert manager builds")
-    }
-
-    fn crl_config(enabled: bool) -> CrlConfig {
-        CrlConfig {
-            enabled,
-            nitro_verifier_address: None,
-            fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
-        }
-    }
-
-    fn noop_signer_manager(
-        config: SignerManagerConfig,
-    ) -> Arc<SignerManager<NoopProofProvider, NoopRegistry, NoopTxManager>> {
-        Arc::new(SignerManager::new(NoopProofProvider, NoopRegistry, NoopTxManager, config))
-    }
-
-    fn default_config(cancel: CancellationToken) -> DriverConfig {
-        DriverConfig {
+    fn cycle_driver<S>(
+        instances: Vec<ProverInstance>,
+        signer_client: S,
+        cancel: CancellationToken,
+    ) -> RegistrationDriver<Vec<ProverInstance>, S, NoopProofProvider, NoopRegistry, NoopTxManager>
+    where
+        S: SignerClient + 'static,
+    {
+        let config = DriverConfig {
             poll_interval: Duration::from_secs(1),
             cancel,
             max_concurrency: DEFAULT_MAX_CONCURRENCY,
             unhealthy_registration_window: Duration::from_secs(
                 DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
             ),
-        }
-    }
+        };
+        let crl_config = CrlConfig {
+            enabled: false,
+            nitro_verifier_address: None,
+            fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
+        };
+        let cert_manager =
+            CertManager::new(&crl_config, Arc::new(NoopNitroVerifier), NoopTxManager)
+                .expect("test cert manager builds");
+        let signer_manager = Arc::new(SignerManager::new(
+            NoopProofProvider,
+            NoopRegistry,
+            NoopTxManager,
+            SignerManagerConfig {
+                registry_address: TEST_REGISTRY_ADDRESS,
+                max_concurrency: DEFAULT_MAX_CONCURRENCY,
+                max_tx_retries: DEFAULT_MAX_TX_RETRIES,
+                tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
+            },
+        ));
 
-    fn signer_manager_config() -> SignerManagerConfig {
-        SignerManagerConfig {
-            registry_address: TEST_REGISTRY_ADDRESS,
-            max_concurrency: DEFAULT_MAX_CONCURRENCY,
-            max_tx_retries: DEFAULT_MAX_TX_RETRIES,
-            tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
-        }
-    }
-
-    fn cycle_driver<S>(
-        instances: Vec<ProverInstance>,
-        signer_client: S,
-        cancel: CancellationToken,
-    ) -> RegistrationDriver<MockDiscovery, S, NoopProofProvider, NoopRegistry, NoopTxManager>
-    where
-        S: SignerClient + 'static,
-    {
-        let config = default_config(cancel);
-        let cert_manager = mock_cert_manager(NoopTxManager);
-        let signer_manager = noop_signer_manager(signer_manager_config());
-        RegistrationDriver::new(
-            MockDiscovery { instances },
-            signer_client,
-            config,
-            cert_manager,
-            signer_manager,
-        )
+        RegistrationDriver::new(instances, signer_client, config, cert_manager, signer_manager)
     }
 
     #[tokio::test]
@@ -617,17 +580,10 @@ mod tests {
         );
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
-        assert_eq!(
-            resolution.registerable.len(),
-            1,
-            "recently-launched unhealthy instance should be registerable"
-        );
+        assert_eq!(resolution.registerable.len(), 1);
         assert_eq!(resolution.registerable[0].signer, addr);
-        assert!(
-            resolution.active_signers.contains(&addr),
-            "recently-launched unhealthy signer should be in active_signers"
-        );
-        assert!(ok_to_dereg, "resolved instance permits orphan cleanup");
+        assert!(resolution.active_signers.contains(&addr));
+        assert!(ok_to_dereg);
     }
 
     #[tokio::test]
@@ -636,8 +592,8 @@ mod tests {
             cycle_driver(vec![], MockSignerClient::from_keys(&[]), CancellationToken::new());
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
-        assert!(resolution.active_signers.is_empty(), "no instances → no active signers");
-        assert!(ok_to_dereg, "zero-instance fleet drain is a legitimate empty active set",);
+        assert!(resolution.active_signers.is_empty());
+        assert!(ok_to_dereg);
     }
 
     #[tokio::test]
@@ -649,7 +605,7 @@ mod tests {
 
         let (_, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
-        assert!(!ok_to_dereg, "cancellation observed during resolution must clear ok_to_dereg",);
+        assert!(!ok_to_dereg);
     }
 
     #[tokio::test]
@@ -664,7 +620,7 @@ mod tests {
 
         let (_, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
-        assert!(!ok_to_dereg, "1/3 reachable must block orphan-deregistration",);
+        assert!(!ok_to_dereg);
     }
 
     #[tokio::test]
@@ -688,16 +644,9 @@ mod tests {
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
-        assert_eq!(
-            resolution.registerable.len(),
-            reachable.len(),
-            "all reachable instances should be registerable despite 1 unreachable",
-        );
-        assert!(
-            resolution.unresolved_instance_ids.contains(&unreachable.instance_id),
-            "unreachable instance must be marked as unresolved so reconcile skips its cancel-pass",
-        );
-        assert!(!ok_to_dereg, "unresolved instance must block orphan-dereg",);
+        assert_eq!(resolution.registerable.len(), reachable.len());
+        assert!(resolution.unresolved_instance_ids.contains(&unreachable.instance_id));
+        assert!(!ok_to_dereg);
     }
 
     #[tokio::test]
@@ -712,10 +661,7 @@ mod tests {
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
-        assert!(
-            resolution.registerable.is_empty(),
-            "draining instance must not appear in the registerable set",
-        );
+        assert!(resolution.registerable.is_empty());
         assert!(resolution.active_signers.contains(&addr0));
         assert!(resolution.active_signers.contains(&addr1));
         assert!(ok_to_dereg);
@@ -737,50 +683,30 @@ mod tests {
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
-        assert_eq!(
-            resolution.registerable.len(),
-            1,
-            "only the healthy instance should be registerable",
-        );
+        assert_eq!(resolution.registerable.len(), 1);
         assert_eq!(resolution.registerable[0].signer, addr_healthy);
-        assert!(
-            resolution.active_signers.contains(&addr_unhealthy),
-            "unhealthy signer must remain in active_signers to block dereg",
-        );
+        assert!(resolution.active_signers.contains(&addr_unhealthy));
         assert!(ok_to_dereg);
     }
 
-    #[rstest]
-    #[case::mismatch(false)]
-    #[case::rpc_error(true)]
     #[tokio::test]
-    async fn discover_and_resolve_attestation_failure_keeps_signer_active_and_unresolved(
-        #[case] rpc_error: bool,
-    ) {
+    async fn discover_and_resolve_attestation_failure_keeps_signer_active_and_unresolved() {
         let signer_addr = signer_from_private_key(&HARDHAT_KEY_0);
         let inst = healthy_prover_instance(EP1);
-        let signer_client = if rpc_error {
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestation_failure(EP1)
-        } else {
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestations(EP1, vec![])
-        };
+        let signer_clients = [
+            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestations(EP1, vec![]),
+            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]).with_attestation_failure(EP1),
+        ];
 
-        let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
+        for signer_client in signer_clients {
+            let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
 
-        let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
+            let (resolution, ok_to_dereg) = driver.discover_and_resolve().await.unwrap();
 
-        assert!(
-            resolution.active_signers.contains(&signer_addr),
-            "partial resolution must keep the signer in the active set",
-        );
-        assert!(
-            resolution.registerable.is_empty(),
-            "without a matching attestation the signer must not be registerable",
-        );
-        assert!(
-            resolution.unresolved_instance_ids.contains(&inst.instance_id),
-            "partial resolution must preserve in-flight tasks for the instance",
-        );
-        assert!(!ok_to_dereg, "unresolved attestation state must block orphan-dereg",);
+            assert!(resolution.active_signers.contains(&signer_addr));
+            assert!(resolution.registerable.is_empty());
+            assert!(resolution.unresolved_instance_ids.contains(&inst.instance_id));
+            assert!(!ok_to_dereg);
+        }
     }
 }

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -52,8 +52,7 @@ pub use registry::{RegistryClient, RegistryContractClient};
 
 mod signer_manager;
 pub use signer_manager::{
-    PendingRegistration, ProofTaskOutcome, ProofTaskSet, SignerLifecycle, SignerManager,
-    SignerManagerConfig,
+    PendingRegistration, ProofTaskOutcome, ProofTaskSet, SignerManager, SignerManagerConfig,
 };
 
 mod traits;

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -27,9 +27,8 @@ pub use discovery::AwsTargetGroupDiscovery;
 
 mod driver;
 pub use driver::{
-    DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
-    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DiscoveryResolution, DriverConfig,
-    RegisterableSigner, RegistrationDriver,
+    DEFAULT_MAX_CONCURRENCY, DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DiscoveryResolution,
+    DriverConfig, RegisterableSigner, RegistrationDriver,
 };
 
 mod error;
@@ -52,7 +51,8 @@ pub use registry::{RegistryClient, RegistryContractClient};
 
 mod signer_manager;
 pub use signer_manager::{
-    PendingRegistration, ProofTaskOutcome, ProofTaskSet, SignerManager, SignerManagerConfig,
+    DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, PendingRegistration, ProofTaskOutcome,
+    ProofTaskSet, SignerManager, SignerManagerConfig,
 };
 
 mod traits;

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -29,7 +29,7 @@ mod driver;
 pub use driver::{
     DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DiscoveryResolution, DriverConfig,
-    RegisterableSigner, RegistrationDriver, ResolveOutcome,
+    RegisterableSigner, RegistrationDriver,
 };
 
 mod error;

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -466,13 +466,9 @@ mod tests {
                 enclave_index: 0,
             });
         }
-        let total = kept.len();
         DiscoveryResolution {
             registerable,
             active_signers,
-            reachable_count: total,
-            total_count: total,
-            ok_to_dereg: true,
             unresolved_instance_ids: HashSet::new(),
         }
     }
@@ -612,9 +608,6 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
-            reachable_count: 0,
-            total_count: 1,
-            ok_to_dereg: false,
             unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
         };
 
@@ -629,9 +622,6 @@ mod tests {
         let resolution_conclusive = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
-            reachable_count: 1,
-            total_count: 1,
-            ok_to_dereg: true,
             unresolved_instance_ids: HashSet::new(),
         };
         reconcile(&manager, &resolution_conclusive, &mut proof_tasks);
@@ -660,9 +650,6 @@ mod tests {
                 },
             ],
             active_signers: HashSet::from([signer]),
-            reachable_count: 2,
-            total_count: 2,
-            ok_to_dereg: false,
             unresolved_instance_ids: HashSet::new(),
         };
         let mut proof_tasks = ProofTaskSet::new();
@@ -702,9 +689,6 @@ mod tests {
                 },
             ],
             active_signers: HashSet::from([signer_a, signer_b]),
-            reachable_count: 2,
-            total_count: 2,
-            ok_to_dereg: false,
             unresolved_instance_ids: HashSet::new(),
         };
         let mut proof_tasks = ProofTaskSet::new();
@@ -828,9 +812,6 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::from([active_signer]),
-            reachable_count: 1,
-            total_count: 1,
-            ok_to_dereg: true,
             unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
         };
         let protected = proof_tasks.protected_signers(&resolution);

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use alloy_primitives::Address;
-use async_trait::async_trait;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::TxManager;
 use tokio::{
@@ -86,117 +85,6 @@ impl<P, R, T> SignerManager<P, R, T> {
     pub fn new(proof_provider: P, registry: R, tx_manager: T, config: SignerManagerConfig) -> Self {
         let proof_semaphore = Semaphore::new(config.max_concurrency.max(1));
         Self { proof_provider, registry, tx_manager, proof_semaphore, config }
-    }
-}
-
-/// Driver-facing signer lifecycle boundary.
-///
-/// The production implementation is [`SignerManager`], but the driver only
-/// needs to reconcile proof tasks and run orphan cleanup. Keeping this as a
-/// trait lets driver tests mock signer lifecycle behavior without standing up
-/// proof tasks or registry state.
-#[async_trait]
-pub trait SignerLifecycle: Send + Sync + fmt::Debug {
-    /// Reconciles in-flight registration tasks against fetched prover signers.
-    ///
-    /// New proof-task child tokens are derived from `cancel`, which is owned
-    /// by the driver so every signer lifecycle operation shares one shutdown
-    /// source of truth.
-    fn reconcile_proof_tasks(
-        &self,
-        resolution: &DiscoveryResolution,
-        proof_tasks: &mut ProofTaskSet,
-        cancel: &CancellationToken,
-    );
-
-    /// Queries onchain signers and deregisters orphans.
-    ///
-    /// The caller-provided cancellation token controls every registry read and
-    /// transaction submission attempted by the deregistration pass.
-    async fn run_orphan_dereg(
-        &self,
-        protected_signers: &HashSet<Address>,
-        cancel: &CancellationToken,
-    ) -> Result<()>;
-}
-
-#[async_trait]
-impl<P, R, T> SignerLifecycle for Arc<SignerManager<P, R, T>>
-where
-    P: AttestationProofProvider + 'static,
-    R: RegistryClient + 'static,
-    T: TxManager + 'static,
-{
-    fn reconcile_proof_tasks(
-        &self,
-        resolution: &DiscoveryResolution,
-        proof_tasks: &mut ProofTaskSet,
-        cancel: &CancellationToken,
-    ) {
-        if cancel.is_cancelled() {
-            return;
-        }
-
-        let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
-        let mut live_signers = HashSet::new();
-
-        for (signer, task) in &mut proof_tasks.pending {
-            if task.cancel.is_cancelled() {
-                continue;
-            }
-
-            if wanted.contains(signer) {
-                live_signers.insert(*signer);
-                continue;
-            }
-
-            if resolution.unresolved_instance_ids.contains(&task.instance_id) {
-                live_signers.insert(*signer);
-                debug!(
-                    signer = %signer,
-                    instance = %task.instance_id,
-                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
-                );
-            } else {
-                info!(
-                    signer = %signer,
-                    instance = %task.instance_id,
-                    "cancelling proof task: signer no longer registerable"
-                );
-                task.cancel.cancel();
-                task.cancelled_by_reconcile = true;
-                RegistrarMetrics::proof_tasks_cancelled().increment(1);
-            }
-        }
-
-        for entry in &resolution.registerable {
-            if !live_signers.insert(entry.signer) {
-                continue;
-            }
-            let signer_cancel = cancel.child_token();
-            let manager = Self::clone(self);
-            let instance_owned = entry.instance.clone();
-            let instance_id = instance_owned.instance_id.clone();
-            let attestation = entry.attestation.clone();
-            let task_cancel = signer_cancel.clone();
-            let signer = entry.signer;
-            let enclave_index = entry.enclave_index;
-
-            proof_tasks.spawn_task(signer, instance_id, signer_cancel, async move {
-                let result = manager
-                    .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
-                    .await;
-                ProofTaskOutcome { signer, result }
-            });
-        }
-    }
-
-    async fn run_orphan_dereg(
-        &self,
-        protected_signers: &HashSet<Address>,
-        cancel: &CancellationToken,
-    ) -> Result<()> {
-        self.as_ref().run_orphan_dereg(protected_signers, cancel).await
     }
 }
 
@@ -354,6 +242,75 @@ where
     R: RegistryClient + 'static,
     T: TxManager + 'static,
 {
+    /// Reconciles in-flight registration tasks against fetched prover signers.
+    ///
+    /// New proof-task child tokens are derived from `cancel`, which is owned
+    /// by the driver so every signer lifecycle operation shares one shutdown
+    /// source of truth.
+    pub fn reconcile_proof_tasks(
+        self: &Arc<Self>,
+        resolution: &DiscoveryResolution,
+        proof_tasks: &mut ProofTaskSet,
+        cancel: &CancellationToken,
+    ) {
+        if cancel.is_cancelled() {
+            return;
+        }
+
+        let wanted: HashSet<Address> = resolution.registerable.iter().map(|e| e.signer).collect();
+        let mut live_signers = HashSet::new();
+
+        for (signer, task) in &mut proof_tasks.pending {
+            if task.cancel.is_cancelled() {
+                continue;
+            }
+
+            if wanted.contains(signer) {
+                live_signers.insert(*signer);
+                continue;
+            }
+
+            if resolution.unresolved_instance_ids.contains(&task.instance_id) {
+                live_signers.insert(*signer);
+                debug!(
+                    signer = %signer,
+                    instance = %task.instance_id,
+                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
+                );
+            } else {
+                info!(
+                    signer = %signer,
+                    instance = %task.instance_id,
+                    "cancelling proof task: signer no longer registerable"
+                );
+                task.cancel.cancel();
+                task.cancelled_by_reconcile = true;
+                RegistrarMetrics::proof_tasks_cancelled().increment(1);
+            }
+        }
+
+        for entry in &resolution.registerable {
+            if !live_signers.insert(entry.signer) {
+                continue;
+            }
+            let signer_cancel = cancel.child_token();
+            let manager = Arc::clone(self);
+            let instance_owned = entry.instance.clone();
+            let instance_id = instance_owned.instance_id.clone();
+            let attestation = entry.attestation.clone();
+            let task_cancel = signer_cancel.clone();
+            let signer = entry.signer;
+            let enclave_index = entry.enclave_index;
+
+            proof_tasks.spawn_task(signer, instance_id, signer_cancel, async move {
+                let result = manager
+                    .run_proof_task(instance_owned, signer, enclave_index, attestation, task_cancel)
+                    .await;
+                ProofTaskOutcome { signer, result }
+            });
+        }
+    }
+
     /// Runs a signer registration through [`RegistrationManager`].
     pub async fn run_proof_task(
         self: Arc<Self>,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -26,6 +26,13 @@ use crate::{
     RegistrarMetrics, RegistrationManager, RegistryClient, Result,
 };
 
+/// Default maximum number of transaction submission retries for transient
+/// errors before giving up.
+pub const DEFAULT_MAX_TX_RETRIES: u32 = 3;
+
+/// Default delay between transaction submission retries.
+pub const DEFAULT_TX_RETRY_DELAY_SECS: u64 = 5;
+
 /// Runtime settings for signer lifecycle management.
 #[derive(Debug, Clone)]
 pub struct SignerManagerConfig {

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -277,12 +277,12 @@ where
                 continue;
             }
 
-            if resolution.has_unresolved_instances {
+            if resolution.unresolved_instance_ids.contains(&task.instance_id) {
                 live_signers.insert(*signer);
                 debug!(
                     signer = %signer,
                     instance = %task.instance_id,
-                    "preserving proof task: discovery was inconclusive this cycle"
+                    "preserving proof task: source instance failed to resolve this cycle"
                 );
             } else {
                 info!(
@@ -473,7 +473,11 @@ mod tests {
                 enclave_index: 0,
             });
         }
-        DiscoveryResolution { registerable, active_signers, has_unresolved_instances: false }
+        DiscoveryResolution {
+            registerable,
+            active_signers,
+            unresolved_instance_ids: HashSet::new(),
+        }
     }
 
     fn spawn_pending_success_task(
@@ -611,7 +615,7 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
-            has_unresolved_instances: true,
+            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
         };
 
         reconcile(&manager, &resolution, &mut proof_tasks);
@@ -625,7 +629,7 @@ mod tests {
         let resolution_conclusive = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
-            has_unresolved_instances: false,
+            unresolved_instance_ids: HashSet::new(),
         };
         reconcile(&manager, &resolution_conclusive, &mut proof_tasks);
         assert!(task_cancel.is_cancelled(), "conclusive absence must cancel the task");
@@ -653,7 +657,7 @@ mod tests {
                 },
             ],
             active_signers: HashSet::from([signer]),
-            has_unresolved_instances: false,
+            unresolved_instance_ids: HashSet::new(),
         };
         let mut proof_tasks = ProofTaskSet::new();
 
@@ -692,7 +696,7 @@ mod tests {
                 },
             ],
             active_signers: HashSet::from([signer_a, signer_b]),
-            has_unresolved_instances: false,
+            unresolved_instance_ids: HashSet::new(),
         };
         let mut proof_tasks = ProofTaskSet::new();
 
@@ -815,7 +819,7 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::from([active_signer]),
-            has_unresolved_instances: true,
+            unresolved_instance_ids: HashSet::new(),
         };
         let protected = proof_tasks.protected_signers(&resolution);
         assert_eq!(protected, HashSet::from([active_signer, pending_signer]));

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -277,12 +277,12 @@ where
                 continue;
             }
 
-            if resolution.unresolved_instance_ids.contains(&task.instance_id) {
+            if resolution.has_unresolved_instances {
                 live_signers.insert(*signer);
                 debug!(
                     signer = %signer,
                     instance = %task.instance_id,
-                    "preserving proof task: source instance failed to resolve this cycle (inconclusive)"
+                    "preserving proof task: discovery was inconclusive this cycle"
                 );
             } else {
                 info!(
@@ -473,11 +473,7 @@ mod tests {
                 enclave_index: 0,
             });
         }
-        DiscoveryResolution {
-            registerable,
-            active_signers,
-            unresolved_instance_ids: HashSet::new(),
-        }
+        DiscoveryResolution { registerable, active_signers, has_unresolved_instances: false }
     }
 
     fn spawn_pending_success_task(
@@ -615,7 +611,7 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
-            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
+            has_unresolved_instances: true,
         };
 
         reconcile(&manager, &resolution, &mut proof_tasks);
@@ -629,7 +625,7 @@ mod tests {
         let resolution_conclusive = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::new(),
-            unresolved_instance_ids: HashSet::new(),
+            has_unresolved_instances: false,
         };
         reconcile(&manager, &resolution_conclusive, &mut proof_tasks);
         assert!(task_cancel.is_cancelled(), "conclusive absence must cancel the task");
@@ -657,7 +653,7 @@ mod tests {
                 },
             ],
             active_signers: HashSet::from([signer]),
-            unresolved_instance_ids: HashSet::new(),
+            has_unresolved_instances: false,
         };
         let mut proof_tasks = ProofTaskSet::new();
 
@@ -696,7 +692,7 @@ mod tests {
                 },
             ],
             active_signers: HashSet::from([signer_a, signer_b]),
-            unresolved_instance_ids: HashSet::new(),
+            has_unresolved_instances: false,
         };
         let mut proof_tasks = ProofTaskSet::new();
 
@@ -819,7 +815,7 @@ mod tests {
         let resolution = DiscoveryResolution {
             registerable: Vec::new(),
             active_signers: HashSet::from([active_signer]),
-            unresolved_instance_ids: HashSet::from([TEST_PENDING_INSTANCE_ID.to_string()]),
+            has_unresolved_instances: true,
         };
         let protected = proof_tasks.protected_signers(&resolution);
         assert_eq!(protected, HashSet::from([active_signer, pending_signer]));


### PR DESCRIPTION
### What changed? Why?

Refactors the TEE registrar driver so it owns discovery/resolution orchestration while signer lifecycle work lives directly on `SignerManager`. This removes the `SignerLifecycle` test boundary and `ResolveOutcome` wrapper, keeps deregistration quorum/cancellation state local to `discover_and_resolve`, and leaves the driver with a smaller `DiscoveryResolution` shape.

CRL enablement now lives inside `CertManager`, so disabled CRL checks no-op before parsing attestations or querying the Nitro verifier. The CLI now builds `DriverConfig` and `SignerManagerConfig` separately: discovery concurrency stays on the driver config, while signer transaction retry settings stay with the signer manager.

### Notes to reviewers

This is intended as a behavior-preserving cleanup of the registrar path. The important invariants remain covered: reachable signers protect against orphan deregistration, unresolved instances preserve in-flight proof tasks and block orphan cleanup, empty-fleet deregistration is still allowed, and majority-unreachable discovery results still skip orphan cleanup.

The driver tests now focus on `discover_and_resolve`; proof-task reconciliation coverage remains with `SignerManager`.

### How has it been tested?

`cargo test -p base-proof-tee-registrar`