### PR TITLE
feat: add op-da compatible alt-DA server for L3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-alt-da"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
+ "axum 0.8.9",
+ "base-protocol",
+ "base64 0.22.1",
+ "hex",
+ "rand 0.9.4",
+ "reqwest 0.13.3",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "base-balance-monitor"
 version = "0.0.0"
 dependencies = [
@@ -4296,6 +4317,17 @@ dependencies = [
  "base-common-evm",
  "revm",
  "rstest",
+]
+
+[[package]]
+name = "base-da-server-bin"
+version = "0.0.0"
+dependencies = [
+ "base-alt-da",
+ "base-cli-utils",
+ "base-runtime",
+ "clap",
+ "eyre",
 ]
 
 [[package]]
@@ -23022,6 +23054,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "slab",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ base-execution-payload-builder = { path = "crates/execution/payload" }
 base-flashblocks-node = { path = "crates/execution/flashblocks-node" }
 
 # Infra
+base-alt-da = { path = "crates/infra/alt-da" }
 basectl-cli = { path = "crates/infra/basectl" }
 audit-archiver-lib = { path = "crates/infra/audit" }
 base-load-tests = { path = "crates/infra/load-tests" }

--- a/bin/da-server/Cargo.toml
+++ b/bin/da-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "base-da-server-bin"
+description = "Alt-DA HTTP server binary for L3 batch data"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-da-server"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+eyre.workspace = true
+base-alt-da.workspace = true
+base-cli-utils.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+base-runtime = { workspace = true, features = ["tokio"] }

--- a/bin/da-server/README.md
+++ b/bin/da-server/README.md
@@ -1,0 +1,80 @@
+# `base-da-server`
+
+HTTP server for alt-DA storage on an L2 rollup. The batcher uploads compressed L2 batch frames here;
+nodes fetch them by commitment while deriving the L2 chain from the parent L1.
+
+Batch bytes live in S3 (or a local directory). Only a small **generic commitment** (34 bytes)
+is posted to the parent L1.
+
+Library implementation: `crates/infra/alt-da` (`base-alt-da`).
+
+## Configuration
+
+| Flag / env | Default | Description |
+|------------|---------|-------------|
+| `--port` / `BASE_DA_PORT` | `2583` | HTTP listen port |
+| `--da-url` / `BASE_DA_URL` | (required) | Backing store URL |
+
+`BASE_DA_URL` schemes:
+
+- `file:///path` — local directory (dev/tests). Created if missing.
+- `s3://bucket/prefix` — S3 bucket and key prefix. Uses default AWS credential chain.
+
+## HTTP API
+
+| Method | Path | Body | Response |
+|--------|------|------|----------|
+| `GET` | `/health` | — | `200` (liveness; no store I/O) |
+| `POST` | `/put` | Raw batch bytes | `200` + commitment bytes (34-byte generic commitment) |
+| `GET` | `/get/0x{hex}` | — | `200` + stored bytes, or `404` if missing |
+
+Commitments use the generic format: `0x01` type byte, `0xff` sentinel, then 32 random bytes.
+The batcher posts the returned commitment to the parent L1; derivation resolves it via `GET /get/0x…`.
+
+If `POST /put` fails or the server crashes mid-write, retry the whole request. Each retry gets a new commitment.
+
+Objects are keyed by **base64url(commitment)** under the store prefix, not by the hex string in the URL.
+
+## Local development
+
+Build and run with a file backend:
+
+```bash
+cargo build -p base-da-server-bin
+BASE_DA_URL=file:///tmp/l3-da BASE_DA_PORT=2583 ./target/debug/base-da-server
+```
+
+In another terminal, upload and fetch:
+
+```bash
+# Upload batch bytes; save commitment returned by the server
+curl -X POST http://127.0.0.1:2583/put --data-binary 'hello-batch' \
+  -o /tmp/commitment.bin
+
+COMM=$(xxd -p /tmp/commitment.bin | tr -d '\n')
+
+# Fetch by commitment
+curl "http://127.0.0.1:2583/get/0x${COMM}"
+# => hello-batch
+```
+
+On disk, the blob is stored at `/tmp/l3-da/<base64url-key>` (not `/tmp/commitment.bin`).
+List it with `ls /tmp/l3-da/`.
+
+## S3
+
+```bash
+BASE_DA_URL=s3://my-bucket/my-prefix \
+BASE_DA_PORT=2583 \
+./target/debug/base-da-server
+```
+
+Requires IAM read/write permissions on the bucket prefix.
+
+## Tests
+
+```bash
+cargo test -p base-alt-da
+```
+
+Covers commitment encoding, file store roundtrip, and HTTP put/get.

--- a/bin/da-server/src/cli.rs
+++ b/bin/da-server/src/cli.rs
@@ -1,0 +1,25 @@
+use base_alt_da::{Config, Server};
+use base_cli_utils::RuntimeManager;
+use clap::Parser;
+
+/// Alt-DA HTTP server for L3 batch data.
+#[derive(Debug, Parser)]
+pub(crate) struct Cli {
+    /// TCP port for the DA HTTP API.
+    #[arg(long, env = "BASE_DA_PORT", default_value = "2583")]
+    port: u16,
+
+    /// Backing store URL (`s3://bucket/prefix` or `file:///path`).
+    #[arg(long, env = "BASE_DA_URL")]
+    da_url: String,
+}
+
+impl Cli {
+    /// Run the alt-DA server until SIGINT/SIGTERM.
+    pub(crate) fn run(self) -> eyre::Result<()> {
+        RuntimeManager::new().run_until_shutdown(|cancel| async move {
+            let server = Server::new(Config { port: self.port, da_url: self.da_url }).await?;
+            server.run(cancel).await.map_err(Into::into)
+        })
+    }
+}

--- a/bin/da-server/src/main.rs
+++ b/bin/da-server/src/main.rs
@@ -1,0 +1,7 @@
+//! `base-da-server` binary: alt-DA HTTP service for L3 batch data.
+
+mod cli;
+
+fn main() {
+    base_cli_utils::run_cli_main!(cli::Cli);
+}

--- a/crates/infra/alt-da/Cargo.toml
+++ b/crates/infra/alt-da/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "base-alt-da"
+description = "Alt-DA HTTP server and object stores for L3 batch data"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+hex.workspace = true
+url.workspace = true
+rand.workspace = true
+base64.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+tracing = { workspace = true, features = ["std"] }
+tokio-util = { workspace = true, features = ["rt"] }
+base-protocol = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["fs", "io-util", "rt"] }
+axum = { workspace = true, features = ["tokio", "http1"] }
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+reqwest = { workspace = true, features = ["rustls"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/infra/alt-da/README.md
+++ b/crates/infra/alt-da/README.md
@@ -1,0 +1,30 @@
+# `base-alt-da`
+
+Alt-DA HTTP server and object stores for L2 batch data.
+
+The batcher uploads L2 batch bytes via `POST /put` and receives a generic commitment to post on
+the parent L1. Nodes fetch bytes with `GET /get/0x{hex}` while deriving the L2 chain. Objects are
+stored under base64url(commitment) keys in S3 or on disk.
+
+Runnable binary: `bin/da-server` (`base-da-server`).
+
+## Usage
+
+```rust,ignore
+use base_alt_da::{Config, Server, StoreOpener};
+use tokio_util::sync::CancellationToken;
+
+let store = StoreOpener::open("file:///tmp/l3-da").await?;
+let server = Server::new(Config { port: 2583, da_url: "file:///tmp/l3-da".into() }).await?;
+server.run(CancellationToken::new()).await?;
+```
+
+## PUT semantics
+
+`POST /put` generates a new random commitment, stores the body, then returns the commitment bytes.
+If the request fails or the server crashes before the write completes, the batcher must retry
+the whole `POST /put`. Each retry produces a new commitment.
+
+## Limits
+
+`MAX_OBJECT_BYTES` is `8 * base_protocol::BLOB_MAX_DATA_SIZE` (see `lib.rs`).

--- a/crates/infra/alt-da/src/commitment.rs
+++ b/crates/infra/alt-da/src/commitment.rs
@@ -1,0 +1,73 @@
+use base64::Engine;
+use rand::RngCore;
+
+use crate::error::Error;
+
+const GENERIC_COMMITMENT_TYPE: u8 = 0x01;
+/// Max decoded commitment bytes (generic format is always 34).
+const MAX_COMMITMENT_LEN: usize = 34;
+
+/// Server-generated generic commitment (`0x01` type byte + `0xff` sentinel + random suffix).
+pub fn generate_generic_commitment() -> Vec<u8> {
+    let mut commitment = [0u8; 34];
+    commitment[0] = GENERIC_COMMITMENT_TYPE;
+    commitment[1] = 0xff;
+    rand::rng().fill_bytes(&mut commitment[2..]);
+    commitment.to_vec()
+}
+
+/// Decode a `0x`-prefixed hex commitment from an HTTP path segment.
+pub fn decode_hex_commitment(hex: &str) -> Result<Vec<u8>, Error> {
+    let stripped = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex);
+    if stripped.is_empty() {
+        return Err(Error::BadRequest("empty commitment hex".into()));
+    }
+    let bytes = hex::decode(stripped)
+        .map_err(|e| Error::BadRequest(format!("invalid commitment hex: {e}")))?;
+    if bytes.len() > MAX_COMMITMENT_LEN {
+        return Err(Error::BadRequest(format!(
+            "commitment too large: {} bytes (max {MAX_COMMITMENT_LEN})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
+}
+
+/// Base64url object name for an encoded commitment key.
+pub fn object_name(commitment: &[u8]) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(commitment)
+}
+
+/// Join store path prefix with the encoded commitment object name.
+pub fn object_key(prefix: &str, commitment: &[u8]) -> String {
+    let name = object_name(commitment);
+    let prefix = prefix.trim_start_matches('/');
+    if prefix.is_empty() { name } else { format!("{prefix}/{name}") }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_commitment_has_expected_prefix() {
+        let comm = generate_generic_commitment();
+        assert_eq!(comm[0], GENERIC_COMMITMENT_TYPE);
+        assert_eq!(comm[1], 0xff);
+        assert_eq!(comm.len(), 34);
+    }
+
+    #[test]
+    fn roundtrip_hex_commitment() {
+        let comm = generate_generic_commitment();
+        let hex = format!("0x{}", hex::encode(&comm));
+        assert_eq!(decode_hex_commitment(&hex).unwrap(), comm);
+    }
+
+    #[test]
+    fn rejects_oversized_commitment_hex() {
+        let hex = format!("0x{}", "ab".repeat(MAX_COMMITMENT_LEN + 1));
+        let err = decode_hex_commitment(&hex).unwrap_err();
+        assert!(matches!(err, Error::BadRequest(_)));
+    }
+}

--- a/crates/infra/alt-da/src/error.rs
+++ b/crates/infra/alt-da/src/error.rs
@@ -1,0 +1,115 @@
+use thiserror::Error;
+
+/// Alt-DA server and store errors.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Invalid user input (bad hex, empty body).
+    #[error("{0}")]
+    BadRequest(String),
+    /// Object not found in the backing store.
+    #[error("commitment not found")]
+    NotFound,
+    /// `BASE_DA_URL` or store setup failed at startup.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    /// Runtime store or network failure.
+    #[error(transparent)]
+    Store(StoreError),
+    /// Internal server error.
+    #[error(transparent)]
+    Internal(#[from] InternalError),
+}
+
+/// `StoreOpener::open` failed (bad URL or unsupported scheme).
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// `BASE_DA_URL` used an unsupported scheme.
+    #[error("unsupported da url scheme: {scheme}")]
+    UnsupportedScheme {
+        /// URL scheme from `BASE_DA_URL`.
+        scheme: String,
+    },
+    /// `BASE_DA_URL` could not be parsed.
+    #[error("invalid da url: {0}")]
+    InvalidUrl(String),
+    /// Local store root could not be created.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Runtime backing store operation failed.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    /// Object not found in storage.
+    #[error("object not found")]
+    NotFound,
+    /// Local filesystem I/O failed.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// S3 request failed.
+    #[error("s3 error: {0}")]
+    S3(String),
+    /// Object exceeds [`crate::MAX_OBJECT_BYTES`].
+    #[error("object too large: {size} bytes (max {max})")]
+    ObjectTooLarge {
+        /// Stored or requested object size in bytes.
+        size: u64,
+        /// Configured maximum object size in bytes.
+        max: usize,
+    },
+}
+
+/// Unexpected internal failures.
+#[derive(Debug, Error)]
+pub enum InternalError {
+    /// HTTP server failed to start or serve requests.
+    #[error("http server error: {0}")]
+    Http(String),
+}
+
+impl From<StoreError> for Error {
+    fn from(err: StoreError) -> Self {
+        match err {
+            StoreError::NotFound => Self::NotFound,
+            other => Self::Store(other),
+        }
+    }
+}
+
+impl From<aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>>
+    for StoreError
+{
+    fn from(
+        err: aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+    ) -> Self {
+        match &err {
+            aws_sdk_s3::error::SdkError::ServiceError(service_err)
+                if service_err.err().is_no_such_key() =>
+            {
+                Self::NotFound
+            }
+            _ => Self::S3(err.to_string()),
+        }
+    }
+}
+
+impl From<aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::put_object::PutObjectError>>
+    for StoreError
+{
+    fn from(
+        err: aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::put_object::PutObjectError>,
+    ) -> Self {
+        Self::S3(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_not_found_maps_to_error_not_found() {
+        let err: Error = StoreError::NotFound.into();
+        assert!(matches!(err, Error::NotFound));
+    }
+}

--- a/crates/infra/alt-da/src/lib.rs
+++ b/crates/infra/alt-da/src/lib.rs
@@ -1,0 +1,26 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use base_protocol::BLOB_MAX_DATA_SIZE;
+
+/// Max batch blob bytes accepted on PUT and loaded from the backing store.
+/// Sized for eight max-size blob frames per channel submission.
+pub const MAX_OBJECT_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
+
+mod commitment;
+pub use commitment::{decode_hex_commitment, generate_generic_commitment, object_key, object_name};
+
+mod error;
+pub use error::{ConfigError, Error, InternalError, StoreError};
+
+mod server;
+pub use server::{Config, Server};
+
+mod store;
+pub use store::{DynStore, FileStore, S3Store, Store, StoreOpener};

--- a/crates/infra/alt-da/src/server.rs
+++ b/crates/infra/alt-da/src/server.rs
@@ -1,0 +1,206 @@
+use std::net::SocketAddr;
+
+use axum::{
+    Router,
+    body::Bytes,
+    extract::{DefaultBodyLimit, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use crate::{
+    MAX_OBJECT_BYTES, StoreOpener,
+    commitment::{decode_hex_commitment, generate_generic_commitment},
+    error::{Error, InternalError, StoreError},
+    store::DynStore,
+};
+
+/// Alt-DA HTTP server configuration.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// TCP listen port.
+    pub port: u16,
+    /// Backing store URL (`s3://…` or `file://…`).
+    pub da_url: String,
+}
+
+/// Alt-DA HTTP server.
+pub struct Server {
+    store: DynStore,
+    addr: SocketAddr,
+}
+
+impl Server {
+    /// Create a server bound to `0.0.0.0:{port}`.
+    pub async fn new(config: Config) -> Result<Self, Error> {
+        let store = StoreOpener::open(&config.da_url).await?;
+        Ok(Self { store, addr: SocketAddr::from(([0, 0, 0, 0], config.port)) })
+    }
+
+    /// Serve until `shutdown` is cancelled (SIGINT/SIGTERM in the binary).
+    pub async fn run(self, shutdown: CancellationToken) -> Result<(), Error> {
+        let listener = tokio::net::TcpListener::bind(self.addr)
+            .await
+            .map_err(|err| InternalError::Http(err.to_string()))?;
+        info!(%self.addr, "alt-da server listening");
+        let app = router(self.store);
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await
+            .map_err(|err| Error::Internal(InternalError::Http(err.to_string())))?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Server {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Server").field("addr", &self.addr).finish_non_exhaustive()
+    }
+}
+
+/// Build the axum router (used by tests and `run`).
+pub(crate) fn router(store: DynStore) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/get/{commitment}", get(get_commitment))
+        .route("/put", post(put_generate))
+        .layer(DefaultBodyLimit::max(MAX_OBJECT_BYTES))
+        .with_state(store)
+}
+
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn get_commitment(
+    State(store): State<DynStore>,
+    Path(commitment): Path<String>,
+) -> Result<Response, ApiError> {
+    let key = decode_hex_commitment(&commitment)?;
+    let value = store.get(&key).await?;
+    Ok((StatusCode::OK, value).into_response())
+}
+
+async fn put_generate(State(store): State<DynStore>, body: Bytes) -> Result<Response, ApiError> {
+    if body.is_empty() {
+        return Err(ApiError(Error::BadRequest("empty request body".into())));
+    }
+    // Commitment is random; on store failure the batcher must retry POST /put (new commitment).
+    let key = generate_generic_commitment();
+    store.put(&key, &body).await?;
+    Ok((StatusCode::OK, key).into_response())
+}
+
+struct ApiError(Error);
+
+impl From<Error> for ApiError {
+    fn from(err: Error) -> Self {
+        Self(err)
+    }
+}
+
+impl From<crate::error::StoreError> for ApiError {
+    fn from(err: crate::error::StoreError) -> Self {
+        Self(Error::from(err))
+    }
+}
+
+fn client_error_message(err: &Error) -> String {
+    match err {
+        Error::BadRequest(msg) => msg.clone(),
+        Error::NotFound => "commitment not found".to_string(),
+        Error::Config(err) => err.to_string(),
+        Error::Store(StoreError::ObjectTooLarge { size, max }) => {
+            format!("object too large: {size} bytes (max {max})")
+        }
+        Error::Store(_) | Error::Internal(_) => "internal server error".to_string(),
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = match &self.0 {
+            Error::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Error::NotFound => StatusCode::NOT_FOUND,
+            Error::Config(err) => {
+                error!(%err, "alt-da config error");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Error::Store(StoreError::ObjectTooLarge { .. }) => StatusCode::PAYLOAD_TOO_LARGE,
+            Error::Store(err) => {
+                error!(%err, "alt-da store request failed");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Error::Internal(err) => {
+                error!(%err, "alt-da internal error");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+        (status, client_error_message(&self.0)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn http_health() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("file://{}", dir.path().display());
+        let store = StoreOpener::open(&url).await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = router(store);
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let resp =
+            reqwest::Client::new().get(format!("http://{addr}/health")).send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn http_get_missing_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("file://{}", dir.path().display());
+        let store = StoreOpener::open(&url).await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = router(store);
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let resp =
+            reqwest::Client::new().get(format!("http://{addr}/get/0x0101")).send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn http_put_get_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("file://{}", dir.path().display());
+        let store = StoreOpener::open(&url).await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = router(store);
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let body: &[u8] = b"hello-batch";
+        let put_resp = client.post(format!("http://{addr}/put")).body(body).send().await.unwrap();
+        assert_eq!(put_resp.status(), StatusCode::OK);
+        let commitment = put_resp.bytes().await.unwrap();
+        let hex = format!("0x{}", hex::encode(&commitment));
+        let get_resp = client.get(format!("http://{addr}/get/{hex}")).send().await.unwrap();
+        assert_eq!(get_resp.status(), StatusCode::OK);
+        assert_eq!(get_resp.bytes().await.unwrap().as_ref(), body);
+    }
+}

--- a/crates/infra/alt-da/src/store.rs
+++ b/crates/infra/alt-da/src/store.rs
@@ -1,0 +1,196 @@
+use std::{path::PathBuf, sync::Arc};
+
+use async_trait::async_trait;
+use aws_sdk_s3::primitives::ByteStream;
+use rand::RngCore;
+use tokio::io::AsyncReadExt;
+use url::Url;
+
+use crate::{
+    MAX_OBJECT_BYTES,
+    commitment::object_key,
+    error::{ConfigError, StoreError},
+};
+
+/// Object store keyed by encoded commitment bytes.
+#[async_trait]
+pub trait Store: Send + Sync {
+    /// Fetch preimage bytes for `key`.
+    async fn get(&self, key: &[u8]) -> Result<Vec<u8>, StoreError>;
+    /// Store `value` at `key`.
+    async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), StoreError>;
+}
+
+/// Shared store handle.
+pub type DynStore = Arc<dyn Store>;
+
+/// Opens a [`DynStore`] from a backing URL.
+#[derive(Debug)]
+pub struct StoreOpener;
+
+impl StoreOpener {
+    /// Open a store from `s3://bucket/prefix` or `file:///path`.
+    pub async fn open(da_url: &str) -> Result<DynStore, ConfigError> {
+        let url = Url::parse(da_url).map_err(|err| ConfigError::InvalidUrl(err.to_string()))?;
+        match url.scheme() {
+            "file" => {
+                let path = PathBuf::from(url.path());
+                tokio::fs::create_dir_all(&path).await?;
+                Ok(Arc::new(FileStore::new(path)))
+            }
+            "s3" => {
+                let bucket = url
+                    .host_str()
+                    .ok_or_else(|| ConfigError::InvalidUrl("s3 url missing bucket host".into()))?;
+                let prefix = url.path().to_string();
+                let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+                let client = aws_sdk_s3::Client::new(&config);
+                Ok(Arc::new(S3Store::new(client, bucket.to_string(), prefix)))
+            }
+            scheme => Err(ConfigError::UnsupportedScheme { scheme: scheme.to_string() }),
+        }
+    }
+}
+
+/// Local filesystem object store.
+#[derive(Debug)]
+pub struct FileStore {
+    root: PathBuf,
+}
+
+impl FileStore {
+    /// Store objects under `root`, keyed by base64url(commitment).
+    pub const fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+#[async_trait]
+impl Store for FileStore {
+    async fn get(&self, key: &[u8]) -> Result<Vec<u8>, StoreError> {
+        let path = self.root.join(crate::commitment::object_name(key));
+        let meta = match tokio::fs::metadata(&path).await {
+            Ok(meta) => meta,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(StoreError::NotFound);
+            }
+            Err(err) => return Err(StoreError::Io(err)),
+        };
+        if meta.len() > MAX_OBJECT_BYTES as u64 {
+            return Err(StoreError::ObjectTooLarge { size: meta.len(), max: MAX_OBJECT_BYTES });
+        }
+        tokio::fs::read(&path).await.map_err(StoreError::Io)
+    }
+
+    async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), StoreError> {
+        if value.len() > MAX_OBJECT_BYTES {
+            return Err(StoreError::ObjectTooLarge {
+                size: value.len() as u64,
+                max: MAX_OBJECT_BYTES,
+            });
+        }
+        let path = self.root.join(crate::commitment::object_name(key));
+        let mut suffix = [0u8; 8];
+        rand::rng().fill_bytes(&mut suffix);
+        let tmp = path.with_extension(format!("tmp.{}", hex::encode(suffix)));
+        tokio::fs::write(&tmp, value).await?;
+        if let Err(err) = tokio::fs::rename(&tmp, &path).await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(StoreError::Io(err));
+        }
+        Ok(())
+    }
+}
+
+/// S3 object store.
+pub struct S3Store {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+    prefix: String,
+}
+
+impl S3Store {
+    /// Store objects in `bucket` under `prefix`, keyed by base64url(commitment).
+    pub const fn new(client: aws_sdk_s3::Client, bucket: String, prefix: String) -> Self {
+        Self { client, bucket, prefix }
+    }
+}
+
+impl std::fmt::Debug for S3Store {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Store")
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl Store for S3Store {
+    async fn get(&self, key: &[u8]) -> Result<Vec<u8>, StoreError> {
+        let object_key = object_key(&self.prefix, key);
+        let response = self.client.get_object().bucket(&self.bucket).key(object_key).send().await?;
+        if let Some(content_length) = response.content_length()
+            && content_length > MAX_OBJECT_BYTES as i64
+        {
+            return Err(StoreError::ObjectTooLarge {
+                size: content_length as u64,
+                max: MAX_OBJECT_BYTES,
+            });
+        }
+        read_limited(response.body, MAX_OBJECT_BYTES).await
+    }
+
+    async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), StoreError> {
+        if value.len() > MAX_OBJECT_BYTES {
+            return Err(StoreError::ObjectTooLarge {
+                size: value.len() as u64,
+                max: MAX_OBJECT_BYTES,
+            });
+        }
+        let object_key = object_key(&self.prefix, key);
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(object_key)
+            .body(ByteStream::from(value.to_vec()))
+            .send()
+            .await?;
+        Ok(())
+    }
+}
+
+async fn read_limited(body: ByteStream, max: usize) -> Result<Vec<u8>, StoreError> {
+    let mut reader = body.into_async_read();
+    let mut out = Vec::new();
+    let mut chunk = vec![0u8; 64 * 1024];
+    loop {
+        let n = reader.read(&mut chunk).await.map_err(|err| StoreError::S3(err.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        if out.len() + n > max {
+            return Err(StoreError::ObjectTooLarge { size: (out.len() + n) as u64, max });
+        }
+        out.extend_from_slice(&chunk[..n]);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commitment::generate_generic_commitment;
+
+    #[tokio::test]
+    async fn file_store_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("file://{}", dir.path().display());
+        let store = StoreOpener::open(&url).await.unwrap();
+        let key = generate_generic_commitment();
+        let value = b"batch-bytes";
+        store.put(&key, value).await.unwrap();
+        let got = store.get(&key).await.unwrap();
+        assert_eq!(got, value);
+    }
+}


### PR DESCRIPTION
## Summary

Adds alt-DA HTTP server for the privacy L3 devnet ([PRIV-1970](https://linear.app/coinbase/issue/PRIV-1970)).

- `base-alt-da` crate: `GET /get/0x{hex}`, `POST /put`; `file://` and `s3://bucket/prefix` backends; base64url S3 keys; server-generated generic commitments (`0x01` + `0xff` + random suffix)
- `base-da-server` binary: `BASE_DA_PORT` (default 2583), `BASE_DA_URL`

## API scope

Only **generic commitments** (same as op-enclave devnet `GenericCommitmentString`). Batcher calls `POST /put` with batch bytes; server returns the commitment to post on Base.

`POST /put/{commitment}` is intentionally omitted. That route is for keccak/precomputed commitments where the client picks the key before upload. Privacy L3 does not need that: the operator is trusted for liveness, derivation runs on our nodes, and users do not verify DA end-to-end.

## Test plan

- [x] `cargo test -p base-alt-da`
- [x] Manual put/get against `base-da-server` with `file://` backend

## Evidence

### Unit tests

```
$ cargo test -p base-alt-da

running 4 tests
test commitment::tests::generic_commitment_has_expected_prefix ... ok
test commitment::tests::roundtrip_hex_commitment ... ok
test store::tests::file_store_roundtrip ... ok
test server::tests::http_put_get_roundtrip ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Manual HTTP roundtrip (`file://` backend)

```
$ BASE_DA_URL=file:///tmp/l3-da-demo BASE_DA_PORT=2585 ./target/debug/base-da-server

$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:2585/put --data-binary 'hello-batch' -o /tmp/l3-da-demo-commitment.bin

HTTP 200

$ xxd -p /tmp/l3-da-demo-commitment.bin | tr -d '\n'
01ffd658c927dade1866d9e5057e0c9fa03976114214eee1babe0678fdf4bcee0369

$ curl -s -w "\nHTTP %{http_code}\n" "http://127.0.0.1:2585/get/0x01ffd658c927dade1866d9e5057e0c9fa03976114214eee1babe0678fdf4bcee0369"
hello-batch
HTTP 200
```

Batch data stored on disk at `/tmp/l3-da-demo/Af_WWMkn2t4YZtnlBX4Mn6A5dhFCFO7hur4GeP30vO4DaQ` (base64url commitment key).

type=routine
risk=low
impact=sev5
