### PR TITLE
feat(trie/rocksdb): implement BaseProofsStore read methods and cursor factories

### DIFF
--- a/crates/execution/trie/src/db/rocksdb.rs
+++ b/crates/execution/trie/src/db/rocksdb.rs
@@ -24,7 +24,9 @@ use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
 };
-use reth_trie_common::{BranchNodeCompact, Nibbles, StoredNibbles};
+use reth_trie_common::{
+    BranchNodeCompact, HashedPostState, Nibbles, StoredNibbles, updates::TrieUpdates,
+};
 use rocksdb::{
     BlockBasedIndexType, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
     CompactionPri, DBCompressionType, DBWithThreadMode, Direction, IteratorMode, MultiThreaded,
@@ -1690,7 +1692,7 @@ impl BaseProofsStore for RocksdbProofsStorage {
         Self: 'tx;
 
     fn ro_tx<'tx>(&'tx self) -> BaseProofsStorageResult<Self::Tx<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(Arc::new(RocksdbReadSnapshot::new(self.db.as_ref())))
     }
 
     fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
@@ -1703,82 +1705,100 @@ impl BaseProofsStore for RocksdbProofsStorage {
 
     fn storage_trie_cursor<'tx>(
         &'tx self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        // Standalone cursor factories intentionally create independent snapshots. Use `ro_tx` and
+        // the `*_with_tx` factories when multiple cursors need one consistent view.
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new(
+            self.db.as_ref(),
+            max_block_number,
+            Some(hashed_address),
+        ))
     }
 
     fn account_trie_cursor<'tx>(
         &'tx self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new(self.db.as_ref(), max_block_number, None))
     }
 
     fn storage_hashed_cursor<'tx>(
         &'tx self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbStorageCursor::new(self.db.as_ref(), max_block_number, hashed_address))
     }
 
     fn account_hashed_cursor<'tx>(
         &'tx self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbAccountCursor::new(self.db.as_ref(), max_block_number))
     }
 
     fn storage_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbTrieCursor::<StorageTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            Some(hashed_address),
+        ))
     }
 
     fn account_trie_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbTrieCursor::<AccountTrieHistory>::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            None,
+        ))
     }
 
     fn storage_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbStorageCursor::new_with_snapshot(
+            Arc::clone(tx),
+            max_block_number,
+            hashed_address,
+        ))
     }
 
     fn account_hashed_cursor_with_tx<'tx, 'db>(
         &self,
-        _tx: &'tx Self::Tx<'db>,
-        _max_block_number: u64,
+        tx: &'tx Self::Tx<'db>,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>
     where
         Self: 'db,
         'db: 'tx,
     {
-        unimplemented!("read path not yet implemented")
+        Ok(RocksdbAccountCursor::new_with_snapshot(Arc::clone(tx), max_block_number))
     }
 
     fn store_trie_updates(
@@ -1795,8 +1815,111 @@ impl BaseProofsStore for RocksdbProofsStorage {
         Ok(counts)
     }
 
-    fn fetch_trie_updates(&self, _block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
-        unimplemented!("read path not yet implemented")
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
+        let snapshot = self.db.snapshot();
+        let change_set = self
+            .get_table_from_snapshot::<BlockChangeSet>(&snapshot, block_number)?
+            .ok_or(BaseProofsStorageError::NoChangeSetForBlock(block_number))?;
+
+        let mut trie_updates = TrieUpdates::default();
+        for key in change_set.account_trie_keys {
+            let entry = match get_history_exact::<AccountTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingAccountTrieHistory(
+                        key.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            if let Some(value) = entry {
+                trie_updates.account_nodes.insert(key.0, value);
+            } else {
+                trie_updates.removed_nodes.insert(key.0);
+            }
+        }
+
+        for key in change_set.storage_trie_keys {
+            let entry = match get_history_exact::<StorageTrieHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingStorageTrieHistory(
+                        key.hashed_address,
+                        key.path.0,
+                        block_number,
+                    ));
+                }
+            };
+
+            let storage_updates = trie_updates.storage_tries.entry(key.hashed_address).or_default();
+            if let Some(value) = entry {
+                storage_updates.storage_nodes.insert(key.path.0, value);
+            } else {
+                storage_updates.removed_nodes.insert(key.path.0);
+            }
+        }
+
+        let mut post_state = HashedPostState::with_capacity(change_set.hashed_account_keys.len());
+        for key in change_set.hashed_account_keys {
+            let entry = match get_history_exact::<HashedAccountHistory, _>(
+                &snapshot,
+                &self.db,
+                key,
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedAccountHistory(
+                        key,
+                        block_number,
+                    ));
+                }
+            };
+            post_state.accounts.insert(key, entry);
+        }
+
+        for key in change_set.hashed_storage_keys {
+            let entry = match get_history_exact::<HashedStorageHistory, _>(
+                &snapshot,
+                &self.db,
+                key.clone(),
+                block_number,
+            )? {
+                Some(value) if value.block_number == block_number => value.value.0,
+                _ => {
+                    return Err(BaseProofsStorageError::MissingHashedStorageHistory {
+                        hashed_address: key.hashed_address,
+                        hashed_storage_key: key.hashed_storage_key,
+                        block_number,
+                    });
+                }
+            };
+
+            let storage = post_state.storages.entry(key.hashed_address).or_default();
+            if let Some(value) = entry {
+                storage.storage.insert(key.hashed_storage_key, value.0);
+            } else {
+                // handle wiped storage scenario
+                // Issue: https://github.com/op-rs/op-reth/issues/323
+                storage.storage.insert(key.hashed_storage_key, U256::ZERO);
+            }
+        }
+
+        Ok(BlockStateDiff {
+            sorted_trie_updates: trie_updates.into_sorted(),
+            sorted_post_state: post_state.into_sorted(),
+        })
     }
 
     fn prune_earliest_state(
@@ -1872,10 +1995,54 @@ impl BaseProofsStore for RocksdbProofsStorage {
 
     fn replace_updates(
         &self,
-        _latest_common_block: BlockNumHash,
-        _blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
+        latest_common_block: BlockNumHash,
+        mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
     ) -> BaseProofsStorageResult<()> {
-        unimplemented!("read path not yet implemented")
+        blocks_to_add.sort_unstable_by_key(|(block, _)| block.block.number);
+
+        let _guard = self.history_gate.write();
+
+        let mut latest_block_hash = latest_common_block.hash;
+        for (block_with_parent, _) in &blocks_to_add {
+            let block_number = block_with_parent.block.number;
+            if latest_block_hash != block_with_parent.parent {
+                return Err(BaseProofsStorageError::OutOfOrder {
+                    block_number,
+                    parent_block_hash: block_with_parent.parent,
+                    latest_block_hash,
+                });
+            }
+            latest_block_hash = block_with_parent.block.hash;
+        }
+
+        let history_to_delete = if let Some(start_block) = latest_common_block.number.checked_add(1)
+        {
+            self.collect_history_ranged(start_block..)?
+        } else {
+            RocksdbHistoryDeleteBatch::default()
+        };
+        let mut batch = WriteBatch::default();
+        self.delete_history_ranged(&mut batch, history_to_delete)?;
+        self.put_proof_window(
+            &mut batch,
+            ProofWindowKey::LatestBlock,
+            latest_common_block.number,
+            latest_common_block.hash,
+        )?;
+
+        let mut replacement_state = RocksdbReplacementState::default();
+        for (block_with_parent, diff) in blocks_to_add {
+            self.store_replacement_trie_updates_append_only(
+                &mut batch,
+                latest_common_block.number,
+                &mut replacement_state,
+                block_with_parent,
+                diff,
+            )?;
+        }
+
+        self.db.write_opt(batch, &self.write_options).map_err(rocksdb_error)?;
+        Ok(())
     }
 
     fn set_earliest_block_number(
@@ -2087,32 +2254,32 @@ impl BaseProofsBatchSession for RocksdbBatchSession<'_> {
 
     fn storage_trie_cursor(
         &self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.storage_trie_cursor_with_tx(&self.snapshot, hashed_address, max_block_number)
     }
 
     fn account_trie_cursor(
         &self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.account_trie_cursor_with_tx(&self.snapshot, max_block_number)
     }
 
     fn storage_hashed_cursor(
         &self,
-        _hashed_address: B256,
-        _max_block_number: u64,
+        hashed_address: B256,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::StorageCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.storage_hashed_cursor_with_tx(&self.snapshot, hashed_address, max_block_number)
     }
 
     fn account_hashed_cursor(
         &self,
-        _max_block_number: u64,
+        max_block_number: u64,
     ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'_>> {
-        unimplemented!("read path not yet implemented")
+        self.storage.account_hashed_cursor_with_tx(&self.snapshot, max_block_number)
     }
 
     fn store_trie_updates(
@@ -2400,7 +2567,6 @@ impl<'db> RocksdbTrieCursor<'db, AccountTrieHistory> {
         Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
     }
 
-    #[expect(dead_code, reason = "used by RocksDB read cursor factories added in follow-up split")]
     const fn new_with_snapshot(
         snapshot: Arc<RocksdbReadSnapshot<'db>>,
         max_block_number: u64,
@@ -2419,7 +2585,6 @@ impl<'db> RocksdbTrieCursor<'db, StorageTrieHistory> {
         Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
     }
 
-    #[expect(dead_code, reason = "used by RocksDB read cursor factories added in follow-up split")]
     const fn new_with_snapshot(
         snapshot: Arc<RocksdbReadSnapshot<'db>>,
         max_block_number: u64,
@@ -2537,7 +2702,6 @@ impl<'db> RocksdbStorageCursor<'db> {
         Self { inner: RocksdbVersionedCursor::new(db, max_block_number), hashed_address }
     }
 
-    #[expect(dead_code, reason = "used by RocksDB read cursor factories added in follow-up split")]
     const fn new_with_snapshot(
         snapshot: Arc<RocksdbReadSnapshot<'db>>,
         max_block_number: u64,
@@ -2619,7 +2783,6 @@ impl<'db> RocksdbAccountCursor<'db> {
         Self { inner: RocksdbVersionedCursor::new(db, max_block_number) }
     }
 
-    #[expect(dead_code, reason = "used by RocksDB read cursor factories added in follow-up split")]
     const fn new_with_snapshot(
         snapshot: Arc<RocksdbReadSnapshot<'db>>,
         max_block_number: u64,
@@ -2690,7 +2853,6 @@ where
 }
 
 /// Reads one exact history value for a key at a specific block number.
-#[expect(dead_code, reason = "used by RocksDB read-store wiring added in follow-up split")]
 fn get_history_exact<T, V>(
     snapshot: &SnapshotWithThreadMode<'_, RocksDb>,
     db: &Arc<RocksDb>,
@@ -2929,10 +3091,21 @@ fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    use reth_trie_common::{HashedPostState, updates::TrieUpdates};
+    use std::{
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    };
+
     use tempfile::TempDir;
 
     use super::*;
+
+    fn temp_storage() -> (Arc<RocksdbProofsStorage>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let storage = Arc::new(RocksdbProofsStorage::new(dir.path()).unwrap());
+        (storage, dir)
+    }
 
     #[test]
     fn max_total_wal_size_tracks_column_family_write_buffers() {
@@ -3040,9 +3213,12 @@ mod tests {
         storage.store_trie_updates(block(1, B256::ZERO), account_update(account, 1)).unwrap();
 
         assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
-        let mut cursor =
-            RocksdbVersionedCursor::<HashedAccountHistory>::new(storage.db.as_ref(), 1);
-        let (key, acc) = cursor.seek_exact(account).unwrap().expect("account exists");
+        let (key, acc) = storage
+            .account_hashed_cursor(1)
+            .unwrap()
+            .seek(account)
+            .unwrap()
+            .expect("account exists");
         assert_eq!(key, account);
         assert_eq!(acc.nonce, 1);
     }
@@ -3065,6 +3241,12 @@ mod tests {
             sorted_trie_updates: TrieUpdates::default().into_sorted(),
             sorted_post_state: post_state.into_sorted(),
         }
+    }
+
+    fn assert_completes(rx: mpsc::Receiver<BaseProofsStorageResult<()>>) {
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("operation should complete")
+            .expect("operation should succeed");
     }
 
     #[test]
@@ -3187,5 +3369,231 @@ mod tests {
         let mut encoded = encode_packed_nibbles(&Nibbles::from_nibbles_unchecked([1])).unwrap();
         encoded[0] |= 1;
         assert!(decode_packed_nibbles(&encoded).is_err());
+    }
+
+    #[test]
+    fn append_can_run_while_prune_holds_history_read_gate() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert_completes(rx);
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+    }
+
+    #[test]
+    fn exclusive_history_gate_blocks_append() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let history_guard = storage.history_gate.write();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_lock_serializes_append_writers() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let append_guard = storage.append_lock.lock();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage
+                .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
+                .map(|_| ());
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(append_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn prune_history_read_gate_blocks_history_rewrite() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let history_guard = storage.history_gate.read();
+        let (tx, rx) = mpsc::channel();
+        let task_storage = Arc::clone(&storage);
+
+        thread::spawn(move || {
+            let result = task_storage.replace_updates(BlockNumHash::new(0, B256::ZERO), vec![]);
+            tx.send(result).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(history_guard);
+        assert_completes(rx);
+    }
+
+    #[test]
+    fn append_during_prepared_prune_preserves_latest_block() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+        storage.store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default()).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), BlockStateDiff::default())
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared =
+            storage.prepare_prune(block(1, B256::ZERO)).unwrap().expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), BlockStateDiff::default())
+            .unwrap();
+        storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert!(latest_diff.sorted_trie_updates.account_nodes_ref().is_empty());
+        assert!(latest_diff.sorted_trie_updates.storage_tries_ref().is_empty());
+        assert!(latest_diff.sorted_post_state.accounts.is_empty());
+        assert!(latest_diff.sorted_post_state.storages.is_empty());
+    }
+
+    #[test]
+    fn append_inside_requested_prune_range_survives() {
+        let (storage, _dir) = temp_storage();
+        storage.set_earliest_block_number_hash(0, B256::ZERO).unwrap();
+
+        let address = B256::repeat_byte(0xAA);
+        storage.store_trie_updates(block(1, B256::ZERO), account_update(address, 1)).unwrap();
+        storage
+            .store_trie_updates(block(2, B256::repeat_byte(1)), account_update(address, 2))
+            .unwrap();
+
+        let _prune_guard = storage.prune_lock.lock();
+        let _history_guard = storage.history_gate.read();
+        let prepared = storage
+            .prepare_prune(block(10, B256::repeat_byte(2)))
+            .unwrap()
+            .expect("prepared prune");
+
+        storage
+            .store_trie_updates(block(3, B256::repeat_byte(2)), account_update(address, 3))
+            .unwrap();
+        let counts = storage.commit_prepared_prune(prepared).unwrap();
+
+        assert_eq!(counts.hashed_accounts_written_total, 1);
+        assert_eq!(counts.account_trie_updates_written_total, 0);
+        assert_eq!(counts.storage_trie_updates_written_total, 0);
+        assert_eq!(counts.hashed_storages_written_total, 0);
+        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((2, B256::repeat_byte(2))));
+        assert_eq!(storage.get_latest_block_number().unwrap(), Some((3, B256::repeat_byte(3))));
+
+        let latest_diff = storage.fetch_trie_updates(3).unwrap();
+        assert_eq!(
+            &latest_diff.sorted_post_state.accounts[..],
+            &[(address, Some(Account { nonce: 3, ..Default::default() }))]
+        );
+
+        let mut cursor = storage.account_hashed_cursor(3).unwrap();
+        assert_eq!(
+            cursor.seek(address).unwrap(),
+            Some((address, Account { nonce: 3, ..Default::default() }))
+        );
+    }
+
+    #[test]
+    fn storage_trie_cursor_finds_all_nibble_paths_after_flush() {
+        let (storage, _dir) = temp_storage();
+        let address = B256::repeat_byte(0xAA);
+
+        let nibble_paths = [
+            Nibbles::from_nibbles_unchecked(vec![0, 1]),
+            Nibbles::from_nibbles_unchecked(vec![1, 0]),
+            Nibbles::from_nibbles_unchecked(vec![2, 3, 4]),
+            Nibbles::from_nibbles_unchecked(vec![15, 0, 1]),
+        ];
+
+        let branch = BranchNodeCompact::new(
+            reth_trie_common::TrieMask::new(0b11),
+            reth_trie_common::TrieMask::default(),
+            reth_trie_common::TrieMask::default(),
+            vec![],
+            None,
+        );
+
+        let mut parent_hash = B256::ZERO;
+        for (i, path) in nibble_paths.iter().enumerate() {
+            let block_number = (i + 1) as u64;
+            let parent = block(block_number.saturating_sub(1), parent_hash);
+
+            let mut trie_updates = TrieUpdates::default();
+            let mut storage_updates = reth_trie_common::updates::StorageTrieUpdates::default();
+            storage_updates.storage_nodes.insert(*path, branch.clone());
+            trie_updates.storage_tries.insert(address, storage_updates);
+
+            let diff = BlockStateDiff {
+                sorted_trie_updates: trie_updates.into_sorted(),
+                sorted_post_state: HashedPostState::default().into_sorted(),
+            };
+
+            parent_hash = parent.block.hash;
+            storage.store_trie_updates(parent, diff).expect("store should succeed");
+
+            storage.flush_and_compact().expect("flush should succeed");
+        }
+
+        // seek_exact uses exact_prefix_read_options (with prefix_same_as_start)
+        // and should find each entry individually.
+        for path in &nibble_paths {
+            let mut cursor =
+                storage.storage_trie_cursor(address, u64::MAX).expect("cursor should open");
+            let result = cursor.seek_exact(*path).expect("seek_exact should succeed");
+            assert!(result.is_some(), "seek_exact should find entry for path {path:?}");
+        }
+
+        // seek/next use prefix_read_options with a 32-byte address prefix
+        // on a CF with a 65-byte prefix extractor. After flush, the bloom
+        // filter can cause the iterator to skip SST blocks whose 65-byte
+        // prefix doesn't match the one extracted from the seek key.
+        let mut cursor =
+            storage.storage_trie_cursor(address, u64::MAX).expect("cursor should open");
+
+        let first = cursor.seek(Nibbles::default()).expect("seek should succeed");
+        assert!(first.is_some(), "seek should find at least one entry");
+
+        let mut found = vec![first.unwrap().0];
+        while let Some((path, _)) = cursor.next().expect("next should succeed") {
+            found.push(path);
+        }
+
+        let expected: Vec<Nibbles> = nibble_paths.to_vec();
+        assert_eq!(
+            found, expected,
+            "cursor should find all nibble paths for the address after flush"
+        );
     }
 }

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -459,708 +459,783 @@ impl<C> InitTable for StoragesTrieInit<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use alloy_primitives::{Address, U256, keccak256};
-    use reth_db::{
-        Database, cursor::DbCursorRW, test_utils::create_test_rw_db, transaction::DbTxMut,
-    };
-    use reth_primitives_traits::Account;
-    use reth_trie::{
-        BranchNodeCompact, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey, TrieMask,
-        hashed_cursor::HashedCursor, trie_cursor::TrieCursor,
-    };
-    use tempfile::TempDir;
-
-    use super::*;
-    use crate::MdbxProofsStorage;
-
-    /// Helper function to create a key
-    fn k(b: u8) -> B256 {
-        let mut bytes = [0u8; 32];
-        bytes[0] = b;
-        B256::from(bytes)
-    }
-
-    /// Helper function to create a test branch node
-    fn create_test_branch_node() -> BranchNodeCompact {
-        let mut state_mask = TrieMask::default();
-        state_mask.set_bit(0);
-        state_mask.set_bit(1);
-
-        BranchNodeCompact {
-            state_mask,
-            tree_mask: TrieMask::default(),
-            hash_mask: TrieMask::default(),
-            hashes: Arc::new(vec![]),
-            root_hash: None,
-        }
-    }
-
-    #[test]
-    fn test_initialize_hashed_accounts() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test accounts into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-
-        let mut accounts = vec![
-            (
-                keccak256(Address::repeat_byte(0x01)),
-                Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
-            ),
-            (
-                keccak256(Address::repeat_byte(0x02)),
-                Account { nonce: 2, balance: U256::from(200), bytecode_hash: None },
-            ),
-            (
-                keccak256(Address::repeat_byte(0x03)),
-                Account { nonce: 3, balance: U256::from(300), bytecode_hash: None },
-            ),
-        ];
-
-        // Sort accounts by address for cursor.append (which requires sorted order)
-        accounts.sort_by_key(|(addr, _)| *addr);
-
-        for (addr, account) in &accounts {
-            cursor.append(*addr, account).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_hashed_accounts(None).unwrap();
-
-        // Verify data was stored (will be in sorted order)
-        let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
-        let mut count = 0;
-        while let Some((key, account)) = account_cursor.next().unwrap() {
-            // Find matching account in our test data
-            let expected = accounts.iter().find(|(addr, _)| *addr == key).unwrap();
-            assert_eq!((key, account), *expected);
-            count += 1;
-        }
-        assert_eq!(count, 3);
-    }
-
-    #[test]
-    fn test_initialize_hashed_storage() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test storage into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-
-        let addr1 = keccak256(Address::repeat_byte(0x01));
-        let addr2 = keccak256(Address::repeat_byte(0x02));
-
-        let storage_entries = vec![
-            (
-                addr1,
-                StorageEntry { key: keccak256(B256::repeat_byte(0x10)), value: U256::from(100) },
-            ),
-            (
-                addr1,
-                StorageEntry { key: keccak256(B256::repeat_byte(0x20)), value: U256::from(200) },
-            ),
-            (
-                addr2,
-                StorageEntry { key: keccak256(B256::repeat_byte(0x30)), value: U256::from(300) },
-            ),
-        ];
-
-        for (addr, entry) in &storage_entries {
-            cursor.upsert(*addr, entry).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_hashed_storages(None).unwrap();
-
-        // Verify data was stored for addr1
-        let mut storage_cursor = storage.storage_hashed_cursor(addr1, 100).unwrap();
-        let mut found = vec![];
-        while let Some((key, value)) = storage_cursor.next().unwrap() {
-            found.push((key, value));
-        }
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0], (storage_entries[0].1.key, storage_entries[0].1.value));
-        assert_eq!(found[1], (storage_entries[1].1.key, storage_entries[1].1.value));
-
-        // Verify data was stored for addr2
-        let mut storage_cursor = storage.storage_hashed_cursor(addr2, 100).unwrap();
-        let mut found = vec![];
-        while let Some((key, value)) = storage_cursor.next().unwrap() {
-            found.push((key, value));
-        }
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0], (storage_entries[2].1.key, storage_entries[2].1.value));
-    }
-
-    #[test]
-    fn test_initialize_accounts_trie() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test trie nodes into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-
-        let branch = create_test_branch_node();
-        let nodes = vec![
-            (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])), branch.clone()),
-            (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2])), branch.clone()),
-            (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3])), branch),
-        ];
-
-        for (path, node) in &nodes {
-            cursor.append(path.clone(), node).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_accounts_trie(None).unwrap();
-
-        // Verify data was stored
-        let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
-        let mut count = 0;
-        while let Some((path, _node)) = trie_cursor.next().unwrap() {
-            assert_eq!(path, nodes[count].0.0);
-            count += 1;
-        }
-        assert_eq!(count, 3);
-    }
-
-    #[test]
-    fn test_initialize_storages_trie() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert test storage trie nodes into database
-        let tx = db.tx_mut().unwrap();
-        let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-
-        let branch = create_test_branch_node();
-        let addr1 = keccak256(Address::repeat_byte(0x01));
-        let addr2 = keccak256(Address::repeat_byte(0x02));
-
-        let nodes = vec![
-            (
-                addr1,
-                StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1])),
-                    node: branch.clone(),
-                },
-            ),
-            (
-                addr1,
-                StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![2])),
-                    node: branch.clone(),
-                },
-            ),
-            (
-                addr2,
-                StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![3])),
-                    node: branch,
-                },
-            ),
-        ];
-
-        for (addr, entry) in &nodes {
-            cursor.upsert(*addr, entry).unwrap();
-        }
-        drop(cursor);
-        tx.commit().unwrap();
-
-        // Run initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        job.initialize_storages_trie(None).unwrap();
-
-        // Verify data was stored for addr1
-        let mut trie_cursor = storage.storage_trie_cursor(addr1, 100).unwrap();
-        let mut found = vec![];
-        while let Some((path, _node)) = trie_cursor.next().unwrap() {
-            found.push(path);
-        }
-        assert_eq!(found.len(), 2);
-        assert_eq!(found[0], nodes[0].1.nibbles.0);
-        assert_eq!(found[1], nodes[1].1.nibbles.0);
-
-        // Verify data was stored for addr2
-        let mut trie_cursor = storage.storage_trie_cursor(addr2, 100).unwrap();
-        let mut found = vec![];
-        while let Some((path, _node)) = trie_cursor.next().unwrap() {
-            found.push(path);
-        }
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0], nodes[2].1.nibbles.0);
-    }
-
-    #[test]
-    fn test_full_initialize_run() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // Insert some test data
-        let tx = db.tx_mut().unwrap();
-
-        // Add accounts
-        let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-        let addr = keccak256(Address::repeat_byte(0x01));
-        cursor
-            .append(addr, &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None })
-            .unwrap();
-        drop(cursor);
-
-        // Add storage
-        let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-        cursor
-            .upsert(
-                addr,
-                &StorageEntry { key: keccak256(B256::repeat_byte(0x10)), value: U256::from(100) },
-            )
-            .unwrap();
-        drop(cursor);
-
-        // Add account trie
-        let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-        cursor
-            .append(
-                StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])),
-                &create_test_branch_node(),
-            )
-            .unwrap();
-        drop(cursor);
-
-        // Add storage trie
-        let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-        cursor
-            .upsert(
-                addr,
-                &StorageTrieEntry {
-                    nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1])),
-                    node: create_test_branch_node(),
-                },
-            )
-            .unwrap();
-        drop(cursor);
-
-        tx.commit().unwrap();
-
-        // Run full initialization
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-        let best_number = 100;
-        let best_hash = B256::repeat_byte(0x42);
-
-        // Should be None initially
-        assert_eq!(storage.initial_state_anchor().unwrap().block, None);
-        assert_eq!(storage.get_earliest_block_number().unwrap(), None);
-
-        job.run(best_number, best_hash).unwrap();
-
-        // Should be set after initialization
-        assert_eq!(storage.get_earliest_block_number().unwrap(), Some((best_number, best_hash)));
-
-        // Verify data was initialized
-        let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
-        assert!(account_cursor.next().unwrap().is_some());
-
-        let mut storage_cursor = storage.storage_hashed_cursor(addr, 100).unwrap();
-        assert!(storage_cursor.next().unwrap().is_some());
-
-        let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
-        assert!(trie_cursor.next().unwrap().is_some());
-
-        let mut storage_trie_cursor = storage.storage_trie_cursor(addr, 100).unwrap();
-        assert!(storage_trie_cursor.next().unwrap().is_some());
-    }
-
-    #[test]
-    fn test_initialize_run_skips_if_already_done() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let storage = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        // set and commit initial state anchor
-        storage
-            .set_initial_state_anchor(BlockNumHash::new(50, B256::repeat_byte(0x01)))
-            .expect("set anchor");
-        storage.commit_initial_state().expect("commit anchor");
-
-        let tx = db.tx().unwrap();
-        let job = InitializationJob::new(Arc::clone(&storage), tx);
-
-        // Run initialization - should skip
-        job.run(100, B256::repeat_byte(0x42)).unwrap();
-
-        // Should still have the old anchor
-        let anchor_block =
-            storage.initial_state_anchor().expect("get anchor").block.expect("block");
-        assert_eq!(
-            Some((anchor_block.number, anchor_block.hash)),
-            Some((50, B256::repeat_byte(0x01)))
-        );
-
-        // Should still have the old earliest block
-        assert_eq!(
-            storage.get_earliest_block_number().unwrap(),
-            Some((50, B256::repeat_byte(0x01)))
-        );
-    }
-
-    #[test]
-    fn test_initialize_resumes_hashed_accounts_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        // Phase 1 in source: k1, k2
-        let k1 = k(1);
-        let k2 = k(2);
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-            cur.append(k1, &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None })
-                .unwrap();
-            cur.append(k2, &Account { nonce: 2, balance: U256::from(200), bytecode_hash: None })
-                .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_accounts(None).unwrap();
-        }
-
-        // Resume point must be k2 (max)
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
-            Some(k2)
-        );
-
-        // Phase 2 in source: k3, k4
-        let k3 = k(3);
-        let k4 = k(4);
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
-            cur.append(k3, &Account { nonce: 3, balance: U256::from(300), bytecode_hash: None })
-                .unwrap();
-            cur.append(k4, &Account { nonce: 4, balance: U256::from(400), bytecode_hash: None })
-                .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2 (restart)
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_accounts(Some(k2)).unwrap();
-        }
-
-        // Now resume point must be k4
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
-            Some(k4)
-        );
-
-        // Verify order + no dupes by iterating proofs cursor
-        let mut cur = store.account_hashed_cursor(0).unwrap();
-        let mut got = Vec::new();
-        while let Some((key, acct)) = cur.next().unwrap() {
-            got.push((key, acct));
-        }
-
-        // Expect exactly 4, in increasing key order.
-        assert_eq!(got.len(), 4);
-        assert_eq!(got[0].0, k1);
-        assert_eq!(got[1].0, k2);
-        assert_eq!(got[2].0, k3);
-        assert_eq!(got[3].0, k4);
-
-        // No dupes
-        for w in got.windows(2) {
-            assert!(w[0].0 < w[1].0);
-        }
-    }
-
-    #[test]
-    fn test_initialize_resumes_hashed_storages_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        let a1 = k(0x10);
-        let a2 = k(0x20);
-
-        let s11 = k(0x01);
-        let s12 = k(0x02);
-        let s21 = k(0x03);
-        let s22 = k(0x04);
-
-        // Phase 1 source:
-        // a1: s11,s12
-        // a2: s21
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-            cur.upsert(a1, &StorageEntry { key: s11, value: U256::from(11) }).unwrap();
-            cur.upsert(a1, &StorageEntry { key: s12, value: U256::from(12) }).unwrap();
-            cur.upsert(a2, &StorageEntry { key: s21, value: U256::from(21) }).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_storages(None).unwrap();
-        }
-
-        // Latest key must be (a2, s21) because a2 > a1
-        let last1 = store
-            .initial_state_anchor()
-            .expect("get anchor")
-            .latest_hashed_storage_key
-            .expect("ok");
-        assert_eq!(last1.hashed_address, a2);
-        assert_eq!(last1.hashed_storage_key, s21);
-
-        // Phase 2 source: add s22 to a2
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
-            cur.upsert(a2, &StorageEntry { key: s22, value: U256::from(22) }).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_hashed_storages(Some(HashedStorageKey::new(a2, s21))).unwrap();
-        }
-
-        // Latest key now must be (a2, s22)
-        let last2 = store
-            .initial_state_anchor()
-            .expect("get anchor")
-            .latest_hashed_storage_key
-            .expect("ok");
-        assert_eq!(last2.hashed_address, a2);
-        assert_eq!(last2.hashed_storage_key, s22);
-
-        // Verify no dupes by iterating per-address
-        {
-            let mut c = store.storage_hashed_cursor(a1, 0).unwrap();
-            let mut got = Vec::new();
-            while let Some((slot, val)) = c.next().unwrap() {
-                got.push((slot, val));
+    macro_rules! proof_storage_init_tests {
+        ($mod_name:ident, $storage:ident) => {
+            mod $mod_name {
+                use std::sync::Arc;
+
+                use alloy_primitives::{Address, U256, keccak256};
+                use reth_db::{
+                    Database, cursor::DbCursorRW, test_utils::create_test_rw_db,
+                    transaction::DbTxMut,
+                };
+                use reth_primitives_traits::Account;
+                use reth_trie::{
+                    BranchNodeCompact, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
+                    TrieMask, hashed_cursor::HashedCursor, trie_cursor::TrieCursor,
+                };
+                use tempfile::TempDir;
+
+                use super::super::*;
+                use crate::$storage;
+
+                /// Helper function to create a key
+                fn k(b: u8) -> B256 {
+                    let mut bytes = [0u8; 32];
+                    bytes[0] = b;
+                    B256::from(bytes)
+                }
+
+                /// Helper function to create a test branch node
+                fn create_test_branch_node() -> BranchNodeCompact {
+                    let mut state_mask = TrieMask::default();
+                    state_mask.set_bit(0);
+                    state_mask.set_bit(1);
+
+                    BranchNodeCompact {
+                        state_mask,
+                        tree_mask: TrieMask::default(),
+                        hash_mask: TrieMask::default(),
+                        hashes: Arc::new(vec![]),
+                        root_hash: None,
+                    }
+                }
+
+                #[test]
+                fn test_initialize_hashed_accounts() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test accounts into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+
+                    let mut accounts = vec![
+                        (
+                            keccak256(Address::repeat_byte(0x01)),
+                            Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
+                        ),
+                        (
+                            keccak256(Address::repeat_byte(0x02)),
+                            Account { nonce: 2, balance: U256::from(200), bytecode_hash: None },
+                        ),
+                        (
+                            keccak256(Address::repeat_byte(0x03)),
+                            Account { nonce: 3, balance: U256::from(300), bytecode_hash: None },
+                        ),
+                    ];
+
+                    // Sort accounts by address for cursor.append (which requires sorted order)
+                    accounts.sort_by_key(|(addr, _)| *addr);
+
+                    for (addr, account) in &accounts {
+                        cursor.append(*addr, account).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_hashed_accounts(None).unwrap();
+
+                    // Verify data was stored (will be in sorted order)
+                    let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
+                    let mut count = 0;
+                    while let Some((key, account)) = account_cursor.next().unwrap() {
+                        // Find matching account in our test data
+                        let expected = accounts.iter().find(|(addr, _)| *addr == key).unwrap();
+                        assert_eq!((key, account), *expected);
+                        count += 1;
+                    }
+                    assert_eq!(count, 3);
+                }
+
+                #[test]
+                fn test_initialize_hashed_storage() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test storage into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+
+                    let addr1 = keccak256(Address::repeat_byte(0x01));
+                    let addr2 = keccak256(Address::repeat_byte(0x02));
+
+                    let storage_entries = vec![
+                        (
+                            addr1,
+                            StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x10)),
+                                value: U256::from(100),
+                            },
+                        ),
+                        (
+                            addr1,
+                            StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x20)),
+                                value: U256::from(200),
+                            },
+                        ),
+                        (
+                            addr2,
+                            StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x30)),
+                                value: U256::from(300),
+                            },
+                        ),
+                    ];
+
+                    for (addr, entry) in &storage_entries {
+                        cursor.upsert(*addr, entry).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_hashed_storages(None).unwrap();
+
+                    // Verify data was stored for addr1
+                    let mut storage_cursor = storage.storage_hashed_cursor(addr1, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((key, value)) = storage_cursor.next().unwrap() {
+                        found.push((key, value));
+                    }
+                    assert_eq!(found.len(), 2);
+                    assert_eq!(found[0], (storage_entries[0].1.key, storage_entries[0].1.value));
+                    assert_eq!(found[1], (storage_entries[1].1.key, storage_entries[1].1.value));
+
+                    // Verify data was stored for addr2
+                    let mut storage_cursor = storage.storage_hashed_cursor(addr2, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((key, value)) = storage_cursor.next().unwrap() {
+                        found.push((key, value));
+                    }
+                    assert_eq!(found.len(), 1);
+                    assert_eq!(found[0], (storage_entries[2].1.key, storage_entries[2].1.value));
+                }
+
+                #[test]
+                fn test_initialize_accounts_trie() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test trie nodes into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+
+                    let branch = create_test_branch_node();
+                    let nodes = vec![
+                        (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])), branch.clone()),
+                        (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2])), branch.clone()),
+                        (StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3])), branch),
+                    ];
+
+                    for (path, node) in &nodes {
+                        cursor.append(path.clone(), node).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_accounts_trie(None).unwrap();
+
+                    // Verify data was stored
+                    let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
+                    let mut count = 0;
+                    while let Some((path, _node)) = trie_cursor.next().unwrap() {
+                        assert_eq!(path, nodes[count].0.0);
+                        count += 1;
+                    }
+                    assert_eq!(count, 3);
+                }
+
+                #[test]
+                fn test_initialize_storages_trie() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert test storage trie nodes into database
+                    let tx = db.tx_mut().unwrap();
+                    let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+
+                    let branch = create_test_branch_node();
+                    let addr1 = keccak256(Address::repeat_byte(0x01));
+                    let addr2 = keccak256(Address::repeat_byte(0x02));
+
+                    let nodes = vec![
+                        (
+                            addr1,
+                            StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![1],
+                                )),
+                                node: branch.clone(),
+                            },
+                        ),
+                        (
+                            addr1,
+                            StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![2],
+                                )),
+                                node: branch.clone(),
+                            },
+                        ),
+                        (
+                            addr2,
+                            StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![3],
+                                )),
+                                node: branch,
+                            },
+                        ),
+                    ];
+
+                    for (addr, entry) in &nodes {
+                        cursor.upsert(*addr, entry).unwrap();
+                    }
+                    drop(cursor);
+                    tx.commit().unwrap();
+
+                    // Run initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    job.initialize_storages_trie(None).unwrap();
+
+                    // Verify data was stored for addr1
+                    let mut trie_cursor = storage.storage_trie_cursor(addr1, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((path, _node)) = trie_cursor.next().unwrap() {
+                        found.push(path);
+                    }
+                    assert_eq!(found.len(), 2);
+                    assert_eq!(found[0], nodes[0].1.nibbles.0);
+                    assert_eq!(found[1], nodes[1].1.nibbles.0);
+
+                    // Verify data was stored for addr2
+                    let mut trie_cursor = storage.storage_trie_cursor(addr2, 100).unwrap();
+                    let mut found = vec![];
+                    while let Some((path, _node)) = trie_cursor.next().unwrap() {
+                        found.push(path);
+                    }
+                    assert_eq!(found.len(), 1);
+                    assert_eq!(found[0], nodes[2].1.nibbles.0);
+                }
+
+                #[test]
+                fn test_full_initialize_run() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // Insert some test data
+                    let tx = db.tx_mut().unwrap();
+
+                    // Add accounts
+                    let mut cursor = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+                    let addr = keccak256(Address::repeat_byte(0x01));
+                    cursor
+                        .append(
+                            addr,
+                            &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    // Add storage
+                    let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+                    cursor
+                        .upsert(
+                            addr,
+                            &StorageEntry {
+                                key: keccak256(B256::repeat_byte(0x10)),
+                                value: U256::from(100),
+                            },
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    // Add account trie
+                    let mut cursor = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+                    cursor
+                        .append(
+                            StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1])),
+                            &create_test_branch_node(),
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    // Add storage trie
+                    let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+                    cursor
+                        .upsert(
+                            addr,
+                            &StorageTrieEntry {
+                                nibbles: StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(
+                                    vec![1],
+                                )),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                    drop(cursor);
+
+                    tx.commit().unwrap();
+
+                    // Run full initialization
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let best_number = 100;
+                    let best_hash = B256::repeat_byte(0x42);
+
+                    // Should be None initially
+                    assert_eq!(storage.initial_state_anchor().unwrap().block, None);
+                    assert_eq!(storage.get_earliest_block_number().unwrap(), None);
+
+                    job.run(best_number, best_hash).unwrap();
+
+                    // Should be set after initialization
+                    assert_eq!(
+                        storage.get_earliest_block_number().unwrap(),
+                        Some((best_number, best_hash))
+                    );
+
+                    // Verify data was initialized
+                    let mut account_cursor = storage.account_hashed_cursor(100).unwrap();
+                    assert!(account_cursor.next().unwrap().is_some());
+
+                    let mut storage_cursor = storage.storage_hashed_cursor(addr, 100).unwrap();
+                    assert!(storage_cursor.next().unwrap().is_some());
+
+                    let mut trie_cursor = storage.account_trie_cursor(100).unwrap();
+                    assert!(trie_cursor.next().unwrap().is_some());
+
+                    let mut storage_trie_cursor = storage.storage_trie_cursor(addr, 100).unwrap();
+                    assert!(storage_trie_cursor.next().unwrap().is_some());
+                }
+
+                #[test]
+                fn test_initialize_run_skips_if_already_done() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    // set and commit initial state anchor
+                    storage
+                        .set_initial_state_anchor(BlockNumHash::new(50, B256::repeat_byte(0x01)))
+                        .expect("set anchor");
+                    storage.commit_initial_state().expect("commit anchor");
+
+                    let tx = db.tx().unwrap();
+                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+
+                    // Run initialization - should skip
+                    job.run(100, B256::repeat_byte(0x42)).unwrap();
+
+                    // Should still have the old anchor
+                    let anchor_block =
+                        storage.initial_state_anchor().expect("get anchor").block.expect("block");
+                    assert_eq!(
+                        Some((anchor_block.number, anchor_block.hash)),
+                        Some((50, B256::repeat_byte(0x01)))
+                    );
+
+                    // Should still have the old earliest block
+                    assert_eq!(
+                        storage.get_earliest_block_number().unwrap(),
+                        Some((50, B256::repeat_byte(0x01)))
+                    );
+                }
+
+                #[test]
+                fn test_initialize_resumes_hashed_accounts_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    // Phase 1 in source: k1, k2
+                    let k1 = k(1);
+                    let k2 = k(2);
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+                        cur.append(
+                            k1,
+                            &Account { nonce: 1, balance: U256::from(100), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        cur.append(
+                            k2,
+                            &Account { nonce: 2, balance: U256::from(200), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_accounts(None).unwrap();
+                    }
+
+                    // Resume point must be k2 (max)
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
+                        Some(k2)
+                    );
+
+                    // Phase 2 in source: k3, k4
+                    let k3 = k(3);
+                    let k4 = k(4);
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::HashedAccounts>().unwrap();
+                        cur.append(
+                            k3,
+                            &Account { nonce: 3, balance: U256::from(300), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        cur.append(
+                            k4,
+                            &Account { nonce: 4, balance: U256::from(400), bytecode_hash: None },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2 (restart)
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_accounts(Some(k2)).unwrap();
+                    }
+
+                    // Now resume point must be k4
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_hashed_account_key,
+                        Some(k4)
+                    );
+
+                    // Verify order + no dupes by iterating proofs cursor
+                    let mut cur = store.account_hashed_cursor(0).unwrap();
+                    let mut got = Vec::new();
+                    while let Some((key, acct)) = cur.next().unwrap() {
+                        got.push((key, acct));
+                    }
+
+                    // Expect exactly 4, in increasing key order.
+                    assert_eq!(got.len(), 4);
+                    assert_eq!(got[0].0, k1);
+                    assert_eq!(got[1].0, k2);
+                    assert_eq!(got[2].0, k3);
+                    assert_eq!(got[3].0, k4);
+
+                    // No dupes
+                    for w in got.windows(2) {
+                        assert!(w[0].0 < w[1].0);
+                    }
+                }
+
+                #[test]
+                fn test_initialize_resumes_hashed_storages_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    let a1 = k(0x10);
+                    let a2 = k(0x20);
+
+                    let s11 = k(0x01);
+                    let s12 = k(0x02);
+                    let s21 = k(0x03);
+                    let s22 = k(0x04);
+
+                    // Phase 1 source:
+                    // a1: s11,s12
+                    // a2: s21
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+                        cur.upsert(a1, &StorageEntry { key: s11, value: U256::from(11) }).unwrap();
+                        cur.upsert(a1, &StorageEntry { key: s12, value: U256::from(12) }).unwrap();
+                        cur.upsert(a2, &StorageEntry { key: s21, value: U256::from(21) }).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_storages(None).unwrap();
+                    }
+
+                    // Latest key must be (a2, s21) because a2 > a1
+                    let last1 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_hashed_storage_key
+                        .expect("ok");
+                    assert_eq!(last1.hashed_address, a2);
+                    assert_eq!(last1.hashed_storage_key, s21);
+
+                    // Phase 2 source: add s22 to a2
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
+                        cur.upsert(a2, &StorageEntry { key: s22, value: U256::from(22) }).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_hashed_storages(Some(HashedStorageKey::new(a2, s21)))
+                            .unwrap();
+                    }
+
+                    // Latest key now must be (a2, s22)
+                    let last2 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_hashed_storage_key
+                        .expect("ok");
+                    assert_eq!(last2.hashed_address, a2);
+                    assert_eq!(last2.hashed_storage_key, s22);
+
+                    // Verify no dupes by iterating per-address
+                    {
+                        let mut c = store.storage_hashed_cursor(a1, 0).unwrap();
+                        let mut got = Vec::new();
+                        while let Some((slot, val)) = c.next().unwrap() {
+                            got.push((slot, val));
+                        }
+                        assert_eq!(got.len(), 2);
+                        assert_eq!(got[0].0, s11);
+                        assert_eq!(got[1].0, s12);
+                    }
+                    {
+                        let mut c = store.storage_hashed_cursor(a2, 0).unwrap();
+                        let mut got = Vec::new();
+                        while let Some((slot, val)) = c.next().unwrap() {
+                            got.push((slot, val));
+                        }
+                        assert_eq!(got.len(), 2);
+                        assert_eq!(got[0].0, s21);
+                        assert_eq!(got[1].0, s22);
+                    }
+                }
+
+                #[test]
+                fn test_initialize_resumes_accounts_trie_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    let p1 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1]));
+                    let p2 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2]));
+                    let p3 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3]));
+                    let p4 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![4]));
+
+                    // Phase 1 source: p1,p2
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+                        cur.append(p1.clone(), &create_test_branch_node()).unwrap();
+                        cur.append(p2.clone(), &create_test_branch_node()).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_accounts_trie(None).unwrap();
+                    }
+
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
+                        Some(p2.clone())
+                    );
+
+                    // Phase 2 source: p3,p4
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
+                        cur.append(p3.clone(), &create_test_branch_node()).unwrap();
+                        cur.append(p4.clone(), &create_test_branch_node()).unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_accounts_trie(Some(p2.clone())).unwrap();
+                    }
+
+                    assert_eq!(
+                        store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
+                        Some(p4.clone())
+                    );
+
+                    // Verify 4 ordered, no dupes
+                    let mut c = store.account_trie_cursor(0).unwrap();
+                    let mut got = Vec::new();
+                    while let Some((path, _node)) = c.next().unwrap() {
+                        got.push(path);
+                    }
+                    assert_eq!(got.len(), 4);
+                    assert_eq!(got[0], p1.0);
+                    assert_eq!(got[1], p2.0);
+                    assert_eq!(got[2], p3.0);
+                    assert_eq!(got[3], p4.0);
+                }
+
+                #[test]
+                fn test_initialize_resumes_storages_trie_with_no_dups() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let store = Arc::new($storage::new(dir.path()).expect("env"));
+
+                    store
+                        .set_initial_state_anchor(BlockNumHash::new(0, B256::default()))
+                        .expect("set anchor");
+
+                    let a1 = k(0x10);
+                    let a2 = k(0x20);
+
+                    let n1 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1]));
+                    let n2 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![2]));
+                    let n3 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![3]));
+
+                    // Phase 1 source: (a1,n1), (a2,n2)
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+                        cur.upsert(
+                            a1,
+                            &StorageTrieEntry {
+                                nibbles: n1.clone(),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                        cur.upsert(
+                            a2,
+                            &StorageTrieEntry {
+                                nibbles: n2.clone(),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #1
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_storages_trie(None).unwrap();
+                    }
+
+                    // Latest must be (a2, n2) because a2 > a1
+                    let last1 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_storage_trie_key
+                        .expect("ok");
+                    assert_eq!(last1.hashed_address, a2);
+                    assert_eq!(last1.path.0, n2.0);
+
+                    // Phase 2 source: add (a2,n3)
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
+                        cur.upsert(
+                            a2,
+                            &StorageTrieEntry {
+                                nibbles: n3.clone(),
+                                node: create_test_branch_node(),
+                            },
+                        )
+                        .unwrap();
+                        tx.commit().unwrap();
+                    }
+
+                    // Initialization #2
+                    {
+                        let tx = db.tx().unwrap();
+                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        job.initialize_storages_trie(Some(StorageTrieKey::new(
+                            a2,
+                            StoredNibbles::from(n2.0),
+                        )))
+                        .unwrap();
+                    }
+
+                    // Latest must now be (a2,n3)
+                    let last2 = store
+                        .initial_state_anchor()
+                        .expect("get anchor")
+                        .latest_storage_trie_key
+                        .expect("ok");
+                    assert_eq!(last2.hashed_address, a2);
+                    assert_eq!(last2.path.0, n3.0);
+
+                    // Verify per-address no dupes and stable ordering
+                    {
+                        let mut c = store.storage_trie_cursor(a1, 0).unwrap();
+
+                        let mut got = Vec::new();
+
+                        // next returns the rest
+                        while let Some((path, _node)) = c.next().unwrap() {
+                            got.push(path);
+                        }
+
+                        assert_eq!(got, vec![n1.0]);
+                    }
+                    {
+                        let mut c = store.storage_trie_cursor(a2, 0).unwrap();
+
+                        let mut got = Vec::new();
+
+                        // next returns the rest
+                        while let Some((path, _node)) = c.next().unwrap() {
+                            got.push(path);
+                        }
+                        assert_eq!(got, vec![n2.0, n3.0]);
+                    }
+                }
             }
-            assert_eq!(got.len(), 2);
-            assert_eq!(got[0].0, s11);
-            assert_eq!(got[1].0, s12);
-        }
-        {
-            let mut c = store.storage_hashed_cursor(a2, 0).unwrap();
-            let mut got = Vec::new();
-            while let Some((slot, val)) = c.next().unwrap() {
-                got.push((slot, val));
-            }
-            assert_eq!(got.len(), 2);
-            assert_eq!(got[0].0, s21);
-            assert_eq!(got[1].0, s22);
-        }
+        };
     }
 
-    #[test]
-    fn test_initialize_resumes_accounts_trie_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        let p1 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![1]));
-        let p2 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![2]));
-        let p3 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![3]));
-        let p4 = StoredNibbles(Nibbles::from_nibbles_unchecked(vec![4]));
-
-        // Phase 1 source: p1,p2
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-            cur.append(p1.clone(), &create_test_branch_node()).unwrap();
-            cur.append(p2.clone(), &create_test_branch_node()).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_accounts_trie(None).unwrap();
-        }
-
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
-            Some(p2.clone())
-        );
-
-        // Phase 2 source: p3,p4
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_write::<tables::AccountsTrie>().unwrap();
-            cur.append(p3.clone(), &create_test_branch_node()).unwrap();
-            cur.append(p4.clone(), &create_test_branch_node()).unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_accounts_trie(Some(p2.clone())).unwrap();
-        }
-
-        assert_eq!(
-            store.initial_state_anchor().expect("get anchor").latest_account_trie_key,
-            Some(p4.clone())
-        );
-
-        // Verify 4 ordered, no dupes
-        let mut c = store.account_trie_cursor(0).unwrap();
-        let mut got = Vec::new();
-        while let Some((path, _node)) = c.next().unwrap() {
-            got.push(path);
-        }
-        assert_eq!(got.len(), 4);
-        assert_eq!(got[0], p1.0);
-        assert_eq!(got[1], p2.0);
-        assert_eq!(got[2], p3.0);
-        assert_eq!(got[3], p4.0);
-    }
-
-    #[test]
-    fn test_initialize_resumes_storages_trie_with_no_dups() {
-        let db = create_test_rw_db();
-        let dir = TempDir::new().unwrap();
-        let store = Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
-
-        store.set_initial_state_anchor(BlockNumHash::new(0, B256::default())).expect("set anchor");
-
-        let a1 = k(0x10);
-        let a2 = k(0x20);
-
-        let n1 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![1]));
-        let n2 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![2]));
-        let n3 = StoredNibblesSubKey(Nibbles::from_nibbles_unchecked(vec![3]));
-
-        // Phase 1 source: (a1,n1), (a2,n2)
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-            cur.upsert(
-                a1,
-                &StorageTrieEntry { nibbles: n1.clone(), node: create_test_branch_node() },
-            )
-            .unwrap();
-            cur.upsert(
-                a2,
-                &StorageTrieEntry { nibbles: n2.clone(), node: create_test_branch_node() },
-            )
-            .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #1
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_storages_trie(None).unwrap();
-        }
-
-        // Latest must be (a2, n2) because a2 > a1
-        let last1 =
-            store.initial_state_anchor().expect("get anchor").latest_storage_trie_key.expect("ok");
-        assert_eq!(last1.hashed_address, a2);
-        assert_eq!(last1.path.0, n2.0);
-
-        // Phase 2 source: add (a2,n3)
-        {
-            let tx = db.tx_mut().unwrap();
-            let mut cur = tx.cursor_dup_write::<tables::StoragesTrie>().unwrap();
-            cur.upsert(
-                a2,
-                &StorageTrieEntry { nibbles: n3.clone(), node: create_test_branch_node() },
-            )
-            .unwrap();
-            tx.commit().unwrap();
-        }
-
-        // Initialization #2
-        {
-            let tx = db.tx().unwrap();
-            let job = InitializationJob::new(Arc::clone(&store), tx);
-            job.initialize_storages_trie(Some(StorageTrieKey::new(a2, StoredNibbles::from(n2.0))))
-                .unwrap();
-        }
-
-        // Latest must now be (a2,n3)
-        let last2 =
-            store.initial_state_anchor().expect("get anchor").latest_storage_trie_key.expect("ok");
-        assert_eq!(last2.hashed_address, a2);
-        assert_eq!(last2.path.0, n3.0);
-
-        // Verify per-address no dupes and stable ordering
-        {
-            let mut c = store.storage_trie_cursor(a1, 0).unwrap();
-
-            let mut got = Vec::new();
-
-            // next returns the rest
-            while let Some((path, _node)) = c.next().unwrap() {
-                got.push(path);
-            }
-
-            assert_eq!(got, vec![n1.0]);
-        }
-        {
-            let mut c = store.storage_trie_cursor(a2, 0).unwrap();
-
-            let mut got = Vec::new();
-
-            // next returns the rest
-            while let Some((path, _node)) = c.next().unwrap() {
-                got.push(path);
-            }
-            assert_eq!(got, vec![n2.0, n3.0]);
-        }
-    }
+    proof_storage_init_tests!(mdbx_tests, MdbxProofsStorage);
+    proof_storage_init_tests!(rocksdb_tests, RocksdbProofsStorage);
 }

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -208,23 +208,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use alloy_eips::{BlockHashOrNumber, NumHash};
-    use alloy_primitives::{B256, BlockNumber, U256, keccak256};
+    use alloy_primitives::{B256, BlockNumber, keccak256};
     use mockall::mock;
-    use reth_primitives_traits::Account;
     use reth_storage_errors::provider::ProviderResult;
-    use reth_trie::{
-        BranchNodeCompact, HashedPostState, HashedStorage, Nibbles,
-        hashed_cursor::HashedCursor,
-        trie_cursor::TrieCursor,
-        updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
-    };
-    use tempfile::TempDir;
 
     use super::*;
-    use crate::{BlockStateDiff, db::MdbxProofsStorage};
 
     mock! (
         #[derive(Debug)]
@@ -255,356 +244,408 @@ mod tests {
         BlockWithParent::new(parent, NumHash::new(n, b256(n)))
     }
 
-    #[tokio::test]
-    async fn run_inner_and_and_verify_updated_state() {
-        // --- env/store ---
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+    macro_rules! proof_storage_pruner_tests {
+        ($mod_name:ident, $storage:ident) => {
+            mod $mod_name {
+                use std::sync::Arc;
 
-        store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
+                use alloy_primitives::{B256, U256};
+                use reth_primitives_traits::Account;
+                use reth_trie::{
+                    BranchNodeCompact, HashedPostState, HashedStorage, Nibbles,
+                    hashed_cursor::HashedCursor,
+                    trie_cursor::TrieCursor,
+                    updates::{StorageTrieUpdates, TrieUpdates, TrieUpdatesSorted},
+                };
+                use tempfile::TempDir;
 
-        // --- entities ---
-        // accounts
-        let a1 = B256::from([0xA1; 32]);
-        let a2 = B256::from([0xA2; 32]);
-        let a3 = B256::from([0xA3; 32]); // introduced later
+                use super::{super::*, MockBlockHashReader, b256, block};
+                use crate::{BlockStateDiff, $storage};
 
-        // one storage address with 3 slots
-        let stor_addr = B256::from([0x10; 32]);
-        let s1 = B256::from([0xB1; 32]);
-        let s2 = B256::from([0xB2; 32]);
-        let s3 = B256::from([0xB3; 32]);
+                #[tokio::test]
+                async fn run_inner_and_and_verify_updated_state() {
+                    // --- env/store ---
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
 
-        // account-trie paths (p1 gets removed by block 3; p2 remains; p3 added later)
-        let p1 = Nibbles::from_nibbles_unchecked([0x01, 0x02]);
-        let p2 = Nibbles::from_nibbles_unchecked([0x03, 0x04]);
-        let p3 = Nibbles::from_nibbles_unchecked([0x05, 0x06]);
+                    store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
-        let node_p1 = BranchNodeCompact::new(0b1, 0, 0, vec![], Some(B256::from([0x11; 32])));
-        let node_p2 = BranchNodeCompact::new(0b10, 0, 0, vec![], Some(B256::from([0x22; 32])));
-        let node_p3 = BranchNodeCompact::new(0b11, 0, 0, vec![], Some(B256::from([0x33; 32])));
+                    // --- entities ---
+                    // accounts
+                    let a1 = B256::from([0xA1; 32]);
+                    let a2 = B256::from([0xA2; 32]);
+                    let a3 = B256::from([0xA3; 32]); // introduced later
 
-        // storage-trie paths (st1 removed by block 3; st2 remains; st3 added later)
-        let st1 = Nibbles::from_nibbles_unchecked([0x0A]);
-        let st2 = Nibbles::from_nibbles_unchecked([0x0B]);
-        let st3 = Nibbles::from_nibbles_unchecked([0x0C]);
+                    // one storage address with 3 slots
+                    let stor_addr = B256::from([0x10; 32]);
+                    let s1 = B256::from([0xB1; 32]);
+                    let s2 = B256::from([0xB2; 32]);
+                    let s3 = B256::from([0xB3; 32]);
 
-        let node_st2 = BranchNodeCompact::new(0b101, 0, 0, vec![], Some(B256::from([0x44; 32])));
-        let node_st3 = BranchNodeCompact::new(0b110, 0, 0, vec![], Some(B256::from([0x55; 32])));
+                    // account-trie paths (p1 gets removed by block 3; p2 remains; p3 added later)
+                    let p1 = Nibbles::from_nibbles_unchecked([0x01, 0x02]);
+                    let p2 = Nibbles::from_nibbles_unchecked([0x03, 0x04]);
+                    let p3 = Nibbles::from_nibbles_unchecked([0x05, 0x06]);
 
-        // --- write 5 blocks manually ---
-        let mut parent = B256::ZERO;
+                    let node_p1 =
+                        BranchNodeCompact::new(0b1, 0, 0, vec![], Some(B256::from([0x11; 32])));
+                    let node_p2 =
+                        BranchNodeCompact::new(0b10, 0, 0, vec![], Some(B256::from([0x22; 32])));
+                    let node_p3 =
+                        BranchNodeCompact::new(0b11, 0, 0, vec![], Some(B256::from([0x33; 32])));
 
-        // Block 1: add a1,a2; s1=100, s2=200; add p1, st1
-        {
-            let b1 = block(1, parent);
+                    // storage-trie paths (st1 removed by block 3; st2 remains; st3 added later)
+                    let st1 = Nibbles::from_nibbles_unchecked([0x0A]);
+                    let st2 = Nibbles::from_nibbles_unchecked([0x0B]);
+                    let st3 = Nibbles::from_nibbles_unchecked([0x0C]);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                    let node_st2 =
+                        BranchNodeCompact::new(0b101, 0, 0, vec![], Some(B256::from([0x44; 32])));
+                    let node_st3 =
+                        BranchNodeCompact::new(0b110, 0, 0, vec![], Some(B256::from([0x55; 32])));
 
-            d_post_state.accounts.insert(
-                a1,
-                Some(Account { nonce: 1, balance: U256::from(1_001), ..Default::default() }),
-            );
-            d_post_state.accounts.insert(
-                a2,
-                Some(Account { nonce: 1, balance: U256::from(1_002), ..Default::default() }),
-            );
+                    // --- write 5 blocks manually ---
+                    let mut parent = B256::ZERO;
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s1, U256::from(100));
-            hs.storage.insert(s2, U256::from(200));
-            d_post_state.storages.insert(stor_addr, hs);
+                    // Block 1: add a1,a2; s1=100, s2=200; add p1, st1
+                    {
+                        let b1 = block(1, parent);
 
-            d_trie_updates.account_nodes.insert(p1, node_p1);
-            let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
-            e.storage_nodes.insert(st1, BranchNodeCompact::default());
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b1, d).expect("b1");
-            parent = b256(1);
-        }
+                        d_post_state.accounts.insert(
+                            a1,
+                            Some(Account {
+                                nonce: 1,
+                                balance: U256::from(1_001),
+                                ..Default::default()
+                            }),
+                        );
+                        d_post_state.accounts.insert(
+                            a2,
+                            Some(Account {
+                                nonce: 1,
+                                balance: U256::from(1_002),
+                                ..Default::default()
+                            }),
+                        );
 
-        // Block 2: update a2; add a3; s2=220, s3=300; add p2, st2
-        {
-            let b2 = block(2, parent);
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s1, U256::from(100));
+                        hs.storage.insert(s2, U256::from(200));
+                        d_post_state.storages.insert(stor_addr, hs);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                        d_trie_updates.account_nodes.insert(p1, node_p1);
+                        let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
+                        e.storage_nodes.insert(st1, BranchNodeCompact::default());
 
-            d_post_state.accounts.insert(
-                a2,
-                Some(Account { nonce: 2, balance: U256::from(2_002), ..Default::default() }),
-            );
-            d_post_state.accounts.insert(
-                a3,
-                Some(Account { nonce: 1, balance: U256::from(1_003), ..Default::default() }),
-            );
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b1, d).expect("b1");
+                        parent = b256(1);
+                    }
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s2, U256::from(220));
-            hs.storage.insert(s3, U256::from(300));
-            d_post_state.storages.insert(stor_addr, hs);
+                    // Block 2: update a2; add a3; s2=220, s3=300; add p2, st2
+                    {
+                        let b2 = block(2, parent);
 
-            d_trie_updates.account_nodes.insert(p2, node_p2.clone());
-            let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
-            e.storage_nodes.insert(st2, node_st2.clone());
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b2, d).expect("b2");
-            parent = b256(2);
-        }
+                        d_post_state.accounts.insert(
+                            a2,
+                            Some(Account {
+                                nonce: 2,
+                                balance: U256::from(2_002),
+                                ..Default::default()
+                            }),
+                        );
+                        d_post_state.accounts.insert(
+                            a3,
+                            Some(Account {
+                                nonce: 1,
+                                balance: U256::from(1_003),
+                                ..Default::default()
+                            }),
+                        );
 
-        // Block 3: delete a1; leave a2,a3; remove p1; remove st1 (storage-trie)
-        {
-            let b3 = block(3, parent);
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s2, U256::from(220));
+                        hs.storage.insert(s3, U256::from(300));
+                        d_post_state.storages.insert(stor_addr, hs);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                        d_trie_updates.account_nodes.insert(p2, node_p2.clone());
+                        let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
+                        e.storage_nodes.insert(st2, node_st2.clone());
 
-            // delete a1, keep a2 & a3 values unchanged for this block
-            d_post_state.accounts.insert(a1, None);
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b2, d).expect("b2");
+                        parent = b256(2);
+                    }
 
-            // remove account trie node p1
-            d_trie_updates.removed_nodes.insert(p1);
+                    // Block 3: delete a1; leave a2,a3; remove p1; remove st1 (storage-trie)
+                    {
+                        let b3 = block(3, parent);
 
-            // remove storage-trie node st1
-            let mut st_upd = StorageTrieUpdates::default();
-            st_upd.removed_nodes.insert(st1);
-            d_trie_updates.storage_tries.insert(stor_addr, st_upd);
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b3, d).expect("b3");
-            parent = b256(3);
-        }
+                        // delete a1, keep a2 & a3 values unchanged for this block
+                        d_post_state.accounts.insert(a1, None);
 
-        // Block 4 (kept): update a2; s1=140; add p3, st3
-        {
-            let b4 = block(4, parent);
+                        // remove account trie node p1
+                        d_trie_updates.removed_nodes.insert(p1);
 
-            let mut d_trie_updates = TrieUpdates::default();
-            let mut d_post_state = HashedPostState::default();
+                        // remove storage-trie node st1
+                        let mut st_upd = StorageTrieUpdates::default();
+                        st_upd.removed_nodes.insert(st1);
+                        d_trie_updates.storage_tries.insert(stor_addr, st_upd);
 
-            d_post_state.accounts.insert(
-                a2,
-                Some(Account { nonce: 3, balance: U256::from(3_002), ..Default::default() }),
-            );
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b3, d).expect("b3");
+                        parent = b256(3);
+                    }
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s1, U256::from(140));
-            d_post_state.storages.insert(stor_addr, hs);
-            d_trie_updates.account_nodes.insert(p3, node_p3.clone());
-            let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
-            e.storage_nodes.insert(st3, node_st3.clone());
+                    // Block 4 (kept): update a2; s1=140; add p3, st3
+                    {
+                        let b4 = block(4, parent);
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: d_trie_updates.into_sorted(),
-            };
-            store.store_trie_updates(b4, d).expect("b4");
-            parent = b256(4);
-        }
+                        let mut d_trie_updates = TrieUpdates::default();
+                        let mut d_post_state = HashedPostState::default();
 
-        // Block 5 (kept): update a3; s3=330
-        {
-            let b5 = block(5, parent);
+                        d_post_state.accounts.insert(
+                            a2,
+                            Some(Account {
+                                nonce: 3,
+                                balance: U256::from(3_002),
+                                ..Default::default()
+                            }),
+                        );
 
-            let mut d_post_state = HashedPostState::default();
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s1, U256::from(140));
+                        d_post_state.storages.insert(stor_addr, hs);
+                        d_trie_updates.account_nodes.insert(p3, node_p3.clone());
+                        let e = d_trie_updates.storage_tries.entry(stor_addr).or_default();
+                        e.storage_nodes.insert(st3, node_st3.clone());
 
-            d_post_state.accounts.insert(
-                a3,
-                Some(Account { nonce: 2, balance: U256::from(2_003), ..Default::default() }),
-            );
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: d_trie_updates.into_sorted(),
+                        };
+                        store.store_trie_updates(b4, d).expect("b4");
+                        parent = b256(4);
+                    }
 
-            let mut hs = HashedStorage::default();
-            hs.storage.insert(s3, U256::from(330));
-            d_post_state.storages.insert(stor_addr, hs);
+                    // Block 5 (kept): update a3; s3=330
+                    {
+                        let b5 = block(5, parent);
 
-            let d = BlockStateDiff {
-                sorted_post_state: d_post_state.into_sorted(),
-                sorted_trie_updates: TrieUpdatesSorted::default(),
-            };
-            store.store_trie_updates(b5, d).expect("b5");
-        }
+                        let mut d_post_state = HashedPostState::default();
 
-        // sanity: earliest=0, latest=5
-        {
-            let e = store.get_earliest_block_number().expect("earliest").expect("some");
-            let l = store.get_latest_block_number().expect("latest").expect("some");
-            assert_eq!(e.0, 0);
-            assert_eq!(l.0, 5);
-        }
+                        d_post_state.accounts.insert(
+                            a3,
+                            Some(Account {
+                                nonce: 2,
+                                balance: U256::from(2_003),
+                                ..Default::default()
+                            }),
+                        );
 
-        // --- prune: remove the first 3 blocks, keep 4 and 5
-        // new_earliest = 5-1 = 4
-        let mut block_hash_reader = MockBlockHashReader::new();
-        block_hash_reader
-            .expect_block_hash()
-            .withf(move |block_num| *block_num == 4)
-            .returning(move |_| Ok(Some(b256(4))));
+                        let mut hs = HashedStorage::default();
+                        hs.storage.insert(s3, U256::from(330));
+                        d_post_state.storages.insert(stor_addr, hs);
 
-        let pruner = BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
-        let out = pruner.run_inner().expect("pruner ok");
-        assert_eq!(out.start_block, 0);
-        assert_eq!(out.end_block, 4, "pruned up to 4 (inclusive); new earliest is 4");
+                        let d = BlockStateDiff {
+                            sorted_post_state: d_post_state.into_sorted(),
+                            sorted_trie_updates: TrieUpdatesSorted::default(),
+                        };
+                        store.store_trie_updates(b5, d).expect("b5");
+                    }
 
-        // proof window moved: earliest=4, latest=5
-        {
-            let e = store.get_earliest_block_number().expect("earliest").expect("some");
-            let l = store.get_latest_block_number().expect("latest").expect("some");
-            assert_eq!(e.0, 4);
-            assert_eq!(e.1, b256(4));
-            assert_eq!(l.0, 5);
-            assert_eq!(l.1, b256(5));
-        }
+                    // sanity: earliest=0, latest=5
+                    {
+                        let e = store.get_earliest_block_number().expect("earliest").expect("some");
+                        let l = store.get_latest_block_number().expect("latest").expect("some");
+                        assert_eq!(e.0, 0);
+                        assert_eq!(l.0, 5);
+                    }
 
-        // --- DB checks
-        let mut acc_cur = store.account_hashed_cursor(4).expect("acc cur");
-        let mut stor_cur = store.storage_hashed_cursor(stor_addr, 4).expect("stor cur");
-        let mut acc_trie_cur = store.account_trie_cursor(4).expect("acc trie cur");
-        let mut stor_trie_cur = store.storage_trie_cursor(stor_addr, 4).expect("stor trie cur");
+                    // --- prune: remove the first 3 blocks, keep 4 and 5
+                    // new_earliest = 5-1 = 4
+                    let mut block_hash_reader = MockBlockHashReader::new();
+                    block_hash_reader
+                        .expect_block_hash()
+                        .withf(move |block_num| *block_num == 4)
+                        .returning(move |_| Ok(Some(b256(4))));
 
-        // Check these histories have been removed
-        let pruned_hashed_account = a1;
-        let pruned_trie_accounts = p1;
-        let pruned_trie_storage = st1;
+                    let pruner =
+                        BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
+                    let out = pruner.run_inner().expect("pruner ok");
+                    assert_eq!(out.start_block, 0);
+                    assert_eq!(out.end_block, 4, "pruned up to 4 (inclusive); new earliest is 4");
 
-        assert_ne!(
-            acc_cur.seek(pruned_hashed_account).expect("seek").unwrap().0,
-            pruned_hashed_account,
-            "deleted account must not exist in earliest snapshot"
-        );
-        assert_ne!(
-            acc_trie_cur.seek(pruned_trie_accounts).expect("seek").unwrap().0,
-            pruned_trie_accounts,
-            "deleted account trie must not exist in earliest snapshot"
-        );
-        assert_ne!(
-            stor_trie_cur.seek(pruned_trie_storage).expect("seek").unwrap().0,
-            pruned_trie_storage,
-            "deleted storage trie must not exist in earliest snapshot"
-        );
+                    // proof window moved: earliest=4, latest=5
+                    {
+                        let e = store.get_earliest_block_number().expect("earliest").expect("some");
+                        let l = store.get_latest_block_number().expect("latest").expect("some");
+                        assert_eq!(e.0, 4);
+                        assert_eq!(e.1, b256(4));
+                        assert_eq!(l.0, 5);
+                        assert_eq!(l.1, b256(5));
+                    }
 
-        // Check these histories have been updated - till block 4
-        let updated_hashed_accounts = vec![
-            (a2, Account { nonce: 3, balance: U256::from(3_002), ..Default::default() }), /* block 4 */
-            (a3, Account { nonce: 1, balance: U256::from(1_003), ..Default::default() }), /* block 2 */
-        ];
-        let updated_hashed_storage = vec![
-            (s1, U256::from(140)), // block 4
-            (s2, U256::from(220)), // block 2
-            (s3, U256::from(300)), // block 2
-        ];
-        let updated_trie_accounts = vec![
-            (p2, node_p2), // block 2
-            (p3, node_p3), // block 4
-        ];
-        let updated_trie_storage = vec![
-            (st2, node_st2), // block 2
-            (st3, node_st3), // block 4
-        ];
+                    // --- DB checks
+                    let mut acc_cur = store.account_hashed_cursor(4).expect("acc cur");
+                    let mut stor_cur = store.storage_hashed_cursor(stor_addr, 4).expect("stor cur");
+                    let mut acc_trie_cur = store.account_trie_cursor(4).expect("acc trie cur");
+                    let mut stor_trie_cur =
+                        store.storage_trie_cursor(stor_addr, 4).expect("stor trie cur");
 
-        for (key, val) in updated_hashed_accounts {
-            let (k, vv) = acc_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
+                    // Check these histories have been removed
+                    let pruned_hashed_account = a1;
+                    let pruned_trie_accounts = p1;
+                    let pruned_trie_storage = st1;
 
-        for (key, val) in updated_hashed_storage {
-            let (k, vv) = stor_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
+                    assert_ne!(
+                        acc_cur.seek(pruned_hashed_account).expect("seek").unwrap().0,
+                        pruned_hashed_account,
+                        "deleted account must not exist in earliest snapshot"
+                    );
+                    assert_ne!(
+                        acc_trie_cur.seek(pruned_trie_accounts).expect("seek").unwrap().0,
+                        pruned_trie_accounts,
+                        "deleted account trie must not exist in earliest snapshot"
+                    );
+                    assert_ne!(
+                        stor_trie_cur.seek(pruned_trie_storage).expect("seek").unwrap().0,
+                        pruned_trie_storage,
+                        "deleted storage trie must not exist in earliest snapshot"
+                    );
 
-        for (key, val) in updated_trie_accounts {
-            let (k, vv) = acc_trie_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
-        for (key, val) in updated_trie_storage {
-            let (k, vv) = stor_trie_cur.seek(key).expect("seek").unwrap();
-            assert_eq!(key, k, "key must exist");
-            assert_eq!(val, vv, "value must be updated");
-        }
+                    // Check these histories have been updated - till block 4
+                    let updated_hashed_accounts = vec![
+                        (
+                            a2,
+                            Account { nonce: 3, balance: U256::from(3_002), ..Default::default() },
+                        ),
+                        (
+                            a3,
+                            Account { nonce: 1, balance: U256::from(1_003), ..Default::default() },
+                        ),
+                    ];
+                    let updated_hashed_storage =
+                        vec![(s1, U256::from(140)), (s2, U256::from(220)), (s3, U256::from(300))];
+                    let updated_trie_accounts = vec![(p2, node_p2), (p3, node_p3)];
+                    let updated_trie_storage = vec![(st2, node_st2), (st3, node_st3)];
+
+                    for (key, val) in updated_hashed_accounts {
+                        let (k, vv) = acc_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+
+                    for (key, val) in updated_hashed_storage {
+                        let (k, vv) = stor_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+
+                    for (key, val) in updated_trie_accounts {
+                        let (k, vv) = acc_trie_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+                    for (key, val) in updated_trie_storage {
+                        let (k, vv) = stor_trie_cur.seek(key).expect("seek").unwrap();
+                        assert_eq!(key, k, "key must exist");
+                        assert_eq!(val, vv, "value must be updated");
+                    }
+                }
+
+                // Both latest and earliest blocks are None -> early return default; DB untouched.
+                #[tokio::test]
+                async fn run_inner_where_latest_block_is_none() {
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
+
+                    let earliest = store.get_earliest_block_number().unwrap();
+                    let latest = store.get_latest_block_number().unwrap();
+                    assert!(earliest.is_none());
+                    assert!(latest.is_none());
+
+                    let block_hash_reader = MockBlockHashReader::new();
+                    let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 10, 1000);
+                    let out = pruner.run_inner().expect("ok");
+                    assert_eq!(out, PrunerOutput::default(), "should early-return default output");
+                }
+
+                // The earliest block is None, but the latest block exists -> early return default.
+                #[tokio::test]
+                async fn run_inner_earliest_none_real_db() {
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
+
+                    // Write a single block to set *latest* only.
+                    store
+                        .store_trie_updates(block(3, B256::ZERO), BlockStateDiff::default())
+                        .expect("store b1");
+
+                    let earliest = store.get_earliest_block_number().unwrap();
+                    let latest = store.get_latest_block_number().unwrap();
+                    assert!(earliest.is_none(), "earliest must remain None");
+                    assert_eq!(latest.unwrap().0, 3);
+
+                    let block_hash_reader = MockBlockHashReader::new();
+                    let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 1, 1000);
+                    let out = pruner.run_inner().expect("ok");
+                    assert_eq!(out, PrunerOutput::default(), "should early-return default output");
+                }
+
+                // interval < min_block_interval -> "Nothing to prune" path; default output.
+                #[tokio::test]
+                async fn run_inner_interval_too_small_real_db() {
+                    let dir = TempDir::new().unwrap();
+                    let store: BaseProofsStorage<Arc<$storage>> =
+                        BaseProofsStorage::from(Arc::new($storage::new(dir.path()).expect("env")));
+
+                    // Set earliest=4 explicitly
+                    let earliest_num = 4u64;
+                    let h4 = b256(4);
+                    store.set_earliest_block_number(earliest_num, h4).expect("set earliest");
+
+                    // Set latest=5 by storing block 5
+                    let b5 = block(5, h4);
+                    store.store_trie_updates(b5, BlockStateDiff::default()).expect("store b5");
+
+                    // Sanity: earliest=4, latest=5 => interval=1
+                    let e = store.get_earliest_block_number().unwrap().unwrap();
+                    let l = store.get_latest_block_number().unwrap().unwrap();
+                    assert_eq!(e.0, 4);
+                    assert_eq!(l.0, 5);
+
+                    // Require min_block_interval=2 (or greater) so interval < min
+                    let block_hash_reader = MockBlockHashReader::new();
+                    let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 2, 1000);
+                    let out = pruner.run_inner().expect("ok");
+                    assert_eq!(out, PrunerOutput::default(), "no pruning should occur");
+                }
+            }
+        };
     }
 
-    // Both latest and earliest blocks are None -> early return default; DB untouched.
-    #[tokio::test]
-    async fn run_inner_where_latest_block_is_none() {
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
-
-        let earliest = store.get_earliest_block_number().unwrap();
-        let latest = store.get_latest_block_number().unwrap();
-        assert!(earliest.is_none());
-        assert!(latest.is_none());
-
-        let block_hash_reader = MockBlockHashReader::new();
-        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 10, 1000);
-        let out = pruner.run_inner().expect("ok");
-        assert_eq!(out, PrunerOutput::default(), "should early-return default output");
-    }
-
-    // The earliest block is None, but the latest block exists -> early return default.
-    #[tokio::test]
-    async fn run_inner_earliest_none_real_db() {
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
-
-        // Write a single block to set *latest* only.
-        store
-            .store_trie_updates(block(3, B256::ZERO), BlockStateDiff::default())
-            .expect("store b1");
-
-        let earliest = store.get_earliest_block_number().unwrap();
-        let latest = store.get_latest_block_number().unwrap();
-        assert!(earliest.is_none(), "earliest must remain None");
-        assert_eq!(latest.unwrap().0, 3);
-
-        let block_hash_reader = MockBlockHashReader::new();
-        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 1, 1000);
-        let out = pruner.run_inner().expect("ok");
-        assert_eq!(out, PrunerOutput::default(), "should early-return default output");
-    }
-
-    // interval < min_block_interval -> "Nothing to prune" path; default output.
-    #[tokio::test]
-    async fn run_inner_interval_too_small_real_db() {
-        let dir = TempDir::new().unwrap();
-        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
-
-        // Set earliest=4 explicitly
-        let earliest_num = 4u64;
-        let h4 = b256(4);
-        store.set_earliest_block_number(earliest_num, h4).expect("set earliest");
-
-        // Set latest=5 by storing block 5
-        let b5 = block(5, h4);
-        store.store_trie_updates(b5, BlockStateDiff::default()).expect("store b5");
-
-        // Sanity: earliest=4, latest=5 => interval=1
-        let e = store.get_earliest_block_number().unwrap().unwrap();
-        let l = store.get_latest_block_number().unwrap().unwrap();
-        assert_eq!(e.0, 4);
-        assert_eq!(l.0, 5);
-
-        // Require min_block_interval=2 (or greater) so interval < min
-        let block_hash_reader = MockBlockHashReader::new();
-        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 2, 1000);
-        let out = pruner.run_inner().expect("ok");
-        assert_eq!(out, PrunerOutput::default(), "no pruning should occur");
-    }
+    proof_storage_pruner_tests!(mdbx_tests, MdbxProofsStorage);
+    proof_storage_pruner_tests!(rocksdb_tests, RocksdbProofsStorage);
 }

--- a/crates/execution/trie/tests/branch_cursors/mod.rs
+++ b/crates/execution/trie/tests/branch_cursors/mod.rs
@@ -12,7 +12,7 @@ use super::*;
 /// Test cursor operations on empty trie
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -31,7 +31,7 @@ fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test cursor operations with single entry
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -60,7 +60,7 @@ fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// `seek_exact` on an absent key returns `None` and leaves `current()` unset.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_exact_absent_key_returns_none<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -83,7 +83,7 @@ fn test_seek_exact_absent_key_returns_none<S: BaseProofsStore + BaseProofsInitia
 /// Test cursor operations with multiple entries
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -125,7 +125,7 @@ fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore
 /// Test `seek_exact` with existing path
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -145,7 +145,7 @@ fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStor
 /// Test `seek_exact` with non-existing path
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -165,7 +165,7 @@ fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialState
 /// Test `seek_exact` with empty path
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -185,7 +185,7 @@ fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test seek to existing path
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -205,7 +205,7 @@ fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test seek between existing nodes
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -229,7 +229,7 @@ fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateS
 /// Test seek after all nodes
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -250,7 +250,7 @@ fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test seek before all nodes
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -276,7 +276,7 @@ fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test next without prior seek
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -297,7 +297,7 @@ fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore
 /// Test next after seek
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -322,7 +322,7 @@ fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test next at end of trie
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -344,7 +344,7 @@ fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test multiple consecutive next calls
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -373,7 +373,7 @@ fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateSto
 /// Test current after operations
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -404,7 +404,7 @@ fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStor
 /// Test current with no prior operations
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -424,7 +424,7 @@ fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateS
 /// Test same path with different blocks
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -453,7 +453,7 @@ fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateSt
 /// Test deleted branch nodes
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -491,7 +491,7 @@ fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test account-specific cursor
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -529,7 +529,7 @@ fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore
 /// Test state trie cursor
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -562,7 +562,7 @@ fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test mixed account and state data
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -604,7 +604,7 @@ fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStor
 /// Test lexicographic ordering
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -644,7 +644,7 @@ fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>
 /// Test path prefix scenarios
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -679,7 +679,7 @@ fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test complex nibble combinations
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,

--- a/crates/execution/trie/tests/hashed_cursors/mod.rs
+++ b/crates/execution/trie/tests/hashed_cursors/mod.rs
@@ -35,7 +35,7 @@ fn storage_exact<S: BaseProofsStore>(
 /// Test store and retrieve single account
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -61,7 +61,7 @@ fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitial
 /// Test account cursor navigation
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -99,7 +99,6 @@ fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateSto
 
 /// Test that a `RocksDB` cursor reads from the snapshot captured when it is created.
 #[test]
-#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
 #[serial]
 fn test_rocksdb_account_cursor_uses_creation_snapshot() -> Result<(), BaseProofsStorageError> {
     let storage = create_rocksdb_proofs_storage();
@@ -156,7 +155,7 @@ fn test_rocksdb_account_cursor_uses_creation_snapshot() -> Result<(), BaseProofs
 /// Test account block versioning
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -188,7 +187,7 @@ fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStor
 /// Test store and retrieve storage
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -219,7 +218,7 @@ fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateSt
 /// Test storage cursor navigation
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -252,7 +251,7 @@ fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateSto
 /// Test storage account isolation
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -288,7 +287,7 @@ fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateSto
 /// Test storage block versioning
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -316,7 +315,7 @@ fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStor
 /// Test storage zero value deletion
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -356,7 +355,7 @@ fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateS
 /// Test that zero values are skipped during iteration
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -406,7 +405,7 @@ fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialS
 /// Test empty cursors
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -427,7 +426,7 @@ fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
 /// Test cursor boundary conditions
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -457,7 +456,7 @@ fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateSt
 /// Test large batch operations
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -492,7 +491,7 @@ fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>
 
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_exact_account_reads_do_not_return_lower_bound_neighbor<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -519,7 +518,7 @@ fn test_exact_account_reads_do_not_return_lower_bound_neighbor<
 
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_exact_storage_reads_do_not_return_lower_bound_neighbor<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -545,7 +544,7 @@ fn test_exact_storage_reads_do_not_return_lower_bound_neighbor<
 
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_exact_reads_hide_deleted_account_and_zero_storage<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -577,7 +576,6 @@ fn test_exact_reads_hide_deleted_account_and_zero_storage<
 }
 
 #[test]
-#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
 #[serial]
 fn test_rocksdb_exact_reads_use_supplied_snapshot() -> Result<(), BaseProofsStorageError> {
     let storage = create_rocksdb_proofs_storage();
@@ -639,7 +637,6 @@ fn test_rocksdb_exact_reads_use_supplied_snapshot() -> Result<(), BaseProofsStor
 }
 
 #[test]
-#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
 #[serial]
 fn test_rocksdb_exact_lookup_finds_latest_version_at_or_below_bound()
 -> Result<(), BaseProofsStorageError> {
@@ -677,7 +674,6 @@ fn test_rocksdb_exact_lookup_finds_latest_version_at_or_below_bound()
 }
 
 #[test]
-#[ignore = "RocksDB read path not yet implemented; will be enabled in a later PR"]
 #[serial]
 fn test_rocksdb_exact_lookup_returns_none_when_versions_are_above_bound()
 -> Result<(), BaseProofsStorageError> {

--- a/crates/execution/trie/tests/history/mod.rs
+++ b/crates/execution/trie/tests/history/mod.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_fetch_trie_updates_basic<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -56,7 +56,7 @@ fn test_fetch_trie_updates_basic<S: BaseProofsStore + BaseProofsInitialStateStor
 }
 
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_store_trie_updates_out_of_order_rejects<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -74,7 +74,7 @@ fn test_store_trie_updates_out_of_order_rejects<
 }
 
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_prune_earliest_state_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -131,7 +131,7 @@ fn test_prune_earliest_state_comprehensive<S: BaseProofsStore + BaseProofsInitia
 }
 
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_prune_earliest_state_returns_correct_counts<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -170,7 +170,7 @@ fn test_prune_earliest_state_returns_correct_counts<
 }
 
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_unwind_history_with_trie_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -200,7 +200,7 @@ fn test_unwind_history_with_trie_nodes<S: BaseProofsStore + BaseProofsInitialSta
 }
 
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_unwind_history_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -260,7 +260,7 @@ fn test_unwind_history_comprehensive<S: BaseProofsStore + BaseProofsInitialState
 }
 
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_unwind_history_idempotent<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,

--- a/crates/execution/trie/tests/proof_window/mod.rs
+++ b/crates/execution/trie/tests/proof_window/mod.rs
@@ -8,7 +8,7 @@ use super::*;
 /// Test basic storage and retrieval of earliest block number
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -30,7 +30,7 @@ fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateSto
 
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_proof_window<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,

--- a/crates/execution/trie/tests/trie_updates/mod.rs
+++ b/crates/execution/trie/tests/trie_updates/mod.rs
@@ -8,7 +8,7 @@ use super::*;
 /// Test storing and retrieving trie updates
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -38,7 +38,7 @@ fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore
 /// it should iterate all existing values for that address and create deletion entries for them.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -128,7 +128,7 @@ fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsIni
 /// downstream of `LiveTrieCollector`.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_store_trie_updates_with_wiped_storage_and_new_slots<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -212,7 +212,7 @@ fn test_store_trie_updates_with_wiped_storage_and_new_slots<
 /// through the cursor APIs.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -385,7 +385,7 @@ fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialS
 /// (`hashed_accounts`, `hashed_storages`, `account_branches`, `storage_branches`).
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -649,7 +649,7 @@ fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsIniti
 /// replacement chain.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_replace_updates_wipes_storage_added_by_prior_replacement_block<
     S: BaseProofsStore + BaseProofsInitialStateStore,
@@ -721,7 +721,7 @@ fn test_replace_updates_wipes_storage_added_by_prior_replacement_block<
 /// it is properly stored as a deletion and subsequent queries return None for that path.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
@@ -854,7 +854,7 @@ fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialSt
 /// when processing trie updates that both remove and update the same node.
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
-#[test_case(create_rocksdb_proofs_storage() => ignore; "Rocksdb")]
+#[test_case(create_rocksdb_proofs_storage(); "Rocksdb")]
 #[serial]
 fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,


### PR DESCRIPTION
Part of the RocksDB proof storage stack, stacked on the cursor traits PR.

Implements the remaining `BaseProofsStore` read methods: `ro_tx`, all cursor factory methods (`storage_trie_cursor`, `account_trie_cursor`, `storage_hashed_cursor`, `account_hashed_cursor` + `_with_tx` variants), `fetch_trie_updates`, `replace_updates`, and `BaseProofsBatchSession` cursor factories.

Also enables the `rocksdb_tests` pruner test variant and adds 7 concurrency/locking unit tests.

After this PR, `BaseProofsStore` is fully implemented for RocksDB.

**Most of this change is moving initialization and pruning tests to allow them to run on both MDBX and RocksDB.**

Stack:
- #3518 merged
- #3517 feat(trie/rocksdb): implement RocksDB block write path
- test(trie/rocksdb): add integration tests and benchmarks
- feat(trie/rocksdb): implement RocksdbVersionedCursor
- feat(trie/rocksdb): implement TrieCursor and HashedCursor trait impls
- **this PR** feat(trie/rocksdb): implement BaseProofsStore read methods and cursor factories
- feat(node): wire RocksDB proof storage into node and CLI
