### PR TITLE
chore(proof): add nitro host debug logs

### DIFF
--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -24,7 +24,7 @@ use base_proof_preimage::{PreimageKey, PreimageKeyType};
 use base_protocol::{BlockInfo, OutputRoot};
 use futures::FutureExt;
 use tokio::sync::Semaphore;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     HostConfig, HostError, HostProviders, Metrics, Result, SharedKeyValueStore, store_ordered_trie,
@@ -659,9 +659,10 @@ impl L1HeaderPrefetcher {
         let decoded_header = match Header::decode(&mut raw_header.as_ref()) {
             Ok(header) => header,
             Err(err) => {
-                debug!(
+                warn!(
                     target: HOST_SERVER_TARGET,
                     block_number,
+                    raw_header_len = raw_header.len(),
                     error = %err,
                     "l1 header prefetch skipped: failed to decode raw header"
                 );
@@ -930,7 +931,7 @@ async fn handle_hint_inner(
             }
 
             let hash: B256 = hint.data.as_ref().try_into()?;
-            let (raw_header, should_mark_ready) = if let Some(prefetcher) =
+            let (raw_header, should_mark_ready, raw_header_source) = if let Some(prefetcher) =
                 l1_header_prefetcher.as_ref()
                 && let Some(raw_header) = prefetcher.get_ready(hash)
             {
@@ -939,13 +940,35 @@ async fn handle_hint_inner(
                     hash = %hash,
                     "l1 header served from prefetch cache"
                 );
-                (raw_header, false)
+                (raw_header, false, "prefetch_cache")
             } else {
                 let raw_header: Bytes =
                     providers.l1.client().request("debug_getRawHeader", [hash]).await?;
-                (raw_header, true)
+                (raw_header, true, "rpc")
             };
-            let header = Header::decode(&mut raw_header.as_ref())?;
+            if raw_header.len() < 512 {
+                warn!(
+                    target: HOST_SERVER_TARGET,
+                    hash = %hash,
+                    raw_header_len = raw_header.len(),
+                    raw_header_source,
+                    "l1 header raw rlp is suspiciously short"
+                );
+            }
+            let header = match Header::decode(&mut raw_header.as_ref()) {
+                Ok(header) => header,
+                Err(err) => {
+                    error!(
+                        target: HOST_SERVER_TARGET,
+                        hash = %hash,
+                        raw_header_len = raw_header.len(),
+                        raw_header_source,
+                        error = %err,
+                        "failed to decode l1 header rlp"
+                    );
+                    return Err(err.into());
+                }
+            };
             let decoded_hash = header.hash_slow();
             if decoded_hash != hash {
                 return Err(HostError::HeaderPreimageHashMismatch {

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_provider::{Network, RootProvider};
+use alloy_provider::{Network, Provider, RootProvider};
 use base_common_evm::BaseEvmFactory;
 use base_common_network::Base;
 use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
@@ -14,7 +14,7 @@ use tokio::{
     sync::RwLock,
     task::{self, JoinHandle},
 };
-use tracing::{Instrument, info, info_span};
+use tracing::{Instrument, info, info_span, warn};
 
 #[cfg(feature = "disk")]
 use crate::DiskKeyValueStore;
@@ -98,6 +98,42 @@ impl Host {
 
         let kv_store = self.create_key_value_store()?;
         let providers = self.create_providers().await?;
+        match providers.l1.get_block_number().await {
+            Ok(l1_provider_head_number)
+                if l1_provider_head_number < self.config.request.l1_head_number =>
+            {
+                warn!(
+                    l2_block = self.config.request.claimed_l2_block_number,
+                    requested_l1_head = %self.config.request.l1_head,
+                    requested_l1_head_number = self.config.request.l1_head_number,
+                    l1_provider_head_number,
+                    l1_provider_lag_blocks = self
+                        .config
+                        .request
+                        .l1_head_number
+                        .saturating_sub(l1_provider_head_number),
+                    "l1 provider is behind requested l1 head before witness capture"
+                );
+            }
+            Ok(l1_provider_head_number) => {
+                info!(
+                    l2_block = self.config.request.claimed_l2_block_number,
+                    requested_l1_head = %self.config.request.l1_head,
+                    requested_l1_head_number = self.config.request.l1_head_number,
+                    l1_provider_head_number,
+                    "l1 provider head before witness capture"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    l2_block = self.config.request.claimed_l2_block_number,
+                    requested_l1_head = %self.config.request.l1_head,
+                    requested_l1_head_number = self.config.request.l1_head_number,
+                    error = %err,
+                    "failed to read l1 provider head before witness capture"
+                );
+            }
+        }
         let backend = Arc::new(
             OnlineHostBackend::new_with_l1_header_cache(
                 self.config.clone(),

--- a/crates/proof/host/src/server.rs
+++ b/crates/proof/host/src/server.rs
@@ -50,7 +50,14 @@ where
         loop {
             match oracle_server.next_preimage_request(backend.as_ref()).await {
                 Ok(_) => {}
-                Err(PreimageOracleError::IOError(_)) => return Ok(()),
+                Err(PreimageOracleError::IOError(e)) => {
+                    info!(
+                        target: "host_server",
+                        error = %e,
+                        "oracle server channel closed; exiting"
+                    );
+                    return Ok(());
+                }
                 Err(e) => {
                     error!(target: "host_server", error = %e, "failed to serve preimage request");
                     return Err(HostError::PreimageRequestFailed(e));
@@ -64,7 +71,10 @@ where
         loop {
             match hint_reader.next_hint(backend.as_ref()).await {
                 Ok(_) => {}
-                Err(PreimageOracleError::IOError(_)) => return Ok(()),
+                Err(PreimageOracleError::IOError(e)) => {
+                    info!(target: "host_server", error = %e, "hint router channel closed; exiting");
+                    return Ok(());
+                }
                 Err(e) => {
                     error!(target: "host_server", error = %e, "failed to route hint");
                     return Err(HostError::RouteHintFailed(e));

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -66,7 +66,14 @@ impl<B: ProverBackend> ProverService<B> {
         &self,
         request: ProofRequest,
     ) -> Result<ProofResult, ProverError<B>> {
-        info!(l2_block = request.claimed_l2_block_number, "starting proof generation");
+        info!(
+            l2_block = request.claimed_l2_block_number,
+            l1_head = %request.l1_head,
+            l1_head_number = request.l1_head_number,
+            agreed_l2_head = %request.agreed_l2_head_hash,
+            intermediate_block_interval = request.intermediate_block_interval,
+            "starting proof generation"
+        );
 
         let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
         let l1_header_cache = self.l1_header_cache.get_or_init(L1HeaderCache::new).clone();

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -167,6 +167,8 @@ where
             lock_id = %request.lock_id,
             worker_id = %request.worker_id,
             l2_block = request.proof.claimed_l2_block_number,
+            l1_head = %request.proof.l1_head,
+            l1_head_number = request.proof.l1_head_number,
             "starting nitro proof generation"
         );
 
@@ -182,6 +184,8 @@ where
                     lock_id = %request.lock_id,
                     worker_id = %request.worker_id,
                     l2_block,
+                    l1_head = %request.proof.l1_head,
+                    l1_head_number = request.proof.l1_head_number,
                     error = %source,
                     "nitro proof generation failed"
                 );
@@ -194,6 +198,8 @@ where
                     lock_id = %request.lock_id,
                     worker_id = %request.worker_id,
                     l2_block,
+                    l1_head = %request.proof.l1_head,
+                    l1_head_number = request.proof.l1_head_number,
                     error = %source,
                     "aborting nitro proof generation due to heartbeat failure"
                 );
@@ -230,6 +236,9 @@ where
             session_id = %request.session_id,
             lock_id = %request.lock_id,
             worker_id = %request.worker_id,
+            l2_block,
+            l1_head = %request.proof.l1_head,
+            l1_head_number = request.proof.l1_head_number,
             "nitro proof generated; proof submitter task spawned"
         );
 


### PR DESCRIPTION
### What changed? Why?

Adds targeted Nitro host and witness logs for debugging zeronet proof failures:

- Include L1 head metadata on Nitro proof start, failure, and success logs.
- Include L1 head metadata when host proof generation starts.
- Log the L1 provider head before witness capture, with a warning when the provider is behind the requested L1 head.
- Log raw L1 header source and length when header RLP is suspiciously short or fails to decode.
- Log oracle and hint-router channel close IO errors before exiting those loops.

This should help distinguish RPC lag, malformed `debug_getRawHeader` responses, prefetch-cache issues, and expected channel shutdowns.

### Notes to reviewers

Logging-only change. Existing proof, witness, retry, and error-return behavior is unchanged.

### How has it been tested?

- `cargo fmt --package base-proof-host --package base-proof-tee-nitro-host`
- `cargo check -p base-proof-host -p base-proof-tee-nitro-host`