### PR TITLE
feat(consensus): Add Upgrade Active Metric

### DIFF
--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -46,13 +46,15 @@ impl BaseCli {
             .init_tracing_subscriber()
             .wrap_err("failed to initialize tracing")?;
 
-        MetricsConfig::from(metrics)
+        let metrics = MetricsConfig::from(metrics);
+
+        metrics
             .init_with(|| {
                 base_cli_utils::register_version_metrics!();
             })
             .wrap_err("failed to install Prometheus recorder")?;
 
-        command.run(ChainResolver::new(chain))
+        command.run(ChainResolver::new(chain), &metrics)
     }
 }
 #[cfg(test)]

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -1,5 +1,8 @@
 //! Combined consensus and execution bootnode command.
 
+use std::time::Duration;
+
+use base_cli_utils::MetricsConfig;
 use base_consensus_cli::{BootnodeP2PArgs, CliMetrics, L2ConfigFile};
 use base_execution_cli::commands::p2p::bootnode::Command as ExecutionBootnodeCommand;
 use clap::Args;
@@ -28,12 +31,24 @@ pub(crate) struct BootnodeCommand {
 
 impl BootnodeCommand {
     /// Runs both discovery-only bootnodes.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics: &MetricsConfig,
+    ) -> eyre::Result<()> {
         let consensus_chain = resolved_chain.consensus_chain_args();
         let rollup_config = self.l2_config.load(&consensus_chain.l2_chain_id)?;
 
-        CliMetrics::init_rollup_config(&rollup_config);
-        CliMetrics::init_bootnode_p2p(&self.consensus);
+        let _active_upgrade_metrics = if metrics.enabled {
+            CliMetrics::init_rollup_config(&rollup_config);
+            CliMetrics::init_bootnode_p2p(&self.consensus);
+            Some(CliMetrics::spawn_active_upgrade_recorder(
+                rollup_config.clone(),
+                Duration::from_secs(metrics.interval),
+            ))
+        } else {
+            None
+        };
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|_| async move {
             let chain_id = rollup_config.l2_chain_id.id();

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -1,5 +1,6 @@
 //! Top-level command dispatch for the unified Base binary.
 
+use base_cli_utils::MetricsConfig;
 use clap::Subcommand;
 
 use crate::{
@@ -30,11 +31,15 @@ pub(crate) enum BaseCommand {
 
 impl BaseCommand {
     /// Runs the selected top-level command.
-    pub(crate) fn run(self, chain_resolver: ChainResolver) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        chain_resolver: ChainResolver,
+        metrics: &MetricsConfig,
+    ) -> eyre::Result<()> {
         match self {
-            Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?),
-            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?),
-            Self::Sequencer(sequencer) => (*sequencer).run(chain_resolver.resolve()?),
+            Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?, metrics),
+            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?, metrics),
+            Self::Sequencer(sequencer) => (*sequencer).run(chain_resolver.resolve()?, metrics),
             Self::Update(update) => (*update).run(),
         }
     }

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -2,6 +2,7 @@
 
 use std::{path::Path, sync::Arc};
 
+use base_cli_utils::MetricsConfig;
 use base_consensus_cli::{
     CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
 };
@@ -43,7 +44,11 @@ pub(crate) struct RpcCommand {
 
 impl RpcCommand {
     /// Runs the `rpc` flavor.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics: &MetricsConfig,
+    ) -> eyre::Result<()> {
         let execution_chain = match self.execution_chain {
             Some(chain) => chain,
             None => resolved_chain.execution_chain_spec()?,
@@ -53,6 +58,9 @@ impl RpcCommand {
         let rollup_config = consensus_args.load_rollup_config()?;
 
         let execution = self.execution.into_launch_config(execution_chain).with_auth_ipc();
+        let upgrade_metrics_enabled =
+            metrics.enabled || execution.node_config.metrics.prometheus.is_some();
+        let upgrade_metrics_interval = std::time::Duration::from_secs(metrics.interval);
         let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
@@ -63,11 +71,15 @@ impl RpcCommand {
             let execution_node = handle.node;
             let execution_exit = handle.node_exit_future;
 
-            CliMetrics::init_rollup_config(&rollup_config);
-            CliMetrics::spawn_active_upgrade_recorder(
-                rollup_config.clone(),
-                CliMetrics::ACTIVE_UPGRADE_RECORDING_INTERVAL,
-            );
+            let _active_upgrade_metrics = if upgrade_metrics_enabled {
+                CliMetrics::init_rollup_config(&rollup_config);
+                Some(CliMetrics::spawn_active_upgrade_recorder(
+                    rollup_config.clone(),
+                    upgrade_metrics_interval,
+                ))
+            } else {
+                None
+            };
 
             let overrides = ConsensusNodeOverrides {
                 l2_engine_rpc: Some(l2_engine_rpc),

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -3,7 +3,7 @@
 use std::{path::Path, sync::Arc};
 
 use base_consensus_cli::{
-    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
+    CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
 };
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{ExecutionNodeArgs, chainspec::chain_value_parser};
@@ -62,6 +62,12 @@ impl RpcCommand {
             // Keep the execution node handle alive until both services have coordinated shutdown.
             let execution_node = handle.node;
             let execution_exit = handle.node_exit_future;
+
+            CliMetrics::init_rollup_config(&rollup_config);
+            CliMetrics::spawn_active_upgrade_recorder(
+                rollup_config.clone(),
+                CliMetrics::ACTIVE_UPGRADE_RECORDING_INTERVAL,
+            );
 
             let overrides = ConsensusNodeOverrides {
                 l2_engine_rpc: Some(l2_engine_rpc),

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use base_builder_cli::Args as BuilderArgs;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
+use base_cli_utils::MetricsConfig;
 use base_consensus_cli::{
     CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
 };
@@ -40,7 +41,11 @@ pub(crate) struct SequencerCommand {
 
 impl SequencerCommand {
     /// Runs the `sequencer` flavor.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics: &MetricsConfig,
+    ) -> eyre::Result<()> {
         let execution_chain = match self.execution_chain {
             Some(chain) => chain,
             None => resolved_chain.execution_chain_spec()?,
@@ -58,6 +63,9 @@ impl SequencerCommand {
         let gas_limit_config = builder_config.gas_limit_config.clone();
 
         let execution = self.execution.into_runtime_config(execution_chain).with_auth_ipc();
+        let upgrade_metrics_enabled =
+            metrics.enabled || execution.node_config.metrics.prometheus.is_some();
+        let upgrade_metrics_interval = std::time::Duration::from_secs(metrics.interval);
         let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
@@ -77,11 +85,15 @@ impl SequencerCommand {
             let execution_node = handle.node;
             let execution_exit = handle.node_exit_future;
 
-            CliMetrics::init_rollup_config(&rollup_config);
-            CliMetrics::spawn_active_upgrade_recorder(
-                rollup_config.clone(),
-                CliMetrics::ACTIVE_UPGRADE_RECORDING_INTERVAL,
-            );
+            let _active_upgrade_metrics = if upgrade_metrics_enabled {
+                CliMetrics::init_rollup_config(&rollup_config);
+                Some(CliMetrics::spawn_active_upgrade_recorder(
+                    rollup_config.clone(),
+                    upgrade_metrics_interval,
+                ))
+            } else {
+                None
+            };
 
             let overrides = ConsensusNodeOverrides {
                 l2_engine_rpc: Some(l2_engine_rpc),

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -6,7 +6,7 @@ use base_builder_cli::Args as BuilderArgs;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
 use base_consensus_cli::{
-    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
+    CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
 };
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{ExecutionNodeConfigArgs, chainspec::chain_value_parser};
@@ -76,6 +76,12 @@ impl SequencerCommand {
             // Keep the execution node handle alive until both services have coordinated shutdown.
             let execution_node = handle.node;
             let execution_exit = handle.node_exit_future;
+
+            CliMetrics::init_rollup_config(&rollup_config);
+            CliMetrics::spawn_active_upgrade_recorder(
+                rollup_config.clone(),
+                CliMetrics::ACTIVE_UPGRADE_RECORDING_INTERVAL,
+            );
 
             let overrides = ConsensusNodeOverrides {
                 l2_engine_rpc: Some(l2_engine_rpc),

--- a/crates/consensus/cli/src/bootnode.rs
+++ b/crates/consensus/cli/src/bootnode.rs
@@ -66,9 +66,13 @@ impl Bootnode {
         base_cli_utils::MetricsConfig::from(self.metrics.clone()).init_with(|| {
             base_cli_utils::register_version_metrics!();
             CliMetrics::init_rollup_config(&cfg);
-            CliMetrics::spawn_active_upgrade_recorder(cfg.clone(), metrics_interval);
             CliMetrics::init_bootnode_p2p(&self.p2p);
         })?;
+        let _active_upgrade_metrics = if self.metrics.enabled {
+            Some(CliMetrics::spawn_active_upgrade_recorder(cfg.clone(), metrics_interval))
+        } else {
+            None
+        };
 
         RuntimeManager::new().run_until_ctrl_c(self.exec(cfg))
     }

--- a/crates/consensus/cli/src/bootnode.rs
+++ b/crates/consensus/cli/src/bootnode.rs
@@ -61,10 +61,12 @@ impl Bootnode {
         )?;
 
         let cfg = self.l2_config.load(&chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+        let metrics_interval = Duration::from_secs(self.metrics.interval);
 
         base_cli_utils::MetricsConfig::from(self.metrics.clone()).init_with(|| {
             base_cli_utils::register_version_metrics!();
             CliMetrics::init_rollup_config(&cfg);
+            CliMetrics::spawn_active_upgrade_recorder(cfg.clone(), metrics_interval);
             CliMetrics::init_bootnode_p2p(&self.p2p);
         })?;
 

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -49,14 +49,16 @@ impl ConsensusFollowNodeCommand {
         })?;
 
         let args = ConsensusFollowNodeArgs::new(chain, self.args);
-        if self.metrics.enabled {
+        let _active_upgrade_metrics = if self.metrics.enabled {
             let cfg = args.load_rollup_config()?;
             CliMetrics::init_rollup_config(&cfg);
-            CliMetrics::spawn_active_upgrade_recorder(
+            Some(CliMetrics::spawn_active_upgrade_recorder(
                 cfg,
                 Duration::from_secs(self.metrics.interval),
-            );
-        }
+            ))
+        } else {
+            None
+        };
 
         RuntimeManager::new().run_until_ctrl_c(args.start())
     }

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -52,6 +52,10 @@ impl ConsensusFollowNodeCommand {
         if self.metrics.enabled {
             let cfg = args.load_rollup_config()?;
             CliMetrics::init_rollup_config(&cfg);
+            CliMetrics::spawn_active_upgrade_recorder(
+                cfg,
+                Duration::from_secs(self.metrics.interval),
+            );
         }
 
         RuntimeManager::new().run_until_ctrl_c(args.start())

--- a/crates/consensus/cli/src/lib.rs
+++ b/crates/consensus/cli/src/lib.rs
@@ -31,7 +31,7 @@ mod l2;
 pub use l2::{EmbeddedL2ClientArgs, L2ClientArgs};
 
 mod metrics;
-pub use metrics::CliMetrics;
+pub use metrics::{ActiveUpgradeMetricsRecorder, CliMetrics};
 
 mod node;
 pub use node::{

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -1,6 +1,13 @@
 //! CLI Options Metrics
 
+use std::{
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use base_common_chains::BaseUpgrade;
 use base_common_genesis::RollupConfig;
+use tracing::warn;
 
 use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
 
@@ -9,6 +16,25 @@ use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
 pub struct CliMetrics;
 
 impl CliMetrics {
+    /// The default interval for refreshing active upgrade metrics.
+    pub const ACTIVE_UPGRADE_RECORDING_INTERVAL: Duration = Duration::from_secs(30);
+
+    /// Base upgrade labels emitted by [`CliMetrics::UPGRADE_ACTIVE`].
+    pub const BASE_UPGRADE_LABELS: [(BaseUpgrade, &'static str); 12] = [
+        (BaseUpgrade::Bedrock, "bedrock"),
+        (BaseUpgrade::Regolith, "regolith"),
+        (BaseUpgrade::Canyon, "canyon"),
+        (BaseUpgrade::Ecotone, "ecotone"),
+        (BaseUpgrade::Fjord, "fjord"),
+        (BaseUpgrade::Granite, "granite"),
+        (BaseUpgrade::Holocene, "holocene"),
+        (BaseUpgrade::Isthmus, "isthmus"),
+        (BaseUpgrade::Jovian, "jovian"),
+        (BaseUpgrade::Azul, "azul"),
+        (BaseUpgrade::Beryl, "beryl"),
+        (BaseUpgrade::Cobalt, "cobalt"),
+    ];
+
     /// The identifier for the cli metrics gauge.
     pub const IDENTIFIER: &'static str = "base_cli_opts";
 
@@ -68,6 +94,9 @@ impl CliMetrics {
 
     /// Hardfork activation times.
     pub const HARDFORK_ACTIVATION_TIMES: &'static str = "base_node_hardforks";
+
+    /// Whether each configured Base network upgrade is active.
+    pub const UPGRADE_ACTIVE: &'static str = "base_node_upgrade_active";
 
     /// Top-level rollup config settings.
     pub const ROLLUP_CONFIG: &'static str = "base_node_rollup_config";
@@ -144,6 +173,10 @@ impl CliMetrics {
             Self::HARDFORK_ACTIVATION_TIMES,
             "Activation times for hardforks in Base"
         );
+        metrics::describe_gauge!(
+            Self::UPGRADE_ACTIVE,
+            "Whether each Base network upgrade is active according to the node configuration"
+        );
 
         metrics::gauge!(
             Self::ROLLUP_CONFIG,
@@ -170,6 +203,114 @@ impl CliMetrics {
             // Use `-1` as a signal that the fork is not scheduled.
             let time: f64 = activation_time.map(|t| t as f64).unwrap_or(-1f64);
             metrics::gauge!(Self::HARDFORK_ACTIVATION_TIMES, "fork" => fork_name).set(time);
+        }
+    }
+
+    /// Records active upgrade gauges using the current wall-clock timestamp.
+    pub fn record_active_upgrades(config: &RollupConfig) {
+        Self::record_active_upgrades_at(config, Self::current_unix_timestamp());
+    }
+
+    /// Records active upgrade gauges at the given Unix timestamp.
+    pub fn record_active_upgrades_at(config: &RollupConfig, timestamp: u64) {
+        let active_upgrade = BaseUpgrade::from_timestamp(config, timestamp);
+        for (upgrade, label) in Self::BASE_UPGRADE_LABELS {
+            metrics::gauge!(Self::UPGRADE_ACTIVE, "upgrade" => label)
+                .set(Self::upgrade_active_value(upgrade, active_upgrade));
+        }
+    }
+
+    /// Starts a background recorder that refreshes active upgrade gauges.
+    pub fn spawn_active_upgrade_recorder(config: RollupConfig, interval: Duration) {
+        let interval =
+            if interval.is_zero() { Self::ACTIVE_UPGRADE_RECORDING_INTERVAL } else { interval };
+
+        Self::record_active_upgrades(&config);
+
+        if let Err(error) =
+            thread::Builder::new().name("active-upgrade-metrics".to_string()).spawn(move || {
+                loop {
+                    thread::sleep(interval);
+                    Self::record_active_upgrades(&config);
+                }
+            })
+        {
+            warn!(error = %error, "failed to spawn active upgrade metrics recorder");
+        }
+    }
+
+    /// Returns the gauge value for an upgrade relative to the currently active upgrade.
+    pub const fn upgrade_active_value(upgrade: BaseUpgrade, active_upgrade: BaseUpgrade) -> f64 {
+        if upgrade.idx() <= active_upgrade.idx() { 1.0 } else { 0.0 }
+    }
+
+    /// Returns the current Unix timestamp in seconds.
+    pub fn current_unix_timestamp() -> u64 {
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_secs())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_chains::BaseUpgrade;
+    use base_common_genesis::{HardForkConfig, HardforkConfig, RollupConfig};
+
+    use super::CliMetrics;
+
+    fn rollup_config(azul: Option<u64>, beryl: Option<u64>, cobalt: Option<u64>) -> RollupConfig {
+        RollupConfig {
+            hardforks: HardForkConfig {
+                base: HardforkConfig { azul, beryl, cobalt },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn active_upgrade_values_mark_azul_active_at_activation() {
+        let config = rollup_config(Some(10), Some(20), Some(30));
+        let active_upgrade = BaseUpgrade::from_timestamp(&config, 10);
+
+        assert_eq!(active_upgrade, BaseUpgrade::Azul);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Jovian, active_upgrade), 1.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Azul, active_upgrade), 1.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Beryl, active_upgrade), 0.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Cobalt, active_upgrade), 0.0);
+    }
+
+    #[test]
+    fn active_upgrade_values_mark_prior_upgrades_active_after_beryl() {
+        let config = rollup_config(Some(10), Some(20), Some(30));
+        let active_upgrade = BaseUpgrade::from_timestamp(&config, 25);
+
+        assert_eq!(active_upgrade, BaseUpgrade::Beryl);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Azul, active_upgrade), 1.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Beryl, active_upgrade), 1.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Cobalt, active_upgrade), 0.0);
+    }
+
+    #[test]
+    fn active_upgrade_values_keep_unscheduled_base_upgrades_inactive() {
+        let config = rollup_config(None, None, None);
+        let active_upgrade = BaseUpgrade::from_timestamp(&config, u64::MAX);
+
+        assert_eq!(active_upgrade, BaseUpgrade::Bedrock);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Bedrock, active_upgrade), 1.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Azul, active_upgrade), 0.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Beryl, active_upgrade), 0.0);
+        assert_eq!(CliMetrics::upgrade_active_value(BaseUpgrade::Cobalt, active_upgrade), 0.0);
+    }
+
+    #[test]
+    fn upgrade_labels_are_lowercase_and_cover_every_upgrade() {
+        assert_eq!(CliMetrics::BASE_UPGRADE_LABELS.len(), 12);
+
+        for (expected_idx, (upgrade, label)) in
+            CliMetrics::BASE_UPGRADE_LABELS.into_iter().enumerate()
+        {
+            assert_eq!(upgrade.idx(), expected_idx);
+            assert!(label.chars().all(|c| c.is_ascii_lowercase() || c == '_'));
         }
     }
 }

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -1,7 +1,9 @@
 //! CLI Options Metrics
 
 use std::{
+    sync::mpsc::{self, RecvTimeoutError, Sender},
     thread,
+    thread::JoinHandle,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -14,6 +16,45 @@ use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
 /// Metrics to record various CLI options.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CliMetrics;
+
+/// Background active-upgrade metrics recorder.
+#[derive(Debug)]
+pub struct ActiveUpgradeMetricsRecorder {
+    shutdown: Option<Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ActiveUpgradeMetricsRecorder {
+    /// Creates an empty recorder when the background thread could not be spawned.
+    pub const fn empty() -> Self {
+        Self { shutdown: None, handle: None }
+    }
+
+    /// Stops the background recorder and waits for it to exit.
+    pub fn stop(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(handle) = self.handle.take()
+            && handle.join().is_err()
+        {
+            warn!("active upgrade metrics recorder panicked");
+        }
+    }
+}
+
+impl Drop for ActiveUpgradeMetricsRecorder {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(handle) = self.handle.take()
+            && handle.join().is_err()
+        {
+            warn!("active upgrade metrics recorder panicked");
+        }
+    }
+}
 
 impl CliMetrics {
     /// The default interval for refreshing active upgrade metrics.
@@ -221,21 +262,31 @@ impl CliMetrics {
     }
 
     /// Starts a background recorder that refreshes active upgrade gauges.
-    pub fn spawn_active_upgrade_recorder(config: RollupConfig, interval: Duration) {
+    pub fn spawn_active_upgrade_recorder(
+        config: RollupConfig,
+        interval: Duration,
+    ) -> ActiveUpgradeMetricsRecorder {
         let interval =
             if interval.is_zero() { Self::ACTIVE_UPGRADE_RECORDING_INTERVAL } else { interval };
+        let (shutdown, shutdown_signal) = mpsc::channel();
 
         Self::record_active_upgrades(&config);
 
-        if let Err(error) =
-            thread::Builder::new().name("active-upgrade-metrics".to_string()).spawn(move || {
-                loop {
-                    thread::sleep(interval);
-                    Self::record_active_upgrades(&config);
+        match thread::Builder::new().name("active-upgrade-metrics".to_string()).spawn(move || {
+            loop {
+                match shutdown_signal.recv_timeout(interval) {
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
+                    Err(RecvTimeoutError::Timeout) => Self::record_active_upgrades(&config),
                 }
-            })
-        {
-            warn!(error = %error, "failed to spawn active upgrade metrics recorder");
+            }
+        }) {
+            Ok(handle) => {
+                ActiveUpgradeMetricsRecorder { shutdown: Some(shutdown), handle: Some(handle) }
+            }
+            Err(error) => {
+                warn!(error = %error, "failed to spawn active upgrade metrics recorder");
+                ActiveUpgradeMetricsRecorder::empty()
+            }
         }
     }
 

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -29,18 +29,6 @@ impl ActiveUpgradeMetricsRecorder {
     pub const fn empty() -> Self {
         Self { shutdown: None, handle: None }
     }
-
-    /// Stops the background recorder and waits for it to exit.
-    pub fn stop(mut self) {
-        if let Some(shutdown) = self.shutdown.take() {
-            let _ = shutdown.send(());
-        }
-        if let Some(handle) = self.handle.take()
-            && handle.join().is_err()
-        {
-            warn!("active upgrade metrics recorder panicked");
-        }
-    }
 }
 
 impl Drop for ActiveUpgradeMetricsRecorder {

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -60,12 +60,16 @@ impl ConsensusNodeCommand {
 
         let args = ConsensusNodeArgs::new(chain, self.args);
         let cfg = args.load_rollup_config()?;
-        if self.metrics.enabled {
+        let _active_upgrade_metrics = if self.metrics.enabled {
             CliMetrics::init_rollup_config(&cfg);
-            CliMetrics::spawn_active_upgrade_recorder(
+            Some(CliMetrics::spawn_active_upgrade_recorder(
                 cfg.clone(),
                 Duration::from_secs(self.metrics.interval),
-            );
+            ))
+        } else {
+            None
+        };
+        if self.metrics.enabled {
             CliMetrics::init_p2p(&args.config.p2p_flags);
         }
 

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -1,6 +1,6 @@
 //! Reusable consensus node arguments and launch helpers.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::JwtSecret;
@@ -62,6 +62,10 @@ impl ConsensusNodeCommand {
         let cfg = args.load_rollup_config()?;
         if self.metrics.enabled {
             CliMetrics::init_rollup_config(&cfg);
+            CliMetrics::spawn_active_upgrade_recorder(
+                cfg.clone(),
+                Duration::from_secs(self.metrics.interval),
+            );
             CliMetrics::init_p2p(&args.config.p2p_flags);
         }
 


### PR DESCRIPTION
## Summary

This adds a base_node_upgrade_active gauge that exposes whether each Base upgrade is active according to the node's configured rollup schedule. The metric uses lowercase upgrade labels for Datadog queries and refreshes periodically so it can flip without a node restart. It is wired into standalone consensus nodes and unified base rpc/sequencer nodes so the gauge is available from the scraped metrics endpoint.