### PR TITLE
fix(proof): use block tags for proof RPC calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,6 +3624,7 @@ name = "base-challenger"
 version = "0.0.0"
 dependencies = [
  "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-provider 2.0.5",
  "alloy-rlp",
@@ -5985,6 +5986,7 @@ name = "base-proposer"
 version = "0.0.0"
 dependencies = [
  "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-provider 2.0.5",
  "alloy-rpc-types-eth 2.0.5",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # Alloy
 alloy-rlp.workspace = true
+alloy-eips.workspace = true
 alloy-provider.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -10,6 +10,7 @@ use std::{
 use alloy_consensus::{
     Eip658Value, Header as ConsensusHeader, Receipt, ReceiptEnvelope, ReceiptWithBloom,
 };
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256, keccak256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{EIP1186AccountProofResponse, Header as RpcHeader, TransactionReceipt};
@@ -657,8 +658,11 @@ impl L2Provider for MockL2Provider {
             .ok_or_else(|| RpcError::ProofNotFound(format!("no proof for hash {block_hash}")))
     }
 
-    async fn header_by_number(&self, number: Option<u64>) -> RpcResult<RpcHeader> {
-        let block_number = number.unwrap_or(0);
+    async fn header_by_number(&self, block: BlockNumberOrTag) -> RpcResult<RpcHeader> {
+        let block_number = match block {
+            BlockNumberOrTag::Number(number) => number,
+            _ => 0,
+        };
         if self.error_blocks.contains(&block_number) {
             return Err(RpcError::BlockNotFound(format!("block {block_number} not available")));
         }
@@ -668,7 +672,10 @@ impl L2Provider for MockL2Provider {
             .ok_or_else(|| RpcError::HeaderNotFound(format!("no header for block {block_number}")))
     }
 
-    async fn block_by_number(&self, _number: Option<u64>) -> RpcResult<base_proof_rpc::BaseBlock> {
+    async fn block_by_number(
+        &self,
+        _block: BlockNumberOrTag,
+    ) -> RpcResult<base_proof_rpc::BaseBlock> {
         Err(RpcError::BlockNotFound("not implemented in mock".into()))
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -661,7 +661,7 @@ impl L2Provider for MockL2Provider {
     async fn header_by_number(&self, block: BlockNumberOrTag) -> RpcResult<RpcHeader> {
         let block_number = match block {
             BlockNumberOrTag::Number(number) => number,
-            _ => 0,
+            other => panic!("MockL2Provider::header_by_number does not support tag {other:?}"),
         };
         if self.error_blocks.contains(&block_number) {
             return Err(RpcError::BlockNotFound(format!("block {block_number} not available")));
@@ -979,6 +979,14 @@ mod tests {
 
     use super::*;
     use crate::scanner::{GameCategory, GameScanner};
+
+    #[tokio::test]
+    #[should_panic(expected = "MockL2Provider::header_by_number does not support tag finalized")]
+    async fn test_mock_l2_provider_rejects_block_tags() {
+        let provider = MockL2Provider::new();
+
+        let _ = provider.header_by_number(BlockNumberOrTag::Finalized).await;
+    }
 
     /// Happy path: mixed games, only `IN_PROGRESS` / non-nullified returned.
     #[tokio::test]

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -8,6 +8,7 @@
 
 use std::sync::Arc;
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256};
 use base_common_consensus::Predeploys;
 use base_proof_rpc::{L2Provider, RpcError};
@@ -176,8 +177,11 @@ impl<L2: L2Provider> OutputValidator<L2> {
         &self,
         block_number: u64,
     ) -> Result<(B256, B256), ValidatorError> {
-        let rpc_header =
-            self.l2_provider.header_by_number(Some(block_number)).await.map_err(|e| match &e {
+        let rpc_header = self
+            .l2_provider
+            .header_by_number(BlockNumberOrTag::Number(block_number))
+            .await
+            .map_err(|e| match &e {
                 RpcError::HeaderNotFound(_) | RpcError::BlockNotFound(_) => {
                     ValidatorError::BlockNotAvailable { block_number }
                 }

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # Alloy
+alloy-eips.workspace = true
 alloy-provider.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -1983,7 +1983,7 @@ mod tests {
         }
         async fn header_by_number(
             &self,
-            _: Option<u64>,
+            _: alloy_eips::BlockNumberOrTag,
         ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
             Err(RpcError::Transport("simulated L1 outage".into()))
         }
@@ -2002,7 +2002,7 @@ mod tests {
         async fn code_at(
             &self,
             _: Address,
-            _: Option<u64>,
+            _: alloy_eips::BlockNumberOrTag,
         ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
             unimplemented!()
         }
@@ -2010,7 +2010,7 @@ mod tests {
             &self,
             _: Address,
             _: alloy_primitives::Bytes,
-            _: Option<u64>,
+            _: alloy_eips::BlockNumberOrTag,
         ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
             unimplemented!()
         }

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1416,7 +1416,7 @@ mod tests {
 
         async fn header_by_number(
             &self,
-            _: Option<u64>,
+            _: alloy_eips::BlockNumberOrTag,
         ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
             Err(base_proof_rpc::RpcError::Transport("simulated L1 outage".into()))
         }
@@ -1438,7 +1438,7 @@ mod tests {
         async fn code_at(
             &self,
             _: Address,
-            _: Option<u64>,
+            _: alloy_eips::BlockNumberOrTag,
         ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
             unimplemented!("tests do not fetch code")
         }
@@ -1447,7 +1447,7 @@ mod tests {
             &self,
             _: Address,
             _: alloy_primitives::Bytes,
-            _: Option<u64>,
+            _: alloy_eips::BlockNumberOrTag,
         ) -> base_proof_rpc::RpcResult<alloy_primitives::Bytes> {
             unimplemented!("tests do not call contracts")
         }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
@@ -158,10 +159,15 @@ where
         claimed_l2_output_root: B256,
     ) -> Result<ProofRequest, ProposerError> {
         let (l1_head, agreed_l2_head) = tokio::try_join!(
-            async { self.l1_client.header_by_number(None).await.map_err(ProposerError::Rpc) },
+            async {
+                self.l1_client
+                    .header_by_number(BlockNumberOrTag::Finalized)
+                    .await
+                    .map_err(ProposerError::Rpc)
+            },
             async {
                 self.l2_client
-                    .header_by_number(Some(recovered.l2_block_number))
+                    .header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number))
                     .await
                     .map_err(ProposerError::Rpc)
             },

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -9,7 +9,7 @@
 //! 2. Intermediate-root validation: extract the per-block intermediate roots
 //!    from the underlying proposals, fetch fresh canonical roots for each
 //!    intermediate block, and verify they all match the canonical chain.
-//! 3. Optional pre-submission TEE signer validation against the on-chain
+//! 3. Optional pre-submission TEE signer validation against the onchain
 //!    `TEEProverRegistry`.
 //! 4. Calls `output_proposer.propose_output(..)` to create the dispute game on
 //!    L1 and maps contract-level errors into the [`SubmitAction`] variants the
@@ -21,6 +21,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Signature, keccak256};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::{
@@ -46,7 +47,7 @@ pub enum SubmitAction {
     /// chain. The pipeline drops the cached recovery and re-proves on the
     /// next tick.
     RootMismatch,
-    /// The dispute game already exists on-chain by a previous attempt whose
+    /// The dispute game already exists onchain by a previous attempt whose
     /// result was lost to an RPC propagation delay. The pipeline must
     /// invalidate its recovery cache so the next forward walk discovers the
     /// existing game.
@@ -85,7 +86,7 @@ pub struct ProofSubmitterConfig {
     pub intermediate_block_interval: u64,
     /// Expected TEE enclave image hash.
     pub tee_image_hash: B256,
-    /// Optional on-chain `TEEProverRegistry` address. When set, the submitter
+    /// Optional onchain `TEEProverRegistry` address. When set, the submitter
     /// performs an `isValidSigner` pre-flight check before calling
     /// `propose_output`.
     pub tee_prover_registry_address: Option<Address>,
@@ -236,7 +237,7 @@ where
 
         // Pre-submission signer validation: if a TEE prover registry is
         // configured, recover the signer from the aggregate proposal signature
-        // and check `isValidSigner` on-chain. If the signer is invalid, skip
+        // and check `isValidSigner` onchain. If the signer is invalid, skip
         // submission to avoid wasting gas on a transaction that will revert.
         if let Some(registry_address) = self.config.tee_prover_registry_address {
             match self
@@ -250,13 +251,13 @@ where
             {
                 Ok(true) => {}
                 Ok(false) => {
-                    // The proof's signer is not registered on-chain. Discard
+                    // The proof's signer is not registered onchain. Discard
                     // this proof so the pipeline re-proves with a (potentially
                     // different, registered) enclave on the next attempt.
-                    warn!(target_block, "TEE signer is not valid on-chain, discarding proof");
+                    warn!(target_block, "TEE signer is not valid onchain, discarding proof");
                     Metrics::tee_signer_invalid_total().increment(1);
                     return Err(SubmitAction::Discard(ProposerError::Internal(
-                        "TEE signer not registered on-chain".into(),
+                        "TEE signer not registered onchain".into(),
                     )));
                 }
                 Err(e) => {
@@ -266,7 +267,7 @@ where
                     // This also handles the case where the registry contract
                     // is not yet deployed (rolling out the
                     // --tee-prover-registry-address config before the contract
-                    // exists on-chain).
+                    // exists onchain).
                     warn!(error = %e, target_block, "signer validity check failed, proceeding anyway");
                 }
             }
@@ -352,7 +353,7 @@ where
                     warn!(
                         error = %e,
                         target_block,
-                        "Proof signer is invalid on-chain, discarding proof to re-prove"
+                        "Proof signer is invalid onchain, discarding proof to re-prove"
                     );
                     Metrics::tee_signer_invalid_total().increment(1);
                     Err(SubmitAction::Discard(e))
@@ -426,7 +427,7 @@ where
                     error = %e,
                     target_block,
                     game_address = %game_address,
-                    "Proof signer is invalid on-chain, discarding proof to re-prove"
+                    "Proof signer is invalid onchain, discarding proof to re-prove"
                 );
                 Metrics::tee_signer_invalid_total().increment(1);
                 Err(SubmitAction::Discard(e))
@@ -479,7 +480,7 @@ where
         let calldata = ITEEProverRegistry::isValidSignerCall { signer }.abi_encode();
         let result = self
             .l1_client
-            .call_contract(registry_address, calldata.into(), None)
+            .call_contract(registry_address, calldata.into(), BlockNumberOrTag::Latest)
             .await
             .map_err(ProposerError::Rpc)?;
 

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -8,6 +8,7 @@ use std::{
     },
 };
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_rpc_types_eth::EIP1186AccountProofResponse;
 use async_trait::async_trait;
@@ -43,7 +44,10 @@ impl L1Provider for MockL1 {
     async fn block_number(&self) -> RpcResult<u64> {
         Ok(self.latest_block_number)
     }
-    async fn header_by_number(&self, _: Option<u64>) -> RpcResult<alloy_rpc_types_eth::Header> {
+    async fn header_by_number(
+        &self,
+        _: BlockNumberOrTag,
+    ) -> RpcResult<alloy_rpc_types_eth::Header> {
         Ok(alloy_rpc_types_eth::Header { hash: B256::repeat_byte(0x11), ..Default::default() })
     }
     async fn header_by_hash(&self, _: B256) -> RpcResult<alloy_rpc_types_eth::Header> {
@@ -55,10 +59,10 @@ impl L1Provider for MockL1 {
     ) -> RpcResult<Vec<alloy_rpc_types_eth::TransactionReceipt>> {
         unimplemented!()
     }
-    async fn code_at(&self, _: Address, _: Option<u64>) -> RpcResult<Bytes> {
+    async fn code_at(&self, _: Address, _: BlockNumberOrTag) -> RpcResult<Bytes> {
         unimplemented!()
     }
-    async fn call_contract(&self, _: Address, _: Bytes, _: Option<u64>) -> RpcResult<Bytes> {
+    async fn call_contract(&self, _: Address, _: Bytes, _: BlockNumberOrTag) -> RpcResult<Bytes> {
         unimplemented!()
     }
     async fn get_balance(&self, _: Address) -> RpcResult<U256> {
@@ -84,11 +88,14 @@ impl L2Provider for MockL2 {
     async fn get_proof(&self, _: Address, _: B256) -> RpcResult<EIP1186AccountProofResponse> {
         unimplemented!()
     }
-    async fn header_by_number(&self, _: Option<u64>) -> RpcResult<alloy_rpc_types_eth::Header> {
+    async fn header_by_number(
+        &self,
+        _: BlockNumberOrTag,
+    ) -> RpcResult<alloy_rpc_types_eth::Header> {
         let hash = self.canonical_hash.unwrap_or(B256::repeat_byte(0x30));
         Ok(alloy_rpc_types_eth::Header { hash, ..Default::default() })
     }
-    async fn block_by_number(&self, _: Option<u64>) -> RpcResult<BaseBlock> {
+    async fn block_by_number(&self, _: BlockNumberOrTag) -> RpcResult<BaseBlock> {
         if self.block_not_found {
             Err(RpcError::BlockNotFound("mock: no blocks".into()))
         } else {

--- a/crates/proof/rpc/README.md
+++ b/crates/proof/rpc/README.md
@@ -14,9 +14,9 @@ Provides async client traits and concrete Alloy-backed implementations for:
 - **`RollupClient`**: Querying rollup configuration and sync status from op-node.
 
 Also provides a `MeteredCache` with hit/miss tracking, `RetryConfig` for exponential
-backoff, a shared `BaseBlock` alias, and an `RpcError` type for error handling. Rollup
-response types such as `L1BlockRef`, `L2BlockRef`, and `SyncStatus` are provided by
-`base-optimism-rpc`.
+backoff, tag-aware latest/finalized block access, a shared `BaseBlock` alias, and an
+`RpcError` type for error handling. Rollup response types such as `L1BlockRef`,
+`L2BlockRef`, and `SyncStatus` are provided by `base-optimism-rpc`.
 
 These abstractions are used by both [`base-proposer`](../proposer/) and the challenger.
 
@@ -32,11 +32,14 @@ base-proof-rpc = { workspace = true }
 Instantiate the Alloy-backed clients to query L1, L2, and rollup nodes:
 
 ```rust,ignore
-use base_proof_rpc::{L1Client, L2Client, RollupClient};
+use alloy_eips::BlockNumberOrTag;
+use base_proof_rpc::{L1Client, L1Provider, L2Client, RollupClient};
 
 let l1 = L1Client::new(l1_url)?;
 let l2 = L2Client::new(l2_url)?;
 let rollup = RollupClient::new(rollup_url)?;
+
+let finalized_header = l1.header_by_number(BlockNumberOrTag::Finalized).await?;
 ```
 
 ## License

--- a/crates/proof/rpc/src/l1_client.rs
+++ b/crates/proof/rpc/src/l1_client.rs
@@ -162,9 +162,8 @@ impl L1Provider for L1Client {
             .await
     }
 
-    async fn header_by_number(&self, number: Option<u64>) -> RpcResult<Header> {
-        let block_id: BlockId =
-            number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number).into();
+    async fn header_by_number(&self, block: BlockNumberOrTag) -> RpcResult<Header> {
+        let block_id: BlockId = block.into();
 
         let backoff = self.retry_config.to_backoff_builder();
 
@@ -244,10 +243,8 @@ impl L1Provider for L1Client {
         Ok(receipts)
     }
 
-    async fn code_at(&self, address: Address, block_number: Option<u64>) -> RpcResult<Bytes> {
-        let block_id = BlockId::Number(
-            block_number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number),
-        );
+    async fn code_at(&self, address: Address, block: BlockNumberOrTag) -> RpcResult<Bytes> {
+        let block_id = BlockId::Number(block);
 
         let backoff = self.retry_config.to_backoff_builder();
 
@@ -266,11 +263,9 @@ impl L1Provider for L1Client {
         &self,
         to: Address,
         data: Bytes,
-        block_number: Option<u64>,
+        block: BlockNumberOrTag,
     ) -> RpcResult<Bytes> {
-        let block_id = BlockId::Number(
-            block_number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number),
-        );
+        let block_id = BlockId::Number(block);
 
         let backoff = self.retry_config.to_backoff_builder();
 

--- a/crates/proof/rpc/src/l2_client.rs
+++ b/crates/proof/rpc/src/l2_client.rs
@@ -238,9 +238,8 @@ impl L2Provider for L2Client {
         Ok(proof)
     }
 
-    async fn header_by_number(&self, number: Option<u64>) -> RpcResult<Header> {
-        let block_id: BlockId =
-            number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number).into();
+    async fn header_by_number(&self, block: BlockNumberOrTag) -> RpcResult<Header> {
+        let block_id: BlockId = block.into();
 
         let backoff = self.retry_config.to_backoff_builder();
 
@@ -263,9 +262,8 @@ impl L2Provider for L2Client {
         Ok(header)
     }
 
-    async fn block_by_number(&self, number: Option<u64>) -> RpcResult<BaseBlock> {
-        let block_id: BlockId =
-            number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number).into();
+    async fn block_by_number(&self, block: BlockNumberOrTag) -> RpcResult<BaseBlock> {
+        let block_id: BlockId = block.into();
 
         let backoff = self.retry_config.to_backoff_builder();
 

--- a/crates/proof/rpc/src/traits.rs
+++ b/crates/proof/rpc/src/traits.rs
@@ -1,5 +1,6 @@
 //! Async trait definitions for RPC clients.
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_rpc_types_eth::{EIP1186AccountProofResponse, Header, TransactionReceipt};
 use async_trait::async_trait;
@@ -14,9 +15,8 @@ pub trait L1Provider: Send + Sync {
     /// Gets the latest block number.
     async fn block_number(&self) -> RpcResult<u64>;
 
-    /// Gets a header by block number.
-    /// If `number` is `None`, returns the latest header.
-    async fn header_by_number(&self, number: Option<u64>) -> RpcResult<Header>;
+    /// Gets a header by block number or tag.
+    async fn header_by_number(&self, block: BlockNumberOrTag) -> RpcResult<Header>;
 
     /// Gets a header by block hash.
     async fn header_by_hash(&self, hash: B256) -> RpcResult<Header>;
@@ -24,17 +24,15 @@ pub trait L1Provider: Send + Sync {
     /// Gets block receipts by block hash.
     async fn block_receipts(&self, hash: B256) -> RpcResult<Vec<TransactionReceipt>>;
 
-    /// Gets contract code at the given address.
-    /// If `block_number` is `None`, uses the latest block.
-    async fn code_at(&self, address: Address, block_number: Option<u64>) -> RpcResult<Bytes>;
+    /// Gets contract code at the given address and block number or tag.
+    async fn code_at(&self, address: Address, block: BlockNumberOrTag) -> RpcResult<Bytes>;
 
-    /// Executes a contract call without creating a transaction.
-    /// If `block_number` is `None`, uses the latest block.
+    /// Executes a contract call at a block number or tag without creating a transaction.
     async fn call_contract(
         &self,
         to: Address,
         data: Bytes,
-        block_number: Option<u64>,
+        block: BlockNumberOrTag,
     ) -> RpcResult<Bytes>;
 
     /// Gets the ETH balance of an address at the latest block.
@@ -54,13 +52,11 @@ pub trait L2Provider: Send + Sync {
         block_hash: B256,
     ) -> RpcResult<EIP1186AccountProofResponse>;
 
-    /// Gets a header by block number.
-    /// If `number` is `None`, returns the latest header.
-    async fn header_by_number(&self, number: Option<u64>) -> RpcResult<Header>;
+    /// Gets a header by block number or tag.
+    async fn header_by_number(&self, block: BlockNumberOrTag) -> RpcResult<Header>;
 
-    /// Gets a block by number with full transactions.
-    /// If `number` is `None`, returns the latest block.
-    async fn block_by_number(&self, number: Option<u64>) -> RpcResult<BaseBlock>;
+    /// Gets a block by block number or tag with full transactions.
+    async fn block_by_number(&self, block: BlockNumberOrTag) -> RpcResult<BaseBlock>;
 
     /// Gets a block by hash with full transactions.
     async fn block_by_hash(&self, hash: B256) -> RpcResult<BaseBlock>;


### PR DESCRIPTION
### What changed? Why?

- Updated proof RPC traits and Alloy clients to take `BlockNumberOrTag` instead of `Option<u64>`, so callers can request latest, finalized, or numbered blocks explicitly.
- Updated proposer and challenger call sites and mocks, including L1 head selection for proof requests to use finalized headers.
- Documented tag-aware RPC usage.

### Notes to reviewers

This keeps numeric call sites explicit and removes the implicit `None` means latest behavior from the proof RPC trait boundary. The proposer proof request path now asks L1 for a finalized header.

### How has it been tested?

- `cargo check -p base-proof-rpc -p base-proposer -p base-challenger`
- `cargo fmt --check` (passes; emits existing stable-rustfmt warnings about nightly-only config keys)