### PR TITLE
feat(node): wire RocksDB proof storage into node and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5922,9 +5922,7 @@ dependencies = [
 name = "base-proofs-extension"
 version = "0.0.0"
 dependencies = [
- "base-common-consensus",
  "base-execution-exex",
- "base-execution-payload-builder",
  "base-execution-rpc",
  "base-execution-trie",
  "base-node-core",

--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -10,7 +10,7 @@
 //! - `per_flashblock` (`calculate_state_root = true`) — state root
 //!   recomputed from scratch after every flashblock.
 //!
-//! The benchmarks use an MDBX-backed [`MdbxProofsStorage`] pre-populated with
+//! The benchmarks use a RocksDB-backed [`RocksdbProofsStorage`] pre-populated with
 //! 50k base-state accounts so that state root computation exercises real disk
 //! I/O through the production trie overlay path.
 //!
@@ -25,7 +25,7 @@ use std::{hint::black_box, sync::Arc};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsInitialStateStore, BaseProofsStorage, MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorage, RocksdbProofsStorage,
     provider::BaseProofsStateProviderRef,
 };
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -41,7 +41,7 @@ const FLASHBLOCKS: usize = 10;
 /// Storage slots per account.
 const SLOTS_PER_ACCOUNT: usize = 5;
 
-/// Number of pre-existing accounts in the MDBX base state.
+/// Number of pre-existing accounts in the `RocksDB` base state.
 ///
 /// This simulates a realistic chain state where the trie already contains
 /// existing accounts before any flashblock deltas are applied.
@@ -105,12 +105,13 @@ fn setup_flashblock_data(
     (deltas, full_state)
 }
 
-/// Creates an MDBX-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
+/// Creates a RocksDB-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
 /// accounts and their storage slots. Returns the temp directory handle (must be
 /// kept alive) and the wrapped storage.
-fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStorage>>) {
+fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<RocksdbProofsStorage>>) {
     let dir = TempDir::new().expect("failed to create temp dir");
-    let mdbx = Arc::new(MdbxProofsStorage::new(dir.path()).expect("failed to create MDBX storage"));
+    let rocksdb =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("failed to create RocksDB storage"));
 
     // Generate base state accounts.
     let mut rng = StdRng::seed_from_u64(42);
@@ -119,19 +120,21 @@ fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStora
     // Pre-populate hashed accounts.
     let hashed_accounts: Vec<(B256, Option<Account>)> =
         accounts.iter().map(|(addr, acct, _)| (*addr, Some(*acct))).collect();
-    mdbx.store_hashed_accounts(hashed_accounts).expect("failed to store hashed accounts");
+    rocksdb.store_hashed_accounts(hashed_accounts).expect("failed to store hashed accounts");
 
     // Pre-populate hashed storages.
     for (addr, _, slots) in &accounts {
         let slot_data: Vec<(B256, U256)> = slots.iter().map(|(k, v)| (*k, *v)).collect();
-        mdbx.store_hashed_storages(*addr, slot_data).expect("failed to store hashed storages");
+        rocksdb.store_hashed_storages(*addr, slot_data).expect("failed to store hashed storages");
     }
 
     // Set initial state anchor and commit.
-    mdbx.set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO)).expect("failed to set anchor");
-    mdbx.commit_initial_state().expect("failed to commit initial state");
+    rocksdb
+        .set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO))
+        .expect("failed to set anchor");
+    rocksdb.commit_initial_state().expect("failed to commit initial state");
 
-    let storage = BaseProofsStorage::from(mdbx);
+    let storage = BaseProofsStorage::from(rocksdb);
     (dir, storage)
 }
 

--- a/crates/execution/cli/src/commands/base_proofs/init.rs
+++ b/crates/execution/cli/src/commands/base_proofs/init.rs
@@ -5,8 +5,10 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStore, InitializationJob, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, InitializationJob,
+    MdbxProofsStorage, RocksdbProofsStorage,
 };
+use base_node_core::args::{ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs};
 use clap::Parser;
 use reth_chainspec::ChainInfo;
 use reth_cli::chainspec::ChainSpecParser;
@@ -34,6 +36,14 @@ pub struct InitCommand<C: ChainSpecParser> {
         required = true
     )]
     pub storage_path: PathBuf,
+
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "mdbx")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
 }
 
 impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
@@ -42,19 +52,53 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {
+        let Self { env, storage_path, proofs_history_db, proofs_history_rocksdb } = self;
+
         info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Initializing Base proofs storage");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Initializing Base proofs storage"
+        );
+        proofs_history_db.ensure_storage_path_matches(&storage_path)?;
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO, runtime)?;
 
-        // Create the proofs storage
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &storage_path,
+                        proofs_history_rocksdb.storage_options()?,
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::initialize_storage(storage, &provider_factory)?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::initialize_storage(storage, &provider_factory)?;
+            }
+        }
 
+        Ok(())
+    }
+
+    fn initialize_storage<S, F>(
+        storage: BaseProofsStorage<Arc<S>>,
+        provider_factory: &F,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsInitialStateStore + BaseProofsStore + 'static,
+        F: BlockNumReader + DatabaseProviderFactory,
+    {
         // Check if already initialized
         if let Some((block_number, block_hash)) = storage.get_earliest_block_number()? {
             info!(

--- a/crates/execution/cli/src/commands/base_proofs/prune.rs
+++ b/crates/execution/cli/src/commands/base_proofs/prune.rs
@@ -5,7 +5,12 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage,
+    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, MdbxProofsStorage,
+    RocksdbProofsStorage,
+};
+use base_node_core::{
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs,
+    TWELVE_HOURS_IN_BLOCKS,
 };
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
@@ -27,21 +32,36 @@ pub struct PruneCommand<C: ChainSpecParser> {
     )]
     pub storage_path: PathBuf,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "mdbx")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
+    ///
+    /// Must be greater than 12 hours of blocks based on 2 seconds block time.
     #[arg(
         long = "proofs-history.window",
-        default_value_t = 1_296_000,
-        value_name = "PROOFS_HISTORY_WINDOW"
+        default_value_t = DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        value_name = "PROOFS_HISTORY_WINDOW",
+        value_parser = clap::value_parser!(u64).range((TWELVE_HOURS_IN_BLOCKS + 1)..)
     )]
     pub proofs_history_window: u64,
 
     /// The batch size for pruning operations.
+    ///
+    /// Each batch materializes up to this many blocks of change-set keys before committing, so
+    /// reduce this value to bound memory usage when pruning a large range.
     #[arg(
         long = "proofs-history.prune-batch-size",
         default_value_t = 1000,
-        value_name = "PROOFS_HISTORY_PRUNE_BATCH_SIZE"
+        value_name = "PROOFS_HISTORY_PRUNE_BATCH_SIZE",
+        value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub proofs_history_prune_batch_size: u64,
 }
@@ -52,18 +72,71 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {
+        let Self {
+            env,
+            storage_path,
+            proofs_history_db,
+            proofs_history_rocksdb,
+            proofs_history_window,
+            proofs_history_prune_batch_size,
+        } = self;
+
         info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Pruning Base proofs storage");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Pruning Base proofs storage"
+        );
+        proofs_history_db.ensure_storage_path_matches(&storage_path)?;
 
         // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO, runtime)?;
 
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &storage_path,
+                        proofs_history_rocksdb.storage_options()?,
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::prune_storage(
+                    storage,
+                    provider_factory,
+                    proofs_history_window,
+                    proofs_history_prune_batch_size,
+                )?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::prune_storage(
+                    storage,
+                    provider_factory,
+                    proofs_history_window,
+                    proofs_history_prune_batch_size,
+                )?;
+            }
+        }
 
+        Ok(())
+    }
+    fn prune_storage<S, H>(
+        storage: BaseProofsStorage<Arc<S>>,
+        hash_reader: H,
+        proofs_history_window: u64,
+        proofs_history_prune_batch_size: u64,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsStore + 'static,
+        H: reth_provider::BlockHashReader,
+    {
         let earliest_block = storage.get_earliest_block_number()?;
         let latest_block = storage.get_latest_block_number()?;
         info!(
@@ -75,9 +148,9 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
 
         let pruner = BaseProofStoragePruner::new(
             storage,
-            provider_factory,
-            self.proofs_history_window,
-            self.proofs_history_prune_batch_size,
+            hash_reader,
+            proofs_history_window,
+            proofs_history_prune_batch_size,
         );
         pruner.run();
         Ok(())

--- a/crates/execution/cli/src/commands/base_proofs/unwind.rs
+++ b/crates/execution/cli/src/commands/base_proofs/unwind.rs
@@ -4,11 +4,14 @@ use std::{path::PathBuf, sync::Arc};
 
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_trie::{BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage};
+use base_execution_trie::{
+    BaseProofsStorage, BaseProofsStore, MdbxProofsStorage, RocksdbProofsStorage,
+};
+use base_node_core::args::{ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs};
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
-use reth_node_core::version::version_metadata;
+use reth_node_core::{primitives::AlloyBlockHeader as _, version::version_metadata};
 use reth_provider::{BlockReader, TransactionVariant};
 use tracing::{info, warn};
 
@@ -28,17 +31,98 @@ pub struct UnwindCommand<C: ChainSpecParser> {
     )]
     pub storage_path: PathBuf,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "mdbx")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
+
     /// The target block number to unwind to.
     ///
-    /// All history *after* this block will be removed.
+    /// All history *at and after* this block will be removed.
     #[arg(long, value_name = "TARGET_BLOCK")]
     pub target: u64,
 }
 
-impl<C: ChainSpecParser> UnwindCommand<C> {
+impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
+    /// Execute [`UnwindCommand`].
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
+        self,
+        runtime: reth_tasks::Runtime,
+    ) -> eyre::Result<()> {
+        let Self { env, storage_path, proofs_history_db, proofs_history_rocksdb, target } = self;
+
+        info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
+        info!(
+            target: "reth::cli",
+            path = ?storage_path,
+            backend = ?proofs_history_db,
+            "Unwinding Base proofs storage"
+        );
+        proofs_history_db.ensure_storage_path_matches(&storage_path)?;
+
+        // Initialize the environment with read-only access
+        let Environment { provider_factory, .. } = env.init::<N>(AccessRights::RO, runtime)?;
+
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &storage_path,
+                        proofs_history_rocksdb.storage_options()?,
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::unwind_storage(target, &provider_factory, storage)?;
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+                    MdbxProofsStorage::new(&storage_path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                )
+                .into();
+                Self::unwind_storage(target, &provider_factory, storage)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn unwind_storage<S, P>(
+        target: u64,
+        provider_factory: &P,
+        storage: BaseProofsStorage<Arc<S>>,
+    ) -> eyre::Result<()>
+    where
+        S: BaseProofsStore + 'static,
+        P: BlockReader,
+    {
+        // Validate that the target block is within a valid range for unwinding
+        if !Self::validate_unwind_range(target, &storage)? {
+            return Ok(());
+        }
+
+        // Get the target block from the main database
+        let block = provider_factory
+            .recovered_block(target.into(), TransactionVariant::NoHash)?
+            .ok_or_else(|| eyre::eyre!("Target block {} not found in the main database", target))?;
+
+        info!(
+            target: "reth::cli",
+            block_number = block.number(),
+            block_hash = %block.hash(),
+            "Unwinding to target block"
+        );
+        storage.unwind_history(block.block_with_parent())?;
+        Ok(())
+    }
+
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: BaseProofsStore>(
-        &self,
+        target: u64,
         storage: &BaseProofsStorage<Store>,
     ) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
@@ -48,55 +132,17 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
             return Ok(false);
         };
 
-        if self.target <= earliest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
+        if target <= earliest {
+            warn!(target: "reth::cli", unwind_target = ?target, ?earliest, "Target block is less than the earliest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
-        if self.target > latest {
-            warn!(target: "reth::cli", unwind_target = ?self.target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
+        if target > latest {
+            warn!(target: "reth::cli", unwind_target = ?target, ?latest, "Target block is not less than the latest block in proofs storage. Nothing to unwind.");
             return Ok(false);
         }
 
         Ok(true)
-    }
-}
-
-impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
-    /// Execute [`UnwindCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = BasePrimitives>>(
-        self,
-        runtime: reth_tasks::Runtime,
-    ) -> eyre::Result<()> {
-        info!(target: "reth::cli", version = %version_metadata().short_version, "reth starting");
-        info!(target: "reth::cli", path = ?self.storage_path, "Unwinding Base proofs storage");
-
-        // Initialize the environment with read-only access
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
-
-        // Create the proofs storage
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-            MdbxProofsStorage::new(&self.storage_path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
-
-        // Validate that the target block is within a valid range for unwinding
-        if !self.validate_unwind_range(&storage)? {
-            return Ok(());
-        }
-
-        // Get the target block from the main database
-        let block = provider_factory
-            .recovered_block(self.target.into(), TransactionVariant::NoHash)?
-            .ok_or_else(|| {
-                eyre::eyre!("Target block {} not found in the main database", self.target)
-            })?;
-
-        info!(target: "reth::cli", block_number = block.number, block_hash = %block.hash(), "Unwinding to target block");
-        storage.unwind_history(block.block_with_parent())?;
-
-        Ok(())
     }
 }
 

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -36,8 +36,8 @@ use tracing::{debug, error, info};
 /// [`BaseProofsExExBuilder::with_max_prune_blocks_startup`].
 const DEFAULT_MAX_PRUNE_BLOCKS_STARTUP: u64 = 100_000;
 
-/// How many blocks to process in a single batch before yielding. Default is 50 blocks.
-const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
+/// How many blocks to process in a single sync turn before yielding.
+const SYNC_BLOCKS_PER_TURN: usize = 50;
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -135,7 +135,7 @@ where
 /// use base_execution_chainspec::BaseChainSpec;
 /// use base_execution_exex::BaseProofsExEx;
 /// use base_node_core::{BaseNode, args::RollupArgs};
-/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, db::MdbxProofsStorage};
+/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, RocksdbProofsStorage};
 /// use reth_provider::providers::BlockchainProvider;
 /// use std::{sync::Arc, time::Duration};
 ///
@@ -152,8 +152,8 @@ where
 /// # let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
 /// # let storage_path = temp_dir.path().join("proofs_storage");
 ///
-/// # let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
-/// #    MdbxProofsStorage::new(&storage_path).expect("Failed to create MdbxProofsStorage"),
+/// # let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::new(
+/// #    RocksdbProofsStorage::new(&storage_path).expect("Failed to create RocksdbProofsStorage"),
 /// # ).into();
 ///
 /// let storage_exec = storage.clone();
@@ -459,14 +459,14 @@ where
                 return;
             }
 
-            let end = (latest + SYNC_BLOCKS_BATCH_SIZE as u64).min(target);
+            let end = latest.saturating_add(SYNC_BLOCKS_PER_TURN as u64).min(target);
             info!(
                 target: "base::exex",
                 start = latest + 1,
                 end,
                 target,
-                batch_size = end - latest,
-                "Processing proofs storage sync batch"
+                blocks = end - latest,
+                "Processing proofs storage sync turn"
             );
 
             let mut batch: Vec<BatchBlock<Primitives>> =
@@ -709,7 +709,7 @@ mod tests {
     use alloy_consensus::private::alloy_primitives::B256;
     use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
     use base_execution_trie::{
-        BaseProofsStorage, BaseProofsStore, BlockStateDiff, db::MdbxProofsStorage,
+        BaseProofsStorage, BaseProofsStore, BlockStateDiff, RocksdbProofsStorage,
     };
     use reth_db::test_utils::tempdir_path;
     use reth_ethereum_primitives::{Block, Receipt};
@@ -820,10 +820,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_chain_committed() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -847,10 +847,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_chain_committed_caches_already_stored_blocks() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -881,10 +881,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_chain_reorged() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -925,10 +925,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_chain_reorged_beyond_stored_blocks() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -965,10 +965,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_chain_reverted() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -1003,10 +1003,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_chain_reverted_beyond_stored_blocks() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 5, &proofs);
@@ -1041,10 +1041,10 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_initialized_errors_on_storage_not_initialized() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -1055,10 +1055,10 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_initialized_errors_when_prune_exceeds_threshold() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1083,10 +1083,10 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_initialized_succeeds() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1099,10 +1099,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_notification_schedules_async_on_gap() {
-        // MDBX proofs storage
+        // RocksDB proofs storage
         let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let store = Arc::new(RocksdbProofsStorage::new(dir.as_path()).expect("env"));
+        let proofs: BaseProofsStorage<Arc<RocksdbProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -2,10 +2,33 @@
 
 //! clap [Args](clap::Args) for Base rollup configuration
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
+use base_execution_trie::RocksdbProofsStorageOptions;
 use base_upgrade_signal::{UpgradeSignalArgs, UpgradeSignalL1RpcArgs};
-use clap::{ValueEnum, builder::ArgPredicate};
+use clap::{ArgAction, ValueEnum, builder::ArgPredicate};
+
+/// Default proofs history window: 1 month of blocks at 2s block time.
+pub const DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS: u64 = 1_296_000;
+
+/// Twelve hours of blocks at 2s block time.
+pub const TWELVE_HOURS_IN_BLOCKS: u64 = 21_600;
+
+const MIB: u64 = 1024 * 1024;
+const DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_MIB: u64 = 1024;
+const DEFAULT_ROCKSDB_BYTES_PER_SYNC_MIB: u64 = 1;
+const DEFAULT_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB: u64 = 0;
+const DEFAULT_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: i32 = 4;
+const DEFAULT_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER: i32 = 20;
+const DEFAULT_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER: i32 = 36;
+const DEFAULT_ROCKSDB_MAX_BACKGROUND_JOBS: i32 = 4;
+const DEFAULT_ROCKSDB_MAX_SUBCOMPACTIONS: u32 = 1;
+const DEFAULT_ROCKSDB_MAX_WRITE_BUFFER_NUMBER: i32 = 3;
+const DEFAULT_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB: u64 = 256;
+const DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB: u64 = 64;
 
 /// Transaction ordering strategy for the mempool.
 ///
@@ -24,6 +47,243 @@ pub enum TxpoolOrdering {
     /// Transactions are ordered by when they were received by the mempool,
     /// regardless of the fees they offer.
     Timestamp,
+}
+
+/// On-disk database backend for proofs history.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ProofsHistoryDbBackend {
+    /// Store proofs history in `RocksDB`. Also accepted as `v2`.
+    #[value(alias = "v2")]
+    Rocksdb,
+    /// Store proofs history in `MDBX`.
+    #[default]
+    Mdbx,
+}
+
+impl ProofsHistoryDbBackend {
+    /// Returns an error if an existing proofs-history directory belongs to a different backend.
+    pub fn ensure_storage_path_matches(self, path: &Path) -> eyre::Result<()> {
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let has_rocksdb_marker = path.join("CURRENT").exists();
+        let has_mdbx_marker = path.join("mdbx.dat").exists();
+
+        if has_rocksdb_marker && has_mdbx_marker {
+            return Err(eyre::eyre!(
+                "storage path contains both RocksDB marker CURRENT and MDBX marker mdbx.dat: {}",
+                path.display()
+            ));
+        }
+
+        match self {
+            Self::Rocksdb if has_mdbx_marker => Err(eyre::eyre!(
+                "proofs-history.db=rocksdb but storage path contains MDBX marker mdbx.dat: {}",
+                path.display()
+            )),
+            Self::Mdbx if has_rocksdb_marker => Err(eyre::eyre!(
+                "proofs-history.db=mdbx but storage path contains RocksDB marker CURRENT: {}",
+                path.display()
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Runtime tuning options for the `RocksDB` proofs history backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::Args)]
+pub struct ProofsHistoryRocksdbArgs {
+    /// `RocksDB` block cache size in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.block-cache-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_BLOCK_CACHE_SIZE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_MIB,
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub block_cache_size_mib: u64,
+
+    /// Bytes-per-sync threshold in `MiB`. Set 0 to disable.
+    #[arg(
+        long = "proofs-history.rocksdb.bytes-per-sync-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_BYTES_PER_SYNC_MIB",
+        default_value_t = DEFAULT_ROCKSDB_BYTES_PER_SYNC_MIB,
+        hide = true
+    )]
+    pub bytes_per_sync_mib: u64,
+
+    /// Readahead size in `MiB` for compaction input reads. Set 0 to disable.
+    #[arg(
+        long = "proofs-history.rocksdb.compaction-readahead-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB,
+        hide = true
+    )]
+    pub compaction_readahead_size_mib: u64,
+
+    /// Number of L0 files that triggers compaction.
+    #[arg(
+        long = "proofs-history.rocksdb.level-zero-file-num-compaction-trigger",
+        value_name = "PROOFS_HISTORY_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER",
+        default_value_t = DEFAULT_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub level_zero_file_num_compaction_trigger: i32,
+
+    /// Number of L0 files that triggers write slowdown. Set 0 to disable slowdown.
+    #[arg(
+        long = "proofs-history.rocksdb.level-zero-slowdown-writes-trigger",
+        value_name = "PROOFS_HISTORY_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER",
+        default_value_t = DEFAULT_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER,
+        value_parser = clap::value_parser!(i32).range(0..),
+        hide = true
+    )]
+    pub level_zero_slowdown_writes_trigger: i32,
+
+    /// Number of L0 files that stops writes.
+    #[arg(
+        long = "proofs-history.rocksdb.level-zero-stop-writes-trigger",
+        value_name = "PROOFS_HISTORY_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER",
+        default_value_t = DEFAULT_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub level_zero_stop_writes_trigger: i32,
+
+    /// Maximum `RocksDB` background jobs for proof history.
+    #[arg(
+        long = "proofs-history.rocksdb.max-background-jobs",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_BACKGROUND_JOBS",
+        default_value_t = DEFAULT_ROCKSDB_MAX_BACKGROUND_JOBS,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub max_background_jobs: i32,
+
+    /// Maximum subcompactions per compaction.
+    #[arg(
+        long = "proofs-history.rocksdb.max-subcompactions",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_SUBCOMPACTIONS",
+        default_value_t = DEFAULT_ROCKSDB_MAX_SUBCOMPACTIONS,
+        value_parser = clap::value_parser!(u32).range(1..),
+        hide = true
+    )]
+    pub max_subcompactions: u32,
+
+    /// Maximum total WAL size in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.max-total-wal-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_TOTAL_WAL_SIZE_MIB",
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub max_total_wal_size_mib: Option<u64>,
+
+    /// Maximum write buffers per proof-history column family.
+    #[arg(
+        long = "proofs-history.rocksdb.max-write-buffer-number",
+        value_name = "PROOFS_HISTORY_ROCKSDB_MAX_WRITE_BUFFER_NUMBER",
+        default_value_t = DEFAULT_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,
+        value_parser = clap::value_parser!(i32).range(1..),
+        hide = true
+    )]
+    pub max_write_buffer_number: i32,
+
+    /// Base target SST file size in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.target-file-size-base-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB,
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub target_file_size_base_mib: u64,
+
+    /// Write buffer size per proof-history column family in `MiB`.
+    #[arg(
+        long = "proofs-history.rocksdb.write-buffer-size-mib",
+        value_name = "PROOFS_HISTORY_ROCKSDB_WRITE_BUFFER_SIZE_MIB",
+        default_value_t = DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB,
+        value_parser = clap::value_parser!(u64).range(1..),
+        hide = true
+    )]
+    pub write_buffer_size_mib: u64,
+
+    /// Enable direct I/O for `RocksDB` flush and compaction.
+    #[arg(
+        long = "proofs-history.rocksdb.direct-io-for-flush-and-compaction",
+        default_value_t = true,
+        action = ArgAction::Set,
+        hide = true
+    )]
+    pub direct_io_for_flush_and_compaction: bool,
+}
+
+impl Default for ProofsHistoryRocksdbArgs {
+    fn default() -> Self {
+        Self {
+            block_cache_size_mib: DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_MIB,
+            bytes_per_sync_mib: DEFAULT_ROCKSDB_BYTES_PER_SYNC_MIB,
+            compaction_readahead_size_mib: DEFAULT_ROCKSDB_COMPACTION_READAHEAD_SIZE_MIB,
+            level_zero_file_num_compaction_trigger:
+                DEFAULT_ROCKSDB_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
+            level_zero_slowdown_writes_trigger: DEFAULT_ROCKSDB_LEVEL_ZERO_SLOWDOWN_WRITES_TRIGGER,
+            level_zero_stop_writes_trigger: DEFAULT_ROCKSDB_LEVEL_ZERO_STOP_WRITES_TRIGGER,
+            max_background_jobs: DEFAULT_ROCKSDB_MAX_BACKGROUND_JOBS,
+            max_subcompactions: DEFAULT_ROCKSDB_MAX_SUBCOMPACTIONS,
+            max_total_wal_size_mib: None,
+            max_write_buffer_number: DEFAULT_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,
+            target_file_size_base_mib: DEFAULT_ROCKSDB_TARGET_FILE_SIZE_BASE_MIB,
+            write_buffer_size_mib: DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB,
+            direct_io_for_flush_and_compaction: true,
+        }
+    }
+}
+
+impl ProofsHistoryRocksdbArgs {
+    /// Converts CLI arguments into storage options.
+    pub fn storage_options(self) -> eyre::Result<RocksdbProofsStorageOptions> {
+        if self.level_zero_slowdown_writes_trigger > 0
+            && self.level_zero_file_num_compaction_trigger > self.level_zero_slowdown_writes_trigger
+        {
+            return Err(eyre::eyre!(
+                "proofs-history.rocksdb.level-zero-file-num-compaction-trigger ({}) must be <= level-zero-slowdown-writes-trigger ({}) when slowdown is enabled",
+                self.level_zero_file_num_compaction_trigger,
+                self.level_zero_slowdown_writes_trigger
+            ));
+        }
+
+        if self.level_zero_file_num_compaction_trigger > self.level_zero_stop_writes_trigger {
+            return Err(eyre::eyre!(
+                "proofs-history.rocksdb.level-zero-file-num-compaction-trigger ({}) must be <= level-zero-stop-writes-trigger ({})",
+                self.level_zero_file_num_compaction_trigger,
+                self.level_zero_stop_writes_trigger
+            ));
+        }
+
+        Ok(RocksdbProofsStorageOptions {
+            block_cache_size: mib_to_usize(self.block_cache_size_mib),
+            bytes_per_sync: self.bytes_per_sync_mib.saturating_mul(MIB),
+            compaction_readahead_size: mib_to_usize(self.compaction_readahead_size_mib),
+            level_zero_file_num_compaction_trigger: self.level_zero_file_num_compaction_trigger,
+            level_zero_slowdown_writes_trigger: self.level_zero_slowdown_writes_trigger,
+            level_zero_stop_writes_trigger: self.level_zero_stop_writes_trigger,
+            max_background_jobs: self.max_background_jobs,
+            max_subcompactions: self.max_subcompactions,
+            max_total_wal_size: self.max_total_wal_size_mib.map(|size| size.saturating_mul(MIB)),
+            max_write_buffer_number: self.max_write_buffer_number,
+            target_file_size_base: self.target_file_size_base_mib.saturating_mul(MIB),
+            write_buffer_size: mib_to_usize(self.write_buffer_size_mib),
+            use_direct_io_for_flush_and_compaction: self.direct_io_for_flush_and_compaction,
+        })
+    }
+}
+
+fn mib_to_usize(size_mib: u64) -> usize {
+    usize::try_from(size_mib.saturating_mul(MIB)).unwrap_or(usize::MAX)
 }
 
 /// Parameters for rollup configuration
@@ -90,13 +350,24 @@ pub struct RollupArgs {
     #[arg(long = "proofs-history.storage-path", value_name = "PROOFS_HISTORY_STORAGE_PATH")]
     pub proofs_history_storage_path: Option<PathBuf>,
 
+    /// The on-disk database backend for proofs history.
+    #[arg(long = "proofs-history.db", value_name = "PROOFS_HISTORY_DB", default_value = "mdbx")]
+    pub proofs_history_db: ProofsHistoryDbBackend,
+
+    /// Runtime tuning options for the `RocksDB` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
+    ///
+    /// Must be greater than 12 hours of blocks based on 2 seconds block time.
     #[arg(
         long = "proofs-history.window",
-        default_value_t = 1_296_000,
-        value_name = "PROOFS_HISTORY_WINDOW"
+        default_value_t = DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        value_name = "PROOFS_HISTORY_WINDOW",
+        value_parser = clap::value_parser!(u64).range((TWELVE_HOURS_IN_BLOCKS + 1)..)
     )]
     pub proofs_history_window: u64,
 
@@ -119,6 +390,7 @@ pub struct RollupArgs {
         value_parser = humantime::parse_duration
     )]
     pub proofs_history_prune_interval: Duration,
+
     /// Verification interval: perform full block execution every N blocks for data integrity.
     /// - 0: Disabled (Default) (always use fast path with pre-computed data from notifications)
     /// - 1: Always verify (always execute blocks, slowest)
@@ -157,7 +429,9 @@ impl Default for RollupArgs {
             max_inflight_delegated_slots: 1,
             proofs_history: false,
             proofs_history_storage_path: None,
-            proofs_history_window: 1_296_000,
+            proofs_history_db: ProofsHistoryDbBackend::default(),
+            proofs_history_rocksdb: Default::default(),
+            proofs_history_window: DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
             upgrade_signal: UpgradeSignalArgs::default(),
@@ -169,7 +443,7 @@ impl Default for RollupArgs {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
-    use clap::{Args, Parser};
+    use clap::{Args, CommandFactory, Parser};
 
     use super::*;
 
@@ -304,5 +578,156 @@ mod tests {
             args.upgrade_signal_l1_rpc.upgrade_signal_l1_rpc.as_ref().map(|url| url.as_str()),
             Some("http://localhost:8545/")
         );
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_default() {
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_v2_alias() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.db", "v2"]).args;
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Rocksdb);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_mdbx() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history",
+            "--proofs-history.db",
+            "mdbx",
+        ])
+        .args;
+        assert!(args.proofs_history);
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_db_without_enabling_history() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.db", "mdbx"]).args;
+        assert!(!args.proofs_history);
+        assert_eq!(args.proofs_history_db, ProofsHistoryDbBackend::Mdbx);
+    }
+
+    #[test]
+    fn test_proofs_history_db_rejects_ambiguous_storage_markers() {
+        let dir = std::env::temp_dir().join(format!(
+            "proofs-history-markers-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("CURRENT"), b"rocksdb").unwrap();
+        std::fs::write(dir.join("mdbx.dat"), b"mdbx").unwrap();
+
+        let rocksdb_error =
+            ProofsHistoryDbBackend::Rocksdb.ensure_storage_path_matches(&dir).unwrap_err();
+        assert!(
+            rocksdb_error
+                .to_string()
+                .contains("both RocksDB marker CURRENT and MDBX marker mdbx.dat")
+        );
+
+        let mdbx_error =
+            ProofsHistoryDbBackend::Mdbx.ensure_storage_path_matches(&dir).unwrap_err();
+        assert!(
+            mdbx_error.to_string().contains("both RocksDB marker CURRENT and MDBX marker mdbx.dat")
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn test_parse_proofs_history_rocksdb_tuning_options() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history.rocksdb.block-cache-size-mib",
+            "256",
+            "--proofs-history.rocksdb.bytes-per-sync-mib",
+            "4",
+            "--proofs-history.rocksdb.compaction-readahead-size-mib",
+            "8",
+            "--proofs-history.rocksdb.level-zero-file-num-compaction-trigger",
+            "6",
+            "--proofs-history.rocksdb.level-zero-slowdown-writes-trigger",
+            "0",
+            "--proofs-history.rocksdb.level-zero-stop-writes-trigger",
+            "64",
+            "--proofs-history.rocksdb.max-background-jobs",
+            "2",
+            "--proofs-history.rocksdb.max-subcompactions",
+            "2",
+            "--proofs-history.rocksdb.max-total-wal-size-mib",
+            "1024",
+            "--proofs-history.rocksdb.max-write-buffer-number",
+            "4",
+            "--proofs-history.rocksdb.target-file-size-base-mib",
+            "512",
+            "--proofs-history.rocksdb.write-buffer-size-mib",
+            "128",
+            "--proofs-history.rocksdb.direct-io-for-flush-and-compaction",
+            "false",
+        ])
+        .args;
+
+        let options = args.proofs_history_rocksdb.storage_options().unwrap();
+        assert_eq!(options.block_cache_size, mib_to_usize(256));
+        assert_eq!(options.bytes_per_sync, 4 * MIB);
+        assert_eq!(options.compaction_readahead_size, mib_to_usize(8));
+        assert_eq!(options.level_zero_file_num_compaction_trigger, 6);
+        assert_eq!(options.level_zero_slowdown_writes_trigger, 0);
+        assert_eq!(options.level_zero_stop_writes_trigger, 64);
+        assert_eq!(options.max_background_jobs, 2);
+        assert_eq!(options.max_subcompactions, 2);
+        assert_eq!(options.max_total_wal_size, Some(1024 * MIB));
+        assert_eq!(options.max_write_buffer_number, 4);
+        assert_eq!(options.target_file_size_base, 512 * MIB);
+        assert_eq!(options.write_buffer_size, mib_to_usize(128));
+        assert!(!options.use_direct_io_for_flush_and_compaction);
+    }
+
+    #[test]
+    fn test_proofs_history_rocksdb_tuning_options_hidden_from_help() {
+        let help = CommandParser::<RollupArgs>::command().render_help().to_string();
+        assert!(!help.contains("proofs-history.rocksdb.compression"));
+        assert!(!help.contains("proofs-history.rocksdb.max-background-jobs"));
+        assert!(!help.contains("proofs-history.rocksdb.rate-limit-mib-per-sec"));
+    }
+
+    #[test]
+    fn test_parse_proofs_history_rocksdb_tuning_rejects_bad_l0_ordering() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history.rocksdb.level-zero-file-num-compaction-trigger",
+            "40",
+            "--proofs-history.rocksdb.level-zero-stop-writes-trigger",
+            "1",
+        ])
+        .args;
+
+        assert!(args.proofs_history_rocksdb.storage_options().is_err());
+    }
+
+    #[test]
+    fn test_parse_proofs_history_window() {
+        let args =
+            CommandParser::<RollupArgs>::parse_from(["reth", "--proofs-history.window", "21601"])
+                .args;
+        assert_eq!(args.proofs_history_window, 21_601);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_window_rejects_twelve_hours_or_less() {
+        let result = CommandParser::<RollupArgs>::try_parse_from([
+            "reth",
+            "--proofs-history.window",
+            "21600",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -12,7 +12,10 @@ use reth_db_api as _;
 
 /// CLI argument parsing for the Base node.
 pub mod args;
-pub use args::TxpoolOrdering;
+pub use args::{
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs,
+    TWELVE_HOURS_IN_BLOCKS, TxpoolOrdering,
+};
 
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)
 /// trait.

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -1,109 +1,189 @@
-//! Node luncher with proof history support.
+//! Node launcher with proof history support.
 
 use std::{sync::Arc, time::Duration};
 
-use base_common_consensus::BaseTxEnvelope;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_exex::BaseProofsExEx;
-use base_execution_payload_builder::BasePayloadBuilderAttributes;
 use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{BaseProofsStorage, db::MdbxProofsStorage};
+use base_execution_trie::{
+    BaseProofsBatchStore, BaseProofsStorage, MdbxProofsStorage, RocksdbProofsStorage,
+};
 use eyre::ErrReport;
 use futures::FutureExt;
 use reth_db::DatabaseEnv;
 use reth_db_api::database_metrics::DatabaseMetrics;
-use reth_node_builder::{FullNodeComponents, NodeBuilder, WithLaunchContext};
+use reth_node_builder::{
+    FullNodeComponents, Node as RethNode, NodeBuilder, NodeBuilderWithComponents, RethFullAdapter,
+    WithLaunchContext,
+};
 use reth_tasks::TaskExecutor;
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::{BaseNode, args::RollupArgs};
+use crate::{
+    BaseNode, BaseNodeComponentBuilder,
+    args::{DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, RollupArgs},
+};
+
+type ProofHistoryNodeTypes = RethFullAdapter<Arc<DatabaseEnv>, BaseNode>;
+type ProofHistoryNodeBuilder = WithLaunchContext<
+    NodeBuilderWithComponents<
+        ProofHistoryNodeTypes,
+        BaseNodeComponentBuilder<ProofHistoryNodeTypes>,
+        <BaseNode as RethNode<ProofHistoryNodeTypes>>::AddOns,
+    >,
+>;
 
 /// - no proofs history (plain node),
 /// - in-mem proofs storage,
-/// - MDBX proofs storage.
+/// - on-disk proofs storage.
 pub async fn launch_node_with_proof_history(
     builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, BaseChainSpec>>,
     args: RollupArgs,
 ) -> eyre::Result<(), ErrReport> {
     let RollupArgs {
+        sequencer,
+        disable_txpool_gossip,
+        compute_pending_block,
+        discovery_v4,
+        sequencer_headers,
+        min_suggested_priority_fee,
+        txpool_ordering,
+        max_inflight_delegated_slots,
         proofs_history,
+        proofs_history_storage_path,
+        proofs_history_db,
+        proofs_history_rocksdb,
         proofs_history_window,
         proofs_history_prune_interval,
         proofs_history_verification_interval,
-        ..
+        upgrade_signal,
+        upgrade_signal_l1_rpc,
     } = args;
 
     // Start from a plain BaseNode builder
-    let mut node_builder = builder.node(BaseNode::new(args.clone()));
+    let mut node_builder = builder.node(BaseNode::new(RollupArgs {
+        sequencer,
+        disable_txpool_gossip,
+        compute_pending_block,
+        discovery_v4,
+        sequencer_headers,
+        min_suggested_priority_fee,
+        txpool_ordering,
+        max_inflight_delegated_slots,
+        proofs_history: false,
+        proofs_history_storage_path: None,
+        proofs_history_db: ProofsHistoryDbBackend::default(),
+        proofs_history_rocksdb: Default::default(),
+        proofs_history_window: DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
+        proofs_history_prune_interval: Duration::from_secs(15),
+        proofs_history_verification_interval: 0,
+        upgrade_signal,
+        upgrade_signal_l1_rpc,
+    }));
 
     if proofs_history {
-        let path = args
-            .proofs_history_storage_path
-            .clone()
-            .expect("Path must be provided if not using in-memory storage");
+        let path = proofs_history_storage_path.ok_or_else(|| {
+            eyre::eyre!("--proofs-history requires --proofs-history.storage-path")
+        })?;
         info!(target: "reth::cli", "Using on-disk storage for proofs history");
+        proofs_history_db.ensure_storage_path_matches(&path)?;
 
-        let mdbx = Arc::new(
-            MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        );
-        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
-
-        let storage_exec = storage.clone();
-
-        node_builder = node_builder
-            .on_node_started(move |node| {
-                spawn_proofs_db_metrics(
-                    node.task_executor,
+        match proofs_history_db {
+            ProofsHistoryDbBackend::Rocksdb => {
+                let rocksdb = Arc::new(
+                    RocksdbProofsStorage::new_with_options(
+                        &path,
+                        proofs_history_rocksdb.storage_options()?,
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))?,
+                );
+                node_builder = install_proofs_history(
+                    node_builder,
+                    rocksdb,
+                    proofs_history_window,
+                    proofs_history_prune_interval,
+                    proofs_history_verification_interval,
+                );
+            }
+            ProofsHistoryDbBackend::Mdbx => {
+                let mdbx = Arc::new(
+                    MdbxProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                );
+                node_builder = install_proofs_history(
+                    node_builder,
                     mdbx,
-                    node.config.metrics.push_gateway_interval,
+                    proofs_history_window,
+                    proofs_history_prune_interval,
+                    proofs_history_verification_interval,
                 );
-                Ok(())
-            })
-            .install_exex("proofs-history", async move |exex_context| {
-                Ok(BaseProofsExEx::builder(exex_context, storage_exec)
-                    .with_proofs_history_window(proofs_history_window)
-                    .with_proofs_history_prune_interval(proofs_history_prune_interval)
-                    .with_verification_interval(proofs_history_verification_interval)
-                    .build()
-                    .run()
-                    .boxed())
-            })
-            .extend_rpc_modules(move |ctx| {
-                let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
-                let debug_ext: DebugApiExt<
-                    _,
-                    _,
-                    _,
-                    _,
-                    BasePayloadBuilderAttributes<BaseTxEnvelope>,
-                > = DebugApiExt::new(
-                    ctx.node().provider().clone(),
-                    ctx.registry.eth_api().clone(),
-                    storage,
-                    ctx.node().task_executor().clone(),
-                    ctx.node().evm_config().clone(),
-                );
-                ctx.modules.replace_configured(api_ext.into_rpc())?;
-                ctx.modules.replace_configured(debug_ext.into_rpc())?;
-                Ok(())
-            });
+            }
+        }
     }
 
     // In all cases (with or without proofs), launch the node.
     let handle = node_builder.launch_with_debug_capabilities().await?;
     handle.node_exit_future.await
 }
+
+fn install_proofs_history<S>(
+    node_builder: ProofHistoryNodeBuilder,
+    storage_backend: Arc<S>,
+    proofs_history_window: u64,
+    proofs_history_prune_interval: Duration,
+    proofs_history_verification_interval: u64,
+) -> ProofHistoryNodeBuilder
+where
+    S: BaseProofsBatchStore + DatabaseMetrics + Send + Sync + 'static,
+{
+    let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
+    let storage_exec = storage.clone();
+
+    node_builder
+        .on_node_started(move |node| {
+            spawn_proofs_db_metrics(
+                node.task_executor,
+                storage_backend,
+                node.config.metrics.push_gateway_interval,
+            );
+            Ok(())
+        })
+        .install_exex("proofs-history", async move |exex_context| {
+            Ok(BaseProofsExEx::builder(exex_context, storage_exec)
+                .with_proofs_history_window(proofs_history_window)
+                .with_proofs_history_prune_interval(proofs_history_prune_interval)
+                .with_verification_interval(proofs_history_verification_interval)
+                .build()
+                .run()
+                .boxed())
+        })
+        .extend_rpc_modules(move |ctx| {
+            let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+            let debug_ext = DebugApiExt::new(
+                ctx.node().provider().clone(),
+                ctx.registry.eth_api().clone(),
+                storage,
+                ctx.node().task_executor().clone(),
+                ctx.node().evm_config().clone(),
+            );
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            ctx.modules.replace_configured(debug_ext.into_rpc())?;
+            Ok(())
+        })
+}
+
 /// Spawns a task that periodically reports metrics for the proofs DB.
-fn spawn_proofs_db_metrics(
+fn spawn_proofs_db_metrics<S>(
     executor: TaskExecutor,
-    storage: Arc<MdbxProofsStorage>,
+    storage: Arc<S>,
     metrics_report_interval: Duration,
-) {
+) where
+    S: DatabaseMetrics + Send + Sync + 'static,
+{
     executor.spawn_critical_task("base-proofs-storage-metrics", async move {
         info!(
             target: "reth::cli",

--- a/crates/execution/proofs/Cargo.toml
+++ b/crates/execution/proofs/Cargo.toml
@@ -22,8 +22,6 @@ reth-node-api.workspace = true
 base-node-core.workspace = true
 base-execution-rpc.workspace = true
 base-execution-trie.workspace = true
-base-common-consensus.workspace = true
-base-execution-payload-builder.workspace = true
 base-execution-exex = { workspace = true, features = ["metrics"] }
 
 # tokio

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -1,14 +1,14 @@
 use std::{sync::Arc, time::Duration};
 
-use base_common_consensus::BaseTxEnvelope;
 use base_execution_exex::BaseProofsExEx;
-use base_execution_payload_builder::BasePayloadBuilderAttributes;
 use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{BaseProofsStorage, MdbxProofsStorage};
-use base_node_core::args::RollupArgs;
+use base_execution_trie::{
+    BaseProofsBatchStore, BaseProofsStorage, MdbxProofsStorage, RocksdbProofsStorage,
+};
+use base_node_core::args::{ProofsHistoryDbBackend, RollupArgs};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_db::database_metrics::DatabaseMetrics;
 use reth_node_api::FullNodeComponents;
@@ -19,15 +19,15 @@ use tracing::{error, info};
 /// Type alias for the proofs history configuration.
 pub type ProofsHistoryConfig = RollupArgs;
 
-/// Helper struct that wires the transaction pool features into the node builder.
+/// Helper struct that wires proofs history into the node builder.
 #[derive(Debug, Clone)]
 pub struct ProofsHistoryExtension {
-    /// Transaction pool configuration.
+    /// Proofs history configuration.
     config: RollupArgs,
 }
 
 impl ProofsHistoryExtension {
-    /// Creates a new transaction pool extension helper.
+    /// Creates a new proofs history extension helper.
     pub const fn new(config: RollupArgs) -> Self {
         Self { config }
     }
@@ -39,68 +39,83 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         // TODO: if NodeHooks exposes the underlying Builder, we can call launch_node_with_proof_history
         let args = self.config;
         let proofs_history_enabled = args.proofs_history;
+        let proofs_history_db = args.proofs_history_db;
+        let proofs_history_rocksdb = args.proofs_history_rocksdb;
         let proofs_history_window = args.proofs_history_window;
         let proofs_history_prune_interval = args.proofs_history_prune_interval;
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
 
         if proofs_history_enabled {
-            let path = args
-                .proofs_history_storage_path
-                .expect("Path must be provided if not using in-memory storage");
+            let Some(path) = args.proofs_history_storage_path else {
+                error!(
+                    target: "reth::cli",
+                    "--proofs-history requires --proofs-history.storage-path"
+                );
+                return hooks.add_node_started_hook(|_| {
+                    Err(eyre::eyre!("--proofs-history requires --proofs-history.storage-path"))
+                });
+            };
             info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
-            let mdbx = match MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
-            {
-                Ok(mdbx) => mdbx,
-                Err(e) => {
-                    error!(target: "reth::cli", error = ?e, "Failed to create MdbxProofsStorage, continuing without proofs history");
-                    return hooks;
-                }
-            };
-            let mdbx = Arc::new(mdbx);
-            let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
+            if let Err(e) = proofs_history_db.ensure_storage_path_matches(&path) {
+                error!(target: "reth::cli", error = ?e, "Proofs history storage path does not match selected backend");
+                return hooks.add_node_started_hook(move |_| Err(e));
+            }
 
-            let storage_exec = storage.clone();
-
-            // ignore unused if metrics feature is disabled
-            hooks = hooks.add_node_started_hook(move |node| {
-                spawn_proofs_db_metrics(
-                    node.task_executor,
-                    mdbx,
-                    node.config.metrics.push_gateway_interval,
-                );
-                Ok(())
-            });
-
-            hooks = hooks
-                .install_exex("proofs-history", async move |exex_context| {
-                    Ok(BaseProofsExEx::builder(exex_context, storage_exec)
-                        .with_proofs_history_prune_interval(proofs_history_prune_interval)
-                        .with_proofs_history_window(proofs_history_window)
-                        .with_verification_interval(proofs_history_verification_interval)
-                        .build()
-                        .run())
-                })
-                .add_rpc_module(move |ctx| {
-                    let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
-                    let debug_ext: DebugApiExt<
-                        _,
-                        _,
-                        _,
-                        _,
-                        BasePayloadBuilderAttributes<BaseTxEnvelope>,
-                    > = DebugApiExt::new(
-                        ctx.node().provider().clone(),
-                        ctx.registry.eth_api().clone(),
-                        storage,
-                        ctx.node().task_executor().clone(),
-                        ctx.node().evm_config().clone(),
+            match proofs_history_db {
+                ProofsHistoryDbBackend::Rocksdb => {
+                    let storage_options = match proofs_history_rocksdb.storage_options() {
+                        Ok(options) => options,
+                        Err(e) => {
+                            error!(target: "reth::cli", error = ?e, "Invalid RocksDB proofs history options");
+                            return hooks.add_node_started_hook(move |_| Err(e));
+                        }
+                    };
+                    let rocksdb =
+                        match RocksdbProofsStorage::new_with_options(&path, storage_options)
+                            .map_err(|e| eyre::eyre!("Failed to create RocksdbProofsStorage: {e}"))
+                        {
+                            Ok(rocksdb) => rocksdb,
+                            Err(e) => {
+                                error!(
+                                    target: "reth::cli",
+                                    error = ?e,
+                                    "Failed to create RocksdbProofsStorage"
+                                );
+                                return hooks.add_node_started_hook(move |_| Err(e));
+                            }
+                        };
+                    hooks = install_proofs_history(
+                        hooks,
+                        Arc::new(rocksdb),
+                        proofs_history_window,
+                        proofs_history_prune_interval,
+                        proofs_history_verification_interval,
                     );
-                    ctx.modules.replace_configured(api_ext.into_rpc())?;
-                    ctx.modules.replace_configured(debug_ext.into_rpc())?;
-                    Ok(())
-                });
+                }
+                ProofsHistoryDbBackend::Mdbx => {
+                    let mdbx = match MdbxProofsStorage::new(&path)
+                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
+                    {
+                        Ok(mdbx) => mdbx,
+                        Err(e) => {
+                            error!(
+                                target: "reth::cli",
+                                error = ?e,
+                                "Failed to create MdbxProofsStorage"
+                            );
+                            return hooks.add_node_started_hook(move |_| Err(e));
+                        }
+                    };
+                    hooks = install_proofs_history(
+                        hooks,
+                        Arc::new(mdbx),
+                        proofs_history_window,
+                        proofs_history_prune_interval,
+                        proofs_history_verification_interval,
+                    );
+                }
+            }
         }
         hooks
     }
@@ -114,12 +129,60 @@ impl FromExtensionConfig for ProofsHistoryExtension {
     }
 }
 
+fn install_proofs_history<S>(
+    mut hooks: NodeHooks,
+    storage_backend: Arc<S>,
+    proofs_history_window: u64,
+    proofs_history_prune_interval: Duration,
+    proofs_history_verification_interval: u64,
+) -> NodeHooks
+where
+    S: BaseProofsBatchStore + DatabaseMetrics + Send + Sync + 'static,
+{
+    let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
+    let storage_exec = storage.clone();
+
+    hooks = hooks.add_node_started_hook(move |node| {
+        spawn_proofs_db_metrics(
+            node.task_executor,
+            storage_backend,
+            node.config.metrics.push_gateway_interval,
+        );
+        Ok(())
+    });
+
+    hooks
+        .install_exex("proofs-history", async move |exex_context| {
+            Ok(BaseProofsExEx::builder(exex_context, storage_exec)
+                .with_proofs_history_prune_interval(proofs_history_prune_interval)
+                .with_proofs_history_window(proofs_history_window)
+                .with_verification_interval(proofs_history_verification_interval)
+                .build()
+                .run())
+        })
+        .add_rpc_module(move |ctx| {
+            let api_ext = EthApiExt::new(ctx.registry.eth_api().clone(), storage.clone());
+            let debug_ext = DebugApiExt::new(
+                ctx.node().provider().clone(),
+                ctx.registry.eth_api().clone(),
+                storage,
+                ctx.node().task_executor().clone(),
+                ctx.node().evm_config().clone(),
+            );
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            ctx.modules.replace_configured(debug_ext.into_rpc())?;
+            Ok(())
+        })
+}
+
 /// Spawns a task that periodically reports metrics for the proofs DB.
-fn spawn_proofs_db_metrics(
+fn spawn_proofs_db_metrics<S>(
     executor: TaskExecutor,
-    storage: Arc<MdbxProofsStorage>,
+    storage: Arc<S>,
     metrics_report_interval: Duration,
-) {
+) where
+    S: DatabaseMetrics + Send + Sync + 'static,
+{
     executor.spawn_critical_task("base-proofs-storage-metrics", async move {
         info!(
             target: "reth::cli",

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 use alloy_primitives::keccak256;
-use derive_more::Constructor;
+use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 use reth_primitives_traits::{Account, Bytecode};
 use reth_provider::{
     AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, ProviderError,
@@ -34,7 +34,6 @@ use crate::{
 };
 
 /// State provider for external proofs storage.
-#[derive(Constructor)]
 pub struct BaseProofsStateProviderRef<'a, Storage: BaseProofsStore> {
     /// Historical state provider for non-state related tasks.
     latest: Box<dyn StateProvider + Send + 'a>,
@@ -44,6 +43,34 @@ pub struct BaseProofsStateProviderRef<'a, Storage: BaseProofsStore> {
 
     /// Max block number that can be used for state lookups.
     block_number: BlockNumber,
+
+    /// Lazily-acquired read-only transaction shared across all EVM state reads.
+    ///
+    /// Acquired once on the first [`basic_account`](AccountReader::basic_account) or
+    /// [`storage`](StateProvider::storage) call and reused for the lifetime of this provider,
+    /// so that all EVM state reads within a single execution context share one database snapshot
+    /// and avoid per-call transaction-acquisition contention.
+    lazy_tx: Mutex<Option<Storage::Tx<'a>>>,
+}
+
+impl<'a, Storage: BaseProofsStore> BaseProofsStateProviderRef<'a, Storage> {
+    /// Creates a new state provider.
+    pub fn new(
+        latest: Box<dyn StateProvider + Send + 'a>,
+        storage: &'a BaseProofsStorage<Storage>,
+        block_number: BlockNumber,
+    ) -> Self {
+        Self { latest, storage, block_number, lazy_tx: Mutex::new(None) }
+    }
+
+    fn ensure_tx(&self) -> ProviderResult<MappedMutexGuard<'_, Storage::Tx<'a>>> {
+        let mut guard = self.lazy_tx.lock();
+        if guard.is_none() {
+            *guard = Some(self.storage.ro_tx().map_err(Into::<ProviderError>::into)?);
+        }
+
+        Ok(MutexGuard::map(guard, |tx| tx.as_mut().expect("read-only transaction initialized")))
+    }
 }
 
 impl<'a, Storage> Debug for BaseProofsStateProviderRef<'a, Storage>
@@ -64,13 +91,14 @@ impl<'a, Storage: BaseProofsStore + Clone> BaseProofsStateProviderRef<'a, Storag
         address: Address,
         hashed_key: B256,
     ) -> ProviderResult<Option<StorageValue>> {
+        let tx = self.ensure_tx()?;
         Ok(self
             .storage
-            .storage_hashed_cursor(keccak256(address.0), self.block_number)
+            .storage_hashed_cursor_with_tx(&tx, keccak256(address.0), self.block_number)
             .map_err(Into::<ProviderError>::into)?
             .seek(hashed_key)
             .map_err(Into::<ProviderError>::into)?
-            .and_then(|(key, storage)| (key == hashed_key).then_some(storage)))
+            .and_then(|(key, val)| (key == hashed_key).then_some(val)))
     }
 }
 
@@ -206,9 +234,10 @@ impl<'a, Storage: BaseProofsStore> HashedPostStateProvider
 impl<'a, Storage: BaseProofsStore> AccountReader for BaseProofsStateProviderRef<'a, Storage> {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         let hashed_key = keccak256(address.0);
+        let tx = self.ensure_tx()?;
         Ok(self
             .storage
-            .account_hashed_cursor(self.block_number)
+            .account_hashed_cursor_with_tx(&tx, self.block_number)
             .map_err(Into::<ProviderError>::into)?
             .seek(hashed_key)
             .map_err(Into::<ProviderError>::into)?

--- a/crates/execution/trie/tests/live.rs
+++ b/crates/execution/trie/tests/live.rs
@@ -2,11 +2,11 @@
 
 use std::sync::Arc;
 
-use alloy_consensus::{BlockHeader, Header, TxEip2930, constants::ETH_TO_WEI};
+use alloy_consensus::{BlockHeader, Header, SignableTransaction, TxEip2930, constants::ETH_TO_WEI};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStorageError, MdbxProofsStorage, initialize::InitializationJob,
+    BaseProofsStorage, BaseProofsStorageError, RocksdbProofsStorage, initialize::InitializationJob,
     live::LiveTrieCollector,
 };
 use derive_more::Constructor;
@@ -17,7 +17,7 @@ use reth_ethereum_primitives::{Block, BlockBody, Receipt, Transaction, Transacti
 use reth_evm::{ConfigureEvm, execute::Executor};
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{NodePrimitives, NodeTypesWithDB};
-use reth_primitives_traits::{Block as _, RecoveredBlock};
+use reth_primitives_traits::{Block as _, RecoveredBlock, crypto::secp256k1::sign_message};
 use reth_provider::{
     BlockWriter as _, ExecutionOutcome, HashedPostStateProvider, LatestStateProviderRef,
     ProviderFactory, StateRootProvider,
@@ -36,8 +36,6 @@ fn public_key_to_address(pubkey: secp256k1::PublicKey) -> Address {
 
 /// Signs a transaction with the given keypair.
 fn sign_tx_with_key_pair(key_pair: Keypair, tx: Transaction) -> TransactionSigned {
-    use alloy_consensus::SignableTransaction;
-    use reth_primitives_traits::crypto::secp256k1::sign_message;
     let secret = B256::from_slice(&key_pair.secret_bytes());
     let sig = sign_message(secret, tx.signature_hash()).unwrap();
     tx.into_signed(sig).into()
@@ -220,7 +218,7 @@ fn run_test_scenario<N>(
     provider_factory: ProviderFactory<N>,
     chain_spec: Arc<ChainSpec>,
     key_pair: Keypair,
-    storage: BaseProofsStorage<Arc<MdbxProofsStorage>>,
+    storage: BaseProofsStorage<Arc<RocksdbProofsStorage>>,
 ) -> eyre::Result<()>
 where
     N: ProviderNodeTypes<
@@ -299,8 +297,8 @@ where
 #[test]
 fn test_execute_and_store_block_updates() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")).into();
 
     // Create a keypair for signing transactions
     let secp = Secp256k1::new();
@@ -332,8 +330,8 @@ fn test_execute_and_store_block_updates() {
 #[test]
 fn test_execute_and_store_block_updates_missing_parent_block() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")).into();
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -386,8 +384,8 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
 #[test]
 fn test_execute_and_store_block_updates_state_root_mismatch() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")).into();
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -451,8 +449,8 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
 #[test]
 fn test_multiple_blocks_before_and_after_initialization() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")).into();
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());
@@ -489,8 +487,8 @@ fn test_multiple_blocks_before_and_after_initialization() {
 #[test]
 fn test_blocks_with_multiple_transactions() {
     let dir = TempDir::new().unwrap();
-    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
-        Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
+    let storage: BaseProofsStorage<Arc<RocksdbProofsStorage>> =
+        Arc::new(RocksdbProofsStorage::new(dir.path()).expect("env")).into();
 
     let secp = Secp256k1::new();
     let key_pair = Keypair::new(&secp, &mut rand_08::thread_rng());

--- a/crates/execution/trie/tests/tx_sharing.rs
+++ b/crates/execution/trie/tests/tx_sharing.rs
@@ -27,7 +27,8 @@ use base_execution_trie::{
 };
 use reth_primitives_traits::Account;
 use reth_provider::{
-    StateProofProvider, StateRootProvider, StorageRootProvider, noop::NoopProvider,
+    AccountReader, StateProofProvider, StateProvider, StateRootProvider, StorageRootProvider,
+    noop::NoopProvider,
 };
 use reth_trie_common::{
     ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProofTargets, TrieInput,
@@ -236,6 +237,19 @@ fn storage_root_acquires_one_tx_per_call() {
         provider
             .storage_multiproof(address, &slots, hashed_storage.clone())
             .expect("storage_multiproof");
+    });
+}
+
+#[test]
+fn evm_state_reads_share_one_lazy_tx_per_provider() {
+    let (_dir, storage) = setup();
+    let provider = BaseProofsStateProviderRef::new(Box::<NoopProvider>::default(), &storage, 0);
+    let (address, slots) = seed_layout().into_iter().next().expect("seed");
+
+    assert_tx_acquisitions(&storage, 1, "evm_state_reads", || {
+        provider.basic_account(&address).expect("account");
+        provider.storage(address, slots[0]).expect("storage 0");
+        provider.storage(address, slots[1]).expect("storage 1");
     });
 }
 


### PR DESCRIPTION
Part of the RocksDB proof storage stack, stacked on the store-read PR.

Wires the fully-implemented RocksDB `BaseProofsStore` into the node:
- `proof_history.rs`: installs RocksDB backend in the node launcher
- `args.rs`: RocksDB CLI tuning args (block cache, write buffers, compaction)
- `proofs.rs`: dispatches between MDBX and RocksDB backends
- `exex/lib.rs`: `SYNC_BLOCKS_PER_TURN=50`
- CLI: `base_proofs init`, `prune`, `unwind` commands
  - `proofs unwind --target` removes proofs history/state updates at and after the target block, leaving the latest retained block as `target - 1`.
- Integration tests: `live.rs`, `tx_sharing.rs`

Stack:
- #3518 merged
- #3517 feat(trie/rocksdb): implement RocksDB block write path
- test(trie/rocksdb): add integration tests and benchmarks
- feat(trie/rocksdb): implement RocksdbVersionedCursor
- feat(trie/rocksdb): implement TrieCursor and HashedCursor trait impls
- feat(trie/rocksdb): implement BaseProofsStore read methods and cursor factories
- **this PR** feat(node): wire RocksDB proof storage into node and CLI
