### PR TITLE
refactor(registrar): simplify cert manager

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -21,10 +21,9 @@ use base_proof_tee_registrar::{
     AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, CertManager, CrlConfig,
     DEFAULT_CRL_FETCH_TIMEOUT_SECS, DEFAULT_MAX_ATTESTATION_AGE_SECS, DEFAULT_MAX_CONCURRENCY,
     DEFAULT_MAX_RECOVERY_ATTEMPTS, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
-    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, NitroVerifierClient,
-    NitroVerifierContractClient, ProverClient, ProvingConfig, RegistrarConfig, RegistrarError,
-    RegistrarMetrics, RegistrationDriver, RegistryContractClient, SignerManager,
-    SignerManagerConfig,
+    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, NitroVerifierContractClient,
+    ProverClient, ProvingConfig, RegistrarConfig, RegistrarError, RegistrarMetrics,
+    RegistrationDriver, RegistryContractClient, SignerManager, SignerManagerConfig,
 };
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use boundless_market::{
@@ -636,9 +635,10 @@ impl Cli {
         // disabled and no verifier address is configured, bind the unused
         // client to the zero address.
         let nitro_verifier_address = config.crl.nitro_verifier_address.unwrap_or(Address::ZERO);
-        let nitro_verifier: Arc<dyn NitroVerifierClient> = Arc::new(
-            NitroVerifierContractClient::new(nitro_verifier_address, config.l1_rpc_url.clone()),
-        );
+        let nitro_verifier = Box::new(NitroVerifierContractClient::new(
+            nitro_verifier_address,
+            config.l1_rpc_url.clone(),
+        ));
 
         // ── 6. Build proof provider ──────────────────────────────────────────
         let proof_provider: Box<dyn AttestationProofProvider> = match config.proving {

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -92,7 +92,18 @@ where
         }
 
         RegistrarMetrics::crl_revocations_detected().increment(revoked_certs.len() as u64);
-        self.submit_revocations_for_revoked_certs(&revoked_certs, instance).await;
+        let verifier_address = self.nitro_verifier.address();
+        let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
+
+        for revoked in &revoked_certs {
+            warn!(
+                cert_index = revoked.index,
+                path_digest = %revoked.path_digest,
+                instance = %instance.instance_id,
+                "submitting revokeCert transaction"
+            );
+            cert_revoker.revoke_cert(revoked.path_digest).await;
+        }
 
         Ok(true)
     }
@@ -128,38 +139,17 @@ where
         debug!(instance = %instance_id, "onchain revocation pre-check passed");
         Ok(false)
     }
-
-    /// Checks each CRL-hit against the onchain sentinel and submits needed revocations.
-    pub async fn submit_revocations_for_revoked_certs(
-        &self,
-        revoked_certs: &[crl::RevokedCertInfo],
-        instance: &ProverInstance,
-    ) {
-        let verifier_address = self.nitro_verifier.address();
-        let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
-
-        for revoked in revoked_certs {
-            warn!(
-                cert_index = revoked.index,
-                path_digest = %revoked.path_digest,
-                instance = %instance.instance_id,
-                "submitting revokeCert transaction"
-            );
-            cert_revoker.revoke_cert(revoked.path_digest).await;
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
-    use base_tx_manager::{TxCandidate, TxManagerError};
 
     use super::*;
-    use crate::test_utils::{NoopNitroVerifier, NoopTxManager};
+    use crate::test_utils::{NoopNitroVerifier, NoopTxManager, healthy_prover_instance};
 
     const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
     const INTER1_INDEX: usize = 1;
@@ -169,7 +159,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct MockNitroVerifier {
         revoked: Option<B256>,
-        fail_next: AtomicBool,
+        fail: bool,
         call_count: AtomicU32,
     }
 
@@ -179,7 +169,7 @@ mod tests {
         }
 
         fn failing() -> Self {
-            Self { fail_next: AtomicBool::new(true), ..Self::default() }
+            Self { fail: true, ..Self::default() }
         }
 
         fn call_count(&self) -> u32 {
@@ -195,39 +185,13 @@ mod tests {
 
         async fn is_revoked(&self, cert_hash: B256) -> Result<bool> {
             self.call_count.fetch_add(1, Ordering::Relaxed);
-            if self.fail_next.swap(false, Ordering::Relaxed) {
+            if self.fail {
                 return Err(RegistrarError::NitroVerifierCall {
                     context: "revokedCerts(0xdeadbeef)".into(),
                     source: "boom".into(),
                 });
             }
             Ok(self.revoked == Some(cert_hash))
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct MockTxManager {
-        send_count: AtomicU32,
-    }
-
-    impl MockTxManager {
-        fn send_count(&self) -> u32 {
-            self.send_count.load(Ordering::Relaxed)
-        }
-    }
-
-    impl TxManager for MockTxManager {
-        async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            self.send_count.fetch_add(1, Ordering::Relaxed);
-            Err(TxManagerError::ChannelClosed)
-        }
-
-        async fn send_async(&self, _candidate: TxCandidate) -> base_tx_manager::SendHandle {
-            unreachable!("submit_revocations_for_revoked_certs only uses send")
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
         }
     }
 
@@ -244,21 +208,12 @@ mod tests {
         B256::repeat_byte(index as u8)
     }
 
-    fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
+    fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<NoopTxManager> {
         CertManager {
             enabled: true,
             http_client: reqwest::Client::new(),
             nitro_verifier: verifier,
-            tx_manager: MockTxManager::default(),
-        }
-    }
-
-    fn test_instance() -> ProverInstance {
-        ProverInstance {
-            instance_id: ONCHAIN_TEST_INSTANCE_ID.to_string(),
-            endpoint: "http://127.0.0.1:8000/".parse().unwrap(),
-            health_status: crate::InstanceHealthStatus::Healthy,
-            launch_time: None,
+            tx_manager: NoopTxManager,
         }
     }
 
@@ -272,8 +227,12 @@ mod tests {
         let cert_manager = CertManager::new(&config, Arc::new(NoopNitroVerifier), NoopTxManager)
             .expect("disabled cert manager still builds");
 
-        let result =
-            cert_manager.check_and_revoke_crls(b"not-an-attestation", &test_instance()).await;
+        let result = cert_manager
+            .check_and_revoke_crls(
+                b"not-an-attestation",
+                &healthy_prover_instance("127.0.0.1:8000"),
+            )
+            .await;
 
         assert!(!result.expect("disabled CRL checks must no-op"));
     }
@@ -329,23 +288,5 @@ mod tests {
             matches!(err, RegistrarError::NitroVerifierCall { .. }),
             "expected NitroVerifierCall, got: {err:?}"
         );
-    }
-
-    #[tokio::test]
-    async fn submit_revocations_sends_crl_hits_without_rechecking_onchain() {
-        let path_digest = path_digest_for(INTER1_INDEX);
-        let verifier = Arc::new(MockNitroVerifier::default());
-        let cert_manager = test_cert_manager(Arc::clone(&verifier));
-        let instance = test_instance();
-
-        cert_manager
-            .submit_revocations_for_revoked_certs(
-                &[crl::RevokedCertInfo { index: INTER1_INDEX, path_digest }],
-                &instance,
-            )
-            .await;
-
-        assert_eq!(verifier.call_count(), 0);
-        assert_eq!(cert_manager.tx_manager.send_count(), 1);
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -139,30 +139,6 @@ where
         let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
 
         for revoked in revoked_certs {
-            match self.nitro_verifier.is_revoked(revoked.path_digest).await {
-                Ok(true) => {
-                    warn!(
-                        cert_index = revoked.index,
-                        path_digest = %revoked.path_digest,
-                        instance = %instance.instance_id,
-                        "certificate already revoked onchain, skipping revokeCert"
-                    );
-                    RegistrarMetrics::onchain_revocations_detected().increment(1);
-                    continue;
-                }
-                Ok(false) => {}
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        cert_index = revoked.index,
-                        path_digest = %revoked.path_digest,
-                        instance = %instance.instance_id,
-                        "onchain revocation check failed for CRL hit; submitting revokeCert"
-                    );
-                    RegistrarMetrics::onchain_revocation_check_errors().increment(1);
-                }
-            }
-
             warn!(
                 cert_index = revoked.index,
                 path_digest = %revoked.path_digest,
@@ -186,7 +162,6 @@ mod tests {
     use crate::test_utils::{NoopNitroVerifier, NoopTxManager};
 
     const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
-    const TEST_VERIFIER_ADDRESS: Address = Address::repeat_byte(0xAB);
     const INTER1_INDEX: usize = 1;
     const INTER2_INDEX: usize = 2;
 
@@ -215,7 +190,7 @@ mod tests {
     #[async_trait]
     impl crate::NitroVerifierClient for MockNitroVerifier {
         fn address(&self) -> Address {
-            TEST_VERIFIER_ADDRESS
+            Address::ZERO
         }
 
         async fn is_revoked(&self, cert_hash: B256) -> Result<bool> {
@@ -303,10 +278,6 @@ mod tests {
         assert!(!result.expect("disabled CRL checks must no-op"));
     }
 
-    fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {
-        crl::RevokedCertInfo { index: INTER1_INDEX, path_digest }
-    }
-
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
         let verifier = Arc::new(verifier);
         let cert_manager = test_cert_manager(Arc::clone(&verifier));
@@ -361,28 +332,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_revocations_checks_onchain_before_sending() {
+    async fn submit_revocations_sends_crl_hits_without_rechecking_onchain() {
         let path_digest = path_digest_for(INTER1_INDEX);
+        let verifier = Arc::new(MockNitroVerifier::default());
+        let cert_manager = test_cert_manager(Arc::clone(&verifier));
+        let instance = test_instance();
 
-        for (case, verifier, expected_send_count) in [
-            ("already revoked", MockNitroVerifier::revoking(path_digest), 0),
-            ("clean", MockNitroVerifier::default(), 1),
-            ("RPC failure", MockNitroVerifier::failing(), 1),
-        ] {
-            let verifier = Arc::new(verifier);
-            let cert_manager = test_cert_manager(Arc::clone(&verifier));
-            let instance = test_instance();
+        cert_manager
+            .submit_revocations_for_revoked_certs(
+                &[crl::RevokedCertInfo { index: INTER1_INDEX, path_digest }],
+                &instance,
+            )
+            .await;
 
-            cert_manager
-                .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
-                .await;
-
-            assert_eq!(verifier.call_count(), 1, "{case}: should check onchain once");
-            assert_eq!(
-                cert_manager.tx_manager.send_count(),
-                expected_send_count,
-                "{case}: unexpected revokeCert send count",
-            );
-        }
+        assert_eq!(verifier.call_count(), 0);
+        assert_eq!(cert_manager.tx_manager.send_count(), 1);
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -186,24 +186,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashSet,
-        sync::{
-            Mutex,
-            atomic::{AtomicBool, AtomicU32, Ordering},
-        },
-        time::Duration,
-    };
+    use std::sync::Mutex;
 
-    use alloy_primitives::{Address, B256, Bytes, FixedBytes};
+    use alloy_primitives::{Address, B256, Bytes};
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
     use base_proof_contracts::INitroEnclaveVerifier;
     use base_tx_manager::{TxCandidate, TxManagerError};
-    use rstest::rstest;
 
     use super::*;
-    use crate::test_utils::{CertFixtures, INTER1_HEX, INTER2_HEX, LEAF_HEX, ROOT_HEX};
 
     const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
     const TEST_VERIFIER_ADDRESS: Address = Address::repeat_byte(0xAB);
@@ -215,26 +206,36 @@ mod tests {
     /// Mock [`NitroVerifierClient`] for unit-testing the onchain pre-check.
     #[derive(Debug, Default)]
     struct MockNitroVerifier {
-        revoked: HashSet<FixedBytes<32>>,
-        fail_next: AtomicBool,
-        call_count: AtomicU32,
+        revoked: Vec<B256>,
+        state: Mutex<MockNitroVerifierState>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockNitroVerifierState {
+        fail_next: bool,
+        call_count: u32,
     }
 
     impl MockNitroVerifier {
-        fn revoking(hashes: impl IntoIterator<Item = FixedBytes<32>>) -> Self {
-            Self {
-                revoked: hashes.into_iter().collect(),
-                fail_next: AtomicBool::new(false),
-                call_count: AtomicU32::new(0),
-            }
+        fn revoking(hashes: impl IntoIterator<Item = B256>) -> Self {
+            Self { revoked: hashes.into_iter().collect(), ..Self::default() }
         }
 
         fn failing() -> Self {
             Self {
-                revoked: HashSet::new(),
-                fail_next: AtomicBool::new(true),
-                call_count: AtomicU32::new(0),
+                state: Mutex::new(MockNitroVerifierState { fail_next: true, call_count: 0 }),
+                ..Self::default()
             }
+        }
+
+        fn call_count(&self) -> u32 {
+            self.state.lock().unwrap().call_count
+        }
+
+        fn should_fail_next_call(&self) -> bool {
+            let mut state = self.state.lock().unwrap();
+            state.call_count += 1;
+            std::mem::take(&mut state.fail_next)
         }
     }
 
@@ -244,9 +245,8 @@ mod tests {
             TEST_VERIFIER_ADDRESS
         }
 
-        async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool> {
-            self.call_count.fetch_add(1, Ordering::SeqCst);
-            if self.fail_next.swap(false, Ordering::SeqCst) {
+        async fn is_revoked(&self, cert_hash: B256) -> Result<bool> {
+            if self.should_fail_next_call() {
                 return Err(RegistrarError::NitroVerifierCall {
                     context: "revokedCerts(0xdeadbeef)".into(),
                     source: "boom".into(),
@@ -282,28 +282,25 @@ mod tests {
         }
     }
 
-    fn full_chain_der() -> Vec<Vec<u8>> {
-        CertFixtures::decode_chain(&[ROOT_HEX, INTER1_HEX, INTER2_HEX, LEAF_HEX])
+    fn cert_info(index: usize) -> crl::CertCrlInfo {
+        crl::CertCrlInfo {
+            index,
+            serial_number: Vec::new(),
+            crl_url: None,
+            path_digest: path_digest_for(index),
+        }
     }
 
-    fn chain_subset(indices: &[usize]) -> Vec<Vec<u8>> {
-        let full = full_chain_der();
-        indices.iter().map(|&i| full[i].clone()).collect()
+    fn cert_infos(indices: &[usize]) -> Vec<crl::CertCrlInfo> {
+        indices.iter().copied().map(cert_info).collect()
     }
 
-    fn path_digest_for(index: usize) -> FixedBytes<32> {
-        let der = full_chain_der();
-        let refs: Vec<&[u8]> = der.iter().map(Vec::as_slice).collect();
-        crl::CertCrlInfo::from_chain(&refs)
-            .expect("static fixtures parse")
-            .remove(index)
-            .path_digest
+    fn path_digest_for(index: usize) -> B256 {
+        B256::repeat_byte(index as u8)
     }
 
     fn full_chain_cert_infos() -> Vec<crl::CertCrlInfo> {
-        let der = full_chain_der();
-        let refs: Vec<&[u8]> = der.iter().map(Vec::as_slice).collect();
-        crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse")
+        cert_infos(&[ROOT_INDEX, INTER1_INDEX, INTER2_INDEX, LEAF_INDEX])
     }
 
     fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
@@ -324,18 +321,13 @@ mod tests {
         }
     }
 
-    fn crl_config() -> CrlConfig {
-        CrlConfig {
-            enabled: true,
-            nitro_verifier_address: None,
-            fetch_timeout: Duration::from_secs(1),
-        }
-    }
-
     #[tokio::test]
     async fn check_and_revoke_crls_noops_when_disabled() {
-        let mut config = crl_config();
-        config.enabled = false;
+        let config = CrlConfig {
+            enabled: false,
+            nitro_verifier_address: None,
+            fetch_timeout: std::time::Duration::from_secs(1),
+        };
         let verifier = Arc::new(MockNitroVerifier::default());
         let cert_manager = CertManager::new(
             &config,
@@ -348,11 +340,7 @@ mod tests {
             cert_manager.check_and_revoke_crls(b"not-an-attestation", &test_instance()).await;
 
         assert!(!result.expect("disabled CRL checks must no-op"));
-        assert_eq!(
-            verifier.call_count.load(Ordering::SeqCst),
-            0,
-            "disabled CRL checks must not query the verifier",
-        );
+        assert_eq!(verifier.call_count(), 0, "disabled CRL checks must not query the verifier",);
     }
 
     fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {
@@ -370,7 +358,7 @@ mod tests {
         let result = cert_manager
             .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
             .await;
-        (result, verifier.call_count.load(Ordering::SeqCst))
+        (result, verifier.call_count())
     }
 
     #[tokio::test]
@@ -385,25 +373,23 @@ mod tests {
         assert_eq!(calls, 2, "every intermediate must be queried when none are revoked");
     }
 
-    #[rstest]
-    #[case::inter1_revoked(INTER1_INDEX, 1)]
-    #[case::inter2_revoked(INTER2_INDEX, 2)]
     #[tokio::test]
-    async fn onchain_revocation_check_blocks_when_any_intermediate_revoked(
-        #[case] revoked_index: usize,
-        #[case] expected_calls_at_short_circuit: u32,
-    ) {
-        let verifier = MockNitroVerifier::revoking([path_digest_for(revoked_index)]);
-        let (result, calls) = run_pre_check(verifier).await;
+    async fn onchain_revocation_check_blocks_when_any_intermediate_revoked() {
+        for (revoked_index, expected_calls_at_short_circuit) in
+            [(INTER1_INDEX, 1), (INTER2_INDEX, 2)]
+        {
+            let verifier = MockNitroVerifier::revoking([path_digest_for(revoked_index)]);
+            let (result, calls) = run_pre_check(verifier).await;
 
-        assert!(
-            result.expect("revoked-intermediate query must succeed"),
-            "revoked intermediate must block registration",
-        );
-        assert_eq!(
-            calls, expected_calls_at_short_circuit,
-            "pre-check must short-circuit at the first revoked intermediate",
-        );
+            assert!(
+                result.expect("revoked-intermediate query must succeed"),
+                "revoked intermediate must block registration",
+            );
+            assert_eq!(
+                calls, expected_calls_at_short_circuit,
+                "pre-check must short-circuit at the first revoked intermediate",
+            );
+        }
     }
 
     #[tokio::test]
@@ -418,31 +404,28 @@ mod tests {
         );
     }
 
-    #[rstest]
-    #[case::root_only(&[ROOT_INDEX], 0)]
-    #[case::root_and_leaf(&[ROOT_INDEX, LEAF_INDEX], 0)]
-    #[case::three_cert(&[ROOT_INDEX, INTER1_INDEX, LEAF_INDEX], 1)]
     #[tokio::test]
-    async fn onchain_revocation_check_queries_intermediates_only(
-        #[case] indices: &[usize],
-        #[case] expected_calls: u32,
-    ) {
-        let owned = chain_subset(indices);
-        let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
-        let cert_infos = crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse");
-        let verifier = Arc::new(MockNitroVerifier::default());
-        let cert_manager = test_cert_manager(Arc::clone(&verifier));
+    async fn onchain_revocation_check_queries_intermediates_only() {
+        for (indices, expected_calls) in [
+            (&[ROOT_INDEX][..], 0),
+            (&[ROOT_INDEX, LEAF_INDEX][..], 0),
+            (&[ROOT_INDEX, INTER1_INDEX, LEAF_INDEX][..], 1),
+        ] {
+            let cert_infos = cert_infos(indices);
+            let verifier = Arc::new(MockNitroVerifier::default());
+            let cert_manager = test_cert_manager(Arc::clone(&verifier));
 
-        let result = cert_manager
-            .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
-            .await;
+            let result = cert_manager
+                .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
+                .await;
 
-        assert!(!result.expect("query must succeed"), "clean chain not revoked");
-        assert_eq!(
-            verifier.call_count.load(Ordering::SeqCst),
-            expected_calls,
-            "only intermediates (root and leaf skipped) should produce RPC calls",
-        );
+            assert!(!result.expect("query must succeed"), "clean chain not revoked");
+            assert_eq!(
+                verifier.call_count(),
+                expected_calls,
+                "only intermediates (root and leaf skipped) should produce RPC calls",
+            );
+        }
     }
 
     #[tokio::test]
@@ -457,7 +440,7 @@ mod tests {
             .await;
 
         assert_eq!(
-            verifier.call_count.load(Ordering::SeqCst),
+            verifier.call_count(),
             1,
             "CRL-hit cert should be checked onchain before deciding whether to submit revokeCert",
         );
@@ -476,7 +459,7 @@ mod tests {
             .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
             .await;
 
-        assert_eq!(verifier.call_count.load(Ordering::SeqCst), 1);
+        assert_eq!(verifier.call_count(), 1);
         let candidates = cert_manager.tx_manager.take_candidates();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
@@ -494,7 +477,7 @@ mod tests {
             .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
             .await;
 
-        assert_eq!(verifier.call_count.load(Ordering::SeqCst), 1);
+        assert_eq!(verifier.call_count(), 1);
         let candidates = cert_manager.tx_manager.take_candidates();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -4,8 +4,6 @@
 //! fetches AWS Nitro CRLs, and submits `revokeCert` transactions for
 //! certificates that are newly observed on a CRL.
 
-use std::sync::Arc;
-
 use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::TxManager;
 use tracing::{debug, warn};
@@ -20,7 +18,7 @@ use crate::{
 pub struct CertManager<T> {
     enabled: bool,
     http_client: reqwest::Client,
-    nitro_verifier: Arc<dyn NitroVerifierClient>,
+    nitro_verifier: Box<dyn NitroVerifierClient>,
     tx_manager: T,
 }
 
@@ -36,7 +34,7 @@ where
     /// Returns [`RegistrarError::Config`] if the CRL HTTP client cannot be built.
     pub fn new(
         config: &CrlConfig,
-        nitro_verifier: Arc<dyn NitroVerifierClient>,
+        nitro_verifier: Box<dyn NitroVerifierClient>,
         tx_manager: T,
     ) -> Result<Self> {
         let http_client = crl::build_crl_http_client(config.fetch_timeout).map_err(|e| {
@@ -142,7 +140,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    };
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
@@ -155,7 +156,7 @@ mod tests {
     struct MockNitroVerifier {
         revoked: Option<B256>,
         fail: bool,
-        call_count: AtomicU32,
+        call_count: Arc<AtomicU32>,
     }
 
     #[async_trait]
@@ -181,12 +182,8 @@ mod tests {
             index,
             serial_number: Vec::new(),
             crl_url: None,
-            path_digest: path_digest_for(index),
+            path_digest: B256::repeat_byte(index as u8),
         }
-    }
-
-    fn path_digest_for(index: usize) -> B256 {
-        B256::repeat_byte(index as u8)
     }
 
     #[tokio::test]
@@ -196,7 +193,7 @@ mod tests {
             nitro_verifier_address: None,
             fetch_timeout: std::time::Duration::from_secs(1),
         };
-        let cert_manager = CertManager::new(&config, Arc::new(NoopNitroVerifier), NoopTxManager)
+        let cert_manager = CertManager::new(&config, Box::new(NoopNitroVerifier), NoopTxManager)
             .expect("disabled cert manager still builds");
 
         let result = cert_manager
@@ -210,49 +207,33 @@ mod tests {
     }
 
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
-        let verifier = Arc::new(verifier);
+        let call_count = verifier.call_count.clone();
         let cert_manager = CertManager {
             enabled: true,
             http_client: reqwest::Client::new(),
-            nitro_verifier: verifier.clone(),
+            nitro_verifier: Box::new(verifier),
             tx_manager: NoopTxManager,
         };
         let cert_infos = (0..=3).map(cert_info).collect::<Vec<_>>();
         let result = cert_manager
             .has_onchain_revoked_intermediate(&cert_infos, "i-onchain-revocation-test")
             .await;
-        (result, verifier.call_count.load(Ordering::Relaxed))
+        (result, call_count.load(Ordering::Relaxed))
     }
 
     #[tokio::test]
-    async fn onchain_revocation_check_returns_false_when_no_intermediates_revoked() {
-        let verifier = MockNitroVerifier::default();
-        let (result, calls) = run_pre_check(verifier).await;
-
-        assert!(
-            !result.expect("clean chain must succeed"),
-            "no intermediates flagged as revoked; registration must proceed"
-        );
-        assert_eq!(calls, 2, "every intermediate must be queried when none are revoked");
-    }
-
-    #[tokio::test]
-    async fn onchain_revocation_check_blocks_when_any_intermediate_revoked() {
-        for (revoked_index, expected_calls_at_short_circuit) in [(1, 1), (2, 2)] {
+    async fn onchain_revocation_check_reports_intermediate_status() {
+        for (revoked_index, expected_result, expected_calls) in
+            [(None, false, 2), (Some(1), true, 1), (Some(2), true, 2)]
+        {
             let verifier = MockNitroVerifier {
-                revoked: Some(path_digest_for(revoked_index)),
+                revoked: revoked_index.map(|index| B256::repeat_byte(index as u8)),
                 ..MockNitroVerifier::default()
             };
             let (result, calls) = run_pre_check(verifier).await;
 
-            assert!(
-                result.expect("revoked-intermediate query must succeed"),
-                "revoked intermediate must block registration",
-            );
-            assert_eq!(
-                calls, expected_calls_at_short_circuit,
-                "pre-check must short-circuit at the first revoked intermediate",
-            );
+            assert_eq!(result.expect("revocation query succeeds"), expected_result);
+            assert_eq!(calls, expected_calls);
         }
     }
 

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -181,10 +181,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Mutex,
-        atomic::{AtomicBool, AtomicU32, Ordering},
-    };
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
@@ -195,22 +192,20 @@ mod tests {
 
     const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
     const TEST_VERIFIER_ADDRESS: Address = Address::repeat_byte(0xAB);
-    const ROOT_INDEX: usize = 0;
     const INTER1_INDEX: usize = 1;
     const INTER2_INDEX: usize = 2;
-    const LEAF_INDEX: usize = 3;
 
     /// Mock [`NitroVerifierClient`] for unit-testing the onchain pre-check.
     #[derive(Debug, Default)]
     struct MockNitroVerifier {
-        revoked: Vec<B256>,
+        revoked: Option<B256>,
         fail_next: AtomicBool,
         call_count: AtomicU32,
     }
 
     impl MockNitroVerifier {
-        fn revoking(hashes: impl IntoIterator<Item = B256>) -> Self {
-            Self { revoked: hashes.into_iter().collect(), ..Self::default() }
+        fn revoking(hash: B256) -> Self {
+            Self { revoked: Some(hash), ..Self::default() }
         }
 
         fn failing() -> Self {
@@ -240,24 +235,24 @@ mod tests {
                     source: "boom".into(),
                 });
             }
-            Ok(self.revoked.contains(&cert_hash))
+            Ok(self.revoked == Some(cert_hash))
         }
     }
 
-    #[derive(Debug, Default, Clone)]
+    #[derive(Debug, Default)]
     struct MockTxManager {
-        sent_candidates: Arc<Mutex<Vec<TxCandidate>>>,
+        send_count: AtomicU32,
     }
 
     impl MockTxManager {
-        fn take_candidates(&self) -> Vec<TxCandidate> {
-            std::mem::take(&mut *self.sent_candidates.lock().unwrap())
+        fn send_count(&self) -> u32 {
+            self.send_count.load(Ordering::Relaxed)
         }
     }
 
     impl TxManager for MockTxManager {
-        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
-            self.sent_candidates.lock().unwrap().push(candidate);
+        async fn send(&self, _candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.send_count.fetch_add(1, Ordering::Relaxed);
             Err(TxManagerError::ChannelClosed)
         }
 
@@ -279,16 +274,8 @@ mod tests {
         }
     }
 
-    fn cert_infos(indices: &[usize]) -> Vec<crl::CertCrlInfo> {
-        indices.iter().copied().map(cert_info).collect()
-    }
-
     fn path_digest_for(index: usize) -> B256 {
         B256::repeat_byte(index as u8)
-    }
-
-    fn full_chain_cert_infos() -> Vec<crl::CertCrlInfo> {
-        cert_infos(&[ROOT_INDEX, INTER1_INDEX, INTER2_INDEX, LEAF_INDEX])
     }
 
     fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
@@ -332,7 +319,7 @@ mod tests {
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
         let verifier = Arc::new(verifier);
         let cert_manager = test_cert_manager(Arc::clone(&verifier));
-        let cert_infos = full_chain_cert_infos();
+        let cert_infos = (0..=3).map(cert_info).collect::<Vec<_>>();
         let result = cert_manager
             .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
             .await;
@@ -356,7 +343,7 @@ mod tests {
         for (revoked_index, expected_calls_at_short_circuit) in
             [(INTER1_INDEX, 1), (INTER2_INDEX, 2)]
         {
-            let verifier = MockNitroVerifier::revoking([path_digest_for(revoked_index)]);
+            let verifier = MockNitroVerifier::revoking(path_digest_for(revoked_index));
             let (result, calls) = run_pre_check(verifier).await;
 
             assert!(
@@ -385,7 +372,7 @@ mod tests {
     #[tokio::test]
     async fn submit_revocations_skips_revoke_cert_when_already_revoked() {
         let path_digest = path_digest_for(INTER1_INDEX);
-        let verifier = Arc::new(MockNitroVerifier::revoking([path_digest]));
+        let verifier = Arc::new(MockNitroVerifier::revoking(path_digest));
         let cert_manager = test_cert_manager(Arc::clone(&verifier));
         let instance = test_instance();
 
@@ -398,8 +385,7 @@ mod tests {
             1,
             "CRL-hit cert should be checked onchain before deciding whether to submit revokeCert",
         );
-        let candidates = cert_manager.tx_manager.take_candidates();
-        assert!(candidates.is_empty(), "already-revoked certs should not submit revokeCert");
+        assert_eq!(cert_manager.tx_manager.send_count(), 0);
     }
 
     #[tokio::test]
@@ -415,9 +401,7 @@ mod tests {
                 .await;
 
             assert_eq!(verifier.call_count(), 1);
-            let candidates = cert_manager.tx_manager.take_candidates();
-            assert_eq!(candidates.len(), 1);
-            assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
+            assert_eq!(cert_manager.tx_manager.send_count(), 1);
         }
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -92,8 +92,7 @@ where
         }
 
         RegistrarMetrics::crl_revocations_detected().increment(revoked_certs.len() as u64);
-        let verifier_address = self.nitro_verifier.address();
-        let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
+        let cert_revoker = CertRevoker::new(self.nitro_verifier.address(), &self.tx_manager);
 
         for revoked in &revoked_certs {
             warn!(
@@ -151,30 +150,12 @@ mod tests {
     use super::*;
     use crate::test_utils::{NoopNitroVerifier, NoopTxManager, healthy_prover_instance};
 
-    const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
-    const INTER1_INDEX: usize = 1;
-    const INTER2_INDEX: usize = 2;
-
     /// Mock [`NitroVerifierClient`] for unit-testing the onchain pre-check.
     #[derive(Debug, Default)]
     struct MockNitroVerifier {
         revoked: Option<B256>,
         fail: bool,
         call_count: AtomicU32,
-    }
-
-    impl MockNitroVerifier {
-        fn revoking(hash: B256) -> Self {
-            Self { revoked: Some(hash), ..Self::default() }
-        }
-
-        fn failing() -> Self {
-            Self { fail: true, ..Self::default() }
-        }
-
-        fn call_count(&self) -> u32 {
-            self.call_count.load(Ordering::Relaxed)
-        }
     }
 
     #[async_trait]
@@ -208,15 +189,6 @@ mod tests {
         B256::repeat_byte(index as u8)
     }
 
-    fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<NoopTxManager> {
-        CertManager {
-            enabled: true,
-            http_client: reqwest::Client::new(),
-            nitro_verifier: verifier,
-            tx_manager: NoopTxManager,
-        }
-    }
-
     #[tokio::test]
     async fn check_and_revoke_crls_noops_when_disabled() {
         let config = CrlConfig {
@@ -239,12 +211,17 @@ mod tests {
 
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
         let verifier = Arc::new(verifier);
-        let cert_manager = test_cert_manager(Arc::clone(&verifier));
+        let cert_manager = CertManager {
+            enabled: true,
+            http_client: reqwest::Client::new(),
+            nitro_verifier: verifier.clone(),
+            tx_manager: NoopTxManager,
+        };
         let cert_infos = (0..=3).map(cert_info).collect::<Vec<_>>();
         let result = cert_manager
-            .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
+            .has_onchain_revoked_intermediate(&cert_infos, "i-onchain-revocation-test")
             .await;
-        (result, verifier.call_count())
+        (result, verifier.call_count.load(Ordering::Relaxed))
     }
 
     #[tokio::test]
@@ -261,10 +238,11 @@ mod tests {
 
     #[tokio::test]
     async fn onchain_revocation_check_blocks_when_any_intermediate_revoked() {
-        for (revoked_index, expected_calls_at_short_circuit) in
-            [(INTER1_INDEX, 1), (INTER2_INDEX, 2)]
-        {
-            let verifier = MockNitroVerifier::revoking(path_digest_for(revoked_index));
+        for (revoked_index, expected_calls_at_short_circuit) in [(1, 1), (2, 2)] {
+            let verifier = MockNitroVerifier {
+                revoked: Some(path_digest_for(revoked_index)),
+                ..MockNitroVerifier::default()
+            };
             let (result, calls) = run_pre_check(verifier).await;
 
             assert!(
@@ -280,7 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn onchain_revocation_check_propagates_rpc_errors() {
-        let verifier = MockNitroVerifier::failing();
+        let verifier = MockNitroVerifier { fail: true, ..MockNitroVerifier::default() };
         let (result, _calls) = run_pre_check(verifier).await;
 
         let err = result.expect_err("RPC errors must surface to the caller");

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -4,7 +4,7 @@
 //! fetches AWS Nitro CRLs, and submits `revokeCert` transactions for
 //! certificates that are newly observed on a CRL.
 
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::TxManager;
@@ -16,20 +16,12 @@ use crate::{
 };
 
 /// Manages Nitro certificate revocation checks and revocation transaction submission.
+#[derive(Debug)]
 pub struct CertManager<T> {
     enabled: bool,
     http_client: reqwest::Client,
     nitro_verifier: Arc<dyn NitroVerifierClient>,
     tx_manager: T,
-}
-
-impl<T> fmt::Debug for CertManager<T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CertManager").finish_non_exhaustive()
-    }
 }
 
 impl<T> CertManager<T>
@@ -198,18 +190,16 @@ mod tests {
         collections::HashSet,
         sync::{
             Mutex,
-            atomic::{AtomicU32, Ordering},
+            atomic::{AtomicBool, AtomicU32, Ordering},
         },
         time::Duration,
     };
 
-    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom, Bytes, FixedBytes};
-    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_primitives::{Address, B256, Bytes, FixedBytes};
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
     use base_proof_contracts::INitroEnclaveVerifier;
-    use base_tx_manager::TxCandidate;
+    use base_tx_manager::{TxCandidate, TxManagerError};
     use rstest::rstest;
 
     use super::*;
@@ -226,7 +216,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct MockNitroVerifier {
         revoked: HashSet<FixedBytes<32>>,
-        error: Mutex<Option<RegistrarError>>,
+        fail_next: AtomicBool,
         call_count: AtomicU32,
     }
 
@@ -234,15 +224,15 @@ mod tests {
         fn revoking(hashes: impl IntoIterator<Item = FixedBytes<32>>) -> Self {
             Self {
                 revoked: hashes.into_iter().collect(),
-                error: Mutex::new(None),
+                fail_next: AtomicBool::new(false),
                 call_count: AtomicU32::new(0),
             }
         }
 
-        fn failing(error: RegistrarError) -> Self {
+        fn failing() -> Self {
             Self {
                 revoked: HashSet::new(),
-                error: Mutex::new(Some(error)),
+                fail_next: AtomicBool::new(true),
                 call_count: AtomicU32::new(0),
             }
         }
@@ -256,8 +246,11 @@ mod tests {
 
         async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
-            if let Some(err) = self.error.lock().unwrap().take() {
-                return Err(err);
+            if self.fail_next.swap(false, Ordering::SeqCst) {
+                return Err(RegistrarError::NitroVerifierCall {
+                    context: "revokedCerts(0xdeadbeef)".into(),
+                    source: "boom".into(),
+                });
             }
             Ok(self.revoked.contains(&cert_hash))
         }
@@ -277,7 +270,7 @@ mod tests {
     impl TxManager for MockTxManager {
         async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
             self.sent_candidates.lock().unwrap().push(candidate);
-            Ok(stub_receipt())
+            Err(TxManagerError::ChannelClosed)
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> base_tx_manager::SendHandle {
@@ -287,13 +280,6 @@ mod tests {
         fn sender_address(&self) -> Address {
             Address::ZERO
         }
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    enum OnchainCheckOutcome {
-        AlreadyRevoked,
-        NotRevoked,
-        RpcError,
     }
 
     fn full_chain_der() -> Vec<Vec<u8>> {
@@ -320,10 +306,6 @@ mod tests {
         crl::CertCrlInfo::from_chain(&refs).expect("static fixtures parse")
     }
 
-    fn full_chain_intermediate_count() -> u32 {
-        u32::try_from(full_chain_der().len().saturating_sub(2)).unwrap()
-    }
-
     fn test_cert_manager(verifier: Arc<MockNitroVerifier>) -> CertManager<MockTxManager> {
         CertManager {
             enabled: true,
@@ -348,13 +330,6 @@ mod tests {
             nitro_verifier_address: None,
             fetch_timeout: Duration::from_secs(1),
         }
-    }
-
-    #[test]
-    fn new_builds_crl_manager_with_verifier() {
-        let verifier = Arc::new(MockNitroVerifier::default());
-        let result = CertManager::new(&crl_config(), verifier, MockTxManager::default());
-        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -388,31 +363,6 @@ mod tests {
         Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: path_digest }.abi_encode())
     }
 
-    fn stub_receipt() -> TransactionReceipt {
-        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt {
-                status: Eip658Value::success(),
-                cumulative_gas_used: 21_000,
-                logs: vec![],
-            },
-            logs_bloom: Bloom::ZERO,
-        });
-        TransactionReceipt {
-            inner,
-            transaction_hash: B256::ZERO,
-            transaction_index: Some(0),
-            block_hash: Some(B256::ZERO),
-            block_number: Some(1),
-            gas_used: 21_000,
-            effective_gas_price: 1_000_000_000,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
-    }
-
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
         let verifier = Arc::new(verifier);
         let cert_manager = test_cert_manager(Arc::clone(&verifier));
@@ -432,11 +382,7 @@ mod tests {
             !result.expect("clean chain must succeed"),
             "no intermediates flagged as revoked; registration must proceed"
         );
-        assert_eq!(
-            calls,
-            full_chain_intermediate_count(),
-            "every intermediate must be queried when none are revoked"
-        );
+        assert_eq!(calls, 2, "every intermediate must be queried when none are revoked");
     }
 
     #[rstest]
@@ -461,40 +407,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn onchain_revocation_check_short_circuits_when_all_intermediates_revoked() {
-        let verifier = MockNitroVerifier::revoking([
-            path_digest_for(INTER1_INDEX),
-            path_digest_for(INTER2_INDEX),
-        ]);
-        let (result, calls) = run_pre_check(verifier).await;
-
-        assert!(result.expect("query must succeed"), "any revoked intermediate must block");
-        assert_eq!(calls, 1, "first intermediate triggers short-circuit");
-    }
-
-    #[tokio::test]
-    async fn onchain_revocation_check_skips_root_and_leaf() {
-        let verifier =
-            MockNitroVerifier::revoking([path_digest_for(ROOT_INDEX), path_digest_for(LEAF_INDEX)]);
-        let (result, calls) = run_pre_check(verifier).await;
-
-        assert!(
-            !result.expect("query must succeed"),
-            "root/leaf revocation flags must not block registration",
-        );
-        assert_eq!(
-            calls,
-            full_chain_intermediate_count(),
-            "only intermediates are queried; root and leaf are skipped",
-        );
-    }
-
-    #[tokio::test]
     async fn onchain_revocation_check_propagates_rpc_errors() {
-        let verifier = MockNitroVerifier::failing(RegistrarError::NitroVerifierCall {
-            context: "revokedCerts(0xdeadbeef)".into(),
-            source: "boom".into(),
-        });
+        let verifier = MockNitroVerifier::failing();
         let (result, _calls) = run_pre_check(verifier).await;
 
         let err = result.expect_err("RPC errors must surface to the caller");
@@ -531,28 +445,10 @@ mod tests {
         );
     }
 
-    #[rstest]
-    #[case::already_revoked(OnchainCheckOutcome::AlreadyRevoked, false)]
-    #[case::not_revoked(OnchainCheckOutcome::NotRevoked, true)]
-    #[case::rpc_error(OnchainCheckOutcome::RpcError, true)]
     #[tokio::test]
-    async fn submit_revocations_checks_onchain_before_deciding_whether_to_submit(
-        #[case] onchain_check: OnchainCheckOutcome,
-        #[case] expect_revoke_cert: bool,
-    ) {
+    async fn submit_revocations_skips_revoke_cert_when_already_revoked() {
         let path_digest = path_digest_for(INTER1_INDEX);
-        let verifier = match onchain_check {
-            OnchainCheckOutcome::AlreadyRevoked => {
-                Arc::new(MockNitroVerifier::revoking([path_digest]))
-            }
-            OnchainCheckOutcome::NotRevoked => Arc::new(MockNitroVerifier::default()),
-            OnchainCheckOutcome::RpcError => {
-                Arc::new(MockNitroVerifier::failing(RegistrarError::NitroVerifierCall {
-                    context: "revokedCerts(0xdeadbeef)".into(),
-                    source: "boom".into(),
-                }))
-            }
-        };
+        let verifier = Arc::new(MockNitroVerifier::revoking([path_digest]));
         let cert_manager = test_cert_manager(Arc::clone(&verifier));
         let instance = test_instance();
 
@@ -566,14 +462,42 @@ mod tests {
             "CRL-hit cert should be checked onchain before deciding whether to submit revokeCert",
         );
         let candidates = cert_manager.tx_manager.take_candidates();
-        assert_eq!(
-            candidates.len(),
-            usize::from(expect_revoke_cert),
-            "revokeCert submission expectation did not match onchain check outcome",
-        );
-        if expect_revoke_cert {
-            assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
-            assert_eq!(candidates[0].tx_data, revoke_cert_calldata(path_digest));
-        }
+        assert!(candidates.is_empty(), "already-revoked certs should not submit revokeCert");
+    }
+
+    #[tokio::test]
+    async fn submit_revocations_submits_revoke_cert_when_not_revoked() {
+        let path_digest = path_digest_for(INTER1_INDEX);
+        let verifier = Arc::new(MockNitroVerifier::default());
+        let cert_manager = test_cert_manager(Arc::clone(&verifier));
+        let instance = test_instance();
+
+        cert_manager
+            .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
+            .await;
+
+        assert_eq!(verifier.call_count.load(Ordering::SeqCst), 1);
+        let candidates = cert_manager.tx_manager.take_candidates();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
+        assert_eq!(candidates[0].tx_data, revoke_cert_calldata(path_digest));
+    }
+
+    #[tokio::test]
+    async fn submit_revocations_submits_revoke_cert_when_onchain_check_errors() {
+        let path_digest = path_digest_for(INTER1_INDEX);
+        let verifier = Arc::new(MockNitroVerifier::failing());
+        let cert_manager = test_cert_manager(Arc::clone(&verifier));
+        let instance = test_instance();
+
+        cert_manager
+            .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
+            .await;
+
+        assert_eq!(verifier.call_count.load(Ordering::SeqCst), 1);
+        let candidates = cert_manager.tx_manager.take_candidates();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
+        assert_eq!(candidates[0].tx_data, revoke_cert_calldata(path_digest));
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -52,11 +52,6 @@ where
     /// Returns `Ok(true)` if any intermediate is revoked by either the
     /// onchain sentinel or the AWS CRL layer, `Ok(false)` if every checked
     /// intermediate is clean.
-    ///
-    /// The durable onchain pre-check preserves previously-revoked
-    /// intermediates even if AWS later prunes its CRL. AWS CRLs are then
-    /// checked for each intermediate, and every CRL hit is checked onchain
-    /// before a `revokeCert` transaction is submitted.
     pub async fn check_and_revoke_crls(
         &self,
         attestation_bytes: &[u8],
@@ -215,11 +210,6 @@ mod tests {
         fn call_count(&self) -> u32 {
             self.call_count.load(Ordering::Relaxed)
         }
-
-        fn should_fail_next_call(&self) -> bool {
-            self.call_count.fetch_add(1, Ordering::Relaxed);
-            self.fail_next.swap(false, Ordering::Relaxed)
-        }
     }
 
     #[async_trait]
@@ -229,7 +219,8 @@ mod tests {
         }
 
         async fn is_revoked(&self, cert_hash: B256) -> Result<bool> {
-            if self.should_fail_next_call() {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            if self.fail_next.swap(false, Ordering::Relaxed) {
                 return Err(RegistrarError::NitroVerifierCall {
                     context: "revokedCerts(0xdeadbeef)".into(),
                     source: "boom".into(),
@@ -370,28 +361,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_revocations_skips_revoke_cert_when_already_revoked() {
+    async fn submit_revocations_checks_onchain_before_sending() {
         let path_digest = path_digest_for(INTER1_INDEX);
-        let verifier = Arc::new(MockNitroVerifier::revoking(path_digest));
-        let cert_manager = test_cert_manager(Arc::clone(&verifier));
-        let instance = test_instance();
 
-        cert_manager
-            .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
-            .await;
-
-        assert_eq!(
-            verifier.call_count(),
-            1,
-            "CRL-hit cert should be checked onchain before deciding whether to submit revokeCert",
-        );
-        assert_eq!(cert_manager.tx_manager.send_count(), 0);
-    }
-
-    #[tokio::test]
-    async fn submit_revocations_submits_revoke_cert_when_needed() {
-        for verifier in [MockNitroVerifier::default(), MockNitroVerifier::failing()] {
-            let path_digest = path_digest_for(INTER1_INDEX);
+        for (case, verifier, expected_send_count) in [
+            ("already revoked", MockNitroVerifier::revoking(path_digest), 0),
+            ("clean", MockNitroVerifier::default(), 1),
+            ("RPC failure", MockNitroVerifier::failing(), 1),
+        ] {
             let verifier = Arc::new(verifier);
             let cert_manager = test_cert_manager(Arc::clone(&verifier));
             let instance = test_instance();
@@ -400,8 +377,12 @@ mod tests {
                 .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
                 .await;
 
-            assert_eq!(verifier.call_count(), 1);
-            assert_eq!(cert_manager.tx_manager.send_count(), 1);
+            assert_eq!(verifier.call_count(), 1, "{case}: should check onchain once");
+            assert_eq!(
+                cert_manager.tx_manager.send_count(),
+                expected_send_count,
+                "{case}: unexpected revokeCert send count",
+            );
         }
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -207,7 +207,7 @@ mod tests {
     }
 
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
-        let call_count = verifier.call_count.clone();
+        let call_count = Arc::clone(&verifier.call_count);
         let cert_manager = CertManager {
             enabled: true,
             http_client: reqwest::Client::new(),

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -66,16 +66,13 @@ where
             return Ok(false);
         }
 
-        let cert_infos = {
-            let report = AttestationReport::parse(attestation_bytes).map_err(|e| {
-                RegistrarError::ProverClient {
-                    instance: instance.endpoint.to_string(),
-                    source: format!("failed to parse attestation for CRL check: {e}").into(),
-                }
-            })?;
-            let cert_chain_der = report.cert_chain_der();
-            crl::CertCrlInfo::from_chain(&cert_chain_der)?
-        };
+        let report = AttestationReport::parse(attestation_bytes).map_err(|e| {
+            RegistrarError::ProverClient {
+                instance: instance.endpoint.to_string(),
+                source: format!("failed to parse attestation for CRL check: {e}").into(),
+            }
+        })?;
+        let cert_infos = crl::CertCrlInfo::from_chain(&report.cert_chain_der())?;
 
         RegistrarMetrics::onchain_revocation_checks_total().increment(1);
         match self.has_onchain_revoked_intermediate(&cert_infos, &instance.instance_id).await {
@@ -122,9 +119,8 @@ where
     ) -> Result<bool> {
         for info in crl::CertCrlInfo::intermediates(cert_infos) {
             if self.nitro_verifier.is_revoked(info.path_digest).await? {
-                let cert = info.intermediate_label();
                 warn!(
-                    cert = %cert,
+                    cert_index = info.index,
                     path_digest = %info.path_digest,
                     instance = %instance_id,
                     "intermediate is revoked onchain (durable sentinel set), skipping registration"
@@ -148,11 +144,10 @@ where
         let cert_revoker = CertRevoker::new(verifier_address, &self.tx_manager);
 
         for revoked in revoked_certs {
-            let cert = revoked.intermediate_label();
             match self.nitro_verifier.is_revoked(revoked.path_digest).await {
                 Ok(true) => {
                     warn!(
-                        cert = %cert,
+                        cert_index = revoked.index,
                         path_digest = %revoked.path_digest,
                         instance = %instance.instance_id,
                         "certificate already revoked onchain, skipping revokeCert"
@@ -164,7 +159,7 @@ where
                 Err(e) => {
                     warn!(
                         error = %e,
-                        cert = %cert,
+                        cert_index = revoked.index,
                         path_digest = %revoked.path_digest,
                         instance = %instance.instance_id,
                         "onchain revocation check failed for CRL hit; submitting revokeCert"
@@ -174,7 +169,7 @@ where
             }
 
             warn!(
-                cert = %cert,
+                cert_index = revoked.index,
                 path_digest = %revoked.path_digest,
                 instance = %instance.instance_id,
                 "submitting revokeCert transaction"
@@ -186,15 +181,17 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    };
 
-    use alloy_primitives::{Address, B256, Bytes};
-    use alloy_sol_types::SolCall;
+    use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
-    use base_proof_contracts::INitroEnclaveVerifier;
     use base_tx_manager::{TxCandidate, TxManagerError};
 
     use super::*;
+    use crate::test_utils::{NoopNitroVerifier, NoopTxManager};
 
     const ONCHAIN_TEST_INSTANCE_ID: &str = "i-onchain-revocation-test";
     const TEST_VERIFIER_ADDRESS: Address = Address::repeat_byte(0xAB);
@@ -207,13 +204,8 @@ mod tests {
     #[derive(Debug, Default)]
     struct MockNitroVerifier {
         revoked: Vec<B256>,
-        state: Mutex<MockNitroVerifierState>,
-    }
-
-    #[derive(Debug, Default)]
-    struct MockNitroVerifierState {
-        fail_next: bool,
-        call_count: u32,
+        fail_next: AtomicBool,
+        call_count: AtomicU32,
     }
 
     impl MockNitroVerifier {
@@ -222,20 +214,16 @@ mod tests {
         }
 
         fn failing() -> Self {
-            Self {
-                state: Mutex::new(MockNitroVerifierState { fail_next: true, call_count: 0 }),
-                ..Self::default()
-            }
+            Self { fail_next: AtomicBool::new(true), ..Self::default() }
         }
 
         fn call_count(&self) -> u32 {
-            self.state.lock().unwrap().call_count
+            self.call_count.load(Ordering::Relaxed)
         }
 
         fn should_fail_next_call(&self) -> bool {
-            let mut state = self.state.lock().unwrap();
-            state.call_count += 1;
-            std::mem::take(&mut state.fail_next)
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            self.fail_next.swap(false, Ordering::Relaxed)
         }
     }
 
@@ -328,27 +316,17 @@ mod tests {
             nitro_verifier_address: None,
             fetch_timeout: std::time::Duration::from_secs(1),
         };
-        let verifier = Arc::new(MockNitroVerifier::default());
-        let cert_manager = CertManager::new(
-            &config,
-            Arc::<MockNitroVerifier>::clone(&verifier),
-            MockTxManager::default(),
-        )
-        .expect("disabled cert manager still builds");
+        let cert_manager = CertManager::new(&config, Arc::new(NoopNitroVerifier), NoopTxManager)
+            .expect("disabled cert manager still builds");
 
         let result =
             cert_manager.check_and_revoke_crls(b"not-an-attestation", &test_instance()).await;
 
         assert!(!result.expect("disabled CRL checks must no-op"));
-        assert_eq!(verifier.call_count(), 0, "disabled CRL checks must not query the verifier",);
     }
 
     fn revoked_cert(path_digest: B256) -> crl::RevokedCertInfo {
         crl::RevokedCertInfo { index: INTER1_INDEX, path_digest }
-    }
-
-    fn revoke_cert_calldata(path_digest: B256) -> Bytes {
-        Bytes::from(INitroEnclaveVerifier::revokeCertCall { certHash: path_digest }.abi_encode())
     }
 
     async fn run_pre_check(verifier: MockNitroVerifier) -> (Result<bool>, u32) {
@@ -405,30 +383,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn onchain_revocation_check_queries_intermediates_only() {
-        for (indices, expected_calls) in [
-            (&[ROOT_INDEX][..], 0),
-            (&[ROOT_INDEX, LEAF_INDEX][..], 0),
-            (&[ROOT_INDEX, INTER1_INDEX, LEAF_INDEX][..], 1),
-        ] {
-            let cert_infos = cert_infos(indices);
-            let verifier = Arc::new(MockNitroVerifier::default());
-            let cert_manager = test_cert_manager(Arc::clone(&verifier));
-
-            let result = cert_manager
-                .has_onchain_revoked_intermediate(&cert_infos, ONCHAIN_TEST_INSTANCE_ID)
-                .await;
-
-            assert!(!result.expect("query must succeed"), "clean chain not revoked");
-            assert_eq!(
-                verifier.call_count(),
-                expected_calls,
-                "only intermediates (root and leaf skipped) should produce RPC calls",
-            );
-        }
-    }
-
-    #[tokio::test]
     async fn submit_revocations_skips_revoke_cert_when_already_revoked() {
         let path_digest = path_digest_for(INTER1_INDEX);
         let verifier = Arc::new(MockNitroVerifier::revoking([path_digest]));
@@ -449,38 +403,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_revocations_submits_revoke_cert_when_not_revoked() {
-        let path_digest = path_digest_for(INTER1_INDEX);
-        let verifier = Arc::new(MockNitroVerifier::default());
-        let cert_manager = test_cert_manager(Arc::clone(&verifier));
-        let instance = test_instance();
+    async fn submit_revocations_submits_revoke_cert_when_needed() {
+        for verifier in [MockNitroVerifier::default(), MockNitroVerifier::failing()] {
+            let path_digest = path_digest_for(INTER1_INDEX);
+            let verifier = Arc::new(verifier);
+            let cert_manager = test_cert_manager(Arc::clone(&verifier));
+            let instance = test_instance();
 
-        cert_manager
-            .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
-            .await;
+            cert_manager
+                .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
+                .await;
 
-        assert_eq!(verifier.call_count(), 1);
-        let candidates = cert_manager.tx_manager.take_candidates();
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
-        assert_eq!(candidates[0].tx_data, revoke_cert_calldata(path_digest));
-    }
-
-    #[tokio::test]
-    async fn submit_revocations_submits_revoke_cert_when_onchain_check_errors() {
-        let path_digest = path_digest_for(INTER1_INDEX);
-        let verifier = Arc::new(MockNitroVerifier::failing());
-        let cert_manager = test_cert_manager(Arc::clone(&verifier));
-        let instance = test_instance();
-
-        cert_manager
-            .submit_revocations_for_revoked_certs(&[revoked_cert(path_digest)], &instance)
-            .await;
-
-        assert_eq!(verifier.call_count(), 1);
-        let candidates = cert_manager.tx_manager.take_candidates();
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
-        assert_eq!(candidates[0].tx_data, revoke_cert_calldata(path_digest));
+            assert_eq!(verifier.call_count(), 1);
+            let candidates = cert_manager.tx_manager.take_candidates();
+            assert_eq!(candidates.len(), 1);
+            assert_eq!(candidates[0].to, Some(TEST_VERIFIER_ADDRESS));
+        }
     }
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -544,7 +544,7 @@ mod tests {
             fetch_timeout: Duration::from_secs(crate::DEFAULT_CRL_FETCH_TIMEOUT_SECS),
         };
         let cert_manager =
-            CertManager::new(&crl_config, Arc::new(NoopNitroVerifier), NoopTxManager)
+            CertManager::new(&crl_config, Box::new(NoopNitroVerifier), NoopTxManager)
                 .expect("test cert manager builds");
         let signer_manager = Arc::new(SignerManager::new(
             signer_client.clone(),

--- a/crates/proof/tee/registrar/src/verifier.rs
+++ b/crates/proof/tee/registrar/src/verifier.rs
@@ -16,7 +16,7 @@ use crate::{RegistrarError, Result};
 /// Reads the durable revocation sentinel from the onchain
 /// `NitroEnclaveVerifier`.
 #[async_trait]
-pub trait NitroVerifierClient: Send + Sync {
+pub trait NitroVerifierClient: Send + Sync + std::fmt::Debug {
     /// Returns the onchain address of the verifier this client is bound to.
     /// Used by the driver as the destination for `revokeCert` transactions.
     fn address(&self) -> Address;


### PR DESCRIPTION
### What changed? Why?

Simplifies registrar CRL handling and the cert manager tests.

`CertManager` now owns the Nitro verifier as a `Box<dyn NitroVerifierClient>`, derives `Debug`, parses attestation certificates directly into CRL metadata, and keeps one durable onchain pre-check before consulting AWS CRLs. When AWS reports revoked certificates, the manager now submits `revokeCert` for each CRL hit directly instead of doing a second `revokedCerts` lookup per hit.

The test cleanup removes DER fixture parsing from the cert manager unit tests, drops the custom tx manager / receipt construction from this file, and replaces several overlapping cases with one table-driven pre-check test plus the RPC error case. `CertRevoker` tests continue to cover `revokeCert` calldata and submission behavior.

### Notes to reviewers

The notable behavior change is the post-CRL path: already-revoked CRL hits are no longer skipped by a second onchain read before submission. Duplicate revocation attempts flow through the existing tx result handling, including the reverted `revokeCert` metric.

`NitroVerifierClient` now requires `Debug` so `CertManager` can derive `Debug`; the concrete contract client and test verifiers already satisfy that bound.

### How has it been tested?

- cargo fmt --package base-proof-tee-registrar --check
- cargo check -p base-proof-tee-registrar
- cargo test -p base-proof-tee-registrar
