### PR TITLE
feat(eip8130): account-configuration change authorization (SCOPE_CONFIG path)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4528,6 +4528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-execution-eip8130-nonce"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "base-common-consensus",
+ "base-common-precompiles",
+ "base-precompile-storage",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "base-execution-eip8130-state"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ base-execution-eip8130 = { path = "crates/execution/eip8130", default-features =
 base-execution-eip8130-state = { path = "crates/execution/eip8130-state", default-features = false }
 base-execution-eip8130-authorize = { path = "crates/execution/eip8130-authorize", default-features = false }
 base-execution-eip8130-tx = { path = "crates/execution/eip8130-tx", default-features = false }
+base-execution-eip8130-nonce = { path = "crates/execution/eip8130-nonce", default-features = false }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }

--- a/crates/execution/eip8130-nonce/Cargo.toml
+++ b/crates/execution/eip8130-nonce/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "base-execution-eip8130-nonce"
+description = "EIP-8130 2D nonce validation (protocol, channel, and nonce-free modes)"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-primitives.workspace = true
+
+# base
+base-common-precompiles.workspace = true
+base-precompile-storage.workspace = true
+base-common-consensus = { workspace = true, default-features = false }
+
+# misc
+thiserror.workspace = true
+
+[dev-dependencies]
+base-precompile-storage = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/eip8130-nonce/README.md
+++ b/crates/execution/eip8130-nonce/README.md
@@ -1,0 +1,45 @@
+# base-execution-eip8130-nonce
+
+2D nonce validation for EIP-8130 — the stateful nonce step of the validation
+pipeline, shared by mempool admission and block inclusion. It consumes the
+resolved sender account (from [`base-execution-eip8130-tx`](../eip8130-tx)) and
+checks a transaction's `(nonce_key, nonce_sequence)` against the live nonce
+state.
+
+[`NonceValidator::validate`] resolves the channel implied by `nonce_key` and
+compares the transaction's `nonce_sequence` to that channel's current value:
+
+- **Protocol nonce** (`nonce_key == 0`): the channel value is the account's
+  basic protocol nonce, held in account state rather than the nonce manager, so
+  it is supplied by the caller as `protocol_nonce`.
+- **2D channel** (`0 < nonce_key < NONCE_KEY_MAX`): the channel value is read
+  from the [`NonceManager`](base_common_precompiles::NonceManagerStorage)
+  precompile via `get_nonce(account, nonce_key)`. Independent channels let one
+  account keep many independently-ordered transactions in flight.
+- **Nonce-free** (`nonce_key == NONCE_KEY_MAX`): there is no sequence channel.
+  Replay protection comes from the nonce manager's expiring-nonce set, keyed by
+  the signature-invariant replay hash `keccak256(account ‖ sender_signature_hash)`
+  so re-signed fee-payer variants of one logical transaction collapse to a single
+  entry.
+
+## Modes
+
+The same comparison serves both consumers, differing only in how a sequence
+*ahead* of the channel is treated:
+
+- [`NonceMode::Inclusion`] — the sequence must equal the channel nonce. A higher
+  sequence is a gap that cannot execute now ([`NonceError::TooHigh`]).
+- [`NonceMode::Pool`] — a higher sequence is admissible and **buffered**
+  ([`NonceStatus::Buffered`]) until its predecessors arrive, matching mempool
+  semantics for gapped transactions.
+
+A sequence *below* the channel nonce is always stale ([`NonceError::TooLow`]).
+
+## Scope (what this is and is not)
+
+This layer is a read-only check: it reads the channel nonce (or the
+expiring-nonce set) and decides admissibility. It does **not** advance nonces,
+record the expiring-nonce replay hash, or validate the structural nonce-free
+rules (`nonce_sequence == 0`, the `expiry` window) — those are enforced by
+`Eip8130Signed::validate_timestamp` and applied by the execution layer that
+calls `increment_nonce` / `check_and_mark_expiring_nonce`.

--- a/crates/execution/eip8130-nonce/src/error.rs
+++ b/crates/execution/eip8130-nonce/src/error.rs
@@ -1,0 +1,41 @@
+//! Errors returned by the EIP-8130 nonce validation step.
+
+use base_precompile_storage::BasePrecompileError;
+
+/// Reason a transaction's nonce could not be validated against the live nonce
+/// state. Every variant is a hard rejection for block inclusion; in the mempool
+/// a sequence *ahead* of the channel is not an error (see
+/// [`NonceStatus::Buffered`](crate::NonceStatus)).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NonceError {
+    /// The transaction's `nonce_sequence` is below the channel's current nonce,
+    /// so it has already been used. Stale in every mode.
+    #[error("nonce sequence {got} is below the channel nonce {channel}")]
+    TooLow {
+        /// The channel's current nonce read from state.
+        channel: u64,
+        /// The sequence carried by the transaction.
+        got: u64,
+    },
+
+    /// The transaction's `nonce_sequence` is ahead of the channel's current
+    /// nonce, leaving a gap. Only an error under [`NonceMode::Inclusion`](crate::NonceMode);
+    /// the pool buffers such transactions instead.
+    #[error("nonce sequence {got} is ahead of the channel nonce {channel}")]
+    TooHigh {
+        /// The channel's current nonce read from state.
+        channel: u64,
+        /// The sequence carried by the transaction.
+        got: u64,
+    },
+
+    /// A nonce-free (`NONCE_KEY_MAX`) transaction's replay hash is already
+    /// recorded and has not yet expired. Mirrors the nonce manager's
+    /// `ExpiringNonceReplay`.
+    #[error("nonce-free replay hash already recorded")]
+    Replay,
+
+    /// A read against the nonce manager precompile storage failed.
+    #[error("nonce-manager read failed: {0}")]
+    Storage(#[from] BasePrecompileError),
+}

--- a/crates/execution/eip8130-nonce/src/lib.rs
+++ b/crates/execution/eip8130-nonce/src/lib.rs
@@ -1,0 +1,7 @@
+#![doc = include_str!("../README.md")]
+
+mod error;
+pub use error::NonceError;
+
+mod validate;
+pub use validate::{NonceMode, NonceStatus, NonceValidator};

--- a/crates/execution/eip8130-nonce/src/validate.rs
+++ b/crates/execution/eip8130-nonce/src/validate.rs
@@ -1,0 +1,229 @@
+//! Stateful 2D nonce validation: resolve the channel implied by `nonce_key` and
+//! compare the transaction's `nonce_sequence` against the live nonce state.
+
+use core::cmp::Ordering;
+
+use alloy_primitives::{Address, B256, Keccak256, U256};
+use base_common_consensus::{Eip8130Constants, TxEip8130};
+use base_common_precompiles::NonceManagerStorage;
+
+use crate::NonceError;
+
+/// Which consumer is validating the nonce. The check is identical except for how
+/// a sequence *ahead* of the channel nonce is treated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NonceMode {
+    /// Mempool admission. A sequence ahead of the channel is admissible and
+    /// buffered until its predecessors arrive.
+    Pool,
+    /// Block inclusion. The sequence must equal the channel nonce exactly.
+    Inclusion,
+}
+
+/// Outcome of a successful nonce validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NonceStatus {
+    /// The transaction's sequence equals the channel nonce (or is a nonce-free
+    /// transaction whose replay hash has not been seen) and may execute now.
+    Ready,
+    /// Pool-only: the sequence is ahead of the channel nonce by `gap` and is
+    /// buffered until the intervening sequences are filled.
+    Buffered {
+        /// How far ahead of the current channel nonce the sequence is.
+        gap: u64,
+    },
+}
+
+/// Validates an EIP-8130 transaction's 2D nonce against the live nonce state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NonceValidator;
+
+impl NonceValidator {
+    /// Validates `tx`'s `(nonce_key, nonce_sequence)` for `account` (the resolved
+    /// transaction sender).
+    ///
+    /// `sender_signature_hash` is [`TxEip8130::sender_signature_hash`], taken as
+    /// a parameter because the earlier authenticate stage has already computed it
+    /// — recomputing it here (an RLP encode + keccak256) would be redundant work
+    /// on the nonce-free hot path. It is consulted only for the nonce-free
+    /// (`NONCE_KEY_MAX`) replay hash.
+    ///
+    /// `protocol_nonce` is the account's current basic nonce, read by the caller
+    /// from account state; it is consulted only for the protocol channel
+    /// (`nonce_key == 0`). `storage` serves the 2D channels and the nonce-free
+    /// replay set. `now` (Unix seconds; block timestamp at inclusion, wall-clock
+    /// in the pool) bounds the nonce-free replay-set lookup and is unused for
+    /// sequence channels.
+    ///
+    /// Returns [`NonceStatus::Ready`] when the transaction may execute now,
+    /// [`NonceStatus::Buffered`] when a pool transaction is ahead of its channel,
+    /// or a [`NonceError`] for a stale, gapped (inclusion), or replayed nonce.
+    pub fn validate(
+        tx: &TxEip8130,
+        account: Address,
+        sender_signature_hash: B256,
+        protocol_nonce: u64,
+        storage: &NonceManagerStorage<'_>,
+        mode: NonceMode,
+        now: u64,
+    ) -> Result<NonceStatus, NonceError> {
+        if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
+            // Nonce-free: no sequence channel. The structural rules
+            // (nonce_sequence == 0, expiry window) are enforced upstream by
+            // `Eip8130Signed::validate_timestamp`; the only stateful check is
+            // that this logical transaction's replay hash is not already
+            // recorded and unexpired.
+            let replay = Self::replay_hash(account, sender_signature_hash);
+            if storage.is_expiring_nonce_seen(replay, now)? {
+                return Err(NonceError::Replay);
+            }
+            return Ok(NonceStatus::Ready);
+        }
+
+        // Protocol nonce (key 0) lives in account state, not the nonce manager;
+        // every other channel is served by the manager precompile.
+        let channel = if tx.nonce_key == U256::ZERO {
+            protocol_nonce
+        } else {
+            storage.get_nonce(account, tx.nonce_key)?
+        };
+
+        match tx.nonce_sequence.cmp(&channel) {
+            Ordering::Less => Err(NonceError::TooLow { channel, got: tx.nonce_sequence }),
+            Ordering::Equal => Ok(NonceStatus::Ready),
+            Ordering::Greater => match mode {
+                NonceMode::Inclusion => {
+                    Err(NonceError::TooHigh { channel, got: tx.nonce_sequence })
+                }
+                NonceMode::Pool => Ok(NonceStatus::Buffered { gap: tx.nonce_sequence - channel }),
+            },
+        }
+    }
+
+    /// The signature-invariant nonce-free replay hash,
+    /// `keccak256(account ‖ sender_signature_hash)`, matching the value the nonce
+    /// manager records in its expiring-nonce set.
+    ///
+    /// Public so the execution layer can recompute the identical key when it
+    /// records the nonce via `check_and_mark_expiring_nonce` at block inclusion,
+    /// rather than duplicating the derivation and risking divergence.
+    #[must_use]
+    pub fn replay_hash(account: Address, sender_signature_hash: B256) -> B256 {
+        let mut hasher = Keccak256::new();
+        hasher.update(account.as_slice());
+        hasher.update(sender_signature_hash.as_slice());
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+
+    const ACCOUNT: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn tx_with(nonce_key: U256, nonce_sequence: u64) -> TxEip8130 {
+        TxEip8130 { nonce_key, nonce_sequence, ..Default::default() }
+    }
+
+    /// Runs `validate` against a freshly-seeded nonce manager. `seed` may mutate
+    /// the manager (e.g. advance a channel) before the (immutable) check.
+    fn check(
+        tx: &TxEip8130,
+        protocol_nonce: u64,
+        mode: NonceMode,
+        now: u64,
+        seed: impl FnOnce(&mut NonceManagerStorage<'_>),
+    ) -> Result<NonceStatus, NonceError> {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            seed(&mut mgr);
+            NonceValidator::validate(
+                tx,
+                ACCOUNT,
+                tx.sender_signature_hash(),
+                protocol_nonce,
+                &mgr,
+                mode,
+                now,
+            )
+        })
+    }
+
+    #[test]
+    fn protocol_nonce_ready_when_sequence_matches() {
+        let tx = tx_with(U256::ZERO, 5);
+        assert_eq!(check(&tx, 5, NonceMode::Inclusion, 0, |_| {}), Ok(NonceStatus::Ready));
+    }
+
+    #[test]
+    fn protocol_nonce_below_channel_is_too_low() {
+        let tx = tx_with(U256::ZERO, 4);
+        assert_eq!(
+            check(&tx, 5, NonceMode::Pool, 0, |_| {}),
+            Err(NonceError::TooLow { channel: 5, got: 4 })
+        );
+    }
+
+    #[test]
+    fn protocol_nonce_gap_rejected_at_inclusion_buffered_in_pool() {
+        let tx = tx_with(U256::ZERO, 8);
+        assert_eq!(
+            check(&tx, 5, NonceMode::Inclusion, 0, |_| {}),
+            Err(NonceError::TooHigh { channel: 5, got: 8 })
+        );
+        assert_eq!(check(&tx, 5, NonceMode::Pool, 0, |_| {}), Ok(NonceStatus::Buffered { gap: 3 }));
+    }
+
+    #[test]
+    fn channel_nonce_is_read_from_the_manager() {
+        let key = U256::from(7u64);
+        // Advance the 2D channel to 3, then the protocol_nonce arg must be ignored.
+        let seed = |mgr: &mut NonceManagerStorage<'_>| {
+            for _ in 0..3 {
+                mgr.increment_nonce(ACCOUNT, key).unwrap();
+            }
+        };
+        assert_eq!(
+            check(&tx_with(key, 3), 999, NonceMode::Inclusion, 0, seed),
+            Ok(NonceStatus::Ready)
+        );
+        assert_eq!(
+            check(&tx_with(key, 2), 999, NonceMode::Pool, 0, seed),
+            Err(NonceError::TooLow { channel: 3, got: 2 })
+        );
+        assert_eq!(
+            check(&tx_with(key, 5), 999, NonceMode::Pool, 0, seed),
+            Ok(NonceStatus::Buffered { gap: 2 })
+        );
+        assert_eq!(
+            check(&tx_with(key, 5), 999, NonceMode::Inclusion, 0, seed),
+            Err(NonceError::TooHigh { channel: 3, got: 5 })
+        );
+    }
+
+    #[test]
+    fn nonce_free_ready_when_replay_hash_unseen() {
+        let tx = tx_with(Eip8130Constants::NONCE_KEY_MAX, 0);
+        assert_eq!(check(&tx, 0, NonceMode::Pool, 1_000, |_| {}), Ok(NonceStatus::Ready));
+    }
+
+    #[test]
+    fn nonce_free_replay_is_rejected() {
+        let now = 1_000u64;
+        let tx = tx_with(Eip8130Constants::NONCE_KEY_MAX, 0);
+        let replay = NonceValidator::replay_hash(ACCOUNT, tx.sender_signature_hash());
+        let seed = |mgr: &mut NonceManagerStorage<'_>| {
+            mgr.check_and_mark_expiring_nonce(replay, now + 20).unwrap();
+        };
+        assert_eq!(check(&tx, 0, NonceMode::Inclusion, now, seed), Err(NonceError::Replay));
+    }
+}

--- a/crates/execution/eip8130-tx/README.md
+++ b/crates/execution/eip8130-tx/README.md
@@ -20,6 +20,27 @@ An actor with `scope == 0` (unrestricted) satisfies every context; otherwise the
 relevant scope bit must be set, matching `AccountConfiguration`'s
 `scope == 0 || scope & REQUIRED != 0` rule.
 
+## Config-change authorization
+
+[`ConfigChangeAuthorizer`] authorizes an account-configuration change (a
+`ConfigChange` entry in `account_changes`) against the account's config — the
+native mirror of `AccountConfiguration.applySignedActorChanges`'s authorization
+tail. For one entry it:
+
+1. rejects a **locked** account (`onlyUnlocked`);
+2. enforces the **chain binding** and selects the sequence channel
+   (`chain_id == 0` → multichain, else local);
+3. requires the entry's `sequence` to equal the account's current channel
+   sequence (the value the contract reads from state and the signer signs over);
+4. reconstructs the **`SignedActorChanges`** digest (byte-identical to
+   `_computeSignedActorChangesDigest`), authorizes the entry's `auth` through the
+   [`ActorAuthorizer`], and requires **`SCOPE_CONFIG`**.
+
+It authorizes a single entry against the account's *current* on-chain sequence;
+ordering/sequence advancement across multiple same-channel entries in one
+transaction, and **applying** the changes (decoding `data`, mutating
+`actor_config`), are layered on top.
+
 ## Sender auth formats
 
 The sender auth blob differs by path, mirroring the wire format:
@@ -34,9 +55,12 @@ The sender auth blob differs by path, mirroring the wire format:
 
 ## Scope (what this is and is not)
 
-This layer covers **sender + payer** authorization and scope gating only. It does
-**not** validate account changes (the `SCOPE_CONFIG` owner-changes path, layered
-next), 2D nonces, gas/payment amounts, account locking, or call execution — those
-consume the [`TxActors`] this returns.
+This layer covers **sender + payer** authorization (via [`ActorTxVerifier`]) and
+single-entry **config-change** authorization (via [`ConfigChangeAuthorizer`]),
+each with its scope gate, plus the config-change lock/chain/sequence checks. It
+does **not** apply account changes, simulate cross-entry sequencing, or validate
+2D nonces, gas/payment amounts, or call execution — those consume the
+[`TxActors`] / [`ResolvedActor`] these return.
 
 [`Eip8130Signed`]: base_common_consensus::Eip8130Signed
+[`ResolvedActor`]: base_execution_eip8130_authorize::ResolvedActor

--- a/crates/execution/eip8130-tx/src/config.rs
+++ b/crates/execution/eip8130-tx/src/config.rs
@@ -1,19 +1,26 @@
 //! Account-configuration change authorization — the `SCOPE_CONFIG` path of the
 //! EIP-8130 validation flow.
 
-use alloy_primitives::{Address, B256, Keccak256, keccak256};
+use alloy_primitives::{Address, B256, Keccak256, b256, keccak256};
 use base_common_consensus::ConfigChange;
 use base_execution_eip8130_authorize::{ActorAuthorizer, AuthorizeError, ResolvedActor};
 use base_execution_eip8130_state::AccountConfigurationStorage;
 
 use crate::{Operation, TxAuthError};
 
-/// `SignedActorChanges` EIP-712-style type string, identical to the one hashed
-/// by `AccountConfiguration` (the trailing `ActorChange(...)` is the referenced
-/// struct's type, per the EIP-712 encoding rules).
-const SIGNED_ACTOR_CHANGES_TYPE: &[u8] = b"SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)";
-/// `ActorChange` type string used for the per-change leaf hashes.
-const ACTOR_CHANGE_TYPE: &[u8] = b"ActorChange(uint8 changeType,bytes32 actorId,bytes data)";
+/// Precomputed `keccak256` typehash of the `SignedActorChanges` EIP-712-style
+/// struct, identical to the one hashed by `AccountConfiguration` (the trailing
+/// `ActorChange(...)` is the referenced struct's type, per the EIP-712 encoding
+/// rules):
+/// `keccak256("SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)")`.
+/// Pinned to its preimage by `typehashes_match_their_preimages`.
+const SIGNED_ACTOR_CHANGES_TYPEHASH: B256 =
+    b256!("3528344db25dddc3f16dbdc7302aacb555665c0af1beedc07d5fe28e8512bb3f");
+/// Precomputed `keccak256` typehash for the per-change `ActorChange` leaves:
+/// `keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)")`.
+/// Pinned to its preimage by `typehashes_match_their_preimages`.
+const ACTOR_CHANGE_TYPEHASH: B256 =
+    b256!("76ddc97127f9b5fc6a394060571bb32201243ae2344f1f09e6039df7fd19bbd7");
 
 /// Authorizes EIP-8130 account-configuration changes against an
 /// [`AccountConfigurationStorage`] view.
@@ -90,12 +97,11 @@ impl ConfigChangeAuthorizer {
     /// result is folded into the outer struct hash.
     #[must_use]
     pub fn signed_actor_changes_digest(account: Address, change: &ConfigChange) -> B256 {
-        let actor_change_typehash = keccak256(ACTOR_CHANGE_TYPE);
         let mut packed = Keccak256::new();
         for ac in &change.actor_changes {
             // abi.encode(bytes32, uint8, bytes32, bytes32): four right-aligned words.
             let mut leaf = [0u8; 128];
-            leaf[..32].copy_from_slice(actor_change_typehash.as_slice());
+            leaf[..32].copy_from_slice(ACTOR_CHANGE_TYPEHASH.as_slice());
             leaf[63] = ac.change_type.op_byte();
             leaf[64..96].copy_from_slice(ac.actor_id.as_slice());
             leaf[96..128].copy_from_slice(keccak256(&ac.data).as_slice());
@@ -105,7 +111,7 @@ impl ConfigChangeAuthorizer {
 
         // abi.encode(bytes32, address, uint64, uint64, bytes32): five right-aligned words.
         let mut outer = [0u8; 160];
-        outer[..32].copy_from_slice(keccak256(SIGNED_ACTOR_CHANGES_TYPE).as_slice());
+        outer[..32].copy_from_slice(SIGNED_ACTOR_CHANGES_TYPEHASH.as_slice());
         outer[44..64].copy_from_slice(account.as_slice());
         outer[88..96].copy_from_slice(&change.chain_id.to_be_bytes());
         outer[120..128].copy_from_slice(&change.sequence.to_be_bytes());
@@ -126,6 +132,20 @@ mod tests {
     const NOW: u64 = 1_000;
     const LOCAL: u64 = 8453;
     const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+
+    #[test]
+    fn typehashes_match_their_preimages() {
+        assert_eq!(
+            SIGNED_ACTOR_CHANGES_TYPEHASH,
+            keccak256(
+                b"SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
+            )
+        );
+        assert_eq!(
+            ACTOR_CHANGE_TYPEHASH,
+            keccak256(b"ActorChange(uint8 changeType,bytes32 actorId,bytes data)")
+        );
+    }
 
     fn key(byte: u8) -> K256SigningKey {
         K256SigningKey::from_slice(&[byte; 32]).unwrap()

--- a/crates/execution/eip8130-tx/src/config.rs
+++ b/crates/execution/eip8130-tx/src/config.rs
@@ -1,0 +1,374 @@
+//! Account-configuration change authorization — the `SCOPE_CONFIG` path of the
+//! EIP-8130 validation flow.
+
+use alloy_primitives::{Address, B256, Keccak256, keccak256};
+use base_common_consensus::ConfigChange;
+use base_execution_eip8130_authorize::{ActorAuthorizer, AuthorizeError, ResolvedActor};
+use base_execution_eip8130_state::AccountConfigurationStorage;
+
+use crate::{Operation, TxAuthError};
+
+/// `SignedActorChanges` EIP-712-style type string, identical to the one hashed
+/// by `AccountConfiguration` (the trailing `ActorChange(...)` is the referenced
+/// struct's type, per the EIP-712 encoding rules).
+const SIGNED_ACTOR_CHANGES_TYPE: &[u8] = b"SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)";
+/// `ActorChange` type string used for the per-change leaf hashes.
+const ACTOR_CHANGE_TYPE: &[u8] = b"ActorChange(uint8 changeType,bytes32 actorId,bytes data)";
+
+/// Authorizes EIP-8130 account-configuration changes against an
+/// [`AccountConfigurationStorage`] view.
+///
+/// Native mirror of `AccountConfiguration.applySignedActorChanges`'s
+/// authorization tail: it reconstructs the `SignedActorChanges` digest, runs the
+/// entry's `auth` through the stateful [`ActorAuthorizer`], and enforces the
+/// `SCOPE_CONFIG` gate, the account lock, the chain binding, and the sequence
+/// channel. It does **not** apply the actor changes (decode `data`, mutate
+/// `actor_config`) — that is the consuming validator's responsibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConfigChangeAuthorizer;
+
+impl ConfigChangeAuthorizer {
+    /// Authorize a single [`ConfigChange`] entry for `account` (the resolved
+    /// transaction sender, against whose config the change applies).
+    ///
+    /// `now` is the timestamp used for the lock check and actor expiry (block
+    /// timestamp at inclusion, wall-clock in the pool). Returns the authorizing
+    /// actor's resolved surface, or the first [`TxAuthError`] encountered.
+    ///
+    /// Scope: authorizes exactly one entry against the account's *current*
+    /// on-chain sequence. Ordering and sequence advancement across multiple
+    /// same-channel entries within one transaction (and applying the changes) is
+    /// the orchestrator's responsibility, layered on top.
+    pub fn authorize(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        local_chain_id: u64,
+        change: &ConfigChange,
+        now: u64,
+    ) -> Result<ResolvedActor, TxAuthError> {
+        // Locked accounts reject all config changes (`onlyUnlocked`).
+        if storage.is_locked(account, now).map_err(AuthorizeError::Storage)? {
+            return Err(TxAuthError::AccountLocked);
+        }
+
+        // Chain binding + channel selection: 0 = multichain, else the local chain.
+        if change.chain_id != 0 && change.chain_id != local_chain_id {
+            return Err(TxAuthError::ConfigChainId {
+                expected: local_chain_id,
+                got: change.chain_id,
+            });
+        }
+
+        // The contract reads the sequence from state and the signer signs over
+        // the value that will be used; require the entry to match the account's
+        // current channel sequence so the reconstructed digest is the signed one.
+        let (multichain_seq, local_seq) =
+            storage.get_change_sequences(account).map_err(AuthorizeError::Storage)?;
+        let expected = if change.chain_id == 0 { multichain_seq } else { local_seq };
+        if change.sequence != expected {
+            return Err(TxAuthError::ConfigSequence { expected, got: change.sequence });
+        }
+
+        // Reconstruct the digest, authorize the entry's auth, and require CONFIG scope.
+        let digest = Self::signed_actor_changes_digest(account, change);
+        let resolved =
+            ActorAuthorizer::authenticate_actor(storage, account, digest, &change.auth, now)?;
+        if !Operation::Config.is_granted(&resolved) {
+            return Err(TxAuthError::Scope { operation: Operation::Config, scope: resolved.scope });
+        }
+        Ok(resolved)
+    }
+
+    /// Computes the EIP-8130 `SignedActorChanges` digest for `change` against
+    /// `account`, byte-identical to
+    /// `AccountConfiguration._computeSignedActorChangesDigest`.
+    ///
+    /// Each actor change is hashed as
+    /// `keccak256(abi.encode(ACTORCHANGE_TYPEHASH, changeType, actorId, keccak256(data)))`,
+    /// the leaf hashes are concatenated (`abi.encodePacked`) and hashed, and the
+    /// result is folded into the outer struct hash.
+    #[must_use]
+    pub fn signed_actor_changes_digest(account: Address, change: &ConfigChange) -> B256 {
+        let actor_change_typehash = keccak256(ACTOR_CHANGE_TYPE);
+        let mut packed = Keccak256::new();
+        for ac in &change.actor_changes {
+            // abi.encode(bytes32, uint8, bytes32, bytes32): four right-aligned words.
+            let mut leaf = [0u8; 128];
+            leaf[..32].copy_from_slice(actor_change_typehash.as_slice());
+            leaf[63] = ac.change_type.op_byte();
+            leaf[64..96].copy_from_slice(ac.actor_id.as_slice());
+            leaf[96..128].copy_from_slice(keccak256(&ac.data).as_slice());
+            packed.update(keccak256(leaf).as_slice());
+        }
+        let actor_changes_hash = packed.finalize();
+
+        // abi.encode(bytes32, address, uint64, uint64, bytes32): five right-aligned words.
+        let mut outer = [0u8; 160];
+        outer[..32].copy_from_slice(keccak256(SIGNED_ACTOR_CHANGES_TYPE).as_slice());
+        outer[44..64].copy_from_slice(account.as_slice());
+        outer[88..96].copy_from_slice(&change.chain_id.to_be_bytes());
+        outer[120..128].copy_from_slice(&change.sequence.to_be_bytes());
+        outer[128..160].copy_from_slice(actor_changes_hash.as_slice());
+        keccak256(outer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Bytes, U256, address};
+    use base_common_consensus::{ActorChange, ActorChangeType, Eip8130Constants};
+    use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
+    use k256::ecdsa::SigningKey as K256SigningKey;
+
+    use super::*;
+
+    const NOW: u64 = 1_000;
+    const LOCAL: u64 = 8453;
+    const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+
+    fn key(byte: u8) -> K256SigningKey {
+        K256SigningKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn addr(key: &K256SigningKey) -> Address {
+        let point = key.verifying_key().to_encoded_point(false);
+        Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+    }
+
+    fn actor_id(account: Address) -> B256 {
+        AccountConfigurationStorage::self_actor_id(account)
+    }
+
+    /// 65-byte `r || s || v` signature over `hash`, `v` in `{27, 28}`, low-s.
+    fn sig(key: &K256SigningKey, hash: B256) -> Vec<u8> {
+        let (signature, recid) = key.sign_prehash_recoverable(hash.as_slice()).unwrap();
+        let mut out = vec![0u8; 65];
+        out[..64].copy_from_slice(&signature.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    /// `authenticator(20) || data`.
+    fn auth_blob(authenticator: Address, data: &[u8]) -> Bytes {
+        let mut out = Vec::with_capacity(20 + data.len());
+        out.extend_from_slice(authenticator.as_slice());
+        out.extend_from_slice(data);
+        Bytes::from(out)
+    }
+
+    /// Canonical Solidity packing of `ActorConfig`.
+    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+        U256::from_be_slice(authenticator.as_slice())
+            | (U256::from(scope) << 160)
+            | (U256::from(expiry) << 168)
+            | (U256::from(policy_type) << 216)
+    }
+
+    /// Canonical Solidity packing of `AccountState`.
+    fn pack_state(multichain: u64, local: u64, unlocks_at: u64) -> U256 {
+        let mut b = [0u8; 32];
+        b[24..32].copy_from_slice(&multichain.to_be_bytes());
+        b[16..24].copy_from_slice(&local.to_be_bytes());
+        b[11..16].copy_from_slice(&unlocks_at.to_be_bytes()[3..]);
+        U256::from_be_bytes(b)
+    }
+
+    fn revoke(actor_byte: u8) -> ActorChange {
+        ActorChange {
+            change_type: ActorChangeType::Revoke,
+            actor_id: B256::repeat_byte(actor_byte),
+            data: Bytes::new(),
+        }
+    }
+
+    fn authorize_change(actor_byte: u8, data: &[u8]) -> ActorChange {
+        ActorChange {
+            change_type: ActorChangeType::Authorize,
+            actor_id: B256::repeat_byte(actor_byte),
+            data: Bytes::copy_from_slice(data),
+        }
+    }
+
+    /// A [`ConfigChange`] whose `auth` is a fresh signature over its own digest.
+    fn signed_change(
+        account: Address,
+        authenticator: Address,
+        signer: &K256SigningKey,
+        chain_id: u64,
+        sequence: u64,
+        actor_changes: Vec<ActorChange>,
+    ) -> ConfigChange {
+        let mut change = ConfigChange { chain_id, sequence, actor_changes, auth: Bytes::new() };
+        let digest = ConfigChangeAuthorizer::signed_actor_changes_digest(account, &change);
+        change.auth = auth_blob(authenticator, &sig(signer, digest));
+        change
+    }
+
+    fn with_storage<R>(body: impl FnOnce(&mut AccountConfigurationStorage<'_>) -> R) -> R {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| body(&mut AccountConfigurationStorage::new(ctx)))
+    }
+
+    #[test]
+    fn implicit_eoa_owner_authorizes_config_change() {
+        let k = key(0x11);
+        let account = addr(&k);
+        let change = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xab)]);
+        with_storage(|acc| {
+            let resolved =
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
+            assert!(resolved.is_unrestricted());
+        });
+    }
+
+    #[test]
+    fn configured_config_actor_authorizes() {
+        let k = key(0x22);
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let id = actor_id(addr(&k));
+        let change = signed_change(account, ECRECOVER, &k, 0, 0, vec![revoke(0xcd)]);
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&id)
+                .at_mut(&account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .unwrap();
+            let resolved =
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
+            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_CONFIG);
+        });
+    }
+
+    #[test]
+    fn actor_without_config_scope_is_rejected() {
+        let k = key(0x22);
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let id = actor_id(addr(&k));
+        let change = signed_change(account, ECRECOVER, &k, 0, 0, vec![revoke(0x01)]);
+        with_storage(|acc| {
+            // Bound actor that lacks CONFIG (only SENDER).
+            acc.actor_config
+                .at_mut(&id)
+                .at_mut(&account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .unwrap();
+            assert_eq!(
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
+                Err(TxAuthError::Scope {
+                    operation: Operation::Config,
+                    scope: Eip8130Constants::SCOPE_SENDER,
+                }),
+            );
+        });
+    }
+
+    #[test]
+    fn locked_account_is_rejected() {
+        let k = key(0x11);
+        let account = addr(&k);
+        let change = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0x01)]);
+        with_storage(|acc| {
+            // Locked until after `now`.
+            acc.account_state.at_mut(&account).write(pack_state(0, 0, NOW + 1)).unwrap();
+            assert_eq!(
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
+                Err(TxAuthError::AccountLocked),
+            );
+        });
+    }
+
+    #[test]
+    fn foreign_chain_id_is_rejected() {
+        let k = key(0x11);
+        let account = addr(&k);
+        let change = signed_change(account, Address::ZERO, &k, LOCAL + 1, 0, vec![revoke(0x01)]);
+        with_storage(|acc| {
+            assert_eq!(
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
+                Err(TxAuthError::ConfigChainId { expected: LOCAL, got: LOCAL + 1 }),
+            );
+        });
+    }
+
+    #[test]
+    fn stale_sequence_is_rejected() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // Multichain channel sequence in state is 0; the entry claims 5.
+        let change = signed_change(account, Address::ZERO, &k, 0, 5, vec![revoke(0x01)]);
+        with_storage(|acc| {
+            assert_eq!(
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
+                Err(TxAuthError::ConfigSequence { expected: 0, got: 5 }),
+            );
+        });
+    }
+
+    #[test]
+    fn local_channel_uses_local_sequence() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // Local channel (chain_id == LOCAL); the entry must match local_sequence.
+        let change = signed_change(account, Address::ZERO, &k, LOCAL, 3, vec![revoke(0x01)]);
+        with_storage(|acc| {
+            acc.account_state.at_mut(&account).write(pack_state(0, 3, 0)).unwrap();
+            let resolved =
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
+            assert!(resolved.is_unrestricted());
+        });
+    }
+
+    #[test]
+    fn implicit_eoa_wrong_signer_is_rejected() {
+        let owner = key(0x11);
+        let account = addr(&owner);
+        let attacker = key(0x99);
+        // The digest binds `account`, but the auth is signed by a different key.
+        let mut change = ConfigChange {
+            chain_id: 0,
+            sequence: 0,
+            actor_changes: vec![revoke(0x01)],
+            auth: Bytes::new(),
+        };
+        let digest = ConfigChangeAuthorizer::signed_actor_changes_digest(account, &change);
+        change.auth = auth_blob(Address::ZERO, &sig(&attacker, digest));
+        with_storage(|acc| {
+            assert!(matches!(
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
+                Err(TxAuthError::Authorize(AuthorizeError::ImplicitEoaMismatch)),
+            ));
+        });
+    }
+
+    #[test]
+    fn digest_binds_account_chain_sequence_and_changes() {
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let base = ConfigChange {
+            chain_id: 0,
+            sequence: 0,
+            actor_changes: vec![revoke(0x01)],
+            auth: Bytes::new(),
+        };
+        let d0 = ConfigChangeAuthorizer::signed_actor_changes_digest(account, &base);
+
+        // Deterministic.
+        assert_eq!(d0, ConfigChangeAuthorizer::signed_actor_changes_digest(account, &base));
+
+        // Account, chain, sequence, and actor-change content each shift the digest.
+        let other = address!("0x00000000000000000000000000000000000000bb");
+        assert_ne!(d0, ConfigChangeAuthorizer::signed_actor_changes_digest(other, &base));
+
+        let mut chain = base.clone();
+        chain.chain_id = LOCAL;
+        assert_ne!(d0, ConfigChangeAuthorizer::signed_actor_changes_digest(account, &chain));
+
+        let mut seq = base.clone();
+        seq.sequence = 1;
+        assert_ne!(d0, ConfigChangeAuthorizer::signed_actor_changes_digest(account, &seq));
+
+        let mut changed = base;
+        changed.actor_changes = vec![authorize_change(0x01, b"policy-data")];
+        assert_ne!(d0, ConfigChangeAuthorizer::signed_actor_changes_digest(account, &changed));
+    }
+}

--- a/crates/execution/eip8130-tx/src/error.rs
+++ b/crates/execution/eip8130-tx/src/error.rs
@@ -27,4 +27,31 @@ pub enum TxAuthError {
         /// The resolved actor's scope bitfield.
         scope: u8,
     },
+
+    /// A config change targets a locked account. All config changes are rejected
+    /// while locked. Mirrors `AccountConfiguration`'s `onlyUnlocked` modifier.
+    #[error("account is locked")]
+    AccountLocked,
+
+    /// A config change is bound to a chain other than `0` (multichain) or the
+    /// local chain. Mirrors `require(chainId == 0 || chainId == block.chainid)`.
+    #[error("config change chain id {got} is neither 0 nor the local chain {expected}")]
+    ConfigChainId {
+        /// The local chain id.
+        expected: u64,
+        /// The chain id carried by the config change.
+        got: u64,
+    },
+
+    /// A config change's sequence does not match the account's current sequence
+    /// for its channel. The contract reads the sequence from state, so a
+    /// mismatch means the entry is stale or out of order (and its signed digest
+    /// would not match the value that will actually be applied).
+    #[error("config change sequence {got} does not match the expected {expected}")]
+    ConfigSequence {
+        /// The sequence read from the account's state for the entry's channel.
+        expected: u64,
+        /// The sequence carried by the config change.
+        got: u64,
+    },
 }

--- a/crates/execution/eip8130-tx/src/lib.rs
+++ b/crates/execution/eip8130-tx/src/lib.rs
@@ -8,3 +8,6 @@ pub use scope::Operation;
 
 mod verify;
 pub use verify::{ActorTxVerifier, AuthorizedActor, TxActors};
+
+mod config;
+pub use config::ConfigChangeAuthorizer;


### PR DESCRIPTION
## Summary

Adds `ConfigChangeAuthorizer` to `base-execution-eip8130-tx` — the native mirror of `AccountConfiguration.applySignedActorChanges`'s authorization tail, shared by mempool admission and block inclusion. This is the `SCOPE_CONFIG` ("owner changes") path of the EIP-8130 validation flow.

For one `ConfigChange` entry, against the resolved sender's account, it:

1. rejects a **locked** account (`onlyUnlocked`);
2. enforces the **chain binding** and selects the sequence channel (`chain_id == 0` → multichain, else local);
3. requires the entry's `sequence` to equal the account's **current channel sequence** — the value the contract reads from state and the signer signs over, so a mismatch is stale/out-of-order and its signed digest wouldn't match what's applied;
4. reconstructs the **`SignedActorChanges`** digest byte-identically to `_computeSignedActorChangesDigest`, authorizes the entry's `auth` through the [`ActorAuthorizer`](https://github.com/base/base/pull/3535), and requires **`SCOPE_CONFIG`** (satisfied by an unrestricted `0x00` actor, e.g. an implicit-EOA owner).

The digest is folded without allocation via an incremental keccak over the per-change leaf hashes (`keccak256(abi.encode(ACTORCHANGE_TYPEHASH, changeType, actorId, keccak256(data)))`).

This depends on the realigned `ActorChange { change_type, actor_id, data }` wire type (#3553) — the digest hashes `keccak256(data)`, which the pre-realignment lossy type could not express.

## Scope (what this is / is not)

Authorizes a **single entry** against the account's current on-chain sequence. It does **not** apply the changes (decode `data`, mutate `actor_config`) or advance/validate sequences across multiple same-channel entries in one transaction — those are layered on top next.

## Test plan

- [x] `cargo test -p base-execution-eip8130-tx --all-features` (18 passed; 9 new config tests: implicit-EOA owner, configured CONFIG actor, missing-scope rejection, lock, foreign chain, stale sequence, local channel selection, wrong signer, digest field-binding)
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt`