### PR TITLE
feat(proof): add zk host proving backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5935,13 +5935,17 @@ dependencies = [
  "bincode 2.0.1",
  "serde",
  "serde_json",
+ "sp1-cluster-artifact",
  "sp1-cluster-common",
+ "sp1-cluster-utils",
  "sp1-prover-types",
  "sp1-sdk",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tonic 0.14.6",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6220,8 +6224,10 @@ dependencies = [
  "clap",
  "eyre",
  "serde",
+ "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/bin/prover/zk-host/Cargo.toml
+++ b/bin/prover/zk-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base-prover-zk-host"
-description = "ZK prover-service worker host"
+description = "ZK prover host worker (pulls jobs from the prover service)"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -16,8 +16,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-# base
-base-cli-utils.workspace = true
+# Workspace – Prover
 base-proof-worker.workspace = true
 base-proof-zk-host.workspace = true
 base-proof-zk-backend.workspace = true
@@ -25,15 +24,17 @@ base-prover-service-client.workspace = true
 
 # CLI / errors
 eyre.workspace = true
+base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
-# Required by base-cli-utils logging and metrics macro expansions.
 serde = { workspace = true, features = ["derive", "std"] }
 
-# async
+# Async
 tokio-util.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 
-# misc
+# URL / identifiers
+url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
-# observability
+# Tracing
 tracing.workspace = true

--- a/bin/prover/zk-host/README.md
+++ b/bin/prover/zk-host/README.md
@@ -2,6 +2,5 @@
 
 ZK prover-service worker host binary.
 
-This binary is the CLI entry point for the ZK worker host. The worker loop is
-wired through `base-proof-zk-host` and currently supports the mock and dry-run
-ZK proving backends.
+This binary is the CLI entry point for claiming ZK proof jobs from the prover
+service and running them with the configured ZK backend.

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -1,33 +1,37 @@
-//! CLI definition for the ZK prover-service worker host binary.
+//! CLI definition for the ZK prover host worker binary.
 
-use std::{fmt, sync::Arc, time::Duration};
+use std::{fmt, time::Duration};
 
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
 };
-use base_proof_zk_backend::{DryRunZkProver, MockZkProver};
+use base_proof_zk_backend::{
+    SuccinctClusterBackendConfig, SuccinctNetworkBackendConfig, SuccinctRpcConfig,
+    SuccinctZkBackendConfig, SuccinctZkProverBuilder,
+};
 use base_proof_zk_host::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
     DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, ProofGeneratorHeartbeatConfig,
-    ZkHost, ZkHostConfig, ZkProofClaimType, ZkProver,
+    ZkHost, ZkHostConfig, ZkProofClaimType,
 };
 use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::{Parser, ValueEnum};
-use eyre::WrapErr;
+use eyre::{WrapErr, eyre};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
+use url::Url;
 use uuid::Uuid;
 
 base_cli_utils::define_log_args!("BASE_PROVER_ZK_HOST");
 base_cli_utils::define_metrics_args!("BASE_PROVER_ZK_HOST", 7303);
 
-/// ZK prover-service worker host binary.
+/// ZK prover host worker binary.
 #[derive(Parser)]
 #[command(author, version)]
 pub(crate) struct Cli {
     #[command(flatten)]
-    args: ZkHostArgs,
+    worker: WorkerArgs,
 
     /// Logging arguments.
     #[command(flatten)]
@@ -38,9 +42,9 @@ pub(crate) struct Cli {
     metrics: MetricsArgs,
 }
 
-/// ZK worker host configuration.
-#[derive(Parser, Debug)]
-struct ZkHostArgs {
+/// Worker-mode arguments for claiming and generating ZK proof jobs.
+#[derive(Parser)]
+struct WorkerArgs {
     /// Prover-service JSON-RPC endpoint.
     #[arg(long, env = "PROVER_SERVICE_ENDPOINT")]
     prover_service_endpoint: String,
@@ -53,13 +57,90 @@ struct ZkHostArgs {
     #[arg(long, env = "PROVER_WORKER_ID")]
     worker_id: Option<String>,
 
-    /// ZK proof type this worker should claim.
+    /// ZK proof type to claim: `compressed` or `snark_groth16`.
     #[arg(long, env = "PROOF_TYPE", value_enum, default_value = "compressed")]
     proof_type: ZkProofTypeArg,
 
-    /// Proving backend to run.
+    /// Proving backend to run: `mock`, `dry_run`, `cluster`, or `network`.
     #[arg(long, env = "ZK_BACKEND", value_enum)]
     backend: ZkBackendArg,
+
+    /// Base consensus node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    #[arg(
+        long,
+        env = "BASE_CONSENSUS_ADDRESS",
+        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+    )]
+    base_consensus_address: Option<Url>,
+
+    /// L1 execution node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    #[arg(
+        long,
+        env = "L1_NODE_ADDRESS",
+        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+    )]
+    l1_node_address: Option<Url>,
+
+    /// L1 beacon node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    #[arg(
+        long,
+        env = "L1_BEACON_ADDRESS",
+        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+    )]
+    l1_beacon_address: Option<Url>,
+
+    /// L2 execution node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    #[arg(
+        long,
+        env = "L2_NODE_ADDRESS",
+        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+    )]
+    l2_node_address: Option<Url>,
+
+    /// Default sequence window for L1 head calculations.
+    #[arg(long, env = "DEFAULT_SEQUENCE_WINDOW", default_value_t = 50)]
+    default_sequence_window: u64,
+
+    /// SP1 cluster gRPC endpoint. Required for `ZK_BACKEND=cluster`.
+    #[arg(long, env = "SP1_CLUSTER_API_ENDPOINT", required_if_eq("backend", "cluster"))]
+    sp1_cluster_api_endpoint: Option<String>,
+
+    /// SP1 cluster proof timeout in hours.
+    #[arg(long, env = "SP1_CLUSTER_TIMEOUT_HOURS", default_value_t = 24)]
+    sp1_cluster_timeout_hours: u64,
+
+    /// S3 artifact store bucket for `ZK_BACKEND=cluster`.
+    #[arg(long, env = "CLI_S3_BUCKET", required_if_eq("backend", "cluster"))]
+    cli_s3_bucket: Option<String>,
+
+    /// S3 artifact store region for `ZK_BACKEND=cluster`.
+    #[arg(long, env = "CLI_S3_REGION", required_if_eq("backend", "cluster"))]
+    cli_s3_region: Option<String>,
+
+    /// SP1 network requester private key, or KMS key ARN when `USE_KMS_REQUESTER=true`.
+    #[arg(
+        long,
+        env = "NETWORK_PRIVATE_KEY",
+        hide_env_values = true,
+        required_if_eq("backend", "network")
+    )]
+    network_private_key: Option<String>,
+
+    /// Use the requester key as an AWS KMS ARN instead of a local private key.
+    #[arg(long, env = "USE_KMS_REQUESTER", default_value_t = false)]
+    use_kms_requester: bool,
+
+    /// SP1 network proof timeout in hours.
+    #[arg(long, env = "SP1_NETWORK_TIMEOUT_HOURS", default_value_t = 24)]
+    sp1_network_timeout_hours: u64,
+
+    /// Cycle limit for range proof requests.
+    #[arg(long, env = "RANGE_CYCLE_LIMIT", default_value_t = 1_000_000_000_000)]
+    range_cycle_limit: u64,
+
+    /// Gas limit for range proof requests.
+    #[arg(long, env = "RANGE_GAS_LIMIT", default_value_t = 1_000_000_000_000)]
+    range_gas_limit: u64,
 
     /// Delay after an empty or failed discovery attempt, in milliseconds.
     #[arg(long, env = "JOB_DISCOVERY_POLL_INTERVAL_MS", default_value_t = 5_000)]
@@ -81,7 +162,7 @@ struct ZkHostArgs {
     )]
     job_discovery_max_concurrent_jobs: usize,
 
-    /// Delay between worker API heartbeats while a ZK proof is being generated.
+    /// Delay between worker API heartbeats while a proof is being generated.
     #[arg(long, env = "PROOF_GENERATOR_HEARTBEAT_INTERVAL_SECS", default_value_t = 30)]
     proof_generator_heartbeat_interval_secs: u64,
 
@@ -129,30 +210,115 @@ enum ZkBackendArg {
     /// Return empty proof bytes without an external backend.
     #[value(alias = "dry_run", alias = "dryrun")]
     DryRun,
+    /// Submit proofs to an SP1 cluster.
+    Cluster,
+    /// Submit proofs to the Succinct SP1 Network.
+    Network,
 }
 
-impl ZkBackendArg {
-    fn prover(self) -> Arc<dyn ZkProver> {
+impl AsRef<str> for ZkBackendArg {
+    fn as_ref(&self) -> &str {
         match self {
-            Self::Mock => Arc::new(MockZkProver),
-            Self::DryRun => Arc::new(DryRunZkProver),
+            Self::Mock => "mock",
+            Self::DryRun => "dry_run",
+            Self::Cluster => "cluster",
+            Self::Network => "network",
         }
     }
 }
 
 impl fmt::Display for ZkBackendArg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl ZkBackendArg {
+    const fn supports_proof_type(self, proof_type: ZkProofTypeArg) -> bool {
         match self {
-            Self::Mock => f.write_str("mock"),
-            Self::DryRun => f.write_str("dry_run"),
+            Self::Mock | Self::DryRun => true,
+            Self::Cluster | Self::Network => matches!(proof_type, ZkProofTypeArg::Compressed),
         }
     }
 }
 
+impl WorkerArgs {
+    fn backend_config(&self) -> eyre::Result<SuccinctZkBackendConfig> {
+        match self.backend {
+            ZkBackendArg::Mock => Ok(SuccinctZkBackendConfig::Mock),
+            ZkBackendArg::DryRun => Ok(SuccinctZkBackendConfig::DryRun),
+            ZkBackendArg::Cluster => {
+                Ok(SuccinctZkBackendConfig::Cluster(SuccinctClusterBackendConfig {
+                    rpc: self.rpc_config()?,
+                    cluster_rpc: Self::required_string(
+                        &self.sp1_cluster_api_endpoint,
+                        "SP1_CLUSTER_API_ENDPOINT",
+                    )?,
+                    s3_bucket: Self::required_string(&self.cli_s3_bucket, "CLI_S3_BUCKET")?,
+                    s3_region: Self::required_string(&self.cli_s3_region, "CLI_S3_REGION")?,
+                    timeout: Self::duration_from_hours(
+                        self.sp1_cluster_timeout_hours,
+                        "SP1_CLUSTER_TIMEOUT_HOURS",
+                    )?,
+                    range_cycle_limit: self.range_cycle_limit,
+                    range_gas_limit: self.range_gas_limit,
+                }))
+            }
+            ZkBackendArg::Network => {
+                Ok(SuccinctZkBackendConfig::Network(SuccinctNetworkBackendConfig {
+                    rpc: self.rpc_config()?,
+                    network_private_key: Self::required_string(
+                        &self.network_private_key,
+                        "NETWORK_PRIVATE_KEY",
+                    )?,
+                    use_kms_requester: self.use_kms_requester,
+                    timeout: Self::duration_from_hours(
+                        self.sp1_network_timeout_hours,
+                        "SP1_NETWORK_TIMEOUT_HOURS",
+                    )?,
+                    range_cycle_limit: self.range_cycle_limit,
+                    range_gas_limit: self.range_gas_limit,
+                }))
+            }
+        }
+    }
+
+    fn rpc_config(&self) -> eyre::Result<SuccinctRpcConfig> {
+        Ok(SuccinctRpcConfig {
+            base_consensus_rpc: Self::required_url(
+                &self.base_consensus_address,
+                "BASE_CONSENSUS_ADDRESS",
+            )?,
+            l1_rpc: Self::required_url(&self.l1_node_address, "L1_NODE_ADDRESS")?,
+            l1_beacon_rpc: Self::required_url(&self.l1_beacon_address, "L1_BEACON_ADDRESS")?,
+            l2_rpc: Self::required_url(&self.l2_node_address, "L2_NODE_ADDRESS")?,
+            default_sequence_window: self.default_sequence_window,
+        })
+    }
+
+    fn required_url(value: &Option<Url>, env: &'static str) -> eyre::Result<Url> {
+        value.clone().ok_or_else(|| eyre!("{env} must be set for the selected ZK_BACKEND"))
+    }
+
+    fn required_string(value: &Option<String>, env: &'static str) -> eyre::Result<String> {
+        value
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| eyre!("{env} must be set for the selected ZK_BACKEND"))
+    }
+
+    fn duration_from_hours(hours: u64, env: &'static str) -> eyre::Result<Duration> {
+        let seconds = hours.checked_mul(3600).ok_or_else(|| eyre!("{env} is too large"))?;
+        Ok(Duration::from_secs(seconds))
+    }
+}
+
 impl Cli {
-    /// Run the ZK worker host.
+    /// Run the worker.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        let Self { args, logging, metrics } = self;
+        let Self { worker, logging, metrics } = self;
         LogConfig::from(logging).init_tracing_subscriber()?;
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
@@ -160,44 +326,92 @@ impl Cli {
 
         RuntimeManager::new()
             .with_thread_stack_size(8 * 1024 * 1024)
-            .run_until_shutdown(|cancel| async move { args.run(cancel).await })
+            .run_until_shutdown(|cancel| async move { worker.run(cancel).await })
     }
 }
 
-impl ZkHostArgs {
+impl WorkerArgs {
     async fn run(self, cancel: CancellationToken) -> eyre::Result<()> {
-        let worker_id = self.worker_id.unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
-        let proof_type = ZkProofClaimType::from(self.proof_type);
-        let prover = self.backend.prover();
+        let args = &self;
+        if !args.backend.supports_proof_type(args.proof_type) {
+            return Err(eyre!(
+                "ZK_BACKEND={} currently supports PROOF_TYPE=compressed only",
+                args.backend
+            ));
+        }
+        let proof_type = ZkProofClaimType::from(args.proof_type);
+        info!(
+            prover_service_endpoint = %args.prover_service_endpoint,
+            proof_type = ?proof_type,
+            backend = %args.backend,
+            "initializing zk prover host worker"
+        );
 
-        let client_config = ProverServiceClientConfig::new(self.prover_service_endpoint.clone())
-            .with_request_timeout(Duration::from_secs(self.prover_service_request_timeout_secs));
-        let client = ProverWorkerClient::connect(&client_config)
-            .wrap_err("failed to connect to prover service")?;
+        let backend_config = args.backend_config()?;
+        let Some(prover) = SuccinctZkProverBuilder::new(backend_config)
+            .build_until_cancelled(&cancel)
+            .await
+            .wrap_err("failed to initialize zk proving backend")?
+        else {
+            info!(
+                proof_type = ?proof_type,
+                backend = %args.backend,
+                "zk prover host worker initialization cancelled"
+            );
+            return Ok(());
+        };
+
+        let client_config = ProverServiceClientConfig::new(args.prover_service_endpoint.clone())
+            .with_request_timeout(Duration::from_secs(args.prover_service_request_timeout_secs));
+        let Some(client) = Self::connect_prover_service_client(&client_config, &cancel).await?
+        else {
+            info!(
+                proof_type = ?proof_type,
+                backend = %args.backend,
+                "zk prover host worker startup cancelled"
+            );
+            return Ok(());
+        };
 
         let heartbeat = ProofGeneratorHeartbeatConfig::with_max_consecutive_failures(
-            Duration::from_secs(self.proof_generator_heartbeat_interval_secs),
-            self.proof_generator_heartbeat_lock_duration_seconds,
-            self.proof_generator_max_consecutive_heartbeat_failures,
+            Duration::from_secs(args.proof_generator_heartbeat_interval_secs),
+            args.proof_generator_heartbeat_lock_duration_seconds,
+            args.proof_generator_max_consecutive_heartbeat_failures,
         );
+
+        let worker_id =
+            args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
         let host_config = ZkHostConfig::sp1(worker_id.clone(), proof_type)
             .with_job_discovery_poll_interval(Duration::from_millis(
-                self.job_discovery_poll_interval_ms,
+                args.job_discovery_poll_interval_ms,
             ))
-            .with_job_discovery_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
-            .with_job_discovery_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
+            .with_job_discovery_lock_duration_seconds(args.job_discovery_lock_duration_seconds)
+            .with_job_discovery_max_concurrent_jobs(args.job_discovery_max_concurrent_jobs)
             .with_proof_generator_heartbeat(heartbeat);
         let host = ZkHost::new(client, prover, host_config);
 
         info!(
             worker_id = %worker_id,
-            prover_service_endpoint = %self.prover_service_endpoint,
+            prover_service_endpoint = %args.prover_service_endpoint,
             proof_type = ?proof_type,
-            backend = %self.backend,
+            backend = %args.backend,
             "starting zk prover host worker"
         );
         host.run_until_cancelled(cancel).await;
-
         Ok(())
+    }
+
+    async fn connect_prover_service_client(
+        client_config: &ProverServiceClientConfig,
+        cancel: &CancellationToken,
+    ) -> eyre::Result<Option<ProverWorkerClient>> {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => Ok(None),
+            result = async {
+                ProverWorkerClient::connect(client_config)
+                    .wrap_err("failed to connect to prover service")
+            } => result.map(Some),
+        }
     }
 }

--- a/bin/prover/zk-host/src/main.rs
+++ b/bin/prover/zk-host/src/main.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![recursion_limit = "256"]
 #![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/crates/proof/succinct/utils/proof/src/lib.rs
+++ b/crates/proof/succinct/utils/proof/src/lib.rs
@@ -69,6 +69,18 @@ pub async fn cluster_setup_keys()
     .await?
 }
 
+/// Set up only the range proving key via blocking `CpuProver`.
+///
+/// Runs in `spawn_blocking` because `CpuProver` creates its own tokio runtime
+/// internally, which would panic if called directly from an async context.
+pub async fn cluster_setup_range_key() -> Result<SP1ProvingKey> {
+    tokio::task::spawn_blocking(|| {
+        let cpu_prover = CpuProver::new();
+        cpu_prover.setup(Elf::Static(get_range_elf_embedded())).context("range ELF setup failed")
+    })
+    .await?
+}
+
 /// Compute only the verifying keys for the range and aggregation ELFs.
 ///
 /// Uses [`LightProver`] which skips the expensive proving-key generation,

--- a/crates/proof/zk/backend/Cargo.toml
+++ b/crates/proof/zk/backend/Cargo.toml
@@ -23,17 +23,22 @@ base-proof-succinct-client-utils.workspace = true
 base-proof-succinct-ethereum-host-utils.workspace = true
 
 # network
+url.workspace = true
 tonic.workspace = true
 alloy-primitives.workspace = true
 
 # sp1
 sp1-prover-types.workspace = true
+sp1-cluster-utils.workspace = true
 sp1-cluster-common.workspace = true
+sp1-cluster-artifact.workspace = true
 sp1-sdk = { workspace = true, features = ["network"] }
 
 # async
 backoff.workspace = true
 async-trait.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["macros"] }
 
 # error handling
 thiserror.workspace = true

--- a/crates/proof/zk/backend/src/lib.rs
+++ b/crates/proof/zk/backend/src/lib.rs
@@ -4,5 +4,7 @@ mod succinct;
 pub use succinct::{
     ClusterSessionId, ClusterZkProver, ClusterZkProverConfig, DRY_RUN_SNARK_PREFIX, DryRunZkProver,
     L1HeadSource, MOCK_PROOF_BYTES, MOCK_SNARK_PREFIX, MockZkProver, NetworkZkProver,
-    NetworkZkProverConfig, OpSuccinctWitnessProvider, WitnessError, WitnessParams,
+    NetworkZkProverConfig, OpSuccinctWitnessProvider, SuccinctClusterBackendConfig,
+    SuccinctNetworkBackendConfig, SuccinctRpcConfig, SuccinctZkBackendConfig,
+    SuccinctZkProverBuildError, SuccinctZkProverBuilder, WitnessError, WitnessParams,
 };

--- a/crates/proof/zk/backend/src/succinct/builder.rs
+++ b/crates/proof/zk/backend/src/succinct/builder.rs
@@ -1,0 +1,170 @@
+//! Backend construction for Succinct ZK provers.
+
+use std::{error::Error, future::Future, sync::Arc};
+
+use base_proof_succinct_host_utils::fetcher::{OPSuccinctDataFetcher, RPCConfig};
+use base_proof_zk_host::ZkProver;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use url::Url;
+
+use crate::succinct::{
+    ClusterZkProver, DryRunZkProver, MockZkProver, NetworkZkProver, OpSuccinctWitnessProvider,
+    SuccinctClusterBackendConfig, SuccinctNetworkBackendConfig,
+};
+
+/// Errors raised while building a Succinct ZK prover backend.
+#[derive(Debug, Error)]
+pub enum SuccinctZkProverBuildError {
+    /// A configuration value is invalid.
+    #[error("configuration error: {0}")]
+    Config(String),
+    /// A backend initialization step failed.
+    #[error("{context}")]
+    Operation {
+        /// Failed initialization operation.
+        context: &'static str,
+        /// Underlying operation error.
+        #[source]
+        source: Box<dyn Error + Send + Sync + 'static>,
+    },
+}
+
+impl SuccinctZkProverBuildError {
+    /// Creates a configuration error.
+    pub fn config(message: impl Into<String>) -> Self {
+        Self::Config(message.into())
+    }
+
+    /// Creates an operation error with source context.
+    pub fn operation(context: &'static str, source: impl Error + Send + Sync + 'static) -> Self {
+        Self::Operation { context, source: Box::new(source) }
+    }
+
+    /// Creates an operation error from a boxed source.
+    pub fn boxed_operation(
+        context: &'static str,
+        source: Box<dyn Error + Send + Sync + 'static>,
+    ) -> Self {
+        Self::Operation { context, source }
+    }
+}
+
+/// Succinct backend implementation to build.
+#[derive(Clone, Debug)]
+pub enum SuccinctZkBackendConfig {
+    /// Return placeholder proof bytes without an external backend.
+    Mock,
+    /// Return empty proof bytes without an external backend.
+    DryRun,
+    /// Submit proofs to an SP1 cluster.
+    Cluster(SuccinctClusterBackendConfig),
+    /// Submit proofs to the Succinct SP1 Network.
+    Network(SuccinctNetworkBackendConfig),
+}
+
+/// Shared RPC settings for Succinct proving backends.
+#[derive(Clone, Debug)]
+pub struct SuccinctRpcConfig {
+    /// Base consensus node RPC URL.
+    pub base_consensus_rpc: Url,
+    /// L1 execution node RPC URL.
+    pub l1_rpc: Url,
+    /// L1 beacon node RPC URL.
+    pub l1_beacon_rpc: Url,
+    /// L2 execution node RPC URL.
+    pub l2_rpc: Url,
+    /// Default sequence window for L1 head calculations.
+    pub default_sequence_window: u64,
+}
+
+/// Builds concrete Succinct ZK prover backends from config.
+#[derive(Clone, Debug)]
+pub struct SuccinctZkProverBuilder {
+    config: SuccinctZkBackendConfig,
+}
+
+impl SuccinctZkProverBuilder {
+    /// Creates a builder for a Succinct ZK prover backend.
+    pub const fn new(config: SuccinctZkBackendConfig) -> Self {
+        Self { config }
+    }
+
+    /// Builds the configured prover unless cancellation is requested first.
+    pub async fn build_until_cancelled(
+        self,
+        cancel: &CancellationToken,
+    ) -> Result<Option<Arc<dyn ZkProver>>, SuccinctZkProverBuildError> {
+        if cancel.is_cancelled() {
+            return Ok(None);
+        }
+
+        match self.config {
+            SuccinctZkBackendConfig::Mock => Ok(Some(Arc::new(MockZkProver))),
+            SuccinctZkBackendConfig::DryRun => Ok(Some(Arc::new(DryRunZkProver))),
+            SuccinctZkBackendConfig::Cluster(config) => {
+                ClusterZkProver::build_until_cancelled(config, cancel).await
+            }
+            SuccinctZkBackendConfig::Network(config) => {
+                NetworkZkProver::build_until_cancelled(config, cancel).await
+            }
+        }
+    }
+
+    /// Builds a Succinct witness provider.
+    pub async fn build_witness_provider(
+        rpc: SuccinctRpcConfig,
+        cancel: &CancellationToken,
+    ) -> Result<Option<OpSuccinctWitnessProvider>, SuccinctZkProverBuildError> {
+        let rpc_config = RPCConfig {
+            l1_rpc: rpc.l1_rpc,
+            l1_beacon_rpc: Some(rpc.l1_beacon_rpc),
+            l2_rpc: rpc.l2_rpc,
+            l2_node_rpc: rpc.base_consensus_rpc,
+        };
+        let Some(fetcher) = Self::complete_unless_cancelled(
+            cancel,
+            async {
+                OPSuccinctDataFetcher::from_rpc_config_with_rollup_config(rpc_config).await.map_err(
+                    |error| {
+                        SuccinctZkProverBuildError::boxed_operation(
+                            "failed to create OPSuccinctDataFetcher",
+                            error.into_boxed_dyn_error(),
+                        )
+                    },
+                )
+            },
+            "op_succinct_data_fetcher",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let fetcher = Arc::new(fetcher);
+
+        Ok(Some(OpSuccinctWitnessProvider::new(fetcher)))
+    }
+
+    /// Completes an initialization operation unless cancellation is requested.
+    pub async fn complete_unless_cancelled<F, T>(
+        cancel: &CancellationToken,
+        operation: F,
+        operation_name: &'static str,
+    ) -> Result<Option<T>, SuccinctZkProverBuildError>
+    where
+        F: Future<Output = Result<T, SuccinctZkProverBuildError>> + Send,
+    {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                info!(
+                    operation = %operation_name,
+                    "cancelled Succinct backend initialization operation"
+                );
+                Ok(None)
+            }
+            result = operation => result.map(Some),
+        }
+    }
+}

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -15,20 +15,46 @@ use base_proof_succinct_proof_utils::{ClusterArtifactStore, ClusterProofConfig};
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
 use base_prover_service_protocol::{ProofResult, ZkProofResult, ZkVm};
 use serde::{Deserialize, Serialize};
-use sp1_cluster_common::proto::{
-    ExecutionFailureCause, ExecutionStatus, ProofRequest as ClusterProtoProofRequest,
-    ProofRequestCreateRequest, ProofRequestGetRequest, ProofRequestStatus,
+use sp1_cluster_common::{
+    client::ClusterServiceClient,
+    proto::{
+        ExecutionFailureCause, ExecutionStatus, ProofRequest as ClusterProtoProofRequest,
+        ProofRequestCreateRequest, ProofRequestGetRequest, ProofRequestStatus,
+    },
 };
 use sp1_prover_types::{Artifact, ArtifactClient as _, ArtifactType};
 use sp1_sdk::{ProofFromNetwork, SP1ProofWithPublicValues, SP1Stdin};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::succinct::{L1HeadSource, OpSuccinctWitnessProvider, WitnessParams};
+use crate::succinct::{
+    L1HeadSource, OpSuccinctWitnessProvider, SuccinctRpcConfig, SuccinctZkProverBuildError,
+    SuccinctZkProverBuilder, WitnessParams,
+};
 
 macro_rules! backend_error {
     ($($arg:tt)*) => {
         ZkProverError::Backend(std::io::Error::other(format!($($arg)*)).into())
     };
+}
+
+/// SP1 cluster backend settings.
+#[derive(Clone, Debug)]
+pub struct SuccinctClusterBackendConfig {
+    /// Shared RPC settings.
+    pub rpc: SuccinctRpcConfig,
+    /// SP1 cluster gRPC endpoint.
+    pub cluster_rpc: String,
+    /// S3 artifact store bucket.
+    pub s3_bucket: String,
+    /// S3 artifact store region.
+    pub s3_region: String,
+    /// Proof timeout.
+    pub timeout: Duration,
+    /// Cycle limit for range proof requests.
+    pub range_cycle_limit: u64,
+    /// Gas limit for range proof requests.
+    pub range_gas_limit: u64,
 }
 
 /// Configuration for [`ClusterZkProver`].
@@ -103,6 +129,124 @@ impl ClusterZkProver {
     /// Create a cluster prover with a witness provider and cluster config.
     pub const fn new(provider: OpSuccinctWitnessProvider, config: ClusterZkProverConfig) -> Self {
         Self { provider, config }
+    }
+
+    /// Builds an SP1 cluster backend.
+    pub async fn build_until_cancelled(
+        config: SuccinctClusterBackendConfig,
+        cancel: &CancellationToken,
+    ) -> Result<Option<Arc<dyn ZkProver>>, SuccinctZkProverBuildError> {
+        let SuccinctClusterBackendConfig {
+            rpc,
+            cluster_rpc,
+            s3_bucket,
+            s3_region,
+            timeout,
+            range_cycle_limit,
+            range_gas_limit,
+        } = config;
+        let base_consensus_url = rpc.base_consensus_rpc.as_str().to_owned();
+        let l1_node_url = rpc.l1_rpc.as_str().to_owned();
+        let default_sequence_window = rpc.default_sequence_window;
+
+        info!(backend = "cluster", "using Succinct SP1 cluster backend");
+        let Some(provider) = SuccinctZkProverBuilder::build_witness_provider(rpc, cancel).await?
+        else {
+            return Ok(None);
+        };
+        let Some((artifact_store, artifact_store_config)) =
+            Self::s3_artifact_store(s3_bucket, s3_region, cancel).await?
+        else {
+            return Ok(None);
+        };
+        let Some(service_client) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async {
+                // The upstream constructor consumes the endpoint string, and the proof config
+                // needs to retain it for request submission.
+                ClusterServiceClient::new(cluster_rpc.clone()).await.map_err(|error| {
+                    SuccinctZkProverBuildError::boxed_operation(
+                        "failed to create SP1 cluster client",
+                        error.into(),
+                    )
+                })
+            },
+            "sp1_cluster_client",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let prover_config = ClusterZkProverConfig {
+            base_consensus_url,
+            l1_node_url,
+            default_sequence_window,
+            cluster: Arc::new(ClusterProofConfig {
+                cluster_rpc,
+                artifact_store,
+                artifact_store_config,
+                service_client,
+            }),
+            timeout,
+            range_cycle_limit,
+            range_gas_limit,
+        };
+
+        Ok(Some(Arc::new(Self::new(provider, prover_config))))
+    }
+
+    /// Builds S3 artifact storage for SP1 cluster requests.
+    pub async fn s3_artifact_store(
+        bucket: String,
+        region: String,
+        cancel: &CancellationToken,
+    ) -> Result<
+        Option<(ClusterArtifactStore, sp1_cluster_utils::ArtifactStoreConfig)>,
+        SuccinctZkProverBuildError,
+    > {
+        info!("using S3 artifact storage");
+        let Some(download_client) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async {
+                Ok(sp1_cluster_artifact::s3::S3ArtifactClient::create_s3_sdk_download_client(
+                    region.clone(),
+                )
+                .await)
+            },
+            "s3_download_client",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let download_mode = sp1_cluster_artifact::s3::S3DownloadMode::AwsSDK(download_client);
+        let bucket_for_config = bucket.clone();
+        let region_for_config = region.clone();
+        let Some(client) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async move {
+                Ok(sp1_cluster_artifact::s3::S3ArtifactClient::new(
+                    region,
+                    bucket,
+                    32,
+                    download_mode,
+                )
+                .await)
+            },
+            "s3_artifact_client",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some((
+            ClusterArtifactStore::S3(client),
+            sp1_cluster_utils::ArtifactStoreConfig::S3 {
+                bucket: bucket_for_config,
+                region: region_for_config,
+            },
+        )))
     }
 
     /// Build the cluster proof id for a prover-service session attempt.

--- a/crates/proof/zk/backend/src/succinct/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/mod.rs
@@ -6,11 +6,18 @@
 mod provider;
 pub use provider::{L1HeadSource, OpSuccinctWitnessProvider, WitnessError, WitnessParams};
 
+mod builder;
+pub use builder::{
+    SuccinctRpcConfig, SuccinctZkBackendConfig, SuccinctZkProverBuildError, SuccinctZkProverBuilder,
+};
+
 mod cluster;
-pub use cluster::{ClusterSessionId, ClusterZkProver, ClusterZkProverConfig};
+pub use cluster::{
+    ClusterSessionId, ClusterZkProver, ClusterZkProverConfig, SuccinctClusterBackendConfig,
+};
 
 mod network;
-pub use network::{NetworkZkProver, NetworkZkProverConfig};
+pub use network::{NetworkZkProver, NetworkZkProverConfig, SuccinctNetworkBackendConfig};
 
 mod dry_run;
 pub use dry_run::{DRY_RUN_SNARK_PREFIX, DryRunZkProver};

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -5,7 +5,7 @@
 //! the network, `poll` checks the network proof request status, and `download`
 //! fetches and serializes the completed proof for `submitProof`.
 
-use std::{sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
 use async_trait::async_trait;
@@ -13,21 +13,59 @@ use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
 use base_prover_service_protocol::{ProofResult, ZkProofResult, ZkVm};
 use sp1_sdk::{
-    HashableKey, NetworkProver, ProveRequest, Prover, ProvingKey, SP1ProofWithPublicValues,
-    SP1ProvingKey,
-    network::proto::{
-        GetProofRequestStatusResponse,
-        types::{FulfillmentStatus, FulfillmentStrategy},
+    HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey,
+    SP1ProofWithPublicValues, SP1ProvingKey,
+    network::{
+        NetworkMode,
+        proto::{
+            GetProofRequestStatusResponse,
+            types::{FulfillmentStatus, FulfillmentStrategy},
+        },
+        signer::NetworkSigner,
     },
 };
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-use crate::succinct::{L1HeadSource, OpSuccinctWitnessProvider, WitnessParams};
+use crate::succinct::{
+    L1HeadSource, OpSuccinctWitnessProvider, SuccinctRpcConfig, SuccinctZkProverBuildError,
+    SuccinctZkProverBuilder, WitnessParams,
+};
 
 macro_rules! backend_error {
     ($($arg:tt)*) => {
         ZkProverError::Backend(std::io::Error::other(format!($($arg)*)).into())
     };
+}
+
+/// SP1 Network backend settings.
+#[derive(Clone)]
+pub struct SuccinctNetworkBackendConfig {
+    /// Shared RPC settings.
+    pub rpc: SuccinctRpcConfig,
+    /// SP1 network requester private key, or KMS key ARN when `use_kms_requester` is true.
+    pub network_private_key: String,
+    /// Use the requester key as an AWS KMS ARN instead of a local private key.
+    pub use_kms_requester: bool,
+    /// Proof timeout.
+    pub timeout: Duration,
+    /// Cycle limit for range proof requests.
+    pub range_cycle_limit: u64,
+    /// Gas limit for range proof requests.
+    pub range_gas_limit: u64,
+}
+
+impl fmt::Debug for SuccinctNetworkBackendConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SuccinctNetworkBackendConfig")
+            .field("rpc", &self.rpc)
+            .field("network_private_key", &"<redacted>")
+            .field("use_kms_requester", &self.use_kms_requester)
+            .field("timeout", &self.timeout)
+            .field("range_cycle_limit", &self.range_cycle_limit)
+            .field("range_gas_limit", &self.range_gas_limit)
+            .finish()
+    }
 }
 
 /// Configuration for [`NetworkZkProver`].
@@ -43,8 +81,6 @@ pub struct NetworkZkProverConfig {
     pub network_prover: Arc<NetworkProver>,
     /// Range program proving key.
     pub range_pk: Arc<SP1ProvingKey>,
-    /// Fulfillment strategy for range proof requests.
-    pub fulfillment_strategy: FulfillmentStrategy,
     /// Proof timeout.
     pub timeout: Duration,
     /// Cycle limit for range proof requests.
@@ -53,8 +89,8 @@ pub struct NetworkZkProverConfig {
     pub range_gas_limit: u64,
 }
 
-impl std::fmt::Debug for NetworkZkProverConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for NetworkZkProverConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let range_pk = self.range_pk.verifying_key().bytes32();
 
         f.debug_struct("NetworkZkProverConfig")
@@ -62,7 +98,6 @@ impl std::fmt::Debug for NetworkZkProverConfig {
             .field("l1_node_url", &self.l1_node_url)
             .field("default_sequence_window", &self.default_sequence_window)
             .field("range_pk", &range_pk)
-            .field("fulfillment_strategy", &self.fulfillment_strategy)
             .field("timeout", &self.timeout)
             .field("range_cycle_limit", &self.range_cycle_limit)
             .field("range_gas_limit", &self.range_gas_limit)
@@ -87,6 +122,124 @@ impl NetworkZkProver {
     /// Create a network prover with a witness provider and network config.
     pub const fn new(provider: OpSuccinctWitnessProvider, config: NetworkZkProverConfig) -> Self {
         Self { provider, config }
+    }
+
+    /// Builds an SP1 Network backend.
+    pub async fn build_until_cancelled(
+        config: SuccinctNetworkBackendConfig,
+        cancel: &CancellationToken,
+    ) -> Result<Option<Arc<dyn ZkProver>>, SuccinctZkProverBuildError> {
+        let SuccinctNetworkBackendConfig {
+            rpc,
+            network_private_key,
+            use_kms_requester,
+            timeout,
+            range_cycle_limit,
+            range_gas_limit,
+        } = config;
+        let base_consensus_url = rpc.base_consensus_rpc.as_str().to_owned();
+        let l1_node_url = rpc.l1_rpc.as_str().to_owned();
+        let default_sequence_window = rpc.default_sequence_window;
+
+        info!(backend = "network", "using Succinct SP1 Network backend");
+        info!("computing range proving key");
+        let Some(range_pk) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async {
+                base_proof_succinct_proof_utils::cluster_setup_range_key().await.map_err(|error| {
+                    SuccinctZkProverBuildError::boxed_operation(
+                        "failed to compute range proving key",
+                        error.into_boxed_dyn_error(),
+                    )
+                })
+            },
+            "range_proving_key",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        info!("range proving key computed successfully");
+
+        let Some(provider) = SuccinctZkProverBuilder::build_witness_provider(rpc, cancel).await?
+        else {
+            return Ok(None);
+        };
+
+        // This worker always submits public SP1 Network auction requests; reserved and hosted
+        // capacity are intentionally not exposed as deployment knobs.
+        let fulfillment_strategy = FulfillmentStrategy::Auction;
+        let network_mode = NetworkMode::Mainnet;
+        let Some(network_signer) =
+            Self::network_signer(network_private_key, use_kms_requester, cancel).await?
+        else {
+            return Ok(None);
+        };
+
+        info!(
+            network_mode = ?network_mode,
+            fulfillment_strategy = ?fulfillment_strategy,
+            "creating SP1 Network prover"
+        );
+        let Some(network_prover) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async move {
+                Ok(ProverClient::builder()
+                    .network_for(network_mode)
+                    .signer(network_signer)
+                    .build()
+                    .await)
+            },
+            "sp1_network_prover",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let network_prover = Arc::new(network_prover);
+
+        let prover_config = NetworkZkProverConfig {
+            base_consensus_url,
+            l1_node_url,
+            default_sequence_window,
+            network_prover,
+            range_pk: range_pk.into(),
+            timeout,
+            range_cycle_limit,
+            range_gas_limit,
+        };
+
+        Ok(Some(Arc::new(Self::new(provider, prover_config))))
+    }
+
+    /// Builds an SP1 Network signer.
+    pub async fn network_signer(
+        key: String,
+        use_kms_requester: bool,
+        cancel: &CancellationToken,
+    ) -> Result<Option<NetworkSigner>, SuccinctZkProverBuildError> {
+        if use_kms_requester {
+            SuccinctZkProverBuilder::complete_unless_cancelled(
+                cancel,
+                async {
+                    NetworkSigner::aws_kms(&key).await.map_err(|error| {
+                        SuccinctZkProverBuildError::operation(
+                            "failed to create KMS network signer",
+                            error,
+                        )
+                    })
+                },
+                "kms_network_signer",
+            )
+            .await
+        } else {
+            NetworkSigner::local(&key).map(Some).map_err(|error| {
+                SuccinctZkProverBuildError::operation(
+                    "failed to create local network signer",
+                    error,
+                )
+            })
+        }
     }
 
     /// Parse a network proof ID from its hex string representation.
@@ -194,7 +347,7 @@ impl NetworkZkProver {
             .prove(self.config.range_pk.as_ref(), stdin)
             .compressed()
             .skip_simulation(true)
-            .strategy(self.config.fulfillment_strategy)
+            .strategy(FulfillmentStrategy::Auction)
             .timeout(self.config.timeout)
             .cycle_limit(self.config.range_cycle_limit)
             .gas_limit(self.config.range_gas_limit)

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -128,6 +128,14 @@ impl ZkHostConfig {
             .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
             .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
     }
+
+    /// Converts this config into the shared worker discovery config.
+    pub fn into_job_discovery_config(self) -> JobDiscoveryConfig {
+        JobDiscoveryConfig::zk(self.worker_id, self.proof_type, self.zk_vms)
+            .with_poll_interval(self.job_discovery_poll_interval)
+            .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
+            .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
+    }
 }
 
 /// Runs ZK proof generation jobs claimed from the prover service.
@@ -156,14 +164,12 @@ where
 {
     /// Runs the host until cancellation is requested.
     pub async fn run_until_cancelled(self, cancel: CancellationToken) {
-        let submitter = ProofSubmitter::new(self.client.clone());
-        let proof_generator = Arc::new(ProofGenerator::new(
-            self.prover,
-            submitter,
-            self.config.proof_generator_heartbeat,
-        ));
+        let Self { client, prover, config } = self;
+        let submitter = ProofSubmitter::new(client.clone());
+        let proof_generator =
+            Arc::new(ProofGenerator::new(prover, submitter, config.proof_generator_heartbeat));
         let discovery =
-            JobDiscovery::new(self.client, proof_generator, self.config.job_discovery_config());
+            JobDiscovery::new(client, proof_generator, config.into_job_discovery_config());
 
         discovery.run_until_cancelled(cancel).await;
     }


### PR DESCRIPTION
## Summary

Adds Succinct-backed proving implementations for the zk-host worker, wiring mock, dry-run, cluster, and network backend construction through the shared backend crate with cancellation-aware startup, RPC witness setup, S3 artifact storage, and SP1 network signing.
