### PR TITLE
fix: add Base Sepolia to L1_CONFIGS for L3 proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,10 +3681,12 @@ dependencies = [
  "alloy-genesis 2.0.5",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
+ "alloy-serde 2.0.5",
  "auto_impl",
  "base-common-genesis",
  "revm",
  "serde",
+ "serde_json",
  "spin 0.10.0",
 ]
 

--- a/crates/common/chains/Cargo.toml
+++ b/crates/common/chains/Cargo.toml
@@ -34,6 +34,8 @@ revm.workspace = true
 spin.workspace = true
 auto_impl.workspace = true
 serde = { workspace = true, optional = true }
+alloy-serde.workspace = true
+serde_json = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
 alloy-chains.workspace = true
@@ -49,9 +51,11 @@ std = [
 	"alloy-eips/std",
 	"alloy-genesis/std",
 	"alloy-primitives/std",
+	"alloy-serde/std",
 	"base-common-genesis/std",
 	"revm/std",
 	"serde?/std",
+	"serde_json/std",
 	"spin/std",
 ]
 serde = [

--- a/crates/common/chains/Cargo.toml
+++ b/crates/common/chains/Cargo.toml
@@ -19,6 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 # alloy
 alloy-eips.workspace = true
+alloy-serde.workspace = true
 alloy-chains.workspace = true
 alloy-genesis.workspace = true
 alloy-hardforks.workspace = true
@@ -34,7 +35,6 @@ revm.workspace = true
 spin.workspace = true
 auto_impl.workspace = true
 serde = { workspace = true, optional = true }
-alloy-serde.workspace = true
 serde_json = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]

--- a/crates/common/chains/src/ethereum/base_sepolia.rs
+++ b/crates/common/chains/src/ethereum/base_sepolia.rs
@@ -20,6 +20,8 @@ use alloy_serde::OtherFields;
 pub struct BaseSepolia;
 
 impl BaseSepolia {
+    const TTD: u128 = 0;
+
     /// Returns the Base Sepolia [`ChainConfig`].
     pub fn l1_config() -> ChainConfig {
         let mut extra_fields = OtherFields::default();
@@ -59,7 +61,7 @@ impl BaseSepolia {
             ethash: Some(EthashConfig {}),
             blob_schedule: super::BlobSchedule::schedule(),
             // OP Stack L2: no PoW, TTD = 0 (matches Hoodi pattern for post-merge genesis).
-            terminal_total_difficulty: Some(U256::from(0u128)),
+            terminal_total_difficulty: Some(U256::from(Self::TTD)),
             merge_netsplit_block: None,
             // No beacon deposit contract on an OP Stack L2.
             deposit_contract_address: None,

--- a/crates/common/chains/src/ethereum/base_sepolia.rs
+++ b/crates/common/chains/src/ethereum/base_sepolia.rs
@@ -21,9 +21,6 @@ pub struct BaseSepolia;
 impl BaseSepolia {
     /// Returns the Base Sepolia [`ChainConfig`].
     pub fn l1_config() -> ChainConfig {
-        let mut extra_fields = alloy_serde::OtherFields::default();
-        extra_fields.insert("optimism".to_string(), serde_json::json!({}));
-
         ChainConfig {
             chain_id: 84532,
             // All pre-merge hardforks active at genesis (OP Stack L2, post-merge chain).
@@ -64,7 +61,7 @@ impl BaseSepolia {
             deposit_contract_address: None,
             clique: None,
             parlia: None,
-            extra_fields,
+            extra_fields: Default::default(),
             terminal_total_difficulty_passed: false,
             _non_exhaustive: (),
         }
@@ -73,20 +70,12 @@ impl BaseSepolia {
 
 #[cfg(test)]
 mod tests {
-    use base_common_genesis::L1TxFormat;
-
     use super::*;
 
     #[test]
     fn base_sepolia_chain_id() {
         let cfg = BaseSepolia::l1_config();
         assert_eq!(cfg.chain_id, 84532);
-    }
-
-    #[test]
-    fn base_sepolia_l1_tx_format_is_base() {
-        let cfg = BaseSepolia::l1_config();
-        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
     }
 
     #[test]

--- a/crates/common/chains/src/ethereum/base_sepolia.rs
+++ b/crates/common/chains/src/ethereum/base_sepolia.rs
@@ -4,23 +4,27 @@
 //! [`alloy_genesis::ChainConfig`] needed by the prover and derivation pipeline when an L3
 //! chain reports `l1_chain_id: 84532`.
 
+use alloc::string::ToString;
+
 use alloy_genesis::{ChainConfig, EthashConfig};
 use alloy_primitives::U256;
+use alloy_serde::OtherFields;
 
 /// Base Sepolia chain configuration builder.
 ///
 /// Unlike Ethereum L1 configs, Base Sepolia is an OP Stack L2 with no PoW history.
 /// Pre-merge hardfork blocks are all 0 (active at genesis), and the `"optimism"` extra
-/// field is set so the derivation pipeline selects [`L1TxFormat::Base`] (calldata-only DA,
+/// field is set so the derivation pipeline selects `L1TxFormat::Base` (calldata-only DA,
 /// OP Stack transaction envelopes).
-///
-/// [`L1TxFormat::Base`]: crate::L1TxFormat
 #[derive(Debug, Clone, Copy)]
 pub struct BaseSepolia;
 
 impl BaseSepolia {
     /// Returns the Base Sepolia [`ChainConfig`].
     pub fn l1_config() -> ChainConfig {
+        let mut extra_fields = OtherFields::default();
+        extra_fields.insert("optimism".to_string(), serde_json::Value::Object(Default::default()));
+
         ChainConfig {
             chain_id: 84532,
             // All pre-merge hardforks active at genesis (OP Stack L2, post-merge chain).
@@ -61,7 +65,7 @@ impl BaseSepolia {
             deposit_contract_address: None,
             clique: None,
             parlia: None,
-            extra_fields: Default::default(),
+            extra_fields,
             terminal_total_difficulty_passed: false,
             _non_exhaustive: (),
         }
@@ -70,12 +74,20 @@ impl BaseSepolia {
 
 #[cfg(test)]
 mod tests {
+    use base_common_genesis::L1TxFormat;
+
     use super::*;
 
     #[test]
     fn base_sepolia_chain_id() {
         let cfg = BaseSepolia::l1_config();
         assert_eq!(cfg.chain_id, 84532);
+    }
+
+    #[test]
+    fn base_sepolia_l1_tx_format_is_base() {
+        let cfg = BaseSepolia::l1_config();
+        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
     }
 
     #[test]

--- a/crates/common/chains/src/ethereum/base_sepolia.rs
+++ b/crates/common/chains/src/ethereum/base_sepolia.rs
@@ -12,7 +12,7 @@ use alloy_serde::OtherFields;
 
 /// Base Sepolia chain configuration builder.
 ///
-/// Unlike Ethereum L1 configs, Base Sepolia is an OP Stack L2 with no PoW history.
+/// Unlike Ethereum L1 configs, Base Sepolia is an OP Stack L2 with no `PoW` history.
 /// Pre-merge hardfork blocks are all 0 (active at genesis), and the `"optimism"` extra
 /// field is set so the derivation pipeline selects `L1TxFormat::Base` (calldata-only DA,
 /// OP Stack transaction envelopes).

--- a/crates/common/chains/src/ethereum/base_sepolia.rs
+++ b/crates/common/chains/src/ethereum/base_sepolia.rs
@@ -1,0 +1,97 @@
+//! Base Sepolia (OP Stack L2) chain configuration for L3 settlement.
+//!
+//! Base Sepolia acts as the settlement layer ("L1") for L3 chains. This config provides the
+//! [`alloy_genesis::ChainConfig`] needed by the prover and derivation pipeline when an L3
+//! chain reports `l1_chain_id: 84532`.
+
+use alloy_genesis::{ChainConfig, EthashConfig};
+use alloy_primitives::U256;
+
+/// Base Sepolia chain configuration builder.
+///
+/// Unlike Ethereum L1 configs, Base Sepolia is an OP Stack L2 with no PoW history.
+/// Pre-merge hardfork blocks are all 0 (active at genesis), and the `"optimism"` extra
+/// field is set so the derivation pipeline selects [`L1TxFormat::Base`] (calldata-only DA,
+/// OP Stack transaction envelopes).
+///
+/// [`L1TxFormat::Base`]: crate::L1TxFormat
+#[derive(Debug, Clone, Copy)]
+pub struct BaseSepolia;
+
+impl BaseSepolia {
+    /// Returns the Base Sepolia [`ChainConfig`].
+    pub fn l1_config() -> ChainConfig {
+        let mut extra_fields = alloy_serde::OtherFields::default();
+        extra_fields.insert("optimism".to_string(), serde_json::json!({}));
+
+        ChainConfig {
+            chain_id: 84532,
+            // All pre-merge hardforks active at genesis (OP Stack L2, post-merge chain).
+            homestead_block: Some(0),
+            dao_fork_block: Some(0),
+            dao_fork_support: true,
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            muir_glacier_block: Some(0),
+            berlin_block: Some(0),
+            london_block: Some(0),
+            arrow_glacier_block: Some(0),
+            gray_glacier_block: Some(0),
+            // Post-merge timestamp-based forks: Shanghai and Cancun active at genesis.
+            // Prague/Osaka not relevant — Base Sepolia headers have excess_blob_gas = 0
+            // (hardcoded by OP Stack), so blob base fee is always 1 regardless of params.
+            shanghai_time: Some(0),
+            cancun_time: Some(0),
+            prague_time: None,
+            osaka_time: None,
+            amsterdam_time: None,
+            bpo1_time: None,
+            bpo2_time: None,
+            bpo3_time: None,
+            bpo4_time: None,
+            bpo5_time: None,
+            ethash: Some(EthashConfig {}),
+            blob_schedule: super::BlobSchedule::schedule(),
+            // OP Stack L2: no PoW, TTD = 0 (matches Hoodi pattern for post-merge genesis).
+            terminal_total_difficulty: Some(U256::from(0u128)),
+            merge_netsplit_block: None,
+            // No beacon deposit contract on an OP Stack L2.
+            deposit_contract_address: None,
+            clique: None,
+            parlia: None,
+            extra_fields,
+            terminal_total_difficulty_passed: false,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::L1TxFormat;
+
+    use super::*;
+
+    #[test]
+    fn base_sepolia_chain_id() {
+        let cfg = BaseSepolia::l1_config();
+        assert_eq!(cfg.chain_id, 84532);
+    }
+
+    #[test]
+    fn base_sepolia_l1_tx_format_is_base() {
+        let cfg = BaseSepolia::l1_config();
+        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
+    }
+
+    #[test]
+    fn base_sepolia_no_beacon_deposit_contract() {
+        let cfg = BaseSepolia::l1_config();
+        assert!(cfg.deposit_contract_address.is_none());
+    }
+}

--- a/crates/common/chains/src/ethereum/config.rs
+++ b/crates/common/chains/src/ethereum/config.rs
@@ -5,7 +5,7 @@ use alloy_genesis::ChainConfig as GenesisChainConfig;
 use alloy_primitives::map::HashMap;
 use spin::Lazy;
 
-use crate::{Holesky, Hoodi, Mainnet, Sepolia};
+use crate::{BaseSepolia, Holesky, Hoodi, Mainnet, Sepolia};
 
 /// Ethereum L1 chain configurations keyed by chain ID.
 pub static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> = Lazy::new(|| {
@@ -14,6 +14,7 @@ pub static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> = Lazy::new(|| {
     map.insert(NamedChain::Sepolia.into(), Sepolia::l1_config());
     map.insert(NamedChain::Holesky.into(), Holesky::l1_config());
     map.insert(NamedChain::Hoodi.into(), Hoodi::l1_config());
+    map.insert(84532, BaseSepolia::l1_config());
     map
 });
 
@@ -37,6 +38,7 @@ mod tests {
         assert!(L1_CONFIGS.get(&sepolia_chain_id).is_some());
         assert!(L1_CONFIGS.get(&holesky_chain_id).is_some());
         assert!(L1_CONFIGS.get(&hoodi_chain_id).is_some());
+        assert!(L1_CONFIGS.get(&84532).is_some());
         assert!(L1_CONFIGS.get(&99999).is_none());
     }
 

--- a/crates/common/chains/src/ethereum/mod.rs
+++ b/crates/common/chains/src/ethereum/mod.rs
@@ -19,6 +19,9 @@ pub use holesky::Holesky;
 mod hoodi;
 pub use hoodi::Hoodi;
 
+mod base_sepolia;
+pub use base_sepolia::BaseSepolia;
+
 mod config;
 pub use config::L1_CONFIGS;
 

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -21,7 +21,7 @@ mod macros;
 pub use macros::RollupConfigSource;
 
 mod ethereum;
-pub use ethereum::{Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
+pub use ethereum::{BaseSepolia, Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/common/genesis/src/l1_tx_format.rs
+++ b/crates/common/genesis/src/l1_tx_format.rs
@@ -24,8 +24,20 @@ impl L1TxFormat {
     /// Derives the parent-chain transaction format from an L1 config.
     ///
     /// This only selects decoding for bytes already committed by L1 header roots.
+    /// Detection uses the `"optimism"` extra field when present (e.g. configs deserialized
+    /// from JSON) and falls back to a known chain-ID allowlist for statically-constructed
+    /// configs that cannot set `extra_fields` without a `serde_json` dependency.
     pub fn from_l1_config(cfg: &ChainConfig) -> Self {
-        if cfg.extra_fields.contains_key("optimism") { Self::Base } else { Self::Ethereum }
+        if cfg.extra_fields.contains_key("optimism") || Self::is_op_stack_chain(cfg.chain_id) {
+            Self::Base
+        } else {
+            Self::Ethereum
+        }
+    }
+
+    /// Returns `true` for chain IDs of known OP Stack L2s used as settlement layers.
+    const fn is_op_stack_chain(chain_id: u64) -> bool {
+        matches!(chain_id, 8453 | 84532)
     }
 }
 
@@ -51,5 +63,21 @@ mod tests {
         let cfg = ChainConfig::default();
 
         assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Ethereum);
+    }
+
+    #[test]
+    fn base_sepolia_chain_id_derives_base_format() {
+        let mut cfg = ChainConfig::default();
+        cfg.chain_id = 84532;
+
+        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
+    }
+
+    #[test]
+    fn base_mainnet_chain_id_derives_base_format() {
+        let mut cfg = ChainConfig::default();
+        cfg.chain_id = 8453;
+
+        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
     }
 }

--- a/crates/common/genesis/src/l1_tx_format.rs
+++ b/crates/common/genesis/src/l1_tx_format.rs
@@ -24,20 +24,8 @@ impl L1TxFormat {
     /// Derives the parent-chain transaction format from an L1 config.
     ///
     /// This only selects decoding for bytes already committed by L1 header roots.
-    /// Detection uses the `"optimism"` extra field when present (e.g. configs deserialized
-    /// from JSON) and falls back to a known chain-ID allowlist for statically-constructed
-    /// configs that cannot set `extra_fields` without a `serde_json` dependency.
     pub fn from_l1_config(cfg: &ChainConfig) -> Self {
-        if cfg.extra_fields.contains_key("optimism") || Self::is_op_stack_chain(cfg.chain_id) {
-            Self::Base
-        } else {
-            Self::Ethereum
-        }
-    }
-
-    /// Returns `true` for chain IDs of known OP Stack L2s used as settlement layers.
-    const fn is_op_stack_chain(chain_id: u64) -> bool {
-        matches!(chain_id, 8453 | 84532)
+        if cfg.extra_fields.contains_key("optimism") { Self::Base } else { Self::Ethereum }
     }
 }
 
@@ -63,21 +51,5 @@ mod tests {
         let cfg = ChainConfig::default();
 
         assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Ethereum);
-    }
-
-    #[test]
-    fn base_sepolia_chain_id_derives_base_format() {
-        let mut cfg = ChainConfig::default();
-        cfg.chain_id = 84532;
-
-        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
-    }
-
-    #[test]
-    fn base_mainnet_chain_id_derives_base_format() {
-        let mut cfg = ChainConfig::default();
-        cfg.chain_id = 8453;
-
-        assert_eq!(L1TxFormat::from_l1_config(&cfg), L1TxFormat::Base);
     }
 }


### PR DESCRIPTION
## Bug

`base-prover-nitro-host` crashes with `Error: unknown L1 chain ID: 84532` when proving for L3 chain 84534 (devnet settling to Base Sepolia).

## Root Cause

`L1_CONFIGS` in `crates/common/chains/src/ethereum/config.rs` only contained Ethereum L1 chains (Mainnet, Sepolia, Holesky, Hoodi). L3 chains settle to L2s-as-L1 — the prover fetches `l1_chain_id: 84532` from the rollup config and fails the lookup.

## Fix

Add a `GenesisChainConfig` for Base Sepolia (chain ID 84532) to `L1_CONFIGS`:

- **`extra_fields`**: Contains `"optimism"` key → selects `L1TxFormat::Base` (calldata-only DA, OP Stack transaction envelopes)
- **Pre-merge fork blocks**: All `Some(0)` (post-merge genesis, OP Stack L2)
- **`shanghai_time` / `cancun_time`**: `Some(0)` (active at genesis)
- **`prague_time` / `osaka_time`**: `None` — OP Stack L2 headers hardcode `excess_blob_gas = 0`, so blob base fee is always 1 regardless of blob params
- **TTD / ethash**: Hoodi pattern (`TTD=0`, `ethash=Some`) for consistency with existing configs
- **`deposit_contract_address`**: `None` (no beacon deposit contract on OP Stack)

## Files Changed

| File | Change |
|---|---|
| `crates/common/chains/src/ethereum/base_sepolia.rs` | New — `BaseSepolia` struct with `l1_config()` |
| `crates/common/chains/src/ethereum/mod.rs` | Export `BaseSepolia` |
| `crates/common/chains/src/ethereum/config.rs` | Register in `L1_CONFIGS`, add test coverage |

## Design Decisions

- **No Base Mainnet (8453)** in this PR — add when mainnet L3s exist
- **No `L1_CONFIGS` rename** to `SETTLEMENT_CONFIGS` — scope creep for a bugfix
- **`blob_schedule`**: Uses shared `BlobSchedule::schedule()` for pattern consistency, even though values are irrelevant (excess_blob_gas always 0)

## Note

Could not run `cargo check` locally — pre-existing `lld` linker not installed. CI will validate.