### PR TITLE
feat(eip8130): transaction authorization orchestrator

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -82,8 +82,8 @@ impl Eip8130Contracts {
     // ─────────────────────────────────────────────────────────────────────────
 
     // Note: secp256k1 has no contract entry. It is the protocol-reserved native
-    // ecrecover sentinel
-    // [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`](super::Eip8130Constants::ECRECOVER_AUTHENTICATOR)
+    // k1 sentinel
+    // [`Eip8130Constants::K1_AUTHENTICATOR`](super::Eip8130Constants::K1_AUTHENTICATOR)
     // (`address(1)`), handled directly by the protocol, not a deployed contract.
 
     /// secp256r1 / P-256 (raw) authenticator contract.

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -87,16 +87,26 @@ impl Eip8130Constants {
     /// `actor_change` operation byte: revoke an existing actor.
     pub const ACTOR_CHANGE_REVOKE: u8 = 0x02;
 
-    /// Lower-bound authenticator address. The `ECRECOVER_AUTHENTICATOR` native is fixed at
-    /// `address(1)`; authenticator addresses smaller than this are reserved.
-    pub const ECRECOVER_AUTHENTICATOR: Address =
-        address!("0x0000000000000000000000000000000000000001");
+    /// The single canonical secp256k1 ("k1") authenticator, fixed at
+    /// `address(1)`. Native `ecrecover`: the protocol recovers from the `data`
+    /// blob (`r || s || v`) rather than `STATICCALL`-ing a contract. The same
+    /// identity serves both the implicit default EOA and any explicitly
+    /// registered k1 actor; the `actor_config` slot alone distinguishes a
+    /// full-owner EOA from a scoped key.
+    ///
+    /// `address(0)` is reserved as the empty / "no actor configured" sentinel and
+    /// is never a valid authenticator selector; addresses below this are reserved.
+    pub const K1_AUTHENTICATOR: Address = address!("0x0000000000000000000000000000000000000001");
 
-    /// Sentinel authenticator address indicating an actor slot has been revoked
-    /// (`type(uint160).max`). Submitting authentication data prefixed with this
-    /// authenticator MUST be rejected.
-    pub const REVOKED_AUTHENTICATOR: Address =
-        address!("0xffffffffffffffffffffffffffffffffffffffff");
+    /// `AccountState.flags` bit that disables the implicit default-EOA path.
+    ///
+    /// The implicit default EOA is a [`Self::K1_AUTHENTICATOR`] signature whose
+    /// recovered signer equals the account; with no explicit `actor_config` it
+    /// resolves to a full owner, gated solely on this flag. Set by
+    /// `createAccount`/`importAccount` (disabled by default), and by authorizing
+    /// or revoking the self-actor; once set it is never cleared (monotonic), so
+    /// an explicit self-actor entry always implies the flag is set.
+    pub const DEFAULT_EOA_REVOKED: u8 = 0x01;
 
     /// Maximum number of `ConfigChange` entries the mempool accepts in a single
     /// transaction. The spec marks this as a node policy ("Nodes SHOULD enforce

--- a/crates/execution/eip8130/README.md
+++ b/crates/execution/eip8130/README.md
@@ -47,3 +47,8 @@ The crate keeps the protocol stages explicit while avoiding crate sprawl:
 - **Authorize** binds resolved actors to account config, expiry, scope, and policy.
 - **Transaction auth** applies sender, payer, and config-change operation gates.
 - **Nonce validation** checks protocol, 2D-channel, and nonce-free replay state.
+- **Orchestration** composes the final sender/payer signatures with the
+  transaction's ordered account-configuration changes — advancing each channel
+  sequence per applied entry — into one authorization verdict (`TransactionAuthorizer`),
+  shared by mempool admission and block inclusion. It reads state but never
+  mutates it; nonce, gas, and fee/balance checks remain separate stages.

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -46,33 +46,50 @@ impl AccountConfigurationStorage<'_> {
         Ok(ActorConfig::from_word(self.actor_config.at(&actor_id).at(&account).read()?))
     }
 
-    /// Mirrors `AccountConfiguration.isActor`: `true` for any explicit entry
-    /// (a non-empty authenticator), or the implicit default-EOA self-actor (empty
-    /// slot whose `actor_id` is the account) while its `DEFAULT_EOA_REVOKED` flag
-    /// is unset.
+    /// Mirrors `AccountConfiguration.isActor`: `true` for any explicit
+    /// `actor_config` entry (a non-empty authenticator), or the secp256k1 self
+    /// key (the `actor_id` is the account, with no explicit entry) while its
+    /// `DEFAULT_EOA_REVOKED` flag is unset. A live *scoped* self has no explicit
+    /// entry — its config lives inline in `AccountState` — and so resolves
+    /// through this same self path.
     pub fn is_actor(&self, account: Address, actor_id: B256) -> Result<bool> {
         // An explicit entry (any non-empty authenticator) is always a live actor.
         if self.get_actor_config(account, actor_id)?.authenticator != Address::ZERO {
             return Ok(true);
         }
-        // No explicit entry: the self-actor is the implicit default EOA, live
-        // unless disabled by the account's `DEFAULT_EOA_REVOKED` flag.
+        // No explicit entry: the self-actor is the secp256k1 self key (full owner
+        // or inline-scoped), live unless the `DEFAULT_EOA_REVOKED` flag is set.
         if actor_id == Self::self_actor_id(account) {
             return Ok(!self.get_account_state(account)?.default_eoa_revoked());
         }
         Ok(false)
     }
 
-    /// Mirrors `AccountConfiguration.getPolicy`: an ungated actor
-    /// (`policy_type == 0`) resolves to `(address(0), bytes32(0))`; otherwise the
-    /// stored `(manager, commitment)`.
-    pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(Address, B256)> {
-        if self.get_actor_config(account, actor_id)?.policy_type == 0 {
-            return Ok((Address::ZERO, B256::ZERO));
+    /// Mirrors `AccountConfiguration.getPolicy`: resolves an actor's policy
+    /// sub-type, gate target, and signed commitment. An ungated actor resolves
+    /// to `(0, address(0), bytes32(0))`; a gated one to `(policy_type, manager,
+    /// commitment)`. The secp256k1 self key's policy lives inline in
+    /// `AccountState` (read only while the self key is live); a non-k1 self and
+    /// every other actor resolve from `actor_config`.
+    pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(u8, Address, B256)> {
+        let stored = self.get_actor_config(account, actor_id)?;
+        let policy_type = if stored.authenticator != Address::ZERO {
+            stored.policy_type
+        } else if actor_id == Self::self_actor_id(account) {
+            let state = self.get_account_state(account)?;
+            if state.default_eoa_revoked() {
+                return Ok((0, Address::ZERO, B256::ZERO));
+            }
+            state.default_eoa_policy_type
+        } else {
+            return Ok((0, Address::ZERO, B256::ZERO));
+        };
+        if policy_type == 0 {
+            return Ok((0, Address::ZERO, B256::ZERO));
         }
         let manager = self.policy_manager.at(&actor_id).at(&account).read()?;
         let commitment = self.policy_commitment.at(&actor_id).at(&account).read()?;
-        Ok((manager, commitment))
+        Ok((policy_type, manager, commitment))
     }
 
     /// Reads only the stored policy *manager* slot for `(account, actor_id)`,
@@ -185,12 +202,22 @@ impl ActorConfig {
 /// Decoded `AccountConfiguration.AccountState` (one packed storage slot).
 ///
 /// Solidity layout `{uint64 multichainSequence; uint64 localSequence; uint40
-/// unlocksAt; uint16 unlockDelay; uint8 flags;}`, packed right-aligned,
-/// lowest-order field first:
+/// unlocksAt; uint16 unlockDelay; uint8 flags; uint8 defaultEOAScope; uint8
+/// defaultEOAPolicyType; uint48 defaultEOAExpiry;}`, packed right-aligned,
+/// lowest-order field first, filling the slot to exactly 32 bytes:
 ///
 /// ```text
-/// bits (LSB-first): multichain 0..64 | local 64..128 | unlocksAt 128..168 | unlockDelay 168..184 | flags 184..192
+/// bits (LSB-first): multichain 0..64 | local 64..128 | unlocksAt 128..168 | unlockDelay 168..184 | flags 184..192 | defaultEOAScope 192..200 | defaultEOAPolicyType 200..208 | defaultEOAExpiry 208..256
 /// ```
+///
+/// The `default_eoa_*` fields are the inline home for the account's own
+/// secp256k1 ("self") key: when `DEFAULT_EOA_REVOKED` is unset, a k1 signature
+/// recovering to the account authenticates with this inline config — all-zero
+/// is the implicit full owner, a non-zero scope/policy/expiry is a scoped self
+/// — so the entire self key resolves in a single account-state SLOAD. The
+/// `actor_config(self)` slot is reserved for a *non*-k1 self authenticator
+/// (e.g. a post-quantum verifier returning the self-actorId); the inline k1
+/// self and a non-k1 self are mutually exclusive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct AccountState {
@@ -205,8 +232,17 @@ pub struct AccountState {
     /// Unlock delay in seconds.
     pub unlock_delay: u16,
     /// Account flags bitfield; bit 0 ([`Eip8130Constants::DEFAULT_EOA_REVOKED`])
-    /// disables the implicit default-EOA path.
+    /// disables the inline secp256k1 self key (both the implicit full owner and
+    /// any inline-scoped self).
     pub flags: u8,
+    /// Inline self-key scope bitfield (`0` = unrestricted full owner). Governs
+    /// only when the self key is live (`!default_eoa_revoked()`).
+    pub default_eoa_scope: u8,
+    /// Inline self-key policy sub-type (`0` = ungated).
+    pub default_eoa_policy_type: u8,
+    /// Inline self-key Unix-seconds expiry (`0` = no expiry). The self key is
+    /// invalid once `now > default_eoa_expiry`.
+    pub default_eoa_expiry: u64,
 }
 
 impl AccountState {
@@ -222,16 +258,21 @@ impl AccountState {
         let mut local = [0u8; 8];
         let mut unlocks_at = [0u8; 8];
         let mut unlock_delay = [0u8; 2];
+        let mut default_eoa_expiry = [0u8; 8];
         multichain.copy_from_slice(&b[24..32]); // uint64
         local.copy_from_slice(&b[16..24]); // uint64
         unlocks_at[3..].copy_from_slice(&b[11..16]); // uint40: 5 bytes, big-endian
         unlock_delay.copy_from_slice(&b[9..11]); // uint16
+        default_eoa_expiry[2..].copy_from_slice(&b[0..6]); // uint48: 6 bytes, big-endian
         Self {
             multichain_sequence: u64::from_be_bytes(multichain),
             local_sequence: u64::from_be_bytes(local),
             unlocks_at: u64::from_be_bytes(unlocks_at),
             unlock_delay: u16::from_be_bytes(unlock_delay),
-            flags: b[8], // uint8 at bits 184..192
+            flags: b[8],                   // uint8 at bits 184..192
+            default_eoa_scope: b[7],       // uint8 at bits 192..200
+            default_eoa_policy_type: b[6], // uint8 at bits 200..208
+            default_eoa_expiry: u64::from_be_bytes(default_eoa_expiry),
         }
     }
 
@@ -278,18 +319,25 @@ mod tests {
             | (U256::from(policy_type) << 216)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn pack_account_state(
         multichain: u64,
         local: u64,
         unlocks_at: u64,
         unlock_delay: u16,
         flags: u8,
+        default_eoa_scope: u8,
+        default_eoa_policy_type: u8,
+        default_eoa_expiry: u64,
     ) -> U256 {
         U256::from(multichain)
             | (U256::from(local) << 64)
             | (U256::from(unlocks_at) << 128)
             | (U256::from(unlock_delay) << 168)
             | (U256::from(flags) << 184)
+            | (U256::from(default_eoa_scope) << 192)
+            | (U256::from(default_eoa_policy_type) << 200)
+            | (U256::from(default_eoa_expiry) << 208)
     }
 
     #[test]
@@ -342,7 +390,16 @@ mod tests {
             // Empty slot, self actor id, DEFAULT_EOA_REVOKED set -> not an actor.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, 0, 0, Eip8130Constants::DEFAULT_EOA_REVOKED))
+                .write(pack_account_state(
+                    0,
+                    1,
+                    0,
+                    0,
+                    Eip8130Constants::DEFAULT_EOA_REVOKED,
+                    0,
+                    0,
+                    0,
+                ))
                 .unwrap();
             assert!(!acc.is_actor(ACCOUNT, self_id).unwrap());
 
@@ -365,13 +422,53 @@ mod tests {
             // Ungated actor (policy_type 0) -> zeroed regardless of stored slots.
             acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(manager)).unwrap();
             acc.policy_manager.at_mut(&ACTOR).at_mut(&ACCOUNT).write(manager).unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (Address::ZERO, B256::ZERO));
+            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (0, Address::ZERO, B256::ZERO));
 
-            // Gated actor -> (manager, commitment).
-            let gated = pack_actor_config(manager, 0, 0, 1);
+            // Gated actor -> (policy_type, manager, commitment).
+            let gated = pack_actor_config(manager, 0, 0, 7);
             acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(gated).unwrap();
             acc.policy_commitment.at_mut(&ACTOR).at_mut(&ACCOUNT).write(commitment).unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (manager, commitment));
+            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (7, manager, commitment));
+        });
+    }
+
+    #[test]
+    fn get_policy_resolves_inline_self_key() {
+        let manager = address!("0x00000000000000000000000000000000000000d4");
+        let commitment =
+            b256!("0x2222222222222222222222222222222222222222222222222222222222222222");
+        let self_id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut acc = AccountConfigurationStorage::new(ctx);
+            acc.policy_manager.at_mut(&self_id).at_mut(&ACCOUNT).write(manager).unwrap();
+            acc.policy_commitment.at_mut(&self_id).at_mut(&ACCOUNT).write(commitment).unwrap();
+
+            // Live full-owner self (inline policy_type 0) -> ungated, slots ignored.
+            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (0, Address::ZERO, B256::ZERO));
+
+            // Live scoped self with an inline gate -> (policy_type, manager, commitment).
+            acc.account_state
+                .at_mut(&ACCOUNT)
+                .write(pack_account_state(0, 1, 0, 0, 0, 0, 9, 0))
+                .unwrap();
+            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (9, manager, commitment));
+
+            // Revoked self -> ungated regardless of the inline policy_type.
+            acc.account_state
+                .at_mut(&ACCOUNT)
+                .write(pack_account_state(
+                    0,
+                    1,
+                    0,
+                    0,
+                    Eip8130Constants::DEFAULT_EOA_REVOKED,
+                    0,
+                    9,
+                    0,
+                ))
+                .unwrap();
+            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (0, Address::ZERO, B256::ZERO));
         });
     }
 
@@ -389,12 +486,16 @@ mod tests {
 
     #[test]
     fn account_state_unpacks_sequences_and_lock_fields() {
+        let expiry = (1u64 << 48) - 1; // full uint48
         let word = pack_account_state(
             7,
             3,
             (1u64 << 40) - 1,
             0xBEEF,
             Eip8130Constants::DEFAULT_EOA_REVOKED,
+            0xAB,
+            0xCD,
+            expiry,
         );
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
@@ -407,6 +508,9 @@ mod tests {
             assert_eq!(state.unlocks_at, AccountState::UNLOCKS_AT_MAX);
             assert_eq!(state.unlock_delay, 0xBEEF);
             assert!(state.default_eoa_revoked());
+            assert_eq!(state.default_eoa_scope, 0xAB);
+            assert_eq!(state.default_eoa_policy_type, 0xCD);
+            assert_eq!(state.default_eoa_expiry, expiry);
             assert_eq!(acc.get_change_sequences(ACCOUNT).unwrap(), (7, 3));
             assert!(acc.is_initialized(ACCOUNT).unwrap());
         });
@@ -422,7 +526,7 @@ mod tests {
             // lock(): unlocks_at = max, delay set. Locked, no unlock initiated.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, AccountState::UNLOCKS_AT_MAX, delay, 0))
+                .write(pack_account_state(0, 1, AccountState::UNLOCKS_AT_MAX, delay, 0, 0, 0, 0))
                 .unwrap();
             assert!(acc.is_locked(ACCOUNT, 1_000).unwrap());
             let status = acc.get_lock_status(ACCOUNT, 1_000).unwrap();
@@ -433,7 +537,7 @@ mod tests {
             // initiateUnlock(): unlocks_at = real future time, delay cleared.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, 2_000, 0, 0))
+                .write(pack_account_state(0, 1, 2_000, 0, 0, 0, 0, 0))
                 .unwrap();
             assert!(acc.is_locked(ACCOUNT, 1_000).unwrap()); // before unlocks_at
             assert!(!acc.is_locked(ACCOUNT, 2_000).unwrap()); // at/after unlocks_at
@@ -443,7 +547,10 @@ mod tests {
             assert_eq!(status.unlocks_at, 2_000);
 
             // Never locked: unlocks_at = 0.
-            acc.account_state.at_mut(&ACCOUNT).write(pack_account_state(0, 1, 0, 0, 0)).unwrap();
+            acc.account_state
+                .at_mut(&ACCOUNT)
+                .write(pack_account_state(0, 1, 0, 0, 0, 0, 0, 0))
+                .unwrap();
             assert!(!acc.is_locked(ACCOUNT, 0).unwrap());
             assert!(!acc.get_lock_status(ACCOUNT, 0).unwrap().has_initiated_unlock);
         });

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -46,17 +46,21 @@ impl AccountConfigurationStorage<'_> {
         Ok(ActorConfig::from_word(self.actor_config.at(&actor_id).at(&account).read()?))
     }
 
-    /// Mirrors `AccountConfiguration.isActor`: `true` for any actor bound to a
-    /// real authenticator (`authenticator >= ECRECOVER && != REVOKED`), or the
-    /// implicit-EOA self-actor (empty slot whose `actor_id` is the account).
+    /// Mirrors `AccountConfiguration.isActor`: `true` for any explicit entry
+    /// (a non-empty authenticator), or the implicit default-EOA self-actor (empty
+    /// slot whose `actor_id` is the account) while its `DEFAULT_EOA_REVOKED` flag
+    /// is unset.
     pub fn is_actor(&self, account: Address, actor_id: B256) -> Result<bool> {
-        let authenticator = self.get_actor_config(account, actor_id)?.authenticator;
-        if authenticator >= Eip8130Constants::ECRECOVER_AUTHENTICATOR
-            && authenticator != Eip8130Constants::REVOKED_AUTHENTICATOR
-        {
+        // An explicit entry (any non-empty authenticator) is always a live actor.
+        if self.get_actor_config(account, actor_id)?.authenticator != Address::ZERO {
             return Ok(true);
         }
-        Ok(authenticator == Address::ZERO && actor_id == Self::self_actor_id(account))
+        // No explicit entry: the self-actor is the implicit default EOA, live
+        // unless disabled by the account's `DEFAULT_EOA_REVOKED` flag.
+        if actor_id == Self::self_actor_id(account) {
+            return Ok(!self.get_account_state(account)?.default_eoa_revoked());
+        }
+        Ok(false)
     }
 
     /// Mirrors `AccountConfiguration.getPolicy`: an ungated actor
@@ -141,7 +145,7 @@ impl AccountConfigurationStorage<'_> {
 #[non_exhaustive]
 pub struct ActorConfig {
     /// Authenticator address bound to the actor (`address(0)` = empty slot,
-    /// `address(1)` = native ecrecover, `address(uint160).max` = revoked).
+    /// `address(1)` = native k1/ecrecover, any other = `IAuthenticator` contract).
     pub authenticator: Address,
     /// Elevated-scope bitfield (`0 = unrestricted`).
     pub scope: u8,
@@ -181,11 +185,11 @@ impl ActorConfig {
 /// Decoded `AccountConfiguration.AccountState` (one packed storage slot).
 ///
 /// Solidity layout `{uint64 multichainSequence; uint64 localSequence; uint40
-/// unlocksAt; uint16 unlockDelay;}`, packed right-aligned, lowest-order field
-/// first:
+/// unlocksAt; uint16 unlockDelay; uint8 flags;}`, packed right-aligned,
+/// lowest-order field first:
 ///
 /// ```text
-/// bits (LSB-first): multichain 0..64 | local 64..128 | unlocksAt 128..168 | unlockDelay 168..184
+/// bits (LSB-first): multichain 0..64 | local 64..128 | unlocksAt 128..168 | unlockDelay 168..184 | flags 184..192
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -200,6 +204,9 @@ pub struct AccountState {
     pub unlocks_at: u64,
     /// Unlock delay in seconds.
     pub unlock_delay: u16,
+    /// Account flags bitfield; bit 0 ([`Eip8130Constants::DEFAULT_EOA_REVOKED`])
+    /// disables the implicit default-EOA path.
+    pub flags: u8,
 }
 
 impl AccountState {
@@ -224,7 +231,15 @@ impl AccountState {
             local_sequence: u64::from_be_bytes(local),
             unlocks_at: u64::from_be_bytes(unlocks_at),
             unlock_delay: u16::from_be_bytes(unlock_delay),
+            flags: b[8], // uint8 at bits 184..192
         }
+    }
+
+    /// `true` when the implicit default-EOA path is disabled for this account
+    /// (the `DEFAULT_EOA_REVOKED` flag bit is set).
+    #[must_use]
+    pub const fn default_eoa_revoked(&self) -> bool {
+        self.flags & Eip8130Constants::DEFAULT_EOA_REVOKED != 0
     }
 }
 
@@ -263,11 +278,18 @@ mod tests {
             | (U256::from(policy_type) << 216)
     }
 
-    fn pack_account_state(multichain: u64, local: u64, unlocks_at: u64, unlock_delay: u16) -> U256 {
+    fn pack_account_state(
+        multichain: u64,
+        local: u64,
+        unlocks_at: u64,
+        unlock_delay: u16,
+        flags: u8,
+    ) -> U256 {
         U256::from(multichain)
             | (U256::from(local) << 64)
             | (U256::from(unlocks_at) << 128)
             | (U256::from(unlock_delay) << 168)
+            | (U256::from(flags) << 184)
     }
 
     #[test]
@@ -301,8 +323,8 @@ mod tests {
     #[test]
     fn is_actor_matches_contract_predicate() {
         let mut storage = HashMapStorageProvider::new(1);
-        let revoked = Eip8130Constants::REVOKED_AUTHENTICATOR;
         let bound = address!("0x00000000000000000000000000000000000000ff");
+        let self_id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
 
@@ -310,16 +332,23 @@ mod tests {
             acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
             assert!(acc.is_actor(ACCOUNT, ACTOR).unwrap());
 
-            // Revoked sentinel -> not an actor.
-            acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(revoked)).unwrap();
-            assert!(!acc.is_actor(ACCOUNT, ACTOR).unwrap());
-
             // Empty slot, non-self actor id -> not an actor.
             let other = b256!("0x00000000000000000000000000000000000000cc000000000000000000000000");
             assert!(!acc.is_actor(ACCOUNT, other).unwrap());
 
-            // Empty slot, self actor id -> implicit EOA actor.
-            let self_id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
+            // Empty slot, self actor id, flag unset -> implicit default EOA actor.
+            assert!(acc.is_actor(ACCOUNT, self_id).unwrap());
+
+            // Empty slot, self actor id, DEFAULT_EOA_REVOKED set -> not an actor.
+            acc.account_state
+                .at_mut(&ACCOUNT)
+                .write(pack_account_state(0, 1, 0, 0, Eip8130Constants::DEFAULT_EOA_REVOKED))
+                .unwrap();
+            assert!(!acc.is_actor(ACCOUNT, self_id).unwrap());
+
+            // Explicit self entry stays live even with the flag set (re-registered
+            // scoped/owner k1 self key); the entry-exists => flag-set invariant.
+            acc.actor_config.at_mut(&self_id).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
             assert!(acc.is_actor(ACCOUNT, self_id).unwrap());
         });
     }
@@ -360,7 +389,13 @@ mod tests {
 
     #[test]
     fn account_state_unpacks_sequences_and_lock_fields() {
-        let word = pack_account_state(7, 3, (1u64 << 40) - 1, 0xBEEF);
+        let word = pack_account_state(
+            7,
+            3,
+            (1u64 << 40) - 1,
+            0xBEEF,
+            Eip8130Constants::DEFAULT_EOA_REVOKED,
+        );
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
@@ -371,6 +406,7 @@ mod tests {
             assert_eq!(state.local_sequence, 3);
             assert_eq!(state.unlocks_at, AccountState::UNLOCKS_AT_MAX);
             assert_eq!(state.unlock_delay, 0xBEEF);
+            assert!(state.default_eoa_revoked());
             assert_eq!(acc.get_change_sequences(ACCOUNT).unwrap(), (7, 3));
             assert!(acc.is_initialized(ACCOUNT).unwrap());
         });
@@ -386,7 +422,7 @@ mod tests {
             // lock(): unlocks_at = max, delay set. Locked, no unlock initiated.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, AccountState::UNLOCKS_AT_MAX, delay))
+                .write(pack_account_state(0, 1, AccountState::UNLOCKS_AT_MAX, delay, 0))
                 .unwrap();
             assert!(acc.is_locked(ACCOUNT, 1_000).unwrap());
             let status = acc.get_lock_status(ACCOUNT, 1_000).unwrap();
@@ -395,7 +431,10 @@ mod tests {
             assert_eq!(status.unlock_delay, delay);
 
             // initiateUnlock(): unlocks_at = real future time, delay cleared.
-            acc.account_state.at_mut(&ACCOUNT).write(pack_account_state(0, 1, 2_000, 0)).unwrap();
+            acc.account_state
+                .at_mut(&ACCOUNT)
+                .write(pack_account_state(0, 1, 2_000, 0, 0))
+                .unwrap();
             assert!(acc.is_locked(ACCOUNT, 1_000).unwrap()); // before unlocks_at
             assert!(!acc.is_locked(ACCOUNT, 2_000).unwrap()); // at/after unlocks_at
             let status = acc.get_lock_status(ACCOUNT, 1_000).unwrap();
@@ -404,7 +443,7 @@ mod tests {
             assert_eq!(status.unlocks_at, 2_000);
 
             // Never locked: unlocks_at = 0.
-            acc.account_state.at_mut(&ACCOUNT).write(pack_account_state(0, 1, 0, 0)).unwrap();
+            acc.account_state.at_mut(&ACCOUNT).write(pack_account_state(0, 1, 0, 0, 0)).unwrap();
             assert!(!acc.is_locked(ACCOUNT, 0).unwrap());
             assert!(!acc.get_lock_status(ACCOUNT, 0).unwrap().has_initiated_unlock);
         });

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -52,9 +52,8 @@ impl ActorAuthorizer {
         data: &[u8],
         now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
-        // The single secp256k1 path: the implicit default EOA and every explicit
-        // k1 actor share `K1_AUTHENTICATOR`. `address(0)` is the empty sentinel,
-        // never a selector, and is rejected by dispatch as non-canonical.
+        // secp256k1 signers — the implicit default EOA and every explicit k1
+        // actor — authenticate through `K1_AUTHENTICATOR`.
         if authenticator == Eip8130Constants::K1_AUTHENTICATOR {
             let recovered = match AuthenticatorDispatch::authenticate(hash, authenticator, data)? {
                 DispatchOutcome::Authenticated { actor_id } => actor_id,

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -107,11 +107,8 @@ impl ActorAuthorizer {
         hash: B256,
         data: &[u8],
     ) -> Result<ResolvedActor, AuthorizeError> {
-        let self_id = AccountConfigurationStorage::self_actor_id(account);
-        if !storage.get_actor_config(account, self_id)?.is_empty() {
-            return Err(AuthorizeError::ImplicitEoaShadowed);
-        }
-        // Reuse the enshrined ecrecover (identical to the sentinel path).
+        // The wire `address(0)` form supplies the account, so the signature must
+        // be recovered and bound to it. Reuse the enshrined (low-s) ecrecover.
         let recovered = match AuthenticatorDispatch::authenticate(
             hash,
             Eip8130Constants::ECRECOVER_AUTHENTICATOR,
@@ -121,8 +118,27 @@ impl ActorAuthorizer {
             // ecrecover never produces a delegate obligation.
             DispatchOutcome::Delegated { .. } => return Err(AuthError::InvalidSignature.into()),
         };
-        if recovered != self_id {
+        if recovered != AccountConfigurationStorage::self_actor_id(account) {
             return Err(AuthorizeError::ImplicitEoaMismatch);
+        }
+        Self::implicit_eoa_owner(storage, account)
+    }
+
+    /// Authorizes the implicit-EOA owner of `account` once the caller has already
+    /// established that the signer is `account` itself: the self-actor slot must
+    /// be empty (an explicit actor there *shadows* the implicit owner), and the
+    /// owner resolves as an unrestricted actor with no policy.
+    ///
+    /// The empty-`sender` transaction path recovers the signer in the verifier
+    /// (the recovered address *is* the account), so it calls this directly rather
+    /// than re-recovering through [`Self::authenticate_implicit_eoa`].
+    pub fn implicit_eoa_owner(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+    ) -> Result<ResolvedActor, AuthorizeError> {
+        let self_id = AccountConfigurationStorage::self_actor_id(account);
+        if !storage.get_actor_config(account, self_id)?.is_empty() {
+            return Err(AuthorizeError::ImplicitEoaShadowed);
         }
         Ok(ResolvedActor::unrestricted(self_id))
     }

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -52,14 +52,20 @@ impl ActorAuthorizer {
         data: &[u8],
         now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
-        // `address(0)` is the implicit-EOA owner: it needs state (empty self-slot
-        // + recovered == account) and so is handled here, not by stateless dispatch.
-        if authenticator == Address::ZERO {
-            return Self::authenticate_implicit_eoa(storage, account, hash, data);
+        // The single secp256k1 path: the implicit default EOA and every explicit
+        // k1 actor share `K1_AUTHENTICATOR`. `address(0)` is the empty sentinel,
+        // never a selector, and is rejected by dispatch as non-canonical.
+        if authenticator == Eip8130Constants::K1_AUTHENTICATOR {
+            let recovered = match AuthenticatorDispatch::authenticate(hash, authenticator, data)? {
+                DispatchOutcome::Authenticated { actor_id } => actor_id,
+                // k1 ecrecover never produces a delegate obligation.
+                DispatchOutcome::Delegated { .. } => return Err(AuthError::InvalidSignature.into()),
+            };
+            return Self::authorize_k1(storage, account, recovered, now);
         }
 
-        // The native ecrecover sentinel, P-256, WebAuthn, and delegate all route
-        // through enshrined dispatch; REVOKED and non-canonical are rejected there.
+        // P-256, WebAuthn, and delegate route through enshrined dispatch;
+        // non-canonical authenticators are rejected there.
         match AuthenticatorDispatch::authenticate(hash, authenticator, data)? {
             DispatchOutcome::Authenticated { actor_id } => {
                 Self::resolve_bound(storage, account, actor_id, authenticator, now)
@@ -98,55 +104,42 @@ impl ActorAuthorizer {
         }
     }
 
-    /// Mirror of `_authenticateImplicitEOA`: native ecrecover, requires the
-    /// self-actor slot empty and `recovered == account`. Implicit EOAs are always
-    /// unrestricted owners with no policy.
-    fn authenticate_implicit_eoa(
-        storage: &AccountConfigurationStorage<'_>,
-        account: Address,
-        hash: B256,
-        data: &[u8],
-    ) -> Result<ResolvedActor, AuthorizeError> {
-        // The wire `address(0)` form supplies the account, so the signature must
-        // be recovered and bound to it. Reuse the enshrined (low-s) ecrecover.
-        let recovered = match AuthenticatorDispatch::authenticate(
-            hash,
-            Eip8130Constants::ECRECOVER_AUTHENTICATOR,
-            data,
-        )? {
-            DispatchOutcome::Authenticated { actor_id } => actor_id,
-            // ecrecover never produces a delegate obligation.
-            DispatchOutcome::Delegated { .. } => return Err(AuthError::InvalidSignature.into()),
-        };
-        if recovered != AccountConfigurationStorage::self_actor_id(account) {
-            return Err(AuthorizeError::ImplicitEoaMismatch);
-        }
-        Self::implicit_eoa_owner(storage, account)
-    }
-
-    /// Authorizes the implicit-EOA owner of `account` once the caller has already
-    /// established that the signer is `account` itself: the self-actor slot must
-    /// be empty (an explicit actor there *shadows* the implicit owner), and the
-    /// owner resolves as an unrestricted actor with no policy.
+    /// Mirror of `_authenticateK1` after recovery: resolve a recovered secp256k1
+    /// signer against `account`.
     ///
+    /// A **live implicit default EOA** — the recovered signer is the account
+    /// (`recovered == bytes32(bytes20(account))`) and the account's
+    /// `DEFAULT_EOA_REVOKED` flag is unset — is an unrestricted owner with no
+    /// policy, resolved from a single account-state read. Otherwise the signer
+    /// must carry an explicit k1 `actor_config` entry (a scoped or re-enabled self
+    /// key, or any other registered k1 actor), validated by [`Self::resolve_bound`].
+    ///
+    /// The "an explicit self-actor entry implies the flag is set" invariant
+    /// guarantees a live self can never have a config to shadow, so the
+    /// full-owner short-circuit is safe.
+    ///
+    /// `recovered` is the recovered signer's `actorId` (`bytes32(bytes20(addr))`).
     /// The empty-`sender` transaction path recovers the signer in the verifier
-    /// (the recovered address *is* the account), so it calls this directly rather
-    /// than re-recovering through [`Self::authenticate_implicit_eoa`].
-    pub fn implicit_eoa_owner(
+    /// (the recovered address *is* the account) and calls this directly rather
+    /// than re-recovering.
+    pub fn authorize_k1(
         storage: &AccountConfigurationStorage<'_>,
         account: Address,
+        recovered: B256,
+        now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
-        let self_id = AccountConfigurationStorage::self_actor_id(account);
-        if !storage.get_actor_config(account, self_id)?.is_empty() {
-            return Err(AuthorizeError::ImplicitEoaShadowed);
+        if recovered == AccountConfigurationStorage::self_actor_id(account)
+            && !storage.get_account_state(account)?.default_eoa_revoked()
+        {
+            return Ok(ResolvedActor::unrestricted(recovered));
         }
-        Ok(ResolvedActor::unrestricted(self_id))
+        Self::resolve_bound(storage, account, recovered, Eip8130Constants::K1_AUTHENTICATOR, now)
     }
 
     /// Loads `actor_config[actor_id][account]`, requires it to be bound to
     /// `authenticator` and not expired, and returns the authorization surface
     /// (`scope`, `policy_type`, resolved `policy_target`). Mirrors the shared tail
-    /// of `_authenticate` / `_authenticateEcrecover`.
+    /// of `_authenticate` / `_authenticateK1`.
     fn resolve_bound(
         storage: &AccountConfigurationStorage<'_>,
         account: Address,
@@ -266,7 +259,9 @@ mod tests {
     fn implicit_eoa_authorizes_unrestricted_owner() {
         let key = k1_key(0x11);
         let account = k1_address(&key);
-        let auth = blob(Address::ZERO, &k1_sig(&key, HASH));
+        // The k1 blob whose signer recovers to the account: a live default EOA
+        // (flag unset, no explicit self entry) resolves to the unrestricted owner.
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             let resolved = ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW);
             assert_eq!(resolved.unwrap(), ResolvedActor::unrestricted(actor_id(account)));
@@ -274,48 +269,84 @@ mod tests {
     }
 
     #[test]
-    fn implicit_eoa_rejected_when_self_slot_occupied() {
+    fn default_eoa_revoked_without_self_config_is_rejected() {
         let key = k1_key(0x11);
         let account = k1_address(&key);
-        let self_id = actor_id(account);
-        let auth = blob(Address::ZERO, &k1_sig(&key, HASH));
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            // An explicit actor registered at the self id shadows the implicit owner.
-            acc.actor_config
-                .at_mut(&self_id)
+            // DEFAULT_EOA_REVOKED set and no explicit self entry: the implicit owner
+            // is gone and the self id is unbound.
+            acc.account_state
                 .at_mut(&account)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0, 0, 0))
+                .write(U256::from(Eip8130Constants::DEFAULT_EOA_REVOKED) << 184)
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW),
-                Err(AuthorizeError::ImplicitEoaShadowed),
+                Err(AuthorizeError::NotBound {
+                    actor_id: actor_id(account),
+                    authenticator: Eip8130Constants::K1_AUTHENTICATOR,
+                }),
             );
         });
     }
 
     #[test]
-    fn implicit_eoa_rejected_when_signer_is_not_the_account() {
+    fn revoked_self_re_registered_resolves_explicit_config() {
         let key = k1_key(0x11);
-        // Authenticate against a different account than the signer recovers to.
-        let auth = blob(Address::ZERO, &k1_sig(&key, HASH));
+        let account = k1_address(&key);
+        let self_id = actor_id(account);
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
+        with_storage(|acc| {
+            // Invariant: an explicit self entry implies the flag is set. With both,
+            // the owner short-circuit is skipped and the scoped self config resolves.
+            acc.account_state
+                .at_mut(&account)
+                .write(U256::from(Eip8130Constants::DEFAULT_EOA_REVOKED) << 184)
+                .unwrap();
+            acc.actor_config
+                .at_mut(&self_id)
+                .at_mut(&account)
+                .write(pack(
+                    Eip8130Constants::K1_AUTHENTICATOR,
+                    Eip8130Constants::SCOPE_SENDER,
+                    0,
+                    0,
+                ))
+                .unwrap();
+            let resolved =
+                ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
+            assert_eq!(resolved.actor_id, self_id);
+            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_SENDER);
+        });
+    }
+
+    #[test]
+    fn k1_signer_without_actor_entry_is_rejected() {
+        let key = k1_key(0x11);
+        // Signer recovers to a non-account address with no registered actor entry.
+        let id = actor_id(k1_address(&key));
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::ImplicitEoaMismatch),
+                Err(AuthorizeError::NotBound {
+                    actor_id: id,
+                    authenticator: Eip8130Constants::K1_AUTHENTICATOR,
+                }),
             );
         });
     }
 
     #[test]
-    fn explicit_ecrecover_resolves_bound_actor_surface() {
+    fn explicit_k1_resolves_bound_actor_surface() {
         let key = k1_key(0x22);
         let id = actor_id(k1_address(&key));
-        let auth = blob(Eip8130Constants::ECRECOVER_AUTHENTICATOR, &k1_sig(&key, HASH));
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0x04, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0x04, 0, 0))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
@@ -335,13 +366,13 @@ mod tests {
     fn ecrecover_unbound_actor_is_rejected() {
         let key = k1_key(0x22);
         let id = actor_id(k1_address(&key));
-        let auth = blob(Eip8130Constants::ECRECOVER_AUTHENTICATOR, &k1_sig(&key, HASH));
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
                 Err(AuthorizeError::NotBound {
                     actor_id: id,
-                    authenticator: Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                    authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
             );
         });
@@ -351,12 +382,12 @@ mod tests {
     fn expiry_is_enforced_against_now() {
         let key = k1_key(0x22);
         let id = actor_id(k1_address(&key));
-        let auth = blob(Eip8130Constants::ECRECOVER_AUTHENTICATOR, &k1_sig(&key, HASH));
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0, 500, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 500, 0))
                 .unwrap();
             // Valid at/under expiry.
             assert!(ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, 500).is_ok());
@@ -373,12 +404,12 @@ mod tests {
         let key = k1_key(0x22);
         let id = actor_id(k1_address(&key));
         let manager = address!("0x00000000000000000000000000000000000000d4");
-        let auth = blob(Eip8130Constants::ECRECOVER_AUTHENTICATOR, &k1_sig(&key, HASH));
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0, 0, 1))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 1))
                 .unwrap();
             acc.policy_manager.at_mut(&id).at_mut(&ACCOUNT).write(manager).unwrap();
             let resolved =
@@ -413,11 +444,11 @@ mod tests {
         });
     }
 
-    /// `DELEGATE || delegate_account(20) || ECRECOVER || nested_sig`.
+    /// `DELEGATE || delegate_account(20) || K1_AUTHENTICATOR || nested_sig`.
     fn delegate_auth(delegate_account: Address, nested_key: &K256SigningKey) -> Vec<u8> {
         let mut data = Vec::new();
         data.extend_from_slice(delegate_account.as_slice());
-        data.extend_from_slice(Eip8130Constants::ECRECOVER_AUTHENTICATOR.as_slice());
+        data.extend_from_slice(Eip8130Constants::K1_AUTHENTICATOR.as_slice());
         data.extend_from_slice(&k1_sig(nested_key, HASH));
         blob(Eip8130Contracts::DELEGATE_AUTHENTICATOR, &data)
     }
@@ -434,7 +465,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 0))
                 .unwrap();
             // Outer delegate actor on the originating account carries the surface.
             acc.actor_config
@@ -470,7 +501,7 @@ mod tests {
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(
-                    Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                    Eip8130Constants::K1_AUTHENTICATOR,
                     Eip8130Constants::SCOPE_PAYER,
                     0,
                     0,
@@ -506,7 +537,7 @@ mod tests {
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(
-                    Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                    Eip8130Constants::K1_AUTHENTICATOR,
                     Eip8130Constants::SCOPE_SIGNATURE,
                     0,
                     0,
@@ -547,7 +578,7 @@ mod tests {
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
                 Err(AuthorizeError::NotBound {
                     actor_id: nested_id,
-                    authenticator: Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                    authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
             );
         });
@@ -565,7 +596,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 0))
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
@@ -589,7 +620,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&Address::ZERO)
-                .write(pack(Eip8130Constants::ECRECOVER_AUTHENTICATOR, 0, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 0))
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
@@ -609,12 +640,13 @@ mod tests {
     }
 
     #[test]
-    fn revoked_authenticator_is_rejected() {
-        let auth = blob(Eip8130Constants::REVOKED_AUTHENTICATOR, &[0u8; 65]);
+    fn zero_authenticator_selector_is_rejected() {
+        // `address(0)` is the empty sentinel, never a valid authenticator selector.
+        let auth = blob(Address::ZERO, &[0u8; 65]);
         with_storage(|acc| {
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::Authenticate(AuthError::Revoked)),
+                Err(AuthorizeError::Authenticate(AuthError::NotCanonical(Address::ZERO))),
             );
         });
     }

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -106,16 +106,14 @@ impl ActorAuthorizer {
     /// Mirror of `_authenticateK1` after recovery: resolve a recovered secp256k1
     /// signer against `account`.
     ///
-    /// A **live implicit default EOA** — the recovered signer is the account
-    /// (`recovered == bytes32(bytes20(account))`) and the account's
-    /// `DEFAULT_EOA_REVOKED` flag is unset — is an unrestricted owner with no
-    /// policy, resolved from a single account-state read. Otherwise the signer
-    /// must carry an explicit k1 `actor_config` entry (a scoped or re-enabled self
-    /// key, or any other registered k1 actor), validated by [`Self::resolve_bound`].
-    ///
-    /// The "an explicit self-actor entry implies the flag is set" invariant
-    /// guarantees a live self can never have a config to shadow, so the
-    /// full-owner short-circuit is safe.
+    /// The account's own key — the **secp256k1 self** (`recovered ==
+    /// bytes32(bytes20(account))`) — resolves entirely from the inline config in
+    /// the account-state slot, a single SLOAD: a set `DEFAULT_EOA_REVOKED` flag
+    /// disables it (revoked, or a non-k1 self is the live self authenticator), an
+    /// all-zero inline config is the implicit full owner, and a non-zero inline
+    /// `scope`/`policy_type`/`expiry` is a scoped self. Every *other* recovered
+    /// signer must carry an explicit k1 `actor_config` entry, validated by
+    /// [`Self::resolve_bound`].
     ///
     /// `recovered` is the recovered signer's `actorId` (`bytes32(bytes20(addr))`).
     /// The empty-`sender` transaction path recovers the signer in the verifier
@@ -127,10 +125,35 @@ impl ActorAuthorizer {
         recovered: B256,
         now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
-        if recovered == AccountConfigurationStorage::self_actor_id(account)
-            && !storage.get_account_state(account)?.default_eoa_revoked()
-        {
-            return Ok(ResolvedActor::unrestricted(recovered));
+        if recovered == AccountConfigurationStorage::self_actor_id(account) {
+            let state = storage.get_account_state(account)?;
+            // Flag set => the inline k1 self is disabled: either revoked outright
+            // or superseded by a non-k1 self in `actor_config`. A k1 signature
+            // recovering to the account can never authorize in that state.
+            if state.default_eoa_revoked() {
+                return Err(AuthorizeError::DefaultEoaRevoked { account });
+            }
+            // 0 = no expiry; otherwise valid while now <= expiry.
+            if state.default_eoa_expiry != 0 && now > state.default_eoa_expiry {
+                return Err(AuthorizeError::Expired {
+                    actor_id: recovered,
+                    expiry: state.default_eoa_expiry,
+                });
+            }
+            // `_resolvePolicyTarget`: address(0) when ungated, else the policy
+            // manager (keyed by the self-actorId, shared keyspace). An ungated
+            // (full-owner) self costs no extra read.
+            let policy_target = if state.default_eoa_policy_type == 0 {
+                Address::ZERO
+            } else {
+                storage.get_policy_manager(account, recovered)?
+            };
+            return Ok(ResolvedActor {
+                actor_id: recovered,
+                scope: state.default_eoa_scope,
+                policy_type: state.default_eoa_policy_type,
+                policy_target,
+            });
         }
         Self::resolve_bound(storage, account, recovered, Eip8130Constants::K1_AUTHENTICATOR, now)
     }
@@ -196,6 +219,16 @@ mod tests {
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
             | (U256::from(policy_type) << 216)
+    }
+
+    /// Packs an `AccountState` word carrying the inline secp256k1 self config
+    /// (each field at its bit offset; sequences/lock left zero).
+    fn pack_self(scope: u8, policy_type: u8, expiry: u64, revoked: bool) -> U256 {
+        let flags = if revoked { Eip8130Constants::DEFAULT_EOA_REVOKED } else { 0 };
+        (U256::from(flags) << 184)
+            | (U256::from(scope) << 192)
+            | (U256::from(policy_type) << 200)
+            | (U256::from(expiry) << 208)
     }
 
     fn actor_id(address: Address) -> B256 {
@@ -268,54 +301,76 @@ mod tests {
     }
 
     #[test]
-    fn default_eoa_revoked_without_self_config_is_rejected() {
+    fn default_eoa_revoked_self_is_rejected() {
         let key = k1_key(0x11);
         let account = k1_address(&key);
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            // DEFAULT_EOA_REVOKED set and no explicit self entry: the implicit owner
-            // is gone and the self id is unbound.
-            acc.account_state
-                .at_mut(&account)
-                .write(U256::from(Eip8130Constants::DEFAULT_EOA_REVOKED) << 184)
-                .unwrap();
+            // DEFAULT_EOA_REVOKED set: the inline k1 self is disabled (revoked, or a
+            // non-k1 self is the live self authenticator), so a k1 signature
+            // recovering to the account is rejected outright.
+            acc.account_state.at_mut(&account).write(pack_self(0, 0, 0, true)).unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW),
-                Err(AuthorizeError::NotBound {
-                    actor_id: actor_id(account),
-                    authenticator: Eip8130Constants::K1_AUTHENTICATOR,
-                }),
+                Err(AuthorizeError::DefaultEoaRevoked { account }),
             );
         });
     }
 
     #[test]
-    fn revoked_self_re_registered_resolves_explicit_config() {
+    fn scoped_self_resolves_inline_config() {
         let key = k1_key(0x11);
         let account = k1_address(&key);
         let self_id = actor_id(account);
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            // Invariant: an explicit self entry implies the flag is set. With both,
-            // the owner short-circuit is skipped and the scoped self config resolves.
+            // Flag unset with an inline scope: the self key is live but scoped, and
+            // resolves from the account-state slot alone (no `actor_config` read).
             acc.account_state
                 .at_mut(&account)
-                .write(U256::from(Eip8130Constants::DEFAULT_EOA_REVOKED) << 184)
-                .unwrap();
-            acc.actor_config
-                .at_mut(&self_id)
-                .at_mut(&account)
-                .write(pack(
-                    Eip8130Constants::K1_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_SENDER,
-                    0,
-                    0,
-                ))
+                .write(pack_self(Eip8130Constants::SCOPE_SENDER, 0, 0, false))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
             assert_eq!(resolved.actor_id, self_id);
             assert_eq!(resolved.scope, Eip8130Constants::SCOPE_SENDER);
+            assert_eq!(resolved.policy_type, 0);
+            assert_eq!(resolved.policy_target, Address::ZERO);
+        });
+    }
+
+    #[test]
+    fn expired_self_is_rejected() {
+        let key = k1_key(0x11);
+        let account = k1_address(&key);
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
+        with_storage(|acc| {
+            // Inline expiry in the past: the self key is no longer valid.
+            acc.account_state.at_mut(&account).write(pack_self(0, 0, NOW - 1, false)).unwrap();
+            assert_eq!(
+                ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW),
+                Err(AuthorizeError::Expired { actor_id: actor_id(account), expiry: NOW - 1 }),
+            );
+        });
+    }
+
+    #[test]
+    fn gated_self_resolves_inline_policy_manager() {
+        let key = k1_key(0x11);
+        let account = k1_address(&key);
+        let self_id = actor_id(account);
+        let manager = address!("0x00000000000000000000000000000000000000d4");
+        let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
+        with_storage(|acc| {
+            // Inline policy_type set: the self key is gated and resolves its policy
+            // target from `policy_manager[self][account]`.
+            acc.account_state.at_mut(&account).write(pack_self(0, 5, 0, false)).unwrap();
+            acc.policy_manager.at_mut(&self_id).at_mut(&account).write(manager).unwrap();
+            let resolved =
+                ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
+            assert_eq!(resolved.actor_id, self_id);
+            assert_eq!(resolved.policy_type, 5);
+            assert_eq!(resolved.policy_target, manager);
         });
     }
 

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -8,7 +8,7 @@ use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
 
 use crate::{
     AccountConfigurationStorage, AuthError, AuthenticatorDispatch, AuthorizeError, DispatchOutcome,
-    ResolvedActor,
+    RecoveredActorId, ResolvedActor,
 };
 
 /// Authorizes actors against an [`AccountConfigurationStorage`] view.
@@ -53,14 +53,16 @@ impl ActorAuthorizer {
         now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
         // secp256k1 signers — the implicit default EOA and every explicit k1
-        // actor — authenticate through `K1_AUTHENTICATOR`.
+        // actor — authenticate through `K1_AUTHENTICATOR`. Recover here (the
+        // `RecoveredActorId` token proves the recovery) and authorize against
+        // the account.
         if authenticator == Eip8130Constants::K1_AUTHENTICATOR {
-            let recovered = match AuthenticatorDispatch::authenticate(hash, authenticator, data)? {
-                DispatchOutcome::Authenticated { actor_id } => actor_id,
-                // k1 ecrecover never produces a delegate obligation.
-                DispatchOutcome::Delegated { .. } => return Err(AuthError::InvalidSignature.into()),
-            };
-            return Self::authorize_k1(storage, account, recovered, now);
+            return Self::authorize_k1(
+                storage,
+                account,
+                RecoveredActorId::recover_k1(hash, data)?,
+                now,
+            );
         }
 
         // P-256, WebAuthn, and delegate route through enshrined dispatch;
@@ -115,16 +117,21 @@ impl ActorAuthorizer {
     /// signer must carry an explicit k1 `actor_config` entry, validated by
     /// [`Self::resolve_bound`].
     ///
-    /// `recovered` is the recovered signer's `actorId` (`bytes32(bytes20(addr))`).
-    /// The empty-`sender` transaction path recovers the signer in the verifier
-    /// (the recovered address *is* the account) and calls this directly rather
-    /// than re-recovering.
+    /// `recovered` is a [`RecoveredActorId`] — a proof-of-recovery token, so
+    /// this method trusts it as a genuinely recovered signer without
+    /// re-verifying. The token can only be produced by a recovery constructor
+    /// ([`RecoveredActorId::recover_k1`] / [`RecoveredActorId::recover_eoa_sender`]),
+    /// which keeps this `pub` entrypoint from granting owner access on a bare
+    /// caller-supplied `B256`. The empty-`sender` transaction path recovers the
+    /// signer once in the verifier and passes the token here rather than
+    /// re-recovering.
     pub fn authorize_k1(
         storage: &AccountConfigurationStorage<'_>,
         account: Address,
-        recovered: B256,
+        recovered: RecoveredActorId,
         now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
+        let recovered = recovered.actor_id();
         if recovered == AccountConfigurationStorage::self_actor_id(account) {
             let state = storage.get_account_state(account)?;
             // Flag set => the inline k1 self is disabled: either revoked outright

--- a/crates/execution/eip8130/src/authorize_error.rs
+++ b/crates/execution/eip8130/src/authorize_error.rs
@@ -13,7 +13,7 @@ use crate::AuthError;
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum AuthorizeError {
     /// The stateless authenticate (dispatch) step failed: malformed blob,
-    /// non-canonical or revoked authenticator, or an invalid signature.
+    /// non-canonical authenticator, or an invalid signature.
     #[error("authenticate failed: {0}")]
     Authenticate(#[from] AuthError),
 
@@ -55,15 +55,4 @@ pub enum AuthorizeError {
         /// The nested actor id that failed the SIGNATURE-scope check.
         actor_id: B256,
     },
-
-    /// The implicit-EOA self-actor slot is occupied by an explicit actor, so the
-    /// implicit owner is shadowed and `address(0)` cannot authenticate. Mirrors
-    /// `require(_actorConfig[self][account].authenticator == address(0))`.
-    #[error("implicit-EOA self-actor slot is occupied by an explicit actor")]
-    ImplicitEoaShadowed,
-
-    /// The implicit-EOA signature recovered an address other than the account
-    /// itself. Mirrors `require(recovered == account)`.
-    #[error("implicit-EOA signer does not match the account")]
-    ImplicitEoaMismatch,
 }

--- a/crates/execution/eip8130/src/authorize_error.rs
+++ b/crates/execution/eip8130/src/authorize_error.rs
@@ -37,6 +37,17 @@ pub enum AuthorizeError {
         authenticator: Address,
     },
 
+    /// A k1 signature recovered to the account itself, but the account's
+    /// secp256k1 self key is disabled: its `DEFAULT_EOA_REVOKED` flag is set, so
+    /// the self key has been revoked outright or superseded by a non-k1 self
+    /// authenticator. Mirrors `_authenticateK1`'s `require(flag unset)` on the
+    /// `recovered == account` path.
+    #[error("secp256k1 self key is disabled for account {account}")]
+    DefaultEoaRevoked {
+        /// The account whose inline self key is disabled.
+        account: Address,
+    },
+
     /// The resolved actor's configured expiry has passed (`now > expiry`).
     #[error("actor {actor_id} expired at {expiry}")]
     Expired {

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -132,7 +132,7 @@ mod tests {
 
     const NOW: u64 = 1_000;
     const LOCAL: u64 = 8453;
-    const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+    const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
 
     #[test]
     fn typehashes_match_their_preimages() {
@@ -235,7 +235,7 @@ mod tests {
     fn implicit_eoa_owner_authorizes_config_change() {
         let k = key(0x11);
         let account = addr(&k);
-        let change = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xab)]);
+        let change = signed_change(account, K1, &k, 0, 0, vec![revoke(0xab)]);
         with_storage(|acc| {
             let resolved =
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
@@ -248,12 +248,12 @@ mod tests {
         let k = key(0x22);
         let account = address!("0x00000000000000000000000000000000000000aa");
         let id = actor_id(addr(&k));
-        let change = signed_change(account, ECRECOVER, &k, 0, 0, vec![revoke(0xcd)]);
+        let change = signed_change(account, K1, &k, 0, 0, vec![revoke(0xcd)]);
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_CONFIG, 0, 0))
                 .unwrap();
             let resolved =
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
@@ -266,13 +266,13 @@ mod tests {
         let k = key(0x22);
         let account = address!("0x00000000000000000000000000000000000000aa");
         let id = actor_id(addr(&k));
-        let change = signed_change(account, ECRECOVER, &k, 0, 0, vec![revoke(0x01)]);
+        let change = signed_change(account, K1, &k, 0, 0, vec![revoke(0x01)]);
         with_storage(|acc| {
             // Bound actor that lacks CONFIG (only SENDER).
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
                 .unwrap();
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
@@ -288,7 +288,7 @@ mod tests {
     fn locked_account_is_rejected() {
         let k = key(0x11);
         let account = addr(&k);
-        let change = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0x01)]);
+        let change = signed_change(account, K1, &k, 0, 0, vec![revoke(0x01)]);
         with_storage(|acc| {
             // Locked until after `now`.
             acc.account_state.at_mut(&account).write(pack_state(0, 0, NOW + 1)).unwrap();
@@ -303,7 +303,7 @@ mod tests {
     fn foreign_chain_id_is_rejected() {
         let k = key(0x11);
         let account = addr(&k);
-        let change = signed_change(account, Address::ZERO, &k, LOCAL + 1, 0, vec![revoke(0x01)]);
+        let change = signed_change(account, K1, &k, LOCAL + 1, 0, vec![revoke(0x01)]);
         with_storage(|acc| {
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
@@ -317,7 +317,7 @@ mod tests {
         let k = key(0x11);
         let account = addr(&k);
         // Multichain channel sequence in state is 0; the entry claims 5.
-        let change = signed_change(account, Address::ZERO, &k, 0, 5, vec![revoke(0x01)]);
+        let change = signed_change(account, K1, &k, 0, 5, vec![revoke(0x01)]);
         with_storage(|acc| {
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
@@ -331,7 +331,7 @@ mod tests {
         let k = key(0x11);
         let account = addr(&k);
         // Local channel (chain_id == LOCAL); the entry must match local_sequence.
-        let change = signed_change(account, Address::ZERO, &k, LOCAL, 3, vec![revoke(0x01)]);
+        let change = signed_change(account, K1, &k, LOCAL, 3, vec![revoke(0x01)]);
         with_storage(|acc| {
             acc.account_state.at_mut(&account).write(pack_state(0, 3, 0)).unwrap();
             let resolved =
@@ -345,6 +345,7 @@ mod tests {
         let owner = key(0x11);
         let account = addr(&owner);
         let attacker = key(0x99);
+        let attacker_id = actor_id(addr(&attacker));
         // The digest binds `account`, but the auth is signed by a different key.
         let mut change = ConfigChange {
             chain_id: 0,
@@ -353,12 +354,16 @@ mod tests {
             auth: Bytes::new(),
         };
         let digest = ConfigChangeAuthorizer::signed_actor_changes_digest(account, &change);
-        change.auth = auth_blob(Address::ZERO, &sig(&attacker, digest));
+        change.auth = auth_blob(K1, &sig(&attacker, digest));
         with_storage(|acc| {
-            assert!(matches!(
+            // The recovered signer is not the account and has no registered actor.
+            assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
-                Err(TxAuthError::Authorize(AuthorizeError::ImplicitEoaMismatch)),
-            ));
+                Err(TxAuthError::Authorize(AuthorizeError::NotBound {
+                    actor_id: attacker_id,
+                    authenticator: Eip8130Constants::K1_AUTHENTICATOR,
+                })),
+            );
         });
     }
 

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -55,6 +55,38 @@ impl ConfigChangeAuthorizer {
         change: &ConfigChange,
         now: u64,
     ) -> Result<ResolvedActor, TxAuthError> {
+        // The contract reads the sequence from state and the signer signs over
+        // the value that will be used; the entry must match the account's
+        // current channel sequence so the reconstructed digest is the signed one.
+        let (multichain_seq, local_seq) =
+            storage.get_change_sequences(account).map_err(AuthorizeError::Storage)?;
+        let expected = if change.chain_id == 0 { multichain_seq } else { local_seq };
+        Self::authorize_at_sequence(storage, account, local_chain_id, change, expected, now)
+    }
+
+    /// Authorize a single [`ConfigChange`] against an explicitly-supplied
+    /// `expected_sequence` rather than the value currently in state.
+    ///
+    /// [`authorize`](Self::authorize) reads the channel sequence from state, so
+    /// it only validates an entry against the account's *current* sequence. When
+    /// one transaction carries several same-channel entries, each applied entry
+    /// advances the channel by one, so the second and later entries must be
+    /// checked against `current + 1`, `current + 2`, … — values not yet written
+    /// to state. An orchestrator validating the full set reads the base sequence
+    /// once and calls this with the running expected value per channel, in tx
+    /// order.
+    ///
+    /// Performs every check `authorize` does (lock, chain binding, sequence,
+    /// digest reconstruction, actor authorization, `SCOPE_CONFIG` gate) except
+    /// that the sequence is compared against `expected_sequence`.
+    pub fn authorize_at_sequence(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        local_chain_id: u64,
+        change: &ConfigChange,
+        expected_sequence: u64,
+        now: u64,
+    ) -> Result<ResolvedActor, TxAuthError> {
         // Locked accounts reject all config changes (`onlyUnlocked`).
         if storage.is_locked(account, now).map_err(AuthorizeError::Storage)? {
             return Err(TxAuthError::AccountLocked);
@@ -68,14 +100,11 @@ impl ConfigChangeAuthorizer {
             });
         }
 
-        // The contract reads the sequence from state and the signer signs over
-        // the value that will be used; require the entry to match the account's
-        // current channel sequence so the reconstructed digest is the signed one.
-        let (multichain_seq, local_seq) =
-            storage.get_change_sequences(account).map_err(AuthorizeError::Storage)?;
-        let expected = if change.chain_id == 0 { multichain_seq } else { local_seq };
-        if change.sequence != expected {
-            return Err(TxAuthError::ConfigSequence { expected, got: change.sequence });
+        if change.sequence != expected_sequence {
+            return Err(TxAuthError::ConfigSequence {
+                expected: expected_sequence,
+                got: change.sequence,
+            });
         }
 
         // Reconstruct the digest, authorize the entry's auth, and require CONFIG scope.

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -5,14 +5,13 @@ use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_sol_types::{SolValue, sol};
 use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
 use p256::ecdsa::{
     Signature as P256Signature, VerifyingKey as P256VerifyingKey,
     signature::hazmat::PrehashVerifier,
 };
 use sha2::{Digest, Sha256};
 
-use crate::{AuthError, DispatchOutcome};
+use crate::{AuthError, DispatchOutcome, RecoveredActorId};
 
 sol! {
     /// Mirror of `OpenZeppelin` `WebAuthn.WebAuthnAuth` (verified against
@@ -108,37 +107,14 @@ impl AuthenticatorDispatch {
         B256::from(id)
     }
 
-    /// Native secp256k1 ecrecover for the `K1_AUTHENTICATOR` sentinel:
-    /// requires `v in {27, 28}` and enforces **EIP-2 low-`s`**, rejecting
-    /// malleable upper-half-`s` signatures. `actorId = bytes32(bytes20(recovered))`.
-    ///
-    /// Low-`s` is enforced (rather than canonicalized-and-accepted) so that every
-    /// authorizing surface contributing to the transaction id commits to a single,
-    /// non-malleable signature encoding. This must stay byte-parity with the
-    /// deployed `AccountConfiguration` reference, which likewise rejects high-`s`;
-    /// the two MUST change in lockstep or the canonical address re-pins.
+    /// Native secp256k1 ecrecover for the `K1_AUTHENTICATOR` sentinel, resolving
+    /// `actorId = bytes32(bytes20(recovered))`. Delegates to
+    /// [`RecoveredActorId::recover_k1`] — the single source of truth for the k1
+    /// recovery (`v in {27, 28}`, EIP-2 low-`s`) — so the dispatch path and the
+    /// proof-of-recovery token cannot drift from one another or from the
+    /// deployed `AccountConfiguration` reference.
     fn ecrecover(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
-        if data.len() != 65 {
-            return Err(AuthError::MalformedAuth);
-        }
-        let recovery = match data[64] {
-            27 | 28 => data[64] - 27,
-            _ => return Err(AuthError::InvalidSignature),
-        };
-        let signature =
-            K256Signature::from_slice(&data[..64]).map_err(|_| AuthError::InvalidSignature)?;
-        // `normalize_s` returns `Some` only when `s` is in the upper half, i.e. a
-        // malleable high-`s` signature: reject it rather than canonicalizing.
-        if signature.normalize_s().is_some() {
-            return Err(AuthError::InvalidSignature);
-        }
-        let recovery_id = RecoveryId::from_byte(recovery).ok_or(AuthError::InvalidSignature)?;
-        let key = K256VerifyingKey::recover_from_prehash(hash.as_slice(), &signature, recovery_id)
-            .map_err(|_| AuthError::InvalidSignature)?;
-        let encoded = key.to_encoded_point(false);
-        // encoded = 0x04 || x(32) || y(32); address = keccak256(x || y)[12..].
-        let address = Address::from_slice(&keccak256(&encoded.as_bytes()[1..])[12..]);
-        Ok(Self::address_actor_id(address))
+        Ok(RecoveredActorId::recover_k1(hash, data)?.actor_id())
     }
 
     /// P-256 raw authenticator. `data = r(32) || s(32) || x(32) || y(32) || pre_hash(1)`
@@ -286,7 +262,7 @@ impl AuthenticatorDispatch {
 mod tests {
     use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
     use alloy_sol_types::SolValue;
-    use k256::ecdsa::SigningKey as K256SigningKey;
+    use k256::ecdsa::{Signature as K256Signature, SigningKey as K256SigningKey};
     use p256::ecdsa::{
         Signature as P256Sig, SigningKey as P256SigningKey, signature::hazmat::PrehashSigner,
     };

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -109,29 +109,29 @@ impl AuthenticatorDispatch {
         B256::from(id)
     }
 
-    /// Native secp256k1 ecrecover for the `ECRECOVER_AUTHENTICATOR` sentinel,
-    /// matching the on-chain reference (`AccountConfiguration._recoverSigner`,
-    /// i.e. the EVM `ecrecover` precompile): requires `v in {27, 28}` and accepts
-    /// any `s` (the precompile does not reject malleable high-`s`).
-    /// `actorId = bytes32(bytes20(recovered))`.
+    /// Native secp256k1 ecrecover for the `ECRECOVER_AUTHENTICATOR` sentinel:
+    /// requires `v in {27, 28}` and enforces **EIP-2 low-`s`**, rejecting
+    /// malleable upper-half-`s` signatures. `actorId = bytes32(bytes20(recovered))`.
     ///
-    /// `k256`'s recovery rejects high-`s`, so a high-`s` input is canonicalized to
-    /// its low-`s` malleable equivalent with the recovery parity flipped — this
-    /// recovers the identical key, since `ecrecover(h, v, r, s)` equals
-    /// `ecrecover(h, v ^ 1, r, n - s)`.
+    /// Low-`s` is enforced (rather than canonicalized-and-accepted) so that every
+    /// authorizing surface contributing to the transaction id commits to a single,
+    /// non-malleable signature encoding. This must stay byte-parity with the
+    /// deployed `AccountConfiguration` reference, which likewise rejects high-`s`;
+    /// the two MUST change in lockstep or the canonical address re-pins.
     fn ecrecover(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
         if data.len() != 65 {
             return Err(AuthError::MalformedAuth);
         }
-        let mut recovery = match data[64] {
+        let recovery = match data[64] {
             27 | 28 => data[64] - 27,
             _ => return Err(AuthError::InvalidSignature),
         };
-        let mut signature =
+        let signature =
             K256Signature::from_slice(&data[..64]).map_err(|_| AuthError::InvalidSignature)?;
-        if let Some(low_s) = signature.normalize_s() {
-            signature = low_s;
-            recovery ^= 1;
+        // `normalize_s` returns `Some` only when `s` is in the upper half, i.e. a
+        // malleable high-`s` signature: reject it rather than canonicalizing.
+        if signature.normalize_s().is_some() {
+            return Err(AuthError::InvalidSignature);
         }
         let recovery_id = RecoveryId::from_byte(recovery).ok_or(AuthError::InvalidSignature)?;
         let key = K256VerifyingKey::recover_from_prehash(hash.as_slice(), &signature, recovery_id)
@@ -371,10 +371,10 @@ mod tests {
     }
 
     #[test]
-    fn ecrecover_accepts_high_s() {
-        // The EVM ecrecover precompile does not reject malleable high-s; the
-        // native sentinel must match. Negating s yields the high-s counterpart,
-        // and flipping the recovery parity recovers the same signer.
+    fn ecrecover_rejects_high_s() {
+        // EIP-2 low-s: the malleable upper-half-s counterpart of a valid signature
+        // (negate s, flip the recovery parity) recovers the same signer but MUST be
+        // rejected so the transaction id cannot be malleated.
         let key = k1_key();
         let (sig, recid) = key.sign_prehash_recoverable(HASH.as_slice()).unwrap();
         let s_high = -*sig.s();
@@ -382,14 +382,14 @@ mod tests {
         let mut bytes = [0u8; 65];
         bytes[..64].copy_from_slice(&high.to_bytes());
         bytes[64] = (recid.to_byte() ^ 1) + 27;
-        let out = AuthenticatorDispatch::authenticate(
-            HASH,
-            Eip8130Constants::ECRECOVER_AUTHENTICATOR,
-            &bytes,
-        )
-        .unwrap();
-        let expected = AuthenticatorDispatch::address_actor_id(k1_address(&key));
-        assert_eq!(out, DispatchOutcome::Authenticated { actor_id: expected });
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                &bytes,
+            ),
+            Err(AuthError::InvalidSignature),
+        );
     }
 
     #[test]

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -58,10 +58,9 @@ impl AuthenticatorDispatch {
     /// delegate authenticator).
     ///
     /// `hash` is the context-appropriate signing hash (sender, payer, or config
-    /// change digest); the caller computes it. For the EOA path (`sender` empty
-    /// in the wire format), the caller passes
-    /// [`Eip8130Constants::ECRECOVER_AUTHENTICATOR`] as `authenticator` with the
-    /// raw 65-byte signature as `data`.
+    /// change digest); the caller computes it. For the native secp256k1 path the
+    /// caller passes [`Eip8130Constants::K1_AUTHENTICATOR`] as `authenticator`
+    /// with the raw 65-byte signature as `data`.
     pub fn authenticate(
         hash: B256,
         authenticator: Address,
@@ -78,12 +77,12 @@ impl AuthenticatorDispatch {
         data: &[u8],
         allow_delegate: bool,
     ) -> Result<DispatchOutcome, AuthError> {
-        if authenticator == Eip8130Constants::REVOKED_AUTHENTICATOR {
-            return Err(AuthError::Revoked);
-        }
-        // secp256k1 is the protocol-reserved native ecrecover sentinel
-        // (`address(1)`); there is no deployed secp256k1 authenticator contract.
-        if authenticator == Eip8130Constants::ECRECOVER_AUTHENTICATOR {
+        // `address(0)` is the empty / "no actor configured" sentinel and is never
+        // a valid authenticator selector; it falls through to `NotCanonical`.
+        //
+        // secp256k1 is the protocol-reserved native k1 sentinel (`address(1)`);
+        // there is no deployed secp256k1 authenticator contract.
+        if authenticator == Eip8130Constants::K1_AUTHENTICATOR {
             return Ok(DispatchOutcome::Authenticated { actor_id: Self::ecrecover(hash, data)? });
         }
         if authenticator == Eip8130Contracts::P256_AUTHENTICATOR {
@@ -109,7 +108,7 @@ impl AuthenticatorDispatch {
         B256::from(id)
     }
 
-    /// Native secp256k1 ecrecover for the `ECRECOVER_AUTHENTICATOR` sentinel:
+    /// Native secp256k1 ecrecover for the `K1_AUTHENTICATOR` sentinel:
     /// requires `v in {27, 28}` and enforces **EIP-2 low-`s`**, rejecting
     /// malleable upper-half-`s` signatures. `actorId = bytes32(bytes20(recovered))`.
     ///
@@ -347,7 +346,7 @@ mod tests {
         let key = k1_key();
         let out = AuthenticatorDispatch::authenticate(
             HASH,
-            Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+            Eip8130Constants::K1_AUTHENTICATOR,
             &k1_sig(&key, HASH),
         )
         .unwrap();
@@ -361,11 +360,7 @@ mod tests {
         let mut sig = k1_sig(&key, HASH);
         sig[64] -= 27; // 0 or 1: invalid for the EVM ecrecover sentinel.
         assert_eq!(
-            AuthenticatorDispatch::authenticate(
-                HASH,
-                Eip8130Constants::ECRECOVER_AUTHENTICATOR,
-                &sig,
-            ),
+            AuthenticatorDispatch::authenticate(HASH, Eip8130Constants::K1_AUTHENTICATOR, &sig,),
             Err(AuthError::InvalidSignature),
         );
     }
@@ -383,11 +378,7 @@ mod tests {
         bytes[..64].copy_from_slice(&high.to_bytes());
         bytes[64] = (recid.to_byte() ^ 1) + 27;
         assert_eq!(
-            AuthenticatorDispatch::authenticate(
-                HASH,
-                Eip8130Constants::ECRECOVER_AUTHENTICATOR,
-                &bytes,
-            ),
+            AuthenticatorDispatch::authenticate(HASH, Eip8130Constants::K1_AUTHENTICATOR, &bytes,),
             Err(AuthError::InvalidSignature),
         );
     }
@@ -397,7 +388,7 @@ mod tests {
         assert_eq!(
             AuthenticatorDispatch::authenticate(
                 HASH,
-                Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                Eip8130Constants::K1_AUTHENTICATOR,
                 &[0u8; 64],
             ),
             Err(AuthError::MalformedAuth),
@@ -509,7 +500,7 @@ mod tests {
 
         let mut data = Vec::new();
         data.extend_from_slice(delegate_account.as_slice());
-        data.extend_from_slice(Eip8130Constants::ECRECOVER_AUTHENTICATOR.as_slice());
+        data.extend_from_slice(Eip8130Constants::K1_AUTHENTICATOR.as_slice());
         data.extend_from_slice(&k1_sig(&nested_key, HASH));
 
         let out = AuthenticatorDispatch::authenticate(
@@ -523,7 +514,7 @@ mod tests {
             DispatchOutcome::Delegated {
                 actor_id: AuthenticatorDispatch::address_actor_id(delegate_account),
                 delegate_account,
-                nested_authenticator: Eip8130Constants::ECRECOVER_AUTHENTICATOR,
+                nested_authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 nested_actor_id: AuthenticatorDispatch::address_actor_id(k1_address(&nested_key)),
             }
         );
@@ -565,14 +556,12 @@ mod tests {
     }
 
     #[test]
-    fn rejects_revoked_authenticator() {
+    fn rejects_zero_authenticator_selector() {
+        // `address(0)` is the empty / "no actor configured" sentinel, never a
+        // valid authenticator selector.
         assert_eq!(
-            AuthenticatorDispatch::authenticate(
-                HASH,
-                Eip8130Constants::REVOKED_AUTHENTICATOR,
-                &[0u8; 65],
-            ),
-            Err(AuthError::Revoked),
+            AuthenticatorDispatch::authenticate(HASH, Address::ZERO, &[0u8; 65]),
+            Err(AuthError::NotCanonical(Address::ZERO)),
         );
     }
 

--- a/crates/execution/eip8130/src/error.rs
+++ b/crates/execution/eip8130/src/error.rs
@@ -14,14 +14,11 @@ pub enum AuthError {
     MalformedAuth,
 
     /// The authenticator address is not in the canonical allowlist (and is not
-    /// the native `ECRECOVER_AUTHENTICATOR` sentinel). Non-canonical
-    /// authenticators are not accepted on the EIP-8130 block-validation path.
+    /// the native `K1_AUTHENTICATOR` sentinel). Non-canonical authenticators —
+    /// including the `address(0)` empty sentinel — are not accepted on the
+    /// EIP-8130 block-validation path.
     #[error("authenticator {0} is not canonical")]
     NotCanonical(Address),
-
-    /// The authenticator address is the `REVOKED_AUTHENTICATOR` sentinel.
-    #[error("authenticator is the revoked sentinel")]
-    Revoked,
 
     /// The signature did not verify against the supplied hash / public key, or
     /// the verifying authenticator returned no actor (`bytes32(0)`).

--- a/crates/execution/eip8130/src/error.rs
+++ b/crates/execution/eip8130/src/error.rs
@@ -13,10 +13,9 @@ pub enum AuthError {
     #[error("authentication data is malformed")]
     MalformedAuth,
 
-    /// The authenticator address is not in the canonical allowlist (and is not
-    /// the native `K1_AUTHENTICATOR` sentinel). Non-canonical authenticators —
-    /// including the `address(0)` empty sentinel — are not accepted on the
-    /// EIP-8130 block-validation path.
+    /// The authenticator address is not one of the canonical EIP-8130
+    /// authenticators (the pinned allowlist and the `K1_AUTHENTICATOR`
+    /// sentinel), so it is not accepted on the block-validation path.
     #[error("authenticator {0} is not canonical")]
     NotCanonical(Address),
 

--- a/crates/execution/eip8130/src/lib.rs
+++ b/crates/execution/eip8130/src/lib.rs
@@ -41,3 +41,6 @@ pub use nonce_error::NonceError;
 
 mod validate;
 pub use validate::{NonceMode, NonceStatus, NonceValidator};
+
+mod transaction;
+pub use transaction::{AuthorizedTransaction, TransactionAuthorizer};

--- a/crates/execution/eip8130/src/lib.rs
+++ b/crates/execution/eip8130/src/lib.rs
@@ -18,6 +18,9 @@ pub use authorize_error::AuthorizeError;
 mod resolved;
 pub use resolved::ResolvedActor;
 
+mod recovered;
+pub use recovered::RecoveredActorId;
+
 mod authorize;
 pub use authorize::ActorAuthorizer;
 

--- a/crates/execution/eip8130/src/recovered.rs
+++ b/crates/execution/eip8130/src/recovered.rs
@@ -1,0 +1,89 @@
+//! Proof-of-recovery actor id: a recovered secp256k1 signer that can only be
+//! produced by a verified signature recovery.
+
+use alloy_primitives::{Address, B256, keccak256};
+use base_common_consensus::Eip8130Signed;
+use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
+
+use crate::AuthError;
+
+/// A recovered secp256k1 signer, carried as its address and resolved `actorId`
+/// (`bytes32(bytes20(address))`).
+///
+/// The wrapped address is private and every constructor performs a real
+/// signature recovery, so a value is *evidence* that the signer authenticated
+/// over the relevant hash. [`ActorAuthorizer::authorize_k1`] consumes this
+/// token instead of a bare `B256`, lifting its "the caller must have recovered
+/// the signer first" precondition into the type system: a caller cannot
+/// fabricate an arbitrary recovered signer and obtain owner access on an
+/// account, because the only ways to obtain a `RecoveredActorId` are the
+/// recovery constructors below.
+///
+/// [`ActorAuthorizer::authorize_k1`]: crate::ActorAuthorizer::authorize_k1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecoveredActorId {
+    address: Address,
+}
+
+impl RecoveredActorId {
+    /// Recovers the signer of `hash` from a 65-byte `r || s || v` secp256k1
+    /// signature — the native `K1_AUTHENTICATOR` wire form — requiring
+    /// `v in {27, 28}` and enforcing **EIP-2 low-`s`** (malleable upper-half-`s`
+    /// signatures are rejected, not canonicalized). This is the recovery the
+    /// enshrined k1 authenticator performs; [`AuthenticatorDispatch`] routes its
+    /// k1 path through here, so the two stay byte-parity with the deployed
+    /// `AccountConfiguration` reference by construction.
+    ///
+    /// [`AuthenticatorDispatch`]: crate::AuthenticatorDispatch
+    pub fn recover_k1(hash: B256, signature: &[u8]) -> Result<Self, AuthError> {
+        if signature.len() != 65 {
+            return Err(AuthError::MalformedAuth);
+        }
+        let recovery = match signature[64] {
+            27 | 28 => signature[64] - 27,
+            _ => return Err(AuthError::InvalidSignature),
+        };
+        let sig =
+            K256Signature::from_slice(&signature[..64]).map_err(|_| AuthError::InvalidSignature)?;
+        // `normalize_s` returns `Some` only when `s` is in the upper half, i.e. a
+        // malleable high-`s` signature: reject it rather than canonicalizing.
+        if sig.normalize_s().is_some() {
+            return Err(AuthError::InvalidSignature);
+        }
+        let recovery_id = RecoveryId::from_byte(recovery).ok_or(AuthError::InvalidSignature)?;
+        let key = K256VerifyingKey::recover_from_prehash(hash.as_slice(), &sig, recovery_id)
+            .map_err(|_| AuthError::InvalidSignature)?;
+        let encoded = key.to_encoded_point(false);
+        // encoded = 0x04 || x(32) || y(32); address = keccak256(x || y)[12..].
+        let address = Address::from_slice(&keccak256(&encoded.as_bytes()[1..])[12..]);
+        Ok(Self { address })
+    }
+
+    /// Recovers the EOA sender of a signed transaction — the empty-`sender` wire
+    /// path — via the checked (EIP-2 low-`s`) recovery over its sender signing
+    /// hash. Returns `Ok(None)` on the configured-actor path
+    /// (`tx.sender == Some`), where there is no EOA signature to recover, and
+    /// `Err` when the empty-`sender` payload is malformed or the signature is
+    /// invalid.
+    pub fn recover_eoa_sender(signed: &Eip8130Signed) -> Result<Option<Self>, AuthError> {
+        Ok(signed
+            .recover_eoa_sender()
+            .map_err(|_| AuthError::InvalidSignature)?
+            .map(|address| Self { address }))
+    }
+
+    /// The recovered signer address.
+    #[must_use]
+    pub const fn address(self) -> Address {
+        self.address
+    }
+
+    /// The recovered signer's actor id, `bytes32(bytes20(address))` — the 20
+    /// address bytes left-aligned, right-padded with zeros.
+    #[must_use]
+    pub fn actor_id(self) -> B256 {
+        let mut id = [0u8; 32];
+        id[..20].copy_from_slice(self.address.as_slice());
+        B256::from(id)
+    }
+}

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -1,0 +1,462 @@
+//! The EIP-8130 transaction-authorization orchestrator: the final sender/payer
+//! signatures plus the transaction's ordered account-configuration changes.
+
+use base_common_consensus::{AccountChange, Eip8130Signed};
+
+use crate::{
+    AccountConfigurationStorage, ActorTxVerifier, AuthorizeError, ConfigChangeAuthorizer,
+    ResolvedActor, TxActors, TxAuthError,
+};
+
+/// The authorized result of an EIP-8130 transaction: its resolved actors and the
+/// authorizing actor of each account-configuration change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AuthorizedTransaction {
+    /// The transaction's sender and (optional) payer, each scope-gated.
+    pub actors: TxActors,
+    /// The authorizing actor resolved for each [`ConfigChange`] entry, in
+    /// transaction order. Empty when the transaction carries no config changes.
+    ///
+    /// [`ConfigChange`]: base_common_consensus::ConfigChange
+    pub config_changes: Vec<ResolvedActor>,
+}
+
+/// Authorizes a signed EIP-8130 transaction against an
+/// [`AccountConfigurationStorage`] view, composing the sender/payer signature
+/// checks with the ordered authorization of its account-configuration changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TransactionAuthorizer;
+
+impl TransactionAuthorizer {
+    /// Authorizes `signed` against `storage` for `local_chain_id` at time `now`
+    /// (block timestamp at inclusion, wall-clock in the pool, used for actor
+    /// expiry and the account lock).
+    ///
+    /// Resolves and scope-gates the sender (and payer), then walks
+    /// `account_changes` in order, authorizing each [`ConfigChange`] with its own
+    /// `SignedActorChanges` signature. Same-channel entries advance their channel
+    /// sequence by one each within the transaction, so entries are validated
+    /// against the running per-channel sequence rather than re-reading state.
+    ///
+    /// Returns the [`AuthorizedTransaction`], or the first [`TxAuthError`]
+    /// encountered (sender, then payer, then config changes in order). Reads
+    /// state but performs no mutations.
+    ///
+    /// [`ConfigChange`]: base_common_consensus::ConfigChange
+    pub fn authorize(
+        signed: &Eip8130Signed,
+        storage: &AccountConfigurationStorage<'_>,
+        local_chain_id: u64,
+        now: u64,
+    ) -> Result<AuthorizedTransaction, TxAuthError> {
+        // 1. The final transaction signatures over the whole body. This also
+        //    resolves the sender account (recovering it for the EOA path), which
+        //    the config changes apply against.
+        let actors = ActorTxVerifier::verify(signed, storage, now)?;
+        let account = actors.sender.account;
+
+        // 2. Read each config-change channel's base sequence once, then validate
+        //    entries against `base + applied`, where `applied` counts the
+        //    same-channel entries already authorized in this transaction (each
+        //    applied entry advances its channel by one). The running value is
+        //    used rather than re-reading the (still-unwritten) state. This is an
+        //    admission-time ordering check only: authorization writes nothing,
+        //    and the execution/apply layer re-validates each entry against the
+        //    committed sequence before advancing it.
+        let (multichain_base, local_base) =
+            storage.get_change_sequences(account).map_err(AuthorizeError::Storage)?;
+        let mut multichain_applied = 0u64;
+        let mut local_applied = 0u64;
+
+        let mut config_changes = Vec::new();
+        for change in &signed.tx().account_changes {
+            // Create and Delegation entries carry no independent authorization:
+            // the sender signature commits to the whole body, and a Create is
+            // additionally bound by its deterministic deploy address (checked at
+            // execution). Only ConfigChange carries its own actor signature.
+            let AccountChange::ConfigChange(cc) = change else {
+                continue;
+            };
+
+            // Select the sequence channel by chain binding, mirroring
+            // `authorize_at_sequence`: `chain_id == 0` is the portable multichain
+            // channel, the local chain is the chain-local channel, and any other
+            // (foreign) `chain_id` is rejected here. Validating the binding before
+            // bucketing keeps each running counter bound to exactly one channel —
+            // a foreign `chain_id` can never share (and silently advance) the
+            // local counter, even if the transaction type is later extended to
+            // carry config changes for several distinct non-zero chains.
+            let (base, applied) = match cc.chain_id {
+                0 => (multichain_base, &mut multichain_applied),
+                id if id == local_chain_id => (local_base, &mut local_applied),
+                got => return Err(TxAuthError::ConfigChainId { expected: local_chain_id, got }),
+            };
+            // `checked_add` rejects the (unreachable) case where the channel
+            // would advance past `u64::MAX` rather than wrapping or saturating
+            // into a state that re-accepts a duplicate sequence.
+            let expected = base.checked_add(*applied).ok_or(TxAuthError::ConfigSequenceOverflow)?;
+
+            let resolved = ConfigChangeAuthorizer::authorize_at_sequence(
+                storage,
+                account,
+                local_chain_id,
+                cc,
+                expected,
+                now,
+            )?;
+            config_changes.push(resolved);
+            *applied += 1;
+        }
+
+        Ok(AuthorizedTransaction { actors, config_changes })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
+    use base_common_consensus::{
+        ActorChange, ActorChangeType, ConfigChange, CreateEntry, Delegation, Eip8130Constants,
+        TxEip8130,
+    };
+    use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
+    use k256::ecdsa::SigningKey as K256SigningKey;
+
+    use super::*;
+    use crate::{ConfigChangeAuthorizer, Operation};
+
+    const NOW: u64 = 1_000;
+    const LOCAL: u64 = 8453;
+    const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+
+    fn key(byte: u8) -> K256SigningKey {
+        K256SigningKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn addr(key: &K256SigningKey) -> Address {
+        let point = key.verifying_key().to_encoded_point(false);
+        Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+    }
+
+    fn actor_id(account: Address) -> B256 {
+        AccountConfigurationStorage::self_actor_id(account)
+    }
+
+    /// 65-byte `r || s || v` signature over `hash`, `v` in `{27, 28}`, low-s.
+    fn sig(key: &K256SigningKey, hash: B256) -> Vec<u8> {
+        let (signature, recid) = key.sign_prehash_recoverable(hash.as_slice()).unwrap();
+        let mut out = vec![0u8; 65];
+        out[..64].copy_from_slice(&signature.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    /// `authenticator(20) || data`.
+    fn auth_blob(authenticator: Address, data: &[u8]) -> Bytes {
+        let mut out = Vec::with_capacity(20 + data.len());
+        out.extend_from_slice(authenticator.as_slice());
+        out.extend_from_slice(data);
+        Bytes::from(out)
+    }
+
+    /// Canonical Solidity packing of `ActorConfig`.
+    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+        U256::from_be_slice(authenticator.as_slice())
+            | (U256::from(scope) << 160)
+            | (U256::from(expiry) << 168)
+            | (U256::from(policy_type) << 216)
+    }
+
+    /// Canonical Solidity packing of `AccountState` (`multichain`, `local`
+    /// sequences and `unlocks_at`).
+    fn pack_state(multichain: u64, local: u64, unlocks_at: u64) -> U256 {
+        let mut b = [0u8; 32];
+        b[24..32].copy_from_slice(&multichain.to_be_bytes());
+        b[16..24].copy_from_slice(&local.to_be_bytes());
+        b[11..16].copy_from_slice(&unlocks_at.to_be_bytes()[3..]);
+        U256::from_be_bytes(b)
+    }
+
+    fn revoke(actor_byte: u8) -> ActorChange {
+        ActorChange {
+            change_type: ActorChangeType::Revoke,
+            actor_id: B256::repeat_byte(actor_byte),
+            data: Bytes::new(),
+        }
+    }
+
+    /// A [`ConfigChange`] whose `auth` is a fresh signature over its own digest.
+    fn signed_change(
+        account: Address,
+        authenticator: Address,
+        signer: &K256SigningKey,
+        chain_id: u64,
+        sequence: u64,
+        actor_changes: Vec<ActorChange>,
+    ) -> ConfigChange {
+        let mut change = ConfigChange { chain_id, sequence, actor_changes, auth: Bytes::new() };
+        let digest = ConfigChangeAuthorizer::signed_actor_changes_digest(account, &change);
+        change.auth = auth_blob(authenticator, &sig(signer, digest));
+        change
+    }
+
+    fn tx_with(
+        sender: Option<Address>,
+        payer: Option<Address>,
+        account_changes: Vec<AccountChange>,
+    ) -> TxEip8130 {
+        TxEip8130 {
+            chain_id: LOCAL,
+            sender,
+            nonce_key: U256::ZERO,
+            nonce_sequence: 0,
+            expiry: 0,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 5_000_000_000,
+            gas_limit: 250_000,
+            account_changes,
+            calls: Vec::new(),
+            metadata: Bytes::new(),
+            payer,
+        }
+    }
+
+    /// Signs `tx` as an EOA (bare `sender_auth`, no payer) and authorizes it.
+    fn eoa_signed(tx: TxEip8130, sender: &K256SigningKey) -> Eip8130Signed {
+        let hash = tx.sender_signature_hash();
+        Eip8130Signed::new(tx, Bytes::from(sig(sender, hash)), Bytes::new())
+    }
+
+    fn with_storage<R>(body: impl FnOnce(&mut AccountConfigurationStorage<'_>) -> R) -> R {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| body(&mut AccountConfigurationStorage::new(ctx)))
+    }
+
+    #[test]
+    fn authorizes_sequential_same_channel_config_changes() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // Two multichain entries: the second is checked against `base + 1`.
+        let cc0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
+        let cc1 = signed_change(account, Address::ZERO, &k, 0, 1, vec![revoke(0xa1)]);
+        let signed = eoa_signed(
+            tx_with(
+                None,
+                None,
+                vec![AccountChange::ConfigChange(cc0), AccountChange::ConfigChange(cc1)],
+            ),
+            &k,
+        );
+        with_storage(|acc| {
+            let out = TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW).unwrap();
+            assert_eq!(out.actors.sender.account, account);
+            assert!(out.actors.payer.is_none());
+            assert_eq!(out.config_changes.len(), 2);
+            assert!(out.config_changes.iter().all(ResolvedActor::is_unrestricted));
+        });
+    }
+
+    #[test]
+    fn stale_second_same_channel_entry_is_rejected() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // Both entries claim sequence 0; the second must fail once the channel
+        // has advanced to 1.
+        let cc0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
+        let stale = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa1)]);
+        let signed = eoa_signed(
+            tx_with(
+                None,
+                None,
+                vec![AccountChange::ConfigChange(cc0), AccountChange::ConfigChange(stale)],
+            ),
+            &k,
+        );
+        with_storage(|acc| {
+            assert_eq!(
+                TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW),
+                Err(TxAuthError::ConfigSequence { expected: 1, got: 0 }),
+            );
+        });
+    }
+
+    #[test]
+    fn multichain_and_local_channels_advance_independently() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // multichain#0, local#0, multichain#1 — each channel counted separately.
+        let m0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
+        let l0 = signed_change(account, Address::ZERO, &k, LOCAL, 0, vec![revoke(0xb0)]);
+        let m1 = signed_change(account, Address::ZERO, &k, 0, 1, vec![revoke(0xa1)]);
+        let signed = eoa_signed(
+            tx_with(
+                None,
+                None,
+                vec![
+                    AccountChange::ConfigChange(m0),
+                    AccountChange::ConfigChange(l0),
+                    AccountChange::ConfigChange(m1),
+                ],
+            ),
+            &k,
+        );
+        with_storage(|acc| {
+            let out = TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW).unwrap();
+            assert_eq!(out.config_changes.len(), 3);
+        });
+    }
+
+    #[test]
+    fn foreign_chain_config_change_is_rejected_without_advancing_a_channel() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // A valid multichain entry followed by one bound to a foreign chain
+        // (neither 0 nor LOCAL). The orchestrator rejects the foreign entry at
+        // channel selection — it must not be bucketed into the local channel —
+        // surfacing `ConfigChainId` rather than silently advancing a counter.
+        const FOREIGN: u64 = LOCAL + 1;
+        let m0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
+        let foreign = signed_change(account, Address::ZERO, &k, FOREIGN, 0, vec![revoke(0xb0)]);
+        let signed = eoa_signed(
+            tx_with(
+                None,
+                None,
+                vec![AccountChange::ConfigChange(m0), AccountChange::ConfigChange(foreign)],
+            ),
+            &k,
+        );
+        with_storage(|acc| {
+            assert_eq!(
+                TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW),
+                Err(TxAuthError::ConfigChainId { expected: LOCAL, got: FOREIGN }),
+            );
+        });
+    }
+
+    #[test]
+    fn channel_sequence_overflow_is_rejected_not_wrapped() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // The first entry sits at the channel's max sequence; authorizing a
+        // second same-channel entry would advance past u64::MAX, which must be
+        // rejected rather than wrapping back to a duplicate-accepting state.
+        let at_max = signed_change(account, Address::ZERO, &k, 0, u64::MAX, vec![revoke(0xa0)]);
+        let next = signed_change(account, Address::ZERO, &k, 0, u64::MAX, vec![revoke(0xa1)]);
+        let signed = eoa_signed(
+            tx_with(
+                None,
+                None,
+                vec![AccountChange::ConfigChange(at_max), AccountChange::ConfigChange(next)],
+            ),
+            &k,
+        );
+        with_storage(|acc| {
+            acc.account_state.at_mut(&account).write(pack_state(u64::MAX, 0, 0)).unwrap();
+            assert_eq!(
+                TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW),
+                Err(TxAuthError::ConfigSequenceOverflow),
+            );
+        });
+    }
+
+    #[test]
+    fn create_and_delegation_entries_do_not_consume_a_sequence() {
+        let k = key(0x11);
+        let account = addr(&k);
+        // A Create and a Delegation bracket a single multichain config change at
+        // sequence 0; the non-config entries are authorized by the sender
+        // signature alone and must not advance (or consume) the channel.
+        let create = AccountChange::Create(CreateEntry {
+            user_salt: B256::ZERO,
+            code: Bytes::from_static(&[0x60, 0x00]),
+            initial_actors: Vec::new(),
+        });
+        let delegation = AccountChange::Delegation(Delegation { target: account });
+        let cc = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
+        let signed = eoa_signed(
+            tx_with(None, None, vec![create, AccountChange::ConfigChange(cc), delegation]),
+            &k,
+        );
+        with_storage(|acc| {
+            let out = TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW).unwrap();
+            assert_eq!(out.config_changes.len(), 1);
+        });
+    }
+
+    #[test]
+    fn sender_failure_short_circuits_config_changes() {
+        let sk = key(0x22);
+        let account = address!("0x00000000000000000000000000000000000000aa");
+        let sid = actor_id(addr(&sk));
+        // A config change that would itself authorize, but the sender gate fails
+        // first, so the config stage is never reached.
+        let cc = signed_change(account, ECRECOVER, &sk, 0, 0, vec![revoke(0xa0)]);
+        let tx = tx_with(Some(account), None, vec![AccountChange::ConfigChange(cc)]);
+        let hash = tx.sender_signature_hash();
+        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&sk, hash)), Bytes::new());
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&sid)
+                .at_mut(&account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .unwrap();
+            assert_eq!(
+                TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW),
+                Err(TxAuthError::Scope {
+                    operation: Operation::Sender,
+                    scope: Eip8130Constants::SCOPE_PAYER,
+                }),
+            );
+        });
+    }
+
+    #[test]
+    fn composes_configured_sender_payer_and_config_change() {
+        let sk = key(0x22);
+        let sender_account = address!("0x00000000000000000000000000000000000000aa");
+        let sid = actor_id(addr(&sk));
+        let pk = key(0x33);
+        let payer_account = address!("0x00000000000000000000000000000000000000cc");
+        let pid = actor_id(addr(&pk));
+        let ck = key(0x44);
+        let cid = actor_id(addr(&ck));
+
+        let cc = signed_change(sender_account, ECRECOVER, &ck, 0, 0, vec![revoke(0xa0)]);
+        let tx = tx_with(
+            Some(sender_account),
+            Some(payer_account),
+            vec![AccountChange::ConfigChange(cc)],
+        );
+        let sender_hash = tx.sender_signature_hash();
+        let payer_hash = tx.payer_signature_hash(sender_account);
+        let signed = Eip8130Signed::new(
+            tx,
+            auth_blob(ECRECOVER, &sig(&sk, sender_hash)),
+            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+        );
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&sid)
+                .at_mut(&sender_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .unwrap();
+            acc.actor_config
+                .at_mut(&pid)
+                .at_mut(&payer_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .unwrap();
+            acc.actor_config
+                .at_mut(&cid)
+                .at_mut(&sender_account)
+                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .unwrap();
+            let out = TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW).unwrap();
+            assert_eq!(out.actors.sender.account, sender_account);
+            assert_eq!(out.actors.payer.expect("payer present").account, payer_account);
+            assert_eq!(out.config_changes.len(), 1);
+            assert_eq!(out.config_changes[0].scope, Eip8130Constants::SCOPE_CONFIG);
+        });
+    }
+}

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -129,7 +129,7 @@ mod tests {
 
     const NOW: u64 = 1_000;
     const LOCAL: u64 = 8453;
-    const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+    const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
 
     fn key(byte: u8) -> K256SigningKey {
         K256SigningKey::from_slice(&[byte; 32]).unwrap()
@@ -239,8 +239,8 @@ mod tests {
         let k = key(0x11);
         let account = addr(&k);
         // Two multichain entries: the second is checked against `base + 1`.
-        let cc0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
-        let cc1 = signed_change(account, Address::ZERO, &k, 0, 1, vec![revoke(0xa1)]);
+        let cc0 = signed_change(account, K1, &k, 0, 0, vec![revoke(0xa0)]);
+        let cc1 = signed_change(account, K1, &k, 0, 1, vec![revoke(0xa1)]);
         let signed = eoa_signed(
             tx_with(
                 None,
@@ -264,8 +264,8 @@ mod tests {
         let account = addr(&k);
         // Both entries claim sequence 0; the second must fail once the channel
         // has advanced to 1.
-        let cc0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
-        let stale = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa1)]);
+        let cc0 = signed_change(account, K1, &k, 0, 0, vec![revoke(0xa0)]);
+        let stale = signed_change(account, K1, &k, 0, 0, vec![revoke(0xa1)]);
         let signed = eoa_signed(
             tx_with(
                 None,
@@ -287,9 +287,9 @@ mod tests {
         let k = key(0x11);
         let account = addr(&k);
         // multichain#0, local#0, multichain#1 — each channel counted separately.
-        let m0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
-        let l0 = signed_change(account, Address::ZERO, &k, LOCAL, 0, vec![revoke(0xb0)]);
-        let m1 = signed_change(account, Address::ZERO, &k, 0, 1, vec![revoke(0xa1)]);
+        let m0 = signed_change(account, K1, &k, 0, 0, vec![revoke(0xa0)]);
+        let l0 = signed_change(account, K1, &k, LOCAL, 0, vec![revoke(0xb0)]);
+        let m1 = signed_change(account, K1, &k, 0, 1, vec![revoke(0xa1)]);
         let signed = eoa_signed(
             tx_with(
                 None,
@@ -317,8 +317,8 @@ mod tests {
         // channel selection — it must not be bucketed into the local channel —
         // surfacing `ConfigChainId` rather than silently advancing a counter.
         const FOREIGN: u64 = LOCAL + 1;
-        let m0 = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
-        let foreign = signed_change(account, Address::ZERO, &k, FOREIGN, 0, vec![revoke(0xb0)]);
+        let m0 = signed_change(account, K1, &k, 0, 0, vec![revoke(0xa0)]);
+        let foreign = signed_change(account, K1, &k, FOREIGN, 0, vec![revoke(0xb0)]);
         let signed = eoa_signed(
             tx_with(
                 None,
@@ -342,8 +342,8 @@ mod tests {
         // The first entry sits at the channel's max sequence; authorizing a
         // second same-channel entry would advance past u64::MAX, which must be
         // rejected rather than wrapping back to a duplicate-accepting state.
-        let at_max = signed_change(account, Address::ZERO, &k, 0, u64::MAX, vec![revoke(0xa0)]);
-        let next = signed_change(account, Address::ZERO, &k, 0, u64::MAX, vec![revoke(0xa1)]);
+        let at_max = signed_change(account, K1, &k, 0, u64::MAX, vec![revoke(0xa0)]);
+        let next = signed_change(account, K1, &k, 0, u64::MAX, vec![revoke(0xa1)]);
         let signed = eoa_signed(
             tx_with(
                 None,
@@ -374,7 +374,7 @@ mod tests {
             initial_actors: Vec::new(),
         });
         let delegation = AccountChange::Delegation(Delegation { target: account });
-        let cc = signed_change(account, Address::ZERO, &k, 0, 0, vec![revoke(0xa0)]);
+        let cc = signed_change(account, K1, &k, 0, 0, vec![revoke(0xa0)]);
         let signed = eoa_signed(
             tx_with(None, None, vec![create, AccountChange::ConfigChange(cc), delegation]),
             &k,
@@ -392,15 +392,15 @@ mod tests {
         let sid = actor_id(addr(&sk));
         // A config change that would itself authorize, but the sender gate fails
         // first, so the config stage is never reached.
-        let cc = signed_change(account, ECRECOVER, &sk, 0, 0, vec![revoke(0xa0)]);
+        let cc = signed_change(account, K1, &sk, 0, 0, vec![revoke(0xa0)]);
         let tx = tx_with(Some(account), None, vec![AccountChange::ConfigChange(cc)]);
         let hash = tx.sender_signature_hash();
-        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&sk, hash)), Bytes::new());
+        let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&sk, hash)), Bytes::new());
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
                 .unwrap();
             assert_eq!(
                 TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW),
@@ -423,7 +423,7 @@ mod tests {
         let ck = key(0x44);
         let cid = actor_id(addr(&ck));
 
-        let cc = signed_change(sender_account, ECRECOVER, &ck, 0, 0, vec![revoke(0xa0)]);
+        let cc = signed_change(sender_account, K1, &ck, 0, 0, vec![revoke(0xa0)]);
         let tx = tx_with(
             Some(sender_account),
             Some(payer_account),
@@ -433,24 +433,24 @@ mod tests {
         let payer_hash = tx.payer_signature_hash(sender_account);
         let signed = Eip8130Signed::new(
             tx,
-            auth_blob(ECRECOVER, &sig(&sk, sender_hash)),
-            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+            auth_blob(K1, &sig(&sk, sender_hash)),
+            auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&cid)
                 .at_mut(&sender_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_CONFIG, 0, 0))
                 .unwrap();
             let out = TransactionAuthorizer::authorize(&signed, acc, LOCAL, NOW).unwrap();
             assert_eq!(out.actors.sender.account, sender_account);

--- a/crates/execution/eip8130/src/tx_error.rs
+++ b/crates/execution/eip8130/src/tx_error.rs
@@ -52,4 +52,12 @@ pub enum TxAuthError {
         /// The sequence carried by the config change.
         got: u64,
     },
+
+    /// Authorizing the next same-channel config change in a transaction would
+    /// advance the channel sequence past `u64::MAX`. Unreachable in practice
+    /// (the per-transaction change count is bounded far below the sequence
+    /// space), but rejected explicitly rather than wrapping or saturating into a
+    /// state that re-accepts a duplicate sequence.
+    #[error("config change sequence channel overflowed u64")]
+    ConfigSequenceOverflow,
 }

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -75,14 +75,12 @@ impl ActorTxVerifier {
         storage: &AccountConfigurationStorage<'_>,
         now: u64,
     ) -> Result<AuthorizedActor, TxAuthError> {
-        let hash = signed.tx().sender_signature_hash();
-
         if let Some(account) = signed.explicit_sender() {
             // Configured account: `sender_auth` is already `authenticator(20) || data`.
             let resolved = Self::authorize_scoped(
                 storage,
                 account,
-                hash,
+                signed.tx().sender_signature_hash(),
                 signed.sender_auth(),
                 Operation::Sender,
                 now,
@@ -90,21 +88,22 @@ impl ActorTxVerifier {
             return Ok(AuthorizedActor { account, resolved });
         }
 
-        // EOA path: recover the sender with the checked (EIP-2) recovery, then
-        // authorize the implicit-EOA owner. `sender_auth` is a bare 65-byte
-        // signature, so synthesize the `address(0)` authenticator prefix that the
-        // unified authorize step expects.
+        // EOA path: recover the sender exactly once with the checked (EIP-2
+        // low-s) recovery. The recovered address *is* the signer, so authorizing
+        // the implicit-EOA owner needs no second ecrecover — only the self-slot
+        // shadow check. (The wire `address(0)` form, by contrast, recovers in
+        // `authenticate_implicit_eoa` because there the account is wire-supplied.)
         let account = signed
             .recover_eoa_sender()
             .map_err(|_| TxAuthError::SenderRecovery)?
             .ok_or(TxAuthError::SenderRecovery)?;
 
-        let mut auth = Vec::with_capacity(Address::len_bytes() + signed.sender_auth().len());
-        auth.extend_from_slice(Address::ZERO.as_slice());
-        auth.extend_from_slice(signed.sender_auth());
-
-        let resolved =
-            Self::authorize_scoped(storage, account, hash, &auth, Operation::Sender, now)?;
+        let resolved = ActorAuthorizer::implicit_eoa_owner(storage, account)?;
+        // Implicit owners are unrestricted, so the sender gate always passes;
+        // enforce it anyway for parity with the configured-account path.
+        if !Operation::Sender.is_granted(&resolved) {
+            return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
+        }
         Ok(AuthorizedActor { account, resolved })
     }
 

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -89,18 +89,21 @@ impl ActorTxVerifier {
         }
 
         // EOA path: recover the sender exactly once with the checked (EIP-2
-        // low-s) recovery. The recovered address *is* the signer, so authorizing
-        // the implicit-EOA owner needs no second ecrecover — only the self-slot
-        // shadow check. (The wire `address(0)` form, by contrast, recovers in
-        // `authenticate_implicit_eoa` because there the account is wire-supplied.)
+        // low-s) recovery. The recovered address *is* the signer, so the k1
+        // resolution runs against the self id directly — no second ecrecover.
+        // A live default EOA resolves to the unrestricted owner; a revoked one
+        // resolves to its explicit (possibly scoped) self config, if any.
         let account = signed
             .recover_eoa_sender()
             .map_err(|_| TxAuthError::SenderRecovery)?
             .ok_or(TxAuthError::SenderRecovery)?;
 
-        let resolved = ActorAuthorizer::implicit_eoa_owner(storage, account)?;
-        // Implicit owners are unrestricted, so the sender gate always passes;
-        // enforce it anyway for parity with the configured-account path.
+        let resolved = ActorAuthorizer::authorize_k1(
+            storage,
+            account,
+            AccountConfigurationStorage::self_actor_id(account),
+            now,
+        )?;
         if !Operation::Sender.is_granted(&resolved) {
             return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
         }
@@ -136,7 +139,7 @@ mod tests {
     use crate::AuthorizeError;
 
     const NOW: u64 = 1_000;
-    const ECRECOVER: Address = Eip8130Constants::ECRECOVER_AUTHENTICATOR;
+    const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
 
     fn key(byte: u8) -> K256SigningKey {
         K256SigningKey::from_slice(&[byte; 32]).unwrap()
@@ -220,12 +223,12 @@ mod tests {
         let id = actor_id(addr(&k));
         let tx = base_tx(Some(account), None);
         let hash = tx.sender_signature_hash();
-        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&k, hash)), Bytes::new());
+        let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
                 .unwrap();
             let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
             assert_eq!(actors.sender.account, account);
@@ -241,13 +244,13 @@ mod tests {
         let id = actor_id(addr(&k));
         let tx = base_tx(Some(account), None);
         let hash = tx.sender_signature_hash();
-        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&k, hash)), Bytes::new());
+        let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
             // Bound, non-zero scope that lacks SCOPE_SENDER.
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
@@ -273,19 +276,19 @@ mod tests {
         let payer_hash = tx.payer_signature_hash(sender_account);
         let signed = Eip8130Signed::new(
             tx,
-            auth_blob(ECRECOVER, &sig(&sk, sender_hash)),
-            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+            auth_blob(K1, &sig(&sk, sender_hash)),
+            auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
                 .unwrap();
             let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
             let payer = actors.payer.expect("payer present");
@@ -311,7 +314,7 @@ mod tests {
         let signed = Eip8130Signed::new(
             tx,
             Bytes::from(sig(&sk, sender_hash)),
-            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+            auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
             // Sender is an implicit-EOA owner (self-slot empty); only the payer
@@ -319,7 +322,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
                 .unwrap();
             let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
             assert_eq!(actors.sender.account, sender_account);
@@ -347,13 +350,13 @@ mod tests {
         let signed = Eip8130Signed::new(
             tx,
             Bytes::from(sig(&sk, sender_hash)),
-            auth_blob(ECRECOVER, &sig(&pk, wrong_payer_hash)),
+            auth_blob(K1, &sig(&pk, wrong_payer_hash)),
         );
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
                 .unwrap();
             // The payer signs the wrong digest, so it recovers a different actor
             // that is not bound on the payer account.
@@ -378,20 +381,20 @@ mod tests {
         let payer_hash = tx.payer_signature_hash(sender_account);
         let signed = Eip8130Signed::new(
             tx,
-            auth_blob(ECRECOVER, &sig(&sk, sender_hash)),
-            auth_blob(ECRECOVER, &sig(&pk, payer_hash)),
+            auth_blob(K1, &sig(&sk, sender_hash)),
+            auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
                 .unwrap();
             // Payer actor bound but lacking SCOPE_PAYER.
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(ECRECOVER, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
@@ -422,7 +425,7 @@ mod tests {
         let account = address!("0x00000000000000000000000000000000000000aa");
         let tx = base_tx(Some(account), None);
         let hash = tx.sender_signature_hash();
-        let signed = Eip8130Signed::new(tx, auth_blob(ECRECOVER, &sig(&k, hash)), Bytes::new());
+        let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
             // No actor seeded: the sender actor is not bound on the account.
             assert!(matches!(

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -4,7 +4,10 @@
 use alloy_primitives::Address;
 use base_common_consensus::Eip8130Signed;
 
-use crate::{AccountConfigurationStorage, ActorAuthorizer, Operation, ResolvedActor, TxAuthError};
+use crate::{
+    AccountConfigurationStorage, ActorAuthorizer, Operation, RecoveredActorId, ResolvedActor,
+    TxAuthError,
+};
 
 /// A resolved transaction actor together with the account it was authorized
 /// against (the sender or payer account, not the actor id).
@@ -89,22 +92,18 @@ impl ActorTxVerifier {
         }
 
         // EOA path: recover the sender exactly once with the checked (EIP-2
-        // low-s) recovery. The recovered address *is* the signer, so the k1
-        // resolution runs against the self id directly — no second ecrecover.
-        // The inline self config governs: a full-owner self resolves to the
-        // unrestricted owner, a scoped self to its inline scope/policy, and a
-        // disabled (`DEFAULT_EOA_REVOKED`) self is rejected.
-        let account = signed
-            .recover_eoa_sender()
+        // low-s) recovery. The recovered address *is* the signer, so the
+        // `RecoveredActorId` token doubles as the account and feeds the k1
+        // resolution directly — no second ecrecover. The inline self config
+        // governs: a full-owner self resolves to the unrestricted owner, a
+        // scoped self to its inline scope/policy, and a disabled
+        // (`DEFAULT_EOA_REVOKED`) self is rejected.
+        let recovered = RecoveredActorId::recover_eoa_sender(signed)
             .map_err(|_| TxAuthError::SenderRecovery)?
             .ok_or(TxAuthError::SenderRecovery)?;
+        let account = recovered.address();
 
-        let resolved = ActorAuthorizer::authorize_k1(
-            storage,
-            account,
-            AccountConfigurationStorage::self_actor_id(account),
-            now,
-        )?;
+        let resolved = ActorAuthorizer::authorize_k1(storage, account, recovered, now)?;
         if !Operation::Sender.is_granted(&resolved) {
             return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
         }

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -91,8 +91,9 @@ impl ActorTxVerifier {
         // EOA path: recover the sender exactly once with the checked (EIP-2
         // low-s) recovery. The recovered address *is* the signer, so the k1
         // resolution runs against the self id directly — no second ecrecover.
-        // A live default EOA resolves to the unrestricted owner; a revoked one
-        // resolves to its explicit (possibly scoped) self config, if any.
+        // The inline self config governs: a full-owner self resolves to the
+        // unrestricted owner, a scoped self to its inline scope/policy, and a
+        // disabled (`DEFAULT_EOA_REVOKED`) self is rejected.
         let account = signed
             .recover_eoa_sender()
             .map_err(|_| TxAuthError::SenderRecovery)?

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -301,11 +301,11 @@ where
     /// range. Mirrors the check in [`Self::validate_initial_actors`] and
     /// [`Self::validate_actor_changes`] so all auth surfaces (`sender_auth`,
     /// `payer_auth`, `cfg.auth`, and per-actor authenticators) reject the reserved
-    /// `< ECRECOVER_AUTHENTICATOR` window and the `REVOKED_AUTHENTICATOR` sentinel
-    /// identically.
+    /// `< K1_AUTHENTICATOR` window identically. `address(0)` (the only address in
+    /// that window) is the empty / "no actor configured" sentinel and is never a
+    /// valid authenticator selector.
     fn authenticator_out_of_range(authenticator: &Address) -> bool {
-        *authenticator < Eip8130Constants::ECRECOVER_AUTHENTICATOR
-            || *authenticator == Eip8130Constants::REVOKED_AUTHENTICATOR
+        *authenticator < Eip8130Constants::K1_AUTHENTICATOR
     }
 
     /// Walks `account_changes` and enforces structural invariants:
@@ -366,8 +366,8 @@ where
     /// Validates `Create.initial_actors`: the slice length is bounded by
     /// [`Eip8130Constants::MAX_ACTORS_PER_ENTRY`] (anti-DoS cap on memory + work
     /// spent on duplicate detection), every `authenticator` is at or above the
-    /// `ECRECOVER_AUTHENTICATOR` floor and never the `REVOKED_AUTHENTICATOR`
-    /// sentinel, and no two entries share the same `actor_id`.
+    /// `K1_AUTHENTICATOR` floor (i.e. not the `address(0)` empty sentinel), and no
+    /// two entries share the same `actor_id`.
     fn validate_initial_actors(actors: &[InitialActor]) -> Result<(), InvalidPoolTransactionError> {
         if actors.len() > Eip8130Constants::MAX_ACTORS_PER_ENTRY {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
@@ -386,7 +386,7 @@ where
 
     /// Validates `ConfigChange.actor_changes`: the same length cap and
     /// `actor_id`-uniqueness rules as [`Self::validate_initial_actors`], plus the
-    /// reserved/`REVOKED` authenticator bound for the *new* actor of each
+    /// reserved-window authenticator bound for the *new* actor of each
     /// `Authorize`. The authenticator lives in the ABI-encoded `data`
     /// (`abi.encode(ActorConfig, bytes)`), where `ActorConfig.authenticator` is
     /// the right-aligned address in the first 32-byte word, so it is read from
@@ -397,10 +397,10 @@ where
     ///
     /// Per EIP-8130 a config change MAY authorize a non-canonical authenticator
     /// (for in-EVM use such as recovery keys); only the reserved window
-    /// (`< ECRECOVER_AUTHENTICATOR`) and the `REVOKED_AUTHENTICATOR` sentinel are
-    /// rejected here, matching the bound applied to the other auth surfaces. A
-    /// `Revoke` names no authenticator and MUST carry empty `data`; a non-empty
-    /// `data` is malformed and rejected at the gate.
+    /// (`< K1_AUTHENTICATOR`, i.e. the `address(0)` empty sentinel) is rejected
+    /// here, matching the bound applied to the other auth surfaces. A `Revoke`
+    /// names no authenticator and MUST carry empty `data`; a non-empty `data` is
+    /// malformed and rejected at the gate.
     fn validate_actor_changes(changes: &[ActorChange]) -> Result<(), InvalidPoolTransactionError> {
         if changes.len() > Eip8130Constants::MAX_ACTORS_PER_ENTRY {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
@@ -834,18 +834,9 @@ mod tests {
         assert_unsupported(TestValidator::validate_sender_auth(&signed));
     }
 
-    #[test]
-    fn rejects_eip8130_configured_actor_with_revoked_authenticator() {
-        let tx = TxEip8130 { sender: Some(Address::repeat_byte(0xaa)), ..minimal_valid_eoa_tx() };
-        // 20-byte authenticator prefix == REVOKED_AUTHENTICATOR, followed by an empty payload.
-        let auth = Bytes::from(Eip8130Constants::REVOKED_AUTHENTICATOR.to_vec());
-        let signed = Eip8130Signed::new(tx, auth, Bytes::new());
-        assert_unsupported(TestValidator::validate_sender_auth(&signed));
-    }
-
     // Regression: configured-actor path must reject the reserved authenticator
-    // range below `ECRECOVER_AUTHENTICATOR`, matching `validate_actor_changes`.
-    // `address(0)` is the canonical reserved value.
+    // range below `K1_AUTHENTICATOR`, matching `validate_actor_changes`.
+    // `address(0)` is the only reserved value (the empty sentinel).
     #[test]
     fn rejects_eip8130_configured_actor_with_reserved_authenticator() {
         let tx = TxEip8130 { sender: Some(Address::repeat_byte(0xaa)), ..minimal_valid_eoa_tx() };
@@ -887,19 +878,8 @@ mod tests {
         assert_unsupported(TestValidator::validate_payer_auth(&signed));
     }
 
-    #[test]
-    fn rejects_eip8130_payer_authenticator_revoked() {
-        let tx = TxEip8130 { payer: Some(Address::repeat_byte(0x11)), ..minimal_valid_eoa_tx() };
-        let signed = Eip8130Signed::new(
-            tx,
-            Bytes::from_static(&[0u8; 65]),
-            Bytes::from(Eip8130Constants::REVOKED_AUTHENTICATOR.to_vec()),
-        );
-        assert_unsupported(TestValidator::validate_payer_auth(&signed));
-    }
-
-    /// Returns a authenticator address comfortably above the `ECRECOVER_AUTHENTICATOR` floor
-    /// and distinct from the `REVOKED_AUTHENTICATOR` sentinel.
+    /// Returns an authenticator address comfortably above the `K1_AUTHENTICATOR`
+    /// floor.
     fn ok_authenticator() -> Address {
         Address::repeat_byte(0x42)
     }
@@ -1021,20 +1001,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_eip8130_create_with_revoked_actor_authenticator() {
-        let mut entry = make_valid_create_entry();
-        entry.initial_actors[0].authenticator = Eip8130Constants::REVOKED_AUTHENTICATOR;
-        let tx = TxEip8130 {
-            account_changes: vec![AccountChange::Create(entry)],
-            ..minimal_valid_eoa_tx()
-        };
-        assert_unsupported(TestValidator::validate_account_changes(
-            &sign_eoa_eip8130(tx),
-            test_chain_id(),
-        ));
-    }
-
-    #[test]
     fn rejects_eip8130_create_with_too_many_initial_actors() {
         let mut entry = make_valid_create_entry();
         entry.initial_actors.clear();
@@ -1097,47 +1063,6 @@ mod tests {
     fn rejects_eip8130_config_change_with_short_auth() {
         let cfg =
             ConfigChange { auth: Bytes::from_static(&[0u8; 5]), ..make_valid_config_change() };
-        let tx = TxEip8130 {
-            account_changes: vec![AccountChange::ConfigChange(cfg)],
-            ..minimal_valid_eoa_tx()
-        };
-        assert_unsupported(TestValidator::validate_account_changes(
-            &sign_eoa_eip8130(tx),
-            test_chain_id(),
-        ));
-    }
-
-    // Mirrors the `sender_auth`/`payer_auth` rejection of a `REVOKED_AUTHENTICATOR`
-    // prefix: the per-`ConfigChange` `auth` blob must use a live authenticator so the
-    // mempool never propagates a config-change scoped to a revoked authority.
-    #[test]
-    fn rejects_eip8130_config_change_with_revoked_authenticator_in_auth() {
-        let cfg = ConfigChange {
-            auth: Bytes::from(Eip8130Constants::REVOKED_AUTHENTICATOR.to_vec()),
-            ..make_valid_config_change()
-        };
-        let tx = TxEip8130 {
-            account_changes: vec![AccountChange::ConfigChange(cfg)],
-            ..minimal_valid_eoa_tx()
-        };
-        assert_unsupported(TestValidator::validate_account_changes(
-            &sign_eoa_eip8130(tx),
-            test_chain_id(),
-        ));
-    }
-
-    // An `Authorize` change must not register a new actor against the
-    // `REVOKED_AUTHENTICATOR` sentinel; the authenticator is read from the
-    // leading word of the ABI-encoded `data`.
-    #[test]
-    fn rejects_eip8130_config_change_with_revoked_authenticator_in_actor_changes() {
-        let cfg = ConfigChange {
-            actor_changes: vec![make_authorize_change(
-                B256::repeat_byte(0x01),
-                Eip8130Constants::REVOKED_AUTHENTICATOR,
-            )],
-            ..make_valid_config_change()
-        };
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::ConfigChange(cfg)],
             ..minimal_valid_eoa_tx()


### PR DESCRIPTION
## Summary

Adds the **authorization orchestrator** of the EIP-8130 validation pipeline, shared by mempool admission and block inclusion. It composes the per-stage primitives into a single verdict over a signed transaction: the **final sender/payer signatures** plus the transaction's **ordered set of account-configuration changes**.

Lands as the **`transaction` module** of the consolidated `base-execution-eip8130` crate (after #3595 folded the per-stage `eip8130-{state,authorize,tx,nonce}` crates into one). Reads state but performs **no mutations**.

### `TransactionAuthorizer::authorize`

1. **Final transaction signatures** — resolves and scope-gates the sender (`SCOPE_SENDER`) and, when sponsored, the payer (`SCOPE_PAYER`) via `ActorTxVerifier`. The sender signature commits to the whole body, so it authorizes the envelope (calls, metadata, and the presence of every account change), and resolves the sender account (recovering it for the EOA path) that the config changes apply against.
2. **Account-configuration changes** — walks `account_changes` in order, authorizing each `ConfigChange` with its own `SignedActorChanges` signature (`SCOPE_CONFIG`), the account lock, and the chain binding. `Create`/`Delegation` entries carry no independent signature at this layer (authorized by the sender signature; `Create` is additionally bound by its deterministic deploy address at execution).

Returns `AuthorizedTransaction { actors, config_changes }`, or the first `TxAuthError` (sender → payer → config changes in order).

### Sequence advancement

A config-change channel (multichain `chain_id == 0`, or the local chain) advances by one per applied entry. `ConfigChangeAuthorizer::authorize` alone only validates against the channel's *current* on-chain sequence, so a transaction carrying several same-channel entries would fail on the second. The orchestrator reads each channel's base sequence once and validates entries against the running value (`base`, `base + 1`, …) in tx order. Channel selection is explicit (`chain_id == 0` → multichain, `== local` → local, anything else → `ConfigChainId`), so a foreign chain id can never advance a local counter. A running sequence that would exceed `u64::MAX` is rejected (`ConfigSequenceOverflow`) rather than wrapped/saturated.

To enable this, `ConfigChangeAuthorizer` gains **`authorize_at_sequence`** (explicit expected sequence); the existing `authorize` is now a thin wrapper that reads the sequence from state and delegates.

### Scope (what this is not)

Authorization only. Nonce validation, intrinsic-gas accounting and fee/balance checks (#3586) are separate stages; composing all of them into one end-to-end transaction verdict is the next layer. Structural/expiry validation is upstream in consensus. No state is mutated (no `actor_config` writes, sequence/nonce advancement, or balance debits) — that belongs to the execution/apply layer.

## Test plan

- `cargo test -p base-execution-eip8130` — 72 tests total; the 7 orchestrator tests cover sequential same-channel advancement, stale second same-channel entry rejected, independent multichain/local channels, foreign-chain config change rejected without advancing a channel, channel-sequence overflow rejected (not wrapped), `Create`/`Delegation` pass-through (no sequence consumed), and full configured sender + sponsored payer + config-change composition.
- `cargo clippy -p base-execution-eip8130 --all-targets`
- `cargo +nightly fmt -p base-execution-eip8130 -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p base-execution-eip8130 --no-deps`