### PR TITLE
feat: add no-dispute mode to the challenger

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -69,9 +69,14 @@ pub struct ChallengerArgs {
     )]
     pub poll_interval: Duration,
 
-    /// URL of the ZK RPC endpoint.
+    /// URL of the ZK RPC endpoint. Required unless `--no-dispute` is set.
     #[arg(long = "zk-rpc-url", env = cli_env!("ZK_RPC_URL"))]
-    pub zk_rpc_url: Url,
+    pub zk_rpc_url: Option<Url>,
+
+    /// Run in no-dispute mode: skip all ZK/proof-dispute paths and run only the
+    /// bond/anchor lifecycle. Requires `--bond-claim-addresses`; forbids `--zk-rpc-url`.
+    #[arg(long = "no-dispute", env = cli_env!("NO_DISPUTE"), default_value_t = false)]
+    pub no_dispute: bool,
 
     /// Timeout for establishing the initial gRPC connection to the ZK proof
     /// service (e.g., "10s", "1m").

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -69,6 +69,18 @@ pub enum ConfigError {
         /// The actual value.
         value: &'static str,
     },
+    /// `--zk-rpc-url` was provided in `--no-dispute` mode.
+    #[error("--zk-rpc-url must not be set in --no-dispute mode")]
+    ZkRpcUrlNotAllowedInNoDisputeMode,
+    /// `--tee-rpc-url` was provided in `--no-dispute` mode.
+    #[error("--tee-rpc-url must not be set in --no-dispute mode")]
+    TeeRpcUrlNotAllowedInNoDisputeMode,
+    /// `--zk-rpc-url` is required when not in `--no-dispute` mode.
+    #[error("--zk-rpc-url is required unless --no-dispute is set")]
+    MissingZkRpcUrl,
+    /// `--bond-claim-addresses` is required in `--no-dispute` mode.
+    #[error("--bond-claim-addresses is required in --no-dispute mode")]
+    MissingBondClaimAddressesInNoDisputeMode,
     /// Invalid metrics configuration.
     #[error("invalid metrics config: {0}")]
     Metrics(&'static str),
@@ -93,8 +105,11 @@ pub struct ChallengerConfig {
     pub anchor_state_registry_addr: Address,
     /// Polling interval for new dispute games.
     pub poll_interval: Duration,
-    /// URL of the ZK RPC endpoint.
-    pub zk_rpc_url: Validated<Url>,
+    /// Run in no-dispute mode: skip all ZK/proof-dispute paths and run only the
+    /// bond/anchor lifecycle.
+    pub no_dispute: bool,
+    /// URL of the ZK RPC endpoint. `None` in `--no-dispute` mode.
+    pub zk_rpc_url: Option<Validated<Url>>,
     /// Timeout for establishing the initial gRPC connection to the ZK proof service.
     pub zk_connect_timeout: Duration,
     /// Timeout for individual gRPC requests to the ZK proof service.
@@ -171,9 +186,30 @@ impl ChallengerConfig {
 
         let l1_eth_rpc = validate_url(cli.challenger.l1_eth_rpc, "l1-eth-rpc")?;
         let l2_eth_rpc = validate_url(cli.challenger.l2_eth_rpc, "l2-eth-rpc")?;
-        let zk_rpc_url = validate_url(cli.challenger.zk_rpc_url, "zk-rpc-url")?;
+        let no_dispute = cli.challenger.no_dispute;
+        let zk_rpc_url =
+            cli.challenger.zk_rpc_url.map(|url| validate_url(url, "zk-rpc-url")).transpose()?;
         let tee_rpc_url =
             cli.challenger.tee_rpc_url.map(|url| validate_url(url, "tee-rpc-url")).transpose()?;
+
+        // Mode gating: `--no-dispute` strips the proving path, so it forbids
+        // both proof endpoints (`--zk-rpc-url`, `--tee-rpc-url`) and requires
+        // `--bond-claim-addresses` (otherwise the driver would be a silent
+        // no-op). When disputing, `--zk-rpc-url` is mandatory because the
+        // prover-service is the only proof backend.
+        if no_dispute {
+            if zk_rpc_url.is_some() {
+                return Err(ConfigError::ZkRpcUrlNotAllowedInNoDisputeMode);
+            }
+            if tee_rpc_url.is_some() {
+                return Err(ConfigError::TeeRpcUrlNotAllowedInNoDisputeMode);
+            }
+            if cli.challenger.bond_claim_addresses.is_empty() {
+                return Err(ConfigError::MissingBondClaimAddressesInNoDisputeMode);
+            }
+        } else if zk_rpc_url.is_none() {
+            return Err(ConfigError::MissingZkRpcUrl);
+        }
 
         if cli.challenger.anchor_state_registry_addr == Address::ZERO {
             return Err(ConfigError::OutOfRange {
@@ -230,6 +266,7 @@ impl ChallengerConfig {
             dispute_game_factory_addr: cli.challenger.dispute_game_factory_addr,
             anchor_state_registry_addr: cli.challenger.anchor_state_registry_addr,
             poll_interval: cli.challenger.poll_interval,
+            no_dispute,
             zk_rpc_url,
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
@@ -546,5 +583,60 @@ mod tests {
         let cli = cli_from_args(&args);
         let config = ChallengerConfig::from_cli(cli).unwrap();
         assert_eq!(config.health_addr, "127.0.0.1:9090".parse::<SocketAddr>().unwrap());
+    }
+
+    /// Like `cli_from_args` but omits the `--zk-rpc-url` default.
+    fn cli_without_zk(extra_args: &[&str]) -> Cli {
+        let base: &[(&str, &str)] = &[
+            ("--l1-eth-rpc", "http://localhost:8545"),
+            ("--l2-eth-rpc", "http://localhost:9545"),
+            ("--dispute-game-factory-addr", "0x1234567890123456789012345678901234567890"),
+            ("--anchor-state-registry-addr", "0x2234567890123456789012345678901234567890"),
+        ];
+
+        let mut args = vec!["challenger"];
+        for (key, value) in base {
+            if !extra_args.contains(key) {
+                args.push(key);
+                args.push(value);
+            }
+        }
+        args.extend_from_slice(extra_args);
+        Cli::try_parse_from(args).unwrap()
+    }
+
+    const BOND_ADDR: &str = "0x1234567890123456789012345678901234567890";
+
+    #[test]
+    fn test_no_dispute_with_zk_rpc_url_rejected() {
+        // `cli_from_args` includes `--zk-rpc-url` by default.
+        let args = [&LOCAL_SIGNER_ARGS[..], &["--no-dispute", "--bond-claim-addresses", BOND_ADDR]]
+            .concat();
+        let result = ChallengerConfig::from_cli(cli_from_args(&args));
+        assert!(matches!(result, Err(ConfigError::ZkRpcUrlNotAllowedInNoDisputeMode)));
+    }
+
+    #[test]
+    fn test_no_dispute_with_tee_rpc_url_rejected() {
+        let args = [
+            &LOCAL_SIGNER_ARGS[..],
+            &["--no-dispute", "--bond-claim-addresses", BOND_ADDR, "--tee-rpc-url", "http://t:1"],
+        ]
+        .concat();
+        let result = ChallengerConfig::from_cli(cli_without_zk(&args));
+        assert!(matches!(result, Err(ConfigError::TeeRpcUrlNotAllowedInNoDisputeMode)));
+    }
+
+    #[test]
+    fn test_no_dispute_without_bond_addresses_rejected() {
+        let args = [&LOCAL_SIGNER_ARGS[..], &["--no-dispute"]].concat();
+        let result = ChallengerConfig::from_cli(cli_without_zk(&args));
+        assert!(matches!(result, Err(ConfigError::MissingBondClaimAddressesInNoDisputeMode)));
+    }
+
+    #[test]
+    fn test_missing_zk_rpc_url_rejected_when_disputing() {
+        let result = ChallengerConfig::from_cli(cli_without_zk(&LOCAL_SIGNER_ARGS));
+        assert!(matches!(result, Err(ConfigError::MissingZkRpcUrl)));
     }
 }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -43,8 +43,6 @@ use crate::{
 pub struct DriverConfig {
     /// How often the driver polls for new games.
     pub poll_interval: Duration,
-    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
-    pub max_proof_duration: Duration,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -56,6 +54,32 @@ pub struct TeeConfig {
     pub l1_head_provider: Arc<dyn L1HeadProvider>,
 }
 
+/// Dependencies for the scan → validate → prove → dispute path. The [`Driver`]
+/// holds them as `Option<DisputeComponents>`: `Some` when disputing, `None` in
+/// no-dispute mode. The single `Option` records the mode and keeps the proving
+/// deps all-present-or-all-absent — they cannot disagree.
+pub struct DisputeComponents<L2: L2Provider, P: ProofRequesterProvider> {
+    /// Scans for new dispute games on L1.
+    pub scanner: GameScanner,
+    /// Validates L2 output roots against the local node.
+    pub validator: OutputValidator<L2>,
+    /// Prover-service requester used to generate and poll fault proofs (TEE and ZK).
+    pub proof_requester: Arc<P>,
+    /// Optional TEE proof configuration (provider + L1 RPC client).
+    pub tee: Option<TeeConfig>,
+    /// Maximum wall-clock time to wait for a proof session before treating it as failed.
+    pub max_proof_duration: Duration,
+}
+
+impl<L2: L2Provider, P: ProofRequesterProvider> std::fmt::Debug for DisputeComponents<L2, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DisputeComponents")
+            .field("tee", &self.tee.as_ref().map(|_| ".."))
+            .field("max_proof_duration", &self.max_proof_duration)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Service-layer dependencies injected into the [`Driver`].
 pub struct DriverComponents<
     L2: L2Provider,
@@ -63,16 +87,10 @@ pub struct DriverComponents<
     T: TxManager,
     C: Clock = TokioRuntime,
 > {
-    /// Scans for new dispute games on L1.
-    pub scanner: GameScanner,
-    /// Validates L2 output roots against the local node.
-    pub validator: OutputValidator<L2>,
-    /// Prover-service requester used to generate and poll ZK fault proofs.
-    pub proof_requester: Arc<P>,
+    /// Dispute-pipeline dependencies. `None` in no-dispute mode.
+    pub dispute: Option<DisputeComponents<L2, P>>,
     /// Submits challenge transactions to L1.
     pub submitter: ChallengeSubmitter<T>,
-    /// Optional TEE proof configuration (provider + L1 RPC client).
-    pub tee: Option<TeeConfig>,
     /// Client for the aggregate verifier contract.
     pub verifier_client: Arc<dyn AggregateVerifierClient>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
@@ -84,40 +102,36 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DriverComponents")
-            .field("scanner", &self.scanner)
-            .field("tee", &self.tee.as_ref().map(|_| ".."))
+            .field("dispute", &self.dispute.as_ref().map(|_| ".."))
             .field("bond_manager", &self.bond_manager)
             .finish_non_exhaustive()
     }
 }
 
-/// Orchestrates the challenger pipeline: scan, validate, prove, submit.
-pub struct Driver<L2, P, T, C: Clock = TokioRuntime>
+/// Orchestrates the challenger: the bond/anchor lifecycle always, plus the
+/// dispute pipeline (scan → validate → prove → dispute) when `dispute`
+/// is `Some`. In no-dispute mode `dispute` is `None` and the pipeline is
+/// skipped entirely.
+pub struct Driver<L2, P, T, C = TokioRuntime>
 where
     L2: L2Provider,
     P: ProofRequesterProvider,
     T: TxManager,
+    C: Clock,
 {
-    /// Scans for new dispute games on L1.
-    pub scanner: GameScanner,
-    /// Validates L2 output roots against the local node.
-    pub validator: OutputValidator<L2>,
-    /// Prover-service requester used to generate and poll ZK fault proofs.
-    pub proof_requester: Arc<P>,
-    /// Submits challenge transactions to L1.
-    pub submitter: ChallengeSubmitter<T>,
-    /// Optional TEE proof configuration (provider + L1 RPC client).
-    pub tee: Option<TeeConfig>,
-    /// Client for the aggregate verifier contract.
-    pub verifier_client: Arc<dyn AggregateVerifierClient>,
+    /// Dispute-pipeline dependencies. `None` in no-dispute mode; when `None`,
+    /// the driver runs only the bond/anchor lifecycle.
+    pub dispute: Option<DisputeComponents<L2, P>>,
     /// In-flight proof sessions keyed by game address.
     pub pending_proofs: PendingProofs,
+    /// Submits challenge transactions to L1.
+    pub submitter: ChallengeSubmitter<T>,
+    /// Client for the aggregate verifier contract.
+    pub verifier_client: Arc<dyn AggregateVerifierClient>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
     pub bond_manager: Option<BondManager<C>>,
     /// Interval between polling cycles.
     pub poll_interval: Duration,
-    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
-    pub max_proof_duration: Duration,
     /// Token used to signal graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -127,6 +141,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Driver")
+            .field("dispute", &self.dispute.as_ref().map(|_| ".."))
             .field("pending_proofs", &self.pending_proofs.len())
             .field("poll_interval", &self.poll_interval)
             .finish_non_exhaustive()
@@ -140,23 +155,19 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     /// Creates a new driver with the given components.
     pub fn new(config: DriverConfig, components: DriverComponents<L2, P, T, C>) -> Self {
         Self {
-            scanner: components.scanner,
-            validator: components.validator,
-            proof_requester: components.proof_requester,
-            submitter: components.submitter,
-            tee: components.tee,
-            verifier_client: components.verifier_client,
+            dispute: components.dispute,
             pending_proofs: PendingProofs::new(),
+            submitter: components.submitter,
+            verifier_client: components.verifier_client,
             bond_manager: components.bond_manager,
             poll_interval: config.poll_interval,
-            max_proof_duration: config.max_proof_duration,
             cancel: config.cancel,
         }
     }
 
     /// Runs the main driver loop until the cancellation token is fired.
     pub async fn run(mut self) {
-        info!("challenger driver starting");
+        info!(no_dispute = self.dispute.is_none(), "challenger driver starting");
         loop {
             if self.cancel.is_cancelled() {
                 info!("challenger driver shutting down");
@@ -180,17 +191,23 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         }
     }
 
-    /// Executes a single scan-validate-prove-submit cycle.
+    /// Executes a single cycle: advance in-flight proofs, run the bond/anchor
+    /// lifecycle, then (when disputing) scan for and process candidates.
     ///
-    /// First polls any in-flight proof sessions that are not in the current
-    /// scan batch, then discovers claimable bonds, advances bond lifecycle
-    /// claims, and finally scans for new candidates and processes them.
+    /// In no-dispute mode (`dispute` is `None`) only the bond/anchor lifecycle
+    /// runs — no scanning, validation, proving, or dispute submission.
     pub async fn step(&mut self) -> eyre::Result<()> {
-        self.poll_pending_proofs().await;
+        if self.dispute.is_some() {
+            self.poll_pending_proofs().await;
+        }
+
         self.discover_claimable_bonds().await;
         self.poll_bond_claims().await;
 
-        let candidates = self.scanner.scan().await?;
+        let candidates = match self.dispute.as_ref() {
+            Some(dispute) => dispute.scanner.scan().await?,
+            None => return Ok(()),
+        };
 
         for candidate in candidates {
             let index = candidate.index;
@@ -203,9 +220,8 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     }
 
     /// Discovers new claimable games via incremental and periodic full
-    /// rescanning. Runs before [`poll_bond_claims`](Self::poll_bond_claims)
-    /// so that newly discovered games are immediately eligible for
-    /// advancement in the same tick.
+    /// rescanning. Runs before [`poll_bond_claims`](Self::poll_bond_claims) so
+    /// newly discovered games are eligible for advancement in the same tick.
     async fn discover_claimable_bonds(&mut self) {
         if let Some(ref mut bond_manager) = self.bond_manager
             && let Err(e) = bond_manager.discover_claimable_games(&*self.verifier_client).await
@@ -215,7 +231,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     }
 
     /// Polls the bond manager to advance tracked games through the bond
-    /// lifecycle (resolve → unlock → delay → withdraw).
+    /// lifecycle (resolve → unlock → delay → withdraw, plus anchor updates).
     async fn poll_bond_claims(&mut self) {
         if let Some(ref mut bond_manager) = self.bond_manager {
             bond_manager.poll(&*self.verifier_client, &self.submitter).await;
@@ -285,7 +301,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             intermediate_roots: &intermediate_roots,
         };
 
-        match self.validator.validate_intermediate_roots(params).await {
+        match self
+            .dispute
+            .as_ref()
+            .expect("dispute components must be set unless --no-dispute is set")
+            .validator
+            .validate_intermediate_roots(params)
+            .await
+        {
             Ok(result) => Ok(Some((result, intermediate_roots))),
             Err(e) => {
                 match &e {
@@ -420,7 +443,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         //   starting_block + interval * (i + 1)
         let checkpoint_block = candidate.checkpoint_start_block(challenged_index + 1)?;
 
-        let expected_root = match self.validator.compute_output_root(checkpoint_block).await {
+        let expected_root = match self
+            .dispute
+            .as_ref()
+            .expect("dispute components must be set unless --no-dispute is set")
+            .validator
+            .compute_output_root(checkpoint_block)
+            .await
+        {
             Ok(root) => root,
             Err(ValidatorError::BlockNotAvailable { .. }) => {
                 debug!(
@@ -493,7 +523,12 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         // (InvalidDualProposal) set `try_tee_first = true`.
         if candidate.tee_prover != Address::ZERO
             && try_tee_first
-            && let Some(tee) = &self.tee
+            && let Some(tee) = self
+                .dispute
+                .as_ref()
+                .expect("dispute components must be set unless --no-dispute is set")
+                .tee
+                .as_ref()
         {
             ChallengerMetrics::tee_proof_attempts_total().increment(1);
             match self.build_tee_request(&candidate, invalid_index, expected_root, tee).await {
@@ -518,7 +553,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                         tee_request,
                         TeeKind::AwsNitro,
                     );
-                    match self.proof_requester.prove_block_range(request).await {
+                    match self
+                        .dispute
+                        .as_ref()
+                        .expect("dispute components must be set unless --no-dispute is set")
+                        .proof_requester
+                        .prove_block_range(request)
+                        .await
+                    {
                         Ok(response) => {
                             info!(
                                 game = %game_address,
@@ -583,7 +625,11 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         let l1_head = candidate.l1_head;
         let (l1_head_number_result, output_root_result) = tokio::join!(
             tee.l1_head_provider.block_number_by_hash(l1_head),
-            self.validator.compute_output_root_with_hash(start_block_number),
+            self.dispute
+                .as_ref()
+                .expect("dispute components must be set unless --no-dispute is set")
+                .validator
+                .compute_output_root_with_hash(start_block_number),
         );
         let l1_head_number = l1_head_number_result?;
         let (agreed_l2_head_hash, agreed_l2_output_root) = output_root_result?;
@@ -643,7 +689,13 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             proof_request.clone(),
         );
 
-        let prove_response = self.proof_requester.prove_block_range(request).await?;
+        let prove_response = self
+            .dispute
+            .as_ref()
+            .expect("dispute components must be set unless --no-dispute is set")
+            .proof_requester
+            .prove_block_range(request)
+            .await?;
 
         info!(
             game = %game_address,
@@ -697,9 +749,13 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         // Poll proof status first — if still pending, skip the contract
         // calls that check game liveness. This avoids 3 RPC round-trips
         // per tick for proofs that are not yet ready.
+        let dispute = self
+            .dispute
+            .as_ref()
+            .expect("dispute components must be set unless --no-dispute is set");
         let proof_update = self
             .pending_proofs
-            .poll(game_address, &*self.proof_requester, self.max_proof_duration)
+            .poll(game_address, &*dispute.proof_requester, dispute.max_proof_duration)
             .await?;
         match &proof_update {
             Some(ProofUpdate::Pending) => {
@@ -883,7 +939,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             request,
         );
 
-        match self.proof_requester.prove_block_range(prove_request).await {
+        match self
+            .dispute
+            .as_ref()
+            .expect("dispute components must be set unless --no-dispute is set")
+            .proof_requester
+            .prove_block_range(prove_request)
+            .await
+        {
             Ok(response) => {
                 info!(
                     game = %game_address,

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -13,7 +13,7 @@ mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};
 
 mod driver;
-pub use driver::{Driver, DriverComponents, DriverConfig, TeeConfig};
+pub use driver::{DisputeComponents, Driver, DriverComponents, DriverConfig, TeeConfig};
 
 mod pending;
 pub use pending::{DisputeIntent, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate};

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -22,8 +22,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
-    BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver, DriverComponents,
-    DriverConfig, GameScanner, OutputValidator,
+    BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, DisputeComponents,
+    Driver, DriverComponents, DriverConfig, GameScanner, OutputValidator,
 };
 
 /// Top-level challenger service.
@@ -38,13 +38,12 @@ impl ChallengerService {
     /// 1. Install TLS provider
     /// 2. Create the cancellation token and signal handler
     /// 3. Create L1 provider, tx-manager, and challenge submitter
-    /// 4. Create contract clients and read onchain config
-    /// 5. Create L2 and ZK clients
-    /// 6. Assemble scanner, validator, and driver
+    /// 4. Create dispute-game-factory and aggregate-verifier clients
+    /// 5. Build the bond manager
+    /// 6. Build the dispute pipeline dependencies (skipped in no-dispute mode)
     /// 7. Start health HTTP server
-    /// 8. Start driver loop
-    /// 9. Wait for shutdown signal
-    /// 10. Graceful shutdown
+    /// 8. Assemble and run the driver
+    /// 9. Graceful shutdown
     ///
     /// # Errors
     ///
@@ -109,48 +108,17 @@ impl ChallengerService {
         );
 
         let verifier_client = AggregateVerifierContractClient::new(l1_rpc_url.clone())?;
-        let anchor_registry_client = AnchorStateRegistryContractClient::new(
-            config.anchor_state_registry_addr,
-            l1_rpc_url.clone(),
-        )?;
-        info!(
-            address = %config.anchor_state_registry_addr,
-            "AnchorStateRegistry client initialized"
-        );
 
         let factory_client = Arc::new(factory_client);
         let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
-        let anchor_registry_client = Arc::new(anchor_registry_client);
 
-        // ── 5. L2 client ─────────────────────────────────────────────────────
-        let l2_config = L2ClientConfig::new(config.l2_eth_rpc.as_ref().clone());
-        let l2_client = Arc::new(L2Client::new(l2_config)?);
-        info!(endpoint = %config.l2_eth_rpc, "L2 client initialized");
-
-        // ── 6. Prover-service requester client ───────────────────────────────
-        let proof_requester_config = ProverServiceClientConfig::new(config.zk_rpc_url.to_string())
-            .with_request_timeout(config.zk_request_timeout);
-        let proof_requester = Arc::new(ProofRequesterClient::connect(&proof_requester_config)?);
-        info!(endpoint = %config.zk_rpc_url, "Prover-service requester client initialized");
-
-        // ── 6b. TEE proof client (optional) ─────────────────────────────────
-        let tee = if let Some(ref tee_url) = config.tee_rpc_url {
-            // TODO(C4): consolidate proof-client config and replace tee_rpc_url as a feature gate.
-            info!(endpoint = %tee_url, "TEE proof sourcing enabled");
-            let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
-            let l1_client = L1Client::new(l1_config)
-                .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
-            Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) })
-        } else {
-            info!("TEE proof sourcing disabled (no --tee-rpc-url)");
-            None
-        };
-
-        // ── 7. Bond manager (optional) ─────────────────────────────────────
+        // ── 5. Bond manager ─────────────────────────────────────────────────
+        // Required in no-dispute mode (enforced by config validation); optional
+        // otherwise.
         let bond_manager = if !config.bond_claim_addresses.is_empty() {
             let mut bm = BondManager::new(
                 config.bond_claim_addresses,
-                l1_rpc_url,
+                l1_rpc_url.clone(),
                 Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
                 config.bond_discovery_lookback_games,
                 config.bond_discovery_interval,
@@ -173,13 +141,64 @@ impl ChallengerService {
             None
         };
 
-        // ── 7b. Assemble scanner, validator, and driver ─────────────────────
-        let scanner =
-            GameScanner::new(factory_client, Arc::clone(&verifier_client), anchor_registry_client);
+        // ── 6. Dispute pipeline dependencies (skipped in no-dispute mode) ───
+        // No-dispute mode runs only the bond/anchor lifecycle, so the
+        // prover-service client, L2 client, scanner, and validator are never
+        // constructed. The type annotation pins the `Driver`'s `L2`/`P`
+        // generics, which are otherwise unconstrained when `dispute` is `None`.
+        let dispute: Option<DisputeComponents<L2Client, ProofRequesterClient>> = if config
+            .no_dispute
+        {
+            info!("no-dispute mode: skipping prover-service, L2 client, scanner, and validator");
+            None
+        } else {
+            let anchor_registry_client = Arc::new(AnchorStateRegistryContractClient::new(
+                config.anchor_state_registry_addr,
+                l1_rpc_url.clone(),
+            )?);
+            info!(
+                address = %config.anchor_state_registry_addr,
+                "AnchorStateRegistry client initialized"
+            );
 
-        let validator = OutputValidator::new(l2_client);
+            let l2_config = L2ClientConfig::new(config.l2_eth_rpc.as_ref().clone());
+            let l2_client = Arc::new(L2Client::new(l2_config)?);
+            info!(endpoint = %config.l2_eth_rpc, "L2 client initialized");
 
-        // ── 8. Start health HTTP server ──────────────────────────────────────
+            let zk_rpc_url = config.zk_rpc_url.as_ref().expect("zk_rpc_url is Some when disputing");
+            let proof_requester_config = ProverServiceClientConfig::new(zk_rpc_url.to_string())
+                .with_request_timeout(config.zk_request_timeout);
+            let proof_requester = Arc::new(ProofRequesterClient::connect(&proof_requester_config)?);
+            info!(endpoint = %zk_rpc_url, "Prover-service requester client initialized");
+
+            let tee = if let Some(ref tee_url) = config.tee_rpc_url {
+                // TODO(C4): consolidate proof-client config and replace tee_rpc_url as a feature gate.
+                info!(endpoint = %tee_url, "TEE proof sourcing enabled");
+                let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
+                let l1_client = L1Client::new(l1_config)
+                    .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
+                Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) })
+            } else {
+                info!("TEE proof sourcing disabled (no --tee-rpc-url)");
+                None
+            };
+
+            let scanner = GameScanner::new(
+                Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+                Arc::clone(&verifier_client),
+                anchor_registry_client,
+            );
+            let validator = OutputValidator::new(l2_client);
+            Some(DisputeComponents {
+                scanner,
+                validator,
+                proof_requester,
+                tee,
+                max_proof_duration: config.max_proof_duration,
+            })
+        };
+
+        // ── 7. Start health HTTP server ──────────────────────────────────────
         let ready = Arc::new(AtomicBool::new(false));
         let health_handle = {
             let addr = config.health_addr;
@@ -188,23 +207,12 @@ impl ChallengerService {
             tokio::spawn(async move { HealthServer::serve(addr, ready_flag, health_cancel).await })
         };
 
-        // ── 9. Run driver ────────────────────────────────────────────────────
-        let driver_config = DriverConfig {
-            poll_interval: config.poll_interval,
-            max_proof_duration: config.max_proof_duration,
-            cancel: cancel.child_token(),
-        };
+        // ── 8. Run driver ────────────────────────────────────────────────────
+        let driver_config =
+            DriverConfig { poll_interval: config.poll_interval, cancel: cancel.child_token() };
         let driver = Driver::new(
             driver_config,
-            DriverComponents {
-                scanner,
-                validator,
-                proof_requester,
-                submitter,
-                tee,
-                verifier_client,
-                bond_manager,
-            },
+            DriverComponents { dispute, submitter, verifier_client, bond_manager },
         );
 
         // Signal readiness immediately after initialization — the driver loop
@@ -217,7 +225,7 @@ impl ChallengerService {
         driver.run().await;
         drop(cancel_guard);
 
-        // ── 10. Graceful shutdown ────────────────────────────────────────────
+        // ── 9. Graceful shutdown ─────────────────────────────────────────────
         info!("Driver stopped, shutting down...");
         ready.store(false, Ordering::SeqCst);
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,9 +8,9 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
-    BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
-    DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofPhase, ProofUpdate, TeeConfig,
+    BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeComponents, DisputeIntent,
+    Driver, DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator,
+    PendingProof, PendingProofs, ProofPhase, ProofUpdate, TeeConfig,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
         MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager,
@@ -84,20 +84,20 @@ fn test_driver_with_tee(
     let validator = OutputValidator::new(l2_provider);
     let submitter = ChallengeSubmitter::new(tx_manager);
 
-    let config = DriverConfig {
-        poll_interval: Duration::from_millis(10),
-        max_proof_duration: Duration::from_secs(4 * 60 * 60),
-        cancel: CancellationToken::new(),
-    };
+    let config =
+        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
 
     Driver::new(
         config,
         DriverComponents {
-            scanner,
-            validator,
-            proof_requester: zk_prover,
+            dispute: Some(DisputeComponents {
+                scanner,
+                validator,
+                proof_requester: zk_prover,
+                tee,
+                max_proof_duration: Duration::from_secs(4 * 60 * 60),
+            }),
             submitter,
-            tee,
             verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
             bond_manager: None,
         },
@@ -386,20 +386,20 @@ async fn test_step_scan_error_propagated() {
     let validator = OutputValidator::new(l2);
     let submitter = ChallengeSubmitter::new(default_tx_manager());
 
-    let config = DriverConfig {
-        poll_interval: Duration::from_millis(10),
-        max_proof_duration: Duration::from_secs(4 * 60 * 60),
-        cancel: CancellationToken::new(),
-    };
+    let config =
+        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
 
     let mut driver = Driver::new(
         config,
         DriverComponents {
-            scanner,
-            validator,
-            proof_requester: default_zk_prover(),
+            dispute: Some(DisputeComponents {
+                scanner,
+                validator,
+                proof_requester: default_zk_prover(),
+                tee: None,
+                max_proof_duration: Duration::from_secs(4 * 60 * 60),
+            }),
             submitter,
-            tee: None,
             verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
             bond_manager: None::<BondManager<TokioRuntime>>,
         },
@@ -935,7 +935,7 @@ async fn test_step_tee_submission_failure_falls_back_to_zk() {
     );
 
     {
-        let mut state = driver.proof_requester.state.lock().unwrap();
+        let mut state = driver.dispute.as_ref().unwrap().proof_requester.state.lock().unwrap();
         state.result = None;
         state.proof = vec![0xDE, 0xAD];
         state.proof_status = ProofStatus::Succeeded;
@@ -1802,4 +1802,28 @@ async fn test_poll_running_timeout_triggers_retry() {
     let entry = proofs.get(&addr(0)).unwrap();
     assert_eq!(entry.retry_count, 1);
     assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
+}
+
+/// With `dispute` = `None`, `step()` must skip the scan/validate/prove path —
+/// reaching it would panic on the absent components. A passing `step()` proves
+/// the gate holds; the dispute pipeline was never entered.
+#[tokio::test]
+async fn test_step_no_dispute_skips_proving() {
+    let verifier = empty_verifier();
+    let submitter = ChallengeSubmitter::new(default_tx_manager());
+
+    let config =
+        DriverConfig { poll_interval: Duration::from_millis(10), cancel: CancellationToken::new() };
+
+    let mut driver: Driver<MockL2Provider, MockZkProofProvider, MockTxManager> = Driver::new(
+        config,
+        DriverComponents {
+            dispute: None,
+            submitter,
+            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+            bond_manager: None,
+        },
+    );
+
+    driver.step().await.expect("no-dispute step must not touch the absent dispute components");
 }


### PR DESCRIPTION
Add a `--no-dispute` mode (env `BASE_CHALLENGER_NO_DISPUTE`) that runs only the bond/anchor lifecycle and skips the scan -> validate -> prove -> dispute pipeline.

This targets L3s with immediate TEE-backed finality: all finality delays are zero, so games resolve to DEFENDER_WINS in the same block they are created, and the ZK verifier is disabled. The dispute pipeline cannot act there — no challengeable window exists, and challenge() requires a ZK proof type with no verifier behind it. The chain still needs the bond/anchor lifecycle (resolve -> claimCredit -> setAnchorState): its resolve() call advances games to DEFENDER_WINS so withdrawals can finalize.

- `--zk-rpc-url` becomes optional — required when disputing, forbidden in no-dispute mode.
- `--no-dispute` requires `--bond-claim-addresses` (else the driver is a silent no-op) and forbids both proof endpoints (`--zk-rpc-url`, `--tee-rpc-url`).
- The driver holds proving dependencies as `Option<DisputeComponents>`, encoding the mode at the type level so the dependencies cannot disagree (all present or all absent).