### PR TITLE
feat(system-tests): support Isthmus activation block

### DIFF
--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -9,6 +9,7 @@ L2_DATA_DIR="${L2_DATA_DIR:-/data}"
 TEMPLATE_DIR="${TEMPLATE_DIR:-/templates}"
 L2_BASE_AZUL_BLOCK="${L2_BASE_AZUL_BLOCK:-}"
 L2_BASE_BERYL_BLOCK="${L2_BASE_BERYL_BLOCK:-}"
+L2_ISTHMUS_BLOCK="${L2_ISTHMUS_BLOCK:-}"
 L2_ACTIVATION_ADMIN_ADDR="${L2_ACTIVATION_ADMIN_ADDR:-$SEQUENCER_ADDR}"
 L2_EL_BOOTNODE_P2P_KEY="${L2_EL_BOOTNODE_P2P_KEY:-1111111111111111111111111111111111111111111111111111111111111111}"
 L2_EL_BOOTNODE_ENODE_ID="${L2_EL_BOOTNODE_ENODE_ID:-4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1}"
@@ -32,6 +33,10 @@ if [ -n "$L2_BASE_BERYL_BLOCK" ] && ! [[ "$L2_BASE_BERYL_BLOCK" =~ ^[0-9]+$ ]]; 
   echo "ERROR: L2_BASE_BERYL_BLOCK must be a non-negative integer when set, got: $L2_BASE_BERYL_BLOCK"
   exit 1
 fi
+if [ -n "$L2_ISTHMUS_BLOCK" ] && ! [[ "$L2_ISTHMUS_BLOCK" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: L2_ISTHMUS_BLOCK must be a non-negative integer when set, got: $L2_ISTHMUS_BLOCK"
+  exit 1
+fi
 
 echo "=== L2 Genesis Generator (Live Deployment) ==="
 echo "L1 RPC URL: $L1_RPC_URL"
@@ -47,6 +52,11 @@ if [ -n "$L2_BASE_BERYL_BLOCK" ]; then
   echo "Base Beryl activation block: $L2_BASE_BERYL_BLOCK"
 else
   echo "Base Beryl activation block: <unset>"
+fi
+if [ -n "$L2_ISTHMUS_BLOCK" ]; then
+  echo "Isthmus activation block: $L2_ISTHMUS_BLOCK"
+else
+  echo "Isthmus activation block: <unset>"
 fi
 echo "Output directory: $OUTPUT_DIR"
 
@@ -165,6 +175,41 @@ echo "Patched activation admin into genesis config"
 
 L2_BLOCK_TIME=$(jq -re '.block_time' "$OUTPUT_DIR/rollup.json")
 L2_GENESIS_TIME=$(jq -re '.genesis.l2_time' "$OUTPUT_DIR/rollup.json")
+if [ -n "$L2_ISTHMUS_BLOCK" ]; then
+  L2_ISTHMUS_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_ISTHMUS_BLOCK))
+
+  echo ""
+  echo "=== Configuring Isthmus Activation ==="
+  echo "L2 genesis time: $L2_GENESIS_TIME"
+  echo "L2 block time: $L2_BLOCK_TIME"
+  echo "Isthmus activation block: $L2_ISTHMUS_BLOCK"
+  echo "Derived Isthmus activation timestamp: $L2_ISTHMUS_TIME"
+
+  TMP_ROLLUP=$(mktemp)
+  jq \
+    --argjson isthmus_time "$L2_ISTHMUS_TIME" \
+    '.isthmus_time = $isthmus_time' \
+    "$OUTPUT_DIR/rollup.json" \
+    >"$TMP_ROLLUP"
+  replace_output_file "$TMP_ROLLUP" "$OUTPUT_DIR/rollup.json"
+
+  TMP_GENESIS=$(mktemp)
+  jq \
+    --argjson isthmus_time "$L2_ISTHMUS_TIME" \
+    '.config.isthmusTime = $isthmus_time' \
+    "$OUTPUT_DIR/genesis.json" \
+    >"$TMP_GENESIS"
+  replace_output_file "$TMP_GENESIS" "$OUTPUT_DIR/genesis.json"
+
+  echo "Patched Isthmus activation into rollup and genesis configs"
+else
+  echo ""
+  echo "=== Configuring Isthmus Activation ==="
+  echo "L2 genesis time: $L2_GENESIS_TIME"
+  echo "L2 block time: $L2_BLOCK_TIME"
+  echo "Isthmus activation block is unset; leaving isthmus_time and isthmusTime unchanged"
+fi
+
 if [ -n "$L2_BASE_AZUL_BLOCK" ]; then
   L2_BASE_AZUL_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_AZUL_BLOCK))
 

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -226,6 +226,7 @@ pub struct SetupContainer {
     chain_id: u64,
     l2_chain_id: u64,
     slot_duration: u64,
+    isthmus_activation_block: Option<u64>,
     base_azul_activation_block: Option<u64>,
     base_beryl_activation_block: Option<u64>,
     network_name: Option<String>,
@@ -239,6 +240,7 @@ impl SetupContainer {
             chain_id: 1337,
             l2_chain_id: 84538453,
             slot_duration: 2,
+            isthmus_activation_block: None,
             base_azul_activation_block: None,
             base_beryl_activation_block: None,
             network_name: None,
@@ -260,6 +262,12 @@ impl SetupContainer {
     /// Sets the slot duration.
     pub const fn with_slot_duration(mut self, slot_duration: u64) -> Self {
         self.slot_duration = slot_duration;
+        self
+    }
+
+    /// Sets the L2 block number at which Isthmus activates.
+    pub const fn with_isthmus_activation_block(mut self, block: u64) -> Self {
+        self.isthmus_activation_block = Some(block);
         self
     }
 
@@ -359,6 +367,10 @@ impl SetupContainer {
             .with_env_var("L2_EL_BOOTNODE_ENODE", EL_BOOTNODE_ENODE)
             .with_env_var("L2_CL_BOOTNODE_P2P_KEY", CL_BOOTNODE_P2P_KEY)
             .with_env_var("L2_CL_BOOTNODE_ENR_PATH", CL_BOOTNODE_ENR_PATH);
+
+        if let Some(block) = self.isthmus_activation_block {
+            container = container.with_env_var("L2_ISTHMUS_BLOCK", block.to_string());
+        }
 
         if let Some(block) = self.base_azul_activation_block {
             container = container.with_env_var("L2_BASE_AZUL_BLOCK", block.to_string());

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -127,6 +127,7 @@ pub struct SystemTestStackBuilder {
     l1_chain_id: Option<u64>,
     l2_chain_id: Option<u64>,
     slot_duration: Option<u64>,
+    isthmus_activation_block: Option<u64>,
     base_azul_activation_block: Option<u64>,
     base_beryl_activation_block: Option<u64>,
     output_dir: Option<PathBuf>,
@@ -156,6 +157,12 @@ impl SystemTestStackBuilder {
     /// Sets the slot duration.
     pub const fn with_slot_duration(mut self, slot_duration: u64) -> Self {
         self.slot_duration = Some(slot_duration);
+        self
+    }
+
+    /// Sets the L2 block number at which Isthmus activates.
+    pub const fn with_isthmus_activation_block(mut self, block: u64) -> Self {
+        self.isthmus_activation_block = Some(block);
         self
     }
 
@@ -211,6 +218,10 @@ impl SystemTestStackBuilder {
             .with_chain_id(l1_chain_id)
             .with_l2_chain_id(l2_chain_id)
             .with_slot_duration(slot_duration);
+
+        if let Some(block) = self.isthmus_activation_block {
+            setup = setup.with_isthmus_activation_block(block);
+        }
 
         if let Some(block) = self.base_azul_activation_block {
             setup = setup.with_base_azul_activation_block(block);


### PR DESCRIPTION
This adds explicit Isthmus activation-block plumbing to the system-test setup path, matching the existing Azul and Beryl override shape. 

We need this to setup a system test that verifies the fix in PR #3197 