### PR TITLE
feat: publish base-da-server image via docker-l3 CI

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [client, base, builder, consensus, proposer, batcher, zk-prover]
+        target: [client, base, builder, consensus, proposer, batcher, da-server, zk-prover]
 
     runs-on: ubuntu-24.04
 

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -126,6 +126,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --profile $PROFILE --package base-batcher-bin --bin base-batcher && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-batcher /app/base-batcher
 
+FROM source AS da-server-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=da-server-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-da-server-bin --bin base-da-server && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-da-server /app/base-da-server
+
 FROM zk-builder-base AS zk-source
 COPY . .
 
@@ -180,6 +188,11 @@ ENTRYPOINT ["./audit-archiver"]
 FROM runtime-base AS batcher
 COPY --from=batcher-builder /app/base-batcher ./base-batcher
 ENTRYPOINT ["./base-batcher"]
+
+FROM runtime-base AS da-server
+COPY --from=da-server-builder /app/base-da-server ./base-da-server
+EXPOSE 2583
+ENTRYPOINT ["./base-da-server"]
 
 FROM runtime-base AS zk-prover
 COPY --from=zk-prover-builder /app/base-prover-zk ./base-prover-zk

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -37,12 +37,13 @@ group "rust-services" {
     "ingress-rpc",
     "audit-archiver",
     "batcher",
+    "da-server",
     "zk-prover",
   ]
 }
 
 group "devnet" {
-  targets = ["builder", "consensus", "client", "base", "batcher", "zk-prover"]
+  targets = ["builder", "consensus", "client", "base", "batcher", "da-server", "zk-prover"]
 }
 
 group "ingress" {
@@ -130,6 +131,16 @@ target "batcher" {
   cache-from = [
     "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
     "type=registry,ref=${REGISTRY_IMAGE}:cache-batcher-${PLATFORM_PAIR}",
+  ]
+}
+
+target "da-server" {
+  inherits = ["_rust-service-common"]
+  target = "da-server"
+  tags = ["base-da-server:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-da-server-${PLATFORM_PAIR}",
   ]
 }
 


### PR DESCRIPTION
Add da-server build/runtime stages to rust-services Dockerfile, bake target, and l3 workflow matrix so ghcr publishes da-server-sha-* tags.