### PR TITLE
docs(cli): Document Unified Sequencer Command

### DIFF
--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -30,6 +30,35 @@ for consensus chain resolution:
 base rpc --execution-chain dev
 ```
 
+## `base sequencer`
+
+`base sequencer` starts a sequencing node by launching an embedded execution node, embedded
+Flashblocks builder, and embedded consensus node in the same process. The execution node exposes the
+Engine API over auth IPC, and the consensus node connects to that IPC endpoint internally.
+
+The command accepts the shared execution flags, builder flags, and sequencer consensus flags. It
+requires L1 execution and beacon RPC endpoints, and sequencer mode requires a signing key provided
+by one of `--p2p.sequencer.key`, `--p2p.sequencer.key.path`, or `--p2p.signer.endpoint`.
+
+Supported forms:
+
+```text
+base sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.sequencer.key.path <path>
+base --chain sepolia sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.signer.endpoint <url>
+base --chain ./chain.toml sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.sequencer.key.path <path>
+```
+
+Useful sequencer-specific flags include:
+
+- `--sequencer.stopped` starts the process with sequencing disabled until the admin API starts it.
+- `--sequencer.recover` enables recovery mode and forces empty block production.
+- `--conductor.rpc` enables conductor-backed leader checks.
+- `--conductor.binary-commit` uses the conductor binary commit endpoint.
+- `--flashblocks.port` selects the Flashblocks websocket port.
+
+`--sequencer.max-safe-lag` is currently accepted for CLI compatibility, but it is not enforced by
+the sequencer runtime.
+
 ## `base update`
 
 `base update` updates the installed `base` binary by running `baseup --bin base` against the same

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -20,7 +20,7 @@ pub(crate) enum BaseCommand {
     /// Run the integrated node in RPC mode.
     #[command(name = "rpc")]
     Rpc(Box<RpcCommand>),
-    /// Run the integrated node in sequencer mode.
+    /// Run integrated execution, builder, and consensus services in sequencer mode.
     #[command(name = "sequencer")]
     Sequencer(Box<SequencerCommand>),
     /// Update the base binary to the latest release.

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -1,4 +1,4 @@
-//! Integrated sequencer node command.
+//! Integrated execution, builder, and consensus sequencer command.
 
 use std::sync::Arc;
 
@@ -25,21 +25,21 @@ pub(crate) struct SequencerCommand {
     #[arg(long = "execution-chain", value_parser = chain_value_parser)]
     pub(crate) execution_chain: Option<Arc<BaseChainSpec>>,
 
-    /// Execution node arguments.
+    /// Embedded execution node arguments.
     #[command(flatten)]
     pub(crate) execution: ExecutionNodeConfigArgs,
 
-    /// Builder node arguments.
+    /// Embedded builder and Flashblocks arguments.
     #[command(flatten)]
     pub(crate) builder: BuilderArgs,
 
-    /// Consensus node arguments.
+    /// Embedded consensus sequencer arguments.
     #[command(flatten)]
     pub(crate) consensus: EmbeddedSequencerConsensusNodeConfigArgs,
 }
 
 impl SequencerCommand {
-    /// Runs the `sequencer` flavor.
+    /// Runs the `sequencer` flavor with execution, builder, and consensus in one process.
     pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
         let execution_chain = match self.execution_chain {
             Some(chain) => chain,

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -206,7 +206,7 @@ pub struct EmbeddedSequencerConsensusNodeConfigArgs {
     #[command(flatten)]
     pub rpc_flags: EmbeddedRpcArgs,
 
-    /// SEQUENCER CLI arguments.
+    /// Sequencer consensus-control CLI arguments.
     #[command(flatten)]
     pub sequencer_flags: SequencerArgs,
 

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -1,4 +1,4 @@
-//! Sequencer CLI Flags
+//! Sequencer consensus-control CLI flags.
 
 use std::{num::ParseIntError, time::Duration};
 
@@ -6,7 +6,7 @@ use base_consensus_node::SequencerConfig;
 use clap::Parser;
 use url::Url;
 
-/// Sequencer CLI Flags
+/// Sequencer consensus-control CLI flags.
 #[derive(Parser, Clone, Debug, PartialEq, Eq)]
 pub struct SequencerArgs {
     /// Initialize the sequencer in a stopped state. The sequencer can be started using the
@@ -19,7 +19,8 @@ pub struct SequencerArgs {
     pub stopped: bool,
 
     /// Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
-    /// Disabled if 0.
+    ///
+    /// Currently accepted by the CLI but not enforced by the sequencer runtime. Disabled if 0.
     #[arg(
         long = "sequencer.max-safe-lag",
         default_value = "0",
@@ -27,12 +28,12 @@ pub struct SequencerArgs {
     )]
     pub max_safe_lag: u64,
 
-    /// Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1
+    /// Number of L1 blocks to keep distance from the L1 head as a sequencer when picking an L1
     /// origin.
     #[arg(long = "sequencer.l1-confs", default_value = "4", env = "BASE_NODE_SEQUENCER_L1_CONFS")]
     pub l1_confs: u64,
 
-    /// Forces the sequencer to strictly prepare the next L1 origin and create empty L2 blocks
+    /// Force the sequencer to strictly prepare the next L1 origin and create empty L2 blocks.
     #[arg(
         long = "sequencer.recover",
         default_value = "false",
@@ -40,11 +41,11 @@ pub struct SequencerArgs {
     )]
     pub recover: bool,
 
-    /// Conductor service rpc endpoint. Providing this value will enable the conductor service.
+    /// Conductor service RPC endpoint. Providing this value enables the conductor service.
     #[arg(long = "conductor.rpc", env = "BASE_NODE_CONDUCTOR_RPC")]
     pub conductor_rpc: Option<Url>,
 
-    /// Conductor service rpc timeout.
+    /// Conductor service RPC timeout.
     #[arg(
         long = "conductor.rpc.timeout",
         default_value = "1",


### PR DESCRIPTION
## Summary

This documents the new base sequencer command in the unified base binary README. It also updates the relevant CLI doc comments so generated help text describes the embedded execution, builder, and consensus services more accurately. The docs now call out signer requirements and note that sequencer.max-safe-lag is accepted but not currently enforced.