### PR TITLE
refactor: add focused basectl typed validation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6653,6 +6653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "toml 1.1.2+spec-1.1.0",

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -4,7 +4,7 @@ use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use alloy_provider::Network;
 use alloy_rpc_types_eth::BlockNumberOrTag;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use base_common_network::Base;
 use basectl_cli::{
     BlockRefParseError, JsonOutput, KeyValueTable, MonitoringConfig, TimestampJson, fetch_block,
@@ -55,18 +55,14 @@ pub(crate) async fn run(
     raw: bool,
 ) -> Result<()> {
     let block_ref = parse_block_ref(reference)?;
-    let block = fetch_block(&config.rpc, block_ref)
-        .await
-        .with_context(|| format!("failed to fetch block {reference}"))?;
+    let block = fetch_block(&config.rpc, block_ref).await?;
     match (json, raw) {
-        (true, true) => JsonOutput::print(&block).context("failed to write block output")?,
+        (true, true) => JsonOutput::print(&block)?,
         (true, false) => {
             let summary = BlockSummaryJson::from_block(&config.name, block_ref, &block);
-            JsonOutput::print(&summary).context("failed to write block output")?;
+            JsonOutput::print(&summary)?;
         }
-        (false, _) => {
-            print_pretty(&config.name, block_ref, &block).context("failed to write block output")?
-        }
+        (false, _) => print_pretty(&config.name, block_ref, &block)?,
     }
     Ok(())
 }

--- a/bin/basectl/src/block.rs
+++ b/bin/basectl/src/block.rs
@@ -4,11 +4,11 @@ use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use alloy_provider::Network;
 use alloy_rpc_types_eth::BlockNumberOrTag;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result};
 use base_common_network::Base;
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, TimestampJson, fetch_block, format_bytes,
-    format_gas, format_gwei, format_unix_timestamp,
+    BlockRefParseError, JsonOutput, KeyValueTable, MonitoringConfig, TimestampJson, fetch_block,
+    format_bytes, format_gas, format_gwei, format_unix_timestamp,
 };
 use serde::Serialize;
 
@@ -20,10 +20,10 @@ use serde::Serialize;
 /// tag (alloy's typed `Block` can't deserialize a pending block's null
 /// number and hash, so accepting it here would only produce a confusing
 /// error after a wasted RPC round-trip).
-pub(crate) fn parse_block_ref(s: &str) -> Result<BlockId> {
+pub(crate) fn parse_block_ref(s: &str) -> Result<BlockId, BlockRefParseError> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
-        bail!("invalid block reference: empty input");
+        return Err(BlockRefParseError::Empty);
     }
     if let Ok(number) = trimmed.parse::<u64>() {
         return Ok(BlockId::Number(BlockNumberOrTag::Number(number)));
@@ -32,16 +32,17 @@ pub(crate) fn parse_block_ref(s: &str) -> Result<BlockId> {
         && hex.len() == 64
         && hex.chars().all(|c| c.is_ascii_hexdigit())
     {
-        let hash: B256 =
-            trimmed.parse().map_err(|_| anyhow!("invalid block reference: malformed hash"))?;
+        let hash: B256 = trimmed
+            .parse()
+            .map_err(|_| BlockRefParseError::MalformedHash { raw: trimmed.to_string() })?;
         return Ok(BlockId::Hash(hash.into()));
     }
-    let tag =
-        trimmed.parse::<BlockNumberOrTag>().map_err(|e| anyhow!("invalid block reference: {e}"))?;
+    let tag = trimmed.parse::<BlockNumberOrTag>().map_err(|e| BlockRefParseError::InvalidTag {
+        raw: trimmed.to_string(),
+        message: e.to_string(),
+    })?;
     if tag == BlockNumberOrTag::Pending {
-        bail!(
-            "the `pending` tag is not supported; use `latest`, `safe`, `finalized`, or `earliest`"
-        );
+        return Err(BlockRefParseError::PendingUnsupported);
     }
     Ok(BlockId::Number(tag))
 }
@@ -54,14 +55,18 @@ pub(crate) async fn run(
     raw: bool,
 ) -> Result<()> {
     let block_ref = parse_block_ref(reference)?;
-    let block = fetch_block(&config.rpc, block_ref).await?;
+    let block = fetch_block(&config.rpc, block_ref)
+        .await
+        .with_context(|| format!("failed to fetch block {reference}"))?;
     match (json, raw) {
-        (true, true) => JsonOutput::print(&block)?,
+        (true, true) => JsonOutput::print(&block).context("failed to write block output")?,
         (true, false) => {
             let summary = BlockSummaryJson::from_block(&config.name, block_ref, &block);
-            JsonOutput::print(&summary)?;
+            JsonOutput::print(&summary).context("failed to write block output")?;
         }
-        (false, _) => print_pretty(&config.name, block_ref, &block)?,
+        (false, _) => {
+            print_pretty(&config.name, block_ref, &block).context("failed to write block output")?
+        }
     }
     Ok(())
 }
@@ -161,6 +166,7 @@ mod tests {
     use alloy_eips::BlockId;
     use alloy_primitives::B256;
     use alloy_rpc_types_eth::BlockNumberOrTag;
+    use basectl_cli::BlockRefParseError;
 
     use super::parse_block_ref;
 
@@ -210,19 +216,21 @@ mod tests {
     #[test]
     fn rejects_pending() {
         for input in ["pending", "Pending", "PENDING"] {
-            let err = parse_block_ref(input).unwrap_err().to_string();
-            assert!(
-                err.contains("`pending` tag is not supported"),
-                "expected pending rejection for {input:?}, got: {err}",
-            );
+            assert!(matches!(
+                parse_block_ref(input).unwrap_err(),
+                BlockRefParseError::PendingUnsupported
+            ));
         }
     }
 
     #[test]
     fn rejects_invalid_input() {
-        assert!(parse_block_ref("notatag").is_err());
-        assert!(parse_block_ref("").is_err());
-        assert!(parse_block_ref("   ").is_err());
+        assert!(matches!(
+            parse_block_ref("notatag").unwrap_err(),
+            BlockRefParseError::InvalidTag { .. }
+        ));
+        assert!(matches!(parse_block_ref("").unwrap_err(), BlockRefParseError::Empty));
+        assert!(matches!(parse_block_ref("   ").unwrap_err(), BlockRefParseError::Empty));
     }
 
     #[test]

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -18,7 +18,9 @@ use crate::{
         ConductorNodeActionArgs, ConductorStatusArgs,
     },
     confirm::{confirm_or_abort, confirm_typed_or_abort},
-    helpers::{CommandOutcome, fmt_bool, fmt_u32, fmt_u64},
+    helpers::{
+        CommandOutcome, find_conductor_node, fmt_bool, fmt_u32, fmt_u64, resolve_conductor_source,
+    },
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -86,7 +88,8 @@ pub(crate) async fn run(
     conductor_rpc: Option<Url>,
     command: ConductorCommands,
 ) -> Result<CommandOutcome> {
-    let source = resolve_source(&config, conductor_rpc)?;
+    let source =
+        resolve_conductor_source(&config, conductor_rpc).map_err(ConductorCommandError::from)?;
     match command {
         ConductorCommands::Status(args) => run_status(config, source, args).await,
         ConductorCommands::TransferLeader(args) => run_transfer_leader(config, source, args).await,
@@ -131,7 +134,7 @@ async fn run_transfer_leader(
     if let Some(target) = args.target.as_deref() {
         // Validate before prompting so a typo does not ask for confirmation and only
         // fail after the operator already answered yes.
-        find_node(&nodes, target)?;
+        find_conductor_node(&nodes, target).map_err(ConductorCommandError::from)?;
     }
 
     let prompt = args.target.as_deref().map_or_else(
@@ -175,7 +178,7 @@ async fn run_node_action(
     action: NodeActionKind,
 ) -> Result<CommandOutcome> {
     let nodes = current_nodes_for_action(&source).await?;
-    let node = find_node(&nodes, &args.node)?;
+    let node = find_conductor_node(&nodes, &args.node).map_err(ConductorCommandError::from)?;
     let json_action = action.action();
     let prompt = format!(
         "{} conductor control loop on {} ({})? [y/N] ",
@@ -238,15 +241,6 @@ async fn run_cluster_action(
     Ok(CommandOutcome::from_failures(fanout_requires_failure_exit(&report)))
 }
 
-fn resolve_source(
-    config: &MonitoringConfig,
-    conductor_rpc: Option<Url>,
-) -> Result<ConductorSource, ConductorCommandError> {
-    config
-        .conductor_source(conductor_rpc)
-        .ok_or_else(|| ConductorCommandError::MissingSource { config_name: config.name.clone() })
-}
-
 async fn current_nodes_for_action(source: &ConductorSource) -> Result<Vec<ConductorNodeConfig>> {
     match source {
         ConductorSource::Static(nodes) => Ok(nodes.clone()),
@@ -305,16 +299,6 @@ async fn current_nodes_for_cluster_action(
 
 const fn fanout_requires_failure_exit(report: &ConductorFanoutReport) -> bool {
     !report.is_success()
-}
-
-fn find_node<'a>(
-    nodes: &'a [ConductorNodeConfig],
-    name: &str,
-) -> Result<&'a ConductorNodeConfig, ConductorCommandError> {
-    nodes.iter().find(|node| node.name == name).ok_or_else(|| ConductorCommandError::MissingNode {
-        requested_node: name.to_string(),
-        available_nodes: nodes.iter().map(|node| node.name.clone()).collect(),
-    })
 }
 
 fn print_status_pretty(status: &ConductorStatusJson) -> Result<()> {
@@ -616,9 +600,9 @@ mod tests {
 
     use super::{
         ConductorAction, ConductorActionJson, ConductorFanoutJson, ConductorNodeJson,
-        ConductorStatusJson, fanout_requires_failure_exit, find_node,
+        ConductorStatusJson, fanout_requires_failure_exit,
     };
-    use crate::helpers::CommandOutcome;
+    use crate::helpers::{CommandOutcome, find_conductor_node};
 
     fn node(name: &str) -> ConductorNodeConfig {
         ConductorNodeConfig {
@@ -820,7 +804,9 @@ mod tests {
     fn find_node_reports_missing_name() {
         let nodes = vec![node("op-conductor-0")];
 
-        let err = find_node(&nodes, "op-conductor-1").expect_err("missing node should error");
+        let err = find_conductor_node(&nodes, "op-conductor-1")
+            .map_err(ConductorCommandError::from)
+            .expect_err("missing node should error");
 
         assert!(matches!(
             err,

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -2,11 +2,11 @@
 
 use std::io::{self, Write};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use basectl_cli::{
-    ConductorClusterSnapshot, ConductorControl, ConductorFanoutReport, ConductorNodeConfig,
-    ConductorNodeFailure, ConductorNodeStatus, ConductorSource, JsonOutput, KeyValueTable,
-    MonitoringConfig,
+    ConductorClusterSnapshot, ConductorCommandError, ConductorControl, ConductorFanoutReport,
+    ConductorNodeConfig, ConductorNodeFailure, ConductorNodeStatus, ConductorSource, JsonOutput,
+    KeyValueTable, MonitoringConfig,
 };
 use serde::Serialize;
 use tracing::warn;
@@ -18,7 +18,7 @@ use crate::{
         ConductorNodeActionArgs, ConductorStatusArgs,
     },
     confirm::{confirm_or_abort, confirm_typed_or_abort},
-    helpers::{CommandOutcome, find_node, fmt_bool, fmt_u32, fmt_u64, resolve_source},
+    helpers::{CommandOutcome, fmt_bool, fmt_u32, fmt_u64},
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -86,7 +86,7 @@ pub(crate) async fn run(
     conductor_rpc: Option<Url>,
     command: ConductorCommands,
 ) -> Result<CommandOutcome> {
-    let source = resolve_source(&config, conductor_rpc, "conductor")?;
+    let source = resolve_source(&config, conductor_rpc)?;
     match command {
         ConductorCommands::Status(args) => run_status(config, source, args).await,
         ConductorCommands::TransferLeader(args) => run_transfer_leader(config, source, args).await,
@@ -110,12 +110,14 @@ async fn run_status(
     source: ConductorSource,
     args: ConductorStatusArgs,
 ) -> Result<CommandOutcome> {
-    let snapshot = ConductorControl::snapshot(source).await?;
+    let snapshot = ConductorControl::snapshot(source)
+        .await
+        .context("failed to fetch conductor status snapshot")?;
     let status = ConductorStatusJson::from_snapshot(&config.name, &snapshot);
     if args.json {
-        JsonOutput::print(&status)?;
+        JsonOutput::print(&status).context("failed to write conductor output")?;
     } else {
-        print_status_pretty(&status)?;
+        print_status_pretty(&status).context("failed to write conductor output")?;
     }
     Ok(CommandOutcome::Success)
 }
@@ -129,7 +131,7 @@ async fn run_transfer_leader(
     if let Some(target) = args.target.as_deref() {
         // Validate before prompting so a typo does not ask for confirmation and only
         // fail after the operator already answered yes.
-        find_node(&nodes, target, "conductor")?;
+        find_node(&nodes, target)?;
     }
 
     let prompt = args.target.as_deref().map_or_else(
@@ -141,11 +143,18 @@ async fn run_transfer_leader(
         },
         |target| format!("Transfer conductor leadership to {target} for {}? [y/N] ", config.name),
     );
-    if !confirm_or_abort(&prompt, args.yes)? {
+    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
         return Ok(CommandOutcome::Success);
     }
 
-    let message = ConductorControl::transfer_leader(&nodes, args.target.as_deref()).await?;
+    let message = ConductorControl::transfer_leader(&nodes, args.target.as_deref())
+        .await
+        .with_context(|| {
+            args.target.as_ref().map_or_else(
+                || "failed to transfer conductor leadership".to_string(),
+                |target| format!("failed to transfer conductor leadership to {target}"),
+            )
+        })?;
     print_single_action(
         &ConductorActionJson::single(
             &config.name,
@@ -154,7 +163,8 @@ async fn run_transfer_leader(
             message,
         ),
         args.json,
-    )?;
+    )
+    .context("failed to write conductor output")?;
     Ok(CommandOutcome::Success)
 }
 
@@ -165,7 +175,7 @@ async fn run_node_action(
     action: NodeActionKind,
 ) -> Result<CommandOutcome> {
     let nodes = current_nodes_for_action(&source).await?;
-    let node = find_node(&nodes, &args.node, "conductor")?;
+    let node = find_node(&nodes, &args.node)?;
     let json_action = action.action();
     let prompt = format!(
         "{} conductor control loop on {} ({})? [y/N] ",
@@ -173,18 +183,23 @@ async fn run_node_action(
         node.name,
         node.conductor_rpc
     );
-    if !confirm_or_abort(&prompt, args.yes)? {
+    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
         return Ok(CommandOutcome::Success);
     }
 
     let message = match action {
-        NodeActionKind::Pause => ConductorControl::pause_node(node).await?,
-        NodeActionKind::Unpause => ConductorControl::resume_node(node).await?,
+        NodeActionKind::Pause => ConductorControl::pause_node(node)
+            .await
+            .with_context(|| format!("failed to pause conductor node {}", node.name))?,
+        NodeActionKind::Unpause => ConductorControl::resume_node(node)
+            .await
+            .with_context(|| format!("failed to resume conductor node {}", node.name))?,
     };
     print_single_action(
         &ConductorActionJson::single(&config.name, json_action, Some(node.name.clone()), message),
         args.json,
-    )?;
+    )
+    .context("failed to write conductor output")?;
     Ok(CommandOutcome::Success)
 }
 
@@ -194,7 +209,7 @@ async fn run_cluster_action(
     args: ConductorClusterActionArgs,
     action: ClusterActionKind,
 ) -> Result<CommandOutcome> {
-    let (nodes, node_scope) = current_nodes_for_cluster_action(&source).await?;
+    let (nodes, node_scope) = current_nodes_for_cluster_action(&source, action).await?;
     let names = nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ");
     let json_action = action.action();
     let prompt = format!(
@@ -205,7 +220,9 @@ async fn run_cluster_action(
         node_scope.description(),
         names
     );
-    if !confirm_typed_or_abort(&prompt, &config.name, args.yes)? {
+    if !confirm_typed_or_abort(&prompt, &config.name, args.yes)
+        .context("failed to read confirmation")?
+    {
         return Ok(CommandOutcome::Success);
     }
 
@@ -216,22 +233,36 @@ async fn run_cluster_action(
     print_fanout_action(
         &ConductorFanoutJson::from_report(&config.name, json_action, &report),
         args.json,
-    )?;
-    Ok(fanout_outcome(&report))
+    )
+    .context("failed to write conductor output")?;
+    Ok(CommandOutcome::from_failures(fanout_requires_failure_exit(&report)))
+}
+
+fn resolve_source(
+    config: &MonitoringConfig,
+    conductor_rpc: Option<Url>,
+) -> Result<ConductorSource, ConductorCommandError> {
+    config
+        .conductor_source(conductor_rpc)
+        .ok_or_else(|| ConductorCommandError::MissingSource { config_name: config.name.clone() })
 }
 
 async fn current_nodes_for_action(source: &ConductorSource) -> Result<Vec<ConductorNodeConfig>> {
     match source {
         ConductorSource::Static(nodes) => Ok(nodes.clone()),
         ConductorSource::Discover { .. } => {
-            let membership = ConductorControl::current_membership(source).await?;
+            let membership = ConductorControl::current_membership(source)
+                .await
+                .context("failed to resolve conductor nodes for action")?;
             ConductorControl::nodes_from_membership(source, &membership)
+                .context("failed to resolve conductor nodes for action")
         }
     }
 }
 
 async fn current_nodes_for_cluster_action(
     source: &ConductorSource,
+    action: ClusterActionKind,
 ) -> Result<(Vec<ConductorNodeConfig>, ClusterNodeScope)> {
     match source {
         // Prefer live membership when it is reachable so stale static entries are
@@ -240,7 +271,14 @@ async fn current_nodes_for_cluster_action(
         ConductorSource::Static(nodes) => {
             match ConductorControl::current_membership(source).await {
                 Ok(membership) => Ok((
-                    ConductorControl::nodes_from_membership(source, &membership)?,
+                    ConductorControl::nodes_from_membership(source, &membership).with_context(
+                        || {
+                            format!(
+                                "failed to prepare conductor cluster fanout for {}",
+                                action.verb()
+                            )
+                        },
+                    )?,
                     ClusterNodeScope::CurrentRaftMembers,
                 )),
                 Err(error) => {
@@ -253,19 +291,30 @@ async fn current_nodes_for_cluster_action(
             }
         }
         ConductorSource::Discover { .. } => {
-            let membership = ConductorControl::current_membership(source).await?;
-            let nodes = ConductorControl::nodes_from_membership(source, &membership)?;
+            let membership =
+                ConductorControl::current_membership(source).await.with_context(|| {
+                    format!("failed to prepare conductor cluster fanout for {}", action.verb())
+                })?;
+            let nodes = ConductorControl::nodes_from_membership(source, &membership).with_context(
+                || format!("failed to prepare conductor cluster fanout for {}", action.verb()),
+            )?;
             Ok((nodes, ClusterNodeScope::CurrentRaftMembers))
         }
     }
 }
 
-/// Maps a fanout report onto the process-exit outcome.
-///
-/// An empty fanout (no nodes targeted) is treated as a failure so operators
-/// notice when a bulk action silently matched nothing.
-const fn fanout_outcome(report: &ConductorFanoutReport) -> CommandOutcome {
-    CommandOutcome::from_failures(!report.is_success())
+const fn fanout_requires_failure_exit(report: &ConductorFanoutReport) -> bool {
+    !report.is_success()
+}
+
+fn find_node<'a>(
+    nodes: &'a [ConductorNodeConfig],
+    name: &str,
+) -> Result<&'a ConductorNodeConfig, ConductorCommandError> {
+    nodes.iter().find(|node| node.name == name).ok_or_else(|| ConductorCommandError::MissingNode {
+        requested_node: name.to_string(),
+        available_nodes: nodes.iter().map(|node| node.name.clone()).collect(),
+    })
 }
 
 fn print_status_pretty(status: &ConductorStatusJson) -> Result<()> {
@@ -559,14 +608,17 @@ impl ConductorNodeJson {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
-    use basectl_cli::{ConductorClusterSnapshot, ConductorNodeConfig, ConductorNodeFailure};
+    use basectl_cli::{
+        ConductorClusterSnapshot, ConductorCommandError, ConductorNodeConfig, ConductorNodeFailure,
+    };
     use serde_json::json;
     use url::Url;
 
     use super::{
         ConductorAction, ConductorActionJson, ConductorFanoutJson, ConductorNodeJson,
-        ConductorStatusJson, fanout_outcome, find_node,
+        ConductorStatusJson, fanout_requires_failure_exit, find_node,
     };
+    use crate::helpers::CommandOutcome;
 
     fn node(name: &str) -> ConductorNodeConfig {
         ConductorNodeConfig {
@@ -680,9 +732,18 @@ mod tests {
             failures: Vec::new(),
         };
 
-        assert!(!fanout_outcome(&success).has_failures());
-        assert!(fanout_outcome(&partial_failure).has_failures());
-        assert!(fanout_outcome(&empty).has_failures());
+        assert_eq!(
+            CommandOutcome::from_failures(fanout_requires_failure_exit(&success)),
+            CommandOutcome::Success
+        );
+        assert_eq!(
+            CommandOutcome::from_failures(fanout_requires_failure_exit(&partial_failure)),
+            CommandOutcome::HasFailures
+        );
+        assert_eq!(
+            CommandOutcome::from_failures(fanout_requires_failure_exit(&empty)),
+            CommandOutcome::HasFailures
+        );
     }
 
     #[test]
@@ -759,10 +820,15 @@ mod tests {
     fn find_node_reports_missing_name() {
         let nodes = vec![node("op-conductor-0")];
 
-        let err = find_node(&nodes, "op-conductor-1", "conductor")
-            .expect_err("missing node should error");
+        let err = find_node(&nodes, "op-conductor-1").expect_err("missing node should error");
 
-        assert!(err.to_string().contains("op-conductor-1"));
-        assert!(err.to_string().contains("op-conductor-0"));
+        assert!(matches!(
+            err,
+            ConductorCommandError::MissingNode {
+                requested_node,
+                available_nodes,
+            } if requested_node == "op-conductor-1"
+                && available_nodes == vec!["op-conductor-0".to_string()]
+        ));
     }
 }

--- a/bin/basectl/src/conductor.rs
+++ b/bin/basectl/src/conductor.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use basectl_cli::{
     ConductorClusterSnapshot, ConductorCommandError, ConductorControl, ConductorFanoutReport,
     ConductorNodeConfig, ConductorNodeFailure, ConductorNodeStatus, ConductorSource, JsonOutput,
@@ -113,14 +113,12 @@ async fn run_status(
     source: ConductorSource,
     args: ConductorStatusArgs,
 ) -> Result<CommandOutcome> {
-    let snapshot = ConductorControl::snapshot(source)
-        .await
-        .context("failed to fetch conductor status snapshot")?;
+    let snapshot = ConductorControl::snapshot(source).await?;
     let status = ConductorStatusJson::from_snapshot(&config.name, &snapshot);
     if args.json {
-        JsonOutput::print(&status).context("failed to write conductor output")?;
+        JsonOutput::print(&status)?;
     } else {
-        print_status_pretty(&status).context("failed to write conductor output")?;
+        print_status_pretty(&status)?;
     }
     Ok(CommandOutcome::Success)
 }
@@ -146,18 +144,11 @@ async fn run_transfer_leader(
         },
         |target| format!("Transfer conductor leadership to {target} for {}? [y/N] ", config.name),
     );
-    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
+    if !confirm_or_abort(&prompt, args.yes)? {
         return Ok(CommandOutcome::Success);
     }
 
-    let message = ConductorControl::transfer_leader(&nodes, args.target.as_deref())
-        .await
-        .with_context(|| {
-            args.target.as_ref().map_or_else(
-                || "failed to transfer conductor leadership".to_string(),
-                |target| format!("failed to transfer conductor leadership to {target}"),
-            )
-        })?;
+    let message = ConductorControl::transfer_leader(&nodes, args.target.as_deref()).await?;
     print_single_action(
         &ConductorActionJson::single(
             &config.name,
@@ -166,8 +157,7 @@ async fn run_transfer_leader(
             message,
         ),
         args.json,
-    )
-    .context("failed to write conductor output")?;
+    )?;
     Ok(CommandOutcome::Success)
 }
 
@@ -186,23 +176,18 @@ async fn run_node_action(
         node.name,
         node.conductor_rpc
     );
-    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
+    if !confirm_or_abort(&prompt, args.yes)? {
         return Ok(CommandOutcome::Success);
     }
 
     let message = match action {
-        NodeActionKind::Pause => ConductorControl::pause_node(node)
-            .await
-            .with_context(|| format!("failed to pause conductor node {}", node.name))?,
-        NodeActionKind::Unpause => ConductorControl::resume_node(node)
-            .await
-            .with_context(|| format!("failed to resume conductor node {}", node.name))?,
+        NodeActionKind::Pause => ConductorControl::pause_node(node).await?,
+        NodeActionKind::Unpause => ConductorControl::resume_node(node).await?,
     };
     print_single_action(
         &ConductorActionJson::single(&config.name, json_action, Some(node.name.clone()), message),
         args.json,
-    )
-    .context("failed to write conductor output")?;
+    )?;
     Ok(CommandOutcome::Success)
 }
 
@@ -212,7 +197,7 @@ async fn run_cluster_action(
     args: ConductorClusterActionArgs,
     action: ClusterActionKind,
 ) -> Result<CommandOutcome> {
-    let (nodes, node_scope) = current_nodes_for_cluster_action(&source, action).await?;
+    let (nodes, node_scope) = current_nodes_for_cluster_action(&source).await?;
     let names = nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ");
     let json_action = action.action();
     let prompt = format!(
@@ -223,9 +208,7 @@ async fn run_cluster_action(
         node_scope.description(),
         names
     );
-    if !confirm_typed_or_abort(&prompt, &config.name, args.yes)
-        .context("failed to read confirmation")?
-    {
+    if !confirm_typed_or_abort(&prompt, &config.name, args.yes)? {
         return Ok(CommandOutcome::Success);
     }
 
@@ -236,8 +219,7 @@ async fn run_cluster_action(
     print_fanout_action(
         &ConductorFanoutJson::from_report(&config.name, json_action, &report),
         args.json,
-    )
-    .context("failed to write conductor output")?;
+    )?;
     Ok(CommandOutcome::from_failures(fanout_requires_failure_exit(&report)))
 }
 
@@ -245,18 +227,14 @@ async fn current_nodes_for_action(source: &ConductorSource) -> Result<Vec<Conduc
     match source {
         ConductorSource::Static(nodes) => Ok(nodes.clone()),
         ConductorSource::Discover { .. } => {
-            let membership = ConductorControl::current_membership(source)
-                .await
-                .context("failed to resolve conductor nodes for action")?;
+            let membership = ConductorControl::current_membership(source).await?;
             ConductorControl::nodes_from_membership(source, &membership)
-                .context("failed to resolve conductor nodes for action")
         }
     }
 }
 
 async fn current_nodes_for_cluster_action(
     source: &ConductorSource,
-    action: ClusterActionKind,
 ) -> Result<(Vec<ConductorNodeConfig>, ClusterNodeScope)> {
     match source {
         // Prefer live membership when it is reachable so stale static entries are
@@ -265,14 +243,7 @@ async fn current_nodes_for_cluster_action(
         ConductorSource::Static(nodes) => {
             match ConductorControl::current_membership(source).await {
                 Ok(membership) => Ok((
-                    ConductorControl::nodes_from_membership(source, &membership).with_context(
-                        || {
-                            format!(
-                                "failed to prepare conductor cluster fanout for {}",
-                                action.verb()
-                            )
-                        },
-                    )?,
+                    ConductorControl::nodes_from_membership(source, &membership)?,
                     ClusterNodeScope::CurrentRaftMembers,
                 )),
                 Err(error) => {
@@ -285,13 +256,8 @@ async fn current_nodes_for_cluster_action(
             }
         }
         ConductorSource::Discover { .. } => {
-            let membership =
-                ConductorControl::current_membership(source).await.with_context(|| {
-                    format!("failed to prepare conductor cluster fanout for {}", action.verb())
-                })?;
-            let nodes = ConductorControl::nodes_from_membership(source, &membership).with_context(
-                || format!("failed to prepare conductor cluster fanout for {}", action.verb()),
-            )?;
+            let membership = ConductorControl::current_membership(source).await?;
+            let nodes = ConductorControl::nodes_from_membership(source, &membership)?;
             Ok((nodes, ClusterNodeScope::CurrentRaftMembers))
         }
     }

--- a/bin/basectl/src/confirm.rs
+++ b/bin/basectl/src/confirm.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, BufRead, Write};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 /// Prints `prompt` and reads a `y`/`yes` answer from stdin.
 pub(crate) fn confirm(prompt: &str, skip: bool) -> Result<bool> {
@@ -46,11 +46,11 @@ fn confirm_with_io<R: BufRead, W: Write>(
         return Ok(true);
     }
 
-    write!(writer, "{prompt}").context("writing confirmation prompt")?;
-    writer.flush().context("flushing confirmation prompt")?;
+    write!(writer, "{prompt}")?;
+    writer.flush()?;
 
     let mut answer = String::new();
-    reader.read_line(&mut answer).context("reading confirmation answer")?;
+    reader.read_line(&mut answer)?;
     Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
 }
 
@@ -65,11 +65,11 @@ fn confirm_typed_with_io<R: BufRead, W: Write>(
         return Ok(true);
     }
 
-    write!(writer, "{prompt}").context("writing typed confirmation prompt")?;
-    writer.flush().context("flushing typed confirmation prompt")?;
+    write!(writer, "{prompt}")?;
+    writer.flush()?;
 
     let mut answer = String::new();
-    reader.read_line(&mut answer).context("reading typed confirmation answer")?;
+    reader.read_line(&mut answer)?;
     Ok(answer.trim() == expected)
 }
 

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -2,10 +2,10 @@
 
 use std::io::{self, Write};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result};
 use basectl_cli::{
-    Doctor, DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus, DoctorThresholds, JsonOutput,
-    MonitoringConfig,
+    Doctor, DoctorArgsError, DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus,
+    DoctorThresholds, JsonOutput, MonitoringConfig,
 };
 
 use crate::{cli::DoctorArgs, helpers::CommandOutcome};
@@ -35,19 +35,25 @@ pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<Co
     let json = args.json;
     let report = Doctor::run(config, options).await;
     if json {
-        JsonOutput::print(&report)?;
+        JsonOutput::print(&report).context("failed to write doctor output")?;
     } else {
-        print_pretty(&report)?;
+        print_pretty(&report).context("failed to write doctor output")?;
     }
     Ok(CommandOutcome::from_failures(report.has_failures()))
 }
 
-fn validate_thresholds(args: &DoctorArgs) -> Result<()> {
+const fn validate_thresholds(args: &DoctorArgs) -> Result<(), DoctorArgsError> {
     if args.head_lag_warn_blocks >= args.head_lag_fail_blocks {
-        bail!("`--head-lag-warn-blocks` must be less than `--head-lag-fail-blocks`");
+        return Err(DoctorArgsError::HeadLagWarnMustBeLessThanFail {
+            warn_blocks: args.head_lag_warn_blocks,
+            fail_blocks: args.head_lag_fail_blocks,
+        });
     }
     if args.safe_recency_warn_blocks >= args.safe_recency_fail_blocks {
-        bail!("`--safe-recency-warn-blocks` must be less than `--safe-recency-fail-blocks`");
+        return Err(DoctorArgsError::SafeRecencyWarnMustBeLessThanFail {
+            warn_blocks: args.safe_recency_warn_blocks,
+            fail_blocks: args.safe_recency_fail_blocks,
+        });
     }
     Ok(())
 }
@@ -194,7 +200,7 @@ fn is_empty_value(value: &serde_json::Value) -> bool {
 mod tests {
     use std::path::PathBuf;
 
-    use basectl_cli::{DoctorCheck, DoctorStatus};
+    use basectl_cli::{DoctorArgsError, DoctorCheck, DoctorStatus};
     use serde_json::json;
     use url::Url;
 
@@ -268,7 +274,10 @@ mod tests {
 
         let err = validate_thresholds(&args).unwrap_err();
 
-        assert!(err.to_string().contains("--head-lag-warn-blocks"));
+        assert!(matches!(
+            err,
+            DoctorArgsError::HeadLagWarnMustBeLessThanFail { warn_blocks: 30, fail_blocks: 10 }
+        ));
     }
 
     #[test]
@@ -280,7 +289,13 @@ mod tests {
 
         let err = validate_thresholds(&args).unwrap_err();
 
-        assert!(err.to_string().contains("--safe-recency-warn-blocks"));
+        assert!(matches!(
+            err,
+            DoctorArgsError::SafeRecencyWarnMustBeLessThanFail {
+                warn_blocks: 300,
+                fail_blocks: 300,
+            }
+        ));
     }
 
     fn test_args(update: impl FnOnce(&mut DoctorArgs)) -> DoctorArgs {

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use basectl_cli::{
     Doctor, DoctorArgsError, DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus,
     DoctorThresholds, JsonOutput, MonitoringConfig,
@@ -35,9 +35,9 @@ pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<Co
     let json = args.json;
     let report = Doctor::run(config, options).await;
     if json {
-        JsonOutput::print(&report).context("failed to write doctor output")?;
+        JsonOutput::print(&report)?;
     } else {
-        print_pretty(&report).context("failed to write doctor output")?;
+        print_pretty(&report)?;
     }
     Ok(CommandOutcome::from_failures(report.has_failures()))
 }

--- a/bin/basectl/src/helpers.rs
+++ b/bin/basectl/src/helpers.rs
@@ -1,5 +1,8 @@
 //! Shared helpers for basectl's non-TUI subcommands.
 
+use basectl_cli::{ConductorNodeConfig, ConductorSource, MonitoringConfig, NodeLookupError};
+use url::Url;
+
 /// Whether a non-TUI subcommand observed failures, used by `main` to set the
 /// process exit code.
 ///
@@ -39,4 +42,23 @@ pub(crate) fn fmt_u64(value: Option<u64>) -> String {
 
 pub(crate) fn fmt_u32(value: Option<u32>) -> String {
     value.map_or_else(|| "unknown".to_string(), |value| value.to_string())
+}
+
+pub(crate) fn resolve_conductor_source(
+    config: &MonitoringConfig,
+    conductor_rpc: Option<Url>,
+) -> Result<ConductorSource, NodeLookupError> {
+    config
+        .conductor_source(conductor_rpc)
+        .ok_or_else(|| NodeLookupError::MissingSource { config_name: config.name.clone() })
+}
+
+pub(crate) fn find_conductor_node<'a>(
+    nodes: &'a [ConductorNodeConfig],
+    name: &str,
+) -> Result<&'a ConductorNodeConfig, NodeLookupError> {
+    nodes.iter().find(|node| node.name == name).ok_or_else(|| NodeLookupError::MissingNode {
+        requested_node: name.to_string(),
+        available_nodes: nodes.iter().map(|node| node.name.clone()).collect(),
+    })
 }

--- a/bin/basectl/src/helpers.rs
+++ b/bin/basectl/src/helpers.rs
@@ -1,9 +1,5 @@
 //! Shared helpers for basectl's non-TUI subcommands.
 
-use anyhow::{Result, anyhow};
-use basectl_cli::{ConductorNodeConfig, ConductorSource, MonitoringConfig};
-use url::Url;
-
 /// Whether a non-TUI subcommand observed failures, used by `main` to set the
 /// process exit code.
 ///
@@ -27,32 +23,6 @@ impl CommandOutcome {
     pub(crate) const fn has_failures(self) -> bool {
         matches!(self, Self::HasFailures)
     }
-}
-
-pub(crate) fn resolve_source(
-    config: &MonitoringConfig,
-    conductor_rpc: Option<Url>,
-    command: &str,
-) -> Result<ConductorSource> {
-    config.conductor_source(conductor_rpc).ok_or_else(|| {
-        anyhow!(
-            "{command} commands need conductor config or a bootstrap RPC URL for '{}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`.",
-            config.name
-        )
-    })
-}
-
-pub(crate) fn find_node<'a>(
-    nodes: &'a [ConductorNodeConfig],
-    name: &str,
-    command: &str,
-) -> Result<&'a ConductorNodeConfig> {
-    nodes.iter().find(|node| node.name == name).ok_or_else(|| {
-        anyhow!(
-            "{command} node {name} not found. Available nodes: {}",
-            nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>().join(", ")
-        )
-    })
 }
 
 pub(crate) const fn fmt_bool(value: Option<bool>) -> &'static str {

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -298,10 +298,10 @@ fn resolve_cl_rpc(
     if let Some(u) = override_url {
         return Ok(u.clone());
     }
-    config.consensus_node_rpc.clone().ok_or_else(|| MissingConsensusRpcError::Missing {
-        config_name: config.name.clone(),
-        command_name: command_name.to_string(),
-    })
+    config
+        .consensus_node_rpc
+        .clone()
+        .ok_or_else(|| MissingConsensusRpcError::new(config.name.clone(), command_name))
 }
 
 /// Minimum length used to catch obvious non-libp2p peer IDs before hitting the CL RPC.
@@ -869,9 +869,10 @@ mod tests {
 
         assert!(matches!(
             resolve_cl_rpc(&config, None, "p2p info").unwrap_err(),
-            MissingConsensusRpcError::Missing {
+            MissingConsensusRpcError {
                 config_name,
                 command_name,
+                ..
             } if config_name == "devnet" && command_name == "p2p info"
         ));
     }

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -2,13 +2,13 @@
 
 use std::io::{self, Write};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use base_consensus_peers::BootNode;
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MissingConsensusRpcError, MonitoringConfig, NodeEndpoint,
-    P2pCommandError, P2pTargetError, PeerListReport, PeerStatsReport, PeerSummary, add_peer,
-    ban_peer, connect_peer, disconnect_peer, fetch_connected_peers, fetch_info, fetch_raw_info,
-    fetch_raw_peers, list_banned_peers, remove_peer, unban_peer,
+    JsonOutput, KeyValueTable, MonitoringConfig, NodeEndpoint, P2pCommandError, P2pTargetError,
+    PeerListReport, PeerStatsReport, PeerSummary, add_peer, ban_peer, connect_peer,
+    disconnect_peer, fetch_connected_peers, fetch_info, fetch_raw_info, fetch_raw_peers,
+    list_banned_peers, remove_peer, unban_peer,
 };
 use serde::Serialize;
 use url::Url;
@@ -40,23 +40,16 @@ async fn run_peers(config: MonitoringConfig, args: P2pArgs) -> Result<()> {
 
     match (json, raw) {
         (true, true) => {
-            let report = fetch_raw_peers(&el_rpc, &cl_rpc).await.with_context(|| {
-                format!("failed to fetch raw peer list from EL {el_rpc} and CL {cl_rpc}")
-            })?;
-            JsonOutput::print(&report).context("failed to write p2p output")?;
+            let report = fetch_raw_peers(&el_rpc, &cl_rpc).await?;
+            JsonOutput::print(&report)?;
         }
         (true, false) => {
-            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await.with_context(|| {
-                format!("failed to fetch peer list from EL {el_rpc} and CL {cl_rpc}")
-            })?;
-            JsonOutput::print(&PeersJson::from_report(&config.name, &report))
-                .context("failed to write p2p output")?;
+            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await?;
+            JsonOutput::print(&PeersJson::from_report(&config.name, &report))?;
         }
         (false, _) => {
-            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await.with_context(|| {
-                format!("failed to fetch peer list from EL {el_rpc} and CL {cl_rpc}")
-            })?;
-            print_peers_pretty(&config.name, &report).context("failed to write p2p output")?;
+            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await?;
+            print_peers_pretty(&config.name, &report)?;
         }
     }
 
@@ -78,13 +71,11 @@ async fn run_add_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Re
             );
             let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
             let prompt = format!("Add EL peer {enode} through {el_rpc}? [y/N] ");
-            if !confirm(&prompt, yes).context("failed to read confirmation")? {
+            if !confirm(&prompt, yes)? {
                 println!("aborted");
                 return Ok(());
             }
-            let accepted = add_peer(&el_rpc, &enode)
-                .await
-                .with_context(|| format!("failed to add EL peer {enode} through {el_rpc}"))?;
+            let accepted = add_peer(&el_rpc, &enode).await?;
             print_peer_action(
                 &PeerActionJson::el(&config.name, PeerAction::Add, enode, accepted),
                 json,
@@ -99,13 +90,11 @@ async fn run_add_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Re
             );
             let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p add-peer")?;
             let prompt = format!("Connect CL peer {multiaddr} through {cl_rpc}? [y/N] ");
-            if !confirm(&prompt, yes).context("failed to read confirmation")? {
+            if !confirm(&prompt, yes)? {
                 println!("aborted");
                 return Ok(());
             }
-            connect_peer(&cl_rpc, &multiaddr).await.with_context(|| {
-                format!("failed to connect CL peer {multiaddr} through {cl_rpc}")
-            })?;
+            connect_peer(&cl_rpc, &multiaddr).await?;
             print_peer_action(&PeerActionJson::cl(&config.name, PeerAction::Add, multiaddr), json)?;
         }
     }
@@ -128,13 +117,11 @@ async fn run_remove_peer(config: MonitoringConfig, args: DestructivePeerArgs) ->
             );
             let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
             let prompt = format!("Remove EL peer {enode} through {el_rpc}? [y/N] ");
-            if !confirm(&prompt, yes).context("failed to read confirmation")? {
+            if !confirm(&prompt, yes)? {
                 println!("aborted");
                 return Ok(());
             }
-            let accepted = remove_peer(&el_rpc, &enode)
-                .await
-                .with_context(|| format!("failed to remove EL peer {enode} through {el_rpc}"))?;
+            let accepted = remove_peer(&el_rpc, &enode).await?;
             print_peer_action(
                 &PeerActionJson::el(&config.name, PeerAction::Remove, enode, accepted),
                 json,
@@ -149,13 +136,11 @@ async fn run_remove_peer(config: MonitoringConfig, args: DestructivePeerArgs) ->
             );
             let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p remove-peer")?;
             let prompt = format!("Disconnect CL peer {peer_id} from {cl_rpc}? [y/N] ");
-            if !confirm(&prompt, yes).context("failed to read confirmation")? {
+            if !confirm(&prompt, yes)? {
                 println!("aborted");
                 return Ok(());
             }
-            disconnect_peer(&cl_rpc, &peer_id)
-                .await
-                .with_context(|| format!("failed to disconnect CL peer {peer_id} from {cl_rpc}"))?;
+            disconnect_peer(&cl_rpc, &peer_id).await?;
             print_peer_action(
                 &PeerActionJson::cl(&config.name, PeerAction::Remove, peer_id),
                 json,
@@ -171,14 +156,12 @@ async fn run_ban_peer(config: MonitoringConfig, args: DestructiveClPeerArgs) -> 
     let peer_id = parse_cl_peer_id(&peer_id)?;
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p ban")?;
     let prompt = format!("Ban CL peer {peer_id} through {cl_rpc}? [y/N] ");
-    if !confirm(&prompt, yes).context("failed to read confirmation")? {
+    if !confirm(&prompt, yes)? {
         println!("aborted");
         return Ok(());
     }
 
-    ban_peer(&cl_rpc, &peer_id)
-        .await
-        .with_context(|| format!("failed to ban CL peer {peer_id} through {cl_rpc}"))?;
+    ban_peer(&cl_rpc, &peer_id).await?;
     let disconnect_error =
         disconnect_peer(&cl_rpc, &peer_id).await.err().map(|err| err.to_string());
     print_peer_action(
@@ -198,14 +181,12 @@ async fn run_unban_peer(config: MonitoringConfig, args: DestructiveClPeerArgs) -
     let peer_id = parse_cl_peer_id(&peer_id)?;
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p unban")?;
     let prompt = format!("Unban CL peer {peer_id} through {cl_rpc}? [y/N] ");
-    if !confirm(&prompt, yes).context("failed to read confirmation")? {
+    if !confirm(&prompt, yes)? {
         println!("aborted");
         return Ok(());
     }
 
-    unban_peer(&cl_rpc, &peer_id)
-        .await
-        .with_context(|| format!("failed to unban CL peer {peer_id} through {cl_rpc}"))?;
+    unban_peer(&cl_rpc, &peer_id).await?;
     print_peer_action(&PeerActionJson::cl(&config.name, PeerAction::Unban, peer_id), json)?;
     Ok(())
 }
@@ -213,9 +194,7 @@ async fn run_unban_peer(config: MonitoringConfig, args: DestructiveClPeerArgs) -
 async fn run_unban_all(config: MonitoringConfig, args: DestructiveClBulkArgs) -> Result<()> {
     let DestructiveClBulkArgs { cl_rpc: cl_rpc_override, yes, json } = args;
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p unban-all")?;
-    let mut peer_ids = list_banned_peers(&cl_rpc)
-        .await
-        .with_context(|| format!("failed to list banned CL peers through {cl_rpc}"))?;
+    let mut peer_ids = list_banned_peers(&cl_rpc).await?;
     peer_ids.sort();
 
     if peer_ids.is_empty() {
@@ -231,7 +210,7 @@ async fn run_unban_all(config: MonitoringConfig, args: DestructiveClBulkArgs) ->
     }
 
     let prompt = format!("Unban all {} banned CL peers through {cl_rpc}? [y/N] ", peer_ids.len());
-    if !confirm(&prompt, yes).context("failed to read confirmation")? {
+    if !confirm(&prompt, yes)? {
         println!("aborted");
         return Ok(());
     }
@@ -264,26 +243,16 @@ async fn run_info(config: MonitoringConfig, args: P2pArgs) -> Result<()> {
 
     match (json, raw) {
         (true, true) => {
-            let report = fetch_raw_info(&el_rpc, &cl_rpc).await.with_context(|| {
-                format!("failed to fetch raw p2p info from EL {el_rpc} and CL {cl_rpc}")
-            })?;
-            JsonOutput::print(&report).context("failed to write p2p output")?;
+            let report = fetch_raw_info(&el_rpc, &cl_rpc).await?;
+            JsonOutput::print(&report)?;
         }
         (true, false) => {
-            let (node_info, peer_stats) =
-                fetch_info(&el_rpc, &cl_rpc).await.with_context(|| {
-                    format!("failed to fetch p2p info from EL {el_rpc} and CL {cl_rpc}")
-                })?;
-            JsonOutput::print(&InfoJson::from_report(&config.name, &node_info, &peer_stats))
-                .context("failed to write p2p output")?;
+            let (node_info, peer_stats) = fetch_info(&el_rpc, &cl_rpc).await?;
+            JsonOutput::print(&InfoJson::from_report(&config.name, &node_info, &peer_stats))?;
         }
         (false, _) => {
-            let (node_info, peer_stats) =
-                fetch_info(&el_rpc, &cl_rpc).await.with_context(|| {
-                    format!("failed to fetch p2p info from EL {el_rpc} and CL {cl_rpc}")
-                })?;
-            print_info_pretty(&config.name, &node_info, &peer_stats)
-                .context("failed to write p2p output")?;
+            let (node_info, peer_stats) = fetch_info(&el_rpc, &cl_rpc).await?;
+            print_info_pretty(&config.name, &node_info, &peer_stats)?;
         }
     }
 
@@ -294,14 +263,14 @@ fn resolve_cl_rpc(
     config: &MonitoringConfig,
     override_url: Option<&Url>,
     command_name: &str,
-) -> Result<Url, MissingConsensusRpcError> {
+) -> Result<Url, P2pCommandError> {
     if let Some(u) = override_url {
         return Ok(u.clone());
     }
-    config
-        .consensus_node_rpc
-        .clone()
-        .ok_or_else(|| MissingConsensusRpcError::new(config.name.clone(), command_name))
+    config.consensus_node_rpc.clone().ok_or_else(|| P2pCommandError::MissingConsensusRpc {
+        config_name: config.name.clone(),
+        command_name: command_name.to_string(),
+    })
 }
 
 /// Minimum length used to catch obvious non-libp2p peer IDs before hitting the CL RPC.
@@ -542,7 +511,7 @@ impl PeerBulkActionResultJson {
 
 fn print_peer_action(action: &PeerActionJson, json: bool) -> Result<()> {
     if json {
-        JsonOutput::print(action).context("failed to write p2p output")?;
+        JsonOutput::print(action)?;
     } else {
         print_peer_action_pretty(action)?;
     }
@@ -554,50 +523,41 @@ fn print_peer_action_pretty(action: &PeerActionJson) -> Result<()> {
     match action {
         PeerActionJson::El { action: PeerAction::Add, target, accepted, .. } => {
             if *accepted {
-                writeln!(stdout, "OK EL accepted peer {target}")
-                    .context("failed to write p2p output")?;
+                writeln!(stdout, "OK EL accepted peer {target}")?;
             } else {
-                writeln!(stdout, "OK EL did not accept peer {target}")
-                    .context("failed to write p2p output")?;
+                writeln!(stdout, "OK EL did not accept peer {target}")?;
             }
         }
         PeerActionJson::El { action: PeerAction::Remove, target, accepted, .. } => {
             if *accepted {
-                writeln!(stdout, "OK EL removed peer {target}")
-                    .context("failed to write p2p output")?;
+                writeln!(stdout, "OK EL removed peer {target}")?;
             } else {
-                writeln!(stdout, "OK EL did not remove peer {target}")
-                    .context("failed to write p2p output")?;
+                writeln!(stdout, "OK EL did not remove peer {target}")?;
             }
         }
         PeerActionJson::Cl { action: PeerAction::Add, target, .. } => {
-            writeln!(stdout, "OK CL connected {target}").context("failed to write p2p output")?;
+            writeln!(stdout, "OK CL connected {target}")?;
         }
         PeerActionJson::Cl { action: PeerAction::Remove, target, .. } => {
-            writeln!(stdout, "OK CL disconnected {target}")
-                .context("failed to write p2p output")?;
+            writeln!(stdout, "OK CL disconnected {target}")?;
         }
         PeerActionJson::Cl { action: PeerAction::Ban, target, disconnect_error, .. } => {
             if let Some(error) = disconnect_error {
-                writeln!(stdout, "OK CL banned {target} (disconnect warning: {error})")
-                    .context("failed to write p2p output")?;
+                writeln!(stdout, "OK CL banned {target} (disconnect warning: {error})")?;
             } else {
-                writeln!(stdout, "OK CL banned {target}").context("failed to write p2p output")?;
+                writeln!(stdout, "OK CL banned {target}")?;
             }
         }
         PeerActionJson::Cl { action: PeerAction::Unban, target, .. } => {
-            writeln!(stdout, "OK CL unbanned {target}").context("failed to write p2p output")?;
+            writeln!(stdout, "OK CL unbanned {target}")?;
         }
         PeerActionJson::ClBulk { succeeded, failed, results, .. } => {
-            writeln!(stdout, "OK CL unbanned {succeeded} banned peer(s)")
-                .context("failed to write p2p output")?;
+            writeln!(stdout, "OK CL unbanned {succeeded} banned peer(s)")?;
             if *failed > 0 {
-                writeln!(stdout, "failed to unban {failed} banned peer(s)")
-                    .context("failed to write p2p output")?;
+                writeln!(stdout, "failed to unban {failed} banned peer(s)")?;
                 for result in results.iter().filter(|result| !result.ok) {
                     let error = result.error.as_deref().unwrap_or("unknown error");
-                    writeln!(stdout, "  {}: {error}", result.target)
-                        .context("failed to write p2p output")?;
+                    writeln!(stdout, "  {}: {error}", result.target)?;
                 }
             }
         }
@@ -811,7 +771,7 @@ fn unavailable_cl_peer_stats() -> String {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::Address;
-    use basectl_cli::{MissingConsensusRpcError, P2pCommandError, P2pTargetError};
+    use basectl_cli::{P2pCommandError, P2pTargetError};
     use serde_json::json;
     use url::Url;
 
@@ -869,7 +829,7 @@ mod tests {
 
         assert!(matches!(
             resolve_cl_rpc(&config, None, "p2p info").unwrap_err(),
-            MissingConsensusRpcError {
+            P2pCommandError::MissingConsensusRpc {
                 config_name,
                 command_name,
                 ..

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -2,12 +2,13 @@
 
 use std::io::{self, Write};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result};
 use base_consensus_peers::BootNode;
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, NodeEndpoint, PeerListReport, PeerStatsReport,
-    PeerSummary, add_peer, ban_peer, connect_peer, disconnect_peer, fetch_connected_peers,
-    fetch_info, fetch_raw_info, fetch_raw_peers, list_banned_peers, remove_peer, unban_peer,
+    JsonOutput, KeyValueTable, MissingConsensusRpcError, MonitoringConfig, NodeEndpoint,
+    P2pCommandError, P2pTargetError, PeerListReport, PeerStatsReport, PeerSummary, add_peer,
+    ban_peer, connect_peer, disconnect_peer, fetch_connected_peers, fetch_info, fetch_raw_info,
+    fetch_raw_peers, list_banned_peers, remove_peer, unban_peer,
 };
 use serde::Serialize;
 use url::Url;
@@ -38,14 +39,24 @@ async fn run_peers(config: MonitoringConfig, args: P2pArgs) -> Result<()> {
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p peers")?;
 
     match (json, raw) {
-        (true, true) => JsonOutput::print(&fetch_raw_peers(&el_rpc, &cl_rpc).await?)?,
+        (true, true) => {
+            let report = fetch_raw_peers(&el_rpc, &cl_rpc).await.with_context(|| {
+                format!("failed to fetch raw peer list from EL {el_rpc} and CL {cl_rpc}")
+            })?;
+            JsonOutput::print(&report).context("failed to write p2p output")?;
+        }
         (true, false) => {
-            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await?;
-            JsonOutput::print(&PeersJson::from_report(&config.name, &report))?;
+            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await.with_context(|| {
+                format!("failed to fetch peer list from EL {el_rpc} and CL {cl_rpc}")
+            })?;
+            JsonOutput::print(&PeersJson::from_report(&config.name, &report))
+                .context("failed to write p2p output")?;
         }
         (false, _) => {
-            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await?;
-            print_peers_pretty(&config.name, &report)?;
+            let report = fetch_connected_peers(&el_rpc, &cl_rpc).await.with_context(|| {
+                format!("failed to fetch peer list from EL {el_rpc} and CL {cl_rpc}")
+            })?;
+            print_peers_pretty(&config.name, &report).context("failed to write p2p output")?;
         }
     }
 
@@ -67,11 +78,13 @@ async fn run_add_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Re
             );
             let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
             let prompt = format!("Add EL peer {enode} through {el_rpc}? [y/N] ");
-            if !confirm(&prompt, yes)? {
+            if !confirm(&prompt, yes).context("failed to read confirmation")? {
                 println!("aborted");
                 return Ok(());
             }
-            let accepted = add_peer(&el_rpc, &enode).await?;
+            let accepted = add_peer(&el_rpc, &enode)
+                .await
+                .with_context(|| format!("failed to add EL peer {enode} through {el_rpc}"))?;
             print_peer_action(
                 &PeerActionJson::el(&config.name, PeerAction::Add, enode, accepted),
                 json,
@@ -86,11 +99,13 @@ async fn run_add_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Re
             );
             let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p add-peer")?;
             let prompt = format!("Connect CL peer {multiaddr} through {cl_rpc}? [y/N] ");
-            if !confirm(&prompt, yes)? {
+            if !confirm(&prompt, yes).context("failed to read confirmation")? {
                 println!("aborted");
                 return Ok(());
             }
-            connect_peer(&cl_rpc, &multiaddr).await?;
+            connect_peer(&cl_rpc, &multiaddr).await.with_context(|| {
+                format!("failed to connect CL peer {multiaddr} through {cl_rpc}")
+            })?;
             print_peer_action(&PeerActionJson::cl(&config.name, PeerAction::Add, multiaddr), json)?;
         }
     }
@@ -113,11 +128,13 @@ async fn run_remove_peer(config: MonitoringConfig, args: DestructivePeerArgs) ->
             );
             let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
             let prompt = format!("Remove EL peer {enode} through {el_rpc}? [y/N] ");
-            if !confirm(&prompt, yes)? {
+            if !confirm(&prompt, yes).context("failed to read confirmation")? {
                 println!("aborted");
                 return Ok(());
             }
-            let accepted = remove_peer(&el_rpc, &enode).await?;
+            let accepted = remove_peer(&el_rpc, &enode)
+                .await
+                .with_context(|| format!("failed to remove EL peer {enode} through {el_rpc}"))?;
             print_peer_action(
                 &PeerActionJson::el(&config.name, PeerAction::Remove, enode, accepted),
                 json,
@@ -132,11 +149,13 @@ async fn run_remove_peer(config: MonitoringConfig, args: DestructivePeerArgs) ->
             );
             let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p remove-peer")?;
             let prompt = format!("Disconnect CL peer {peer_id} from {cl_rpc}? [y/N] ");
-            if !confirm(&prompt, yes)? {
+            if !confirm(&prompt, yes).context("failed to read confirmation")? {
                 println!("aborted");
                 return Ok(());
             }
-            disconnect_peer(&cl_rpc, &peer_id).await?;
+            disconnect_peer(&cl_rpc, &peer_id)
+                .await
+                .with_context(|| format!("failed to disconnect CL peer {peer_id} from {cl_rpc}"))?;
             print_peer_action(
                 &PeerActionJson::cl(&config.name, PeerAction::Remove, peer_id),
                 json,
@@ -152,12 +171,14 @@ async fn run_ban_peer(config: MonitoringConfig, args: DestructiveClPeerArgs) -> 
     let peer_id = parse_cl_peer_id(&peer_id)?;
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p ban")?;
     let prompt = format!("Ban CL peer {peer_id} through {cl_rpc}? [y/N] ");
-    if !confirm(&prompt, yes)? {
+    if !confirm(&prompt, yes).context("failed to read confirmation")? {
         println!("aborted");
         return Ok(());
     }
 
-    ban_peer(&cl_rpc, &peer_id).await?;
+    ban_peer(&cl_rpc, &peer_id)
+        .await
+        .with_context(|| format!("failed to ban CL peer {peer_id} through {cl_rpc}"))?;
     let disconnect_error =
         disconnect_peer(&cl_rpc, &peer_id).await.err().map(|err| err.to_string());
     print_peer_action(
@@ -177,12 +198,14 @@ async fn run_unban_peer(config: MonitoringConfig, args: DestructiveClPeerArgs) -
     let peer_id = parse_cl_peer_id(&peer_id)?;
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p unban")?;
     let prompt = format!("Unban CL peer {peer_id} through {cl_rpc}? [y/N] ");
-    if !confirm(&prompt, yes)? {
+    if !confirm(&prompt, yes).context("failed to read confirmation")? {
         println!("aborted");
         return Ok(());
     }
 
-    unban_peer(&cl_rpc, &peer_id).await?;
+    unban_peer(&cl_rpc, &peer_id)
+        .await
+        .with_context(|| format!("failed to unban CL peer {peer_id} through {cl_rpc}"))?;
     print_peer_action(&PeerActionJson::cl(&config.name, PeerAction::Unban, peer_id), json)?;
     Ok(())
 }
@@ -190,7 +213,9 @@ async fn run_unban_peer(config: MonitoringConfig, args: DestructiveClPeerArgs) -
 async fn run_unban_all(config: MonitoringConfig, args: DestructiveClBulkArgs) -> Result<()> {
     let DestructiveClBulkArgs { cl_rpc: cl_rpc_override, yes, json } = args;
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p unban-all")?;
-    let mut peer_ids = list_banned_peers(&cl_rpc).await?;
+    let mut peer_ids = list_banned_peers(&cl_rpc)
+        .await
+        .with_context(|| format!("failed to list banned CL peers through {cl_rpc}"))?;
     peer_ids.sort();
 
     if peer_ids.is_empty() {
@@ -206,7 +231,7 @@ async fn run_unban_all(config: MonitoringConfig, args: DestructiveClBulkArgs) ->
     }
 
     let prompt = format!("Unban all {} banned CL peers through {cl_rpc}? [y/N] ", peer_ids.len());
-    if !confirm(&prompt, yes)? {
+    if !confirm(&prompt, yes).context("failed to read confirmation")? {
         println!("aborted");
         return Ok(());
     }
@@ -221,8 +246,13 @@ async fn run_unban_all(config: MonitoringConfig, args: DestructiveClBulkArgs) ->
     let action = PeerActionJson::cl_bulk(&config.name, PeerAction::UnbanAll, results);
     let failed = action.failed_count();
     print_peer_action(&action, json)?;
+    fail_unban_all_if_partial(failed)?;
+    Ok(())
+}
+
+const fn fail_unban_all_if_partial(failed: usize) -> Result<(), P2pCommandError> {
     if failed > 0 {
-        bail!("failed to unban {failed} CL peer(s)");
+        return Err(P2pCommandError::UnbanAllPartialFailure { failed });
     }
     Ok(())
 }
@@ -233,14 +263,27 @@ async fn run_info(config: MonitoringConfig, args: P2pArgs) -> Result<()> {
     let cl_rpc = resolve_cl_rpc(&config, cl_rpc_override.as_ref(), "p2p info")?;
 
     match (json, raw) {
-        (true, true) => JsonOutput::print(&fetch_raw_info(&el_rpc, &cl_rpc).await?)?,
+        (true, true) => {
+            let report = fetch_raw_info(&el_rpc, &cl_rpc).await.with_context(|| {
+                format!("failed to fetch raw p2p info from EL {el_rpc} and CL {cl_rpc}")
+            })?;
+            JsonOutput::print(&report).context("failed to write p2p output")?;
+        }
         (true, false) => {
-            let (node_info, peer_stats) = fetch_info(&el_rpc, &cl_rpc).await?;
-            JsonOutput::print(&InfoJson::from_report(&config.name, &node_info, &peer_stats))?;
+            let (node_info, peer_stats) =
+                fetch_info(&el_rpc, &cl_rpc).await.with_context(|| {
+                    format!("failed to fetch p2p info from EL {el_rpc} and CL {cl_rpc}")
+                })?;
+            JsonOutput::print(&InfoJson::from_report(&config.name, &node_info, &peer_stats))
+                .context("failed to write p2p output")?;
         }
         (false, _) => {
-            let (node_info, peer_stats) = fetch_info(&el_rpc, &cl_rpc).await?;
-            print_info_pretty(&config.name, &node_info, &peer_stats)?;
+            let (node_info, peer_stats) =
+                fetch_info(&el_rpc, &cl_rpc).await.with_context(|| {
+                    format!("failed to fetch p2p info from EL {el_rpc} and CL {cl_rpc}")
+                })?;
+            print_info_pretty(&config.name, &node_info, &peer_stats)
+                .context("failed to write p2p output")?;
         }
     }
 
@@ -251,17 +294,13 @@ fn resolve_cl_rpc(
     config: &MonitoringConfig,
     override_url: Option<&Url>,
     command_name: &str,
-) -> Result<Url> {
+) -> Result<Url, MissingConsensusRpcError> {
     if let Some(u) = override_url {
         return Ok(u.clone());
     }
-    config.consensus_node_rpc.clone().ok_or_else(|| {
-        anyhow!(
-            "{command_name} needs a consensus-node RPC URL.\n\
-             The '{}' config does not set `consensus_node_rpc`.\n\
-             Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config.",
-            config.name
-        )
+    config.consensus_node_rpc.clone().ok_or_else(|| MissingConsensusRpcError::Missing {
+        config_name: config.name.clone(),
+        command_name: command_name.to_string(),
     })
 }
 
@@ -291,85 +330,84 @@ enum RemoveTarget {
     PeerId(String),
 }
 
-fn parse_add_target(raw: &str) -> Result<AddTarget> {
+fn parse_add_target(raw: &str) -> Result<AddTarget, P2pTargetError> {
     let target = raw.trim();
     if target.is_empty() {
-        bail!("peer target cannot be empty");
+        return Err(P2pTargetError::EmptyTarget);
     }
     if target.starts_with('/') {
         if !target.contains("/p2p/") {
-            bail!("multiaddr target must include a `/p2p/<peer-id>` component");
+            return Err(P2pTargetError::MultiaddrMissingPeerId { target: target.to_string() });
         }
         return Ok(AddTarget::Multiaddr(target.to_string()));
     }
 
-    let bootnode = BootNode::parse_bootnode(target)
-        .with_context(|| format!("parsing peer target `{target}` as enode or ENR"))?;
+    let bootnode = BootNode::parse_bootnode(target).map_err(|error| {
+        P2pTargetError::InvalidBootnode { target: target.to_string(), message: error.to_string() }
+    })?;
     match &bootnode {
         BootNode::Enode(_) => Ok(AddTarget::Enode(target.to_string())),
         BootNode::Enr(_) => {
             let multiaddr = bootnode.to_multiaddr().ok_or_else(|| {
-                anyhow!(
-                    "ENR target `{target}` does not include enough information to derive a libp2p multiaddr"
-                )
+                P2pTargetError::EnrMissingMultiaddr { target: target.to_string() }
             })?;
             Ok(AddTarget::Multiaddr(multiaddr.to_string()))
         }
     }
 }
 
-fn parse_remove_target(raw: &str) -> Result<RemoveTarget> {
+fn parse_remove_target(raw: &str) -> Result<RemoveTarget, P2pTargetError> {
     let target = raw.trim();
     if target.is_empty() {
-        bail!("peer target cannot be empty");
+        return Err(P2pTargetError::EmptyTarget);
     }
     if target.starts_with("enr:") {
-        bail!(
-            "remove-peer needs a bare libp2p peer ID for CL targets; ENR records are only accepted by add-peer"
-        );
+        return Err(P2pTargetError::RemoveEnrTarget { target: target.to_string() });
     }
     if target.split_whitespace().count() != 1 {
-        bail!("peer target must not contain whitespace");
+        return Err(P2pTargetError::TargetContainsWhitespace { target: target.to_string() });
     }
 
     if target.starts_with("enode://") {
-        let bootnode = BootNode::parse_bootnode(target)
-            .with_context(|| format!("parsing remove-peer target `{target}` as an enode"))?;
+        let bootnode =
+            BootNode::parse_bootnode(target).map_err(|error| P2pTargetError::InvalidBootnode {
+                target: target.to_string(),
+                message: error.to_string(),
+            })?;
         if !matches!(bootnode, BootNode::Enode(_)) {
-            bail!("remove-peer EL targets must be `enode://` records");
+            return Err(P2pTargetError::RemoveElTargetNotEnode { target: target.to_string() });
         }
         return Ok(RemoveTarget::Enode(target.to_string()));
     }
     if target.contains(':') || target.contains('/') {
-        bail!("remove-peer needs a bare libp2p peer ID for CL targets, not a URL or multiaddr");
+        return Err(P2pTargetError::RemoveClTargetNotBarePeerId { target: target.to_string() });
     }
 
     Ok(RemoveTarget::PeerId(parse_cl_peer_id(target)?))
 }
 
-fn parse_cl_peer_id(raw: &str) -> Result<String> {
+fn parse_cl_peer_id(raw: &str) -> Result<String, P2pTargetError> {
     let target = raw.trim();
     if target.is_empty() {
-        bail!("CL peer ID cannot be empty");
+        return Err(P2pTargetError::EmptyClPeerId);
     }
     if target.starts_with("enode://") {
-        bail!("CL peer actions need a bare libp2p peer ID, not an enode record");
+        return Err(P2pTargetError::ClPeerIdIsEnode { target: target.to_string() });
     }
     if target.starts_with("enr:") {
-        bail!(
-            "CL peer actions need a bare libp2p peer ID; ENR records are only accepted by add-peer"
-        );
+        return Err(P2pTargetError::ClPeerIdIsEnr { target: target.to_string() });
     }
     if target.split_whitespace().count() != 1 {
-        bail!("CL peer ID must not contain whitespace");
+        return Err(P2pTargetError::ClPeerIdContainsWhitespace { target: target.to_string() });
     }
     if target.contains(':') || target.contains('/') {
-        bail!("CL peer actions need a bare libp2p peer ID, not a URL or multiaddr");
+        return Err(P2pTargetError::ClPeerIdNotBare { target: target.to_string() });
     }
     if target.len() < MIN_LIBP2P_PEER_ID_LEN {
-        bail!(
-            "CL peer ID `{target}` looks too short to be a valid libp2p peer ID; expected a base58-encoded string (e.g. 16Uiu2HAm...)"
-        );
+        return Err(P2pTargetError::ClPeerIdTooShort {
+            target: target.to_string(),
+            min_len: MIN_LIBP2P_PEER_ID_LEN,
+        });
     }
 
     Ok(target.to_string())
@@ -504,7 +542,7 @@ impl PeerBulkActionResultJson {
 
 fn print_peer_action(action: &PeerActionJson, json: bool) -> Result<()> {
     if json {
-        JsonOutput::print(action)?;
+        JsonOutput::print(action).context("failed to write p2p output")?;
     } else {
         print_peer_action_pretty(action)?;
     }
@@ -516,46 +554,57 @@ fn print_peer_action_pretty(action: &PeerActionJson) -> Result<()> {
     match action {
         PeerActionJson::El { action: PeerAction::Add, target, accepted, .. } => {
             if *accepted {
-                writeln!(stdout, "OK EL accepted peer {target}")?;
+                writeln!(stdout, "OK EL accepted peer {target}")
+                    .context("failed to write p2p output")?;
             } else {
-                writeln!(stdout, "OK EL did not accept peer {target}")?;
+                writeln!(stdout, "OK EL did not accept peer {target}")
+                    .context("failed to write p2p output")?;
             }
         }
         PeerActionJson::El { action: PeerAction::Remove, target, accepted, .. } => {
             if *accepted {
-                writeln!(stdout, "OK EL removed peer {target}")?;
+                writeln!(stdout, "OK EL removed peer {target}")
+                    .context("failed to write p2p output")?;
             } else {
-                writeln!(stdout, "OK EL did not remove peer {target}")?;
+                writeln!(stdout, "OK EL did not remove peer {target}")
+                    .context("failed to write p2p output")?;
             }
         }
         PeerActionJson::Cl { action: PeerAction::Add, target, .. } => {
-            writeln!(stdout, "OK CL connected {target}")?;
+            writeln!(stdout, "OK CL connected {target}").context("failed to write p2p output")?;
         }
         PeerActionJson::Cl { action: PeerAction::Remove, target, .. } => {
-            writeln!(stdout, "OK CL disconnected {target}")?;
+            writeln!(stdout, "OK CL disconnected {target}")
+                .context("failed to write p2p output")?;
         }
         PeerActionJson::Cl { action: PeerAction::Ban, target, disconnect_error, .. } => {
             if let Some(error) = disconnect_error {
-                writeln!(stdout, "OK CL banned {target} (disconnect warning: {error})")?;
+                writeln!(stdout, "OK CL banned {target} (disconnect warning: {error})")
+                    .context("failed to write p2p output")?;
             } else {
-                writeln!(stdout, "OK CL banned {target}")?;
+                writeln!(stdout, "OK CL banned {target}").context("failed to write p2p output")?;
             }
         }
         PeerActionJson::Cl { action: PeerAction::Unban, target, .. } => {
-            writeln!(stdout, "OK CL unbanned {target}")?;
+            writeln!(stdout, "OK CL unbanned {target}").context("failed to write p2p output")?;
         }
         PeerActionJson::ClBulk { succeeded, failed, results, .. } => {
-            writeln!(stdout, "OK CL unbanned {succeeded} banned peer(s)")?;
+            writeln!(stdout, "OK CL unbanned {succeeded} banned peer(s)")
+                .context("failed to write p2p output")?;
             if *failed > 0 {
-                writeln!(stdout, "failed to unban {failed} banned peer(s)")?;
+                writeln!(stdout, "failed to unban {failed} banned peer(s)")
+                    .context("failed to write p2p output")?;
                 for result in results.iter().filter(|result| !result.ok) {
                     let error = result.error.as_deref().unwrap_or("unknown error");
-                    writeln!(stdout, "  {}: {error}", result.target)?;
+                    writeln!(stdout, "  {}: {error}", result.target)
+                        .context("failed to write p2p output")?;
                 }
             }
         }
         PeerActionJson::El { action, .. } | PeerActionJson::Cl { action, .. } => {
-            bail!("unsupported peer action for pretty output: {action:?}");
+            return Err(
+                P2pCommandError::UnsupportedPrettyAction { action: format!("{action:?}") }.into()
+            );
         }
     }
     Ok(())
@@ -762,12 +811,14 @@ fn unavailable_cl_peer_stats() -> String {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::Address;
+    use basectl_cli::{MissingConsensusRpcError, P2pCommandError, P2pTargetError};
     use serde_json::json;
     use url::Url;
 
     use super::{
         AddTarget, PeerAction, PeerActionJson, PeerBulkActionResultJson, RemoveTarget,
-        parse_add_target, parse_cl_peer_id, parse_remove_target, resolve_cl_rpc,
+        fail_unban_all_if_partial, parse_add_target, parse_cl_peer_id, parse_remove_target,
+        resolve_cl_rpc,
     };
 
     const VALID_ENODE: &str = "enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@127.0.0.1:30304?discport=30301";
@@ -816,7 +867,13 @@ mod tests {
     fn resolve_cl_rpc_errors_without_config() {
         let config = test_config(None);
 
-        assert!(resolve_cl_rpc(&config, None, "p2p info").is_err());
+        assert!(matches!(
+            resolve_cl_rpc(&config, None, "p2p info").unwrap_err(),
+            MissingConsensusRpcError::Missing {
+                config_name,
+                command_name,
+            } if config_name == "devnet" && command_name == "p2p info"
+        ));
     }
 
     #[test]
@@ -839,7 +896,10 @@ mod tests {
 
     #[test]
     fn parse_add_target_rejects_garbage() {
-        assert!(parse_add_target("not-a-peer").is_err());
+        assert!(matches!(
+            parse_add_target("not-a-peer").unwrap_err(),
+            P2pTargetError::InvalidBootnode { target, .. } if target == "not-a-peer"
+        ));
     }
 
     #[test]
@@ -857,9 +917,11 @@ mod tests {
         let err = parse_add_target("/ip4/127.0.0.1/tcp/9000")
             .expect_err("multiaddr without peer ID should be rejected");
 
-        assert!(
-            err.to_string().contains("multiaddr target must include a `/p2p/<peer-id>` component")
-        );
+        assert!(matches!(
+            err,
+            P2pTargetError::MultiaddrMissingPeerId { target }
+                if target == "/ip4/127.0.0.1/tcp/9000"
+        ));
     }
 
     #[test]
@@ -882,24 +944,38 @@ mod tests {
 
     #[test]
     fn parse_remove_target_rejects_enr() {
-        assert!(parse_remove_target(VALID_ENR).is_err());
+        assert!(matches!(
+            parse_remove_target(VALID_ENR).unwrap_err(),
+            P2pTargetError::RemoveEnrTarget { target } if target == VALID_ENR
+        ));
     }
 
     #[test]
     fn parse_remove_target_rejects_multiaddr() {
-        assert!(parse_remove_target("/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmExample").is_err());
+        assert!(matches!(
+            parse_remove_target("/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmExample").unwrap_err(),
+            P2pTargetError::RemoveClTargetNotBarePeerId { .. }
+        ));
     }
 
     #[test]
     fn parse_remove_target_rejects_url_like_target() {
-        assert!(parse_remove_target("https://example.com").is_err());
+        assert!(matches!(
+            parse_remove_target("https://example.com").unwrap_err(),
+            P2pTargetError::RemoveClTargetNotBarePeerId { target }
+                if target == "https://example.com"
+        ));
     }
 
     #[test]
     fn parse_remove_target_rejects_obviously_short_peer_id() {
         let err = parse_remove_target("hello").expect_err("short peer ID should be rejected");
 
-        assert!(err.to_string().contains("looks too short to be a valid libp2p peer ID"));
+        assert!(matches!(
+            err,
+            P2pTargetError::ClPeerIdTooShort { target, min_len }
+                if target == "hello" && min_len == super::MIN_LIBP2P_PEER_ID_LEN
+        ));
     }
 
     #[test]
@@ -922,6 +998,15 @@ mod tests {
         ] {
             assert!(parse_cl_peer_id(target).is_err(), "target should be rejected: {target}");
         }
+    }
+
+    #[test]
+    fn unban_all_partial_failure_is_typed() {
+        assert!(fail_unban_all_if_partial(0).is_ok());
+        assert!(matches!(
+            fail_unban_all_if_partial(2).unwrap_err(),
+            P2pCommandError::UnbanAllPartialFailure { failed: 2 }
+        ));
     }
 
     #[test]

--- a/bin/basectl/src/sequencer.rs
+++ b/bin/basectl/src/sequencer.rs
@@ -22,7 +22,9 @@ use url::Url;
 use crate::{
     cli::{SequencerCommands, SequencerNodeActionArgs, SequencerStartArgs, SequencerStatusArgs},
     confirm::confirm_or_abort,
-    helpers::{CommandOutcome, fmt_bool, fmt_u32, fmt_u64},
+    helpers::{
+        CommandOutcome, find_conductor_node, fmt_bool, fmt_u32, fmt_u64, resolve_conductor_source,
+    },
 };
 
 // Allow two full `admin_sequencerActive` polls plus the stabilization sleep,
@@ -37,7 +39,8 @@ pub(crate) async fn run(
     conductor_rpc: Option<Url>,
     command: SequencerCommands,
 ) -> Result<CommandOutcome> {
-    let source = resolve_source(&config, conductor_rpc)?;
+    let source =
+        resolve_conductor_source(&config, conductor_rpc).map_err(SequencerCommandError::from)?;
     match command {
         SequencerCommands::Status(args) => run_status(config, source, args).await,
         SequencerCommands::Start(args) => run_start(config, source, args).await,
@@ -90,7 +93,8 @@ async fn run_start(
     let snapshot = ConductorControl::snapshot(source)
         .await
         .context("failed to fetch sequencer status snapshot")?;
-    let node = find_node(&snapshot.nodes, &args.node)?;
+    let node =
+        find_conductor_node(&snapshot.nodes, &args.node).map_err(SequencerCommandError::from)?;
     let status = snapshot_node_status(&snapshot, &node.name);
     debug!(
         node = %node.name,
@@ -194,7 +198,8 @@ async fn run_stop(
     let snapshot = ConductorControl::snapshot(source)
         .await
         .context("failed to fetch sequencer status snapshot")?;
-    let node = find_node(&snapshot.nodes, &args.node)?;
+    let node =
+        find_conductor_node(&snapshot.nodes, &args.node).map_err(SequencerCommandError::from)?;
     let status = snapshot_node_status(&snapshot, &node.name);
     debug!(
         node = %node.name,
@@ -245,25 +250,6 @@ async fn run_stop(
     );
     print_action(&SequencerActionJson::stop(&config.name, node, captured_head, message), args.json)
         .context("failed to write sequencer output")
-}
-
-fn resolve_source(
-    config: &MonitoringConfig,
-    conductor_rpc: Option<Url>,
-) -> Result<ConductorSource, SequencerCommandError> {
-    config
-        .conductor_source(conductor_rpc)
-        .ok_or_else(|| SequencerCommandError::MissingSource { config_name: config.name.clone() })
-}
-
-fn find_node<'a>(
-    nodes: &'a [ConductorNodeConfig],
-    name: &str,
-) -> Result<&'a ConductorNodeConfig, SequencerCommandError> {
-    nodes.iter().find(|node| node.name == name).ok_or_else(|| SequencerCommandError::MissingNode {
-        requested_node: name.to_string(),
-        available_nodes: nodes.iter().map(|node| node.name.clone()).collect(),
-    })
 }
 
 fn resolve_start_hash(
@@ -444,9 +430,7 @@ where
         match timeout(remaining, fetch()).await {
             Ok(Ok(is_active)) => {
                 last_observed = Some(is_active);
-                if last_error.is_some() {
-                    last_error = None;
-                }
+                let _ = last_error.take();
                 let next_matching_observations =
                     if is_active == expected_active { matching_observations + 1 } else { 0 };
                 debug!(
@@ -680,7 +664,8 @@ impl SequencerStatusJson {
         selected_node: Option<&str>,
     ) -> Result<Self, SequencerCommandError> {
         if let Some(selected_node) = selected_node {
-            find_node(&snapshot.nodes, selected_node)?;
+            find_conductor_node(&snapshot.nodes, selected_node)
+                .map_err(SequencerCommandError::from)?;
         }
 
         let nodes = snapshot
@@ -826,8 +811,9 @@ mod tests {
         OBSERVATION_TIMEOUT, POLL_INTERVAL, REQUIRED_OBSERVATIONS, SequencerAction,
         SequencerActionJson, SequencerStatusJson, UnsafeHeadSource, ensure_leader_target,
         ensure_start_allowed, ensure_start_request_matches_observed_head, ensure_stop_allowed,
-        find_node, parse_unsafe_head, resolve_start_hash, wait_for_expected_state_with_fetch,
+        parse_unsafe_head, resolve_start_hash, wait_for_expected_state_with_fetch,
     };
+    use crate::helpers::find_conductor_node;
 
     fn node(name: &str) -> ConductorNodeConfig {
         ConductorNodeConfig {
@@ -1195,7 +1181,9 @@ mod tests {
     fn find_node_reports_missing_name() {
         let nodes = vec![node("op-conductor-0")];
 
-        let err = find_node(&nodes, "op-conductor-1").expect_err("missing node should error");
+        let err = find_conductor_node(&nodes, "op-conductor-1")
+            .map_err(SequencerCommandError::from)
+            .expect_err("missing node should error");
 
         assert!(matches!(
             err,

--- a/bin/basectl/src/sequencer.rs
+++ b/bin/basectl/src/sequencer.rs
@@ -1060,7 +1060,7 @@ mod tests {
             Duration::from_millis(5),
             || async {
                 tokio::time::sleep(Duration::from_millis(200)).await;
-                Ok(false)
+                Ok::<bool, anyhow::Error>(false)
             },
         )
         .await

--- a/bin/basectl/src/sequencer.rs
+++ b/bin/basectl/src/sequencer.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use basectl_cli::{
     ConductorClusterSnapshot, ConductorControl, ConductorNodeConfig, ConductorNodeStatus,
     ConductorSource, JsonOutput, KeyValueTable, MonitoringConfig, SequencerCommandError,
-    fetch_sequencer_active, start_sequencer, stop_sequencer,
+    StateConvergenceTimeoutError, fetch_sequencer_active, start_sequencer, stop_sequencer,
 };
 use serde::Serialize;
 use tokio::time::{Instant, sleep, timeout};
@@ -567,16 +567,16 @@ impl SequencerAction {
         last_observed: Option<bool>,
         last_error: Option<String>,
     ) -> SequencerCommandError {
-        SequencerCommandError::StateConvergenceTimeout {
+        SequencerCommandError::StateConvergenceTimeout(Box::new(StateConvergenceTimeoutError {
             action: self.infinitive(),
-            node: node.name.clone().into_boxed_str(),
-            cl_rpc: node.cl_rpc.to_string().into_boxed_str(),
+            node: node.name.clone(),
+            cl_rpc: node.cl_rpc.to_string(),
             unsafe_head,
             expected_active: self.expected_active(),
             timeout: observation_timeout,
             last_observed,
-            last_error: last_error.map(String::into_boxed_str),
-        }
+            last_error,
+        }))
     }
 }
 
@@ -1080,20 +1080,15 @@ mod tests {
         assert!(start.elapsed() < Duration::from_millis(120));
         assert!(matches!(
             err,
-            SequencerCommandError::StateConvergenceTimeout {
-                action,
-                node,
-                unsafe_head: Some(unsafe_head),
-                expected_active: true,
-                timeout,
-                last_observed: None,
-                last_error: Some(last_error),
-                ..
-            } if action == "start"
-                && node.as_ref() == "op-conductor-0"
-                && unsafe_head == B256::with_last_byte(1)
-                && timeout == Duration::from_millis(40)
-                && last_error.as_ref() == "timed out waiting for admin_sequencerActive"
+            SequencerCommandError::StateConvergenceTimeout(error)
+                if error.action == "start"
+                && error.node == "op-conductor-0"
+                && error.unsafe_head == Some(B256::with_last_byte(1))
+                && error.expected_active
+                && error.timeout == Duration::from_millis(40)
+                && error.last_observed.is_none()
+                && error.last_error.as_deref()
+                    == Some("timed out waiting for admin_sequencerActive")
         ));
     }
 

--- a/bin/basectl/src/sequencer.rs
+++ b/bin/basectl/src/sequencer.rs
@@ -33,6 +33,12 @@ const OBSERVATION_TIMEOUT: Duration = Duration::from_secs(12);
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 const REQUIRED_OBSERVATIONS: usize = 2;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LeadershipStatus {
+    ConfirmedLeader,
+    Unknown,
+}
+
 /// Runs the `basectl sequencer` command group.
 pub(crate) async fn run(
     config: MonitoringConfig,
@@ -103,20 +109,19 @@ async fn run_start(
         sequencer_active = ?status.and_then(|status| status.sequencer_active),
         "resolved sequencer start target"
     );
-    if let Err(error) = ensure_start_allowed(&snapshot, node, status) {
-        warn!(
-            error = %error,
-            node = %node.name,
-            cl_rpc = %node.cl_rpc,
-            "sequencer start preflight failed"
-        );
-        return Err(error.into());
-    }
-    // No node currently reports itself as leader, and the target is not known
-    // to be a follower, so defer the final leader check to the RPC.
-    if snapshot.statuses.iter().all(|status| status.is_leader != Some(true))
-        && status.and_then(|status| status.is_leader).is_none()
-    {
+    let leadership_status = match ensure_start_allowed(&snapshot, node, status) {
+        Ok(leadership_status) => leadership_status,
+        Err(error) => {
+            warn!(
+                error = %error,
+                node = %node.name,
+                cl_rpc = %node.cl_rpc,
+                "sequencer start preflight failed"
+            );
+            return Err(error.into());
+        }
+    };
+    if matches!(leadership_status, LeadershipStatus::Unknown) {
         warn!(
             node = %node.name,
             cl_rpc = %node.cl_rpc,
@@ -282,7 +287,7 @@ fn ensure_start_allowed(
     snapshot: &ConductorClusterSnapshot,
     node: &ConductorNodeConfig,
     status: Option<&ConductorNodeStatus>,
-) -> Result<(), SequencerCommandError> {
+) -> Result<LeadershipStatus, SequencerCommandError> {
     if status.and_then(|status| status.sequencer_active) == Some(true) {
         return Err(SequencerCommandError::AlreadyActive { node: node.name.clone() });
     }
@@ -304,7 +309,7 @@ fn ensure_leader_target(
     node: &ConductorNodeConfig,
     status: Option<&ConductorNodeStatus>,
     action: SequencerAction,
-) -> Result<(), SequencerCommandError> {
+) -> Result<LeadershipStatus, SequencerCommandError> {
     let leader = snapshot
         .statuses
         .iter()
@@ -312,7 +317,7 @@ fn ensure_leader_target(
         .map(|status| status.name.as_str());
     if let Some(leader) = leader {
         if leader == node.name {
-            return Ok(());
+            return Ok(LeadershipStatus::ConfirmedLeader);
         }
         return Err(SequencerCommandError::NotCurrentLeader {
             requested_node: node.name.clone(),
@@ -326,7 +331,7 @@ fn ensure_leader_target(
             action: action.infinitive().to_string(),
         });
     }
-    Ok(())
+    Ok(LeadershipStatus::Unknown)
 }
 
 fn ensure_start_request_matches_observed_head(
@@ -808,10 +813,11 @@ mod tests {
     use url::Url;
 
     use super::{
-        OBSERVATION_TIMEOUT, POLL_INTERVAL, REQUIRED_OBSERVATIONS, SequencerAction,
-        SequencerActionJson, SequencerStatusJson, UnsafeHeadSource, ensure_leader_target,
-        ensure_start_allowed, ensure_start_request_matches_observed_head, ensure_stop_allowed,
-        parse_unsafe_head, resolve_start_hash, wait_for_expected_state_with_fetch,
+        LeadershipStatus, OBSERVATION_TIMEOUT, POLL_INTERVAL, REQUIRED_OBSERVATIONS,
+        SequencerAction, SequencerActionJson, SequencerStatusJson, UnsafeHeadSource,
+        ensure_leader_target, ensure_start_allowed, ensure_start_request_matches_observed_head,
+        ensure_stop_allowed, parse_unsafe_head, resolve_start_hash,
+        wait_for_expected_state_with_fetch,
     };
     use crate::helpers::find_conductor_node;
 
@@ -1009,6 +1015,25 @@ mod tests {
                 && current_leader == "op-conductor-0"
                 && action == "start"
         ));
+    }
+
+    #[test]
+    fn start_allows_unknown_leadership_with_status_signal() {
+        let snapshot = ConductorClusterSnapshot {
+            nodes: vec![node("op-conductor-0")],
+            statuses: vec![status("op-conductor-0", false, false)],
+            membership: None,
+            membership_error: None,
+            discovered: false,
+        };
+        let mut unknown_status = snapshot.statuses[0].clone();
+        unknown_status.is_leader = None;
+
+        let leadership_status =
+            ensure_start_allowed(&snapshot, &snapshot.nodes[0], Some(&unknown_status))
+                .expect("unknown leadership should defer to server-side RPC");
+
+        assert_eq!(leadership_status, LeadershipStatus::Unknown);
     }
 
     #[test]

--- a/bin/basectl/src/sequencer.rs
+++ b/bin/basectl/src/sequencer.rs
@@ -8,11 +8,11 @@ use std::{
 };
 
 use alloy_primitives::B256;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result};
 use basectl_cli::{
     ConductorClusterSnapshot, ConductorControl, ConductorNodeConfig, ConductorNodeStatus,
-    ConductorSource, JsonOutput, KeyValueTable, MonitoringConfig, fetch_sequencer_active,
-    start_sequencer, stop_sequencer,
+    ConductorSource, JsonOutput, KeyValueTable, MonitoringConfig, SequencerCommandError,
+    fetch_sequencer_active, start_sequencer, stop_sequencer,
 };
 use serde::Serialize;
 use tokio::time::{Instant, sleep, timeout};
@@ -22,7 +22,7 @@ use url::Url;
 use crate::{
     cli::{SequencerCommands, SequencerNodeActionArgs, SequencerStartArgs, SequencerStatusArgs},
     confirm::confirm_or_abort,
-    helpers::{CommandOutcome, find_node, fmt_bool, fmt_u32, fmt_u64, resolve_source},
+    helpers::{CommandOutcome, fmt_bool, fmt_u32, fmt_u64},
 };
 
 // Allow two full `admin_sequencerActive` polls plus the stabilization sleep,
@@ -32,17 +32,12 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 const REQUIRED_OBSERVATIONS: usize = 2;
 
 /// Runs the `basectl sequencer` command group.
-///
-/// Mirrors [`crate::conductor::run`] by returning a [`CommandOutcome`] so `main`
-/// can treat sibling command groups uniformly. Sequencer actions target a single
-/// node and surface failures as `Err`, so the success paths always report
-/// [`CommandOutcome::Success`].
 pub(crate) async fn run(
     config: MonitoringConfig,
     conductor_rpc: Option<Url>,
     command: SequencerCommands,
 ) -> Result<CommandOutcome> {
-    let source = resolve_source(&config, conductor_rpc, "sequencer")?;
+    let source = resolve_source(&config, conductor_rpc)?;
     match command {
         SequencerCommands::Status(args) => run_status(config, source, args).await,
         SequencerCommands::Start(args) => run_start(config, source, args).await,
@@ -61,7 +56,9 @@ async fn run_status(
         selected_node = %args.node.as_deref().unwrap_or("all"),
         "fetching sequencer status"
     );
-    let snapshot = ConductorControl::snapshot(source).await?;
+    let snapshot = ConductorControl::snapshot(source)
+        .await
+        .context("failed to fetch sequencer status snapshot")?;
     let status = SequencerStatusJson::from_snapshot(&config.name, &snapshot, args.node.as_deref())?;
     debug!(
         network = %config.name,
@@ -72,9 +69,9 @@ async fn run_status(
         "sequencer status snapshot ready"
     );
     if args.json {
-        JsonOutput::print(&status)?;
+        JsonOutput::print(&status).context("failed to write sequencer output")?;
     } else {
-        print_status_pretty(&status)?;
+        print_status_pretty(&status).context("failed to write sequencer output")?;
     }
     Ok(())
 }
@@ -90,8 +87,10 @@ async fn run_start(
         requested_unsafe_head = ?args.unsafe_head,
         "running sequencer start command"
     );
-    let snapshot = ConductorControl::snapshot(source).await?;
-    let node = find_node(&snapshot.nodes, &args.node, "sequencer")?;
+    let snapshot = ConductorControl::snapshot(source)
+        .await
+        .context("failed to fetch sequencer status snapshot")?;
+    let node = find_node(&snapshot.nodes, &args.node)?;
     let status = snapshot_node_status(&snapshot, &node.name);
     debug!(
         node = %node.name,
@@ -100,21 +99,20 @@ async fn run_start(
         sequencer_active = ?status.and_then(|status| status.sequencer_active),
         "resolved sequencer start target"
     );
-    let leader_check = match ensure_start_allowed(&snapshot, node, status) {
-        Ok(outcome) => outcome,
-        Err(error) => {
-            warn!(
-                error = %error,
-                node = %node.name,
-                cl_rpc = %node.cl_rpc,
-                "sequencer start preflight failed"
-            );
-            return Err(error);
-        }
-    };
+    if let Err(error) = ensure_start_allowed(&snapshot, node, status) {
+        warn!(
+            error = %error,
+            node = %node.name,
+            cl_rpc = %node.cl_rpc,
+            "sequencer start preflight failed"
+        );
+        return Err(error.into());
+    }
     // No node currently reports itself as leader, and the target is not known
     // to be a follower, so defer the final leader check to the RPC.
-    if leader_check == LeaderCheckOutcome::LeadershipUnknown {
+    if snapshot.statuses.iter().all(|status| status.is_leader != Some(true))
+        && status.and_then(|status| status.is_leader).is_none()
+    {
         warn!(
             node = %node.name,
             cl_rpc = %node.cl_rpc,
@@ -131,7 +129,7 @@ async fn run_start(
                     cl_rpc = %node.cl_rpc,
                     "failed to resolve sequencer start unsafe head"
                 );
-                return Err(error);
+                return Err(error.into());
             }
         };
     if let Err(error) =
@@ -145,11 +143,11 @@ async fn run_start(
             unsafe_head_source = %unsafe_head_source.as_str(),
             "sequencer start unsafe head validation failed"
         );
-        return Err(error);
+        return Err(error.into());
     }
     let prompt =
         format!("Start sequencer on {} ({}) at {}? [y/N] ", node.name, node.cl_rpc, unsafe_head);
-    if !confirm_or_abort(&prompt, args.yes)? {
+    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
         debug!(node = %node.name, cl_rpc = %node.cl_rpc, "sequencer start confirmation declined");
         return Ok(());
     }
@@ -162,9 +160,9 @@ async fn run_start(
         unsafe_head_source = %unsafe_head_source.as_str(),
         "calling admin_startSequencer"
     );
-    start_sequencer(&node.cl_rpc, unsafe_head)
-        .await
-        .with_context(|| format!("starting sequencer on {} via {}", node.name, node.cl_rpc))?;
+    start_sequencer(&node.cl_rpc, unsafe_head).await.with_context(|| {
+        format!("failed to start sequencer on {} ({}) at {}", node.name, node.cl_rpc, unsafe_head)
+    })?;
     wait_for_expected_state(node, SequencerAction::Start, Some(unsafe_head)).await?;
     info!(
         network = %config.name,
@@ -180,6 +178,7 @@ async fn run_start(
         &SequencerActionJson::start(&config.name, node, unsafe_head, unsafe_head_source, message),
         args.json,
     )
+    .context("failed to write sequencer output")
 }
 
 async fn run_stop(
@@ -192,8 +191,10 @@ async fn run_stop(
         requested_node = %args.node,
         "running sequencer stop command"
     );
-    let snapshot = ConductorControl::snapshot(source).await?;
-    let node = find_node(&snapshot.nodes, &args.node, "sequencer")?;
+    let snapshot = ConductorControl::snapshot(source)
+        .await
+        .context("failed to fetch sequencer status snapshot")?;
+    let node = find_node(&snapshot.nodes, &args.node)?;
     let status = snapshot_node_status(&snapshot, &node.name);
     debug!(
         node = %node.name,
@@ -209,10 +210,10 @@ async fn run_stop(
             cl_rpc = %node.cl_rpc,
             "sequencer stop preflight failed"
         );
-        return Err(error);
+        return Err(error.into());
     }
     let prompt = format!("Stop sequencer on {} ({})? [y/N] ", node.name, node.cl_rpc);
-    if !confirm_or_abort(&prompt, args.yes)? {
+    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
         debug!(node = %node.name, cl_rpc = %node.cl_rpc, "sequencer stop confirmation declined");
         return Ok(());
     }
@@ -225,9 +226,9 @@ async fn run_stop(
     );
     let unsafe_head = stop_sequencer(&node.cl_rpc)
         .await
-        .with_context(|| format!("stopping sequencer on {} via {}", node.name, node.cl_rpc))?;
-    // A zero head means the sequencer stopped but the captured head is
-    // unavailable; treat it as absent rather than a valid restart point.
+        .with_context(|| format!("failed to stop sequencer on {} ({})", node.name, node.cl_rpc))?;
+    // A zero head means the sequencer stopped but the captured head is unavailable,
+    // so do not surface it as a valid restart point.
     let captured_head = (unsafe_head != B256::ZERO).then_some(unsafe_head);
     wait_for_expected_state(node, SequencerAction::Stop, captured_head).await?;
     info!(
@@ -243,24 +244,41 @@ async fn run_stop(
         |unsafe_head| format!("sequencer stopped on {} at {unsafe_head}", node.name),
     );
     print_action(&SequencerActionJson::stop(&config.name, node, captured_head, message), args.json)
+        .context("failed to write sequencer output")
+}
+
+fn resolve_source(
+    config: &MonitoringConfig,
+    conductor_rpc: Option<Url>,
+) -> Result<ConductorSource, SequencerCommandError> {
+    config
+        .conductor_source(conductor_rpc)
+        .ok_or_else(|| SequencerCommandError::MissingSource { config_name: config.name.clone() })
+}
+
+fn find_node<'a>(
+    nodes: &'a [ConductorNodeConfig],
+    name: &str,
+) -> Result<&'a ConductorNodeConfig, SequencerCommandError> {
+    nodes.iter().find(|node| node.name == name).ok_or_else(|| SequencerCommandError::MissingNode {
+        requested_node: name.to_string(),
+        available_nodes: nodes.iter().map(|node| node.name.clone()).collect(),
+    })
 }
 
 fn resolve_start_hash(
     snapshot: &ConductorClusterSnapshot,
     node: &ConductorNodeConfig,
     unsafe_head: Option<&str>,
-) -> Result<(B256, UnsafeHeadSource)> {
+) -> Result<(B256, UnsafeHeadSource), SequencerCommandError> {
     match unsafe_head {
         Some(unsafe_head) => Ok((parse_unsafe_head(unsafe_head)?, UnsafeHeadSource::Explicit)),
         None => {
             let hash = snapshot_node_status(snapshot, &node.name)
                 .and_then(|status| status.unsafe_l2_hash)
                 .filter(|hash| *hash != B256::ZERO)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "could not determine unsafe head for {}; pass an explicit 32-byte hash or restore CL reachability",
-                        node.name
-                    )
+                .ok_or_else(|| SequencerCommandError::MissingUnsafeHead {
+                    node: node.name.clone(),
                 })?;
             Ok((hash, UnsafeHeadSource::Observed))
         }
@@ -274,27 +292,13 @@ fn snapshot_node_status<'a>(
     snapshot.statuses.iter().find(|status| status.name == name)
 }
 
-/// Outcome of a successful conductor-leader preflight check.
-///
-/// Distinguishes a positively confirmed leader from the case where no node
-/// reports leadership yet, so callers can decide whether to warn about deferred
-/// validation without re-deriving leadership state from the snapshot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LeaderCheckOutcome {
-    /// A node reported `is_leader == Some(true)` and it matches the target.
-    ConfirmedLeader,
-    /// No node reports leadership and the target is not a known follower, so the
-    /// final leader check is deferred to the server-side RPC.
-    LeadershipUnknown,
-}
-
 fn ensure_start_allowed(
     snapshot: &ConductorClusterSnapshot,
     node: &ConductorNodeConfig,
     status: Option<&ConductorNodeStatus>,
-) -> Result<LeaderCheckOutcome> {
+) -> Result<(), SequencerCommandError> {
     if status.and_then(|status| status.sequencer_active) == Some(true) {
-        bail!("sequencer already active on {}; stop it before starting again", node.name,);
+        return Err(SequencerCommandError::AlreadyActive { node: node.name.clone() });
     }
     ensure_leader_target(snapshot, node, status, SequencerAction::Start)
 }
@@ -302,9 +306,9 @@ fn ensure_start_allowed(
 fn ensure_stop_allowed(
     node: &ConductorNodeConfig,
     status: Option<&ConductorNodeStatus>,
-) -> Result<()> {
+) -> Result<(), SequencerCommandError> {
     if status.and_then(|status| status.sequencer_active) == Some(false) {
-        bail!("sequencer already stopped on {}", node.name);
+        return Err(SequencerCommandError::AlreadyStopped { node: node.name.clone() });
     }
     Ok(())
 }
@@ -314,7 +318,7 @@ fn ensure_leader_target(
     node: &ConductorNodeConfig,
     status: Option<&ConductorNodeStatus>,
     action: SequencerAction,
-) -> Result<LeaderCheckOutcome> {
+) -> Result<(), SequencerCommandError> {
     let leader = snapshot
         .statuses
         .iter()
@@ -322,29 +326,28 @@ fn ensure_leader_target(
         .map(|status| status.name.as_str());
     if let Some(leader) = leader {
         if leader == node.name {
-            return Ok(LeaderCheckOutcome::ConfirmedLeader);
+            return Ok(());
         }
-        bail!(
-            "Node is not the conductor leader. Current leader: {leader}. `basectl sequencer {}` must target the leader instead of {}.",
-            action.infinitive(),
-            node.name,
-        );
+        return Err(SequencerCommandError::NotCurrentLeader {
+            requested_node: node.name.clone(),
+            current_leader: leader.to_string(),
+            action: action.infinitive().to_string(),
+        });
     }
     if status.and_then(|status| status.is_leader) == Some(false) {
-        bail!(
-            "Node is not the conductor leader. `basectl sequencer {}` must target the current leader instead of {}.",
-            action.infinitive(),
-            node.name,
-        );
+        return Err(SequencerCommandError::NotLeader {
+            requested_node: node.name.clone(),
+            action: action.infinitive().to_string(),
+        });
     }
-    Ok(LeaderCheckOutcome::LeadershipUnknown)
+    Ok(())
 }
 
 fn ensure_start_request_matches_observed_head(
     status: Option<&ConductorNodeStatus>,
     unsafe_head: B256,
     unsafe_head_source: UnsafeHeadSource,
-) -> Result<()> {
+) -> Result<(), SequencerCommandError> {
     if !matches!(unsafe_head_source, UnsafeHeadSource::Explicit) {
         return Ok(());
     }
@@ -353,32 +356,37 @@ fn ensure_start_request_matches_observed_head(
         return Ok(());
     };
     if observed_head == B256::ZERO {
-        bail!("no prestate: engine unsafe head is uninitialized, cannot safely start sequencer");
+        return Err(SequencerCommandError::UninitializedUnsafeHead);
     }
     if observed_head != unsafe_head {
-        bail!(
-            "block hash mismatch: engine unsafe head is {observed_head}, caller requested {unsafe_head}"
-        );
+        return Err(SequencerCommandError::UnsafeHeadMismatch {
+            observed_hash: observed_head,
+            requested_hash: unsafe_head,
+        });
     }
     Ok(())
 }
 
-fn parse_unsafe_head(raw: &str) -> Result<B256> {
+fn parse_unsafe_head(raw: &str) -> Result<B256, SequencerCommandError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        bail!("unsafe head hash cannot be empty");
+        return Err(SequencerCommandError::EmptyUnsafeHead);
     }
 
-    let hash = if trimmed.starts_with("0x") || trimmed.starts_with("0X") {
-        B256::from_str(trimmed)
+    let normalized = if trimmed.starts_with("0x") || trimmed.starts_with("0X") {
+        trimmed.to_string()
     } else if trimmed.len() == 64 && trimmed.chars().all(|char| char.is_ascii_hexdigit()) {
-        B256::from_str(&format!("0x{trimmed}"))
+        format!("0x{trimmed}")
     } else {
-        B256::from_str(trimmed)
-    }
-    .with_context(|| format!("parsing unsafe head hash `{trimmed}`"))?;
+        trimmed.to_string()
+    };
+    let hash =
+        B256::from_str(&normalized).map_err(|error| SequencerCommandError::InvalidUnsafeHead {
+            raw: trimmed.to_string(),
+            message: error.to_string(),
+        })?;
     if hash == B256::ZERO {
-        bail!("unsafe head hash must not be zero");
+        return Err(SequencerCommandError::ZeroUnsafeHead { requested_hash: hash });
     }
     Ok(hash)
 }
@@ -387,7 +395,7 @@ async fn wait_for_expected_state(
     node: &ConductorNodeConfig,
     action: SequencerAction,
     unsafe_head: Option<B256>,
-) -> Result<()> {
+) -> Result<(), SequencerCommandError> {
     wait_for_expected_state_with_fetch(
         node,
         action,
@@ -406,7 +414,7 @@ async fn wait_for_expected_state_with_fetch<F, Fut>(
     observation_timeout: Duration,
     poll_interval: Duration,
     mut fetch: F,
-) -> Result<()>
+) -> Result<(), SequencerCommandError>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<bool>>,
@@ -436,7 +444,9 @@ where
         match timeout(remaining, fetch()).await {
             Ok(Ok(is_active)) => {
                 last_observed = Some(is_active);
-                last_error.take();
+                if last_error.is_some() {
+                    last_error = None;
+                }
                 let next_matching_observations =
                     if is_active == expected_active { matching_observations + 1 } else { 0 };
                 debug!(
@@ -501,13 +511,7 @@ where
         last_error = ?last_error,
         "sequencer state did not converge after successful RPC"
     );
-    bail!(action.timeout_message(
-        node,
-        unsafe_head,
-        observation_timeout,
-        last_observed,
-        last_error.as_deref(),
-    ))
+    Err(action.timeout_error(node, unsafe_head, observation_timeout, last_observed, last_error))
 }
 
 fn print_status_pretty(status: &SequencerStatusJson) -> Result<()> {
@@ -566,35 +570,24 @@ impl SequencerAction {
         }
     }
 
-    fn timeout_message(
+    fn timeout_error(
         self,
         node: &ConductorNodeConfig,
         unsafe_head: Option<B256>,
         observation_timeout: Duration,
         last_observed: Option<bool>,
-        last_error: Option<&str>,
-    ) -> String {
-        let unsafe_head_suffix =
-            unsafe_head.map_or_else(String::new, |unsafe_head| format!(" at {unsafe_head}"));
-        let observed_suffix = match (last_observed, last_error) {
-            (Some(observed), Some(error)) => {
-                format!(" (last observed `sequencer_active={observed}`; last poll error: {error})")
-            }
-            (Some(observed), None) => format!(" (last observed `sequencer_active={observed}`)"),
-            (None, Some(error)) => format!(" (last poll error: {error})"),
-            (None, None) => String::new(),
-        };
-
-        format!(
-            "{} RPC succeeded on {} ({}){}, but `sequencer_active={}` was not observed within {:?}{}",
-            self.infinitive(),
-            node.name,
-            node.cl_rpc,
-            unsafe_head_suffix,
-            self.expected_active(),
-            observation_timeout,
-            observed_suffix,
-        )
+        last_error: Option<String>,
+    ) -> SequencerCommandError {
+        SequencerCommandError::StateConvergenceTimeout {
+            action: self.infinitive(),
+            node: node.name.clone().into_boxed_str(),
+            cl_rpc: node.cl_rpc.to_string().into_boxed_str(),
+            unsafe_head,
+            expected_active: self.expected_active(),
+            timeout: observation_timeout,
+            last_observed,
+            last_error: last_error.map(String::into_boxed_str),
+        }
     }
 }
 
@@ -685,9 +678,9 @@ impl SequencerStatusJson {
         network: &str,
         snapshot: &ConductorClusterSnapshot,
         selected_node: Option<&str>,
-    ) -> Result<Self> {
+    ) -> Result<Self, SequencerCommandError> {
         if let Some(selected_node) = selected_node {
-            find_node(&snapshot.nodes, selected_node, "sequencer")?;
+            find_node(&snapshot.nodes, selected_node)?;
         }
 
         let nodes = snapshot
@@ -823,17 +816,17 @@ mod tests {
     use alloy_primitives::B256;
     use basectl_cli::{
         ConductorClusterSnapshot, ConductorNodeConfig, ConductorNodeStatus,
-        SEQUENCER_ACTIVE_RPC_TIMEOUT,
+        SEQUENCER_ACTIVE_RPC_TIMEOUT, SequencerCommandError,
     };
     use serde_json::json;
     use tokio::time::{Duration, Instant};
     use url::Url;
 
     use super::{
-        LeaderCheckOutcome, OBSERVATION_TIMEOUT, POLL_INTERVAL, REQUIRED_OBSERVATIONS,
-        SequencerAction, SequencerActionJson, SequencerStatusJson, UnsafeHeadSource,
-        ensure_leader_target, ensure_start_allowed, ensure_start_request_matches_observed_head,
-        ensure_stop_allowed, find_node, parse_unsafe_head, wait_for_expected_state_with_fetch,
+        OBSERVATION_TIMEOUT, POLL_INTERVAL, REQUIRED_OBSERVATIONS, SequencerAction,
+        SequencerActionJson, SequencerStatusJson, UnsafeHeadSource, ensure_leader_target,
+        ensure_start_allowed, ensure_start_request_matches_observed_head, ensure_stop_allowed,
+        find_node, parse_unsafe_head, resolve_start_hash, wait_for_expected_state_with_fetch,
     };
 
     fn node(name: &str) -> ConductorNodeConfig {
@@ -892,7 +885,12 @@ mod tests {
             parse_unsafe_head("0x0000000000000000000000000000000000000000000000000000000000000000")
                 .expect_err("zero hash should error");
 
-        assert!(err.to_string().contains("must not be zero"));
+        assert!(matches!(
+            err,
+            SequencerCommandError::ZeroUnsafeHead {
+                requested_hash,
+            } if requested_hash == B256::ZERO
+        ));
     }
 
     #[test]
@@ -904,10 +902,50 @@ mod tests {
         )
         .expect_err("mismatched explicit hash should error");
 
-        assert_eq!(
-            err.to_string(),
-            "block hash mismatch: engine unsafe head is 0x0000000000000000000000000000000000000000000000000000000000000001, caller requested 0x0000000000000000000000000000000000000000000000000000000000000009"
-        );
+        assert!(matches!(
+            err,
+            SequencerCommandError::UnsafeHeadMismatch {
+                observed_hash,
+                requested_hash,
+            } if observed_hash == B256::with_last_byte(1)
+                && requested_hash == B256::with_last_byte(9)
+        ));
+    }
+
+    #[test]
+    fn explicit_start_hash_rejects_uninitialized_observed_head() {
+        let mut observed = status("op-conductor-0", true, false);
+        observed.unsafe_l2_hash = Some(B256::ZERO);
+
+        let err = ensure_start_request_matches_observed_head(
+            Some(&observed),
+            B256::with_last_byte(9),
+            UnsafeHeadSource::Explicit,
+        )
+        .expect_err("zero observed hash should error");
+
+        assert!(matches!(err, SequencerCommandError::UninitializedUnsafeHead));
+    }
+
+    #[test]
+    fn resolve_start_hash_errors_when_observed_head_is_missing() {
+        let mut observed = status("op-conductor-0", true, false);
+        observed.unsafe_l2_hash = None;
+        let snapshot = ConductorClusterSnapshot {
+            nodes: vec![node("op-conductor-0")],
+            statuses: vec![observed],
+            membership: None,
+            membership_error: None,
+            discovered: false,
+        };
+
+        let err = resolve_start_hash(&snapshot, &snapshot.nodes[0], None)
+            .expect_err("missing observed hash should error");
+
+        assert!(matches!(
+            err,
+            SequencerCommandError::MissingUnsafeHead { node } if node == "op-conductor-0"
+        ));
     }
 
     #[test]
@@ -923,10 +961,10 @@ mod tests {
         let err = ensure_start_allowed(&snapshot, &snapshot.nodes[0], Some(&snapshot.statuses[0]))
             .expect_err("active node should reject start");
 
-        assert_eq!(
-            err.to_string(),
-            "sequencer already active on op-conductor-0; stop it before starting again"
-        );
+        assert!(matches!(
+            err,
+            SequencerCommandError::AlreadyActive { node } if node == "op-conductor-0"
+        ));
     }
 
     #[test]
@@ -950,10 +988,16 @@ mod tests {
         )
         .expect_err("follower target should error");
 
-        assert_eq!(
-            err.to_string(),
-            "Node is not the conductor leader. Current leader: op-conductor-0. `basectl sequencer start` must target the leader instead of op-conductor-1."
-        );
+        assert!(matches!(
+            err,
+            SequencerCommandError::NotCurrentLeader {
+                requested_node,
+                current_leader,
+                action,
+            } if requested_node == "op-conductor-1"
+                && current_leader == "op-conductor-0"
+                && action == "start"
+        ));
     }
 
     #[test]
@@ -969,43 +1013,16 @@ mod tests {
         let err = ensure_start_allowed(&snapshot, &snapshot.nodes[1], None)
             .expect_err("target should still reject when another leader is known");
 
-        assert_eq!(
-            err.to_string(),
-            "Node is not the conductor leader. Current leader: op-conductor-0. `basectl sequencer start` must target the leader instead of op-conductor-1."
-        );
-    }
-
-    #[test]
-    fn start_confirms_leader_when_target_reports_leadership() {
-        let snapshot = ConductorClusterSnapshot {
-            nodes: vec![node("op-conductor-0")],
-            statuses: vec![status("op-conductor-0", true, false)],
-            membership: None,
-            membership_error: None,
-            discovered: false,
-        };
-
-        let outcome =
-            ensure_start_allowed(&snapshot, &snapshot.nodes[0], Some(&snapshot.statuses[0]))
-                .expect("leader target should be allowed");
-
-        assert_eq!(outcome, LeaderCheckOutcome::ConfirmedLeader);
-    }
-
-    #[test]
-    fn start_reports_unknown_leadership_when_no_node_claims_leader() {
-        let snapshot = ConductorClusterSnapshot {
-            nodes: vec![node("op-conductor-0")],
-            statuses: Vec::new(),
-            membership: None,
-            membership_error: None,
-            discovered: false,
-        };
-
-        let outcome = ensure_start_allowed(&snapshot, &snapshot.nodes[0], None)
-            .expect("unknown leadership should defer to the server-side RPC");
-
-        assert_eq!(outcome, LeaderCheckOutcome::LeadershipUnknown);
+        assert!(matches!(
+            err,
+            SequencerCommandError::NotCurrentLeader {
+                requested_node,
+                current_leader,
+                action,
+            } if requested_node == "op-conductor-1"
+                && current_leader == "op-conductor-0"
+                && action == "start"
+        ));
     }
 
     #[test]
@@ -1024,7 +1041,10 @@ mod tests {
         )
         .expect_err("inactive node should reject stop");
 
-        assert_eq!(err.to_string(), "sequencer already stopped on op-conductor-0");
+        assert!(matches!(
+            err,
+            SequencerCommandError::AlreadyStopped { node } if node == "op-conductor-0"
+        ));
     }
 
     #[tokio::test]
@@ -1047,8 +1067,23 @@ mod tests {
         .expect_err("hung fetch should time out");
 
         assert!(start.elapsed() < Duration::from_millis(120));
-        assert!(err.to_string().contains("timed out waiting for admin_sequencerActive"));
-        assert!(err.to_string().contains("within 40ms"));
+        assert!(matches!(
+            err,
+            SequencerCommandError::StateConvergenceTimeout {
+                action,
+                node,
+                unsafe_head: Some(unsafe_head),
+                expected_active: true,
+                timeout,
+                last_observed: None,
+                last_error: Some(last_error),
+                ..
+            } if action == "start"
+                && node.as_ref() == "op-conductor-0"
+                && unsafe_head == B256::with_last_byte(1)
+                && timeout == Duration::from_millis(40)
+                && last_error.as_ref() == "timed out waiting for admin_sequencerActive"
+        ));
     }
 
     #[test]
@@ -1086,6 +1121,28 @@ mod tests {
                 "unsafeHead": "0x0000000000000000000000000000000000000000000000000000000000000009",
                 "unsafeHeadSource": "observed",
                 "message": "sequencer started on op-conductor-0 at 0x09",
+            })
+        );
+    }
+
+    #[test]
+    fn sequencer_stop_json_omits_missing_unsafe_head() {
+        let value = serde_json::to_value(SequencerActionJson::stop(
+            "devnet",
+            &node("op-conductor-0"),
+            None,
+            "sequencer stopped on op-conductor-0 (unsafe head unavailable)".to_string(),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "network": "devnet",
+                "action": "stop",
+                "node": "op-conductor-0",
+                "clRpc": "http://127.0.0.1:7545/",
+                "message": "sequencer stopped on op-conductor-0 (unsafe head unavailable)",
             })
         );
     }
@@ -1138,10 +1195,15 @@ mod tests {
     fn find_node_reports_missing_name() {
         let nodes = vec![node("op-conductor-0")];
 
-        let err = find_node(&nodes, "op-conductor-1", "sequencer")
-            .expect_err("missing node should error");
+        let err = find_node(&nodes, "op-conductor-1").expect_err("missing node should error");
 
-        assert!(err.to_string().contains("op-conductor-1"));
-        assert!(err.to_string().contains("op-conductor-0"));
+        assert!(matches!(
+            err,
+            SequencerCommandError::MissingNode {
+                requested_node,
+                available_nodes,
+            } if requested_node == "op-conductor-1"
+                && available_nodes == vec!["op-conductor-0".to_string()]
+        ));
     }
 }

--- a/bin/basectl/src/sequencer.rs
+++ b/bin/basectl/src/sequencer.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use alloy_primitives::B256;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use basectl_cli::{
     ConductorClusterSnapshot, ConductorControl, ConductorNodeConfig, ConductorNodeStatus,
     ConductorSource, JsonOutput, KeyValueTable, MonitoringConfig, SequencerCommandError,
@@ -65,9 +65,7 @@ async fn run_status(
         selected_node = %args.node.as_deref().unwrap_or("all"),
         "fetching sequencer status"
     );
-    let snapshot = ConductorControl::snapshot(source)
-        .await
-        .context("failed to fetch sequencer status snapshot")?;
+    let snapshot = ConductorControl::snapshot(source).await?;
     let status = SequencerStatusJson::from_snapshot(&config.name, &snapshot, args.node.as_deref())?;
     debug!(
         network = %config.name,
@@ -78,9 +76,9 @@ async fn run_status(
         "sequencer status snapshot ready"
     );
     if args.json {
-        JsonOutput::print(&status).context("failed to write sequencer output")?;
+        JsonOutput::print(&status)?;
     } else {
-        print_status_pretty(&status).context("failed to write sequencer output")?;
+        print_status_pretty(&status)?;
     }
     Ok(())
 }
@@ -96,9 +94,7 @@ async fn run_start(
         requested_unsafe_head = ?args.unsafe_head,
         "running sequencer start command"
     );
-    let snapshot = ConductorControl::snapshot(source)
-        .await
-        .context("failed to fetch sequencer status snapshot")?;
+    let snapshot = ConductorControl::snapshot(source).await?;
     let node =
         find_conductor_node(&snapshot.nodes, &args.node).map_err(SequencerCommandError::from)?;
     let status = snapshot_node_status(&snapshot, &node.name);
@@ -156,7 +152,7 @@ async fn run_start(
     }
     let prompt =
         format!("Start sequencer on {} ({}) at {}? [y/N] ", node.name, node.cl_rpc, unsafe_head);
-    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
+    if !confirm_or_abort(&prompt, args.yes)? {
         debug!(node = %node.name, cl_rpc = %node.cl_rpc, "sequencer start confirmation declined");
         return Ok(());
     }
@@ -169,9 +165,7 @@ async fn run_start(
         unsafe_head_source = %unsafe_head_source.as_str(),
         "calling admin_startSequencer"
     );
-    start_sequencer(&node.cl_rpc, unsafe_head).await.with_context(|| {
-        format!("failed to start sequencer on {} ({}) at {}", node.name, node.cl_rpc, unsafe_head)
-    })?;
+    start_sequencer(&node.cl_rpc, unsafe_head).await?;
     wait_for_expected_state(node, SequencerAction::Start, Some(unsafe_head)).await?;
     info!(
         network = %config.name,
@@ -186,8 +180,8 @@ async fn run_start(
     print_action(
         &SequencerActionJson::start(&config.name, node, unsafe_head, unsafe_head_source, message),
         args.json,
-    )
-    .context("failed to write sequencer output")
+    )?;
+    Ok(())
 }
 
 async fn run_stop(
@@ -200,9 +194,7 @@ async fn run_stop(
         requested_node = %args.node,
         "running sequencer stop command"
     );
-    let snapshot = ConductorControl::snapshot(source)
-        .await
-        .context("failed to fetch sequencer status snapshot")?;
+    let snapshot = ConductorControl::snapshot(source).await?;
     let node =
         find_conductor_node(&snapshot.nodes, &args.node).map_err(SequencerCommandError::from)?;
     let status = snapshot_node_status(&snapshot, &node.name);
@@ -223,7 +215,7 @@ async fn run_stop(
         return Err(error.into());
     }
     let prompt = format!("Stop sequencer on {} ({})? [y/N] ", node.name, node.cl_rpc);
-    if !confirm_or_abort(&prompt, args.yes).context("failed to read confirmation")? {
+    if !confirm_or_abort(&prompt, args.yes)? {
         debug!(node = %node.name, cl_rpc = %node.cl_rpc, "sequencer stop confirmation declined");
         return Ok(());
     }
@@ -234,9 +226,7 @@ async fn run_stop(
         cl_rpc = %node.cl_rpc,
         "calling admin_stopSequencer"
     );
-    let unsafe_head = stop_sequencer(&node.cl_rpc)
-        .await
-        .with_context(|| format!("failed to stop sequencer on {} ({})", node.name, node.cl_rpc))?;
+    let unsafe_head = stop_sequencer(&node.cl_rpc).await?;
     // A zero head means the sequencer stopped but the captured head is unavailable,
     // so do not surface it as a valid restart point.
     let captured_head = (unsafe_head != B256::ZERO).then_some(unsafe_head);
@@ -253,8 +243,11 @@ async fn run_stop(
         || format!("sequencer stopped on {} (unsafe head unavailable)", node.name),
         |unsafe_head| format!("sequencer stopped on {} at {unsafe_head}", node.name),
     );
-    print_action(&SequencerActionJson::stop(&config.name, node, captured_head, message), args.json)
-        .context("failed to write sequencer output")
+    print_action(
+        &SequencerActionJson::stop(&config.name, node, captured_head, message),
+        args.json,
+    )?;
+    Ok(())
 }
 
 fn resolve_start_hash(

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockNumberOrTag, SyncStatus as EthSyncStatus};
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result};
 use base_protocol::{BlockInfo, L2BlockInfo};
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, TimestampJson, fetch_block,
-    fetch_sync_status, format_duration, format_unix_timestamp,
+    JsonOutput, KeyValueTable, MissingConsensusRpcError, MonitoringConfig, SyncStatusReport,
+    TimestampJson, fetch_block, fetch_sync_status, format_duration, format_unix_timestamp,
 };
 use serde::Serialize;
 use url::Url;
@@ -32,12 +32,15 @@ pub(crate) async fn run(
         fetch_sync_status(&el_rpc, &cl_rpc),
         fetch_block(&config.rpc, BlockId::Number(BlockNumberOrTag::Latest)),
     );
-    let report = sync_result?;
+    let report = sync_result
+        .with_context(|| format!("failed to fetch sync status from EL {el_rpc} and CL {cl_rpc}"))?;
     let public_tip_block = tip_result.ok().map(|b| b.header.number);
     let tip_url = config.rpc.as_str();
 
     match (json, raw) {
-        (true, true) => JsonOutput::print(&report.cl)?,
+        (true, true) => {
+            JsonOutput::print(&report.cl).context("failed to write sync-status output")?
+        }
         (true, false) => {
             let summary = SyncStatusJson::from_report(
                 &config.name,
@@ -46,10 +49,11 @@ pub(crate) async fn run(
                 public_tip_block,
                 tip_tolerance,
             );
-            JsonOutput::print(&summary)?;
+            JsonOutput::print(&summary).context("failed to write sync-status output")?;
         }
         (false, _) => {
-            print_pretty(&config.name, &report, tip_url, public_tip_block, tip_tolerance)?;
+            print_pretty(&config.name, &report, tip_url, public_tip_block, tip_tolerance)
+                .context("failed to write sync-status output")?;
         }
     }
     Ok(())
@@ -60,17 +64,16 @@ pub(crate) async fn run(
 ///
 /// The mainnet and sepolia presets ship `consensus_node_rpc: None`, so
 /// non-devnet users must supply the URL explicitly.
-fn resolve_cl_rpc(config: &MonitoringConfig, override_url: Option<&Url>) -> Result<Url> {
+fn resolve_cl_rpc(
+    config: &MonitoringConfig,
+    override_url: Option<&Url>,
+) -> Result<Url, MissingConsensusRpcError> {
     if let Some(u) = override_url {
         return Ok(u.clone());
     }
-    config.consensus_node_rpc.clone().ok_or_else(|| {
-        anyhow!(
-            "sync-status needs a consensus-node RPC URL.\n\
-             The '{}' config does not set `consensus_node_rpc`.\n\
-             Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config.",
-            config.name
-        )
+    config.consensus_node_rpc.clone().ok_or_else(|| MissingConsensusRpcError::Missing {
+        config_name: config.name.clone(),
+        command_name: "sync-status".to_string(),
     })
 }
 
@@ -346,11 +349,31 @@ fn format_block_info(b: &BlockInfo) -> String {
 #[cfg(test)]
 mod tests {
     use alloy_eips::BlockNumHash;
-    use alloy_primitives::B256;
+    use alloy_primitives::{Address, B256};
     use base_protocol::{BlockInfo, L2BlockInfo, SyncStatus};
-    use basectl_cli::SyncStatusReport;
+    use basectl_cli::{MissingConsensusRpcError, MonitoringConfig, SyncStatusReport};
+    use url::Url;
 
-    use super::SyncStatusJson;
+    use super::{SyncStatusJson, resolve_cl_rpc};
+
+    fn test_config(consensus_node_rpc: Option<Url>) -> MonitoringConfig {
+        MonitoringConfig {
+            name: "mainnet".to_string(),
+            rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
+            flashblocks_ws: Url::parse("ws://127.0.0.1:7111").unwrap(),
+            l1_rpc: Url::parse("http://127.0.0.1:9545").unwrap(),
+            consensus_node_rpc,
+            upgrades: None,
+            system_config: Address::ZERO,
+            batcher_address: None,
+            l1_blob_target: 14,
+            conductors: None,
+            discovery: None,
+            validators: None,
+            proofs: None,
+            pods: None,
+        }
+    }
 
     fn sample_l2(block: u64, ts: u64) -> L2BlockInfo {
         L2BlockInfo::new(
@@ -376,6 +399,19 @@ mod tests {
             finalized_l2: sample_l2(18_425_000, 1_780_260_000),
             local_safe_l2: L2BlockInfo::default(),
         }
+    }
+
+    #[test]
+    fn resolve_cl_rpc_errors_without_config() {
+        let config = test_config(None);
+
+        assert!(matches!(
+            resolve_cl_rpc(&config, None).unwrap_err(),
+            MissingConsensusRpcError::Missing {
+                config_name,
+                command_name,
+            } if config_name == "mainnet" && command_name == "sync-status"
+        ));
     }
 
     #[test]

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockNumberOrTag, SyncStatus as EthSyncStatus};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use base_protocol::{BlockInfo, L2BlockInfo};
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MissingConsensusRpcError, MonitoringConfig, SyncStatusReport,
+    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusCommandError, SyncStatusReport,
     TimestampJson, fetch_block, fetch_sync_status, format_duration, format_unix_timestamp,
 };
 use serde::Serialize;
@@ -32,15 +32,12 @@ pub(crate) async fn run(
         fetch_sync_status(&el_rpc, &cl_rpc),
         fetch_block(&config.rpc, BlockId::Number(BlockNumberOrTag::Latest)),
     );
-    let report = sync_result
-        .with_context(|| format!("failed to fetch sync status from EL {el_rpc} and CL {cl_rpc}"))?;
+    let report = sync_result?;
     let public_tip_block = tip_result.ok().map(|b| b.header.number);
     let tip_url = config.rpc.as_str();
 
     match (json, raw) {
-        (true, true) => {
-            JsonOutput::print(&report.cl).context("failed to write sync-status output")?
-        }
+        (true, true) => JsonOutput::print(&report.cl)?,
         (true, false) => {
             let summary = SyncStatusJson::from_report(
                 &config.name,
@@ -49,11 +46,10 @@ pub(crate) async fn run(
                 public_tip_block,
                 tip_tolerance,
             );
-            JsonOutput::print(&summary).context("failed to write sync-status output")?;
+            JsonOutput::print(&summary)?;
         }
         (false, _) => {
-            print_pretty(&config.name, &report, tip_url, public_tip_block, tip_tolerance)
-                .context("failed to write sync-status output")?;
+            print_pretty(&config.name, &report, tip_url, public_tip_block, tip_tolerance)?;
         }
     }
     Ok(())
@@ -67,14 +63,13 @@ pub(crate) async fn run(
 fn resolve_cl_rpc(
     config: &MonitoringConfig,
     override_url: Option<&Url>,
-) -> Result<Url, MissingConsensusRpcError> {
+) -> Result<Url, SyncStatusCommandError> {
     if let Some(u) = override_url {
         return Ok(u.clone());
     }
-    config
-        .consensus_node_rpc
-        .clone()
-        .ok_or_else(|| MissingConsensusRpcError::new(config.name.clone(), "sync-status"))
+    config.consensus_node_rpc.clone().ok_or_else(|| SyncStatusCommandError::MissingConsensusRpc {
+        config_name: config.name.clone(),
+    })
 }
 
 /// Humanized JSON shape for `basectl sync-status --json`.
@@ -351,7 +346,7 @@ mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{Address, B256};
     use base_protocol::{BlockInfo, L2BlockInfo, SyncStatus};
-    use basectl_cli::{MissingConsensusRpcError, MonitoringConfig, SyncStatusReport};
+    use basectl_cli::{MonitoringConfig, SyncStatusCommandError, SyncStatusReport};
     use url::Url;
 
     use super::{SyncStatusJson, resolve_cl_rpc};
@@ -407,11 +402,10 @@ mod tests {
 
         assert!(matches!(
             resolve_cl_rpc(&config, None).unwrap_err(),
-            MissingConsensusRpcError {
+            SyncStatusCommandError::MissingConsensusRpc {
                 config_name,
-                command_name,
                 ..
-            } if config_name == "mainnet" && command_name == "sync-status"
+            } if config_name == "mainnet"
         ));
     }
 

--- a/bin/basectl/src/sync_status.rs
+++ b/bin/basectl/src/sync_status.rs
@@ -71,10 +71,10 @@ fn resolve_cl_rpc(
     if let Some(u) = override_url {
         return Ok(u.clone());
     }
-    config.consensus_node_rpc.clone().ok_or_else(|| MissingConsensusRpcError::Missing {
-        config_name: config.name.clone(),
-        command_name: "sync-status".to_string(),
-    })
+    config
+        .consensus_node_rpc
+        .clone()
+        .ok_or_else(|| MissingConsensusRpcError::new(config.name.clone(), "sync-status"))
 }
 
 /// Humanized JSON shape for `basectl sync-status --json`.
@@ -407,9 +407,10 @@ mod tests {
 
         assert!(matches!(
             resolve_cl_rpc(&config, None).unwrap_err(),
-            MissingConsensusRpcError::Missing {
+            MissingConsensusRpcError {
                 config_name,
                 command_name,
+                ..
             } if config_name == "mainnet" && command_name == "sync-status"
         ));
     }

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -30,6 +30,7 @@ toml = { workspace = true, features = ["parse", "serde"] }
 url = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
+thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["net", "process", "time"] }
 alloy-eips = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -1,6 +1,6 @@
 use std::{io::Write, time::Instant};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base_common_flashblocks::Flashblock;
 use base_common_genesis::SystemConfig;
 use tokio::sync::{mpsc, watch};
@@ -29,7 +29,9 @@ pub async fn run_app(
     network: &str,
     conductor_rpc: Option<Url>,
 ) -> Result<()> {
-    let mut config = MonitoringConfig::load(network).await?;
+    let mut config = MonitoringConfig::load(network)
+        .await
+        .with_context(|| format!("loading monitor config {network}"))?;
     if config.conductors.is_none()
         && let Some(source) = config.conductor_source(conductor_rpc.clone())
         && let ConductorSource::Discover { bootstrap, .. } = source
@@ -42,7 +44,7 @@ pub async fn run_app(
     let mut resources = Resources::new(config.clone());
     start_background_services(&config, &mut resources, conductor_rpc.clone());
     let app = App::new(resources, initial_view, conductor_rpc);
-    app.run(create_view).await
+    app.run(create_view).await.context("running monitor TUI")
 }
 
 /// Starts all background data-fetching services, wiring their channels into `resources`.
@@ -202,9 +204,9 @@ pub async fn run_flashblocks_json(config: MonitoringConfig) -> Result<()> {
     let mut writer = std::io::BufWriter::new(stdout.lock());
 
     while let Some(fb) = rx.recv().await {
-        serde_json::to_writer(&mut writer, &fb)?;
-        writeln!(writer)?;
-        writer.flush()?;
+        serde_json::to_writer(&mut writer, &fb).context("serializing flashblock")?;
+        writeln!(writer).context("writing flashblocks output")?;
+        writer.flush().context("flushing flashblocks output")?;
     }
 
     Ok(())

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -1,6 +1,6 @@
 use std::{io::Write, time::Instant};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use base_common_flashblocks::Flashblock;
 use base_common_genesis::SystemConfig;
 use tokio::sync::{mpsc, watch};
@@ -29,9 +29,7 @@ pub async fn run_app(
     network: &str,
     conductor_rpc: Option<Url>,
 ) -> Result<()> {
-    let mut config = MonitoringConfig::load(network)
-        .await
-        .with_context(|| format!("loading monitor config {network}"))?;
+    let mut config = MonitoringConfig::load(network).await?;
     if config.conductors.is_none()
         && let Some(source) = config.conductor_source(conductor_rpc.clone())
         && let ConductorSource::Discover { bootstrap, .. } = source
@@ -44,7 +42,7 @@ pub async fn run_app(
     let mut resources = Resources::new(config.clone());
     start_background_services(&config, &mut resources, conductor_rpc.clone());
     let app = App::new(resources, initial_view, conductor_rpc);
-    app.run(create_view).await.context("running monitor TUI")
+    app.run(create_view).await
 }
 
 /// Starts all background data-fetching services, wiring their channels into `resources`.
@@ -204,9 +202,9 @@ pub async fn run_flashblocks_json(config: MonitoringConfig) -> Result<()> {
     let mut writer = std::io::BufWriter::new(stdout.lock());
 
     while let Some(fb) = rx.recv().await {
-        serde_json::to_writer(&mut writer, &fb).context("serializing flashblock")?;
-        writeln!(writer).context("writing flashblocks output")?;
-        writer.flush().context("flushing flashblocks output")?;
+        serde_json::to_writer(&mut writer, &fb)?;
+        writeln!(writer)?;
+        writer.flush()?;
     }
 
     Ok(())

--- a/crates/infra/basectl/src/errors.rs
+++ b/crates/infra/basectl/src/errors.rs
@@ -1,6 +1,6 @@
 //! Shared typed errors for basectl command validation and preflight checks.
 
-use std::{fmt, time::Duration};
+use std::time::Duration;
 
 use alloy_primitives::B256;
 use thiserror::Error;
@@ -29,28 +29,6 @@ pub enum BlockRefParseError {
     /// The `pending` tag is rejected because typed block responses cannot deserialize it.
     #[error("the `pending` tag is not supported; use `latest`, `safe`, `finalized`, or `earliest`")]
     PendingUnsupported,
-}
-
-/// Error returned when a command requires a consensus RPC URL and none is configured.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error(
-    "{command_name} needs a consensus-node RPC URL.\n\
-     The '{config_name}' config does not set `consensus_node_rpc`.\n\
-     Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config."
-)]
-#[non_exhaustive]
-pub struct MissingConsensusRpcError {
-    /// The config name selected for the command.
-    pub config_name: String,
-    /// The command that needed a consensus RPC URL.
-    pub command_name: String,
-}
-
-impl MissingConsensusRpcError {
-    /// Builds an error for a command that could not resolve a consensus RPC URL.
-    pub fn new(config_name: impl Into<String>, command_name: impl Into<String>) -> Self {
-        Self { config_name: config_name.into(), command_name: command_name.into() }
-    }
 }
 
 /// Error returned when shared conductor source or node lookup fails.
@@ -175,6 +153,18 @@ pub enum P2pTargetError {
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum P2pCommandError {
+    /// The command could not resolve a consensus-node RPC URL from flags or config.
+    #[error(
+        "{command_name} needs a consensus-node RPC URL.\n\
+         The '{config_name}' config does not set `consensus_node_rpc`.\n\
+         Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config."
+    )]
+    MissingConsensusRpc {
+        /// The config name selected for the command.
+        config_name: String,
+        /// The command that needed a consensus RPC URL.
+        command_name: String,
+    },
     /// Some peers failed during `unban-all`.
     #[error("failed to unban {failed} CL peer(s)")]
     UnbanAllPartialFailure {
@@ -186,6 +176,22 @@ pub enum P2pCommandError {
     UnsupportedPrettyAction {
         /// The unsupported action name.
         action: String,
+    },
+}
+
+/// Error returned by the `sync-status` command.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum SyncStatusCommandError {
+    /// The command could not resolve a consensus-node RPC URL from flags or config.
+    #[error(
+        "sync-status needs a consensus-node RPC URL.\n\
+         The '{config_name}' config does not set `consensus_node_rpc`.\n\
+         Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config."
+    )]
+    MissingConsensusRpc {
+        /// The config name selected for the command.
+        config_name: String,
     },
 }
 
@@ -223,15 +229,19 @@ impl From<NodeLookupError> for ConductorCommandError {
 }
 
 /// Error returned by sequencer command validation and preflight checks.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum SequencerCommandError {
     /// The command could not resolve a conductor source from config or flags.
+    #[error(
+        "sequencer commands need conductor config or a bootstrap RPC URL for '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`."
+    )]
     MissingSource {
         /// The config name selected for the command.
         config_name: String,
     },
     /// The requested sequencer node name was not found.
+    #[error("sequencer node {requested_node} not found. Available nodes: {}", available_nodes.join(", "))]
     MissingNode {
         /// The node name requested by the caller.
         requested_node: String,
@@ -239,21 +249,29 @@ pub enum SequencerCommandError {
         available_nodes: Vec<String>,
     },
     /// The command could not infer an unsafe head hash from the target node.
+    #[error(
+        "could not determine unsafe head for {node}; pass an explicit 32-byte hash or restore CL reachability"
+    )]
     MissingUnsafeHead {
         /// The target node name.
         node: String,
     },
     /// The target sequencer is already active.
+    #[error("sequencer already active on {node}; stop it before starting again")]
     AlreadyActive {
         /// The target node name.
         node: String,
     },
     /// The target sequencer is already stopped.
+    #[error("sequencer already stopped on {node}")]
     AlreadyStopped {
         /// The target node name.
         node: String,
     },
     /// The command targeted a node that is known not to be the conductor leader.
+    #[error(
+        "Node is not the conductor leader. Current leader: {current_leader}. `basectl sequencer {action}` must target the leader instead of {requested_node}."
+    )]
     NotCurrentLeader {
         /// The node name requested by the caller.
         requested_node: String,
@@ -263,6 +281,9 @@ pub enum SequencerCommandError {
         action: String,
     },
     /// The command targeted a follower while no current leader name was available.
+    #[error(
+        "Node is not the conductor leader. `basectl sequencer {action}` must target the current leader instead of {requested_node}."
+    )]
     NotLeader {
         /// The node name requested by the caller.
         requested_node: String,
@@ -270,8 +291,12 @@ pub enum SequencerCommandError {
         action: String,
     },
     /// The observed unsafe head is zero, so no safe prestate exists for start.
+    #[error("no prestate: engine unsafe head is uninitialized, cannot safely start sequencer")]
     UninitializedUnsafeHead,
     /// The requested unsafe head did not match the node's observed unsafe head.
+    #[error(
+        "block hash mismatch: engine unsafe head is {observed_hash}, caller requested {requested_hash}"
+    )]
     UnsafeHeadMismatch {
         /// The unsafe head observed from the node.
         observed_hash: B256,
@@ -279,8 +304,10 @@ pub enum SequencerCommandError {
         requested_hash: B256,
     },
     /// The unsafe head input was empty after trimming whitespace.
+    #[error("unsafe head hash cannot be empty")]
     EmptyUnsafeHead,
     /// The unsafe head input could not be parsed as a 32-byte hash.
+    #[error("parsing unsafe head hash `{raw}`: {message}")]
     InvalidUnsafeHead {
         /// The original unsafe head supplied by the caller.
         raw: String,
@@ -288,16 +315,21 @@ pub enum SequencerCommandError {
         message: String,
     },
     /// The unsafe head input was the zero hash.
+    #[error("unsafe head hash must not be zero")]
     ZeroUnsafeHead {
         /// The parsed zero hash requested by the caller.
         requested_hash: B256,
     },
     /// The sequencer active state did not converge after the command RPC succeeded.
-    StateConvergenceTimeout(Box<StateConvergenceTimeoutError>),
+    #[error("{0}")]
+    StateConvergenceTimeout(#[source] Box<StateConvergenceTimeoutError>),
 }
 
 /// Error returned when the sequencer active state does not converge after a command RPC succeeds.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error(
+    "{action} RPC succeeded on {node} ({cl_rpc}), but `sequencer_active={expected_active}` was not observed within {timeout:?}; unsafe_head={unsafe_head:?}; last_observed={last_observed:?}; last_error={last_error:?}"
+)]
 pub struct StateConvergenceTimeoutError {
     /// The sequencer action being observed.
     pub action: &'static str,
@@ -316,92 +348,6 @@ pub struct StateConvergenceTimeoutError {
     /// The last polling error, if any poll failed.
     pub last_error: Option<String>,
 }
-
-impl fmt::Display for SequencerCommandError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::MissingSource { config_name } => write!(
-                f,
-                "sequencer commands need conductor config or a bootstrap RPC URL for \
-                 '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or \
-                 pass `--conductor-rpc <url>`."
-            ),
-            Self::MissingNode { requested_node, available_nodes } => write!(
-                f,
-                "sequencer node {requested_node} not found. Available nodes: {}",
-                available_nodes.join(", ")
-            ),
-            Self::MissingUnsafeHead { node } => write!(
-                f,
-                "could not determine unsafe head for {node}; pass an explicit 32-byte hash or \
-                 restore CL reachability"
-            ),
-            Self::AlreadyActive { node } => {
-                write!(f, "sequencer already active on {node}; stop it before starting again")
-            }
-            Self::AlreadyStopped { node } => write!(f, "sequencer already stopped on {node}"),
-            Self::NotCurrentLeader { requested_node, current_leader, action } => write!(
-                f,
-                "Node is not the conductor leader. Current leader: {current_leader}. `basectl \
-                 sequencer {action}` must target the leader instead of {requested_node}."
-            ),
-            Self::NotLeader { requested_node, action } => write!(
-                f,
-                "Node is not the conductor leader. `basectl sequencer {action}` must target the \
-                 current leader instead of {requested_node}."
-            ),
-            Self::UninitializedUnsafeHead => write!(
-                f,
-                "no prestate: engine unsafe head is uninitialized, cannot safely start sequencer"
-            ),
-            Self::UnsafeHeadMismatch { observed_hash, requested_hash } => write!(
-                f,
-                "block hash mismatch: engine unsafe head is {observed_hash}, caller requested \
-                 {requested_hash}"
-            ),
-            Self::EmptyUnsafeHead => write!(f, "unsafe head hash cannot be empty"),
-            Self::InvalidUnsafeHead { raw, message } => {
-                write!(f, "parsing unsafe head hash `{raw}`: {message}")
-            }
-            Self::ZeroUnsafeHead { .. } => write!(f, "unsafe head hash must not be zero"),
-            Self::StateConvergenceTimeout(error) => error.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for SequencerCommandError {}
-
-impl fmt::Display for StateConvergenceTimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let unsafe_head_suffix =
-            self.unsafe_head.map_or_else(String::new, |unsafe_head| format!(" at {unsafe_head}"));
-        let last_status_suffix = match (self.last_observed, self.last_error.as_deref()) {
-            (Some(observed), Some(error)) => {
-                format!(" (last observed `sequencer_active={observed}`; last poll error: {error})")
-            }
-            (Some(observed), None) => {
-                format!(" (last observed `sequencer_active={observed}`)")
-            }
-            (None, Some(error)) => format!(" (last poll error: {error})"),
-            (None, None) => String::new(),
-        };
-
-        write!(
-            f,
-            "{} RPC succeeded on {} ({}){}, but `sequencer_active={}` was not observed within \
-             {:?}{}",
-            self.action,
-            self.node,
-            self.cl_rpc,
-            unsafe_head_suffix,
-            self.expected_active,
-            self.timeout,
-            last_status_suffix
-        )
-    }
-}
-
-impl std::error::Error for StateConvergenceTimeoutError {}
 
 impl From<NodeLookupError> for SequencerCommandError {
     fn from(error: NodeLookupError) -> Self {

--- a/crates/infra/basectl/src/errors.rs
+++ b/crates/infra/basectl/src/errors.rs
@@ -1,6 +1,6 @@
 //! Shared typed errors for basectl command validation and preflight checks.
 
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use alloy_primitives::B256;
 use thiserror::Error;
@@ -33,20 +33,24 @@ pub enum BlockRefParseError {
 
 /// Error returned when a command requires a consensus RPC URL and none is configured.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error(
+    "{command_name} needs a consensus-node RPC URL.\n\
+     The '{config_name}' config does not set `consensus_node_rpc`.\n\
+     Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config."
+)]
 #[non_exhaustive]
-pub enum MissingConsensusRpcError {
-    /// Neither the config nor the command-line flags provided a consensus RPC URL.
-    #[error(
-        "{command_name} needs a consensus-node RPC URL.\n\
-         The '{config_name}' config does not set `consensus_node_rpc`.\n\
-         Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config."
-    )]
-    Missing {
-        /// The config name selected for the command.
-        config_name: String,
-        /// The command that needed a consensus RPC URL.
-        command_name: String,
-    },
+pub struct MissingConsensusRpcError {
+    /// The config name selected for the command.
+    pub config_name: String,
+    /// The command that needed a consensus RPC URL.
+    pub command_name: String,
+}
+
+impl MissingConsensusRpcError {
+    /// Builds an error for a command that could not resolve a consensus RPC URL.
+    pub fn new(config_name: impl Into<String>, command_name: impl Into<String>) -> Self {
+        Self { config_name: config_name.into(), command_name: command_name.into() }
+    }
 }
 
 /// Error returned when shared conductor source or node lookup fails.
@@ -219,19 +223,15 @@ impl From<NodeLookupError> for ConductorCommandError {
 }
 
 /// Error returned by sequencer command validation and preflight checks.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SequencerCommandError {
     /// The command could not resolve a conductor source from config or flags.
-    #[error(
-        "sequencer commands need conductor config or a bootstrap RPC URL for '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`."
-    )]
     MissingSource {
         /// The config name selected for the command.
         config_name: String,
     },
     /// The requested sequencer node name was not found.
-    #[error("sequencer node {requested_node} not found. Available nodes: {}", available_nodes.join(", "))]
     MissingNode {
         /// The node name requested by the caller.
         requested_node: String,
@@ -239,29 +239,21 @@ pub enum SequencerCommandError {
         available_nodes: Vec<String>,
     },
     /// The command could not infer an unsafe head hash from the target node.
-    #[error(
-        "could not determine unsafe head for {node}; pass an explicit 32-byte hash or restore CL reachability"
-    )]
     MissingUnsafeHead {
         /// The target node name.
         node: String,
     },
     /// The target sequencer is already active.
-    #[error("sequencer already active on {node}; stop it before starting again")]
     AlreadyActive {
         /// The target node name.
         node: String,
     },
     /// The target sequencer is already stopped.
-    #[error("sequencer already stopped on {node}")]
     AlreadyStopped {
         /// The target node name.
         node: String,
     },
     /// The command targeted a node that is known not to be the conductor leader.
-    #[error(
-        "Node is not the conductor leader. Current leader: {current_leader}. `basectl sequencer {action}` must target the leader instead of {requested_node}."
-    )]
     NotCurrentLeader {
         /// The node name requested by the caller.
         requested_node: String,
@@ -271,9 +263,6 @@ pub enum SequencerCommandError {
         action: String,
     },
     /// The command targeted a follower while no current leader name was available.
-    #[error(
-        "Node is not the conductor leader. `basectl sequencer {action}` must target the current leader instead of {requested_node}."
-    )]
     NotLeader {
         /// The node name requested by the caller.
         requested_node: String,
@@ -281,12 +270,8 @@ pub enum SequencerCommandError {
         action: String,
     },
     /// The observed unsafe head is zero, so no safe prestate exists for start.
-    #[error("no prestate: engine unsafe head is uninitialized, cannot safely start sequencer")]
     UninitializedUnsafeHead,
     /// The requested unsafe head did not match the node's observed unsafe head.
-    #[error(
-        "block hash mismatch: engine unsafe head is {observed_hash}, caller requested {requested_hash}"
-    )]
     UnsafeHeadMismatch {
         /// The unsafe head observed from the node.
         observed_hash: B256,
@@ -294,10 +279,8 @@ pub enum SequencerCommandError {
         requested_hash: B256,
     },
     /// The unsafe head input was empty after trimming whitespace.
-    #[error("unsafe head hash cannot be empty")]
     EmptyUnsafeHead,
     /// The unsafe head input could not be parsed as a 32-byte hash.
-    #[error("parsing unsafe head hash `{raw}`: {message}")]
     InvalidUnsafeHead {
         /// The original unsafe head supplied by the caller.
         raw: String,
@@ -305,41 +288,120 @@ pub enum SequencerCommandError {
         message: String,
     },
     /// The unsafe head input was the zero hash.
-    #[error("unsafe head hash must not be zero")]
     ZeroUnsafeHead {
         /// The parsed zero hash requested by the caller.
         requested_hash: B256,
     },
     /// The sequencer active state did not converge after the command RPC succeeded.
-    #[error(
-        "{action} RPC succeeded on {node} ({cl_rpc}){}, but `sequencer_active={expected_active}` was not observed within {timeout:?}{}",
-        unsafe_head.map_or_else(String::new, |unsafe_head| format!(" at {unsafe_head}")),
-        match (last_observed, last_error.as_deref()) {
-            (Some(observed), Some(error)) => format!(" (last observed `sequencer_active={observed}`; last poll error: {error})"),
-            (Some(observed), None) => format!(" (last observed `sequencer_active={observed}`)"),
+    StateConvergenceTimeout(Box<StateConvergenceTimeoutError>),
+}
+
+/// Error returned when the sequencer active state does not converge after a command RPC succeeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateConvergenceTimeoutError {
+    /// The sequencer action being observed.
+    pub action: &'static str,
+    /// The target node name.
+    pub node: String,
+    /// The target node consensus-layer RPC URL.
+    pub cl_rpc: String,
+    /// The unsafe head returned or requested for the command, if known.
+    pub unsafe_head: Option<B256>,
+    /// The expected `sequencer_active` state.
+    pub expected_active: bool,
+    /// The observation timeout used for state convergence.
+    pub timeout: Duration,
+    /// The last observed `sequencer_active` state, if any poll succeeded.
+    pub last_observed: Option<bool>,
+    /// The last polling error, if any poll failed.
+    pub last_error: Option<String>,
+}
+
+impl fmt::Display for SequencerCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSource { config_name } => write!(
+                f,
+                "sequencer commands need conductor config or a bootstrap RPC URL for \
+                 '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or \
+                 pass `--conductor-rpc <url>`."
+            ),
+            Self::MissingNode { requested_node, available_nodes } => write!(
+                f,
+                "sequencer node {requested_node} not found. Available nodes: {}",
+                available_nodes.join(", ")
+            ),
+            Self::MissingUnsafeHead { node } => write!(
+                f,
+                "could not determine unsafe head for {node}; pass an explicit 32-byte hash or \
+                 restore CL reachability"
+            ),
+            Self::AlreadyActive { node } => {
+                write!(f, "sequencer already active on {node}; stop it before starting again")
+            }
+            Self::AlreadyStopped { node } => write!(f, "sequencer already stopped on {node}"),
+            Self::NotCurrentLeader { requested_node, current_leader, action } => write!(
+                f,
+                "Node is not the conductor leader. Current leader: {current_leader}. `basectl \
+                 sequencer {action}` must target the leader instead of {requested_node}."
+            ),
+            Self::NotLeader { requested_node, action } => write!(
+                f,
+                "Node is not the conductor leader. `basectl sequencer {action}` must target the \
+                 current leader instead of {requested_node}."
+            ),
+            Self::UninitializedUnsafeHead => write!(
+                f,
+                "no prestate: engine unsafe head is uninitialized, cannot safely start sequencer"
+            ),
+            Self::UnsafeHeadMismatch { observed_hash, requested_hash } => write!(
+                f,
+                "block hash mismatch: engine unsafe head is {observed_hash}, caller requested \
+                 {requested_hash}"
+            ),
+            Self::EmptyUnsafeHead => write!(f, "unsafe head hash cannot be empty"),
+            Self::InvalidUnsafeHead { raw, message } => {
+                write!(f, "parsing unsafe head hash `{raw}`: {message}")
+            }
+            Self::ZeroUnsafeHead { .. } => write!(f, "unsafe head hash must not be zero"),
+            Self::StateConvergenceTimeout(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for SequencerCommandError {}
+
+impl fmt::Display for StateConvergenceTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let unsafe_head_suffix =
+            self.unsafe_head.map_or_else(String::new, |unsafe_head| format!(" at {unsafe_head}"));
+        let last_status_suffix = match (self.last_observed, self.last_error.as_deref()) {
+            (Some(observed), Some(error)) => {
+                format!(" (last observed `sequencer_active={observed}`; last poll error: {error})")
+            }
+            (Some(observed), None) => {
+                format!(" (last observed `sequencer_active={observed}`)")
+            }
             (None, Some(error)) => format!(" (last poll error: {error})"),
             (None, None) => String::new(),
-        }
-    )]
-    StateConvergenceTimeout {
-        /// The sequencer action being observed.
-        action: &'static str,
-        /// The target node name.
-        node: Box<str>,
-        /// The target node consensus-layer RPC URL.
-        cl_rpc: Box<str>,
-        /// The unsafe head returned or requested for the command, if known.
-        unsafe_head: Option<B256>,
-        /// The expected `sequencer_active` state.
-        expected_active: bool,
-        /// The observation timeout used for state convergence.
-        timeout: Duration,
-        /// The last observed `sequencer_active` state, if any poll succeeded.
-        last_observed: Option<bool>,
-        /// The last polling error, if any poll failed.
-        last_error: Option<Box<str>>,
-    },
+        };
+
+        write!(
+            f,
+            "{} RPC succeeded on {} ({}){}, but `sequencer_active={}` was not observed within \
+             {:?}{}",
+            self.action,
+            self.node,
+            self.cl_rpc,
+            unsafe_head_suffix,
+            self.expected_active,
+            self.timeout,
+            last_status_suffix
+        )
+    }
 }
+
+impl std::error::Error for StateConvergenceTimeoutError {}
 
 impl From<NodeLookupError> for SequencerCommandError {
     fn from(error: NodeLookupError) -> Self {

--- a/crates/infra/basectl/src/errors.rs
+++ b/crates/infra/basectl/src/errors.rs
@@ -146,7 +146,7 @@ pub enum P2pTargetError {
 }
 
 /// Error returned by the `p2p` command group.
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum P2pCommandError {
     /// Some peers failed during `unban-all`.

--- a/crates/infra/basectl/src/errors.rs
+++ b/crates/infra/basectl/src/errors.rs
@@ -49,6 +49,28 @@ pub enum MissingConsensusRpcError {
     },
 }
 
+/// Error returned when shared conductor source or node lookup fails.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum NodeLookupError {
+    /// The command could not resolve a conductor source from config or flags.
+    #[error(
+        "commands need conductor config or a bootstrap RPC URL for '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`."
+    )]
+    MissingSource {
+        /// The config name selected for the command.
+        config_name: String,
+    },
+    /// The requested conductor node name was not found.
+    #[error("node {requested_node} not found. Available nodes: {}", available_nodes.join(", "))]
+    MissingNode {
+        /// The node name requested by the caller.
+        requested_node: String,
+        /// The node names available to the command.
+        available_nodes: Vec<String>,
+    },
+}
+
 /// Error returned when a P2P command target is malformed or unsupported.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
@@ -185,6 +207,17 @@ pub enum ConductorCommandError {
     },
 }
 
+impl From<NodeLookupError> for ConductorCommandError {
+    fn from(error: NodeLookupError) -> Self {
+        match error {
+            NodeLookupError::MissingSource { config_name } => Self::MissingSource { config_name },
+            NodeLookupError::MissingNode { requested_node, available_nodes } => {
+                Self::MissingNode { requested_node, available_nodes }
+            }
+        }
+    }
+}
+
 /// Error returned by sequencer command validation and preflight checks.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
@@ -306,6 +339,17 @@ pub enum SequencerCommandError {
         /// The last polling error, if any poll failed.
         last_error: Option<Box<str>>,
     },
+}
+
+impl From<NodeLookupError> for SequencerCommandError {
+    fn from(error: NodeLookupError) -> Self {
+        match error {
+            NodeLookupError::MissingSource { config_name } => Self::MissingSource { config_name },
+            NodeLookupError::MissingNode { requested_node, available_nodes } => {
+                Self::MissingNode { requested_node, available_nodes }
+            }
+        }
+    }
 }
 
 /// Error returned by doctor argument validation.

--- a/crates/infra/basectl/src/errors.rs
+++ b/crates/infra/basectl/src/errors.rs
@@ -1,0 +1,331 @@
+//! Shared typed errors for basectl command validation and preflight checks.
+
+use std::time::Duration;
+
+use alloy_primitives::B256;
+use thiserror::Error;
+
+/// Error returned when a CLI block reference cannot be parsed.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum BlockRefParseError {
+    /// The provided block reference was empty after trimming whitespace.
+    #[error("invalid block reference: empty input")]
+    Empty,
+    /// A 32-byte hash-shaped block reference could not be parsed as a hash.
+    #[error("invalid block reference: malformed hash")]
+    MalformedHash {
+        /// The original block reference supplied by the caller.
+        raw: String,
+    },
+    /// The block reference was not a supported number, hash, or tag.
+    #[error("invalid block reference: {message}")]
+    InvalidTag {
+        /// The original block reference supplied by the caller.
+        raw: String,
+        /// The parser error returned by the underlying tag parser.
+        message: String,
+    },
+    /// The `pending` tag is rejected because typed block responses cannot deserialize it.
+    #[error("the `pending` tag is not supported; use `latest`, `safe`, `finalized`, or `earliest`")]
+    PendingUnsupported,
+}
+
+/// Error returned when a command requires a consensus RPC URL and none is configured.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum MissingConsensusRpcError {
+    /// Neither the config nor the command-line flags provided a consensus RPC URL.
+    #[error(
+        "{command_name} needs a consensus-node RPC URL.\n\
+         The '{config_name}' config does not set `consensus_node_rpc`.\n\
+         Override with `--cl-rpc <url>` or set `consensus_node_rpc` in your YAML config."
+    )]
+    Missing {
+        /// The config name selected for the command.
+        config_name: String,
+        /// The command that needed a consensus RPC URL.
+        command_name: String,
+    },
+}
+
+/// Error returned when a P2P command target is malformed or unsupported.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum P2pTargetError {
+    /// The peer target was empty after trimming whitespace.
+    #[error("peer target cannot be empty")]
+    EmptyTarget,
+    /// A multiaddr target did not include a `/p2p/<peer-id>` component.
+    #[error("multiaddr target must include a `/p2p/<peer-id>` component")]
+    MultiaddrMissingPeerId {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// A peer target could not be parsed as an enode or ENR.
+    #[error("parsing peer target `{target}` as enode or ENR: {message}")]
+    InvalidBootnode {
+        /// The target supplied by the caller.
+        target: String,
+        /// The parser error returned by the underlying bootnode parser.
+        message: String,
+    },
+    /// An ENR target did not contain enough data to derive a libp2p multiaddr.
+    #[error(
+        "ENR target `{target}` does not include enough information to derive a libp2p multiaddr"
+    )]
+    EnrMissingMultiaddr {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// `remove-peer` does not accept ENR targets.
+    #[error(
+        "remove-peer needs a bare libp2p peer ID for CL targets; ENR records are only accepted by add-peer"
+    )]
+    RemoveEnrTarget {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// The peer target contained whitespace.
+    #[error("peer target must not contain whitespace")]
+    TargetContainsWhitespace {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// A remove-peer EL target parsed to something other than an enode.
+    #[error("remove-peer EL targets must be `enode://` records")]
+    RemoveElTargetNotEnode {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// A remove-peer CL target was URL-like or multiaddr-like instead of a bare peer ID.
+    #[error("remove-peer needs a bare libp2p peer ID for CL targets, not a URL or multiaddr")]
+    RemoveClTargetNotBarePeerId {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// The CL peer ID was empty after trimming whitespace.
+    #[error("CL peer ID cannot be empty")]
+    EmptyClPeerId,
+    /// A CL peer action was given an enode record.
+    #[error("CL peer actions need a bare libp2p peer ID, not an enode record")]
+    ClPeerIdIsEnode {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// A CL peer action was given an ENR record.
+    #[error(
+        "CL peer actions need a bare libp2p peer ID; ENR records are only accepted by add-peer"
+    )]
+    ClPeerIdIsEnr {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// The CL peer ID contained whitespace.
+    #[error("CL peer ID must not contain whitespace")]
+    ClPeerIdContainsWhitespace {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// The CL peer ID was URL-like or multiaddr-like instead of a bare peer ID.
+    #[error("CL peer actions need a bare libp2p peer ID, not a URL or multiaddr")]
+    ClPeerIdNotBare {
+        /// The target supplied by the caller.
+        target: String,
+    },
+    /// The CL peer ID was too short to plausibly be a libp2p peer ID.
+    #[error(
+        "CL peer ID `{target}` looks too short to be a valid libp2p peer ID; expected a base58-encoded string (e.g. 16Uiu2HAm...)"
+    )]
+    ClPeerIdTooShort {
+        /// The target supplied by the caller.
+        target: String,
+        /// The minimum accepted length for a libp2p peer ID.
+        min_len: usize,
+    },
+}
+
+/// Error returned by the `p2p` command group.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum P2pCommandError {
+    /// Some peers failed during `unban-all`.
+    #[error("failed to unban {failed} CL peer(s)")]
+    UnbanAllPartialFailure {
+        /// The number of failed peer unban attempts.
+        failed: usize,
+    },
+    /// The pretty-printer received a peer action shape it does not support.
+    #[error("unsupported p2p pretty output action {action}")]
+    UnsupportedPrettyAction {
+        /// The unsupported action name.
+        action: String,
+    },
+}
+
+/// Error returned by the `conductor` command group.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ConductorCommandError {
+    /// The command could not resolve a conductor source from config or flags.
+    #[error(
+        "conductor commands need conductor config or a bootstrap RPC URL for '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`."
+    )]
+    MissingSource {
+        /// The config name selected for the command.
+        config_name: String,
+    },
+    /// The requested conductor node name was not found.
+    #[error("conductor node {requested_node} not found. Available nodes: {}", available_nodes.join(", "))]
+    MissingNode {
+        /// The node name requested by the caller.
+        requested_node: String,
+        /// The node names available to the command.
+        available_nodes: Vec<String>,
+    },
+}
+
+/// Error returned by sequencer command validation and preflight checks.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum SequencerCommandError {
+    /// The command could not resolve a conductor source from config or flags.
+    #[error(
+        "sequencer commands need conductor config or a bootstrap RPC URL for '{config_name}'. Set `conductors` or `discovery.bootstrap_rpc` in config, or pass `--conductor-rpc <url>`."
+    )]
+    MissingSource {
+        /// The config name selected for the command.
+        config_name: String,
+    },
+    /// The requested sequencer node name was not found.
+    #[error("sequencer node {requested_node} not found. Available nodes: {}", available_nodes.join(", "))]
+    MissingNode {
+        /// The node name requested by the caller.
+        requested_node: String,
+        /// The node names available to the command.
+        available_nodes: Vec<String>,
+    },
+    /// The command could not infer an unsafe head hash from the target node.
+    #[error(
+        "could not determine unsafe head for {node}; pass an explicit 32-byte hash or restore CL reachability"
+    )]
+    MissingUnsafeHead {
+        /// The target node name.
+        node: String,
+    },
+    /// The target sequencer is already active.
+    #[error("sequencer already active on {node}; stop it before starting again")]
+    AlreadyActive {
+        /// The target node name.
+        node: String,
+    },
+    /// The target sequencer is already stopped.
+    #[error("sequencer already stopped on {node}")]
+    AlreadyStopped {
+        /// The target node name.
+        node: String,
+    },
+    /// The command targeted a node that is known not to be the conductor leader.
+    #[error(
+        "Node is not the conductor leader. Current leader: {current_leader}. `basectl sequencer {action}` must target the leader instead of {requested_node}."
+    )]
+    NotCurrentLeader {
+        /// The node name requested by the caller.
+        requested_node: String,
+        /// The node currently observed as conductor leader.
+        current_leader: String,
+        /// The sequencer action being validated.
+        action: String,
+    },
+    /// The command targeted a follower while no current leader name was available.
+    #[error(
+        "Node is not the conductor leader. `basectl sequencer {action}` must target the current leader instead of {requested_node}."
+    )]
+    NotLeader {
+        /// The node name requested by the caller.
+        requested_node: String,
+        /// The sequencer action being validated.
+        action: String,
+    },
+    /// The observed unsafe head is zero, so no safe prestate exists for start.
+    #[error("no prestate: engine unsafe head is uninitialized, cannot safely start sequencer")]
+    UninitializedUnsafeHead,
+    /// The requested unsafe head did not match the node's observed unsafe head.
+    #[error(
+        "block hash mismatch: engine unsafe head is {observed_hash}, caller requested {requested_hash}"
+    )]
+    UnsafeHeadMismatch {
+        /// The unsafe head observed from the node.
+        observed_hash: B256,
+        /// The unsafe head requested by the caller.
+        requested_hash: B256,
+    },
+    /// The unsafe head input was empty after trimming whitespace.
+    #[error("unsafe head hash cannot be empty")]
+    EmptyUnsafeHead,
+    /// The unsafe head input could not be parsed as a 32-byte hash.
+    #[error("parsing unsafe head hash `{raw}`: {message}")]
+    InvalidUnsafeHead {
+        /// The original unsafe head supplied by the caller.
+        raw: String,
+        /// The parser error returned by the underlying hash parser.
+        message: String,
+    },
+    /// The unsafe head input was the zero hash.
+    #[error("unsafe head hash must not be zero")]
+    ZeroUnsafeHead {
+        /// The parsed zero hash requested by the caller.
+        requested_hash: B256,
+    },
+    /// The sequencer active state did not converge after the command RPC succeeded.
+    #[error(
+        "{action} RPC succeeded on {node} ({cl_rpc}){}, but `sequencer_active={expected_active}` was not observed within {timeout:?}{}",
+        unsafe_head.map_or_else(String::new, |unsafe_head| format!(" at {unsafe_head}")),
+        match (last_observed, last_error.as_deref()) {
+            (Some(observed), Some(error)) => format!(" (last observed `sequencer_active={observed}`; last poll error: {error})"),
+            (Some(observed), None) => format!(" (last observed `sequencer_active={observed}`)"),
+            (None, Some(error)) => format!(" (last poll error: {error})"),
+            (None, None) => String::new(),
+        }
+    )]
+    StateConvergenceTimeout {
+        /// The sequencer action being observed.
+        action: &'static str,
+        /// The target node name.
+        node: Box<str>,
+        /// The target node consensus-layer RPC URL.
+        cl_rpc: Box<str>,
+        /// The unsafe head returned or requested for the command, if known.
+        unsafe_head: Option<B256>,
+        /// The expected `sequencer_active` state.
+        expected_active: bool,
+        /// The observation timeout used for state convergence.
+        timeout: Duration,
+        /// The last observed `sequencer_active` state, if any poll succeeded.
+        last_observed: Option<bool>,
+        /// The last polling error, if any poll failed.
+        last_error: Option<Box<str>>,
+    },
+}
+
+/// Error returned by doctor argument validation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum DoctorArgsError {
+    /// The head-lag warning threshold is greater than or equal to the failure threshold.
+    #[error("`--head-lag-warn-blocks` must be less than `--head-lag-fail-blocks`")]
+    HeadLagWarnMustBeLessThanFail {
+        /// The configured warning threshold.
+        warn_blocks: u64,
+        /// The configured failure threshold.
+        fail_blocks: u64,
+    },
+    /// The safe-head recency warning threshold is greater than or equal to the failure threshold.
+    #[error("`--safe-recency-warn-blocks` must be less than `--safe-recency-fail-blocks`")]
+    SafeRecencyWarnMustBeLessThanFail {
+        /// The configured warning threshold.
+        warn_blocks: u64,
+        /// The configured failure threshold.
+        fail_blocks: u64,
+    },
+}

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -36,7 +36,7 @@ pub use doctor::{
 mod errors;
 pub use errors::{
     BlockRefParseError, ConductorCommandError, DoctorArgsError, MissingConsensusRpcError,
-    P2pCommandError, P2pTargetError, SequencerCommandError,
+    NodeLookupError, P2pCommandError, P2pTargetError, SequencerCommandError,
 };
 
 mod rpc;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -33,6 +33,12 @@ pub use doctor::{
     DoctorThresholds, LayerEndpointSanity, RethLimitSection, RethLimits, RethToml,
 };
 
+mod errors;
+pub use errors::{
+    BlockRefParseError, ConductorCommandError, DoctorArgsError, MissingConsensusRpcError,
+    P2pCommandError, P2pTargetError, SequencerCommandError,
+};
+
 mod rpc;
 pub use rpc::{
     BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ClInfoReport,

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -37,6 +37,7 @@ mod errors;
 pub use errors::{
     BlockRefParseError, ConductorCommandError, DoctorArgsError, MissingConsensusRpcError,
     NodeLookupError, P2pCommandError, P2pTargetError, SequencerCommandError,
+    StateConvergenceTimeoutError,
 };
 
 mod rpc;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -35,9 +35,8 @@ pub use doctor::{
 
 mod errors;
 pub use errors::{
-    BlockRefParseError, ConductorCommandError, DoctorArgsError, MissingConsensusRpcError,
-    NodeLookupError, P2pCommandError, P2pTargetError, SequencerCommandError,
-    StateConvergenceTimeoutError,
+    BlockRefParseError, ConductorCommandError, DoctorArgsError, NodeLookupError, P2pCommandError,
+    P2pTargetError, SequencerCommandError, StateConvergenceTimeoutError, SyncStatusCommandError,
 };
 
 mod rpc;

--- a/crates/infra/basectl/src/rpc/admin.rs
+++ b/crates/infra/basectl/src/rpc/admin.rs
@@ -44,9 +44,9 @@ pub async fn start_sequencer(cl_rpc: &Url, unsafe_head: B256) -> Result<()> {
 /// Returns the unsafe head hash captured at the moment the sequencer stopped.
 /// A returned [`B256::ZERO`] means the sequencer was stopped but the captured
 /// head is unavailable; it is not a valid restart point and must not be reused.
-/// Because the RPC has already taken effect by the time this returns, an
-/// unexpected zero head is surfaced as a warning rather than an error so callers
-/// do not treat a successful stop as a failure and retry it.
+/// Because the RPC has already taken effect by the time this returns, surface
+/// the missing head as a warning rather than an error so callers do not retry a
+/// successful stop.
 pub async fn stop_sequencer(cl_rpc: &Url) -> Result<B256> {
     // `admin_stopSequencer` may defer its response until the seal pipeline
     // finishes and the final unsafe head is known.

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -177,18 +177,15 @@ impl ConductorControl {
 
         match &source {
             ConductorSource::Static(static_nodes) => {
-                let membership_result = Self::current_membership(&source).await;
-                let (membership, mut membership_error) = match membership_result {
+                let (membership, mut membership_error) = match Self::current_membership(&source)
+                    .await
+                {
                     Ok(membership) => (Some(membership), None),
                     Err(error) => {
                         warn!(error = %error, "failed to fetch conductor cluster membership for static snapshot");
                         (None, Some(error.to_string()))
                     }
                 };
-                // A fetched membership that references servers missing from the
-                // static config cannot be reconciled, but the configured node
-                // list is still usable, so degrade to it instead of failing the
-                // whole snapshot.
                 let nodes = match Self::snapshot_nodes(&source, membership.as_ref()) {
                     Ok(nodes) => nodes,
                     Err(error) => {
@@ -590,12 +587,8 @@ async fn wait_for_stable_leader(
 ///
 /// Classification is by message content rather than JSON-RPC error code on
 /// purpose. This runs against op-conductor's leader-transfer RPCs, which surface
-/// the not-leader condition under several codes (e.g. `-32000` directly and the
-/// generic `-32603` "internal error" when wrapped), so the code is not a
-/// reliable signal and gating on it would miss legitimate stale-leader errors.
-/// [`is_stale_leader_message`] instead keeps false positives in check with a
-/// strict filler-word allowlist (so e.g. "not authorized as cluster leader" does
-/// not match), and the call site only retries a bounded number of times.
+/// the not-leader condition under several codes, so the code is not a reliable
+/// signal and gating on it would miss legitimate stale-leader errors.
 fn is_stale_leader_error(error: &JsonRpcClientError) -> bool {
     match error {
         JsonRpcClientError::Call(payload) => is_stale_leader_message(payload.message()),
@@ -1296,8 +1289,6 @@ mod tests {
             "leader could not be contacted",
             None::<()>,
         ));
-        // Even under the canonical stale-leader code, an unrelated "not ... leader"
-        // phrase is rejected by the filler-word allowlist (no code-based fallback).
         let unrelated_role = JsonRpcClientError::Call(ErrorObjectOwned::owned(
             -32000,
             "not authorized as cluster leader",


### PR DESCRIPTION
## Summary
  - Add shared typed errors for basectl-owned validation, preflight, and semantic outcomes
  - Wire block, sync-status, p2p, conductor, sequencer, and doctor helpers to return typed validation errors
  - Keep execution failures as `anyhow` errors with operation context instead of public wrapper variants

## Test Plan
  - [x] `cargo test -p basectl -p basectl-cli`
  - [x] `cargo clippy -p basectl -p basectl-cli --all-targets`
  - [x] Manual devnet read-only checks for `block`, `sync-status`, `p2p`, `conductor`, `sequencer`, and `doctor`
  - [x] Manual validation/preflight error checks for invalid block refs, P2P targets, missing CL RPC config, conductor node lookup, sequencer preflight, and doctor thresholds