### PR TITLE
feat(system-tests): support follow-mode client consensus

### DIFF
--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -217,7 +217,7 @@ impl InProcessConsensus {
                 result.wrap_err("startup channel closed")?
                       .wrap_err("consensus node failed during startup")?;
             }
-            result = wait_for_rpc(rpc_addr) => {
+            result = wait_for_rpc(rpc_addr, "consensus RPC") => {
                 result?;
             }
         }
@@ -350,7 +350,7 @@ fn extract_signing_key(keypair: &libp2p::identity::Keypair) -> Result<k256::ecds
 }
 
 /// Polls the RPC endpoint until it responds or times out.
-async fn wait_for_rpc(addr: SocketAddr) -> Result<()> {
+pub(super) async fn wait_for_rpc(addr: SocketAddr, description: &str) -> Result<()> {
     let url = format!("http://{}:{}", addr.ip(), addr.port());
     let client = reqwest::Client::new();
 
@@ -358,7 +358,7 @@ async fn wait_for_rpc(addr: SocketAddr) -> Result<()> {
     for i in 0..60 {
         match client.get(&url).send().await {
             Ok(_) => {
-                info!(attempts = i + 1, "consensus RPC is ready");
+                info!(attempts = i + 1, description = %description, "RPC endpoint is ready");
                 return Ok(());
             }
             Err(e) => {
@@ -368,8 +368,11 @@ async fn wait_for_rpc(addr: SocketAddr) -> Result<()> {
         }
     }
 
-    Err(eyre::eyre!(
-        "Consensus RPC at {url} did not become ready within 30s: {}",
-        last_err.unwrap()
-    ))
+    let Some(last_err) = last_err else {
+        return Err(eyre::eyre!(
+            "{description} at {url} did not become ready within 30s: no readiness attempts were made"
+        ));
+    };
+
+    Err(eyre::eyre!("{description} at {url} did not become ready within 30s: {last_err}"))
 }

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -1,0 +1,156 @@
+//! In-process follow-mode consensus node for L2 system test stacks.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
+    sync::Arc,
+    time::Duration,
+};
+
+use alloy_provider::RootProvider;
+use alloy_rpc_types_engine::JwtSecret;
+use base_builder_core::test_utils::get_available_port;
+use base_common_genesis::RollupConfig;
+use base_common_network::Base;
+use base_consensus_node::{EngineConfig, FollowNode, FollowNodeConfig, NodeMode, RemoteL2Client};
+use base_consensus_rpc::RpcBuilder;
+use eyre::{Result, WrapErr};
+use tokio::task::JoinHandle;
+use tracing::info;
+use url::Url;
+
+use super::in_process_consensus::wait_for_rpc;
+
+/// Configuration for starting an in-process follow-mode consensus node.
+#[derive(Debug)]
+pub struct InProcessFollowConsensusConfig {
+    /// Parsed rollup configuration.
+    pub rollup_config: RollupConfig,
+    /// JWT secret for Engine API authentication.
+    pub jwt_secret: JwtSecret,
+    /// L1 RPC endpoint URL.
+    pub l1_rpc_url: Url,
+    /// Local L2 execution RPC endpoint URL.
+    pub local_l2_rpc_url: Url,
+    /// Source L2 execution RPC endpoint URL to follow.
+    pub source_l2_rpc_url: Url,
+    /// Local L2 engine API URL.
+    pub l2_engine_url: Url,
+    /// Optional fixed RPC port.
+    pub rpc_port: Option<u16>,
+    /// Delay after each successful source payload insert.
+    pub insert_delay: Duration,
+}
+
+/// A running in-process follow-mode consensus node.
+pub struct InProcessFollowConsensus {
+    rpc_addr: SocketAddr,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for InProcessFollowConsensus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcessFollowConsensus").field("rpc_addr", &self.rpc_addr).finish()
+    }
+}
+
+impl InProcessFollowConsensus {
+    /// Starts an in-process follow-mode consensus node with the given configuration.
+    pub async fn start(config: InProcessFollowConsensusConfig) -> Result<Self> {
+        let rollup_config = Arc::new(config.rollup_config);
+        let rpc_port = config.rpc_port.unwrap_or_else(get_available_port);
+        let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port);
+
+        let engine_config = EngineConfig {
+            config: Arc::clone(&rollup_config),
+            l2_url: config.l2_engine_url,
+            l2_jwt_secret: config.jwt_secret,
+            l1_url: config.l1_rpc_url,
+            mode: NodeMode::Validator,
+        };
+        let engine_client = Arc::new(
+            engine_config
+                .build_engine_client()
+                .await
+                .map_err(eyre::Report::from)
+                .wrap_err("failed to build follow engine client")?,
+        );
+        let local_l2_provider = RootProvider::<Base>::new_http(config.local_l2_rpc_url);
+        let l2_source = RemoteL2Client::new(config.source_l2_rpc_url);
+        let rpc_builder = RpcBuilder {
+            no_restart: true,
+            socket: rpc_addr,
+            enable_admin: false,
+            admin_persistence: None,
+            ws_enabled: false,
+            dev_enabled: false,
+            http_timeout: Duration::from_secs(60),
+            max_concurrent_requests: NonZeroUsize::new(1024).expect("nonzero"),
+        };
+
+        let node = FollowNode::new(FollowNodeConfig {
+            rollup_config,
+            engine_client,
+            local_l2_provider,
+            l2_source,
+            rpc_builder: Some(rpc_builder),
+            proofs_enabled: false,
+            proofs_max_blocks_ahead: 0,
+            insert_delay: config.insert_delay,
+        });
+
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            info!(rpc_port = rpc_port, "starting in-process follow consensus node");
+            if let Err(e) = node.start().await {
+                let _ = startup_tx.send(eyre::eyre!("follow consensus node failed: {e}"));
+            }
+        });
+
+        tokio::select! {
+            result = startup_rx => {
+                let error = result.wrap_err("startup channel closed")?;
+                return Err(error).wrap_err("follow consensus node failed during startup");
+            }
+            result = wait_for_rpc(rpc_addr, "follow consensus RPC") => {
+                result?;
+            }
+        }
+
+        Ok(Self { rpc_addr, handle: Some(handle) })
+    }
+
+    /// Returns the RPC URL for this consensus node.
+    pub fn rpc_url(&self) -> Url {
+        Url::parse(&format!("http://{}:{}", self.rpc_addr.ip(), self.rpc_addr.port()))
+            .expect("valid RPC URL")
+    }
+
+    /// Returns the RPC port.
+    pub const fn rpc_port(&self) -> u16 {
+        self.rpc_addr.port()
+    }
+
+    /// Stops the in-process follow consensus task and waits for Tokio to observe the abort.
+    pub async fn shutdown(mut self) {
+        if let Some(mut handle) = self.handle.take() {
+            handle.abort();
+            tokio::select! {
+                result = &mut handle => {
+                    let _ = result;
+                }
+                () = tokio::time::sleep(Duration::from_secs(5)) => {
+                    drop(handle);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for InProcessFollowConsensus {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}

--- a/etc/systems/src/l2/mod.rs
+++ b/etc/systems/src/l2/mod.rs
@@ -15,5 +15,8 @@ pub use in_process_client::{InProcessClient, InProcessClientConfig};
 mod in_process_consensus;
 pub use in_process_consensus::{InProcessConsensus, InProcessConsensusConfig};
 
+mod in_process_follow_consensus;
+pub use in_process_follow_consensus::{InProcessFollowConsensus, InProcessFollowConsensusConfig};
+
 mod stack;
-pub use stack::{L2Stack, L2StackConfig};
+pub use stack::{L2ClientConsensus, L2ClientConsensusMode, L2Stack, L2StackConfig};

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -6,6 +6,8 @@
 //! - Batcher (in-process, submits L2 transaction batches to L1)
 //! - Client execution layer (in-process, follows the L2 and builds pending state using Flashblocks)
 
+use std::time::Duration;
+
 use alloy_genesis::ChainConfig;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::JwtSecret;
@@ -18,9 +20,19 @@ use url::Url;
 use super::{
     InProcessBatcher, InProcessBatcherConfig, InProcessBuilder, InProcessBuilderConfig,
     InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
-    L2ContainerConfig,
+    InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ContainerConfig,
 };
 use crate::config::SEQUENCER;
+
+/// Consensus mode used by the L2 client node.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum L2ClientConsensusMode {
+    /// Run the client consensus node as a normal validator.
+    #[default]
+    Validator,
+    /// Run the client consensus node in follow mode against the builder RPC.
+    Follow,
+}
 
 /// Configuration for the L2 stack.
 #[derive(Debug, Clone)]
@@ -51,6 +63,27 @@ pub struct L2StackConfig {
     /// Number of L1 blocks to keep distance from the L1 head for the client (validator)
     /// consensus node's derivation pipeline.
     pub verifier_l1_confs: u64,
+    /// Consensus mode for the L2 client node.
+    pub client_consensus_mode: L2ClientConsensusMode,
+}
+
+/// Running L2 client consensus node.
+#[derive(Debug)]
+pub enum L2ClientConsensus {
+    /// Standard validator consensus node.
+    Validator(InProcessConsensus),
+    /// Follow-mode consensus node.
+    Follow(InProcessFollowConsensus),
+}
+
+impl L2ClientConsensus {
+    /// Returns the RPC URL for this consensus node.
+    pub fn rpc_url(&self) -> Url {
+        match self {
+            Self::Validator(consensus) => consensus.rpc_url(),
+            Self::Follow(consensus) => consensus.rpc_url(),
+        }
+    }
 }
 
 /// A complete L2 network stack composed of Builder + Consensus + Batcher.
@@ -65,14 +98,14 @@ pub struct L2StackConfig {
 /// 2. Builder consensus node connects to builder's engine API (in-process CL, Sequencer mode)
 /// 3. Batcher connects to builder RPC and builder consensus RPC
 /// 4. Client starts (in-process EL)
-/// 5. Client consensus node connects to client's engine API (in-process CL, Validator mode)
-/// 6. Client consensus connects to builder consensus via P2P
+/// 5. Client consensus node connects to client's engine API
+/// 6. Validator-mode client consensus connects to builder consensus via P2P
 pub struct L2Stack {
     builder: InProcessBuilder,
     builder_consensus: InProcessConsensus,
     batcher: InProcessBatcher,
     client: InProcessClient,
-    client_consensus: InProcessConsensus,
+    client_consensus: L2ClientConsensus,
 }
 
 impl std::fmt::Debug for L2Stack {
@@ -184,37 +217,60 @@ impl L2Stack {
             .await
             .wrap_err("Failed to start in-process client")?;
 
-        // 5. Start client consensus (in-process CL, Validator mode).
-        let client_consensus_config = InProcessConsensusConfig {
-            rollup_config,
-            l1_chain_config,
-            jwt_secret: config.jwt_secret,
-            l1_rpc_url,
-            l1_beacon_url,
-            l2_engine_url: client.engine_url()?,
-            mode: NodeMode::Validator,
-            sequencer_key: None,
-            p2p_key: None,
-            rpc_port: container_config.and_then(|c| c.client_consensus_rpc_port),
-            p2p_tcp_port: container_config.and_then(|c| c.client_consensus_p2p_tcp_port),
-            p2p_udp_port: container_config.and_then(|c| c.client_consensus_p2p_udp_port),
-            unsafe_block_signer: SEQUENCER.address,
-            l1_slot_duration_override: Some(4),
-            sequencer_stopped: false,
-            verifier_l1_confs: config.verifier_l1_confs,
+        // 5. Start client consensus.
+        let client_consensus = match config.client_consensus_mode {
+            L2ClientConsensusMode::Validator => {
+                let client_consensus_config = InProcessConsensusConfig {
+                    rollup_config,
+                    l1_chain_config,
+                    jwt_secret: config.jwt_secret,
+                    l1_rpc_url,
+                    l1_beacon_url,
+                    l2_engine_url: client.engine_url()?,
+                    mode: NodeMode::Validator,
+                    sequencer_key: None,
+                    p2p_key: None,
+                    rpc_port: container_config.and_then(|c| c.client_consensus_rpc_port),
+                    p2p_tcp_port: container_config.and_then(|c| c.client_consensus_p2p_tcp_port),
+                    p2p_udp_port: container_config.and_then(|c| c.client_consensus_p2p_udp_port),
+                    unsafe_block_signer: SEQUENCER.address,
+                    l1_slot_duration_override: Some(4),
+                    sequencer_stopped: false,
+                    verifier_l1_confs: config.verifier_l1_confs,
+                };
+                let client_consensus = InProcessConsensus::start(client_consensus_config)
+                    .await
+                    .wrap_err("Failed to start client consensus")?;
+
+                // Connect the client consensus to the builder consensus via P2P.
+                let builder_p2p_addr = builder_consensus.p2p_addr();
+                client_consensus
+                    .connect_peer(&builder_p2p_addr)
+                    .await
+                    .wrap_err("Failed to connect client consensus to builder consensus")?;
+                L2ClientConsensus::Validator(client_consensus)
+            }
+            L2ClientConsensusMode::Follow => {
+                // Follow-mode consensus polls the builder RPC directly, so it does not need a P2P
+                // peer connection before the sequencer starts producing blocks.
+                let client_consensus_config = InProcessFollowConsensusConfig {
+                    rollup_config,
+                    jwt_secret: config.jwt_secret,
+                    l1_rpc_url,
+                    local_l2_rpc_url: client.rpc_url()?,
+                    source_l2_rpc_url: builder.rpc_url()?,
+                    l2_engine_url: client.engine_url()?,
+                    rpc_port: container_config.and_then(|c| c.client_consensus_rpc_port),
+                    insert_delay: Duration::ZERO,
+                };
+                let client_consensus = InProcessFollowConsensus::start(client_consensus_config)
+                    .await
+                    .wrap_err("Failed to start follow client consensus")?;
+                L2ClientConsensus::Follow(client_consensus)
+            }
         };
-        let client_consensus = InProcessConsensus::start(client_consensus_config)
-            .await
-            .wrap_err("Failed to start client consensus")?;
 
-        // 6. Connect the client consensus to the builder consensus via P2P.
-        let builder_p2p_addr = builder_consensus.p2p_addr();
-        client_consensus
-            .connect_peer(&builder_p2p_addr)
-            .await
-            .wrap_err("Failed to connect client consensus to builder consensus")?;
-
-        // 7. Start the sequencer now that peers are connected, ensuring no blocks are missed.
+        // 6. Start the sequencer after the client consensus is ready.
         builder_consensus
             .start_sequencer()
             .await
@@ -241,6 +297,11 @@ impl L2Stack {
     /// Returns a reference to the in-process client.
     pub const fn client(&self) -> &InProcessClient {
         &self.client
+    }
+
+    /// Returns a reference to the client's consensus node.
+    pub const fn client_consensus(&self) -> &L2ClientConsensus {
+        &self.client_consensus
     }
 
     /// Returns the builder's HTTP RPC URL.

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -49,7 +49,8 @@ mod l2;
 pub use l2::{
     InProcessBatcher, InProcessBatcherConfig, InProcessBuilder, InProcessBuilderConfig,
     InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
-    L2ContainerConfig, L2Stack, L2StackConfig,
+    InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ClientConsensus,
+    L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig,
 };
 
 mod network;

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -15,7 +15,7 @@ use url::Url;
 use crate::{
     BATCHER, BUILDER, SEQUENCER,
     l1::{L1ContainerConfig, L1Stack, L1StackConfig},
-    l2::{L2ContainerConfig, L2Stack, L2StackConfig},
+    l2::{L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig},
     setup::{L1GenesisOutput, L2DeploymentOutput, SetupContainer},
     system_config::StableSystemTestConfig,
 };
@@ -133,6 +133,7 @@ pub struct SystemTestStackBuilder {
     stable_config: Option<StableSystemTestConfig>,
     tx_forwarding_config: Option<TxForwardingConfig>,
     verifier_l1_confs: u64,
+    client_consensus_mode: L2ClientConsensusMode,
 }
 
 impl SystemTestStackBuilder {
@@ -195,6 +196,12 @@ impl SystemTestStackBuilder {
     /// client (validator) node's derivation pipeline.
     pub const fn with_verifier_l1_confs(mut self, confs: u64) -> Self {
         self.verifier_l1_confs = confs;
+        self
+    }
+
+    /// Runs the L2 client consensus node in follow mode against the builder RPC.
+    pub const fn with_follow_mode_client_consensus(mut self) -> Self {
+        self.client_consensus_mode = L2ClientConsensusMode::Follow;
         self
     }
 
@@ -305,6 +312,7 @@ impl SystemTestStackBuilder {
             container_config: l2_container_config,
             tx_forwarding_config: self.tx_forwarding_config,
             verifier_l1_confs: self.verifier_l1_confs,
+            client_consensus_mode: self.client_consensus_mode,
         };
 
         let l2_stack = L2Stack::start(l2_config).await.wrap_err("Failed to start L2 stack")?;


### PR DESCRIPTION
This adds reusable system-test plumbing for running the L2 client with in-process follow-mode consensus instead of the default validator consensus path. 