### PR TITLE
test(trie/rocksdb): add integration tests and benchmarks (read path pending)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4713,6 +4713,7 @@ dependencies = [
  "base-metrics",
  "bincode 2.0.1",
  "bytes",
+ "criterion",
  "derive_more 2.1.1",
  "eyre",
  "metrics",

--- a/crates/execution/trie/Cargo.toml
+++ b/crates/execution/trie/Cargo.toml
@@ -81,6 +81,15 @@ tokio = { workspace = true, features = ["test-util", "rt-multi-thread", "macros"
 
 # misc
 serial_test.workspace = true
+criterion = { workspace = true, features = ["html_reports"] }
+
+[[bench]]
+name = "witness_reads"
+harness = false
+
+[[bench]]
+name = "deep_history_reads"
+harness = false
 
 [features]
 serde-bincode-compat = [

--- a/crates/execution/trie/benches/deep_history_reads.rs
+++ b/crates/execution/trie/benches/deep_history_reads.rs
@@ -1,0 +1,228 @@
+//! Benchmarks the proofs-history read path against DEEP per-key version chains.
+//!
+//! Seeds a [`RocksDB`] proofs-history store with `BASE_ACCOUNTS` accounts, each
+//! one updated `VERSIONS_PER_KEY` times across sequential blocks, so every
+//! `HashedAccountHistory` user-key has a long version chain. Then drives
+//! `TARGET_ACCOUNTS` reads through the same `StateProviderDatabase` path that
+//! block execution uses, at two read snapshots: chain head (latest version
+//! sits at the start of the chain) and chain midpoint (the cursor must skip
+//! over the newer half of the chain before landing on its answer).
+//!
+//! This is where the complement-key encoding's asymptotic win should show: the
+//! reversed encoding turns the "latest version <= N" lookup into a single
+//! `seek()` instead of a `seek_for_prev()` that on the LSM-tree memtable runs
+//! 7-8x slower (`RocksDB` PR #5535).
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_trie::{
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, BlockStateDiff,
+    RocksdbProofsStorage, provider::BaseProofsStateProviderRef,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand_08::{RngCore, SeedableRng, rngs::StdRng};
+use reth_primitives_traits::Account;
+use reth_provider::{AccountReader, noop::NoopProvider};
+use reth_revm::{Database, State, database::StateProviderDatabase};
+use reth_trie_common::{HashedPostState, updates::TrieUpdates};
+use tempfile::TempDir;
+
+const BASE_ACCOUNTS: usize = 1_000;
+const VERSIONS_PER_KEY: u64 = 100;
+const TARGET_ACCOUNTS: usize = 256;
+const MISSING_ACCOUNTS: usize = 64;
+
+#[derive(Clone)]
+struct SeedAccount {
+    address: Address,
+    hashed_address: B256,
+}
+
+struct DeepHistoryFixture {
+    _dir: TempDir,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    accounts: Vec<SeedAccount>,
+    targets: Vec<SeedAccount>,
+    missing_addresses: Vec<Address>,
+}
+
+fn random_bytes<const N: usize>(rng: &mut StdRng) -> [u8; N] {
+    let mut bytes = [0; N];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
+fn account_at_version(index: usize, version: u64) -> Account {
+    Account {
+        nonce: version,
+        balance: U256::from((index as u64 + 1) * 1_000 + version),
+        bytecode_hash: None,
+    }
+}
+
+fn generate_accounts(count: usize) -> Vec<SeedAccount> {
+    let mut rng = StdRng::seed_from_u64(0xDEAD_BEEF);
+    (0..count)
+        .map(|_| {
+            let address = Address::from(random_bytes::<20>(&mut rng));
+            let hashed_address = keccak256(address);
+            SeedAccount { address, hashed_address }
+        })
+        .collect()
+}
+
+fn missing_addresses() -> Vec<Address> {
+    (0..MISSING_ACCOUNTS).map(|index| Address::repeat_byte(0x80 | index as u8)).collect()
+}
+
+const fn block_for(number: u64, parent: B256) -> BlockWithParent {
+    BlockWithParent {
+        parent,
+        block: BlockNumHash {
+            number,
+            hash: if number == 0 { B256::ZERO } else { B256::repeat_byte(number as u8) },
+        },
+    }
+}
+
+fn diff_for_all_accounts(accounts: &[SeedAccount], version: u64) -> BlockStateDiff {
+    let mut post_state = HashedPostState::default();
+    for (index, account) in accounts.iter().enumerate() {
+        post_state
+            .accounts
+            .insert(account.hashed_address, Some(account_at_version(index, version)));
+    }
+    BlockStateDiff {
+        sorted_trie_updates: TrieUpdates::default().into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    }
+}
+
+fn create_fixture(compact: bool) -> DeepHistoryFixture {
+    let dir = TempDir::new().expect("create temp dir");
+    let rocksdb = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("create RocksDB storage"));
+    let accounts = generate_accounts(BASE_ACCOUNTS);
+
+    rocksdb
+        .store_hashed_accounts(
+            accounts
+                .iter()
+                .enumerate()
+                .map(|(index, account)| {
+                    (account.hashed_address, Some(account_at_version(index, 0)))
+                })
+                .collect(),
+        )
+        .expect("store hashed accounts");
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("set initial state anchor");
+    rocksdb.commit_initial_state().expect("commit initial state");
+
+    let mut parent_hash = B256::ZERO;
+    for version in 1..=VERSIONS_PER_KEY {
+        let block_ref = block_for(version, parent_hash);
+        let diff = diff_for_all_accounts(&accounts, version);
+        rocksdb.store_trie_updates(block_ref, diff).expect("store version");
+        parent_hash = block_ref.block.hash;
+    }
+
+    if compact {
+        rocksdb.flush_and_compact().expect("flush and compact RocksDB fixture");
+    }
+
+    let targets = accounts.iter().take(TARGET_ACCOUNTS).cloned().collect::<Vec<_>>();
+    let storage = BaseProofsStorage::from(rocksdb);
+    let fixture = DeepHistoryFixture {
+        _dir: dir,
+        storage,
+        accounts,
+        targets,
+        missing_addresses: missing_addresses(),
+    };
+    validate_fixture(&fixture);
+    fixture
+}
+
+fn validate_fixture(fixture: &DeepHistoryFixture) {
+    let head_provider = BaseProofsStateProviderRef::new(
+        Box::<NoopProvider>::default(),
+        &fixture.storage,
+        VERSIONS_PER_KEY,
+    );
+    let mid_block = VERSIONS_PER_KEY / 2;
+    let mid_provider = BaseProofsStateProviderRef::new(
+        Box::<NoopProvider>::default(),
+        &fixture.storage,
+        mid_block,
+    );
+
+    for (index, target) in fixture.accounts.iter().enumerate().take(8) {
+        let head =
+            head_provider.basic_account(&target.address).expect("head read").expect("head exists");
+        assert_eq!(head, account_at_version(index, VERSIONS_PER_KEY));
+
+        let mid =
+            mid_provider.basic_account(&target.address).expect("mid read").expect("mid exists");
+        assert_eq!(mid, account_at_version(index, mid_block));
+    }
+
+    for missing_address in fixture.missing_addresses.iter().take(8) {
+        assert!(head_provider.basic_account(missing_address).expect("missing read").is_none());
+    }
+}
+
+fn read_accounts_at_block(fixture: &DeepHistoryFixture, max_block: u64) -> usize {
+    let provider = BaseProofsStateProviderRef::new(
+        Box::<NoopProvider>::default(),
+        &fixture.storage,
+        max_block,
+    );
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+
+    let mut reads = 0;
+    for target in &fixture.targets {
+        black_box(state.basic(target.address).expect("read account").expect("account exists"));
+        reads += 1;
+    }
+    for missing_address in &fixture.missing_addresses {
+        black_box(state.basic(*missing_address).expect("read missing account"));
+        reads += 1;
+    }
+    reads
+}
+
+fn deep_history_benches(c: &mut Criterion) {
+    let uncompacted = create_fixture(false);
+    let compacted = create_fixture(true);
+    let mid_block = VERSIONS_PER_KEY / 2;
+
+    let mut group = c.benchmark_group("deep_history_reads");
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("chain_head_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&uncompacted, VERSIONS_PER_KEY)));
+    });
+
+    group.bench_function(BenchmarkId::new("chain_mid_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&uncompacted, mid_block)));
+    });
+
+    group.bench_function(BenchmarkId::new("chain_head_reads_compacted", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&compacted, VERSIONS_PER_KEY)));
+    });
+
+    group.bench_function(BenchmarkId::new("chain_mid_reads_compacted", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_at_block(&compacted, mid_block)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, deep_history_benches);
+criterion_main!(benches);

--- a/crates/execution/trie/benches/witness_reads.rs
+++ b/crates/execution/trie/benches/witness_reads.rs
@@ -1,0 +1,262 @@
+//! Benchmarks the proofs-history read path used by debug witness generation.
+//!
+//! This benchmark seeds a `RocksDB` proofs-history store with deterministic
+//! account and storage data, then repeatedly performs the DB-bound reads that
+//! `debug_executionWitness` drives through `StateProviderDatabase` and
+//! `revm::State` while EVM execution records touched state.
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_eips::BlockNumHash;
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_trie::{
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, RocksdbProofsStorage,
+    provider::BaseProofsStateProviderRef,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand_08::{RngCore, SeedableRng, rngs::StdRng};
+use reth_primitives_traits::Account;
+use reth_provider::{AccountReader, StateProofProvider, StateProvider, noop::NoopProvider};
+use reth_revm::{
+    Database, State, database::StateProviderDatabase, witness::ExecutionWitnessRecord,
+};
+use reth_trie_common::{ExecutionWitnessMode, TrieInput};
+use tempfile::TempDir;
+
+const BASE_ACCOUNTS: usize = 10_000;
+const SLOTS_PER_ACCOUNT: usize = 8;
+const TARGET_ACCOUNTS: usize = 256;
+const MISSING_ACCOUNTS: usize = 64;
+
+#[derive(Clone)]
+struct SeedAccount {
+    address: Address,
+    hashed_address: B256,
+    account: Account,
+    slots: Vec<(B256, B256, U256)>,
+}
+
+struct WitnessReadFixture {
+    _dir: TempDir,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
+    targets: Vec<SeedAccount>,
+    missing_addresses: Vec<Address>,
+}
+
+fn random_bytes<const N: usize>(rng: &mut StdRng) -> [u8; N] {
+    let mut bytes = [0; N];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
+fn account_for(index: usize) -> Account {
+    Account {
+        nonce: index as u64,
+        balance: U256::from((index as u64 + 1) * 1_000),
+        bytecode_hash: None,
+    }
+}
+
+fn generate_accounts(count: usize, slots_per_account: usize) -> Vec<SeedAccount> {
+    let mut rng = StdRng::seed_from_u64(0xBEEF_F00D);
+    (0..count)
+        .map(|index| {
+            let address = Address::from(random_bytes::<20>(&mut rng));
+            let hashed_address = keccak256(address);
+            let account = account_for(index);
+            let slots = (0..slots_per_account)
+                .map(|slot_index| {
+                    let storage_key = B256::from(random_bytes::<32>(&mut rng));
+                    let hashed_storage_key = keccak256(storage_key);
+                    let value = U256::from((index as u64 + 1) * 10_000 + slot_index as u64);
+                    (storage_key, hashed_storage_key, value)
+                })
+                .collect();
+            SeedAccount { address, hashed_address, account, slots }
+        })
+        .collect()
+}
+
+fn missing_addresses() -> Vec<Address> {
+    (0..MISSING_ACCOUNTS).map(|index| Address::repeat_byte(0x80 | index as u8)).collect()
+}
+
+fn create_fixture(compact: bool) -> WitnessReadFixture {
+    let dir = TempDir::new().expect("create temp dir");
+    let rocksdb = Arc::new(RocksdbProofsStorage::new(dir.path()).expect("create RocksDB storage"));
+    let accounts = generate_accounts(BASE_ACCOUNTS, SLOTS_PER_ACCOUNT);
+
+    rocksdb
+        .store_hashed_accounts(
+            accounts
+                .iter()
+                .map(|account| (account.hashed_address, Some(account.account)))
+                .collect(),
+        )
+        .expect("store hashed accounts");
+
+    for account in &accounts {
+        let storages = account
+            .slots
+            .iter()
+            .map(|(_, hashed_storage_key, value)| (*hashed_storage_key, *value));
+        rocksdb
+            .store_hashed_storages(account.hashed_address, storages.collect())
+            .expect("store hashed storage");
+    }
+
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("set initial state anchor");
+    rocksdb.commit_initial_state().expect("commit initial state");
+
+    if compact {
+        rocksdb.flush_and_compact().expect("flush and compact RocksDB fixture");
+    }
+
+    let targets = accounts.into_iter().take(TARGET_ACCOUNTS).collect::<Vec<_>>();
+    let storage = BaseProofsStorage::from(rocksdb);
+    let fixture =
+        WitnessReadFixture { _dir: dir, storage, targets, missing_addresses: missing_addresses() };
+    validate_fixture(&fixture);
+    fixture
+}
+
+fn validate_fixture(fixture: &WitnessReadFixture) {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+
+    for target in &fixture.targets {
+        let account =
+            provider.basic_account(&target.address).expect("read account").expect("account exists");
+        assert_eq!(account, target.account);
+
+        for (storage_key, _, value) in &target.slots {
+            let storage_value = provider
+                .storage(target.address, *storage_key)
+                .expect("read storage")
+                .expect("storage exists");
+            assert_eq!(storage_value, *value);
+        }
+
+        assert!(
+            provider
+                .storage(target.address, B256::repeat_byte(0xFE))
+                .expect("read missing storage")
+                .is_none()
+        );
+    }
+
+    for missing_address in &fixture.missing_addresses {
+        assert!(provider.basic_account(missing_address).expect("read missing account").is_none());
+    }
+}
+
+fn read_accounts_and_storage_with_provider<Storage>(
+    provider: &BaseProofsStateProviderRef<'_, Storage>,
+    fixture: &WitnessReadFixture,
+) -> usize
+where
+    Storage: BaseProofsStore + Clone,
+{
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(provider))
+        .with_bundle_update()
+        .build();
+    read_accounts_and_storage_with_state(&mut state, fixture)
+}
+
+fn read_accounts_and_storage_with_state<DB>(
+    state: &mut State<StateProviderDatabase<DB>>,
+    fixture: &WitnessReadFixture,
+) -> usize
+where
+    State<StateProviderDatabase<DB>>: reth_revm::Database,
+{
+    let mut reads = 0;
+
+    for target in &fixture.targets {
+        black_box(state.basic(target.address).expect("read account").expect("account exists"));
+        reads += 1;
+
+        for (storage_key, _, _) in &target.slots {
+            black_box(state.storage(target.address, (*storage_key).into()).expect("read storage"));
+            reads += 1;
+        }
+
+        black_box(
+            state
+                .storage(target.address, B256::repeat_byte(0xFE).into())
+                .expect("read missing storage"),
+        );
+        reads += 1;
+    }
+
+    for missing_address in &fixture.missing_addresses {
+        black_box(state.basic(*missing_address).expect("read missing account"));
+        reads += 1;
+    }
+
+    reads
+}
+
+fn read_accounts_and_storage(fixture: &WitnessReadFixture) -> usize {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+    read_accounts_and_storage_with_provider(&provider, fixture)
+}
+
+fn read_accounts_storage_and_witness(fixture: &WitnessReadFixture) -> usize {
+    let provider =
+        BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &fixture.storage, 0);
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(&provider))
+        .with_bundle_update()
+        .build();
+    let reads = read_accounts_and_storage_with_state(&mut state, fixture);
+    let ExecutionWitnessRecord { hashed_state, codes, keys, lowest_block_number } =
+        ExecutionWitnessRecord::from_executed_state(&state, ExecutionWitnessMode::default());
+    black_box(codes);
+    black_box(keys);
+    black_box(lowest_block_number);
+    black_box(
+        provider
+            .witness(TrieInput::default(), hashed_state, ExecutionWitnessMode::default())
+            .expect("build witness"),
+    );
+    reads
+}
+
+fn witness_read_benches(c: &mut Criterion) {
+    let fixture = create_fixture(false);
+    let compacted_fixture = create_fixture(true);
+    let mut group = c.benchmark_group("debug_execution_witness/proofs_history_reads");
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("account_storage_reads", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_and_storage(&fixture)));
+    });
+
+    group.bench_function(BenchmarkId::new("reads_plus_witness_overlay", TARGET_ACCOUNTS), |b| {
+        b.iter(|| black_box(read_accounts_storage_and_witness(&fixture)));
+    });
+
+    group.bench_function(
+        BenchmarkId::new("account_storage_reads_compacted", TARGET_ACCOUNTS),
+        |b| {
+            b.iter(|| black_box(read_accounts_and_storage(&compacted_fixture)));
+        },
+    );
+
+    group.bench_function(
+        BenchmarkId::new("reads_plus_witness_overlay_compacted", TARGET_ACCOUNTS),
+        |b| {
+            b.iter(|| black_box(read_accounts_storage_and_witness(&compacted_fixture)));
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, witness_read_benches);
+criterion_main!(benches);

--- a/crates/execution/trie/tests/branch_cursors/mod.rs
+++ b/crates/execution/trie/tests/branch_cursors/mod.rs
@@ -1,0 +1,693 @@
+//! Branch trie cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+// =============================================================================
+// 1. Basic Cursor Operations
+// =============================================================================
+
+/// Test cursor operations on empty trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // All operations should return None on empty trie
+    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
+    assert!(cursor.seek(Nibbles::default())?.is_none());
+    assert!(cursor.next()?.is_none());
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with single entry
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    // Store single entry
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test seek_exact
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Test current position
+    assert_eq!(cursor.current()?.unwrap(), path);
+
+    // Test next from end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor operations with multiple entries
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![2, 3]),
+    ];
+    let branch = create_test_branch();
+
+    // Store multiple entries
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Test that we can iterate through all entries
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    assert_eq!(found_paths.len(), 4);
+    // Paths should be in lexicographic order
+    for i in 0..paths.len() {
+        assert_eq!(found_paths[i], paths[i]);
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// 2. Seek Operations
+// =============================================================================
+
+/// Test `seek_exact` with existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test `seek_exact` with non-existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let non_existing = nibbles_from(vec![4, 5, 6]);
+    assert!(cursor.seek_exact(non_existing)?.is_none());
+
+    Ok(())
+}
+
+/// Test `seek_exact` with empty path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
+    assert_eq!(result.0, Nibbles::default());
+
+    Ok(())
+}
+
+/// Test seek to existing path
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2, 3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let result = cursor.seek(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test seek between existing nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![3]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path between 1 and 3, should return path 3
+    let seek_path = nibbles_from(vec![2]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test seek after all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path after all nodes
+    let seek_path = nibbles_from(vec![9]);
+    assert!(cursor.seek(seek_path)?.is_none());
+
+    Ok(())
+}
+
+/// Test seek before all nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![5]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // Seek to path before all nodes, should return first node
+    let seek_path = nibbles_from(vec![1]);
+    let result = cursor.seek(seek_path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+// =============================================================================
+// 3. Navigation Tests
+// =============================================================================
+
+/// Test next without prior seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    // next() without prior seek should start from beginning
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path);
+
+    Ok(())
+}
+
+/// Test next after seek
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path1)?;
+
+    // next() should return second node
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, path2);
+
+    Ok(())
+}
+
+/// Test next at end of trie
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    cursor.seek(path)?;
+
+    // next() at end should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test multiple consecutive next calls
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Iterate through all with consecutive next() calls
+    for expected_path in &paths {
+        let result = cursor.next()?.unwrap();
+        assert_eq!(result.0, *expected_path);
+    }
+
+    // Final next() should return None
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test current after operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let branch = create_test_branch();
+
+    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None initially
+    assert!(cursor.current()?.is_none());
+
+    // After seek, current should track position
+    cursor.seek(path1)?;
+    assert_eq!(cursor.current()?.unwrap(), path1);
+
+    // After next, current should update
+    cursor.next()?;
+    assert_eq!(cursor.current()?.unwrap(), path2);
+
+    Ok(())
+}
+
+/// Test current with no prior operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Current should be None when no operations performed
+    assert!(cursor.current()?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 4. Block Number Filtering
+// =============================================================================
+
+/// Test same path with different blocks
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch1 = create_test_branch();
+    let branch2 = create_test_branch_variant();
+
+    // Store same path at different blocks
+    storage.store_account_branches(vec![(path, Some(branch1))])?;
+    storage.store_account_branches(vec![(path, Some(branch2))])?;
+
+    // Cursor with max_block_number=75 should see only block 50 data
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    let result75 = cursor75.seek_exact(path)?.unwrap();
+    assert_eq!(result75.0, path);
+
+    // Cursor with max_block_number=150 should see block 100 data (latest)
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    let result150 = cursor150.seek_exact(path)?.unwrap();
+    assert_eq!(result150.0, path);
+
+    Ok(())
+}
+
+/// Test deleted branch nodes
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let branch = create_test_branch();
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Store branch node, then delete it (store None)
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // Cursor before deletion should see the node
+    let mut cursor75 = storage.account_trie_cursor(75)?;
+    assert!(cursor75.seek_exact(path)?.is_some());
+
+    let mut block_state_diff_trie_updates = TrieUpdates::default();
+    block_state_diff_trie_updates.removed_nodes.insert(path);
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should not see the node
+    let mut cursor150 = storage.account_trie_cursor(150)?;
+    assert!(cursor150.seek_exact(path)?.is_none());
+
+    Ok(())
+}
+
+// =============================================================================
+// 5. Hashed Address Filtering
+// =============================================================================
+
+/// Test account-specific cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr1 = B256::repeat_byte(0x01);
+    let addr2 = B256::repeat_byte(0x02);
+    let branch = create_test_branch();
+
+    // Store same path for different accounts (using storage branches)
+    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
+    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
+
+    // Cursor for addr1 should only see addr1 data
+    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
+    let result1 = cursor1.seek_exact(path)?.unwrap();
+    assert_eq!(result1.0, path);
+
+    // Cursor for addr2 should only see addr2 data
+    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
+    let result2 = cursor2.seek_exact(path)?.unwrap();
+    assert_eq!(result2.0, path);
+
+    // Cursor for addr1 should not see addr2 data when iterating
+    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
+    let mut found_count = 0;
+    while cursor1_iter.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
+
+    Ok(())
+}
+
+/// Test state trie cursor
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path = nibbles_from(vec![1, 2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store data for account trie and state trie
+    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path, Some(branch))])?;
+
+    // State trie cursor (None address) should only see state trie data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let result = state_cursor.seek_exact(path)?.unwrap();
+    assert_eq!(result.0, path);
+
+    // Verify state cursor doesn't see account data when iterating
+    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
+    let mut found_count = 0;
+    while state_cursor_iter.next()?.is_some() {
+        found_count += 1;
+    }
+
+    assert_eq!(found_count, 1); // Should only see state trie entry
+
+    Ok(())
+}
+
+/// Test mixed account and state data
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let path1 = nibbles_from(vec![1]);
+    let path2 = nibbles_from(vec![2]);
+    let addr = B256::repeat_byte(0x01);
+    let branch = create_test_branch();
+
+    // Store mixed account and state trie data
+    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
+    storage.store_account_branches(vec![(path2, Some(branch))])?;
+
+    // Account cursor should only see account data
+    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
+    let mut account_paths = Vec::new();
+    while let Some((path, _)) = account_cursor.next()? {
+        account_paths.push(path);
+    }
+    assert_eq!(account_paths.len(), 1);
+    assert_eq!(account_paths[0], path1);
+
+    // State cursor should only see state data
+    let mut state_cursor = storage.account_trie_cursor(100)?;
+    let mut state_paths = Vec::new();
+    while let Some((path, _)) = state_cursor.next()? {
+        state_paths.push(path);
+    }
+    assert_eq!(state_paths.len(), 1);
+    assert_eq!(state_paths[0], path2);
+
+    Ok(())
+}
+
+// =============================================================================
+// 6. Path Ordering Tests
+// =============================================================================
+
+/// Test lexicographic ordering
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![3, 1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![1]),
+    ];
+    let branch = create_test_branch();
+
+    // Store paths in random order
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
+    let expected_order = vec![
+        nibbles_from(vec![1]),
+        nibbles_from(vec![1, 2]),
+        nibbles_from(vec![2]),
+        nibbles_from(vec![3, 1]),
+    ];
+
+    assert_eq!(found_paths, expected_order);
+
+    Ok(())
+}
+
+/// Test path prefix scenarios
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let paths = vec![
+        nibbles_from(vec![1]),       // Prefix of next
+        nibbles_from(vec![1, 2]),    // Extends first
+        nibbles_from(vec![1, 2, 3]), // Extends second
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+
+    // Seek to prefix should find exact match
+    let result = cursor.seek_exact(paths[0])?.unwrap();
+    assert_eq!(result.0, paths[0]);
+
+    // Next should go to next path, not skip prefixed paths
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[1]);
+
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, paths[2]);
+
+    Ok(())
+}
+
+/// Test complex nibble combinations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test various nibble patterns including edge values
+    let paths = vec![
+        nibbles_from(vec![0]),
+        nibbles_from(vec![0, 15]),
+        nibbles_from(vec![15]),
+        nibbles_from(vec![15, 0]),
+        nibbles_from(vec![7, 8, 9]),
+    ];
+    let branch = create_test_branch();
+
+    for path in &paths {
+        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    }
+
+    let mut cursor = storage.account_trie_cursor(100)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor.next()? {
+        found_paths.push(path);
+    }
+
+    // All paths should be found and in correct order
+    assert_eq!(found_paths.len(), 5);
+
+    // Verify specific ordering for edge cases
+    assert_eq!(found_paths[0], nibbles_from(vec![0]));
+    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
+    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/hashed_cursors/mod.rs
+++ b/crates/execution/trie/tests/hashed_cursors/mod.rs
@@ -1,0 +1,703 @@
+//! Hashed account and storage cursor behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+fn account_exact<S: BaseProofsStore>(
+    storage: &S,
+    key: B256,
+    max_block: u64,
+) -> Result<Option<Account>, BaseProofsStorageError> {
+    Ok(storage
+        .account_hashed_cursor(max_block)?
+        .seek(key)?
+        .and_then(|(k, v)| (k == key).then_some(v)))
+}
+
+fn storage_exact<S: BaseProofsStore>(
+    storage: &S,
+    hashed_address: B256,
+    key: B256,
+    max_block: u64,
+) -> Result<Option<U256>, BaseProofsStorageError> {
+    Ok(storage
+        .storage_hashed_cursor(hashed_address, max_block)?
+        .seek(key)?
+        .and_then(|(k, v)| (k == key).then_some(v)))
+}
+
+// =============================================================================
+// 7. Leaf Node Tests (Hashed Accounts and Storage)
+// =============================================================================
+
+/// Test store and retrieve single account
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account = create_test_account();
+
+    // Store account
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let result = cursor.seek(account_key)?.unwrap();
+
+    assert_eq!(result.0, account_key);
+    assert_eq!(result.1.nonce, account.nonce);
+    assert_eq!(result.1.balance, account.balance);
+    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
+
+    Ok(())
+}
+
+/// Test account cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let accounts = [
+        (B256::repeat_byte(0x01), create_test_account()),
+        (B256::repeat_byte(0x03), create_test_account()),
+        (B256::repeat_byte(0x05), create_test_account()),
+    ];
+
+    // Store accounts
+    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
+    storage.store_hashed_accounts(accounts_to_store)?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Test seeking to exact key
+    let result = cursor.seek(accounts[1].0)?.unwrap();
+    assert_eq!(result.0, accounts[1].0);
+
+    // Test seeking to key that doesn't exist (should return next greater)
+    let seek_key = B256::repeat_byte(0x02);
+    let result = cursor.seek(seek_key)?.unwrap();
+    assert_eq!(result.0, accounts[1].0); // Should find 0x03
+
+    // Test next() navigation
+    let result = cursor.next()?.unwrap();
+    assert_eq!(result.0, accounts[2].0); // Should find 0x05
+
+    // Test next() at end
+    assert!(cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test that a `RocksDB` cursor reads from the snapshot captured when it is created.
+#[test]
+#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
+#[serial]
+fn test_rocksdb_account_cursor_uses_creation_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let key1 = B256::repeat_byte(0x01);
+    let key2 = B256::repeat_byte(0x02);
+    let account1 = create_test_account_with_values(1, 100, 0xAA);
+    let account2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(key1, Some(account1));
+    post_state.accounts.insert(key2, Some(account2));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let mut cursor = storage.account_hashed_cursor(1)?;
+    let first = cursor.seek(key1)?.expect("first account exists");
+    assert_eq!(first.0, key1);
+
+    let replacement_block1 =
+        BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x22)));
+    let mut replacement_post_state = HashedPostState::default();
+    replacement_post_state.accounts.insert(key1, Some(account1));
+    storage.replace_updates(
+        BlockNumHash::new(0, B256::ZERO),
+        vec![(
+            replacement_block1,
+            BlockStateDiff {
+                sorted_trie_updates: TrieUpdatesSorted::default(),
+                sorted_post_state: replacement_post_state.into_sorted(),
+            },
+        )],
+    )?;
+
+    let next = cursor.next()?.expect("existing cursor keeps its original snapshot");
+    assert_eq!(next.0, key2);
+    assert_eq!(next.1.nonce, account2.nonce);
+
+    let mut fresh_cursor = storage.account_hashed_cursor(1)?;
+    let fresh_result = fresh_cursor.seek(key2)?;
+    assert!(
+        !matches!(fresh_result, Some((found_key, _)) if found_key == key2),
+        "fresh cursor should not see the replaced account"
+    );
+
+    Ok(())
+}
+
+/// Test account block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x01);
+    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
+    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
+
+    // Store account at different blocks
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
+
+    // Cursor with max_block_number=75 should see v1
+    let mut cursor75 = storage.account_hashed_cursor(75)?;
+    let result75 = cursor75.seek(account_key)?.unwrap();
+    assert_eq!(result75.1.nonce, account_v1.nonce);
+    assert_eq!(result75.1.balance, account_v1.balance);
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
+
+    // After update, Cursor with max_block_number=150 should see v2
+    let mut cursor150 = storage.account_hashed_cursor(150)?;
+    let result150 = cursor150.seek(account_key)?.unwrap();
+    assert_eq!(result150.1.nonce, account_v2.nonce);
+    assert_eq!(result150.1.balance, account_v2.balance);
+
+    Ok(())
+}
+
+/// Test store and retrieve storage
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+    ];
+
+    // Store storage slots
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Retrieve via cursor
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Test seeking to each slot
+    for (key, expected_value) in &storage_slots {
+        let result = cursor.seek(*key)?.unwrap();
+        assert_eq!(result.0, *key);
+        assert_eq!(result.1, *expected_value);
+    }
+
+    Ok(())
+}
+
+/// Test storage cursor navigation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x50), U256::from(500)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+
+    // Start from beginning with next()
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    assert_eq!(found_slots.len(), 3);
+    assert_eq!(found_slots[0], storage_slots[0]);
+    assert_eq!(found_slots[1], storage_slots[1]);
+    assert_eq!(found_slots[2], storage_slots[2]);
+
+    Ok(())
+}
+
+/// Test storage account isolation
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let address1 = B256::repeat_byte(0x01);
+    let address2 = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store same storage key for different accounts
+    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
+    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
+
+    // Verify each account sees only its own storage
+    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
+    let result1 = cursor1.seek(storage_key)?.unwrap();
+    assert_eq!(result1.1, U256::from(100));
+
+    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
+    let result2 = cursor2.seek(storage_key)?.unwrap();
+    assert_eq!(result2.1, U256::from(200));
+
+    // Verify cursor1 doesn't see address2's storage
+    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
+    let mut count = 0;
+    while cursor1_iter.next()?.is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 1); // Should only see one entry
+
+    Ok(())
+}
+
+/// Test storage block versioning
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store storage at different blocks
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor with max_block_number=75 should see old value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
+    // Cursor with max_block_number=150 should see new value
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?.unwrap();
+    assert_eq!(result150.1, U256::from(200));
+
+    Ok(())
+}
+
+/// Test storage zero value deletion
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let storage_key = B256::repeat_byte(0x10);
+
+    // Store non-zero value
+    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
+
+    // Cursor before deletion should see the value
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let result75 = cursor75.seek(storage_key)?.unwrap();
+    assert_eq!(result75.1, U256::from(100));
+
+    // "Delete" by storing zero value at block 100
+    let mut block_state_diff_post_state = HashedPostState::default();
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::ZERO);
+    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
+
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: block_state_diff_post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Cursor after deletion should NOT see the entry (zero values are skipped)
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let result150 = cursor150.seek(storage_key)?;
+    assert!(result150.is_none(), "Zero values should be skipped/deleted");
+
+    Ok(())
+}
+
+/// Test that zero values are skipped during iteration
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+
+    // Create a mix of non-zero and zero value storage slots
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
+        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
+        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
+        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
+    ];
+
+    // Store all slots
+    storage.store_hashed_storages(hashed_address, storage_slots)?;
+
+    // Create cursor and iterate through all entries
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor.next()? {
+        found_slots.push((key, value));
+    }
+
+    // Should only find 3 non-zero values
+    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
+
+    // Verify the non-zero values are the ones we stored
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
+
+    // Verify seeking to a zero-value slot returns None or skips to next non-zero
+    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
+    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
+
+    // Should either return None or skip to the next non-zero value (0x30)
+    if let Some((key, value)) = seek_result {
+        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
+        assert_eq!(value, U256::from(300));
+    }
+
+    Ok(())
+}
+
+/// Test empty cursors
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Test empty account cursor
+    let mut account_cursor = storage.account_hashed_cursor(100)?;
+    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
+    assert!(account_cursor.next()?.is_none());
+
+    // Test empty storage cursor
+    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
+    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
+    assert!(storage_cursor.next()?.is_none());
+
+    Ok(())
+}
+
+/// Test cursor boundary conditions
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let account_key = B256::repeat_byte(0x80); // Middle value
+    let account = create_test_account();
+
+    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
+
+    let mut cursor = storage.account_hashed_cursor(100)?;
+
+    // Seek to minimum key should find our account
+    let result = cursor.seek(B256::ZERO)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    // Seek to maximum key should find nothing
+    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
+
+    // Seek to key just before our account should find our account
+    let just_before = B256::repeat_byte(0x7F);
+    let result = cursor.seek(just_before)?.unwrap();
+    assert_eq!(result.0, account_key);
+
+    Ok(())
+}
+
+/// Test large batch operations
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Create large batch of accounts
+    let mut accounts = Vec::new();
+    for i in 0..100 {
+        let key = B256::from([i as u8; 32]);
+        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
+        accounts.push((key, Some(account)));
+    }
+
+    // Store in batch
+    storage.store_hashed_accounts(accounts.clone())?;
+
+    // Verify all accounts can be retrieved
+    let mut cursor = storage.account_hashed_cursor(100)?;
+    let mut found_count = 0;
+    while cursor.next()?.is_some() {
+        found_count += 1;
+    }
+    assert_eq!(found_count, 100);
+
+    // Test specific account retrieval
+    let test_key = B256::from([42u8; 32]);
+    let result = cursor.seek(test_key)?.unwrap();
+    assert_eq!(result.0, test_key);
+    assert_eq!(result.1.nonce, 42);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_exact_account_reads_do_not_return_lower_bound_neighbor<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let left_key = B256::repeat_byte(0x10);
+    let missing_key = B256::repeat_byte(0x20);
+    let right_key = B256::repeat_byte(0x30);
+    let left_account = create_test_account_with_values(1, 100, 0xAA);
+    let right_account = create_test_account_with_values(2, 200, 0xBB);
+
+    storage.store_hashed_accounts(vec![
+        (left_key, Some(left_account)),
+        (right_key, Some(right_account)),
+    ])?;
+
+    assert_eq!(account_exact(&storage, left_key, 100)?, Some(left_account));
+    assert_eq!(account_exact(&storage, right_key, 100)?, Some(right_account));
+    assert_eq!(account_exact(&storage, missing_key, 100)?, None);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_exact_storage_reads_do_not_return_lower_bound_neighbor<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0xA0);
+    let left_key = B256::repeat_byte(0x10);
+    let missing_key = B256::repeat_byte(0x20);
+    let right_key = B256::repeat_byte(0x30);
+
+    storage.store_hashed_storages(
+        hashed_address,
+        vec![(left_key, U256::from(100)), (right_key, U256::from(300))],
+    )?;
+
+    assert_eq!(storage_exact(&storage, hashed_address, left_key, 100)?, Some(U256::from(100)));
+    assert_eq!(storage_exact(&storage, hashed_address, right_key, 100)?, Some(U256::from(300)));
+    assert_eq!(storage_exact(&storage, hashed_address, missing_key, 100)?, None);
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_exact_reads_hide_deleted_account_and_zero_storage<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let deleted_account_key = B256::repeat_byte(0x40);
+    let live_account_key = B256::repeat_byte(0x50);
+    let hashed_address = B256::repeat_byte(0x60);
+    let zero_slot = B256::repeat_byte(0x70);
+    let live_slot = B256::repeat_byte(0x80);
+    let live_account = create_test_account();
+
+    storage.store_hashed_accounts(vec![
+        (deleted_account_key, None),
+        (live_account_key, Some(live_account)),
+    ])?;
+    storage.store_hashed_storages(
+        hashed_address,
+        vec![(zero_slot, U256::ZERO), (live_slot, U256::from(1))],
+    )?;
+
+    assert_eq!(account_exact(&storage, deleted_account_key, 100)?, None);
+    assert_eq!(account_exact(&storage, live_account_key, 100)?, Some(live_account));
+    assert_eq!(storage_exact(&storage, hashed_address, zero_slot, 100)?, None);
+    assert_eq!(storage_exact(&storage, hashed_address, live_slot, 100)?, Some(U256::from(1)));
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
+#[serial]
+fn test_rocksdb_exact_reads_use_supplied_snapshot() -> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x01);
+    let hashed_address = B256::repeat_byte(0x02);
+    let storage_key = B256::repeat_byte(0x03);
+    let account_v1 = create_test_account_with_values(1, 100, 0xAA);
+    let account_v2 = create_test_account_with_values(2, 200, 0xBB);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::from(10));
+    post_state.storages.insert(hashed_address, hashed_storage);
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let tx = storage.ro_tx()?;
+
+    let block2 = BlockWithParent::new(block1.block.hash, NumHash::new(2, B256::repeat_byte(0x22)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v2));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_key, U256::from(20));
+    post_state.storages.insert(hashed_address, hashed_storage);
+    storage.store_trie_updates(
+        block2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let (k, v) = storage
+        .account_hashed_cursor_with_tx(&tx, 2)?
+        .seek(account_key)?
+        .expect("account exists in snapshot");
+    assert_eq!(k, account_key);
+    assert_eq!(v, account_v1);
+
+    assert_eq!(account_exact(&storage, account_key, 2)?, Some(account_v2));
+
+    let (k, v) = storage
+        .storage_hashed_cursor_with_tx(&tx, hashed_address, 2)?
+        .seek(storage_key)?
+        .expect("storage exists in snapshot");
+    assert_eq!(k, storage_key);
+    assert_eq!(v, U256::from(10));
+
+    assert_eq!(storage_exact(&storage, hashed_address, storage_key, 2)?, Some(U256::from(20)));
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
+#[serial]
+fn test_rocksdb_exact_lookup_finds_latest_version_at_or_below_bound()
+-> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x51);
+    let account_v1 = create_test_account_with_values(1, 100, 0xAA);
+    let account_v3 = create_test_account_with_values(3, 300, 0xCC);
+
+    let block1 = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0x11)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v1));
+    storage.store_trie_updates(
+        block1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    let block3 = BlockWithParent::new(block1.block.hash, NumHash::new(3, B256::repeat_byte(0x33)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account_v3));
+    storage.store_trie_updates(
+        block3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    assert_eq!(account_exact(&storage, account_key, 2)?, Some(account_v1));
+    assert_eq!(account_exact(&storage, account_key, 3)?, Some(account_v3));
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
+#[serial]
+fn test_rocksdb_exact_lookup_returns_none_when_versions_are_above_bound()
+-> Result<(), BaseProofsStorageError> {
+    let storage = create_rocksdb_proofs_storage();
+    let account_key = B256::repeat_byte(0x61);
+    let account = create_test_account_with_values(10, 1_000, 0xAA);
+
+    let block10 = BlockWithParent::new(B256::ZERO, NumHash::new(10, B256::repeat_byte(0x10)));
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_key, Some(account));
+    storage.store_trie_updates(
+        block10,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        },
+    )?;
+
+    assert_eq!(account_exact(&storage, account_key, 9)?, None);
+    assert_eq!(account_exact(&storage, account_key, 10)?, Some(account));
+
+    Ok(())
+}

--- a/crates/execution/trie/tests/history/mod.rs
+++ b/crates/execution/trie/tests/history/mod.rs
@@ -1,0 +1,292 @@
+//! History fetch, prune, and unwind behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_fetch_trie_updates_basic<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = test_block(B256::ZERO, 1, 0x11);
+    let account_address = B256::repeat_byte(0x11);
+    let deleted_account = B256::repeat_byte(0x22);
+    let storage_address = B256::repeat_byte(0x33);
+    let trie_storage_address = B256::repeat_byte(0x44);
+    let slot = B256::repeat_byte(0xA1);
+    let account = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(nibbles_from(vec![0, 1, 2, 3]), BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates
+        .storage_nodes
+        .insert(nibbles_from(vec![1, 2, 3, 4]), BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(trie_storage_address, storage_trie_updates);
+
+    let mut post_state = HashedPostState::default();
+    post_state.accounts.insert(account_address, Some(account));
+    post_state.accounts.insert(deleted_account, None);
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(slot, U256::from(1234));
+    post_state.storages.insert(storage_address, hashed_storage);
+
+    let expected = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref, expected.clone())?;
+
+    let actual = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(
+        actual.sorted_trie_updates.account_nodes_ref(),
+        expected.sorted_trie_updates.account_nodes_ref()
+    );
+    assert_eq!(
+        actual.sorted_trie_updates.storage_tries_ref(),
+        expected.sorted_trie_updates.storage_tries_ref()
+    );
+    assert_eq!(actual.sorted_post_state.accounts, expected.sorted_post_state.accounts);
+    assert_eq!(actual.sorted_post_state.storages, expected.sorted_post_state.storages);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_out_of_order_rejects<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let block_42 = test_block(B256::ZERO, 42, 0x42);
+    storage.store_trie_updates(block_42, BlockStateDiff::default())?;
+
+    let bad_block = test_block(B256::repeat_byte(0xFF), 99, 0x99);
+    let error = storage.store_trie_updates(bad_block, BlockStateDiff::default()).unwrap_err();
+    assert!(matches!(error, BaseProofsStorageError::OutOfOrder { .. }));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_address = B256::repeat_byte(1);
+    let storage_slot = B256::repeat_byte(2);
+    let account_path = nibbles_from(vec![1]);
+    let storage_path = nibbles_from(vec![3]);
+    let account_v1 = Account { nonce: 1, balance: U256::from(100), ..Default::default() };
+    let account_v2 = Account { nonce: 2, balance: U256::from(200), ..Default::default() };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.account_nodes.insert(account_path, BranchNodeCompact::default());
+    let mut storage_trie_updates = StorageTrieUpdates::default();
+    storage_trie_updates.storage_nodes.insert(storage_path, BranchNodeCompact::default());
+    trie_updates.storage_tries.insert(account_address, storage_trie_updates);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_address, Some(account_v1));
+    let mut hashed_storage = HashedStorage::default();
+    hashed_storage.storage.insert(storage_slot, U256::from(1234));
+    post_state_1.storages.insert(account_address, hashed_storage);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_address, Some(account_v2));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.prune_earliest_state(block_3)?;
+
+    assert_account_at(&storage, 3, account_address, account_v2)?;
+    assert_storage_at(&storage, account_address, 3, storage_slot, U256::from(1234))?;
+    assert_account_branch_present(&storage, 3, account_path)?;
+
+    let mut storage_cursor = storage.storage_trie_cursor(account_address, 3)?;
+    assert!(storage_cursor.seek_exact(storage_path)?.is_some());
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_prune_earliest_state_returns_correct_counts<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(address, Some(Account { nonce: 1, ..Default::default() }));
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(address, Some(Account { nonce: 2, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+
+    let counts = storage.prune_earliest_state(block_2)?;
+    assert_eq!(counts.hashed_accounts_written_total, 1);
+    assert_eq!(counts.account_trie_updates_written_total, 0);
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_unwind_history_with_trie_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let path_1 = nibbles_from(vec![1]);
+    let path_2 = nibbles_from(vec![2]);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    for (block, path) in [(block_1, path_1), (block_2, path_2), (block_3, path_1)] {
+        let mut trie_updates = TrieUpdates::default();
+        trie_updates.account_nodes.insert(path, BranchNodeCompact::default());
+        storage.store_trie_updates(
+            block,
+            BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostStateSorted::default(),
+            },
+        )?;
+    }
+
+    storage.unwind_history(block_2)?;
+    assert_account_branch_present(&storage, 10, path_1)?;
+    assert_account_branch_missing(&storage, 10, path_2)
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_unwind_history_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let account_1 = B256::repeat_byte(1);
+    let account_2 = B256::repeat_byte(2);
+    let slot_1 = B256::repeat_byte(3);
+    let slot_2 = B256::repeat_byte(4);
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    let mut post_state_1 = HashedPostState::default();
+    post_state_1.accounts.insert(account_1, Some(Account::default()));
+    let mut storage_1 = HashedStorage::default();
+    storage_1.storage.insert(slot_1, U256::from(1111));
+    post_state_1.storages.insert(account_1, storage_1);
+
+    let mut post_state_2 = HashedPostState::default();
+    post_state_2.accounts.insert(account_2, Some(Account::default()));
+    let mut storage_2 = HashedStorage::default();
+    storage_2.storage.insert(slot_2, U256::from(2222));
+    post_state_2.storages.insert(account_2, storage_2);
+
+    let mut post_state_3 = HashedPostState::default();
+    post_state_3.accounts.insert(account_1, Some(Account { nonce: 9, ..Default::default() }));
+
+    storage.store_trie_updates(
+        block_1,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_1.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_2,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_2.into_sorted(),
+        },
+    )?;
+    storage.store_trie_updates(
+        block_3,
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state_3.into_sorted(),
+        },
+    )?;
+
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    assert_eq!(storage.get_latest_block_number()?, Some((1, block_1.block.hash)));
+    Ok(())
+}
+
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_unwind_history_idempotent<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    storage.set_earliest_block_number(0, B256::ZERO)?;
+    let address = B256::repeat_byte(1);
+    let make_diff = |nonce| {
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(address, Some(Account { nonce, ..Default::default() }));
+        BlockStateDiff {
+            sorted_trie_updates: TrieUpdatesSorted::default(),
+            sorted_post_state: post_state.into_sorted(),
+        }
+    };
+    let block_1 = test_block(B256::ZERO, 1, 1);
+    let block_2 = test_block(block_1.block.hash, 2, 2);
+    let block_3 = test_block(block_2.block.hash, 3, 3);
+
+    storage.store_trie_updates(block_1, make_diff(10))?;
+    storage.store_trie_updates(block_2, make_diff(20))?;
+    storage.store_trie_updates(block_3, make_diff(30))?;
+
+    storage.unwind_history(block_2)?;
+    storage.unwind_history(block_2)?;
+    assert!(storage.fetch_trie_updates(1).is_ok());
+    assert!(storage.fetch_trie_updates(2).is_err());
+    assert!(storage.fetch_trie_updates(3).is_err());
+    Ok(())
+}

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -1,23 +1,29 @@
 //! Common test suite for [`BaseProofsStore`] implementations.
 
+mod branch_cursors;
+mod hashed_cursors;
+mod history;
+mod proof_window;
+mod trie_updates;
+
 use std::sync::Arc;
 
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
-    InMemoryProofsStorage, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStorageResult, BaseProofsStore,
+    BlockStateDiff, InMemoryProofsStorage,
+    api::{InitialStateAnchor, WriteCounts},
+    db::{MdbxProofsStorage, RocksdbProofsStorage},
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
     BranchNodeCompact, HashedPostState, HashedPostStateSorted, HashedStorage, Nibbles, TrieMask,
     hashed_cursor::HashedCursor,
     trie_cursor::TrieCursor,
-    updates::{TrieUpdates, TrieUpdatesSorted},
+    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
 };
-use serial_test::serial;
 use tempfile::TempDir;
-use test_case::test_case;
 
 /// Helper to create a simple test branch node
 fn create_test_branch() -> BranchNodeCompact {
@@ -77,1978 +83,259 @@ fn create_mdbx_proofs_storage() -> MdbxProofsStorage {
     MdbxProofsStorage::new(path.path()).unwrap()
 }
 
-/// Test basic storage and retrieval of earliest block number
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Initially should be None
-    let earliest = storage.get_earliest_block_number()?;
-    assert!(earliest.is_none());
-
-    // Set earliest block
-    let block_hash = B256::repeat_byte(0x42);
-    storage.set_earliest_block_number(100, block_hash)?;
-
-    // Should retrieve the same values
-    let earliest = storage.get_earliest_block_number()?;
-    assert_eq!(earliest, Some((100, block_hash)));
-
-    Ok(())
+#[derive(Debug)]
+struct TestRocksdbProofsStorage {
+    storage: RocksdbProofsStorage,
+    _dir: TempDir,
 }
 
-/// Test storing and retrieving trie updates
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-    let sorted_trie_updates = TrieUpdatesSorted::default();
-    let sorted_post_state = HashedPostStateSorted::default();
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: sorted_trie_updates.clone(),
-        sorted_post_state: sorted_post_state.clone(),
-    };
-
-    // Store trie updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Retrieve and verify
-    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
-    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
-
-    Ok(())
+fn create_rocksdb_proofs_storage() -> TestRocksdbProofsStorage {
+    let dir = TempDir::new().unwrap();
+    let storage = RocksdbProofsStorage::new(dir.path()).unwrap();
+    TestRocksdbProofsStorage { storage, _dir: dir }
 }
 
-// =============================================================================
-// 1. Basic Cursor Operations
-// =============================================================================
+impl BaseProofsStore for TestRocksdbProofsStorage {
+    type StorageTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountTrieCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountTrieCursor<'tx>
+    where
+        Self: 'tx;
+    type StorageCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::StorageCursor<'tx>
+    where
+        Self: 'tx;
+    type AccountHashedCursor<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::AccountHashedCursor<'tx>
+    where
+        Self: 'tx;
+    type Tx<'tx>
+        = <RocksdbProofsStorage as BaseProofsStore>::Tx<'tx>
+    where
+        Self: 'tx;
 
-/// Test cursor operations on empty trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // All operations should return None on empty trie
-    assert!(cursor.seek_exact(Nibbles::default())?.is_none());
-    assert!(cursor.seek(Nibbles::default())?.is_none());
-    assert!(cursor.next()?.is_none());
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with single entry
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    // Store single entry
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test seek_exact
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Test current position
-    assert_eq!(cursor.current()?.unwrap(), path);
-
-    // Test next from end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test cursor operations with multiple entries
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![2, 3]),
-    ];
-    let branch = create_test_branch();
-
-    // Store multiple entries
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_earliest_block_number()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Test that we can iterate through all entries
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
+        self.storage.get_latest_block_number()
     }
 
-    assert_eq!(found_paths.len(), 4);
-    // Paths should be in lexicographic order
-    for i in 0..paths.len() {
-        assert_eq!(found_paths[i], paths[i]);
+    fn storage_trie_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+        self.storage.storage_trie_cursor(hashed_address, max_block_number)
     }
 
-    Ok(())
-}
-
-// =============================================================================
-// 2. Seek Operations
-// =============================================================================
-
-/// Test `seek_exact` with existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test `seek_exact` with non-existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let non_existing = nibbles_from(vec![4, 5, 6]);
-    assert!(cursor.seek_exact(non_existing)?.is_none());
-
-    Ok(())
-}
-
-/// Test `seek_exact` with empty path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek_exact(Nibbles::default())?.unwrap();
-    assert_eq!(result.0, Nibbles::default());
-
-    Ok(())
-}
-
-/// Test seek to existing path
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2, 3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let result = cursor.seek(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test seek between existing nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![3]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path between 1 and 3, should return path 3
-    let seek_path = nibbles_from(vec![2]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test seek after all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path after all nodes
-    let seek_path = nibbles_from(vec![9]);
-    assert!(cursor.seek(seek_path)?.is_none());
-
-    Ok(())
-}
-
-/// Test seek before all nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![5]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // Seek to path before all nodes, should return first node
-    let seek_path = nibbles_from(vec![1]);
-    let result = cursor.seek(seek_path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-// =============================================================================
-// 3. Navigation Tests
-// =============================================================================
-
-/// Test next without prior seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    // next() without prior seek should start from beginning
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path);
-
-    Ok(())
-}
-
-/// Test next after seek
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path1)?;
-
-    // next() should return second node
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, path2);
-
-    Ok(())
-}
-
-/// Test next at end of trie
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-    cursor.seek(path)?;
-
-    // next() at end should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test multiple consecutive next calls
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+        self.storage.account_trie_cursor(max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Iterate through all with consecutive next() calls
-    for expected_path in &paths {
-        let result = cursor.next()?.unwrap();
-        assert_eq!(result.0, *expected_path);
+    fn storage_hashed_cursor<'tx>(
+        &'tx self,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
+        self.storage.storage_hashed_cursor(hashed_address, max_block_number)
     }
 
-    // Final next() should return None
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test current after operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let branch = create_test_branch();
-
-    storage.store_account_branches(vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None initially
-    assert!(cursor.current()?.is_none());
-
-    // After seek, current should track position
-    cursor.seek(path1)?;
-    assert_eq!(cursor.current()?.unwrap(), path1);
-
-    // After next, current should update
-    cursor.next()?;
-    assert_eq!(cursor.current()?.unwrap(), path2);
-
-    Ok(())
-}
-
-/// Test current with no prior operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Current should be None when no operations performed
-    assert!(cursor.current()?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 4. Block Number Filtering
-// =============================================================================
-
-/// Test same path with different blocks
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch1 = create_test_branch();
-    let branch2 = create_test_branch_variant();
-
-    // Store same path at different blocks
-    storage.store_account_branches(vec![(path, Some(branch1))])?;
-    storage.store_account_branches(vec![(path, Some(branch2))])?;
-
-    // Cursor with max_block_number=75 should see only block 50 data
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    let result75 = cursor75.seek_exact(path)?.unwrap();
-    assert_eq!(result75.0, path);
-
-    // Cursor with max_block_number=150 should see block 100 data (latest)
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    let result150 = cursor150.seek_exact(path)?.unwrap();
-    assert_eq!(result150.0, path);
-
-    Ok(())
-}
-
-/// Test deleted branch nodes
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let branch = create_test_branch();
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Store branch node, then delete it (store None)
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // Cursor before deletion should see the node
-    let mut cursor75 = storage.account_trie_cursor(75)?;
-    assert!(cursor75.seek_exact(path)?.is_some());
-
-    let mut block_state_diff_trie_updates = TrieUpdates::default();
-    block_state_diff_trie_updates.removed_nodes.insert(path);
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: block_state_diff_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should not see the node
-    let mut cursor150 = storage.account_trie_cursor(150)?;
-    assert!(cursor150.seek_exact(path)?.is_none());
-
-    Ok(())
-}
-
-// =============================================================================
-// 5. Hashed Address Filtering
-// =============================================================================
-
-/// Test account-specific cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr1 = B256::repeat_byte(0x01);
-    let addr2 = B256::repeat_byte(0x02);
-    let branch = create_test_branch();
-
-    // Store same path for different accounts (using storage branches)
-    storage.store_storage_branches(addr1, vec![(path, Some(branch.clone()))])?;
-    storage.store_storage_branches(addr2, vec![(path, Some(branch))])?;
-
-    // Cursor for addr1 should only see addr1 data
-    let mut cursor1 = storage.storage_trie_cursor(addr1, 100)?;
-    let result1 = cursor1.seek_exact(path)?.unwrap();
-    assert_eq!(result1.0, path);
-
-    // Cursor for addr2 should only see addr2 data
-    let mut cursor2 = storage.storage_trie_cursor(addr2, 100)?;
-    let result2 = cursor2.seek_exact(path)?.unwrap();
-    assert_eq!(result2.0, path);
-
-    // Cursor for addr1 should not see addr2 data when iterating
-    let mut cursor1_iter = storage.storage_trie_cursor(addr1, 100)?;
-    let mut found_count = 0;
-    while cursor1_iter.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 1); // Should only see one entry (for addr1)
-
-    Ok(())
-}
-
-/// Test state trie cursor
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path = nibbles_from(vec![1, 2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store data for account trie and state trie
-    storage.store_storage_branches(addr, vec![(path, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path, Some(branch))])?;
-
-    // State trie cursor (None address) should only see state trie data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let result = state_cursor.seek_exact(path)?.unwrap();
-    assert_eq!(result.0, path);
-
-    // Verify state cursor doesn't see account data when iterating
-    let mut state_cursor_iter = storage.account_trie_cursor(100)?;
-    let mut found_count = 0;
-    while state_cursor_iter.next()?.is_some() {
-        found_count += 1;
+    fn account_hashed_cursor<'tx>(
+        &'tx self,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        self.storage.account_hashed_cursor(max_block_number)
     }
 
-    assert_eq!(found_count, 1); // Should only see state trie entry
-
-    Ok(())
-}
-
-/// Test mixed account and state data
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let path1 = nibbles_from(vec![1]);
-    let path2 = nibbles_from(vec![2]);
-    let addr = B256::repeat_byte(0x01);
-    let branch = create_test_branch();
-
-    // Store mixed account and state trie data
-    storage.store_storage_branches(addr, vec![(path1, Some(branch.clone()))])?;
-    storage.store_account_branches(vec![(path2, Some(branch))])?;
-
-    // Account cursor should only see account data
-    let mut account_cursor = storage.storage_trie_cursor(addr, 100)?;
-    let mut account_paths = Vec::new();
-    while let Some((path, _)) = account_cursor.next()? {
-        account_paths.push(path);
-    }
-    assert_eq!(account_paths.len(), 1);
-    assert_eq!(account_paths[0], path1);
-
-    // State cursor should only see state data
-    let mut state_cursor = storage.account_trie_cursor(100)?;
-    let mut state_paths = Vec::new();
-    while let Some((path, _)) = state_cursor.next()? {
-        state_paths.push(path);
-    }
-    assert_eq!(state_paths.len(), 1);
-    assert_eq!(state_paths[0], path2);
-
-    Ok(())
-}
-
-// =============================================================================
-// 6. Path Ordering Tests
-// =============================================================================
-
-/// Test lexicographic ordering
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![3, 1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![1]),
-    ];
-    let branch = create_test_branch();
-
-    // Store paths in random order
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
+        self.storage.ro_tx()
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn storage_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_trie_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    // Should be returned in lexicographic order: [1], [1,2], [2], [3,1]
-    let expected_order = vec![
-        nibbles_from(vec![1]),
-        nibbles_from(vec![1, 2]),
-        nibbles_from(vec![2]),
-        nibbles_from(vec![3, 1]),
-    ];
-
-    assert_eq!(found_paths, expected_order);
-
-    Ok(())
-}
-
-/// Test path prefix scenarios
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let paths = vec![
-        nibbles_from(vec![1]),       // Prefix of next
-        nibbles_from(vec![1, 2]),    // Extends first
-        nibbles_from(vec![1, 2, 3]), // Extends second
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn account_trie_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_trie_cursor_with_tx(tx, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-
-    // Seek to prefix should find exact match
-    let result = cursor.seek_exact(paths[0])?.unwrap();
-    assert_eq!(result.0, paths[0]);
-
-    // Next should go to next path, not skip prefixed paths
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[1]);
-
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, paths[2]);
-
-    Ok(())
-}
-
-/// Test complex nibble combinations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    // Test various nibble patterns including edge values
-    let paths = vec![
-        nibbles_from(vec![0]),
-        nibbles_from(vec![0, 15]),
-        nibbles_from(vec![15]),
-        nibbles_from(vec![15, 0]),
-        nibbles_from(vec![7, 8, 9]),
-    ];
-    let branch = create_test_branch();
-
-    for path in &paths {
-        storage.store_account_branches(vec![(*path, Some(branch.clone()))])?;
+    fn storage_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.storage_hashed_cursor_with_tx(tx, hashed_address, max_block_number)
     }
 
-    let mut cursor = storage.account_trie_cursor(100)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor.next()? {
-        found_paths.push(path);
+    fn account_hashed_cursor_with_tx<'tx, 'db>(
+        &self,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
+    where
+        Self: 'db,
+        'db: 'tx,
+    {
+        self.storage.account_hashed_cursor_with_tx(tx, max_block_number)
     }
 
-    // All paths should be found and in correct order
-    assert_eq!(found_paths.len(), 5);
-
-    // Verify specific ordering for edge cases
-    assert_eq!(found_paths[0], nibbles_from(vec![0]));
-    assert_eq!(found_paths[1], nibbles_from(vec![0, 15]));
-    assert_eq!(found_paths[4], nibbles_from(vec![15, 0]));
-
-    Ok(())
-}
-
-// =============================================================================
-// 7. Leaf Node Tests (Hashed Accounts and Storage)
-// =============================================================================
-
-/// Test store and retrieve single account
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account = create_test_account();
-
-    // Store account
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let result = cursor.seek(account_key)?.unwrap();
-
-    assert_eq!(result.0, account_key);
-    assert_eq!(result.1.nonce, account.nonce);
-    assert_eq!(result.1.balance, account.balance);
-    assert_eq!(result.1.bytecode_hash, account.bytecode_hash);
-
-    Ok(())
-}
-
-/// Test account cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let accounts = [
-        (B256::repeat_byte(0x01), create_test_account()),
-        (B256::repeat_byte(0x03), create_test_account()),
-        (B256::repeat_byte(0x05), create_test_account()),
-    ];
-
-    // Store accounts
-    let accounts_to_store: Vec<_> = accounts.iter().map(|(k, v)| (*k, Some(*v))).collect();
-    storage.store_hashed_accounts(accounts_to_store)?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Test seeking to exact key
-    let result = cursor.seek(accounts[1].0)?.unwrap();
-    assert_eq!(result.0, accounts[1].0);
-
-    // Test seeking to key that doesn't exist (should return next greater)
-    let seek_key = B256::repeat_byte(0x02);
-    let result = cursor.seek(seek_key)?.unwrap();
-    assert_eq!(result.0, accounts[1].0); // Should find 0x03
-
-    // Test next() navigation
-    let result = cursor.next()?.unwrap();
-    assert_eq!(result.0, accounts[2].0); // Should find 0x05
-
-    // Test next() at end
-    assert!(cursor.next()?.is_none());
-
-    Ok(())
-}
-
-/// Test account block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x01);
-    let account_v1 = create_test_account_with_values(1, 100, 0xBB);
-    let account_v2 = create_test_account_with_values(2, 200, 0xDD);
-
-    // Store account at different blocks
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v1))])?;
-
-    // Cursor with max_block_number=75 should see v1
-    let mut cursor75 = storage.account_hashed_cursor(75)?;
-    let result75 = cursor75.seek(account_key)?.unwrap();
-    assert_eq!(result75.1.nonce, account_v1.nonce);
-    assert_eq!(result75.1.balance, account_v1.balance);
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account_v2))])?;
-
-    // After update, Cursor with max_block_number=150 should see v2
-    let mut cursor150 = storage.account_hashed_cursor(150)?;
-    let result150 = cursor150.seek(account_key)?.unwrap();
-    assert_eq!(result150.1.nonce, account_v2.nonce);
-    assert_eq!(result150.1.balance, account_v2.balance);
-
-    Ok(())
-}
-
-/// Test store and retrieve storage
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-
-fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-    ];
-
-    // Store storage slots
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Retrieve via cursor
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Test seeking to each slot
-    for (key, expected_value) in &storage_slots {
-        let result = cursor.seek(*key)?.unwrap();
-        assert_eq!(result.0, *key);
-        assert_eq!(result.1, *expected_value);
+    fn store_trie_updates(
+        &self,
+        block_ref: BlockWithParent,
+        block_state_diff: BlockStateDiff,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.store_trie_updates(block_ref, block_state_diff)
     }
 
-    Ok(())
-}
-
-/// Test storage cursor navigation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x50), U256::from(500)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-
-    // Start from beginning with next()
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        self.storage.fetch_trie_updates(block_number)
     }
 
-    assert_eq!(found_slots.len(), 3);
-    assert_eq!(found_slots[0], storage_slots[0]);
-    assert_eq!(found_slots[1], storage_slots[1]);
-    assert_eq!(found_slots[2], storage_slots[2]);
-
-    Ok(())
-}
-
-/// Test storage account isolation
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let address1 = B256::repeat_byte(0x01);
-    let address2 = B256::repeat_byte(0x02);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store same storage key for different accounts
-    storage.store_hashed_storages(address1, vec![(storage_key, U256::from(100))])?;
-    storage.store_hashed_storages(address2, vec![(storage_key, U256::from(200))])?;
-
-    // Verify each account sees only its own storage
-    let mut cursor1 = storage.storage_hashed_cursor(address1, 100)?;
-    let result1 = cursor1.seek(storage_key)?.unwrap();
-    assert_eq!(result1.1, U256::from(100));
-
-    let mut cursor2 = storage.storage_hashed_cursor(address2, 100)?;
-    let result2 = cursor2.seek(storage_key)?.unwrap();
-    assert_eq!(result2.1, U256::from(200));
-
-    // Verify cursor1 doesn't see address2's storage
-    let mut cursor1_iter = storage.storage_hashed_cursor(address1, 100)?;
-    let mut count = 0;
-    while cursor1_iter.next()?.is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 1); // Should only see one entry
-
-    Ok(())
-}
-
-/// Test storage block versioning
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store storage at different blocks
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor with max_block_number=75 should see old value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(200))])?;
-    // Cursor with max_block_number=150 should see new value
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?.unwrap();
-    assert_eq!(result150.1, U256::from(200));
-
-    Ok(())
-}
-
-/// Test storage zero value deletion
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let storage_key = B256::repeat_byte(0x10);
-
-    // Store non-zero value
-    storage.store_hashed_storages(hashed_address, vec![(storage_key, U256::from(100))])?;
-
-    // Cursor before deletion should see the value
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let result75 = cursor75.seek(storage_key)?.unwrap();
-    assert_eq!(result75.1, U256::from(100));
-
-    // "Delete" by storing zero value at block 100
-    let mut block_state_diff_post_state = HashedPostState::default();
-    let mut hashed_storage = HashedStorage::default();
-    hashed_storage.storage.insert(storage_key, U256::ZERO);
-    block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: block_state_diff_post_state.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // Cursor after deletion should NOT see the entry (zero values are skipped)
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let result150 = cursor150.seek(storage_key)?;
-    assert!(result150.is_none(), "Zero values should be skipped/deleted");
-
-    Ok(())
-}
-
-/// Test that zero values are skipped during iteration
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-
-    // Create a mix of non-zero and zero value storage slots
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)), // Non-zero
-        (B256::repeat_byte(0x20), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x30), U256::from(300)), // Non-zero
-        (B256::repeat_byte(0x40), U256::ZERO),      // Zero value - should be skipped
-        (B256::repeat_byte(0x50), U256::from(500)), // Non-zero
-    ];
-
-    // Store all slots
-    storage.store_hashed_storages(hashed_address, storage_slots)?;
-
-    // Create cursor and iterate through all entries
-    let mut cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor.next()? {
-        found_slots.push((key, value));
+    fn prune_earliest_state(
+        &self,
+        new_earliest_block_ref: BlockWithParent,
+    ) -> BaseProofsStorageResult<WriteCounts> {
+        self.storage.prune_earliest_state(new_earliest_block_ref)
     }
 
-    // Should only find 3 non-zero values
-    assert_eq!(found_slots.len(), 3, "Zero values should be skipped during iteration");
-
-    // Verify the non-zero values are the ones we stored
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x50), U256::from(500)));
-
-    // Verify seeking to a zero-value slot returns None or skips to next non-zero
-    let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 100)?;
-    let seek_result = seek_cursor.seek(B256::repeat_byte(0x20))?;
-
-    // Should either return None or skip to the next non-zero value (0x30)
-    if let Some((key, value)) = seek_result {
-        assert_eq!(key, B256::repeat_byte(0x30), "Should skip zero value and find next non-zero");
-        assert_eq!(value, U256::from(300));
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
+        self.storage.unwind_history(to)
     }
 
+    fn replace_updates(
+        &self,
+        latest_common_block: BlockNumHash,
+        blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.replace_updates(latest_common_block, blocks_to_add)
+    }
+
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.set_earliest_block_number(block_number, hash)
+    }
+}
+
+impl BaseProofsInitialStateStore for TestRocksdbProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
+        self.storage.initial_state_anchor()
+    }
+
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
+        self.storage.set_initial_state_anchor(anchor)
+    }
+
+    fn store_account_branches(
+        &self,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_account_branches(account_nodes)
+    }
+
+    fn store_storage_branches(
+        &self,
+        hashed_address: B256,
+        storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_storage_branches(hashed_address, storage_nodes)
+    }
+
+    fn store_hashed_accounts(
+        &self,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_accounts(accounts)
+    }
+
+    fn store_hashed_storages(
+        &self,
+        hashed_address: B256,
+        storages: Vec<(B256, U256)>,
+    ) -> BaseProofsStorageResult<()> {
+        self.storage.store_hashed_storages(hashed_address, storages)
+    }
+
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
+        self.storage.commit_initial_state()
+    }
+}
+
+const fn test_block(parent: B256, number: u64, hash_byte: u8) -> BlockWithParent {
+    BlockWithParent::new(parent, NumHash::new(number, B256::repeat_byte(hash_byte)))
+}
+
+fn assert_account_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    key: B256,
+    expected: Account,
+) -> Result<(), BaseProofsStorageError> {
+    let mut cursor = storage.account_hashed_cursor(at)?;
+    assert_eq!(cursor.seek(key)?, Some((key, expected)));
     Ok(())
 }
 
-/// Test empty cursors
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_present<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    // Test empty account cursor
-    let mut account_cursor = storage.account_hashed_cursor(100)?;
-    assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
-    assert!(account_cursor.next()?.is_none());
-
-    // Test empty storage cursor
-    let mut storage_cursor = storage.storage_hashed_cursor(B256::repeat_byte(0x01), 100)?;
-    assert!(storage_cursor.seek(B256::repeat_byte(0x10))?.is_none());
-    assert!(storage_cursor.next()?.is_none());
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_some());
     Ok(())
 }
 
-/// Test cursor boundary conditions
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_account_branch_missing<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    at: u64,
+    path: Nibbles,
 ) -> Result<(), BaseProofsStorageError> {
-    let account_key = B256::repeat_byte(0x80); // Middle value
-    let account = create_test_account();
-
-    storage.store_hashed_accounts(vec![(account_key, Some(account))])?;
-
-    let mut cursor = storage.account_hashed_cursor(100)?;
-
-    // Seek to minimum key should find our account
-    let result = cursor.seek(B256::ZERO)?.unwrap();
-    assert_eq!(result.0, account_key);
-
-    // Seek to maximum key should find nothing
-    assert!(cursor.seek(B256::repeat_byte(0xFF))?.is_none());
-
-    // Seek to key just before our account should find our account
-    let just_before = B256::repeat_byte(0x7F);
-    let result = cursor.seek(just_before)?.unwrap();
-    assert_eq!(result.0, account_key);
-
+    let mut cursor = storage.account_trie_cursor(at)?;
+    assert!(cursor.seek_exact(path)?.is_none());
     Ok(())
 }
 
-/// Test large batch operations
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
+fn assert_storage_at<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: &S,
+    hashed_address: B256,
+    at: u64,
+    slot: B256,
+    expected: U256,
 ) -> Result<(), BaseProofsStorageError> {
-    // Create large batch of accounts
-    let mut accounts = Vec::new();
-    for i in 0..100 {
-        let key = B256::from([i as u8; 32]);
-        let account = create_test_account_with_values(i, i * 1000, (i + 1) as u8);
-        accounts.push((key, Some(account)));
-    }
-
-    // Store in batch
-    storage.store_hashed_accounts(accounts.clone())?;
-
-    // Verify all accounts can be retrieved
-    let mut cursor = storage.account_hashed_cursor(100)?;
-    let mut found_count = 0;
-    while cursor.next()?.is_some() {
-        found_count += 1;
-    }
-    assert_eq!(found_count, 100);
-
-    // Test specific account retrieval
-    let test_key = B256::from([42u8; 32]);
-    let result = cursor.seek(test_key)?.unwrap();
-    assert_eq!(result.0, test_key);
-    assert_eq!(result.1.nonce, 42);
-
-    Ok(())
-}
-
-/// Test wiped storage in [`HashedPostState`]
-///
-/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
-/// it should iterate all existing values for that address and create deletion entries for them.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::HashedStorage;
-
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // First, store some storage values at block 50
-    let storage_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-        (B256::repeat_byte(0x30), U256::from(300)),
-        (B256::repeat_byte(0x40), U256::from(400)),
-    ];
-
-    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
-
-    // Verify all values are present at block 75
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        found_slots.push((key, value));
-    }
-    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
-    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
-    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
-    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
-    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
-
-    // Now create a HashedPostState with wiped=true for this address at block 100
-    let mut post_state = HashedPostState::default();
-    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
-    post_state.storages.insert(hashed_address, wiped_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the wiped state
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // After wiping, cursor at block 150 should see NO storage values
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found_slots_after_wipe = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found_slots_after_wipe.push((key, value));
-    }
-
-    assert_eq!(
-        found_slots_after_wipe.len(),
-        0,
-        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
-    );
-
-    // Verify individual seeks also return None
-    for (slot, _) in &storage_slots {
-        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
-        let result = seek_cursor.seek(*slot)?;
-        assert!(
-            result.is_none() || result.unwrap().0 != *slot,
-            "Storage slot {slot:?} should be deleted after wipe"
-        );
-    }
-
-    // Verify cursor at block 75 (before wipe) still sees all values
-    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut found_slots_before_wipe = Vec::new();
-    while let Some((key, value)) = cursor75_after.next()? {
-        found_slots_before_wipe.push((key, value));
-    }
-    assert_eq!(
-        found_slots_before_wipe.len(),
-        4,
-        "All storage slots should still be present when querying before wipe block"
-    );
-
-    Ok(())
-}
-
-/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
-/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
-/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
-/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
-/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
-/// return `None` for the new slots, producing divergent storage / state / output roots
-/// downstream of `LiveTrieCollector`.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_with_wiped_storage_and_new_slots<
-    S: BaseProofsStore + BaseProofsInitialStateStore,
->(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    let hashed_address = B256::repeat_byte(0x01);
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    let pre_existing_slots = vec![
-        (B256::repeat_byte(0x10), U256::from(100)),
-        (B256::repeat_byte(0x20), U256::from(200)),
-    ];
-    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
-
-    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
-    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
-
-    let mut post_state = HashedPostState::default();
-    let wiped_with_new =
-        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
-    post_state.storages.insert(hashed_address, wiped_with_new);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: TrieUpdatesSorted::default(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
-    let mut found = Vec::new();
-    while let Some((key, value)) = cursor150.next()? {
-        found.push((key, value));
-    }
-
-    assert_eq!(
-        found,
-        vec![new_slot_overwriting_old, new_slot_kept],
-        "After wipe+recreate, only the new post-recreation slots must be visible",
-    );
-
-    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_kept.seek(new_slot_kept.0)?,
-        Some(new_slot_kept),
-        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
-    );
-
-    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_overwritten.seek(new_slot_overwriting_old.0)?,
-        Some(new_slot_overwriting_old),
-        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
-    );
-
-    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
-    assert_eq!(
-        seek_dropped.seek(B256::repeat_byte(0x20))?,
-        Some(new_slot_kept),
-        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
-         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
-    );
-
-    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
-    let mut pre_wipe_found = Vec::new();
-    while let Some((key, value)) = cursor75.next()? {
-        pre_wipe_found.push((key, value));
-    }
-    assert_eq!(
-        pre_wipe_found, pre_existing_slots,
-        "Cursor positioned before the wipe block must still see the original slot values",
-    );
-
-    Ok(())
-}
-
-/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
-///
-/// This test verifies that all data stored via `store_trie_updates` can be read back
-/// through the cursor APIs.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
-
-    // Create comprehensive trie updates with branches, leaves, and removals
-    let mut trie_updates = TrieUpdates::default();
-
-    // Add account branch nodes
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let account_branch1 = create_test_branch();
-    let account_branch2 = create_test_branch_variant();
-
-    trie_updates.account_nodes.insert(account_path1, account_branch1);
-    trie_updates.account_nodes.insert(account_path2, account_branch2);
-
-    // Add removed account nodes
-    let removed_account_path = nibbles_from(vec![7, 8, 9]);
-    trie_updates.removed_nodes.insert(removed_account_path);
-
-    // Add storage branch nodes for an address
-    let hashed_address = B256::repeat_byte(0x42);
-    let storage_path1 = nibbles_from(vec![1, 1]);
-    let storage_path2 = nibbles_from(vec![2, 2]);
-    let storage_branch = create_test_branch();
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
-
-    // Add removed storage node
-    let removed_storage_path = nibbles_from(vec![3, 3]);
-    storage_trie.removed_nodes.insert(removed_storage_path);
-
-    trie_updates.insert_storage_updates(hashed_address, storage_trie);
-
-    // Create post state with accounts and storage
-    let mut post_state = HashedPostState::default();
-
-    // Add accounts
-    let account1_addr = B256::repeat_byte(0x10);
-    let account2_addr = B256::repeat_byte(0x20);
-    let account1 = create_test_account_with_values(1, 1000, 0xAA);
-    let account2 = create_test_account_with_values(2, 2000, 0xBB);
-
-    post_state.accounts.insert(account1_addr, Some(account1));
-    post_state.accounts.insert(account2_addr, Some(account2));
-
-    // Add deleted account
-    let deleted_account_addr = B256::repeat_byte(0x30);
-    post_state.accounts.insert(deleted_account_addr, None);
-
-    // Add storage for an address
-    let storage_addr = B256::repeat_byte(0x50);
-    let mut hashed_storage = HashedStorage::new(false);
-    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
-    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
-    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
-    post_state.storages.insert(storage_addr, hashed_storage);
-
-    let block_state_diff = BlockStateDiff {
-        sorted_trie_updates: trie_updates.into_sorted(),
-        sorted_post_state: post_state.into_sorted(),
-    };
-
-    // Store the updates
-    storage.store_trie_updates(block_ref, block_state_diff)?;
-
-    // ========== Verify Account Branch Nodes ==========
-    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
-
-    // Should find the added branches
-    let result1 = account_trie_cursor.seek_exact(account_path1)?;
-    assert!(result1.is_some(), "Account branch node 1 should be found");
-    assert_eq!(result1.unwrap().0, account_path1);
-
-    let result2 = account_trie_cursor.seek_exact(account_path2)?;
-    assert!(result2.is_some(), "Account branch node 2 should be found");
-    assert_eq!(result2.unwrap().0, account_path2);
-
-    // Removed node should not be found
-    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
-    assert!(removed_result.is_none(), "Removed account node should not be found");
-
-    // ========== Verify Storage Branch Nodes ==========
-    let mut storage_trie_cursor =
-        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
-
-    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
-    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
-
-    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
-    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
-
-    // Removed storage node should not be found
-    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
-    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
-
-    // ========== Verify Account Leaves ==========
-    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
-
-    let acc1_result = account_cursor.seek(account1_addr)?;
-    assert!(acc1_result.is_some(), "Account 1 should be found");
-    assert_eq!(acc1_result.unwrap().0, account1_addr);
-    assert_eq!(acc1_result.unwrap().1.nonce, 1);
-    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
-
-    let acc2_result = account_cursor.seek(account2_addr)?;
-    assert!(acc2_result.is_some(), "Account 2 should be found");
-    assert_eq!(acc2_result.unwrap().1.nonce, 2);
-
-    // Deleted account should not be found
-    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
-    assert!(
-        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
-        "Deleted account should not be found"
-    );
-
-    // ========== Verify Storage Leaves ==========
-    let mut storage_cursor =
-        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
-
-    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
-    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
-    assert_eq!(slot1_result.unwrap().1, U256::from(111));
-
-    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
-    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
-    assert_eq!(slot2_result.unwrap().1, U256::from(222));
-
-    // Zero-valued storage should not be found (deleted)
-    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
-    assert!(
-        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
-        "Zero-valued storage slot should not be found"
-    );
-
-    // ========== Verify fetch_trie_updates can retrieve the data ==========
-    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
-
-    // Check that trie updates are stored
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
-        3,
-        "Should have 3 account nodes, including removed"
-    );
-    assert_eq!(
-        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
-        1,
-        "Should have 1 storage trie"
-    );
-
-    // Check that post state is stored
-    assert_eq!(
-        fetched_diff.sorted_post_state.accounts.len(),
-        3,
-        "Should have 3 accounts (including deleted)"
-    );
-    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
-
-    Ok(())
-}
-
-/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
-///
-/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
-/// and `post_states` directly without populating the internal data structures
-/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
-    let initial_account_addr = B256::repeat_byte(0x10);
-    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
-
-    let initial_storage_addr = B256::repeat_byte(0x20);
-    let initial_storage_slot = B256::repeat_byte(0x01);
-    let initial_storage_value = U256::from(100);
-
-    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
-    let initial_branch = create_test_branch();
-
-    // Store initial data at block 50
-    let mut initial_trie_updates_50 = TrieUpdates::default();
-    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_50 = HashedPostState::default();
-    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
-
-    let initial_diff_50 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
-        sorted_post_state: initial_post_state_50.into_sorted(),
-    };
-    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
-
-    // Store data at block 100 (common block)
-    let mut initial_trie_updates_100 = TrieUpdates::default();
-    let common_branch_path = nibbles_from(vec![4, 5, 6]);
-    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
-
-    let mut initial_post_state_100 = HashedPostState::default();
-    let mut initial_storage_100 = HashedStorage::new(false);
-    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
-    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
-
-    let initial_diff_100 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
-        sorted_post_state: initial_post_state_100.into_sorted(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
-
-    // Store data at block 101 (will be replaced)
-    let mut initial_trie_updates_101 = TrieUpdates::default();
-    let old_branch_path = nibbles_from(vec![7, 8, 9]);
-    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
-
-    let mut initial_post_state_101 = HashedPostState::default();
-    let old_account_addr = B256::repeat_byte(0x30);
-    let old_account = create_test_account_with_values(99, 9999, 0xFF);
-    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
-
-    let initial_diff_101 = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
-        sorted_post_state: initial_post_state_101.into_sorted(),
-    };
-    let block_ref_101 =
-        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
-    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
-
-    let block_ref_102 =
-        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
-
-    // ========== Verify initial state exists ==========
-    // Verify block 50 data exists
-    let mut cursor_initial = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
-        "Initial branch should exist before replace"
-    );
-
-    // Verify block 101 old data exists
-    let mut cursor_old = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old.seek_exact(old_branch_path)?.is_some(),
-        "Old branch at block 101 should exist before replace"
-    );
-
-    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
-    assert!(
-        account_cursor_old.seek(old_account_addr)?.is_some(),
-        "Old account at block 101 should exist before replace"
-    );
-
-    // ========== Call replace_updates to replace blocks after 100 ==========
-    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
-
-    // New data for block 101
-    let new_account_addr = B256::repeat_byte(0x40);
-    let new_account = create_test_account_with_values(5, 5000, 0xCC);
-
-    let new_storage_addr = B256::repeat_byte(0x50);
-    let new_storage_slot = B256::repeat_byte(0x02);
-    let new_storage_value = U256::from(999);
-
-    let new_branch_path = nibbles_from(vec![10, 11, 12]);
-    let new_branch = create_test_branch_variant();
-
-    let storage_branch_path = nibbles_from(vec![5, 5]);
-    let storage_hashed_addr = B256::repeat_byte(0x60);
-
-    let mut new_trie_updates = TrieUpdates::default();
-    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
-
-    // Add storage trie updates
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
-    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
-
-    let mut new_post_state = HashedPostState::default();
-    new_post_state.accounts.insert(new_account_addr, Some(new_account));
-
-    let mut new_storage = HashedStorage::new(false);
-    new_storage.storage.insert(new_storage_slot, new_storage_value);
-    new_post_state.storages.insert(new_storage_addr, new_storage);
-
-    blocks_to_add.push((
-        block_ref_101,
-        BlockStateDiff {
-            sorted_trie_updates: new_trie_updates.into_sorted(),
-            sorted_post_state: new_post_state.into_sorted(),
-        },
-    ));
-
-    // New data for block 102
-    let block_102_account_addr = B256::repeat_byte(0x70);
-    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
-
-    let mut trie_updates_102 = TrieUpdates::default();
-    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
-    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
-
-    let mut post_state_102 = HashedPostState::default();
-    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
-
-    blocks_to_add.push((
-        block_ref_102,
-        BlockStateDiff {
-            sorted_trie_updates: trie_updates_102.into_sorted(),
-            sorted_post_state: post_state_102.into_sorted(),
-        },
-    ));
-
-    // Execute replace_updates
-    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
-    // ========== Verify that data up to block 100 still exists ==========
-    let mut cursor_50 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_50.seek_exact(initial_branch_path)?.is_some(),
-        "Block 50 branch should still exist after replace"
-    );
-
-    let mut cursor_100 = storage.account_trie_cursor(100)?;
-    assert!(
-        cursor_100.seek_exact(common_branch_path)?.is_some(),
-        "Block 100 branch should still exist after replace"
-    );
-
-    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
-    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
-    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
-    assert_eq!(
-        result_100.unwrap().1,
-        initial_storage_value,
-        "Block 100 storage value should be unchanged"
-    );
-
-    // ========== Verify that old data after block 100 is gone ==========
-    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
-    assert!(
-        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
-        "Old branch at block 101 should be removed after replace"
-    );
-
-    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
-    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
-    assert!(
-        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
-        "Old account at block 101 should be removed after replace"
-    );
-
-    // ========== Verify new data is properly accessible via cursors ==========
-
-    // Verify new account branch nodes
-    let mut trie_cursor = storage.account_trie_cursor(150)?;
-    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
-    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
-    assert_eq!(branch_result.unwrap().0, new_branch_path);
-
-    // Verify new storage branch nodes
-    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
-    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
-    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
-    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
-
-    // Verify new hashed accounts
-    let mut account_cursor = storage.account_hashed_cursor(150)?;
-    let account_result = account_cursor.seek(new_account_addr)?;
-    assert!(account_result.is_some(), "New account should be accessible via cursor");
-    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
-    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
-    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
-    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
-
-    // Verify new hashed storages
-    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
-    let storage_result = storage_cursor.seek(new_storage_slot)?;
-    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
-    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
-    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
-
-    // Verify block 102 data
-    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
-    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
-    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
-    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
-
-    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
-    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
-    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
-    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
-    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
-
-    // Verify fetch_trie_updates returns the new data
-    let fetched_101 = storage.fetch_trie_updates(101)?;
-    assert_eq!(
-        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
-        1,
-        "Should have 1 account branch node at block 101"
-    );
-    assert!(
-        fetched_101
-            .sorted_trie_updates
-            .account_nodes_ref()
-            .iter()
-            .any(|(addr, _)| *addr == new_branch_path),
-        "New branch path should be in trie_updates"
-    );
-    assert_eq!(
-        fetched_101.sorted_post_state.accounts.len(),
-        1,
-        "Should have 1 account at block 101"
-    );
-    assert!(
-        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
-        "New account should be in post_state"
-    );
-
-    Ok(())
-}
-
-/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
-///
-/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
-/// it is properly stored as a deletion and subsequent queries return None for that path.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path1 = nibbles_from(vec![1, 2, 3]);
-    let account_path2 = nibbles_from(vec![4, 5, 6]);
-    let storage_path1 = nibbles_from(vec![7, 8, 9]);
-    let storage_path2 = nibbles_from(vec![10, 11, 12]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
-    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
-    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path1)?.is_some(),
-        "Initial account branch 1 should exist at block 75"
-    );
-    assert!(
-        cursor_75.seek_exact(account_path2)?.is_some(),
-        "Initial account branch 2 should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
-        "Initial storage branch 1 should exist at block 75"
-    );
-    assert!(
-        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
-        "Initial storage branch 2 should exist at block 75"
-    );
-
-    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
-    let mut deletion_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes ONLY (no updates)
-    deletion_trie_updates.removed_nodes.insert(account_path1);
-
-    // Do the same for storage branch
-    let mut deletion_storage_trie = StorageTrieUpdates::default();
-    deletion_storage_trie.removed_nodes.insert(storage_path1);
-    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
-
-    let deletion_diff = BlockStateDiff {
-        sorted_trie_updates: deletion_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, deletion_diff)?;
-
-    // ========== Verify that deleted nodes return None at block 150 ==========
-
-    // Deleted account branch should not be found
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path1)?;
-    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
-
-    // Non-deleted account branch should still exist
-    let account_result2 = cursor_150.seek_exact(account_path2)?;
-    assert!(
-        account_result2.is_some(),
-        "Non-deleted account branch should still exist at block 150"
-    );
-
-    // Deleted storage branch should not be found
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
-    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
-
-    // Non-deleted storage branch should still exist
-    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
-    assert!(
-        storage_result2.is_some(),
-        "Non-deleted storage branch should still exist at block 150"
-    );
-
-    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75_after.seek_exact(account_path1)?.is_some(),
-        "Deleted node should still exist at block 75 (before deletion)"
-    );
-
-    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
-        "Deleted storage node should still exist at block 75 (before deletion)"
-    );
-
-    // ========== Verify iteration skips deleted nodes ==========
-    let mut cursor_iter = storage.account_trie_cursor(150)?;
-    let mut found_paths = Vec::new();
-    while let Some((path, _)) = cursor_iter.next()? {
-        found_paths.push(path);
-    }
-
-    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
-    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
-
-    Ok(())
-}
-
-/// Test that updates take precedence over removals when both are present
-///
-/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
-/// the update from `account_nodes` takes precedence. This is critical for correctness
-/// when processing trie updates that both remove and update the same node.
-#[test_case(InMemoryProofsStorage::new(); "InMemory")]
-#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[serial]
-fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
-    storage: S,
-) -> Result<(), BaseProofsStorageError> {
-    use reth_trie::updates::StorageTrieUpdates;
-
-    // ========== Setup: Store initial branch nodes at block 50 ==========
-    let account_path = nibbles_from(vec![1, 2, 3]);
-    let storage_path = nibbles_from(vec![4, 5, 6]);
-    let storage_address = B256::repeat_byte(0x42);
-
-    let initial_branch = create_test_branch();
-
-    let mut initial_trie_updates = TrieUpdates::default();
-    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
-
-    let mut storage_trie = StorageTrieUpdates::default();
-    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
-    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
-
-    let initial_diff = BlockStateDiff {
-        sorted_trie_updates: initial_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
-
-    storage.store_trie_updates(block_ref_50, initial_diff)?;
-
-    // Verify initial state exists at block 75
-    let mut cursor_75 = storage.account_trie_cursor(75)?;
-    assert!(
-        cursor_75.seek_exact(account_path)?.is_some(),
-        "Initial account branch should exist at block 75"
-    );
-
-    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
-    assert!(
-        storage_cursor_75.seek_exact(storage_path)?.is_some(),
-        "Initial storage branch should exist at block 75"
-    );
-
-    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
-    // This simulates a scenario where a node is both removed and updated
-    // The update should take precedence
-    let updated_branch = create_test_branch_variant();
-
-    let mut conflicting_trie_updates = TrieUpdates::default();
-
-    // Add to removed_nodes
-    conflicting_trie_updates.removed_nodes.insert(account_path);
-
-    // Also add to account_nodes (this should take precedence)
-    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
-
-    // Do the same for storage branch
-    let mut conflicting_storage_trie = StorageTrieUpdates::default();
-    conflicting_storage_trie.removed_nodes.insert(storage_path);
-    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
-    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
-
-    let conflicting_diff = BlockStateDiff {
-        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
-        sorted_post_state: HashedPostStateSorted::default(),
-    };
-
-    let block_ref_100 =
-        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
-
-    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
-
-    // ========== Verify that updates took precedence at block 150 ==========
-
-    // Account branch should exist (not deleted) with the updated value
-    let mut cursor_150 = storage.account_trie_cursor(150)?;
-    let account_result = cursor_150.seek_exact(account_path)?;
-    assert!(
-        account_result.is_some(),
-        "Account branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_path, found_branch) = account_result.unwrap();
-    assert_eq!(found_path, account_path);
-    // Verify it's the updated branch, not the initial one
-    assert_eq!(
-        found_branch.state_mask, updated_branch.state_mask,
-        "Account branch should be the updated version, not the initial one"
-    );
-
-    // Storage branch should exist (not deleted) with the updated value
-    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
-    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
-    assert!(
-        storage_result.is_some(),
-        "Storage branch should exist at block 150 (update should take precedence over removal)"
-    );
-    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
-    assert_eq!(found_storage_path, storage_path);
-    // Verify it's the updated branch
-    assert_eq!(
-        found_storage_branch.state_mask, updated_branch.state_mask,
-        "Storage branch should be the updated version, not the initial one"
-    );
-
-    // ========== Verify that the old version still exists at block 75 ==========
-    let mut cursor_75_after = storage.account_trie_cursor(75)?;
-    let result_75 = cursor_75_after.seek_exact(account_path)?;
-    assert!(result_75.is_some(), "Initial version should still exist at block 75");
-    let (_, branch_75) = result_75.unwrap();
-    assert_eq!(
-        branch_75.state_mask, initial_branch.state_mask,
-        "Block 75 should see the initial branch, not the updated one"
-    );
-
+    let mut cursor = storage.storage_hashed_cursor(hashed_address, at)?;
+    assert_eq!(cursor.seek(slot)?, Some((slot, expected)));
     Ok(())
 }

--- a/crates/execution/trie/tests/proof_window/mod.rs
+++ b/crates/execution/trie/tests/proof_window/mod.rs
@@ -1,0 +1,48 @@
+//! Proof window metadata behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test basic storage and retrieval of earliest block number
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // Initially should be None
+    let earliest = storage.get_earliest_block_number()?;
+    assert!(earliest.is_none());
+
+    // Set earliest block
+    let block_hash = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(100, block_hash)?;
+
+    // Should retrieve the same values
+    let earliest = storage.get_earliest_block_number()?;
+    assert_eq!(earliest, Some((100, block_hash)));
+
+    Ok(())
+}
+
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_proof_window<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    assert_eq!(storage.get_earliest_block_number()?, None);
+    let block_hash_42 = B256::repeat_byte(0x42);
+    storage.set_earliest_block_number(42, block_hash_42)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((42, block_hash_42)));
+
+    let block_hash_100 = B256::repeat_byte(0x64);
+    storage.set_earliest_block_number(100, block_hash_100)?;
+    assert_eq!(storage.get_earliest_block_number()?, Some((100, block_hash_100)));
+    assert_eq!(storage.get_latest_block_number()?, Some((100, block_hash_100)));
+    Ok(())
+}

--- a/crates/execution/trie/tests/trie_updates/mod.rs
+++ b/crates/execution/trie/tests/trie_updates/mod.rs
@@ -1,0 +1,970 @@
+//! Trie update storage and replacement behavior tests.
+
+use serial_test::serial;
+use test_case::test_case;
+
+use super::*;
+
+/// Test storing and retrieving trie updates
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+    let sorted_trie_updates = TrieUpdatesSorted::default();
+    let sorted_post_state = HashedPostStateSorted::default();
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: sorted_trie_updates.clone(),
+        sorted_post_state: sorted_post_state.clone(),
+    };
+
+    // Store trie updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // Retrieve and verify
+    let retrieved_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+    assert_eq!(retrieved_diff.sorted_trie_updates, sorted_trie_updates);
+    assert_eq!(retrieved_diff.sorted_post_state, sorted_post_state);
+
+    Ok(())
+}
+
+/// Test wiped storage in [`HashedPostState`]
+///
+/// When `store_trie_updates` receives a [`HashedPostState`] with wiped=true for a storage entry,
+/// it should iterate all existing values for that address and create deletion entries for them.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // First, store some storage values at block 50
+    let storage_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+        (B256::repeat_byte(0x30), U256::from(300)),
+        (B256::repeat_byte(0x40), U256::from(400)),
+    ];
+
+    storage.store_hashed_storages(hashed_address, storage_slots.clone())?;
+
+    // Verify all values are present at block 75
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        found_slots.push((key, value));
+    }
+    assert_eq!(found_slots.len(), 4, "All storage slots should be present before wipe");
+    assert_eq!(found_slots[0], (B256::repeat_byte(0x10), U256::from(100)));
+    assert_eq!(found_slots[1], (B256::repeat_byte(0x20), U256::from(200)));
+    assert_eq!(found_slots[2], (B256::repeat_byte(0x30), U256::from(300)));
+    assert_eq!(found_slots[3], (B256::repeat_byte(0x40), U256::from(400)));
+
+    // Now create a HashedPostState with wiped=true for this address at block 100
+    let mut post_state = HashedPostState::default();
+    let wiped_storage = HashedStorage::new(true); // wiped=true, empty storage map
+    post_state.storages.insert(hashed_address, wiped_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the wiped state
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // After wiping, cursor at block 150 should see NO storage values
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found_slots_after_wipe = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found_slots_after_wipe.push((key, value));
+    }
+
+    assert_eq!(
+        found_slots_after_wipe.len(),
+        0,
+        "All storage slots should be deleted after wipe. Found: {found_slots_after_wipe:?}"
+    );
+
+    // Verify individual seeks also return None
+    for (slot, _) in &storage_slots {
+        let mut seek_cursor = storage.storage_hashed_cursor(hashed_address, 150)?;
+        let result = seek_cursor.seek(*slot)?;
+        assert!(
+            result.is_none() || result.unwrap().0 != *slot,
+            "Storage slot {slot:?} should be deleted after wipe"
+        );
+    }
+
+    // Verify cursor at block 75 (before wipe) still sees all values
+    let mut cursor75_after = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut found_slots_before_wipe = Vec::new();
+    while let Some((key, value)) = cursor75_after.next()? {
+        found_slots_before_wipe.push((key, value));
+    }
+    assert_eq!(
+        found_slots_before_wipe.len(),
+        4,
+        "All storage slots should still be present when querying before wipe block"
+    );
+
+    Ok(())
+}
+
+/// When a [`HashedPostState`] entry has `wiped = true` AND non-empty `storage` (the shape revm
+/// produces for `AccountStatus::DestroyedChanged` accounts that are destroyed and recreated in
+/// the same block), `store_trie_updates` must tombstone every prior storage slot for the address
+/// at `block_number` AND persist the new post-recreation slot values from `storage`. Dropping
+/// the new slots corrupts `HashedStorageHistory` and makes `BaseProofsStateProviderRef::storage`
+/// return `None` for the new slots, producing divergent storage / state / output roots
+/// downstream of `LiveTrieCollector`.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_with_wiped_storage_and_new_slots<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let hashed_address = B256::repeat_byte(0x01);
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    let pre_existing_slots = vec![
+        (B256::repeat_byte(0x10), U256::from(100)),
+        (B256::repeat_byte(0x20), U256::from(200)),
+    ];
+    storage.store_hashed_storages(hashed_address, pre_existing_slots.clone())?;
+
+    let new_slot_kept = (B256::repeat_byte(0x30), U256::from(0xCAFE));
+    let new_slot_overwriting_old = (B256::repeat_byte(0x10), U256::from(0xBEEF));
+
+    let mut post_state = HashedPostState::default();
+    let wiped_with_new =
+        HashedStorage::from_iter(true, vec![new_slot_kept, new_slot_overwriting_old]);
+    post_state.storages.insert(hashed_address, wiped_with_new);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: TrieUpdatesSorted::default(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    let mut cursor150 = storage.storage_hashed_cursor(hashed_address, 150)?;
+    let mut found = Vec::new();
+    while let Some((key, value)) = cursor150.next()? {
+        found.push((key, value));
+    }
+
+    assert_eq!(
+        found,
+        vec![new_slot_overwriting_old, new_slot_kept],
+        "After wipe+recreate, only the new post-recreation slots must be visible",
+    );
+
+    let mut seek_kept = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_kept.seek(new_slot_kept.0)?,
+        Some(new_slot_kept),
+        "New slot 0x30 = 0xCAFE must round-trip through the cursor",
+    );
+
+    let mut seek_overwritten = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_overwritten.seek(new_slot_overwriting_old.0)?,
+        Some(new_slot_overwriting_old),
+        "Reused slot 0x10 must reflect the new post-recreation value 0xBEEF, not the wiped 100",
+    );
+
+    let mut seek_dropped = storage.storage_hashed_cursor(hashed_address, 150)?;
+    assert_eq!(
+        seek_dropped.seek(B256::repeat_byte(0x20))?,
+        Some(new_slot_kept),
+        "seek(0x20) must skip the tombstoned old slot and advance to the next visible entry \
+         (0x30 = 0xCAFE), proving 0x20 is not visible at block 150",
+    );
+
+    let mut cursor75 = storage.storage_hashed_cursor(hashed_address, 75)?;
+    let mut pre_wipe_found = Vec::new();
+    while let Some((key, value)) = cursor75.next()? {
+        pre_wipe_found.push((key, value));
+    }
+    assert_eq!(
+        pre_wipe_found, pre_existing_slots,
+        "Cursor positioned before the wipe block must still see the original slot values",
+    );
+
+    Ok(())
+}
+
+/// Test that `store_trie_updates` properly stores branch nodes, leaf nodes, and removals
+///
+/// This test verifies that all data stored via `store_trie_updates` can be read back
+/// through the cursor APIs.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+
+    // Create comprehensive trie updates with branches, leaves, and removals
+    let mut trie_updates = TrieUpdates::default();
+
+    // Add account branch nodes
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let account_branch1 = create_test_branch();
+    let account_branch2 = create_test_branch_variant();
+
+    trie_updates.account_nodes.insert(account_path1, account_branch1);
+    trie_updates.account_nodes.insert(account_path2, account_branch2);
+
+    // Add removed account nodes
+    let removed_account_path = nibbles_from(vec![7, 8, 9]);
+    trie_updates.removed_nodes.insert(removed_account_path);
+
+    // Add storage branch nodes for an address
+    let hashed_address = B256::repeat_byte(0x42);
+    let storage_path1 = nibbles_from(vec![1, 1]);
+    let storage_path2 = nibbles_from(vec![2, 2]);
+    let storage_branch = create_test_branch();
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, storage_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, storage_branch);
+
+    // Add removed storage node
+    let removed_storage_path = nibbles_from(vec![3, 3]);
+    storage_trie.removed_nodes.insert(removed_storage_path);
+
+    trie_updates.insert_storage_updates(hashed_address, storage_trie);
+
+    // Create post state with accounts and storage
+    let mut post_state = HashedPostState::default();
+
+    // Add accounts
+    let account1_addr = B256::repeat_byte(0x10);
+    let account2_addr = B256::repeat_byte(0x20);
+    let account1 = create_test_account_with_values(1, 1000, 0xAA);
+    let account2 = create_test_account_with_values(2, 2000, 0xBB);
+
+    post_state.accounts.insert(account1_addr, Some(account1));
+    post_state.accounts.insert(account2_addr, Some(account2));
+
+    // Add deleted account
+    let deleted_account_addr = B256::repeat_byte(0x30);
+    post_state.accounts.insert(deleted_account_addr, None);
+
+    // Add storage for an address
+    let storage_addr = B256::repeat_byte(0x50);
+    let mut hashed_storage = HashedStorage::new(false);
+    hashed_storage.storage.insert(B256::repeat_byte(0x01), U256::from(111));
+    hashed_storage.storage.insert(B256::repeat_byte(0x02), U256::from(222));
+    hashed_storage.storage.insert(B256::repeat_byte(0x03), U256::ZERO); // Deleted storage
+    post_state.storages.insert(storage_addr, hashed_storage);
+
+    let block_state_diff = BlockStateDiff {
+        sorted_trie_updates: trie_updates.into_sorted(),
+        sorted_post_state: post_state.into_sorted(),
+    };
+
+    // Store the updates
+    storage.store_trie_updates(block_ref, block_state_diff)?;
+
+    // ========== Verify Account Branch Nodes ==========
+    let mut account_trie_cursor = storage.account_trie_cursor(block_ref.block.number + 10)?;
+
+    // Should find the added branches
+    let result1 = account_trie_cursor.seek_exact(account_path1)?;
+    assert!(result1.is_some(), "Account branch node 1 should be found");
+    assert_eq!(result1.unwrap().0, account_path1);
+
+    let result2 = account_trie_cursor.seek_exact(account_path2)?;
+    assert!(result2.is_some(), "Account branch node 2 should be found");
+    assert_eq!(result2.unwrap().0, account_path2);
+
+    // Removed node should not be found
+    let removed_result = account_trie_cursor.seek_exact(removed_account_path)?;
+    assert!(removed_result.is_none(), "Removed account node should not be found");
+
+    // ========== Verify Storage Branch Nodes ==========
+    let mut storage_trie_cursor =
+        storage.storage_trie_cursor(hashed_address, block_ref.block.number + 10)?;
+
+    let storage_result1 = storage_trie_cursor.seek_exact(storage_path1)?;
+    assert!(storage_result1.is_some(), "Storage branch node 1 should be found");
+
+    let storage_result2 = storage_trie_cursor.seek_exact(storage_path2)?;
+    assert!(storage_result2.is_some(), "Storage branch node 2 should be found");
+
+    // Removed storage node should not be found
+    let removed_storage_result = storage_trie_cursor.seek_exact(removed_storage_path)?;
+    assert!(removed_storage_result.is_none(), "Removed storage node should not be found");
+
+    // ========== Verify Account Leaves ==========
+    let mut account_cursor = storage.account_hashed_cursor(block_ref.block.number + 10)?;
+
+    let acc1_result = account_cursor.seek(account1_addr)?;
+    assert!(acc1_result.is_some(), "Account 1 should be found");
+    assert_eq!(acc1_result.unwrap().0, account1_addr);
+    assert_eq!(acc1_result.unwrap().1.nonce, 1);
+    assert_eq!(acc1_result.unwrap().1.balance, U256::from(1000));
+
+    let acc2_result = account_cursor.seek(account2_addr)?;
+    assert!(acc2_result.is_some(), "Account 2 should be found");
+    assert_eq!(acc2_result.unwrap().1.nonce, 2);
+
+    // Deleted account should not be found
+    let deleted_acc_result = account_cursor.seek(deleted_account_addr)?;
+    assert!(
+        deleted_acc_result.is_none() || deleted_acc_result.unwrap().0 != deleted_account_addr,
+        "Deleted account should not be found"
+    );
+
+    // ========== Verify Storage Leaves ==========
+    let mut storage_cursor =
+        storage.storage_hashed_cursor(storage_addr, block_ref.block.number + 10)?;
+
+    let slot1_result = storage_cursor.seek(B256::repeat_byte(0x01))?;
+    assert!(slot1_result.is_some(), "Storage slot 1 should be found");
+    assert_eq!(slot1_result.unwrap().1, U256::from(111));
+
+    let slot2_result = storage_cursor.seek(B256::repeat_byte(0x02))?;
+    assert!(slot2_result.is_some(), "Storage slot 2 should be found");
+    assert_eq!(slot2_result.unwrap().1, U256::from(222));
+
+    // Zero-valued storage should not be found (deleted)
+    let slot3_result = storage_cursor.seek(B256::repeat_byte(0x03))?;
+    assert!(
+        slot3_result.is_none() || slot3_result.unwrap().0 != B256::repeat_byte(0x03),
+        "Zero-valued storage slot should not be found"
+    );
+
+    // ========== Verify fetch_trie_updates can retrieve the data ==========
+    let fetched_diff = storage.fetch_trie_updates(block_ref.block.number)?;
+
+    // Check that trie updates are stored
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.account_nodes_ref().len(),
+        3,
+        "Should have 3 account nodes, including removed"
+    );
+    assert_eq!(
+        fetched_diff.sorted_trie_updates.storage_tries_ref().len(),
+        1,
+        "Should have 1 storage trie"
+    );
+
+    // Check that post state is stored
+    assert_eq!(
+        fetched_diff.sorted_post_state.accounts.len(),
+        3,
+        "Should have 3 accounts (including deleted)"
+    );
+    assert_eq!(fetched_diff.sorted_post_state.storages.len(), 1, "Should have 1 storage entry");
+
+    Ok(())
+}
+
+/// Test that `replace_updates` properly applies hashed/trie storage updates to the DB
+///
+/// This test verifies the bug fix where `replace_updates` was only storing `trie_updates`
+/// and `post_states` directly without populating the internal data structures
+/// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    // ========== Setup: Store initial state at blocks 50, 100, 101 ==========
+    let initial_account_addr = B256::repeat_byte(0x10);
+    let initial_account = create_test_account_with_values(1, 1000, 0xAA);
+
+    let initial_storage_addr = B256::repeat_byte(0x20);
+    let initial_storage_slot = B256::repeat_byte(0x01);
+    let initial_storage_value = U256::from(100);
+
+    let initial_branch_path = nibbles_from(vec![1, 2, 3]);
+    let initial_branch = create_test_branch();
+
+    // Store initial data at block 50
+    let mut initial_trie_updates_50 = TrieUpdates::default();
+    initial_trie_updates_50.account_nodes.insert(initial_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_50 = HashedPostState::default();
+    initial_post_state_50.accounts.insert(initial_account_addr, Some(initial_account));
+
+    let initial_diff_50 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_50.into_sorted(),
+        sorted_post_state: initial_post_state_50.into_sorted(),
+    };
+    storage.store_trie_updates(block_ref_50, initial_diff_50)?;
+
+    // Store data at block 100 (common block)
+    let mut initial_trie_updates_100 = TrieUpdates::default();
+    let common_branch_path = nibbles_from(vec![4, 5, 6]);
+    initial_trie_updates_100.account_nodes.insert(common_branch_path, initial_branch.clone());
+
+    let mut initial_post_state_100 = HashedPostState::default();
+    let mut initial_storage_100 = HashedStorage::new(false);
+    initial_storage_100.storage.insert(initial_storage_slot, initial_storage_value);
+    initial_post_state_100.storages.insert(initial_storage_addr, initial_storage_100);
+
+    let initial_diff_100 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_100.into_sorted(),
+        sorted_post_state: initial_post_state_100.into_sorted(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(block_ref_50.block.hash, NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, initial_diff_100)?;
+
+    // Store data at block 101 (will be replaced)
+    let mut initial_trie_updates_101 = TrieUpdates::default();
+    let old_branch_path = nibbles_from(vec![7, 8, 9]);
+    initial_trie_updates_101.account_nodes.insert(old_branch_path, initial_branch);
+
+    let mut initial_post_state_101 = HashedPostState::default();
+    let old_account_addr = B256::repeat_byte(0x30);
+    let old_account = create_test_account_with_values(99, 9999, 0xFF);
+    initial_post_state_101.accounts.insert(old_account_addr, Some(old_account));
+
+    let initial_diff_101 = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates_101.into_sorted(),
+        sorted_post_state: initial_post_state_101.into_sorted(),
+    };
+    let block_ref_101 =
+        BlockWithParent::new(block_ref_100.block.hash, NumHash::new(101, B256::repeat_byte(0x98)));
+    storage.store_trie_updates(block_ref_101, initial_diff_101)?;
+
+    let block_ref_102 =
+        BlockWithParent::new(block_ref_101.block.hash, NumHash::new(102, B256::repeat_byte(0x99)));
+
+    // ========== Verify initial state exists ==========
+    // Verify block 50 data exists
+    let mut cursor_initial = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_initial.seek_exact(initial_branch_path)?.is_some(),
+        "Initial branch should exist before replace"
+    );
+
+    // Verify block 101 old data exists
+    let mut cursor_old = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old.seek_exact(old_branch_path)?.is_some(),
+        "Old branch at block 101 should exist before replace"
+    );
+
+    let mut account_cursor_old = storage.account_hashed_cursor(150)?;
+    assert!(
+        account_cursor_old.seek(old_account_addr)?.is_some(),
+        "Old account at block 101 should exist before replace"
+    );
+
+    // ========== Call replace_updates to replace blocks after 100 ==========
+    let mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)> = Vec::default();
+
+    // New data for block 101
+    let new_account_addr = B256::repeat_byte(0x40);
+    let new_account = create_test_account_with_values(5, 5000, 0xCC);
+
+    let new_storage_addr = B256::repeat_byte(0x50);
+    let new_storage_slot = B256::repeat_byte(0x02);
+    let new_storage_value = U256::from(999);
+
+    let new_branch_path = nibbles_from(vec![10, 11, 12]);
+    let new_branch = create_test_branch_variant();
+
+    let storage_branch_path = nibbles_from(vec![5, 5]);
+    let storage_hashed_addr = B256::repeat_byte(0x60);
+
+    let mut new_trie_updates = TrieUpdates::default();
+    new_trie_updates.account_nodes.insert(new_branch_path, new_branch.clone());
+
+    // Add storage trie updates
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_branch_path, new_branch.clone());
+    new_trie_updates.insert_storage_updates(storage_hashed_addr, storage_trie);
+
+    let mut new_post_state = HashedPostState::default();
+    new_post_state.accounts.insert(new_account_addr, Some(new_account));
+
+    let mut new_storage = HashedStorage::new(false);
+    new_storage.storage.insert(new_storage_slot, new_storage_value);
+    new_post_state.storages.insert(new_storage_addr, new_storage);
+
+    blocks_to_add.push((
+        block_ref_101,
+        BlockStateDiff {
+            sorted_trie_updates: new_trie_updates.into_sorted(),
+            sorted_post_state: new_post_state.into_sorted(),
+        },
+    ));
+
+    // New data for block 102
+    let block_102_account_addr = B256::repeat_byte(0x70);
+    let block_102_account = create_test_account_with_values(10, 10000, 0xDD);
+
+    let mut trie_updates_102 = TrieUpdates::default();
+    let block_102_branch_path = nibbles_from(vec![15, 14, 13]);
+    trie_updates_102.account_nodes.insert(block_102_branch_path, new_branch);
+
+    let mut post_state_102 = HashedPostState::default();
+    post_state_102.accounts.insert(block_102_account_addr, Some(block_102_account));
+
+    blocks_to_add.push((
+        block_ref_102,
+        BlockStateDiff {
+            sorted_trie_updates: trie_updates_102.into_sorted(),
+            sorted_post_state: post_state_102.into_sorted(),
+        },
+    ));
+
+    // Execute replace_updates
+    storage.replace_updates(BlockNumHash::new(100, block_ref_100.block.hash), blocks_to_add)?;
+    // ========== Verify that data up to block 100 still exists ==========
+    let mut cursor_50 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_50.seek_exact(initial_branch_path)?.is_some(),
+        "Block 50 branch should still exist after replace"
+    );
+
+    let mut cursor_100 = storage.account_trie_cursor(100)?;
+    assert!(
+        cursor_100.seek_exact(common_branch_path)?.is_some(),
+        "Block 100 branch should still exist after replace"
+    );
+
+    let mut storage_cursor_100 = storage.storage_hashed_cursor(initial_storage_addr, 100)?;
+    let result_100 = storage_cursor_100.seek(initial_storage_slot)?;
+    assert!(result_100.is_some(), "Block 100 storage should still exist after replace");
+    assert_eq!(
+        result_100.unwrap().1,
+        initial_storage_value,
+        "Block 100 storage value should be unchanged"
+    );
+
+    // ========== Verify that old data after block 100 is gone ==========
+    let mut cursor_old_gone = storage.account_trie_cursor(150)?;
+    assert!(
+        cursor_old_gone.seek_exact(old_branch_path)?.is_none(),
+        "Old branch at block 101 should be removed after replace"
+    );
+
+    let mut account_cursor_old_gone = storage.account_hashed_cursor(150)?;
+    let old_acc_result = account_cursor_old_gone.seek(old_account_addr)?;
+    assert!(
+        old_acc_result.is_none() || old_acc_result.unwrap().0 != old_account_addr,
+        "Old account at block 101 should be removed after replace"
+    );
+
+    // ========== Verify new data is properly accessible via cursors ==========
+
+    // Verify new account branch nodes
+    let mut trie_cursor = storage.account_trie_cursor(150)?;
+    let branch_result = trie_cursor.seek_exact(new_branch_path)?;
+    assert!(branch_result.is_some(), "New account branch should be accessible via cursor");
+    assert_eq!(branch_result.unwrap().0, new_branch_path);
+
+    // Verify new storage branch nodes
+    let mut storage_trie_cursor = storage.storage_trie_cursor(storage_hashed_addr, 150)?;
+    let storage_branch_result = storage_trie_cursor.seek_exact(storage_branch_path)?;
+    assert!(storage_branch_result.is_some(), "New storage branch should be accessible via cursor");
+    assert_eq!(storage_branch_result.unwrap().0, storage_branch_path);
+
+    // Verify new hashed accounts
+    let mut account_cursor = storage.account_hashed_cursor(150)?;
+    let account_result = account_cursor.seek(new_account_addr)?;
+    assert!(account_result.is_some(), "New account should be accessible via cursor");
+    assert_eq!(account_result.as_ref().unwrap().0, new_account_addr);
+    assert_eq!(account_result.as_ref().unwrap().1.nonce, new_account.nonce);
+    assert_eq!(account_result.as_ref().unwrap().1.balance, new_account.balance);
+    assert_eq!(account_result.as_ref().unwrap().1.bytecode_hash, new_account.bytecode_hash);
+
+    // Verify new hashed storages
+    let mut storage_cursor = storage.storage_hashed_cursor(new_storage_addr, 150)?;
+    let storage_result = storage_cursor.seek(new_storage_slot)?;
+    assert!(storage_result.is_some(), "New storage should be accessible via cursor");
+    assert_eq!(storage_result.as_ref().unwrap().0, new_storage_slot);
+    assert_eq!(storage_result.as_ref().unwrap().1, new_storage_value);
+
+    // Verify block 102 data
+    let mut trie_cursor_102 = storage.account_trie_cursor(150)?;
+    let branch_result_102 = trie_cursor_102.seek_exact(block_102_branch_path)?;
+    assert!(branch_result_102.is_some(), "Block 102 branch should be accessible");
+    assert_eq!(branch_result_102.unwrap().0, block_102_branch_path);
+
+    let mut account_cursor_102 = storage.account_hashed_cursor(150)?;
+    let account_result_102 = account_cursor_102.seek(block_102_account_addr)?;
+    assert!(account_result_102.is_some(), "Block 102 account should be accessible");
+    assert_eq!(account_result_102.as_ref().unwrap().0, block_102_account_addr);
+    assert_eq!(account_result_102.as_ref().unwrap().1.nonce, block_102_account.nonce);
+
+    // Verify fetch_trie_updates returns the new data
+    let fetched_101 = storage.fetch_trie_updates(101)?;
+    assert_eq!(
+        fetched_101.sorted_trie_updates.account_nodes_ref().len(),
+        1,
+        "Should have 1 account branch node at block 101"
+    );
+    assert!(
+        fetched_101
+            .sorted_trie_updates
+            .account_nodes_ref()
+            .iter()
+            .any(|(addr, _)| *addr == new_branch_path),
+        "New branch path should be in trie_updates"
+    );
+    assert_eq!(
+        fetched_101.sorted_post_state.accounts.len(),
+        1,
+        "Should have 1 account at block 101"
+    );
+    assert!(
+        fetched_101.sorted_post_state.accounts.iter().any(|(addr, _)| *addr == new_account_addr),
+        "New account should be in post_state"
+    );
+
+    Ok(())
+}
+
+/// Test that multi-block replacements make wiped storage see storage added earlier in the
+/// replacement chain.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_replace_updates_wipes_storage_added_by_prior_replacement_block<
+    S: BaseProofsStore + BaseProofsInitialStateStore,
+>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    let common_block = BlockWithParent::new(B256::ZERO, NumHash::new(1, B256::repeat_byte(0xA1)));
+    storage.store_trie_updates(common_block, BlockStateDiff::default())?;
+
+    let old_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xB2)));
+    let old_block_3 =
+        BlockWithParent::new(old_block_2.block.hash, NumHash::new(3, B256::repeat_byte(0xB3)));
+    storage.store_trie_updates(old_block_2, BlockStateDiff::default())?;
+    storage.store_trie_updates(old_block_3, BlockStateDiff::default())?;
+
+    let storage_address = B256::repeat_byte(0x44);
+    let storage_slot = B256::repeat_byte(0x55);
+    let storage_value = U256::from(0x1234);
+
+    let replacement_block_2 =
+        BlockWithParent::new(common_block.block.hash, NumHash::new(2, B256::repeat_byte(0xC2)));
+    let replacement_block_3 = BlockWithParent::new(
+        replacement_block_2.block.hash,
+        NumHash::new(3, B256::repeat_byte(0xC3)),
+    );
+
+    let mut replacement_post_state_2 = HashedPostState::default();
+    let mut replacement_storage_2 = HashedStorage::new(false);
+    replacement_storage_2.storage.insert(storage_slot, storage_value);
+    replacement_post_state_2.storages.insert(storage_address, replacement_storage_2);
+
+    let mut replacement_post_state_3 = HashedPostState::default();
+    replacement_post_state_3.storages.insert(storage_address, HashedStorage::new(true));
+
+    storage.replace_updates(
+        BlockNumHash::new(common_block.block.number, common_block.block.hash),
+        vec![
+            (
+                replacement_block_2,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_2.into_sorted(),
+                },
+            ),
+            (
+                replacement_block_3,
+                BlockStateDiff {
+                    sorted_trie_updates: TrieUpdatesSorted::default(),
+                    sorted_post_state: replacement_post_state_3.into_sorted(),
+                },
+            ),
+        ],
+    )?;
+
+    let mut storage_cursor = storage.storage_hashed_cursor(storage_address, 3)?;
+    let storage_result = storage_cursor.seek(storage_slot)?;
+    assert!(
+        !matches!(storage_result, Some((found_slot, _)) if found_slot == storage_slot),
+        "storage added by replacement block 2 should be wiped by replacement block 3"
+    );
+
+    Ok(())
+}
+
+/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
+///
+/// This test verifies that when a node appears only in `removed_nodes` (not in updates),
+/// it is properly stored as a deletion and subsequent queries return None for that path.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path1 = nibbles_from(vec![1, 2, 3]);
+    let account_path2 = nibbles_from(vec![4, 5, 6]);
+    let storage_path1 = nibbles_from(vec![7, 8, 9]);
+    let storage_path2 = nibbles_from(vec![10, 11, 12]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path1, initial_branch.clone());
+    initial_trie_updates.account_nodes.insert(account_path2, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path1, initial_branch.clone());
+    storage_trie.storage_nodes.insert(storage_path2, initial_branch);
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path1)?.is_some(),
+        "Initial account branch 1 should exist at block 75"
+    );
+    assert!(
+        cursor_75.seek_exact(account_path2)?.is_some(),
+        "Initial account branch 2 should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path1)?.is_some(),
+        "Initial storage branch 1 should exist at block 75"
+    );
+    assert!(
+        storage_cursor_75.seek_exact(storage_path2)?.is_some(),
+        "Initial storage branch 2 should exist at block 75"
+    );
+
+    // ========== At block 100: Mark paths as deleted (ONLY in removed_nodes) ==========
+    let mut deletion_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes ONLY (no updates)
+    deletion_trie_updates.removed_nodes.insert(account_path1);
+
+    // Do the same for storage branch
+    let mut deletion_storage_trie = StorageTrieUpdates::default();
+    deletion_storage_trie.removed_nodes.insert(storage_path1);
+    deletion_trie_updates.insert_storage_updates(storage_address, deletion_storage_trie);
+
+    let deletion_diff = BlockStateDiff {
+        sorted_trie_updates: deletion_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, deletion_diff)?;
+
+    // ========== Verify that deleted nodes return None at block 150 ==========
+
+    // Deleted account branch should not be found
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path1)?;
+    assert!(account_result.is_none(), "Deleted account branch should return None at block 150");
+
+    // Non-deleted account branch should still exist
+    let account_result2 = cursor_150.seek_exact(account_path2)?;
+    assert!(
+        account_result2.is_some(),
+        "Non-deleted account branch should still exist at block 150"
+    );
+
+    // Deleted storage branch should not be found
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path1)?;
+    assert!(storage_result.is_none(), "Deleted storage branch should return None at block 150");
+
+    // Non-deleted storage branch should still exist
+    let storage_result2 = storage_cursor_150.seek_exact(storage_path2)?;
+    assert!(
+        storage_result2.is_some(),
+        "Non-deleted storage branch should still exist at block 150"
+    );
+
+    // ========== Verify that the nodes still exist at block 75 (before deletion) ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75_after.seek_exact(account_path1)?.is_some(),
+        "Deleted node should still exist at block 75 (before deletion)"
+    );
+
+    let mut storage_cursor_75_after = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75_after.seek_exact(storage_path1)?.is_some(),
+        "Deleted storage node should still exist at block 75 (before deletion)"
+    );
+
+    // ========== Verify iteration skips deleted nodes ==========
+    let mut cursor_iter = storage.account_trie_cursor(150)?;
+    let mut found_paths = Vec::new();
+    while let Some((path, _)) = cursor_iter.next()? {
+        found_paths.push(path);
+    }
+
+    assert!(!found_paths.contains(&account_path1), "Iteration should skip deleted node");
+    assert!(found_paths.contains(&account_path2), "Iteration should include non-deleted node");
+
+    Ok(())
+}
+
+/// Test that updates take precedence over removals when both are present
+///
+/// This test verifies that when a path appears in both `removed_nodes` and `account_nodes`,
+/// the update from `account_nodes` takes precedence. This is critical for correctness
+/// when processing trie updates that both remove and update the same node.
+#[test_case(InMemoryProofsStorage::new(); "InMemory")]
+#[test_case(create_mdbx_proofs_storage(); "Mdbx")]
+#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[serial]
+fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
+    storage: S,
+) -> Result<(), BaseProofsStorageError> {
+    // ========== Setup: Store initial branch nodes at block 50 ==========
+    let account_path = nibbles_from(vec![1, 2, 3]);
+    let storage_path = nibbles_from(vec![4, 5, 6]);
+    let storage_address = B256::repeat_byte(0x42);
+
+    let initial_branch = create_test_branch();
+
+    let mut initial_trie_updates = TrieUpdates::default();
+    initial_trie_updates.account_nodes.insert(account_path, initial_branch.clone());
+
+    let mut storage_trie = StorageTrieUpdates::default();
+    storage_trie.storage_nodes.insert(storage_path, initial_branch.clone());
+    initial_trie_updates.insert_storage_updates(storage_address, storage_trie);
+
+    let initial_diff = BlockStateDiff {
+        sorted_trie_updates: initial_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
+
+    storage.store_trie_updates(block_ref_50, initial_diff)?;
+
+    // Verify initial state exists at block 75
+    let mut cursor_75 = storage.account_trie_cursor(75)?;
+    assert!(
+        cursor_75.seek_exact(account_path)?.is_some(),
+        "Initial account branch should exist at block 75"
+    );
+
+    let mut storage_cursor_75 = storage.storage_trie_cursor(storage_address, 75)?;
+    assert!(
+        storage_cursor_75.seek_exact(storage_path)?.is_some(),
+        "Initial storage branch should exist at block 75"
+    );
+
+    // ========== At block 100: Add paths to BOTH removed_nodes AND account_nodes ==========
+    // This simulates a scenario where a node is both removed and updated
+    // The update should take precedence
+    let updated_branch = create_test_branch_variant();
+
+    let mut conflicting_trie_updates = TrieUpdates::default();
+
+    // Add to removed_nodes
+    conflicting_trie_updates.removed_nodes.insert(account_path);
+
+    // Also add to account_nodes (this should take precedence)
+    conflicting_trie_updates.account_nodes.insert(account_path, updated_branch.clone());
+
+    // Do the same for storage branch
+    let mut conflicting_storage_trie = StorageTrieUpdates::default();
+    conflicting_storage_trie.removed_nodes.insert(storage_path);
+    conflicting_storage_trie.storage_nodes.insert(storage_path, updated_branch.clone());
+    conflicting_trie_updates.insert_storage_updates(storage_address, conflicting_storage_trie);
+
+    let conflicting_diff = BlockStateDiff {
+        sorted_trie_updates: conflicting_trie_updates.into_sorted(),
+        sorted_post_state: HashedPostStateSorted::default(),
+    };
+
+    let block_ref_100 =
+        BlockWithParent::new(B256::repeat_byte(0x96), NumHash::new(100, B256::repeat_byte(0x97)));
+
+    storage.store_trie_updates(block_ref_100, conflicting_diff)?;
+
+    // ========== Verify that updates took precedence at block 150 ==========
+
+    // Account branch should exist (not deleted) with the updated value
+    let mut cursor_150 = storage.account_trie_cursor(150)?;
+    let account_result = cursor_150.seek_exact(account_path)?;
+    assert!(
+        account_result.is_some(),
+        "Account branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_path, found_branch) = account_result.unwrap();
+    assert_eq!(found_path, account_path);
+    // Verify it's the updated branch, not the initial one
+    assert_eq!(
+        found_branch.state_mask, updated_branch.state_mask,
+        "Account branch should be the updated version, not the initial one"
+    );
+
+    // Storage branch should exist (not deleted) with the updated value
+    let mut storage_cursor_150 = storage.storage_trie_cursor(storage_address, 150)?;
+    let storage_result = storage_cursor_150.seek_exact(storage_path)?;
+    assert!(
+        storage_result.is_some(),
+        "Storage branch should exist at block 150 (update should take precedence over removal)"
+    );
+    let (found_storage_path, found_storage_branch) = storage_result.unwrap();
+    assert_eq!(found_storage_path, storage_path);
+    // Verify it's the updated branch
+    assert_eq!(
+        found_storage_branch.state_mask, updated_branch.state_mask,
+        "Storage branch should be the updated version, not the initial one"
+    );
+
+    // ========== Verify that the old version still exists at block 75 ==========
+    let mut cursor_75_after = storage.account_trie_cursor(75)?;
+    let result_75 = cursor_75_after.seek_exact(account_path)?;
+    assert!(result_75.is_some(), "Initial version should still exist at block 75");
+    let (_, branch_75) = result_75.unwrap();
+    assert_eq!(
+        branch_75.state_mask, initial_branch.state_mask,
+        "Block 75 should see the initial branch, not the updated one"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Part of the RocksDB proof storage stack, stacked on #3517.

Adds integration tests and benchmarks for the RocksDB read path ahead of the implementation. Tests compile but the RocksDB-specific paths will panic until the implementation lands in subsequent PRs.

Stack:
- #3518 feat(trie/rocksdb): add RocksDB backend — bulk initialization write path (merged)
- #3517 feat(trie/rocksdb): implement RocksDB block write path
- **this PR** test(trie/rocksdb): add integration tests and benchmarks
- feat(trie/rocksdb): implement RocksdbVersionedCursor
- feat(trie/rocksdb): implement TrieCursor and HashedCursor trait impls
- feat(trie/rocksdb): implement BaseProofsStore read methods and cursor factories
- feat(node): wire RocksDB proof storage into node and CLI
