### PR TITLE
refactor(registrar): clean up CRL file

### DIFF
--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -37,7 +37,11 @@ where
         nitro_verifier: Box<dyn NitroVerifierClient>,
         tx_manager: T,
     ) -> Result<Self> {
-        let http_client = crl::build_crl_http_client(fetch_timeout)?;
+        let http_client = reqwest::Client::builder()
+            .timeout(fetch_timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| RegistrarError::Config(format!("failed to build HTTP client: {e}")))?;
         Ok(Self { http_client, nitro_verifier, tx_manager })
     }
 
@@ -60,7 +64,7 @@ where
         let cert_infos = crl::CertCrlInfo::from_chain(&report.cert_chain_der())?;
 
         RegistrarMetrics::onchain_revocation_checks_total().increment(1);
-        for info in crl::CertCrlInfo::intermediates(&cert_infos) {
+        for info in &cert_infos {
             match self.nitro_verifier.is_revoked(info.path_digest).await {
                 Ok(true) => {
                     warn!(
@@ -187,7 +191,7 @@ mod tests {
     fn intermediate_digests(attestation: &[u8]) -> Vec<B256> {
         let report = AttestationReport::parse(attestation).unwrap();
         let cert_infos = crl::CertCrlInfo::from_chain(&report.cert_chain_der()).unwrap();
-        crl::CertCrlInfo::intermediates(&cert_infos).map(|info| info.path_digest).collect()
+        cert_infos.iter().map(|info| info.path_digest).collect()
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -230,11 +230,12 @@ pub struct CrlError(
 
 #[cfg(test)]
 mod tests {
+    use hex_literal::hex;
+
     use super::*;
     use crate::test_utils::{
         CertFixtures, INTER1_HEX, INTER2_HEX, INTER3_HEX, INVALID_DER_BYTES, LEAF_HEX, ROOT_HEX,
     };
-    use hex_literal::hex;
 
     const INTER1_EXPECTED_CRL_URL: &str = "http://aws-nitro-enclaves-crl.s3.amazonaws.com/crl/ab4960cc-7d63-42bd-9e9f-59338cb67f84.crl";
 

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -4,8 +4,6 @@
 //! Fetch and parse failures are fail-open; onchain expiry tracking and
 //! periodic re-checks bound the remaining exposure window.
 
-use std::time::Duration;
-
 use alloy_primitives::B256;
 use base_proof_tee_nitro_verifier::compute_path_digests;
 use tracing::{debug, warn};
@@ -16,15 +14,12 @@ use x509_parser::{
     revocation_list::CertificateRevocationList,
 };
 
-/// Default timeout for CRL fetches.
-pub const DEFAULT_CRL_FETCH_TIMEOUT_SECS: u64 = 30;
-
 const MAX_CRL_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const ALLOWED_CRL_HOST_SUFFIX: &str = ".amazonaws.com";
 const ALLOWED_CRL_HOST_KEYWORD: &str = "nitro-enclave";
 
 /// Information extracted from a single certificate needed for CRL checking.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CertCrlInfo {
     /// Position of the certificate in the chain.
     pub index: usize,
@@ -38,7 +33,7 @@ pub struct CertCrlInfo {
 }
 
 impl CertCrlInfo {
-    /// Extracts CRL-relevant information from a DER-encoded chain.
+    /// Extracts CRL-relevant information from a DER-encoded chain's intermediate certificates.
     ///
     /// The certificates must be in chain order: root → intermediates → leaf.
     /// Path digests are computed identically to the onchain
@@ -46,17 +41,24 @@ impl CertCrlInfo {
     ///
     /// # Errors
     ///
-    /// Returns an error if any certificate cannot be parsed from DER.
+    /// Returns an error if any intermediate certificate cannot be parsed from DER.
     pub fn from_chain(certs_der: &[&[u8]]) -> Result<Vec<Self>, CrlError> {
-        let mut infos = Vec::with_capacity(certs_der.len());
+        let mut infos = Vec::with_capacity(certs_der.len().saturating_sub(2));
         let path_digests = compute_path_digests(certs_der);
 
-        for (index, (der, path_digest)) in certs_der.iter().zip(path_digests).enumerate() {
-            let (remaining, cert) = X509Certificate::from_der(der)
-                .map_err(|e| CrlError::CertParse(format!("certificate {index}: {e}")))?;
+        for (index, (der, path_digest)) in certs_der
+            .iter()
+            .zip(path_digests)
+            .enumerate()
+            .skip(1)
+            .take(certs_der.len().saturating_sub(2))
+        {
+            let (remaining, cert) = X509Certificate::from_der(der).map_err(|e| {
+                CrlError(format!("certificate parse error: certificate {index}: {e}"))
+            })?;
             if !remaining.is_empty() {
-                return Err(CrlError::CertParse(format!(
-                    "certificate {index}: trailing DER data ({} bytes)",
+                return Err(CrlError(format!(
+                    "certificate parse error: certificate {index}: trailing DER data ({} bytes)",
                     remaining.len()
                 )));
             }
@@ -69,42 +71,6 @@ impl CertCrlInfo {
 
         Ok(infos)
     }
-
-    /// Returns intermediate certificates, skipping the root and leaf.
-    ///
-    /// Roots manage their own trust and leaves are short-lived
-    /// (~3 hours), so neither participates in the onchain
-    /// `_cacheNewCert` rewrite that the durable revocation sentinel
-    /// guards against; the AWS CRL layer applies the same scope.
-    /// Chains shorter than three certificates yield an empty iterator.
-    pub fn intermediates(infos: &[Self]) -> impl Iterator<Item = &Self> {
-        infos.iter().skip(1).take(infos.len().saturating_sub(2))
-    }
-
-    /// Returns the label used when logging this intermediate certificate.
-    pub fn intermediate_label(&self) -> String {
-        intermediate_cert_label(self.index)
-    }
-}
-
-/// Information about a revoked certificate.
-#[derive(Debug, Clone)]
-pub struct RevokedCertInfo {
-    /// Position of the revoked certificate in the chain.
-    pub index: usize,
-    /// Path digest for onchain `revokeCert()`.
-    pub path_digest: B256,
-}
-
-impl RevokedCertInfo {
-    /// Returns the label used when logging this revoked intermediate certificate.
-    pub fn intermediate_label(&self) -> String {
-        intermediate_cert_label(self.index)
-    }
-}
-
-fn intermediate_cert_label(index: usize) -> String {
-    format!("intermediate {index}")
 }
 
 fn extract_crl_distribution_point(cert: &X509Certificate<'_>) -> Option<String> {
@@ -129,9 +95,11 @@ fn extract_crl_distribution_point(cert: &X509Certificate<'_>) -> Option<String> 
 }
 
 fn is_allowed_crl_host(url: &str) -> bool {
-    url::Url::parse(url).ok().and_then(|u| u.host_str().map(|h| h.to_lowercase())).is_some_and(
-        |host| host.ends_with(ALLOWED_CRL_HOST_SUFFIX) && host.contains(ALLOWED_CRL_HOST_KEYWORD),
-    )
+    reqwest::Url::parse(url).is_ok_and(|u| {
+        u.domain().is_some_and(|host| {
+            host.ends_with(ALLOWED_CRL_HOST_SUFFIX) && host.contains(ALLOWED_CRL_HOST_KEYWORD)
+        })
+    })
 }
 
 /// Checks intermediate certificates against their CRL distribution points.
@@ -145,38 +113,37 @@ fn is_allowed_crl_host(url: &str) -> bool {
 ///   cycle by [`CertCrlInfo::from_chain`] and shared with the onchain
 ///   revocation pre-check so the DER parse only happens once.
 /// * `http_client` - HTTP client for fetching CRLs.
-pub async fn check_chain_against_crls(
-    cert_infos: &[CertCrlInfo],
+pub async fn check_chain_against_crls<'a>(
+    cert_infos: &'a [CertCrlInfo],
     http_client: &reqwest::Client,
-) -> Vec<RevokedCertInfo> {
+) -> Vec<&'a CertCrlInfo> {
     let mut revoked = Vec::new();
 
-    for info in CertCrlInfo::intermediates(cert_infos) {
-        let cert = info.intermediate_label();
+    for info in cert_infos {
         let Some(ref crl_url) = info.crl_url else {
-            debug!(cert = %cert, "no CRL distribution point, skipping");
+            debug!(cert_index = info.index, "no CRL distribution point, skipping");
             continue;
         };
 
-        debug!(cert = %cert, url = %crl_url, "fetching CRL");
+        debug!(cert_index = info.index, url = %crl_url, "fetching CRL");
 
         match fetch_and_check_crl(http_client, crl_url, &info.serial_number).await {
             Ok(true) => {
                 warn!(
-                    cert = %cert,
+                    cert_index = info.index,
                     url = %crl_url,
                     serial = %hex::encode(&info.serial_number),
                     path_digest = %info.path_digest,
                     "certificate found on CRL — REVOKED"
                 );
-                revoked.push(RevokedCertInfo { index: info.index, path_digest: info.path_digest });
+                revoked.push(info);
             }
             Ok(false) => {
-                debug!(cert = %cert, "certificate not on CRL");
+                debug!(cert_index = info.index, "certificate not on CRL");
             }
             Err(e) => {
                 warn!(
-                    cert = %cert,
+                    cert_index = info.index,
                     url = %crl_url,
                     error = %e,
                     "CRL check failed (fail-open, proceeding)"
@@ -194,8 +161,8 @@ async fn fetch_and_check_crl(
     serial_number: &[u8],
 ) -> Result<bool, CrlError> {
     if !is_allowed_crl_host(crl_url) {
-        return Err(CrlError::Fetch(format!(
-            "{crl_url}: host not in CRL allowlist (must be *{ALLOWED_CRL_HOST_SUFFIX} \
+        return Err(CrlError(format!(
+            "CRL fetch error: {crl_url}: host not in CRL allowlist (must be *{ALLOWED_CRL_HOST_SUFFIX} \
              containing '{ALLOWED_CRL_HOST_KEYWORD}')"
         )));
     }
@@ -204,293 +171,165 @@ async fn fetch_and_check_crl(
         .get(crl_url)
         .send()
         .await
-        .map_err(|e| CrlError::Fetch(format!("{crl_url}: {e}")))?;
+        .map_err(|e| CrlError(format!("CRL fetch error: {crl_url}: {e}")))?;
 
     if !response.status().is_success() {
-        return Err(CrlError::Fetch(format!("{crl_url}: HTTP {}", response.status())));
+        return Err(CrlError(format!("CRL fetch error: {crl_url}: HTTP {}", response.status())));
     }
 
     if let Some(content_length) = response.content_length()
         && content_length > MAX_CRL_RESPONSE_BYTES as u64
     {
-        return Err(CrlError::Fetch(format!(
-            "{crl_url}: response too large ({content_length} bytes, max {MAX_CRL_RESPONSE_BYTES})"
+        return Err(CrlError(format!(
+            "CRL fetch error: {crl_url}: response too large ({content_length} bytes, max {MAX_CRL_RESPONSE_BYTES})"
         )));
     }
 
     let crl_bytes = response
         .bytes()
         .await
-        .map_err(|e| CrlError::Fetch(format!("{crl_url}: failed to read body: {e}")))?;
+        .map_err(|e| CrlError(format!("CRL fetch error: {crl_url}: failed to read body: {e}")))?;
 
     if crl_bytes.len() > MAX_CRL_RESPONSE_BYTES {
-        return Err(CrlError::Fetch(format!(
-            "{crl_url}: response too large ({} bytes, max {MAX_CRL_RESPONSE_BYTES})",
+        return Err(CrlError(format!(
+            "CRL fetch error: {crl_url}: response too large ({} bytes, max {MAX_CRL_RESPONSE_BYTES})",
             crl_bytes.len()
         )));
     }
 
-    let (remaining, crl) = CertificateRevocationList::from_der(&crl_bytes)
-        .map_err(|e| CrlError::Parse(format!("{crl_url}: {e}")))?;
+    crl_contains_serial(crl_url, &crl_bytes, serial_number)
+}
+
+fn crl_contains_serial(
+    crl_url: &str,
+    crl_bytes: &[u8],
+    serial_number: &[u8],
+) -> Result<bool, CrlError> {
+    let (remaining, crl) = CertificateRevocationList::from_der(crl_bytes)
+        .map_err(|e| CrlError(format!("CRL parse error: {crl_url}: {e}")))?;
     if !remaining.is_empty() {
-        return Err(CrlError::Parse(format!(
-            "{crl_url}: trailing DER data ({} bytes)",
+        return Err(CrlError(format!(
+            "CRL parse error: {crl_url}: trailing DER data ({} bytes)",
             remaining.len()
         )));
     }
 
     // `to_bytes_be()` normalizes away ASN.1 leading-zero padding.
-    for revoked_cert in crl.iter_revoked_certificates() {
-        if revoked_cert.user_certificate.to_bytes_be() == serial_number {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
+    Ok(crl.iter_revoked_certificates().any(|revoked_cert| {
+        revoked_cert.user_certificate.to_bytes_be().as_slice() == serial_number
+    }))
 }
 
-/// Builds a CRL HTTP client with redirects disabled.
-pub fn build_crl_http_client(timeout: Duration) -> Result<reqwest::Client, CrlError> {
-    reqwest::Client::builder()
-        .timeout(timeout)
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(|e| CrlError::Config(format!("failed to build HTTP client: {e}")))
-}
-
-/// Errors specific to CRL checking.
+/// Error specific to CRL checking.
 #[derive(Debug, thiserror::Error)]
-pub enum CrlError {
-    /// Failed to parse a certificate from DER.
-    #[error("certificate parse error: {0}")]
-    CertParse(String),
-
-    /// Failed to fetch a CRL from a distribution point.
-    #[error("CRL fetch error: {0}")]
-    Fetch(String),
-
-    /// Failed to parse a CRL.
-    #[error("CRL parse error: {0}")]
-    Parse(String),
-
-    /// Configuration error.
-    #[error("CRL config error: {0}")]
-    Config(String),
-}
+#[error("{0}")]
+pub struct CrlError(
+    /// Error detail.
+    pub String,
+);
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        io::{Read, Write},
-        net::{SocketAddr, TcpListener},
-        thread::{self, JoinHandle},
-    };
-
-    use alloy_primitives::{B256, b256};
-    use rstest::{fixture, rstest};
-
     use super::*;
     use crate::test_utils::{
         CertFixtures, INTER1_HEX, INTER2_HEX, INTER3_HEX, INVALID_DER_BYTES, LEAF_HEX, ROOT_HEX,
     };
+    use hex_literal::hex;
 
     const INTER1_EXPECTED_CRL_URL: &str = "http://aws-nitro-enclaves-crl.s3.amazonaws.com/crl/ab4960cc-7d63-42bd-9e9f-59338cb67f84.crl";
 
     const INTER2_EXPECTED_CRL_URL: &str = "http://crl-us-east-1-aws-nitro-enclaves.s3.us-east-1.amazonaws.com/crl/06d48f8e-2c08-4781-a645-b1de402aefb8.crl";
 
-    const ROOT_EXPECTED_SERIAL_HEX: &str = "f93175681b90afe11d46ccb4e4e7f856";
-    const INTER1_EXPECTED_SERIAL_HEX: &str = "56bfc987fd05ac99c475061b1a65eedc";
-    const INTER2_EXPECTED_SERIAL_HEX: &str = "cb286a4a4a09207f8b0c14950dcd6861";
-    const INTER3_EXPECTED_SERIAL_HEX: &str = "c8925d382506d820d93d2c704a7523c4ba2ddfaa";
-    const LEAF_EXPECTED_SERIAL_HEX: &str = "0193685e7fee7d8500000000674b3bd8";
-    const EXPECTED_PATH_DIGESTS: [B256; 5] = [
-        b256!("641a0321a3e244efe456463195d606317ed7cdcc3c1756e09893f3c68f79bb5b"),
-        b256!("aa413b647367f37da57079d2ae215fa2b14cb42ec0c4e4275f56dd3caff95b36"),
-        b256!("bc023b9f717f6a435ab56642c5b5784179fb4d39166d36641d47887d3011c125"),
-        b256!("f8cffb2fa4503ee3753a54d06d3dcbf96f4ea1db505cccc5c14f784f5234604a"),
-        b256!("140ad974a8d3c771bf24a12fdbfff85a7191ba9a9a703869948aebedc16dd3ad"),
-    ];
-    const EMPTY_CRL_DER: [u8; 49] = [
-        0x30, 0x2f, 0x30, 0x1d, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03,
-        0x03, 0x30, 0x00, 0x17, 0x0d, 0x32, 0x34, 0x30, 0x31, 0x30, 0x31, 0x30, 0x30, 0x30, 0x30,
-        0x30, 0x30, 0x5a, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x03,
-        0x03, 0x02, 0x00, 0x00,
-    ];
+    const EMPTY_CRL_DER: [u8; 49] = hex!(
+        "302f301d300a06082a8648ce3d0403033000170d3234303130313030303030305a300a06082a8648ce3d04030303020000"
+    );
 
-    const CRL_TEST_HOST: &str = "aws-nitro-enclave-test.amazonaws.com";
-
-    struct ChainFixture {
-        owned: Vec<Vec<u8>>,
+    fn full_chain() -> Vec<Vec<u8>> {
+        CertFixtures::decode_chain(&[ROOT_HEX, INTER1_HEX, INTER2_HEX, INTER3_HEX, LEAF_HEX])
     }
 
-    impl ChainFixture {
-        fn refs(&self) -> Vec<&[u8]> {
-            self.owned.iter().map(|c| c.as_slice()).collect()
+    #[test]
+    fn extracts_crl_distribution_point_url() {
+        for (cert_hex, expected) in [
+            (INTER1_HEX, Some(INTER1_EXPECTED_CRL_URL)),
+            (INTER2_HEX, Some(INTER2_EXPECTED_CRL_URL)),
+            (INTER3_HEX, None),
+            (ROOT_HEX, None),
+            (LEAF_HEX, None),
+        ] {
+            let der = CertFixtures::decode(cert_hex);
+            let (remaining, cert) = X509Certificate::from_der(&der).unwrap();
+            assert!(remaining.is_empty());
+            let url = extract_crl_distribution_point(&cert);
+            assert_eq!(url.as_deref(), expected);
         }
     }
 
-    #[fixture]
-    fn full_chain() -> ChainFixture {
-        ChainFixture {
-            owned: CertFixtures::decode_chain(&[
-                ROOT_HEX, INTER1_HEX, INTER2_HEX, INTER3_HEX, LEAF_HEX,
-            ]),
-        }
-    }
-
-    #[fixture]
-    fn root_and_leaf_chain() -> ChainFixture {
-        ChainFixture { owned: CertFixtures::decode_chain(&[ROOT_HEX, LEAF_HEX]) }
-    }
-
-    fn crl_url_for_hex(cert_hex: &str) -> Option<String> {
-        let der = CertFixtures::decode(cert_hex);
-        let (remaining, cert) = X509Certificate::from_der(&der).unwrap();
-        assert!(remaining.is_empty());
-        extract_crl_distribution_point(&cert)
-    }
-
-    fn serve_crl_body_once(body: Vec<u8>) -> (reqwest::Client, String, JoinHandle<()>) {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0u8; 1024];
-            let bytes_read = stream.read(&mut request).unwrap();
-            assert!(bytes_read > 0);
-
-            let headers = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                body.len()
-            );
-            stream.write_all(headers.as_bytes()).unwrap();
-            stream.write_all(&body).unwrap();
-        });
-        let client = client_resolving_crl_host_to(addr);
-        let url = format!("http://{CRL_TEST_HOST}/crl");
-
-        (client, url, handle)
-    }
-
-    fn client_resolving_crl_host_to(addr: SocketAddr) -> reqwest::Client {
-        reqwest::Client::builder().no_proxy().resolve(CRL_TEST_HOST, addr).build().unwrap()
-    }
-
-    #[rstest]
-    #[case::intermediate_1(INTER1_HEX, Some(INTER1_EXPECTED_CRL_URL))]
-    #[case::intermediate_2(INTER2_HEX, Some(INTER2_EXPECTED_CRL_URL))]
-    #[case::intermediate_3_has_no_crl_dp(INTER3_HEX, None)]
-    #[case::root_has_no_crl_dp(ROOT_HEX, None)]
-    #[case::leaf_has_no_crl_dp(LEAF_HEX, None)]
-    fn extracts_crl_distribution_point_url(#[case] cert_hex: &str, #[case] expected: Option<&str>) {
-        let url = crl_url_for_hex(cert_hex);
-        assert_eq!(url.as_deref(), expected);
-    }
-
-    #[rstest]
-    #[case::root(0, ROOT_EXPECTED_SERIAL_HEX)]
-    #[case::intermediate_1(1, INTER1_EXPECTED_SERIAL_HEX)]
-    #[case::intermediate_2(2, INTER2_EXPECTED_SERIAL_HEX)]
-    #[case::intermediate_3(3, INTER3_EXPECTED_SERIAL_HEX)]
-    #[case::leaf(4, LEAF_EXPECTED_SERIAL_HEX)]
-    fn extracts_correct_serial_number(
-        full_chain: ChainFixture,
-        #[case] index: usize,
-        #[case] expected_hex: &str,
-    ) {
-        let refs = full_chain.refs();
-        let infos = CertCrlInfo::from_chain(&refs).unwrap();
-        assert_eq!(hex::encode(&infos[index].serial_number), expected_hex);
-    }
-
-    #[rstest]
-    fn path_digests_match_onchain_computation(full_chain: ChainFixture) {
-        let refs = full_chain.refs();
+    #[test]
+    fn extracts_intermediate_cert_info_from_chain() {
+        let full_chain = full_chain();
+        let refs: Vec<&[u8]> = full_chain.iter().map(Vec::as_slice).collect();
         let infos = CertCrlInfo::from_chain(&refs).unwrap();
 
-        assert_eq!(infos.len(), EXPECTED_PATH_DIGESTS.len());
-        for (info, expected_digest) in infos.iter().zip(EXPECTED_PATH_DIGESTS) {
-            assert_eq!(info.path_digest, expected_digest);
-        }
+        assert_eq!(infos.iter().map(|info| info.index).collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(
+            infos.iter().map(|info| hex::encode(&info.serial_number)).collect::<Vec<_>>(),
+            vec![
+                "56bfc987fd05ac99c475061b1a65eedc",
+                "cb286a4a4a09207f8b0c14950dcd6861",
+                "c8925d382506d820d93d2c704a7523c4ba2ddfaa",
+            ]
+        );
     }
 
-    #[rstest]
-    fn empty_chain_returns_empty_vec() {
-        let result = CertCrlInfo::from_chain(&[]);
-        assert!(result.unwrap().is_empty());
-    }
-
-    #[rstest]
-    fn invalid_der_returns_cert_parse_error() {
-        let result = CertCrlInfo::from_chain(&[&INVALID_DER_BYTES[..]]);
+    #[test]
+    fn invalid_intermediate_der_returns_cert_parse_error() {
+        let root = CertFixtures::decode(ROOT_HEX);
+        let leaf = CertFixtures::decode(LEAF_HEX);
+        let result = CertCrlInfo::from_chain(&[&root, &INVALID_DER_BYTES[..], &leaf]);
         let err = result.unwrap_err();
-        assert!(matches!(&err, CrlError::CertParse(_)), "expected CertParse, got: {err}");
+        assert!(
+            err.to_string().contains("certificate parse error"),
+            "expected certificate parse error, got: {err}"
+        );
     }
 
-    #[rstest]
-    fn trailing_der_certificate_alias_returns_cert_parse_error(full_chain: ChainFixture) {
-        let mut aliased = full_chain.owned;
+    #[test]
+    fn trailing_der_certificate_alias_returns_cert_parse_error() {
+        let mut aliased = full_chain();
         aliased[1].extend_from_slice(b"chain-4256-trailing-der");
-        let refs: Vec<&[u8]> = aliased.iter().map(|c| c.as_slice()).collect();
+        let refs: Vec<&[u8]> = aliased.iter().map(Vec::as_slice).collect();
         let err = CertCrlInfo::from_chain(&refs).unwrap_err();
         let msg = err.to_string();
 
-        assert!(matches!(&err, CrlError::CertParse(_)), "expected CertParse, got: {msg}");
-        assert!(msg.contains("certificate 1"), "expected cert index in error, got: {msg}");
         assert!(msg.contains("trailing DER data"), "expected trailing DER error, got: {msg}");
     }
 
-    #[tokio::test]
-    #[rstest]
-    async fn check_chain_against_crls_clean_for_empty_chain() {
-        let client = build_crl_http_client(Duration::from_secs(5)).unwrap();
-        let result = check_chain_against_crls(&[], &client).await;
-        assert!(result.is_empty());
-    }
-
-    #[tokio::test]
-    #[rstest]
-    async fn check_chain_against_crls_skips_root_and_leaf(root_and_leaf_chain: ChainFixture) {
-        let client = build_crl_http_client(Duration::from_secs(1)).unwrap();
-        let refs = root_and_leaf_chain.refs();
-        let cert_infos = CertCrlInfo::from_chain(&refs).unwrap();
-        let result = check_chain_against_crls(&cert_infos, &client).await;
-        assert!(result.is_empty());
-    }
-
-    #[tokio::test]
-    async fn fetch_and_check_crl_accepts_exact_der_response() {
-        let (client, url, handle) = serve_crl_body_once(EMPTY_CRL_DER.to_vec());
-        let revoked = fetch_and_check_crl(&client, &url, &[]).await.unwrap();
-        handle.join().unwrap();
-
-        assert!(!revoked);
-    }
-
-    #[tokio::test]
-    async fn fetch_and_check_crl_rejects_trailing_der_response() {
+    #[test]
+    fn crl_parse_rejects_trailing_der() {
         let mut aliased = EMPTY_CRL_DER.to_vec();
         aliased.extend_from_slice(b"chain-4256-trailing-crl");
-        let (client, url, handle) = serve_crl_body_once(aliased);
-        let err = fetch_and_check_crl(&client, &url, &[]).await.unwrap_err();
-        handle.join().unwrap();
+        let err = crl_contains_serial("test.crl", &aliased, &[]).unwrap_err();
         let msg = err.to_string();
 
-        assert!(matches!(&err, CrlError::Parse(_)), "expected Parse, got: {msg}");
         assert!(msg.contains("trailing DER data"), "expected trailing DER error, got: {msg}");
     }
 
-    #[rstest]
-    #[case::inter1_url(INTER1_EXPECTED_CRL_URL, true)]
-    #[case::inter2_url(INTER2_EXPECTED_CRL_URL, true)]
-    #[case::evil_host("http://evil.com/crl/something.crl", false)]
-    #[case::partial_match_no_keyword("http://s3.amazonaws.com/crl.crl", false)]
-    #[case::no_suffix("http://nitro-enclaves-crl.example.com/crl.crl", false)]
-    fn crl_host_allowlist_check(#[case] url: &str, #[case] expected: bool) {
-        assert_eq!(
-            is_allowed_crl_host(url),
-            expected,
-            "is_allowed_crl_host({url}) should be {expected}"
-        );
+    #[test]
+    fn crl_host_allowlist_check() {
+        for (url, expected) in [
+            (INTER1_EXPECTED_CRL_URL, true),
+            (INTER2_EXPECTED_CRL_URL, true),
+            ("http://AWS-NITRO-ENCLAVES-CRL.S3.AMAZONAWS.COM/crl/test.crl", true),
+            ("http://evil.com/crl/something.crl", false),
+            ("http://s3.amazonaws.com/crl.crl", false),
+            ("http://nitro-enclaves-crl.example.com/crl.crl", false),
+        ] {
+            assert_eq!(
+                is_allowed_crl_host(url),
+                expected,
+                "is_allowed_crl_host({url}) should be {expected}"
+            );
+        }
     }
 }

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -5,10 +5,7 @@ mod cert_manager;
 pub use cert_manager::CertManager;
 
 mod crl;
-pub use crl::{
-    CertCrlInfo, CrlError, DEFAULT_CRL_FETCH_TIMEOUT_SECS, RevokedCertInfo, build_crl_http_client,
-    check_chain_against_crls,
-};
+pub use crl::{CertCrlInfo, CrlError, check_chain_against_crls};
 
 mod deregistration_manager;
 pub use deregistration_manager::DeregistrationManager;

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -27,6 +27,8 @@ use crate::{
     SignerManager, SignerManagerConfig,
 };
 
+const CRL_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Configuration needed to run the registrar service.
 pub struct RegistrarConfig {
     /// L1 Ethereum RPC endpoint.
@@ -224,7 +226,7 @@ impl RegistrarConfig {
         ));
         let cert_manager = if let Some(nitro_verifier_address) = self.crl_nitro_verifier_address {
             Some(CertManager::new(
-                Duration::from_secs(30),
+                CRL_FETCH_TIMEOUT,
                 Box::new(NitroVerifierContractClient::new(nitro_verifier_address, self.l1_rpc_url)),
                 tx_manager,
             )?)

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -22,9 +22,9 @@ use tracing::{info, warn};
 use url::Url;
 
 use crate::{
-    AwsTargetGroupDiscovery, CertManager, DEFAULT_CRL_FETCH_TIMEOUT_SECS, DriverConfig,
-    NitroVerifierContractClient, ProverClient, RegistrarError, RegistrarMetrics,
-    RegistrationDriver, RegistryContractClient, Result, SignerManager, SignerManagerConfig,
+    AwsTargetGroupDiscovery, CertManager, DriverConfig, NitroVerifierContractClient, ProverClient,
+    RegistrarError, RegistrarMetrics, RegistrationDriver, RegistryContractClient, Result,
+    SignerManager, SignerManagerConfig,
 };
 
 /// Configuration needed to run the registrar service.
@@ -224,7 +224,7 @@ impl RegistrarConfig {
         ));
         let cert_manager = if let Some(nitro_verifier_address) = self.crl_nitro_verifier_address {
             Some(CertManager::new(
-                Duration::from_secs(DEFAULT_CRL_FETCH_TIMEOUT_SECS),
+                Duration::from_secs(30),
                 Box::new(NitroVerifierContractClient::new(nitro_verifier_address, self.l1_rpc_url)),
                 tx_manager,
             )?)


### PR DESCRIPTION
### What changed? Why?

- Simplifies registrar CRL handling so `CertCrlInfo` contains only intermediate certificates, matching the revocation scope used by the onchain checks.
- Removes now-unneeded CRL helper exports and builds the CRL HTTP client directly in `CertManager`.
- Trims CRL tests to cover the parsing and allowlist behavior without the extra local HTTP server scaffolding.

### Notes to reviewers

- Root and leaf certificates are now skipped inside `CertCrlInfo::from_chain` instead of by a separate iterator helper.
- The CRL fetch behavior keeps the same 30 second timeout and redirect-disabled client configuration.

### How has it been tested?

- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar`
- `cargo test -p base-proof-tee-registrar` fails locally before tests because `xcrun metal` is unavailable.