### PR TITLE
feat(proof): add zk host worker wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5942,10 +5942,17 @@ dependencies = [
 name = "base-proof-zk-host"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
+ "base-proof-primitives",
+ "base-proof-worker",
+ "base-prover-service-client",
  "base-prover-service-protocol",
+ "chrono",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,7 +5948,6 @@ dependencies = [
  "base-proof-worker",
  "base-prover-service-client",
  "base-prover-service-protocol",
- "chrono",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/proof/zk/host/Cargo.toml
+++ b/crates/proof/zk/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base-proof-zk-host"
-description = "Host-side ZK proving primitives for the prover service."
+description = "Host-side ZK proving worker for the prover service."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -13,13 +13,21 @@ workspace = true
 
 [dependencies]
 # base
+base-proof-worker.workspace = true
+base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
 
 # async
+tokio-util.workspace = true
 async-trait.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
 
 # misc
+tracing.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+chrono.workspace = true
+alloy-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+base-proof-primitives = { workspace = true, features = ["std", "serde"] }

--- a/crates/proof/zk/host/Cargo.toml
+++ b/crates/proof/zk/host/Cargo.toml
@@ -27,7 +27,6 @@ tracing.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-chrono.workspace = true
 alloy-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 base-proof-primitives = { workspace = true, features = ["std", "serde"] }

--- a/crates/proof/zk/host/README.md
+++ b/crates/proof/zk/host/README.md
@@ -2,24 +2,13 @@
 
 Host-side ZK proving worker for the prover service.
 
-This crate provides the worker machinery that lets a ZK proving host pull jobs
-from the prover service over the JSON-RPC worker API and submit results back. It
-mirrors the structure of the TEE host (`base-proof-tee-nitro-host`):
+This crate adapts the shared worker machinery for ZK proving jobs. It provides
+[`ProofGenerator`], which claims a ZK job, drives a [`ZkProver`] backend to
+completion, and hands the proof result to `base_proof_worker::ProofSubmitter`.
 
-- [`JobDiscovery`] polls `getNextProof` for ZK jobs and dispatches claimed jobs
-  with bounded concurrency.
-- [`ProofGenerator`] drives proof generation for a claimed job, heartbeating the
-  claim while the proof is produced, then hands the result to the submitter.
-- [`ProofSubmitter`] delivers the proof result via `submitProof`, retrying
-  retryable failures with exponential backoff.
+The concrete SP1 backend is wired separately. [`UnimplementedZkProver`] is a
+placeholder for early host wiring.
 
-The actual SP1 proof generation is abstracted behind the [`ZkProver`] trait. This
-crate ships [`UnimplementedZkProver`], a stub that returns an error; a real SP1
-"prove-to-completion" implementation that returns proof bytes is wired in
-separately.
-
-[`JobDiscovery`]: crate::JobDiscovery
 [`ProofGenerator`]: crate::ProofGenerator
-[`ProofSubmitter`]: crate::ProofSubmitter
 [`ZkProver`]: crate::ZkProver
 [`UnimplementedZkProver`]: crate::UnimplementedZkProver

--- a/crates/proof/zk/host/README.md
+++ b/crates/proof/zk/host/README.md
@@ -1,7 +1,25 @@
 # base-proof-zk-host
 
-Host-side ZK proving primitives for prover-service workers.
+Host-side ZK proving worker for the prover service.
 
-The `ZkProver` trait captures the backend proving step independently from worker
-job discovery and submission. Concrete backends implement this trait so worker
-hosts can submit, poll, and download proofs through a common interface.
+This crate provides the worker machinery that lets a ZK proving host pull jobs
+from the prover service over the JSON-RPC worker API and submit results back. It
+mirrors the structure of the TEE host (`base-proof-tee-nitro-host`):
+
+- [`JobDiscovery`] polls `getNextProof` for ZK jobs and dispatches claimed jobs
+  with bounded concurrency.
+- [`ProofGenerator`] drives proof generation for a claimed job, heartbeating the
+  claim while the proof is produced, then hands the result to the submitter.
+- [`ProofSubmitter`] delivers the proof result via `submitProof`, retrying
+  retryable failures with exponential backoff.
+
+The actual SP1 proof generation is abstracted behind the [`ZkProver`] trait. This
+crate ships [`UnimplementedZkProver`], a stub that returns an error; a real SP1
+"prove-to-completion" implementation that returns proof bytes is wired in
+separately.
+
+[`JobDiscovery`]: crate::JobDiscovery
+[`ProofGenerator`]: crate::ProofGenerator
+[`ProofSubmitter`]: crate::ProofSubmitter
+[`ZkProver`]: crate::ZkProver
+[`UnimplementedZkProver`]: crate::UnimplementedZkProver

--- a/crates/proof/zk/host/src/lib.rs
+++ b/crates/proof/zk/host/src/lib.rs
@@ -1,10 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-pub use base_proof_worker::{
-    DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
-    JobDiscovery, JobDiscoveryConfig, ProofSubmitter, ProofSubmitterError, ZkProofClaimType,
-};
-
 mod prover;
 pub use prover::{
     UnimplementedZkProver, ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState,

--- a/crates/proof/zk/host/src/lib.rs
+++ b/crates/proof/zk/host/src/lib.rs
@@ -1,6 +1,28 @@
 #![doc = include_str!("../README.md")]
 
+pub use base_proof_worker::{
+    DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
+    JobDiscovery, JobDiscoveryConfig, ProofSubmitter, ProofSubmitterError, ZkProofClaimType,
+};
+
 mod prover;
 pub use prover::{
     UnimplementedZkProver, ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState,
+};
+
+mod session_handle;
+pub use session_handle::ProofSessionHandle;
+
+mod proof_submitter;
+pub use proof_submitter::ProofSubmitterRequest;
+
+mod proof_generator;
+pub use proof_generator::{
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_FAILURE_DRAIN_TIMEOUT,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+    DEFAULT_PROOF_GENERATOR_POLL_INTERVAL, MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+    MIN_PROOF_GENERATOR_POLL_INTERVAL, ProofGenerator, ProofGeneratorError,
+    ProofGeneratorHeartbeatConfig, ProofGeneratorRequest,
 };

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -17,6 +17,7 @@ pub use base_proof_worker::{
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
     BackendSession, BackendSessionState, ProofJob, ProofRequestKind, ProofResult, SessionType,
+    WorkerSubmitProofRequest,
 };
 use thiserror::Error;
 use tokio::time::{sleep, timeout};
@@ -192,12 +193,12 @@ where
             }
         };
 
-        let submit_request = ProofSubmitterRequest::from_zk_result(
-            request.claim.session_id.clone(),
-            request.claim.lock_id.clone(),
-            request.claim.worker_id.clone(),
+        let submit_request = WorkerSubmitProofRequest::try_from(ProofSubmitterRequest {
+            session_id: request.claim.session_id.clone(),
+            lock_id: request.claim.lock_id.clone(),
+            worker_id: request.claim.worker_id.clone(),
             result,
-        )
+        })
         .map_err(|source| ProofGeneratorError::BuildSubmission {
             session_id: request.claim.session_id.clone(),
             source,

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -318,16 +318,26 @@ where
                 }
                 ZkSessionState::Completed => return Ok(()),
                 ZkSessionState::Failed(reason) => {
-                    self.record_backend_failure(request, handle, session_type, backend_session_id)
-                        .await;
+                    self.record_backend_resubmission(
+                        request,
+                        handle,
+                        session_type,
+                        backend_session_id,
+                    )
+                    .await;
                     return Err(ZkProverError::BackendSessionFailed {
                         backend_session_id: backend_session_id.to_owned(),
                         reason,
                     });
                 }
                 ZkSessionState::NotFound => {
-                    self.record_backend_failure(request, handle, session_type, backend_session_id)
-                        .await;
+                    self.record_backend_resubmission(
+                        request,
+                        handle,
+                        session_type,
+                        backend_session_id,
+                    )
+                    .await;
                     return Err(ZkProverError::BackendSessionNotFound {
                         backend_session_id: backend_session_id.to_owned(),
                     });
@@ -336,22 +346,24 @@ where
         }
     }
 
-    async fn record_backend_failure(
+    async fn record_backend_resubmission(
         &self,
         request: &ProofGeneratorRequest,
         handle: &ProofSessionHandle<Client>,
         session_type: SessionType,
         backend_session_id: &str,
     ) {
+        // Worker upsert rejects terminal states; Submitting makes the next claim
+        // replace this dead backend session instead of resuming it.
         if let Err(error) = handle
-            .record(session_type, backend_session_id.to_owned(), BackendSessionState::Failed)
+            .record(session_type, backend_session_id.to_owned(), BackendSessionState::Submitting)
             .await
         {
             warn!(
                 session_id = %request.claim.session_id,
                 backend_session_id = %backend_session_id,
                 error = %error,
-                "failed to record backend session failure"
+                "failed to mark backend session for resubmission"
             );
         }
     }

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -77,6 +77,12 @@ pub struct ProofGenerator<Client> {
     poll_interval: Duration,
 }
 
+struct ResolvedBackendSession {
+    backend_session_id: String,
+    needs_polling: bool,
+    needs_completion_record: bool,
+}
+
 impl<Client> ProofGenerator<Client> {
     /// Create a proof generator with its own submission cancellation token.
     pub fn new(
@@ -226,24 +232,33 @@ where
             .get(session_type)
             .await
             .map_err(|error| ZkProverError::Session(Box::new(error)))?;
-        let (backend_session_id, should_poll, should_record_completion) =
+        let resolved =
             self.resolve_backend_session(request, &handle, session_type, existing).await?;
 
-        if should_poll {
-            self.wait_for_backend_session(request, &handle, session_type, &backend_session_id)
-                .await?;
+        if resolved.needs_polling {
+            self.wait_for_backend_session(
+                request,
+                &handle,
+                session_type,
+                &resolved.backend_session_id,
+            )
+            .await?;
         }
 
-        let proof = self.prover.download(&backend_session_id).await?;
+        let proof = self.prover.download(&resolved.backend_session_id).await?;
 
-        if should_record_completion
+        if resolved.needs_completion_record
             && let Err(error) = handle
-                .record(session_type, backend_session_id.clone(), BackendSessionState::Completed)
+                .record(
+                    session_type,
+                    resolved.backend_session_id.clone(),
+                    BackendSessionState::Completed,
+                )
                 .await
         {
             warn!(
                 session_id = %request.claim.session_id,
-                backend_session_id = %backend_session_id,
+                backend_session_id = %resolved.backend_session_id,
                 error = %error,
                 "failed to record backend session completion"
             );
@@ -258,7 +273,7 @@ where
         handle: &ProofSessionHandle<Client>,
         session_type: SessionType,
         existing: Option<BackendSession>,
-    ) -> Result<(String, bool, bool), ZkProverError> {
+    ) -> Result<ResolvedBackendSession, ZkProverError> {
         match existing {
             Some(BackendSession { backend_session_id, state: BackendSessionState::Running }) => {
                 info!(
@@ -266,7 +281,11 @@ where
                     backend_session_id = %backend_session_id,
                     "resuming in-flight backend session"
                 );
-                Ok((backend_session_id, true, true))
+                Ok(ResolvedBackendSession {
+                    backend_session_id,
+                    needs_polling: true,
+                    needs_completion_record: true,
+                })
             }
             Some(BackendSession { backend_session_id, state: BackendSessionState::Completed }) => {
                 info!(
@@ -274,7 +293,11 @@ where
                     backend_session_id = %backend_session_id,
                     "backend session already completed, skipping to download"
                 );
-                Ok((backend_session_id, false, false))
+                Ok(ResolvedBackendSession {
+                    backend_session_id,
+                    needs_polling: false,
+                    needs_completion_record: false,
+                })
             }
             None
             | Some(BackendSession {
@@ -294,7 +317,11 @@ where
                     backend_session_id = %backend_session_id,
                     "submitted backend session and recorded it"
                 );
-                Ok((backend_session_id, true, true))
+                Ok(ResolvedBackendSession {
+                    backend_session_id,
+                    needs_polling: true,
+                    needs_completion_record: true,
+                })
             }
         }
     }
@@ -318,6 +345,12 @@ where
                 }
                 ZkSessionState::Completed => return Ok(()),
                 ZkSessionState::Failed(reason) => {
+                    warn!(
+                        session_id = %request.claim.session_id,
+                        backend_session_id = %backend_session_id,
+                        error = %reason,
+                        "backend session failed; marking for resubmission"
+                    );
                     self.record_backend_resubmission(
                         request,
                         handle,
@@ -331,6 +364,11 @@ where
                     });
                 }
                 ZkSessionState::NotFound => {
+                    warn!(
+                        session_id = %request.claim.session_id,
+                        backend_session_id = %backend_session_id,
+                        "backend session not found; marking for resubmission"
+                    );
                     self.record_backend_resubmission(
                         request,
                         handle,
@@ -353,8 +391,8 @@ where
         session_type: SessionType,
         backend_session_id: &str,
     ) {
-        // Worker upsert rejects terminal states; Submitting makes the next claim
-        // replace this dead backend session instead of resuming it.
+        // Worker upsert rejects terminal states; poll branches log the failure
+        // detail, then Submitting makes the next claim replace this session.
         if let Err(error) = handle
             .record(session_type, backend_session_id.to_owned(), BackendSessionState::Submitting)
             .await
@@ -419,6 +457,8 @@ where
                             timeout = ?DEFAULT_PROOF_GENERATOR_HEARTBEAT_FAILURE_DRAIN_TIMEOUT,
                             "timed out waiting for zk proof generation after heartbeat failure"
                         );
+                        // Keep the recorded Running backend session. A heartbeat failure means
+                        // this worker lost its claim, not that the backend job has stopped.
                     }
                 }
 

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -320,13 +320,17 @@ where
                 ZkSessionState::Failed(reason) => {
                     self.record_backend_failure(request, handle, session_type, backend_session_id)
                         .await;
-                    return Err(ZkProverError::Backend(std::io::Error::other(reason).into()));
+                    return Err(ZkProverError::BackendSessionFailed {
+                        backend_session_id: backend_session_id.to_owned(),
+                        reason,
+                    });
                 }
                 ZkSessionState::NotFound => {
-                    let reason = format!("backend session {backend_session_id} not found");
                     self.record_backend_failure(request, handle, session_type, backend_session_id)
                         .await;
-                    return Err(ZkProverError::Backend(std::io::Error::other(reason).into()));
+                    return Err(ZkProverError::BackendSessionNotFound {
+                        backend_session_id: backend_session_id.to_owned(),
+                    });
                 }
             }
         }

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -1,0 +1,496 @@
+//! Proof generation orchestration for claimed ZK worker jobs.
+
+use std::{future::Future, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use base_proof_worker::{
+    ClaimedProofJobHandler, ClaimedProofJobMetadata, ClaimedProofJobMetadataError,
+    ProofSubmissionTask, ProofTaskController, WorkerHeartbeat,
+};
+pub use base_proof_worker::{
+    DEFAULT_WORKER_HEARTBEAT_INTERVAL as DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+    DEFAULT_WORKER_HEARTBEAT_LOCK_DURATION_SECONDS as DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES as DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+    MIN_WORKER_HEARTBEAT_INTERVAL as MIN_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
+    WorkerHeartbeatConfig as ProofGeneratorHeartbeatConfig,
+};
+use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
+use base_prover_service_protocol::{
+    BackendSession, BackendSessionState, ProofJob, ProofRequestKind, ProofResult, SessionType,
+};
+use thiserror::Error;
+use tokio::time::{sleep, timeout};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    ProofSessionHandle, ProofSubmitter, ProofSubmitterError, ProofSubmitterRequest,
+    ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState,
+};
+
+/// Minimum delay between backend session polls.
+pub const MIN_PROOF_GENERATOR_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Default delay between backend session polls while waiting for a proof.
+pub const DEFAULT_PROOF_GENERATOR_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Maximum time to wait for generation cleanup after heartbeat failure.
+pub const DEFAULT_PROOF_GENERATOR_HEARTBEAT_FAILURE_DRAIN_TIMEOUT: Duration =
+    Duration::from_secs(60);
+
+/// Claimed prover-service job data needed to generate and submit a ZK proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofGeneratorRequest {
+    /// Common worker claim metadata.
+    pub claim: ClaimedProofJobMetadata,
+    /// Concrete ZK proof request.
+    pub request: ZkProofRequestKind,
+}
+
+impl TryFrom<ProofJob> for ProofGeneratorRequest {
+    type Error = ProofGeneratorError;
+
+    fn try_from(job: ProofJob) -> Result<Self, Self::Error> {
+        let claim = ClaimedProofJobMetadata::from_job(&job)?;
+
+        let request = match job.request.request {
+            ProofRequestKind::Compressed(request) => ZkProofRequestKind::Compressed(request),
+            ProofRequestKind::SnarkGroth16(request) => ZkProofRequestKind::SnarkGroth16(request),
+            ProofRequestKind::Tee(_) => {
+                return Err(ProofGeneratorError::UnsupportedProofRequest {
+                    session_id: claim.session_id,
+                });
+            }
+        };
+
+        Ok(Self { claim, request })
+    }
+}
+
+/// Orchestrates ZK proof generation, claim heartbeats, and async proof submission.
+#[derive(Debug)]
+pub struct ProofGenerator<Client> {
+    prover: Arc<dyn ZkProver>,
+    submitter: ProofSubmitter<Client>,
+    tasks: ProofTaskController,
+    heartbeat: ProofGeneratorHeartbeatConfig,
+    poll_interval: Duration,
+}
+
+impl<Client> ProofGenerator<Client> {
+    /// Create a proof generator with its own submission cancellation token.
+    pub fn new(
+        prover: Arc<dyn ZkProver>,
+        submitter: ProofSubmitter<Client>,
+        heartbeat: ProofGeneratorHeartbeatConfig,
+    ) -> Self {
+        Self {
+            prover,
+            submitter,
+            tasks: ProofTaskController::new(),
+            heartbeat,
+            poll_interval: DEFAULT_PROOF_GENERATOR_POLL_INTERVAL,
+        }
+    }
+
+    /// Use a caller-provided cancellation token for spawned submission tasks.
+    #[must_use]
+    pub fn with_submission_cancel(mut self, submission_cancel: CancellationToken) -> Self {
+        self.tasks = self.tasks.with_submission_cancel(submission_cancel);
+        self
+    }
+
+    /// Sets the delay between backend session polls while waiting for a proof.
+    #[must_use]
+    pub const fn with_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    /// Returns the proof submitter.
+    pub const fn submitter(&self) -> &ProofSubmitter<Client> {
+        &self.submitter
+    }
+
+    /// Returns the cancellation token used for spawned submission tasks.
+    pub const fn submission_cancel(&self) -> &CancellationToken {
+        self.tasks.submission_cancel()
+    }
+
+    /// Returns the heartbeat settings used while proofs are generated.
+    pub const fn heartbeat_config(&self) -> ProofGeneratorHeartbeatConfig {
+        self.heartbeat
+    }
+
+    /// Returns the backend session poll interval, clamped to the minimum allowed delay.
+    pub fn normalized_poll_interval(&self) -> Duration {
+        self.poll_interval.max(MIN_PROOF_GENERATOR_POLL_INTERVAL)
+    }
+}
+
+impl<Client> ProofGenerator<Client>
+where
+    Client: Clone + ProverWorkerProvider + 'static,
+{
+    /// Generate a proof for a claimed worker job and spawn proof submission.
+    pub async fn generate_and_submit(
+        &self,
+        job: ProofJob,
+    ) -> Result<ProofSubmissionTask, ProofGeneratorError> {
+        let request = ProofGeneratorRequest::try_from(job)?;
+
+        info!(
+            session_id = %request.claim.session_id,
+            lock_id = %request.claim.lock_id,
+            worker_id = %request.claim.worker_id,
+            start_block = request.request.start_block_number(),
+            block_count = request.request.number_of_blocks_to_prove(),
+            "starting zk proof generation"
+        );
+
+        let result = match self
+            .with_heartbeat_while_generating(&request, self.prove_to_completion(&request))
+            .await
+        {
+            Ok(result) => result,
+            Err(ProofGeneratorError::Generate { session_id, source }) => {
+                warn!(
+                    session_id = %request.claim.session_id,
+                    lock_id = %request.claim.lock_id,
+                    worker_id = %request.claim.worker_id,
+                    error = %source,
+                    "zk proof generation failed"
+                );
+
+                return Err(ProofGeneratorError::Generate { session_id, source });
+            }
+            Err(ProofGeneratorError::Heartbeat { session_id, source }) => {
+                warn!(
+                    session_id = %request.claim.session_id,
+                    lock_id = %request.claim.lock_id,
+                    worker_id = %request.claim.worker_id,
+                    error = %source,
+                    "aborting zk proof generation due to heartbeat failure"
+                );
+
+                return Err(ProofGeneratorError::Heartbeat { session_id, source });
+            }
+            Err(
+                source @ (ProofGeneratorError::MissingLockId { .. }
+                | ProofGeneratorError::MissingWorkerId { .. }
+                | ProofGeneratorError::UnsupportedProofRequest { .. }
+                | ProofGeneratorError::BuildSubmission { .. }),
+            ) => {
+                unreachable!(
+                    "with_heartbeat_while_generating returned an impossible error: {source}"
+                );
+            }
+        };
+
+        let submit_request = ProofSubmitterRequest::from_zk_result(
+            request.claim.session_id.clone(),
+            request.claim.lock_id.clone(),
+            request.claim.worker_id.clone(),
+            result,
+        )
+        .map_err(|source| ProofGeneratorError::BuildSubmission {
+            session_id: request.claim.session_id.clone(),
+            source,
+        })?;
+
+        let submit_handle = self.tasks.spawn_submission(&self.submitter, submit_request);
+
+        info!(
+            session_id = %request.claim.session_id,
+            lock_id = %request.claim.lock_id,
+            worker_id = %request.claim.worker_id,
+            "zk proof generated; proof submitter task spawned"
+        );
+
+        Ok(ProofSubmissionTask::new(request.claim, submit_handle))
+    }
+
+    async fn prove_to_completion(
+        &self,
+        request: &ProofGeneratorRequest,
+    ) -> Result<ProofResult, ZkProverError> {
+        let session_type = request.request.session_type();
+        let handle = ProofSessionHandle::new(
+            self.submitter.client().clone(),
+            request.claim.session_id.clone(),
+            request.claim.lock_id.clone(),
+            request.claim.worker_id.clone(),
+        );
+
+        let existing = handle
+            .get(session_type)
+            .await
+            .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+        let (backend_session_id, should_poll, should_record_completion) =
+            self.resolve_backend_session(request, &handle, session_type, existing).await?;
+
+        if should_poll {
+            self.wait_for_backend_session(request, &handle, session_type, &backend_session_id)
+                .await?;
+        }
+
+        let proof = self.prover.download(&backend_session_id).await?;
+
+        if should_record_completion
+            && let Err(error) = handle
+                .record(session_type, backend_session_id.clone(), BackendSessionState::Completed)
+                .await
+        {
+            warn!(
+                session_id = %request.claim.session_id,
+                backend_session_id = %backend_session_id,
+                error = %error,
+                "failed to record backend session completion"
+            );
+        }
+
+        Ok(proof)
+    }
+
+    async fn resolve_backend_session(
+        &self,
+        request: &ProofGeneratorRequest,
+        handle: &ProofSessionHandle<Client>,
+        session_type: SessionType,
+        existing: Option<BackendSession>,
+    ) -> Result<(String, bool, bool), ZkProverError> {
+        match existing {
+            Some(BackendSession { backend_session_id, state: BackendSessionState::Running }) => {
+                info!(
+                    session_id = %request.claim.session_id,
+                    backend_session_id = %backend_session_id,
+                    "resuming in-flight backend session"
+                );
+                Ok((backend_session_id, true, true))
+            }
+            Some(BackendSession { backend_session_id, state: BackendSessionState::Completed }) => {
+                info!(
+                    session_id = %request.claim.session_id,
+                    backend_session_id = %backend_session_id,
+                    "backend session already completed, skipping to download"
+                );
+                Ok((backend_session_id, false, false))
+            }
+            None
+            | Some(BackendSession {
+                state: BackendSessionState::Submitting | BackendSessionState::Failed,
+                ..
+            }) => {
+                let backend_session_id =
+                    self.prover.submit(&request.request, &request.claim.session_id).await?;
+
+                handle
+                    .record(session_type, backend_session_id.clone(), BackendSessionState::Running)
+                    .await
+                    .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+
+                info!(
+                    session_id = %request.claim.session_id,
+                    backend_session_id = %backend_session_id,
+                    "submitted backend session and recorded it"
+                );
+                Ok((backend_session_id, true, true))
+            }
+        }
+    }
+
+    async fn wait_for_backend_session(
+        &self,
+        request: &ProofGeneratorRequest,
+        handle: &ProofSessionHandle<Client>,
+        session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<(), ZkProverError> {
+        loop {
+            match self.prover.poll(backend_session_id).await? {
+                ZkSessionState::Running => {
+                    debug!(
+                        session_id = %request.claim.session_id,
+                        backend_session_id = %backend_session_id,
+                        "backend session still running"
+                    );
+                    sleep(self.normalized_poll_interval()).await;
+                }
+                ZkSessionState::Completed => return Ok(()),
+                ZkSessionState::Failed(reason) => {
+                    self.record_backend_failure(request, handle, session_type, backend_session_id)
+                        .await;
+                    return Err(ZkProverError::Backend(std::io::Error::other(reason).into()));
+                }
+                ZkSessionState::NotFound => {
+                    let reason = format!("backend session {backend_session_id} not found");
+                    self.record_backend_failure(request, handle, session_type, backend_session_id)
+                        .await;
+                    return Err(ZkProverError::Backend(std::io::Error::other(reason).into()));
+                }
+            }
+        }
+    }
+
+    async fn record_backend_failure(
+        &self,
+        request: &ProofGeneratorRequest,
+        handle: &ProofSessionHandle<Client>,
+        session_type: SessionType,
+        backend_session_id: &str,
+    ) {
+        if let Err(error) = handle
+            .record(session_type, backend_session_id.to_owned(), BackendSessionState::Failed)
+            .await
+        {
+            warn!(
+                session_id = %request.claim.session_id,
+                backend_session_id = %backend_session_id,
+                error = %error,
+                "failed to record backend session failure"
+            );
+        }
+    }
+
+    async fn with_heartbeat_while_generating<Output, Generate>(
+        &self,
+        request: &ProofGeneratorRequest,
+        generate: Generate,
+    ) -> Result<Output, ProofGeneratorError>
+    where
+        Generate: Future<Output = Result<Output, ZkProverError>>,
+    {
+        let heartbeat =
+            WorkerHeartbeat::until_failure(&self.submitter, &request.claim, self.heartbeat);
+        tokio::pin!(generate);
+        tokio::pin!(heartbeat);
+
+        tokio::select! {
+            biased;
+            result = &mut generate => result.map_err(|source| ProofGeneratorError::Generate {
+                session_id: request.claim.session_id.clone(),
+                source,
+            }),
+            source = &mut heartbeat => {
+                match timeout(
+                    DEFAULT_PROOF_GENERATOR_HEARTBEAT_FAILURE_DRAIN_TIMEOUT,
+                    &mut generate,
+                )
+                .await
+                {
+                    Ok(Ok(_)) => {
+                        info!(
+                            session_id = %request.claim.session_id,
+                            lock_id = %request.claim.lock_id,
+                            worker_id = %request.claim.worker_id,
+                            "discarding zk proof generated after heartbeat failure"
+                        );
+                    }
+                    Ok(Err(error)) => {
+                        warn!(
+                            session_id = %request.claim.session_id,
+                            lock_id = %request.claim.lock_id,
+                            worker_id = %request.claim.worker_id,
+                            error = %error,
+                            "zk proof generation finished with error after heartbeat failure"
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            session_id = %request.claim.session_id,
+                            lock_id = %request.claim.lock_id,
+                            worker_id = %request.claim.worker_id,
+                            timeout = ?DEFAULT_PROOF_GENERATOR_HEARTBEAT_FAILURE_DRAIN_TIMEOUT,
+                            "timed out waiting for zk proof generation after heartbeat failure"
+                        );
+                    }
+                }
+
+                Err(ProofGeneratorError::Heartbeat {
+                    session_id: request.claim.session_id.clone(),
+                    source,
+                })
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl<Client> ClaimedProofJobHandler for ProofGenerator<Client>
+where
+    Client: Clone + ProverWorkerProvider + 'static,
+{
+    type Error = ProofGeneratorError;
+
+    async fn handle_claimed_job(&self, job: ProofJob) -> Result<(), Self::Error> {
+        // Submission continues in the spawned task; shutdown cancels through the controller.
+        Self::generate_and_submit(self, job).await.map(drop)
+    }
+
+    fn shutdown(&self) {
+        self.tasks.cancel_submissions();
+    }
+}
+
+/// Errors raised while generating and dispatching ZK proof submissions.
+#[derive(Debug, Error)]
+pub enum ProofGeneratorError {
+    /// Claimed proof job did not include a lock identifier.
+    #[error("proof job {session_id} is missing lock_id")]
+    MissingLockId {
+        /// Proof session identifier.
+        session_id: String,
+    },
+    /// Claimed proof job did not include a worker identifier.
+    #[error("proof job {session_id} is missing worker_id")]
+    MissingWorkerId {
+        /// Proof session identifier.
+        session_id: String,
+    },
+    /// Claimed proof job is not a ZK proof request.
+    #[error("proof job {session_id} is not a ZK proof request")]
+    UnsupportedProofRequest {
+        /// Proof session identifier.
+        session_id: String,
+    },
+    /// ZK proof generation failed.
+    #[error("proof generation failed for job {session_id}: {source}")]
+    Generate {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying proof generation error.
+        #[source]
+        source: ZkProverError,
+    },
+    /// Worker API heartbeat failed while the proof was being generated.
+    #[error("heartbeat failed while generating proof for job {session_id}: {source}")]
+    Heartbeat {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying worker API error.
+        #[source]
+        source: ProverServiceClientError,
+    },
+    /// The generated proof could not be converted into a worker submission request.
+    #[error("failed to build proof submission for job {session_id}: {source}")]
+    BuildSubmission {
+        /// Proof session identifier.
+        session_id: String,
+        /// Underlying proof submission request error.
+        #[source]
+        source: ProofSubmitterError,
+    },
+}
+
+impl From<ClaimedProofJobMetadataError> for ProofGeneratorError {
+    fn from(error: ClaimedProofJobMetadataError) -> Self {
+        match error {
+            ClaimedProofJobMetadataError::MissingLockId { session_id } => {
+                Self::MissingLockId { session_id }
+            }
+            ClaimedProofJobMetadataError::MissingWorkerId { session_id } => {
+                Self::MissingWorkerId { session_id }
+            }
+        }
+    }
+}

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -80,7 +80,6 @@ pub struct ProofGenerator<Client> {
 struct ResolvedBackendSession {
     backend_session_id: String,
     needs_polling: bool,
-    needs_completion_record: bool,
 }
 
 impl<Client> ProofGenerator<Client> {
@@ -247,23 +246,6 @@ where
 
         let proof = self.prover.download(&resolved.backend_session_id).await?;
 
-        if resolved.needs_completion_record
-            && let Err(error) = handle
-                .record(
-                    session_type,
-                    resolved.backend_session_id.clone(),
-                    BackendSessionState::Completed,
-                )
-                .await
-        {
-            warn!(
-                session_id = %request.claim.session_id,
-                backend_session_id = %resolved.backend_session_id,
-                error = %error,
-                "failed to record backend session completion"
-            );
-        }
-
         Ok(proof)
     }
 
@@ -281,11 +263,7 @@ where
                     backend_session_id = %backend_session_id,
                     "resuming in-flight backend session"
                 );
-                Ok(ResolvedBackendSession {
-                    backend_session_id,
-                    needs_polling: true,
-                    needs_completion_record: true,
-                })
+                Ok(ResolvedBackendSession { backend_session_id, needs_polling: true })
             }
             Some(BackendSession { backend_session_id, state: BackendSessionState::Completed }) => {
                 info!(
@@ -293,11 +271,7 @@ where
                     backend_session_id = %backend_session_id,
                     "backend session already completed, skipping to download"
                 );
-                Ok(ResolvedBackendSession {
-                    backend_session_id,
-                    needs_polling: false,
-                    needs_completion_record: false,
-                })
+                Ok(ResolvedBackendSession { backend_session_id, needs_polling: false })
             }
             None
             | Some(BackendSession {
@@ -317,11 +291,7 @@ where
                     backend_session_id = %backend_session_id,
                     "submitted backend session and recorded it"
                 );
-                Ok(ResolvedBackendSession {
-                    backend_session_id,
-                    needs_polling: true,
-                    needs_completion_record: true,
-                })
+                Ok(ResolvedBackendSession { backend_session_id, needs_polling: true })
             }
         }
     }

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -5,7 +5,7 @@ use std::{future::Future, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use base_proof_worker::{
     ClaimedProofJobHandler, ClaimedProofJobMetadata, ClaimedProofJobMetadataError,
-    ProofSubmissionTask, ProofTaskController, WorkerHeartbeat,
+    ProofSubmissionTask, ProofSubmitter, ProofSubmitterError, ProofTaskController, WorkerHeartbeat,
 };
 pub use base_proof_worker::{
     DEFAULT_WORKER_HEARTBEAT_INTERVAL as DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,
@@ -24,8 +24,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    ProofSessionHandle, ProofSubmitter, ProofSubmitterError, ProofSubmitterRequest,
-    ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState,
+    ProofSessionHandle, ProofSubmitterRequest, ZkProofRequestKind, ZkProver, ZkProverError,
+    ZkSessionState,
 };
 
 /// Minimum delay between backend session polls.

--- a/crates/proof/zk/host/src/proof_submitter.rs
+++ b/crates/proof/zk/host/src/proof_submitter.rs
@@ -1,0 +1,82 @@
+//! ZK-specific worker submission request builder.
+
+use base_proof_worker::ProofSubmitterError;
+use base_prover_service_protocol::{ProofResult, WorkerSubmitProofRequest};
+
+/// Helper for building prover-service worker proof submission requests.
+#[derive(Debug)]
+pub struct ProofSubmitterRequest;
+
+impl ProofSubmitterRequest {
+    /// Builds a worker proof submission request from a generated ZK proof result.
+    pub fn from_zk_result(
+        session_id: String,
+        lock_id: String,
+        worker_id: String,
+        result: ProofResult,
+    ) -> Result<WorkerSubmitProofRequest, ProofSubmitterError> {
+        match result {
+            ProofResult::Compressed(_) | ProofResult::SnarkGroth16(_) => {
+                Ok(WorkerSubmitProofRequest { session_id, lock_id, worker_id, result })
+            }
+            ProofResult::Tee(_) => Err(ProofSubmitterError::UnsupportedProofResult),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_prover_service_protocol::{ProofResult, TeeKind, TeeProofResult, ZkProofResult, ZkVm};
+
+    use super::*;
+
+    fn zk_result() -> ProofResult {
+        ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![1, 2, 3].into() })
+    }
+
+    #[test]
+    fn zk_result_builds_submission_request() {
+        let request = ProofSubmitterRequest::from_zk_result(
+            "session-1".to_owned(),
+            "lock-1".to_owned(),
+            "worker-1".to_owned(),
+            zk_result(),
+        )
+        .expect("zk result should build a submission request");
+
+        assert_eq!(request.session_id, "session-1");
+        assert_eq!(request.lock_id, "lock-1");
+        assert_eq!(request.worker_id, "worker-1");
+        assert!(matches!(request.result, ProofResult::Compressed(_)));
+    }
+
+    fn proposal() -> base_proof_primitives::Proposal {
+        base_proof_primitives::Proposal {
+            output_root: alloy_primitives::B256::repeat_byte(1),
+            signature: alloy_primitives::Bytes::from(vec![0xab; 65]),
+            l1_origin_hash: alloy_primitives::B256::repeat_byte(2),
+            l1_origin_number: 10,
+            l2_block_number: 11,
+            prev_output_root: alloy_primitives::B256::repeat_byte(3),
+            config_hash: alloy_primitives::B256::repeat_byte(4),
+        }
+    }
+
+    #[test]
+    fn tee_result_is_rejected() {
+        let tee_result = ProofResult::Tee(TeeProofResult {
+            aggregate_proposal: proposal(),
+            proposals: vec![proposal()],
+            tee_kind: TeeKind::AwsNitro,
+        });
+
+        let result = ProofSubmitterRequest::from_zk_result(
+            "session-1".to_owned(),
+            "lock-1".to_owned(),
+            "worker-1".to_owned(),
+            tee_result,
+        );
+
+        assert!(matches!(result, Err(ProofSubmitterError::UnsupportedProofResult)));
+    }
+}

--- a/crates/proof/zk/host/src/proof_submitter.rs
+++ b/crates/proof/zk/host/src/proof_submitter.rs
@@ -5,20 +5,28 @@ use base_prover_service_protocol::{ProofResult, WorkerSubmitProofRequest};
 
 /// Helper for building prover-service worker proof submission requests.
 #[derive(Debug)]
-pub struct ProofSubmitterRequest;
+pub struct ProofSubmitterRequest {
+    /// Proof session identifier.
+    pub session_id: String,
+    /// Worker claim lock identifier.
+    pub lock_id: String,
+    /// Worker identifier holding the claim.
+    pub worker_id: String,
+    /// Generated proof result to submit.
+    pub result: ProofResult,
+}
 
-impl ProofSubmitterRequest {
-    /// Builds a worker proof submission request from a generated ZK proof result.
-    pub fn from_zk_result(
-        session_id: String,
-        lock_id: String,
-        worker_id: String,
-        result: ProofResult,
-    ) -> Result<WorkerSubmitProofRequest, ProofSubmitterError> {
-        match result {
-            ProofResult::Compressed(_) | ProofResult::SnarkGroth16(_) => {
-                Ok(WorkerSubmitProofRequest { session_id, lock_id, worker_id, result })
-            }
+impl TryFrom<ProofSubmitterRequest> for WorkerSubmitProofRequest {
+    type Error = ProofSubmitterError;
+
+    fn try_from(request: ProofSubmitterRequest) -> Result<Self, Self::Error> {
+        match request.result {
+            ProofResult::Compressed(_) | ProofResult::SnarkGroth16(_) => Ok(Self {
+                session_id: request.session_id,
+                lock_id: request.lock_id,
+                worker_id: request.worker_id,
+                result: request.result,
+            }),
             ProofResult::Tee(_) => Err(ProofSubmitterError::UnsupportedProofResult),
         }
     }
@@ -36,12 +44,12 @@ mod tests {
 
     #[test]
     fn zk_result_builds_submission_request() {
-        let request = ProofSubmitterRequest::from_zk_result(
-            "session-1".to_owned(),
-            "lock-1".to_owned(),
-            "worker-1".to_owned(),
-            zk_result(),
-        )
+        let request = WorkerSubmitProofRequest::try_from(ProofSubmitterRequest {
+            session_id: "session-1".to_owned(),
+            lock_id: "lock-1".to_owned(),
+            worker_id: "worker-1".to_owned(),
+            result: zk_result(),
+        })
         .expect("zk result should build a submission request");
 
         assert_eq!(request.session_id, "session-1");
@@ -70,12 +78,12 @@ mod tests {
             tee_kind: TeeKind::AwsNitro,
         });
 
-        let result = ProofSubmitterRequest::from_zk_result(
-            "session-1".to_owned(),
-            "lock-1".to_owned(),
-            "worker-1".to_owned(),
-            tee_result,
-        );
+        let result = WorkerSubmitProofRequest::try_from(ProofSubmitterRequest {
+            session_id: "session-1".to_owned(),
+            lock_id: "lock-1".to_owned(),
+            worker_id: "worker-1".to_owned(),
+            result: tee_result,
+        });
 
         assert!(matches!(result, Err(ProofSubmitterError::UnsupportedProofResult)));
     }

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -1,7 +1,9 @@
-//! ZK proving abstraction used by prover-service worker hosts.
+//! ZK proving abstraction used by the host worker.
 
 use async_trait::async_trait;
-use base_prover_service_protocol::{ProofResult, SnarkGroth16ProofRequest, ZkProofRequest};
+use base_prover_service_protocol::{
+    ProofResult, SessionType, SnarkGroth16ProofRequest, ZkProofRequest,
+};
 use thiserror::Error;
 
 /// Concrete ZK proof request claimed from the prover service.
@@ -33,6 +35,14 @@ impl ZkProofRequestKind {
     /// Returns whether this request asks for a Groth16 SNARK proof.
     pub const fn is_snark_groth16(&self) -> bool {
         matches!(self, Self::SnarkGroth16(_))
+    }
+
+    /// Returns the backend session type tracked for this request.
+    pub const fn session_type(&self) -> SessionType {
+        match self {
+            Self::Compressed(_) => SessionType::Stark,
+            Self::SnarkGroth16(_) => SessionType::Snark,
+        }
     }
 }
 
@@ -67,9 +77,6 @@ pub enum ZkProverError {
 #[async_trait]
 pub trait ZkProver: Send + Sync + std::fmt::Debug {
     /// Submit the proving job to the backend and return its backend session id.
-    ///
-    /// `request_session_id` is the prover-service public session id. Backends may
-    /// use it to derive deterministic backend ids for idempotent resubmission.
     async fn submit(
         &self,
         request: &ZkProofRequestKind,
@@ -108,7 +115,7 @@ impl ZkProver for UnimplementedZkProver {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
+    use base_prover_service_protocol::{SessionType, ZkVm};
 
     use super::*;
 
@@ -132,9 +139,22 @@ mod tests {
 
         let snark = ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
             proof: zk_request(),
-            prover_address: Default::default(),
+            prover_address: alloy_primitives::Address::ZERO,
         });
         assert!(snark.is_snark_groth16());
+    }
+
+    #[test]
+    fn request_kind_maps_to_session_type() {
+        assert_eq!(ZkProofRequestKind::Compressed(zk_request()).session_type(), SessionType::Stark);
+        assert_eq!(
+            ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+                proof: zk_request(),
+                prover_address: alloy_primitives::Address::ZERO,
+            })
+            .session_type(),
+            SessionType::Snark
+        );
     }
 
     #[tokio::test]
@@ -146,13 +166,5 @@ mod tests {
             .expect_err("stub prover should not produce a proof");
 
         assert!(matches!(error, ZkProverError::Unimplemented));
-    }
-
-    #[test]
-    fn prover_error_preserves_source() {
-        let error = ZkProverError::Backend(Box::new(std::io::Error::other("backend down")));
-        let source = std::error::Error::source(&error).expect("source should be preserved");
-
-        assert_eq!(source.to_string(), "backend down");
     }
 }

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -65,6 +65,20 @@ pub enum ZkProverError {
     /// ZK proving is not yet implemented for this prover.
     #[error("zk proving is not yet implemented")]
     Unimplemented,
+    /// The backend session failed before proof download.
+    #[error("backend session {backend_session_id} failed: {reason}")]
+    BackendSessionFailed {
+        /// Backend proving session identifier.
+        backend_session_id: String,
+        /// Backend-provided failure reason.
+        reason: String,
+    },
+    /// The backend has no record of the expected session.
+    #[error("backend session {backend_session_id} not found")]
+    BackendSessionNotFound {
+        /// Backend proving session identifier.
+        backend_session_id: String,
+    },
     /// The proving backend failed to produce a proof.
     #[error("zk proving backend failed")]
     Backend(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/proof/zk/host/src/session_handle.rs
+++ b/crates/proof/zk/host/src/session_handle.rs
@@ -1,0 +1,71 @@
+//! Backend-session tracking over the prover-service worker API.
+
+use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
+use base_prover_service_protocol::{
+    BackendSession, BackendSessionState, GetProofSessionRequest, RecordProofSessionRequest,
+    SessionType,
+};
+
+/// Tracks the backend session for one claimed proof job via the prover service.
+#[derive(Clone, Debug)]
+pub struct ProofSessionHandle<Client> {
+    client: Client,
+    session_id: String,
+    lock_id: String,
+    worker_id: String,
+}
+
+impl<Client> ProofSessionHandle<Client> {
+    /// Bind a worker client to a claimed job's session identifiers.
+    pub const fn new(
+        client: Client,
+        session_id: String,
+        lock_id: String,
+        worker_id: String,
+    ) -> Self {
+        Self { client, session_id, lock_id, worker_id }
+    }
+}
+
+impl<Client> ProofSessionHandle<Client>
+where
+    Client: ProverWorkerProvider,
+{
+    /// Look up the active backend session recorded for this job, if any.
+    pub async fn get(
+        &self,
+        session_type: SessionType,
+    ) -> Result<Option<BackendSession>, ProverServiceClientError> {
+        let response = self
+            .client
+            .get_proof_session(GetProofSessionRequest {
+                session_id: self.session_id.clone(),
+                session_type,
+            })
+            .await?;
+
+        Ok(response.session)
+    }
+
+    /// Record (insert or update) the backend session for this job.
+    pub async fn record(
+        &self,
+        session_type: SessionType,
+        backend_session_id: String,
+        state: BackendSessionState,
+    ) -> Result<BackendSession, ProverServiceClientError> {
+        let response = self
+            .client
+            .record_proof_session(RecordProofSessionRequest {
+                session_id: self.session_id.clone(),
+                lock_id: self.lock_id.clone(),
+                worker_id: self.worker_id.clone(),
+                session_type,
+                backend_session_id,
+                state,
+            })
+            .await?;
+
+        Ok(response.session)
+    }
+}


### PR DESCRIPTION
## Summary
- add host-side ZK proof generator orchestration to base-proof-zk-host
- add backend session tracking and proof submission request helpers
- keep concrete Succinct backend and binary wiring out of this PR