### PR TITLE
feat: add DERIVATION_VERSION_1 protocol constant

### DIFF
--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -37,6 +37,9 @@ use crate::ChannelId;
 /// ensure compatibility and enable future protocol upgrades.
 pub const DERIVATION_VERSION_0: u8 = 0;
 
+/// Alt-DA commitment batcher tx version ([OP Stack alt-da](https://specs.optimism.io/experimental/alt-da.html)).
+pub const DERIVATION_VERSION_1: u8 = 1;
+
 /// Maximum number of derivation payload bytes that fit in a single EIP-4844 blob.
 ///
 /// The blob codec packs 127 data bytes into every 128 blob bytes across 1024

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -34,8 +34,8 @@ pub use block::{BlockInfo, FromBlockError, L2BlockInfo};
 
 mod frame;
 pub use frame::{
-    BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, DERIVATION_VERSION_0, Frame,
-    FrameDecodingError, FrameParseError, MAX_BLOB_FRAME_SIZE,
+    BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, DERIVATION_VERSION_0, DERIVATION_VERSION_1,
+    Frame, FrameDecodingError, FrameParseError, MAX_BLOB_FRAME_SIZE,
 };
 
 mod utils;


### PR DESCRIPTION
wire up alt-DA derivation version constant for privacy L3 dual-write:

## Summary
- Add `DERIVATION_VERSION_1` (`0x01`) next to existing `DERIVATION_VERSION_0` (`0x00`) in `base-protocol`

## Context: what is derivation version?

L2 nodes **derive** history by reading batcher txs on L1. Each batch-related L1 tx starts with a 1-byte tag so the node knows how to interpret the rest of the calldata:

| Byte | Constant | Meaning |
|------|----------|---------|
| `0x00` | `DERIVATION_VERSION_0` | **Inline data.** Payload is the batch (compressed frames). Nodes parse it directly. This is today's calldata path. |
| `0x01` | `DERIVATION_VERSION_1` | **Alt-DA pointer.** Payload is a 34-byte commitment, not batch data. Nodes fetch the real bytes (`0x00 ++ frames`) from the DA server (S3). |

Dual-write (PRIV-1972) posts both per batch: a v0 calldata tx (primary, nodes use today) and a v1 commitment tx (shadow, points to the same bytes in S3). This PR only names the v1 byte; the batcher and derivation resolver wire it up in follow-on PRs.

## Test plan
- [x] `cargo check -p base-protocol`

type=routine
risk=low
impact=sev5