### PR TITLE
feat(eip8130): 2D nonce validation (protocol, channel, nonce-free)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4528,6 +4528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-execution-eip8130-nonce"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "base-common-consensus",
+ "base-common-precompiles",
+ "base-precompile-storage",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "base-execution-eip8130-state"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ base-execution-eip8130 = { path = "crates/execution/eip8130", default-features =
 base-execution-eip8130-state = { path = "crates/execution/eip8130-state", default-features = false }
 base-execution-eip8130-authorize = { path = "crates/execution/eip8130-authorize", default-features = false }
 base-execution-eip8130-tx = { path = "crates/execution/eip8130-tx", default-features = false }
+base-execution-eip8130-nonce = { path = "crates/execution/eip8130-nonce", default-features = false }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }

--- a/crates/execution/eip8130-nonce/Cargo.toml
+++ b/crates/execution/eip8130-nonce/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "base-execution-eip8130-nonce"
+description = "EIP-8130 2D nonce validation (protocol, channel, and nonce-free modes)"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-primitives.workspace = true
+
+# base
+base-common-precompiles.workspace = true
+base-precompile-storage.workspace = true
+base-common-consensus = { workspace = true, default-features = false }
+
+# misc
+thiserror.workspace = true
+
+[dev-dependencies]
+base-precompile-storage = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/eip8130-nonce/README.md
+++ b/crates/execution/eip8130-nonce/README.md
@@ -1,0 +1,45 @@
+# base-execution-eip8130-nonce
+
+2D nonce validation for EIP-8130 — the stateful nonce step of the validation
+pipeline, shared by mempool admission and block inclusion. It consumes the
+resolved sender account (from [`base-execution-eip8130-tx`](../eip8130-tx)) and
+checks a transaction's `(nonce_key, nonce_sequence)` against the live nonce
+state.
+
+[`NonceValidator::validate`] resolves the channel implied by `nonce_key` and
+compares the transaction's `nonce_sequence` to that channel's current value:
+
+- **Protocol nonce** (`nonce_key == 0`): the channel value is the account's
+  basic protocol nonce, held in account state rather than the nonce manager, so
+  it is supplied by the caller as `protocol_nonce`.
+- **2D channel** (`0 < nonce_key < NONCE_KEY_MAX`): the channel value is read
+  from the [`NonceManager`](base_common_precompiles::NonceManagerStorage)
+  precompile via `get_nonce(account, nonce_key)`. Independent channels let one
+  account keep many independently-ordered transactions in flight.
+- **Nonce-free** (`nonce_key == NONCE_KEY_MAX`): there is no sequence channel.
+  Replay protection comes from the nonce manager's expiring-nonce set, keyed by
+  the signature-invariant replay hash `keccak256(account ‖ sender_signature_hash)`
+  so re-signed fee-payer variants of one logical transaction collapse to a single
+  entry.
+
+## Modes
+
+The same comparison serves both consumers, differing only in how a sequence
+*ahead* of the channel is treated:
+
+- [`NonceMode::Inclusion`] — the sequence must equal the channel nonce. A higher
+  sequence is a gap that cannot execute now ([`NonceError::TooHigh`]).
+- [`NonceMode::Pool`] — a higher sequence is admissible and **buffered**
+  ([`NonceStatus::Buffered`]) until its predecessors arrive, matching mempool
+  semantics for gapped transactions.
+
+A sequence *below* the channel nonce is always stale ([`NonceError::TooLow`]).
+
+## Scope (what this is and is not)
+
+This layer is a read-only check: it reads the channel nonce (or the
+expiring-nonce set) and decides admissibility. It does **not** advance nonces,
+record the expiring-nonce replay hash, or validate the structural nonce-free
+rules (`nonce_sequence == 0`, the `expiry` window) — those are enforced by
+`Eip8130Signed::validate_timestamp` and applied by the execution layer that
+calls `increment_nonce` / `check_and_mark_expiring_nonce`.

--- a/crates/execution/eip8130-nonce/src/error.rs
+++ b/crates/execution/eip8130-nonce/src/error.rs
@@ -1,0 +1,41 @@
+//! Errors returned by the EIP-8130 nonce validation step.
+
+use base_precompile_storage::BasePrecompileError;
+
+/// Reason a transaction's nonce could not be validated against the live nonce
+/// state. Every variant is a hard rejection for block inclusion; in the mempool
+/// a sequence *ahead* of the channel is not an error (see
+/// [`NonceStatus::Buffered`](crate::NonceStatus)).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NonceError {
+    /// The transaction's `nonce_sequence` is below the channel's current nonce,
+    /// so it has already been used. Stale in every mode.
+    #[error("nonce sequence {got} is below the channel nonce {channel}")]
+    TooLow {
+        /// The channel's current nonce read from state.
+        channel: u64,
+        /// The sequence carried by the transaction.
+        got: u64,
+    },
+
+    /// The transaction's `nonce_sequence` is ahead of the channel's current
+    /// nonce, leaving a gap. Only an error under [`NonceMode::Inclusion`](crate::NonceMode);
+    /// the pool buffers such transactions instead.
+    #[error("nonce sequence {got} is ahead of the channel nonce {channel}")]
+    TooHigh {
+        /// The channel's current nonce read from state.
+        channel: u64,
+        /// The sequence carried by the transaction.
+        got: u64,
+    },
+
+    /// A nonce-free (`NONCE_KEY_MAX`) transaction's replay hash is already
+    /// recorded and has not yet expired. Mirrors the nonce manager's
+    /// `ExpiringNonceReplay`.
+    #[error("nonce-free replay hash already recorded")]
+    Replay,
+
+    /// A read against the nonce manager precompile storage failed.
+    #[error("nonce-manager read failed: {0}")]
+    Storage(#[from] BasePrecompileError),
+}

--- a/crates/execution/eip8130-nonce/src/lib.rs
+++ b/crates/execution/eip8130-nonce/src/lib.rs
@@ -1,0 +1,7 @@
+#![doc = include_str!("../README.md")]
+
+mod error;
+pub use error::NonceError;
+
+mod validate;
+pub use validate::{NonceMode, NonceStatus, NonceValidator};

--- a/crates/execution/eip8130-nonce/src/validate.rs
+++ b/crates/execution/eip8130-nonce/src/validate.rs
@@ -1,0 +1,229 @@
+//! Stateful 2D nonce validation: resolve the channel implied by `nonce_key` and
+//! compare the transaction's `nonce_sequence` against the live nonce state.
+
+use core::cmp::Ordering;
+
+use alloy_primitives::{Address, B256, Keccak256, U256};
+use base_common_consensus::{Eip8130Constants, TxEip8130};
+use base_common_precompiles::NonceManagerStorage;
+
+use crate::NonceError;
+
+/// Which consumer is validating the nonce. The check is identical except for how
+/// a sequence *ahead* of the channel nonce is treated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NonceMode {
+    /// Mempool admission. A sequence ahead of the channel is admissible and
+    /// buffered until its predecessors arrive.
+    Pool,
+    /// Block inclusion. The sequence must equal the channel nonce exactly.
+    Inclusion,
+}
+
+/// Outcome of a successful nonce validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NonceStatus {
+    /// The transaction's sequence equals the channel nonce (or is a nonce-free
+    /// transaction whose replay hash has not been seen) and may execute now.
+    Ready,
+    /// Pool-only: the sequence is ahead of the channel nonce by `gap` and is
+    /// buffered until the intervening sequences are filled.
+    Buffered {
+        /// How far ahead of the current channel nonce the sequence is.
+        gap: u64,
+    },
+}
+
+/// Validates an EIP-8130 transaction's 2D nonce against the live nonce state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NonceValidator;
+
+impl NonceValidator {
+    /// Validates `tx`'s `(nonce_key, nonce_sequence)` for `account` (the resolved
+    /// transaction sender).
+    ///
+    /// `sender_signature_hash` is [`TxEip8130::sender_signature_hash`], taken as
+    /// a parameter because the earlier authenticate stage has already computed it
+    /// — recomputing it here (an RLP encode + keccak256) would be redundant work
+    /// on the nonce-free hot path. It is consulted only for the nonce-free
+    /// (`NONCE_KEY_MAX`) replay hash.
+    ///
+    /// `protocol_nonce` is the account's current basic nonce, read by the caller
+    /// from account state; it is consulted only for the protocol channel
+    /// (`nonce_key == 0`). `storage` serves the 2D channels and the nonce-free
+    /// replay set. `now` (Unix seconds; block timestamp at inclusion, wall-clock
+    /// in the pool) bounds the nonce-free replay-set lookup and is unused for
+    /// sequence channels.
+    ///
+    /// Returns [`NonceStatus::Ready`] when the transaction may execute now,
+    /// [`NonceStatus::Buffered`] when a pool transaction is ahead of its channel,
+    /// or a [`NonceError`] for a stale, gapped (inclusion), or replayed nonce.
+    pub fn validate(
+        tx: &TxEip8130,
+        account: Address,
+        sender_signature_hash: B256,
+        protocol_nonce: u64,
+        storage: &NonceManagerStorage<'_>,
+        mode: NonceMode,
+        now: u64,
+    ) -> Result<NonceStatus, NonceError> {
+        if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
+            // Nonce-free: no sequence channel. The structural rules
+            // (nonce_sequence == 0, expiry window) are enforced upstream by
+            // `Eip8130Signed::validate_timestamp`; the only stateful check is
+            // that this logical transaction's replay hash is not already
+            // recorded and unexpired.
+            let replay = Self::replay_hash(account, sender_signature_hash);
+            if storage.is_expiring_nonce_seen(replay, now)? {
+                return Err(NonceError::Replay);
+            }
+            return Ok(NonceStatus::Ready);
+        }
+
+        // Protocol nonce (key 0) lives in account state, not the nonce manager;
+        // every other channel is served by the manager precompile.
+        let channel = if tx.nonce_key == U256::ZERO {
+            protocol_nonce
+        } else {
+            storage.get_nonce(account, tx.nonce_key)?
+        };
+
+        match tx.nonce_sequence.cmp(&channel) {
+            Ordering::Less => Err(NonceError::TooLow { channel, got: tx.nonce_sequence }),
+            Ordering::Equal => Ok(NonceStatus::Ready),
+            Ordering::Greater => match mode {
+                NonceMode::Inclusion => {
+                    Err(NonceError::TooHigh { channel, got: tx.nonce_sequence })
+                }
+                NonceMode::Pool => Ok(NonceStatus::Buffered { gap: tx.nonce_sequence - channel }),
+            },
+        }
+    }
+
+    /// The signature-invariant nonce-free replay hash,
+    /// `keccak256(account ‖ sender_signature_hash)`, matching the value the nonce
+    /// manager records in its expiring-nonce set.
+    ///
+    /// Public so the execution layer can recompute the identical key when it
+    /// records the nonce via `check_and_mark_expiring_nonce` at block inclusion,
+    /// rather than duplicating the derivation and risking divergence.
+    #[must_use]
+    pub fn replay_hash(account: Address, sender_signature_hash: B256) -> B256 {
+        let mut hasher = Keccak256::new();
+        hasher.update(account.as_slice());
+        hasher.update(sender_signature_hash.as_slice());
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use super::*;
+
+    const ACCOUNT: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn tx_with(nonce_key: U256, nonce_sequence: u64) -> TxEip8130 {
+        TxEip8130 { nonce_key, nonce_sequence, ..Default::default() }
+    }
+
+    /// Runs `validate` against a freshly-seeded nonce manager. `seed` may mutate
+    /// the manager (e.g. advance a channel) before the (immutable) check.
+    fn check(
+        tx: &TxEip8130,
+        protocol_nonce: u64,
+        mode: NonceMode,
+        now: u64,
+        seed: impl FnOnce(&mut NonceManagerStorage<'_>),
+    ) -> Result<NonceStatus, NonceError> {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            seed(&mut mgr);
+            NonceValidator::validate(
+                tx,
+                ACCOUNT,
+                tx.sender_signature_hash(),
+                protocol_nonce,
+                &mgr,
+                mode,
+                now,
+            )
+        })
+    }
+
+    #[test]
+    fn protocol_nonce_ready_when_sequence_matches() {
+        let tx = tx_with(U256::ZERO, 5);
+        assert_eq!(check(&tx, 5, NonceMode::Inclusion, 0, |_| {}), Ok(NonceStatus::Ready));
+    }
+
+    #[test]
+    fn protocol_nonce_below_channel_is_too_low() {
+        let tx = tx_with(U256::ZERO, 4);
+        assert_eq!(
+            check(&tx, 5, NonceMode::Pool, 0, |_| {}),
+            Err(NonceError::TooLow { channel: 5, got: 4 })
+        );
+    }
+
+    #[test]
+    fn protocol_nonce_gap_rejected_at_inclusion_buffered_in_pool() {
+        let tx = tx_with(U256::ZERO, 8);
+        assert_eq!(
+            check(&tx, 5, NonceMode::Inclusion, 0, |_| {}),
+            Err(NonceError::TooHigh { channel: 5, got: 8 })
+        );
+        assert_eq!(check(&tx, 5, NonceMode::Pool, 0, |_| {}), Ok(NonceStatus::Buffered { gap: 3 }));
+    }
+
+    #[test]
+    fn channel_nonce_is_read_from_the_manager() {
+        let key = U256::from(7u64);
+        // Advance the 2D channel to 3, then the protocol_nonce arg must be ignored.
+        let seed = |mgr: &mut NonceManagerStorage<'_>| {
+            for _ in 0..3 {
+                mgr.increment_nonce(ACCOUNT, key).unwrap();
+            }
+        };
+        assert_eq!(
+            check(&tx_with(key, 3), 999, NonceMode::Inclusion, 0, seed),
+            Ok(NonceStatus::Ready)
+        );
+        assert_eq!(
+            check(&tx_with(key, 2), 999, NonceMode::Pool, 0, seed),
+            Err(NonceError::TooLow { channel: 3, got: 2 })
+        );
+        assert_eq!(
+            check(&tx_with(key, 5), 999, NonceMode::Pool, 0, seed),
+            Ok(NonceStatus::Buffered { gap: 2 })
+        );
+        assert_eq!(
+            check(&tx_with(key, 5), 999, NonceMode::Inclusion, 0, seed),
+            Err(NonceError::TooHigh { channel: 3, got: 5 })
+        );
+    }
+
+    #[test]
+    fn nonce_free_ready_when_replay_hash_unseen() {
+        let tx = tx_with(Eip8130Constants::NONCE_KEY_MAX, 0);
+        assert_eq!(check(&tx, 0, NonceMode::Pool, 1_000, |_| {}), Ok(NonceStatus::Ready));
+    }
+
+    #[test]
+    fn nonce_free_replay_is_rejected() {
+        let now = 1_000u64;
+        let tx = tx_with(Eip8130Constants::NONCE_KEY_MAX, 0);
+        let replay = NonceValidator::replay_hash(ACCOUNT, tx.sender_signature_hash());
+        let seed = |mgr: &mut NonceManagerStorage<'_>| {
+            mgr.check_and_mark_expiring_nonce(replay, now + 20).unwrap();
+        };
+        assert_eq!(check(&tx, 0, NonceMode::Inclusion, now, seed), Err(NonceError::Replay));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `base-execution-eip8130-nonce`, the stateful **2D nonce** step of the EIP-8130 validation pipeline, shared by mempool admission and block inclusion. It consumes the resolved sender account (from `base-execution-eip8130-tx`, #3540) and checks a transaction's `(nonce_key, nonce_sequence)` against the live nonce state.

### What it does

`NonceValidator::validate(tx, account, protocol_nonce, storage, mode, now)` resolves the channel implied by `nonce_key`:

| `nonce_key` | Channel source |
|---|---|
| `0` (protocol) | the account's basic protocol nonce, held in account state — passed in as `protocol_nonce` (not served by the nonce manager) |
| `0 < key < NONCE_KEY_MAX` | `NonceManagerStorage::get_nonce(account, key)` (the precompile in `base-common-precompiles`) |
| `NONCE_KEY_MAX` (nonce-free) | no sequence; replay-checked against the expiring-nonce set keyed by `keccak256(account ‖ sender_signature_hash)` |

Then compares `nonce_sequence` to that channel:

- below → `NonceError::TooLow` (stale, every mode)
- equal → `NonceStatus::Ready`
- above → `NonceMode::Inclusion` rejects (`TooHigh`); `NonceMode::Pool` buffers it (`NonceStatus::Buffered { gap }`), matching mempool semantics for gapped transactions.

### Scope (what this is not)

Read-only. It does **not** advance nonces, record the expiring-nonce replay hash, or re-check the structural nonce-free rules (`nonce_sequence == 0`, the `expiry` window) — those are owned by `Eip8130Signed::validate_timestamp` and the execution layer (`increment_nonce` / `check_and_mark_expiring_nonce`).

## Test plan

- `cargo test -p base-execution-eip8130-nonce` — 6 tests: protocol-nonce ready/too-low/gap (inclusion reject + pool buffer), 2D channel read from the manager (ready/too-low/buffer/too-high), nonce-free ready-when-unseen, and nonce-free replay rejection.
- `cargo clippy -p base-execution-eip8130-nonce --all-targets -- -D warnings`
- `cargo +nightly fmt -p base-execution-eip8130-nonce -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p base-execution-eip8130-nonce --no-deps`