### PR TITLE
fix(zlib): drain consumed bytes in read() to prevent infinite frame loop

### DIFF
--- a/crates/batcher/comp/src/zlib.rs
+++ b/crates/batcher/comp/src/zlib.rs
@@ -90,9 +90,10 @@ impl CompressorWriter for ZlibCompressor {
 
     fn read(&mut self, buf: &mut [u8]) -> CompressorResult<usize> {
         self.ensure_compressed();
-        let compressed = self.compressed.borrow();
+        let mut compressed = self.compressed.borrow_mut();
         let len = compressed.len().min(buf.len());
         buf[..len].copy_from_slice(&compressed[..len]);
+        compressed.drain(..len);
         Ok(len)
     }
 }


### PR DESCRIPTION
## Fix

Applies the same fix that BrotliCompressor got in PR #3541 but was missed for Zlib.

**Two changes in `ZlibCompressor::read()`:**

1. `let compressed` → `let mut compressed` — need `&mut` for `drain()`
2. `compressed.drain(..len)` — consume read bytes so subsequent calls don't return the same data

**Why this matters:**

`ZlibCompressor::read()` was not draining consumed bytes from the internal compressed buffer. When `ChannelOut::output_frame()` calls `compressor.read()` inside the `close_current_channel` drain loop:

```rust
while open.out.ready_bytes() > 0 {     // never decreases with Zlib
    match open.out.output_frame(...) {   // reads same data every time
        Ok(frame) => frames.push(Arc::new(frame)),  // grows forever
    }
}
```

Each iteration creates another frame with identical data. The `frames` vec grows unboundedly until the process OOMs.

**Trigger:** Any batcher configured with `compression_algo = "zlib"` hits this on every channel close.

**Related:**
- Fixes #3594
- Ref: #3541 (same fix for Brotli, commit a0ddbc2)