### PR TITLE
feat(PRIV-2000): build base-challenger image for the L3

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -94,6 +94,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-proposer /app/base-proposer
 
+FROM source AS challenger-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=challenger-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-challenger-bin --bin base-challenger && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-challenger /app/base-challenger
+
 FROM source AS websocket-proxy-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
@@ -172,6 +180,10 @@ FROM runtime-base AS proposer
 COPY --from=proposer-builder /app/base-proposer ./base-proposer
 EXPOSE 9090
 ENTRYPOINT ["./base-proposer"]
+
+FROM runtime-base AS challenger
+COPY --from=challenger-builder /app/base-challenger ./base-challenger
+ENTRYPOINT ["./base-challenger"]
 
 FROM runtime-base AS websocket-proxy
 COPY --from=websocket-proxy-builder /app/websocket-proxy ./websocket-proxy

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -33,6 +33,7 @@ group "rust-services" {
     "builder",
     "consensus",
     "proposer",
+    "challenger",
     "websocket-proxy",
     "ingress-rpc",
     "audit-archiver",
@@ -104,6 +105,12 @@ target "proposer" {
   inherits = ["_rust-service-common"]
   target = "proposer"
   tags = ["base-proposer:local"]
+}
+
+target "challenger" {
+  inherits = ["_rust-service-common"]
+  target = "challenger"
+  tags = ["base-challenger:local"]
 }
 
 target "websocket-proxy" {


### PR DESCRIPTION
## Summary

Adds a `base-challenger:local` Docker image target so the challenger binary can run as a long-running Docker Compose service in the L3 dev-multiproof devnet. Mirrors the proposer image (#3552).

- `etc/docker/Dockerfile.rust-services`: `challenger-builder` + `challenger` stages (builds `base-challenger-bin` / bin `base-challenger`).
- `etc/docker/docker-bake.hcl`: `challenger` target (`base-challenger:local`) + membership in the `rust-services` group.

## Why

In the L3 dev-multiproof stack the **challenger is the sole resolver** of dispute games (`resolve()` → `claimCredit()` → `setAnchorState()`) (the proposer's `--auto-resolve` was dropped in #3579). Running it under `just devnet up-l3` (which uses `docker compose up --no-build`) requires a prebuilt image.

Deliberately **not** wired into the `devnet` bake group / `up-l3` build path here; that will land in a follow-up PR alongside the compose services that consume the image

## Test plan

- [x] `docker buildx bake -f etc/docker/docker-bake.hcl challenger --print` resolves the target → `base-challenger:local`.
- [x] `base-challenger-bin` / bin `base-challenger` confirmed present in the workspace.
- [x] `just build-image challenger dev` builds the image end-to-end (CI / reviewer).

Linear: PRIV-2000