### PR TITLE
feat: add base-alt-da HTTP client and generic commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,6 +3214,7 @@ dependencies = [
 name = "base-alt-da"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/crates/infra/alt-da/Cargo.toml
+++ b/crates/infra/alt-da/Cargo.toml
@@ -18,6 +18,8 @@ rand.workspace = true
 base64.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
+alloy-primitives.workspace = true
+reqwest = { workspace = true, features = ["rustls"] }
 tracing = { workspace = true, features = ["std"] }
 tokio-util = { workspace = true, features = ["rt"] }
 base-protocol = { workspace = true, features = ["std"] }
@@ -28,5 +30,4 @@ aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "
 
 [dev-dependencies]
 tempfile.workspace = true
-reqwest = { workspace = true, features = ["rustls"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/infra/alt-da/README.md
+++ b/crates/infra/alt-da/README.md
@@ -8,6 +8,8 @@ stored under base64url(commitment) keys in S3 or on disk.
 
 Runnable binary: `bin/da-server` (`base-da-server`).
 
+Batcher dual-write uses [`Client::put`](crate::Client::put) and [`encode_commitment_tx_data`](crate::encode_commitment_tx_data).
+
 ## Usage
 
 ```rust,ignore

--- a/crates/infra/alt-da/src/client.rs
+++ b/crates/infra/alt-da/src/client.rs
@@ -96,6 +96,7 @@ async fn read_bounded_error_body(mut resp: reqwest::Response) -> Result<String, 
 
 #[cfg(test)]
 mod tests {
+    use axum::{Router, http::StatusCode, routing::post};
     use url::Url;
 
     use crate::{Client, server::router, store::StoreOpener};
@@ -133,8 +134,6 @@ mod tests {
 
     #[tokio::test]
     async fn surfaces_non_success_response_body() {
-        use axum::{Router, http::StatusCode, routing::post};
-
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let app = Router::new()

--- a/crates/infra/alt-da/src/client.rs
+++ b/crates/infra/alt-da/src/client.rs
@@ -1,0 +1,152 @@
+//! HTTP client for the alt-DA `Put`/`Get` API.
+
+use std::time::Duration;
+
+use url::Url;
+
+use crate::{
+    commitment::{GENERIC_COMMITMENT_LEN, GenericCommitment, validate_generic_commitment},
+    error::ClientError,
+};
+
+/// Max PUT response bytes read before rejecting the body.
+const MAX_PUT_RESPONSE_BYTES: usize = GENERIC_COMMITMENT_LEN + 1;
+/// Max error response body bytes preserved on non-success PUT responses.
+const MAX_ERROR_RESPONSE_BYTES: usize = 256;
+
+/// Alt-DA HTTP client used by the batcher to upload batch bytes.
+#[derive(Debug, Clone)]
+pub struct Client {
+    put_url: Url,
+    http: reqwest::Client,
+}
+
+impl Client {
+    /// Build a client targeting `server` (e.g. `http://base-da-server:2583`).
+    pub fn new(server: Url) -> Result<Self, ClientError> {
+        let mut put_url = server;
+        put_url.set_path("put");
+        put_url.set_query(None);
+        put_url.set_fragment(None);
+        let http = reqwest::Client::builder().timeout(Duration::from_secs(60)).build()?;
+        Ok(Self { put_url, http })
+    }
+
+    /// Upload batch bytes; returns the server-generated generic commitment.
+    pub async fn put(&self, body: &[u8]) -> Result<GenericCommitment, ClientError> {
+        if body.is_empty() {
+            return Err(ClientError::EmptyBody);
+        }
+        if body.len() > crate::MAX_OBJECT_BYTES {
+            return Err(ClientError::BodyTooLarge {
+                size: body.len(),
+                max: crate::MAX_OBJECT_BYTES,
+            });
+        }
+
+        let resp = self.http.post(self.put_url.clone()).body(body.to_vec()).send().await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let mut detail = read_bounded_error_body(resp).await?;
+            if detail.is_empty() {
+                detail = "(no response body)".into();
+            }
+            return Err(ClientError::UnexpectedStatus { status: status.as_u16(), detail });
+        }
+
+        if let Some(len) = resp.content_length()
+            && len as usize > MAX_PUT_RESPONSE_BYTES
+        {
+            return Err(ClientError::InvalidCommitmentLen { len: len as usize });
+        }
+
+        let mut bytes = Vec::with_capacity(GENERIC_COMMITMENT_LEN);
+        let mut response = resp;
+        while let Some(chunk) = response.chunk().await? {
+            if bytes.len() + chunk.len() > MAX_PUT_RESPONSE_BYTES {
+                return Err(ClientError::InvalidCommitmentLen { len: bytes.len() + chunk.len() });
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+
+        // Validate the server response at the boundary so downstream code can treat a
+        // GenericCommitment as always-valid (lets encode_commitment_tx_data be infallible).
+        validate_generic_commitment(&bytes)?;
+        let commitment: GenericCommitment = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| ClientError::InvalidCommitmentLen { len: bytes.len() })?;
+        Ok(commitment)
+    }
+}
+
+async fn read_bounded_error_body(mut resp: reqwest::Response) -> Result<String, reqwest::Error> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        let remaining = MAX_ERROR_RESPONSE_BYTES.saturating_sub(bytes.len());
+        if remaining == 0 {
+            break;
+        }
+        let take = chunk.len().min(remaining);
+        bytes.extend_from_slice(&chunk[..take]);
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use crate::{Client, server::router, store::StoreOpener};
+
+    async fn spawn_test_server() -> (Url, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store_url = format!("file://{}", dir.path().display());
+        let store = StoreOpener::open(&store_url).await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = router(store);
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (Url::parse(&format!("http://{addr}")).unwrap(), dir)
+    }
+
+    #[tokio::test]
+    async fn put_returns_generic_commitment() {
+        let (url, _dir) = spawn_test_server().await;
+        let client = Client::new(url).unwrap();
+        let commitment = client.put(b"hello-batch").await.unwrap();
+        assert_eq!(commitment.len(), 34);
+        assert_eq!(commitment[0], 0x01);
+        assert_eq!(commitment[1], 0xff);
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_body() {
+        let (url, _dir) = spawn_test_server().await;
+        let client = Client::new(url).unwrap();
+        let err = client.put(&[]).await.unwrap_err();
+        assert!(matches!(err, crate::ClientError::EmptyBody));
+    }
+
+    #[tokio::test]
+    async fn surfaces_non_success_response_body() {
+        use axum::{Router, http::StatusCode, routing::post};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/put", post(|| async { (StatusCode::BAD_REQUEST, "object too large") }));
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = Client::new(Url::parse(&format!("http://{addr}")).unwrap()).unwrap();
+        let err = client.put(b"hello-batch").await.unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("400"));
+        assert!(message.contains("object too large"));
+    }
+}

--- a/crates/infra/alt-da/src/commitment.rs
+++ b/crates/infra/alt-da/src/commitment.rs
@@ -125,8 +125,6 @@ mod tests {
 
     #[test]
     fn encode_commitment_tx_data_prefixes_derivation_version() {
-        use base_protocol::DERIVATION_VERSION_1;
-
         let comm = generate_generic_commitment();
         let tx_data = encode_commitment_tx_data(comm);
         assert_eq!(tx_data[0], DERIVATION_VERSION_1);

--- a/crates/infra/alt-da/src/commitment.rs
+++ b/crates/infra/alt-da/src/commitment.rs
@@ -1,19 +1,52 @@
+use alloy_primitives::Bytes;
+use base_protocol::DERIVATION_VERSION_1;
 use base64::Engine;
 use rand::RngCore;
 
-use crate::error::Error;
+use crate::error::{CommitmentError, Error};
 
-const GENERIC_COMMITMENT_TYPE: u8 = 0x01;
+/// Generic commitment type byte (`0x01`).
+pub const GENERIC_COMMITMENT_TYPE: u8 = 0x01;
+/// Generic commitment sentinel byte (`0xff`).
+pub const GENERIC_COMMITMENT_SENTINEL: u8 = 0xff;
+/// Encoded generic commitment length in bytes.
+pub const GENERIC_COMMITMENT_LEN: usize = 34;
 /// Max decoded commitment bytes (generic format is always 34).
-const MAX_COMMITMENT_LEN: usize = 34;
+const MAX_COMMITMENT_LEN: usize = GENERIC_COMMITMENT_LEN;
+
+/// Fixed-size generic commitment: `0x01` type byte, `0xff` sentinel, then 32 random bytes.
+pub type GenericCommitment = [u8; GENERIC_COMMITMENT_LEN];
 
 /// Server-generated generic commitment (`0x01` type byte + `0xff` sentinel + random suffix).
-pub fn generate_generic_commitment() -> Vec<u8> {
-    let mut commitment = [0u8; 34];
+pub fn generate_generic_commitment() -> GenericCommitment {
+    let mut commitment = [0u8; GENERIC_COMMITMENT_LEN];
     commitment[0] = GENERIC_COMMITMENT_TYPE;
-    commitment[1] = 0xff;
+    commitment[1] = GENERIC_COMMITMENT_SENTINEL;
     rand::rng().fill_bytes(&mut commitment[2..]);
-    commitment.to_vec()
+    commitment
+}
+
+/// Validate a server-returned generic commitment.
+pub fn validate_generic_commitment(commitment: &[u8]) -> Result<(), CommitmentError> {
+    if commitment.len() != GENERIC_COMMITMENT_LEN {
+        return Err(CommitmentError::InvalidLength { len: commitment.len() });
+    }
+    if commitment[0] != GENERIC_COMMITMENT_TYPE || commitment[1] != GENERIC_COMMITMENT_SENTINEL {
+        return Err(CommitmentError::InvalidPrefix);
+    }
+    Ok(())
+}
+
+/// Encode alt-DA commitment L1 calldata (`DERIVATION_VERSION_1` ++ commitment).
+///
+/// Infallible: a [`GenericCommitment`] is fixed-size and its prefix is set at
+/// construction (`generate_generic_commitment`) or validated at the client boundary
+/// (`Client::put`), so there is nothing left to reject here.
+pub fn encode_commitment_tx_data(commitment: GenericCommitment) -> Bytes {
+    let mut data = Vec::with_capacity(1 + commitment.len());
+    data.push(DERIVATION_VERSION_1);
+    data.extend_from_slice(&commitment);
+    Bytes::from(data)
 }
 
 /// Decode a `0x`-prefixed hex commitment from an HTTP path segment.
@@ -60,8 +93,8 @@ mod tests {
     #[test]
     fn roundtrip_hex_commitment() {
         let comm = generate_generic_commitment();
-        let hex = format!("0x{}", hex::encode(&comm));
-        assert_eq!(decode_hex_commitment(&hex).unwrap(), comm);
+        let hex = format!("0x{}", hex::encode(comm));
+        assert_eq!(decode_hex_commitment(&hex).unwrap().as_slice(), comm.as_slice());
     }
 
     #[test]
@@ -69,5 +102,34 @@ mod tests {
         let hex = format!("0x{}", "ab".repeat(MAX_COMMITMENT_LEN + 1));
         let err = decode_hex_commitment(&hex).unwrap_err();
         assert!(matches!(err, Error::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_accepts_generated_commitment() {
+        assert!(validate_generic_commitment(&generate_generic_commitment()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_wrong_length() {
+        let err = validate_generic_commitment(&[GENERIC_COMMITMENT_TYPE; 10]).unwrap_err();
+        assert!(matches!(err, CommitmentError::InvalidLength { len: 10 }));
+    }
+
+    #[test]
+    fn validate_rejects_bad_prefix() {
+        let mut comm = generate_generic_commitment();
+        comm[1] = 0x00;
+        let err = validate_generic_commitment(&comm).unwrap_err();
+        assert!(matches!(err, CommitmentError::InvalidPrefix));
+    }
+
+    #[test]
+    fn encode_commitment_tx_data_prefixes_derivation_version() {
+        use base_protocol::DERIVATION_VERSION_1;
+
+        let comm = generate_generic_commitment();
+        let tx_data = encode_commitment_tx_data(comm);
+        assert_eq!(tx_data[0], DERIVATION_VERSION_1);
+        assert_eq!(&tx_data[1..], comm.as_slice());
     }
 }

--- a/crates/infra/alt-da/src/error.rs
+++ b/crates/infra/alt-da/src/error.rs
@@ -1,5 +1,24 @@
 use thiserror::Error;
 
+use crate::commitment::GENERIC_COMMITMENT_LEN;
+
+/// Generic commitment failed structural validation.
+///
+/// Independent of the server/store [`Error`] and the [`ClientError`] hierarchies so
+/// both sides can validate a commitment and map the failure into their own type.
+#[derive(Debug, Error)]
+pub enum CommitmentError {
+    /// Commitment was not exactly [`GENERIC_COMMITMENT_LEN`] bytes.
+    #[error("invalid generic commitment length: {len} (expected {GENERIC_COMMITMENT_LEN})")]
+    InvalidLength {
+        /// Actual commitment length in bytes.
+        len: usize,
+    },
+    /// Commitment did not start with the type + sentinel prefix.
+    #[error("invalid generic commitment prefix")]
+    InvalidPrefix,
+}
+
 /// Alt-DA server and store errors.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -65,6 +84,51 @@ pub enum InternalError {
     /// HTTP server failed to start or serve requests.
     #[error("http server error: {0}")]
     Http(String),
+}
+
+/// Alt-DA HTTP client request failed.
+#[derive(Debug, Error)]
+pub enum ClientError {
+    /// Request body was empty.
+    #[error("empty alt-da put body")]
+    EmptyBody,
+    /// Request body exceeds [`crate::MAX_OBJECT_BYTES`].
+    #[error("alt-da put body too large: {size} bytes (max {max})")]
+    BodyTooLarge {
+        /// Request body size in bytes.
+        size: usize,
+        /// Configured maximum object size in bytes.
+        max: usize,
+    },
+    /// HTTP transport or response read failed.
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    /// DA server returned a non-success status.
+    #[error("alt-da put failed with status {status}: {detail}")]
+    UnexpectedStatus {
+        /// HTTP status code.
+        status: u16,
+        /// Bounded response body from the server, if any.
+        detail: String,
+    },
+    /// PUT response was not a 34-byte generic commitment.
+    #[error("alt-da put returned invalid commitment length: {len}")]
+    InvalidCommitmentLen {
+        /// Response body length in bytes.
+        len: usize,
+    },
+    /// PUT response had a malformed generic commitment prefix.
+    #[error("alt-da put returned malformed commitment prefix")]
+    InvalidCommitment,
+}
+
+impl From<CommitmentError> for ClientError {
+    fn from(err: CommitmentError) -> Self {
+        match err {
+            CommitmentError::InvalidLength { len } => Self::InvalidCommitmentLen { len },
+            CommitmentError::InvalidPrefix => Self::InvalidCommitment,
+        }
+    }
 }
 
 impl From<StoreError> for Error {

--- a/crates/infra/alt-da/src/lib.rs
+++ b/crates/infra/alt-da/src/lib.rs
@@ -14,10 +14,17 @@ use base_protocol::BLOB_MAX_DATA_SIZE;
 pub const MAX_OBJECT_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
 
 mod commitment;
-pub use commitment::{decode_hex_commitment, generate_generic_commitment, object_key, object_name};
+pub use commitment::{
+    GENERIC_COMMITMENT_LEN, GENERIC_COMMITMENT_SENTINEL, GENERIC_COMMITMENT_TYPE,
+    GenericCommitment, decode_hex_commitment, encode_commitment_tx_data,
+    generate_generic_commitment, object_key, object_name, validate_generic_commitment,
+};
+
+mod client;
+pub use client::Client;
 
 mod error;
-pub use error::{ConfigError, Error, InternalError, StoreError};
+pub use error::{ClientError, CommitmentError, ConfigError, Error, InternalError, StoreError};
 
 mod server;
 pub use server::{Config, Server};

--- a/crates/infra/alt-da/src/server.rs
+++ b/crates/infra/alt-da/src/server.rs
@@ -91,7 +91,7 @@ async fn put_generate(State(store): State<DynStore>, body: Bytes) -> Result<Resp
     // Commitment is random; on store failure the batcher must retry POST /put (new commitment).
     let key = generate_generic_commitment();
     store.put(&key, &body).await?;
-    Ok((StatusCode::OK, key).into_response())
+    Ok((StatusCode::OK, key.to_vec()).into_response())
 }
 
 struct ApiError(Error);


### PR DESCRIPTION
add alt-DA HTTP client for privacy L3 S3 dual-write:

## Summary
- Add `base-alt-da` `Client::put` with bounded response reads and `GenericCommitment` validation
- Add `encode_commitment_tx_data` (`DERIVATION_VERSION_1` ++ 34-byte commitment) for L1 posting

## Context

#3612 is merged. Commitment L1 txs use derivation version `0x01`: the calldata is a pointer (commitment key), not inline batch bytes. The DA server stores the actual batch payload (`0x00 ++ frames`) in S3; nodes resolve v1 by fetching from the server (PRIV-1973).

## Test plan
- [x] `cargo test -p base-alt-da`
- [x] `cargo clippy -p base-alt-da -- -D warnings`

type=routine
risk=low
impact=sev5