### PR TITLE
feat(PRIV-1985): runtime AggregateVerifier registration for L3 

### DIFF
--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -28,7 +28,10 @@ RUN go build -o /go/bin/eth2-val-tools .
 # The foundry image is Ubuntu-based and multi-arch (amd64/arm64)
 FROM ghcr.io/foundry-rs/foundry:v1.7.1 AS contracts-builder
 
-ARG CONTRACTS_COMMIT=65dd69c69b3cb118341e89ed43377e01e75bcc6e
+# Pinned to the PRIV-1997 contracts branch tip, which adds SystemDeploy.registerAggregateVerifier
+# (deferred AggregateVerifier registration for runtime config_hash) and Artifacts.load.
+# TODO(PRIV-1985): repoint to the l3-changes merge commit once PRIV-1997 lands.
+ARG CONTRACTS_COMMIT=65a997428730279a6dc6246c10483e8d0c023d51
 
 # git is pre-installed in the foundry image (Ubuntu 22.04)
 RUN git config --global user.email "docker@build" && \

--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -28,10 +28,10 @@ RUN go build -o /go/bin/eth2-val-tools .
 # The foundry image is Ubuntu-based and multi-arch (amd64/arm64)
 FROM ghcr.io/foundry-rs/foundry:v1.7.1 AS contracts-builder
 
-# Pinned to the PRIV-1997 contracts branch tip, which adds SystemDeploy.registerAggregateVerifier
-# (deferred AggregateVerifier registration for runtime config_hash) and Artifacts.load.
-# TODO(PRIV-1985): repoint to the l3-changes merge commit once PRIV-1997 lands.
-ARG CONTRACTS_COMMIT=65a997428730279a6dc6246c10483e8d0c023d51
+# base/contracts l3-changes commit (PRIV-1997, #345) that adds SystemDeploy's deferred
+# AggregateVerifier registration (registerAggregateVerifier) and Artifacts.load for the
+# re-entrant post-genesis registration flow.
+ARG CONTRACTS_COMMIT=65dd69c69b3cb118341e89ed43377e01e75bcc6e
 
 # git is pre-installed in the foundry image (Ubuntu 22.04)
 RUN git config --global user.email "docker@build" && \

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -167,6 +167,13 @@ _build-setup-image:
     docker build -t devnet-setup:local -f etc/docker/Dockerfile.devnet \
         $(if [ -n "$CONTRACTS_COMMIT" ]; then echo "--build-arg CONTRACTS_COMMIT=$CONTRACTS_COMMIT"; fi) .
 
+# nitro-host-local image — used by the L3 dev-multiproof compute-config-hash one-shot (and the
+# nitro-local prover service). Built with the dev profile to match the other devnet images.
+[private]
+_build-nitro-host-local:
+    docker build -t nitro-host-local:local -f etc/docker/Dockerfile.nitro-host-local \
+        --build-arg PROFILE=dev .
+
 [private]
 _build-rust-images group profile='dev':
     #!/usr/bin/env bash
@@ -220,6 +227,9 @@ _up-devnet compose_profile l1_mode zk:
         just --justfile {{ source_file() }} down
         just --justfile {{ source_file() }} _build-setup-image
         just --justfile {{ source_file() }} _build-rust-images "devnet" "dev"
+        if [ "$l1_mode" = "l3" ]; then
+          just --justfile {{ source_file() }} _build-nitro-host-local
+        fi
         SP1_PROVER=dry-run docker compose "${env_files[@]}" "${compose_files[@]}" "${l1_profile[@]}" up -d --no-build
         ;;
       cluster)
@@ -270,6 +280,9 @@ _up-devnet compose_profile l1_mode zk:
         just --justfile {{ source_file() }} down
         just --justfile {{ source_file() }} _build-setup-image
         just --justfile {{ source_file() }} _build-rust-images "devnet" "dev"
+        if [ "$l1_mode" = "l3" ]; then
+          just --justfile {{ source_file() }} _build-nitro-host-local
+        fi
         docker compose "${env_files[@]}" --env-file "$cluster_env" "${compose_files[@]}" "${l1_profile[@]}" up -d --no-build
         ;;
       *)

--- a/etc/docker/devnet-l3-env
+++ b/etc/docker/devnet-l3-env
@@ -31,12 +31,17 @@ BATCHER_MAX_PENDING_TRANSACTIONS=4
 L1_CALLDATA_ONLY=true
 
 # Multiproof / TEE configuration
-# Non-zero placeholder that enables dev multiproof at deploy time. The real config hash is
-# deployment-specific (depends on genesis block hashes and contract addresses) and is not
-# known at config-render time; the correct value is computed from the live chain and set on
-# the AggregateVerifier by the runtime-registration step added in a later PR. Nothing
-# consumes the placeholder-hash verifier in this PR.
+# Non-zero placeholder. The real config hash depends on the L2 rollup config (genesis
+# block hashes, system config) which is only known after L2 genesis, so it cannot be
+# baked into the immutable AggregateVerifier.CONFIG_HASH at deploy time. Instead we defer:
+# SystemDeploy skips the AggregateVerifier (see MULTIPROOF_DEFER_REGISTRATION below), and
+# after genesis the compute-config-hash + register-aggregate-verifier one-shots compute the
+# real hash and deploy/register the verifier with it. This placeholder still satisfies the
+# deploy config's "must be set" validation.
 MULTIPROOF_CONFIG_HASH=0x0000000000000000000000000000000000000000000000000000000000000001
+# Defer AggregateVerifier deployment to the post-genesis register-aggregate-verifier one-shot
+# (see docker-compose.yml). Required because CONFIG_HASH is unknown until L2 genesis exists.
+MULTIPROOF_DEFER_REGISTRATION=true
 # Dev TEE signer address — registered in DevTEEProverRegistry during SystemDeploy.
 # The corresponding private key lives in devnet-tee.env (gitignored).
 DEV_TEE_SIGNER=0x6cebCF805c5191BCf26602E43DECa89AEe092b5d

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -210,6 +210,7 @@ services:
       - PROPOSER_ADDR=${PROPOSER_ADDR}
       - CHALLENGER_ADDR=${CHALLENGER_ADDR}
       - MULTIPROOF_CONFIG_HASH=${MULTIPROOF_CONFIG_HASH-}
+      - MULTIPROOF_DEFER_REGISTRATION=${MULTIPROOF_DEFER_REGISTRATION-}
       - DEV_TEE_SIGNER=${DEV_TEE_SIGNER-}
       - TEE_IMAGE_HASH=${TEE_IMAGE_HASH-}
       - BUILDER_P2P_KEY=${BUILDER_P2P_KEY}
@@ -234,6 +235,61 @@ services:
       - L2_RPC_URL=http://base-builder:${L2_BUILDER_HTTP_PORT}
       - CONFIG_DIR=/configs
     entrypoint: ["/usr/local/bin/patch-genesis-hash.sh"]
+
+  # Post-genesis dev-multiproof registration — two ordered one-shots.
+  # AggregateVerifier.CONFIG_HASH is immutable and depends on the L2 rollup config, which only
+  # exists after genesis, so SystemDeploy defers the verifier (MULTIPROOF_DEFER_REGISTRATION).
+  # 1) compute-config-hash: read the real hash from the running op-node.
+  # 2) register-aggregate-verifier: deploy + register the verifier with that hash.
+  # base-l1 profile only: this flow is specific to the L3 / dev-multiproof devnet. In eth-l1 mode
+  # multiproof is disabled and the deploy is not deferred, so these services are not created.
+  compute-config-hash:
+    image: nitro-host-local:local
+    build:
+      context: ../..
+      dockerfile: etc/docker/Dockerfile.nitro-host-local
+    container_name: compute-config-hash
+    profiles: ["base-l1"]
+    depends_on:
+      base-builder-cl:
+        condition: service_healthy
+    volumes:
+      - ../../.devnet/l2/configs:/configs
+      - ../../etc/scripts/devnet/compute-config-hash.sh:/compute-config-hash.sh:ro
+    user: root
+    environment:
+      - L2_CL_URL=http://base-builder-cl:${L2_BUILDER_CL_RPC_PORT}
+      - OUTPUT_DIR=/configs
+    entrypoint: ["/bin/bash", "/compute-config-hash.sh"]
+    restart: on-failure
+
+  register-aggregate-verifier:
+    image: devnet-setup:local
+    container_name: register-aggregate-verifier
+    profiles: ["base-l1"]
+    env_file: devnet-env
+    depends_on:
+      compute-config-hash:
+        condition: service_completed_successfully
+    volumes:
+      - ../../.devnet/l2/configs:/devnet/l2/configs
+    environment:
+      - L1_RPC_URL=http://l1-el:${L1_HTTP_PORT}
+      - L1_CHAIN_ID=${L1_CHAIN_ID}
+      - L2_CHAIN_ID=${L2_CHAIN_ID}
+      - OUTPUT_DIR=/devnet/l2/configs
+      - HASH_FILE=/devnet/l2/configs/multiproof-config-hash
+      - DEPLOYER_ADDR=${DEPLOYER_ADDR}
+      - DEPLOYER_KEY=${DEPLOYER_KEY}
+      - SEQUENCER_ADDR=${SEQUENCER_ADDR}
+      - BATCHER_ADDR=${BATCHER_ADDR}
+      - PROPOSER_ADDR=${PROPOSER_ADDR}
+      - CHALLENGER_ADDR=${CHALLENGER_ADDR}
+      - MULTIPROOF_CONFIG_HASH=${MULTIPROOF_CONFIG_HASH-}
+      - DEV_TEE_SIGNER=${DEV_TEE_SIGNER-}
+      - TEE_IMAGE_HASH=${TEE_IMAGE_HASH-}
+    entrypoint: ["/usr/local/bin/register-aggregate-verifier.sh"]
+    restart: on-failure
 
   base-el-bootnode:
     image: base-reth-node:local

--- a/etc/scripts/devnet/compute-config-hash.sh
+++ b/etc/scripts/devnet/compute-config-hash.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# compute-config-hash.sh — first of two post-genesis one-shots for dev multiproof.
+#
+# Resolves the multiproof CONFIG_HASH from the running op-node and writes it to the shared
+# volume for register-aggregate-verifier.sh to consume. Uses `nitro-host config-hash`, which
+# fetches the rollup config via `optimism_rollupConfig` and hashes it with the same
+# PerChainConfig encoding the enclave uses — so the value is exactly what the on-chain
+# AggregateVerifier.CONFIG_HASH must be.
+#
+# Runs inside the nitro-host-local image (which ships the binary at /app/base-prover-nitro-host).
+
+L2_CL_URL="${L2_CL_URL:-http://base-builder-cl:7549}"
+OUTPUT_DIR="${OUTPUT_DIR:-/configs}"
+HASH_FILE="${HASH_FILE:-$OUTPUT_DIR/multiproof-config-hash}"
+NITRO_HOST="${NITRO_HOST:-/app/base-prover-nitro-host}"
+
+echo "=== Compute multiproof config hash ==="
+echo "L2 CL URL:  $L2_CL_URL"
+echo "Hash file:  $HASH_FILE"
+
+mkdir -p "$OUTPUT_DIR"
+
+# config-hash prints only the hash to stdout; grep guards against any incidental log output.
+HASH="$("$NITRO_HOST" config-hash --l2-cl-url "$L2_CL_URL" | grep -oiE '0x[0-9a-f]{64}' | tail -n1)"
+if ! [[ "$HASH" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+  echo "ERROR: failed to compute a valid config hash (got: '$HASH')"
+  exit 1
+fi
+
+printf '%s' "$HASH" >"$HASH_FILE"
+echo "Wrote config hash $HASH to $HASH_FILE"

--- a/etc/scripts/devnet/register-aggregate-verifier.sh
+++ b/etc/scripts/devnet/register-aggregate-verifier.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+# register-aggregate-verifier.sh — second of two post-genesis one-shots for dev multiproof.
+#
+# The AggregateVerifier's CONFIG_HASH is immutable and depends on the L2 rollup config, which
+# only exists after L2 genesis. So SystemDeploy defers it (MULTIPROOF_DEFER_REGISTRATION=true)
+# and this script finishes the job once the hash is known:
+#   1. compute-config-hash.sh has written the real hash to $HASH_FILE.
+#   2. setup-l2.sh has copied the deploy outfile to the shared volume.
+# We regenerate the deploy config (identical to the deploy) and call SystemDeploy's
+# registerAggregateVerifier(bytes32) re-entrant entrypoint, which deploys the verifier with the
+# real hash and points the DisputeGameFactory's game type at it.
+
+L1_RPC_URL="${L1_RPC_URL:-http://l1-el:4545}"
+L1_CHAIN_ID="${L1_CHAIN_ID:-1337}"
+OUTPUT_DIR="${OUTPUT_DIR:-/devnet/l2/configs}"
+TEMPLATE_DIR="${TEMPLATE_DIR:-/templates}"
+WORKDIR=/contracts
+HASH_FILE="${HASH_FILE:-$OUTPUT_DIR/multiproof-config-hash}"
+DEPLOY_OUTFILE="$OUTPUT_DIR/${L1_CHAIN_ID}-deploy.json"
+
+: "${DEPLOYER_ADDR:?DEPLOYER_ADDR is required}"
+: "${DEPLOYER_KEY:?DEPLOYER_KEY is required}"
+
+echo "=== Register AggregateVerifier (post-genesis) ==="
+echo "L1 RPC URL:    $L1_RPC_URL"
+echo "L1 Chain ID:   $L1_CHAIN_ID"
+echo "Hash file:     $HASH_FILE"
+echo "Deploy outfile: $DEPLOY_OUTFILE"
+
+# The config hash must be present and well-formed (0x + 64 hex chars). compose ordering
+# guarantees compute-config-hash.sh completed first, but validate defensively.
+if [ ! -s "$HASH_FILE" ]; then
+  echo "ERROR: config hash file missing or empty: $HASH_FILE"
+  exit 1
+fi
+MULTIPROOF_CONFIG_HASH_COMPUTED="$(tr -d '[:space:]' <"$HASH_FILE")"
+if ! [[ "$MULTIPROOF_CONFIG_HASH_COMPUTED" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+  echo "ERROR: malformed config hash in $HASH_FILE: '$MULTIPROOF_CONFIG_HASH_COMPUTED'"
+  exit 1
+fi
+echo "Computed config hash: $MULTIPROOF_CONFIG_HASH_COMPUTED"
+
+if [ ! -f "$DEPLOY_OUTFILE" ]; then
+  echo "ERROR: deploy outfile not found: $DEPLOY_OUTFILE (setup-l2 must run with MULTIPROOF_DEFER_REGISTRATION=true)"
+  exit 1
+fi
+
+# Regenerate the deploy config from the template exactly as setup-l2.sh step 1 did, so the
+# verifier's non-hash inputs (teeImageHash, intervals, game type, …) match the original deploy.
+echo ""
+echo "--- Regenerating deploy-config.json ---"
+mkdir -p "$WORKDIR/deploy-config"
+envsubst <"$TEMPLATE_DIR/deploy-config.json.template" >"$WORKDIR/deploy-config/devnet.json"
+
+echo ""
+echo "--- Calling registerAggregateVerifier ---"
+(
+  cd "$WORKDIR"
+  # DEPLOYMENT_OUTFILE points Artifacts at the shared copy: registerAggregateVerifier reloads
+  # the existing addresses from it and appends the new AggregateVerifier entry back to it.
+  FOUNDRY_SCRIPT_EXECUTION_PROTECTION=false \
+    DEPLOY_CONFIG_PATH="$WORKDIR/deploy-config/devnet.json" \
+    DEPLOYMENT_OUTFILE="$DEPLOY_OUTFILE" \
+    forge script scripts/deploy/SystemDeploy.s.sol:SystemDeploy \
+    --sig "registerAggregateVerifier(bytes32)" "$MULTIPROOF_CONFIG_HASH_COMPUTED" \
+    --sender "$DEPLOYER_ADDR" \
+    --rpc-url "$L1_RPC_URL" \
+    --private-key "$DEPLOYER_KEY" \
+    --broadcast \
+    --slow
+)
+
+# Refresh l1-addresses.json so downstream consumers (and smoke.sh) see the AggregateVerifier
+# address now that it has been registered.
+if [ -f "$OUTPUT_DIR/l1-addresses.json" ]; then
+  AGGREGATE_VERIFIER="$(jq -r '.AggregateVerifier // empty' "$DEPLOY_OUTFILE")"
+  if [ -n "$AGGREGATE_VERIFIER" ]; then
+    TMP_ADDRESSES="$(mktemp)"
+    jq --arg av "$AGGREGATE_VERIFIER" '.AggregateVerifier = $av' \
+      "$OUTPUT_DIR/l1-addresses.json" >"$TMP_ADDRESSES"
+    mv "$TMP_ADDRESSES" "$OUTPUT_DIR/l1-addresses.json"
+    echo "Updated l1-addresses.json AggregateVerifier = $AGGREGATE_VERIFIER"
+  fi
+fi
+
+echo ""
+echo "=== AggregateVerifier registration complete ==="

--- a/etc/scripts/devnet/register-aggregate-verifier.sh
+++ b/etc/scripts/devnet/register-aggregate-verifier.sh
@@ -49,10 +49,14 @@ fi
 
 # Regenerate the deploy config from the template exactly as setup-l2.sh step 1 did, so the
 # verifier's non-hash inputs (teeImageHash, intervals, game type, …) match the original deploy.
+# Override MULTIPROOF_CONFIG_HASH with the computed hash (the env carries only the deploy-time
+# placeholder) so the regenerated devnet.json is self-consistent with the value we register —
+# the forge arg below is authoritative, but this avoids a stale hash on disk being read silently.
 echo ""
 echo "--- Regenerating deploy-config.json ---"
 mkdir -p "$WORKDIR/deploy-config"
-envsubst <"$TEMPLATE_DIR/deploy-config.json.template" >"$WORKDIR/deploy-config/devnet.json"
+MULTIPROOF_CONFIG_HASH="$MULTIPROOF_CONFIG_HASH_COMPUTED" \
+  envsubst <"$TEMPLATE_DIR/deploy-config.json.template" >"$WORKDIR/deploy-config/devnet.json"
 
 echo ""
 echo "--- Calling registerAggregateVerifier ---"

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -24,6 +24,9 @@ SEQ2_P2P_KEY="${SEQ2_P2P_KEY:-47e179ec197488593b187f80a00eb0da91f1b9d0b13f873363
 MULTIPROOF_CONFIG_HASH="${MULTIPROOF_CONFIG_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}"
 DEV_TEE_SIGNER="${DEV_TEE_SIGNER:-0x0000000000000000000000000000000000000000}"
 TEE_IMAGE_HASH="${TEE_IMAGE_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}"
+# When true, SystemDeploy skips the AggregateVerifier; the register-aggregate-verifier one-shot
+# deploys + registers it after L2 genesis with the real config hash (see devnet-l3-env).
+MULTIPROOF_DEFER_REGISTRATION="${MULTIPROOF_DEFER_REGISTRATION:-false}"
 
 if [ -n "$L2_BASE_AZUL_BLOCK" ] && ! [[ "$L2_BASE_AZUL_BLOCK" =~ ^[0-9]+$ ]]; then
   echo "ERROR: L2_BASE_AZUL_BLOCK must be a non-negative integer when set, got: $L2_BASE_AZUL_BLOCK"
@@ -113,6 +116,7 @@ echo "--- Step 2: Deploying L1 contracts ---"
   cd /contracts
   FOUNDRY_SCRIPT_EXECUTION_PROTECTION=false \
     DEPLOY_CONFIG_PATH="$WORKDIR/deploy-config/devnet.json" \
+    MULTIPROOF_DEFER_REGISTRATION="$MULTIPROOF_DEFER_REGISTRATION" \
     forge script scripts/deploy/SystemDeploy.s.sol:SystemDeploy \
     --sender "$DEPLOYER_ADDR" \
     --rpc-url "$L1_RPC_URL" \
@@ -120,6 +124,15 @@ echo "--- Step 2: Deploying L1 contracts ---"
     --broadcast \
     --slow
 )
+
+# When deferring AggregateVerifier registration, persist the deploy outfile to the shared
+# volume. The deploy ran in this container's ephemeral /contracts/deployments, but the
+# post-genesis register-aggregate-verifier one-shot runs in a fresh container and reloads
+# these addresses (via Artifacts.load) to deploy + register the verifier.
+if [ "$MULTIPROOF_DEFER_REGISTRATION" = "true" ]; then
+  cp "$WORKDIR/deployments/${L1_CHAIN_ID}-deploy.json" "$OUTPUT_DIR/${L1_CHAIN_ID}-deploy.json"
+  echo "Copied deploy outfile to $OUTPUT_DIR/${L1_CHAIN_ID}-deploy.json for deferred registration"
+fi
 
 # Step 3: Generate L2 genesis allocs via forge script
 # Uses L2GenesisDevnet.s.sol wrapper that reads deploy-config + L1 addresses,

--- a/etc/scripts/devnet/smoke.sh
+++ b/etc/scripts/devnet/smoke.sh
@@ -39,3 +39,33 @@ if curl -sf "$INGRESS_HEALTH_URL" >/dev/null 2>&1; then
 else
     echo "Ingress not running (start with: just devnet ingress)"
 fi
+
+# === Multiproof AggregateVerifier Registration (L3 dev-multiproof only) ===
+# The config-hash file is written by the compute-config-hash one-shot in the L3 devnet; its
+# presence scopes this assertion to dev-multiproof runs. Verify the AggregateVerifier registered
+# for the multiproof game type carries the runtime-computed CONFIG_HASH (deferred registration).
+CONFIG_HASH_FILE=".devnet/l2/configs/multiproof-config-hash"
+if [ -f "$CONFIG_HASH_FILE" ]; then
+    echo ""
+    echo "=== Multiproof AggregateVerifier Verification ==="
+    MULTIPROOF_GAME_TYPE="${MULTIPROOF_GAME_TYPE:-621}"
+    EXPECTED_HASH=$(tr -d '[:space:]' <"$CONFIG_HASH_FILE" | tr '[:upper:]' '[:lower:]')
+    DGF=$(jq -r '.DisputeGameFactoryProxy' "$ADDRESSES")
+
+    VERIFIER=$(cast call --rpc-url "$L1_RPC" "$DGF" "gameImpls(uint32)(address)" "$MULTIPROOF_GAME_TYPE")
+    if [ -z "$VERIFIER" ] || [ "$VERIFIER" = "0x0000000000000000000000000000000000000000" ]; then
+        echo "FAIL: no AggregateVerifier registered for game type $MULTIPROOF_GAME_TYPE"
+        exit 1
+    fi
+    echo "AggregateVerifier (game type $MULTIPROOF_GAME_TYPE): $VERIFIER"
+
+    ONCHAIN_HASH=$(cast call --rpc-url "$L1_RPC" "$VERIFIER" "CONFIG_HASH()(bytes32)" | tr '[:upper:]' '[:lower:]')
+    echo "On-chain CONFIG_HASH: $ONCHAIN_HASH"
+    echo "Expected  CONFIG_HASH: $EXPECTED_HASH"
+
+    if [ "$ONCHAIN_HASH" != "$EXPECTED_HASH" ]; then
+        echo "FAIL: AggregateVerifier CONFIG_HASH does not match the computed config hash"
+        exit 1
+    fi
+    echo "PASS: AggregateVerifier CONFIG_HASH matches the runtime-computed config hash"
+fi

--- a/etc/scripts/devnet/smoke.sh
+++ b/etc/scripts/devnet/smoke.sh
@@ -59,7 +59,7 @@ if [ -f "$CONFIG_HASH_FILE" ]; then
     fi
     echo "AggregateVerifier (game type $MULTIPROOF_GAME_TYPE): $VERIFIER"
 
-    ONCHAIN_HASH=$(cast call --rpc-url "$L1_RPC" "$VERIFIER" "CONFIG_HASH()(bytes32)" | tr '[:upper:]' '[:lower:]')
+    ONCHAIN_HASH=$(cast call --rpc-url "$L1_RPC" "$VERIFIER" "CONFIG_HASH()(bytes32)" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
     echo "On-chain CONFIG_HASH: $ONCHAIN_HASH"
     echo "Expected  CONFIG_HASH: $EXPECTED_HASH"
 


### PR DESCRIPTION
## Summary

In the L3, the `AggregateVerifier`'s immutable `CONFIG_HASH`
must equal `keccak256(PerChainConfig)` of the live chain. That value depends on
genesis anchoring (`genesis.l1.hash` / `genesis.l2.hash` / `l2_time`), and we
**empirically confirmed it is not reproducible across devnet restarts** — `l1-anvil`
stamps the L1 genesis block with wall-clock time, which cascades into the hash. So it
can't be precomputed and hardcoded.

This PR wires up **runtime registration**: after L3 genesis is finalized, compute the
real `config_hash` from the running op-node and deploy + register the `AggregateVerifier`
for game type 621 on the `DisputeGameFactory` — no proxy upgrade, no genesis determinism
required. The proposer (the only game creator, added in part B) starts only after
registration completes, so no game is ever cloned from a placeholder implementation.

This is **part A** (the registration mechanism) of PRIV-1985. Part B — wiring
`nitro-local` + `base-proposer` + `base-challenger` services and gating the proposer on
`register-aggregate-verifier` — is **PRIV-2001 (#3609)**, stacked on this PR.

> **Based on `l3`.** All upstream deps have merged: #3584 (PRIV-1984 — deploy-config
> template + `nitro-host config-hash` tool) and the contracts work (PRIV-1997, #345, on
> `l3-changes`). `CONTRACTS_COMMIT` is pinned here to the merged SHA `65dd69c6`.

## How it works

```
setup-l2  (MULTIPROOF_DEFER_REGISTRATION=true)
  deploy contracts, DEFER the AggregateVerifier, copy the deploy outfile to the shared volume
        │
        ▼
compute-config-hash one-shot  (nitro-host-local image)
  nitro-host config-hash --l2-cl-url <op-node>  →  /configs/multiproof-config-hash
        │
        ▼
register-aggregate-verifier one-shot  (devnet-setup image)
  forge script SystemDeploy --sig registerAggregateVerifier(bytes32) <hash>
  →  deploy verifier + register it for game type 621; patch AggregateVerifier into l1-addresses.json
```

The hash is computed with the enclave's own `base_proof_primitives::PerChainConfig` path
(via `nitro-host config-hash`) against the same `optimism_rollupConfig` the enclave reads,
so on-chain `CONFIG_HASH` is byte-identical to what `nitro-local` signs, by construction.

## Changes
- **`etc/scripts/devnet/setup-l2.sh`** — accept `MULTIPROOF_DEFER_REGISTRATION` (default
  `false`), forward it to the `SystemDeploy` run, and when set copy the deploy outfile into
  the shared `/devnet/l2/configs` volume so the register step can reload addresses.
- **`etc/scripts/devnet/compute-config-hash.sh`** *(new)* — one-shot #1: run
  `nitro-host config-hash` against op-node and write the validated `0x…` hash to
  `/configs/multiproof-config-hash`.
- **`etc/scripts/devnet/register-aggregate-verifier.sh`** *(new)* — one-shot #2: read the
  hash + shared deploy outfile, regenerate the deploy config (rendered with the computed
  hash so it is self-consistent), call `registerAggregateVerifier(bytes32)`, and patch
  `AggregateVerifier` into `l1-addresses.json`.
- **`etc/docker/docker-compose.yml`** — add `compute-config-hash` (depends on op-node
  healthy) and `register-aggregate-verifier` (depends on compute completing) one-shots,
  both `profiles: ["base-l1"]` so they only run for L3.
- **`etc/docker/devnet-l3-env`** — set `MULTIPROOF_DEFER_REGISTRATION=true`; replace the
  stale two-phase comment with the runtime-registration flow.
- **`etc/scripts/devnet/smoke.sh`** — L3-only (guarded by the hash file): assert on-chain
  `AggregateVerifier.CONFIG_HASH()` (via `gameImpls(621)`) equals the computed hash, to
  catch registration failure / drift.
- **`etc/docker/Dockerfile.devnet`** — pin `CONTRACTS_COMMIT` to the merged PRIV-1997 SHA
  (`65dd69c6`), which provides the `registerAggregateVerifier` entrypoint + `Artifacts.load()`.
- **`etc/docker/Justfile`** — add `_build-nitro-host-local` and invoke it in the L3 `up`
  path so `nitro-host-local:local` exists before `docker compose up --no-build`.
