### PR TITLE
fix(common): Upgrade Typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,6 @@ dependencies = [
  "auto_impl",
  "base-common-genesis",
  "revm",
- "serde",
  "spin 0.10.0",
 ]
 

--- a/crates/common/chains/Cargo.toml
+++ b/crates/common/chains/Cargo.toml
@@ -33,7 +33,6 @@ revm.workspace = true
 # misc
 spin.workspace = true
 auto_impl.workspace = true
-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-chains.workspace = true
@@ -51,7 +50,6 @@ std = [
 	"alloy-primitives/std",
 	"base-common-genesis/std",
 	"revm/std",
-	"serde?/std",
 	"spin/std",
 ]
 serde = [
@@ -60,7 +58,6 @@ serde = [
 	"alloy-hardforks/serde",
 	"alloy-primitives/serde",
 	"base-common-genesis/serde",
-	"dep:serde",
 	"revm/serde",
 ]
 test-utils = []

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -1,10 +1,5 @@
-use alloc::vec::Vec;
 use core::ops::Index;
 
-use BaseUpgrade::{
-    Azul, Bedrock, Beryl, Canyon, Cobalt, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian,
-    Regolith,
-};
 // Production imports for upgrade implementations
 use EthereumHardfork::{
     Amsterdam, ArrowGlacier, Berlin, Bpo1, Bpo2, Bpo3, Bpo4, Bpo5, Byzantium, Constantinople, Dao,
@@ -14,7 +9,11 @@ use EthereumHardfork::{
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::U256;
 
-use crate::{BaseUpgrade, Upgrades};
+use crate::{BaseUpgrade, BaseUpgradeExt, Upgrades};
+
+/// Number of upgrades in the Base execution fork ladder
+/// ([`BaseUpgrade::EXECUTION_VARIANTS`]).
+const EXECUTION_FORK_COUNT: usize = BaseUpgrade::EXECUTION_VARIANTS.len();
 
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of
 /// [`BaseUpgrade`]s.
@@ -29,17 +28,26 @@ use crate::{BaseUpgrade, Upgrades};
 /// around.
 #[derive(Debug, Clone)]
 pub struct ChainUpgrades {
-    /// Ordered list of upgrade activations.
-    forks: Vec<(BaseUpgrade, ForkCondition)>,
+    /// Activation conditions for the execution fork ladder, indexed by
+    /// [`BaseUpgrade::execution_idx`]. Upgrades absent from the input default to
+    /// [`ForkCondition::Never`].
+    forks: [ForkCondition; EXECUTION_FORK_COUNT],
 }
 
 impl ChainUpgrades {
-    /// Creates a new [`ChainUpgrades`] with the given list of forks. The input list is sorted
-    /// w.r.t. the hardcoded canonicity of [`BaseUpgrade`]s.
+    /// Creates a new [`ChainUpgrades`] from the given list of forks.
+    ///
+    /// Only execution-ladder upgrades ([`BaseUpgrade::EXECUTION_VARIANTS`]) are stored; any
+    /// contract-only upgrades (e.g. `Delta`, `PectraBlobSchedule`) in the input are ignored.
+    /// When an upgrade appears more than once, the last entry wins.
     pub fn new(forks: impl IntoIterator<Item = (BaseUpgrade, ForkCondition)>) -> Self {
-        let mut forks = forks.into_iter().collect::<Vec<_>>();
-        forks.sort();
-        Self { forks }
+        let mut conditions = [ForkCondition::Never; EXECUTION_FORK_COUNT];
+        for (upgrade, condition) in forks {
+            if let Some(idx) = upgrade.execution_idx() {
+                conditions[idx] = condition;
+            }
+        }
+        Self { forks: conditions }
     }
 
     /// Creates a new [`ChainUpgrades`] with Base mainnet configuration.
@@ -65,28 +73,12 @@ impl ChainUpgrades {
 
 impl EthereumHardforks for ChainUpgrades {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        if self.forks.is_empty() {
-            return ForkCondition::Never;
-        }
-
-        let forks_len = self.forks.len();
-        // check index out of bounds
-        if let Some(base_upgrade) = BaseUpgrade::from_ethereum_hardfork(fork)
-            && forks_len <= base_upgrade.idx()
-        {
-            return ForkCondition::Never;
-        }
-
         self[fork]
     }
 }
 
 impl Upgrades for ChainUpgrades {
     fn upgrade_activation(&self, fork: BaseUpgrade) -> ForkCondition {
-        // check index out of bounds
-        if self.forks.len() <= fork.idx() {
-            return ForkCondition::Never;
-        }
         self[fork]
     }
 }
@@ -95,20 +87,8 @@ impl Index<BaseUpgrade> for ChainUpgrades {
     type Output = ForkCondition;
 
     fn index(&self, hf: BaseUpgrade) -> &Self::Output {
-        match hf {
-            Bedrock => &self.forks[Bedrock.idx()].1,
-            Regolith => &self.forks[Regolith.idx()].1,
-            Canyon => &self.forks[Canyon.idx()].1,
-            Ecotone => &self.forks[Ecotone.idx()].1,
-            Fjord => &self.forks[Fjord.idx()].1,
-            Granite => &self.forks[Granite.idx()].1,
-            Holocene => &self.forks[Holocene.idx()].1,
-            Isthmus => &self.forks[Isthmus.idx()].1,
-            Jovian => &self.forks[Jovian.idx()].1,
-            Azul => &self.forks[Azul.idx()].1,
-            Beryl => &self.forks[Beryl.idx()].1,
-            Cobalt => &self.forks[Cobalt.idx()].1,
-        }
+        // Contract-only upgrades are absent from the execution fork ladder.
+        hf.execution_idx().map_or(&ForkCondition::Never, |idx| &self.forks[idx])
     }
 }
 
@@ -125,7 +105,7 @@ impl Index<EthereumHardfork> for ChainUpgrades {
             Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople
             | Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
-            London | ArrowGlacier | GrayGlacier => &self[Bedrock],
+            London | ArrowGlacier | GrayGlacier => &self[BaseUpgrade::Bedrock],
             Paris => &ForkCondition::TTD {
                 activation_block_number: 0,
                 fork_block: Some(0),

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -9,7 +9,7 @@ mod config;
 pub use config::{Bootnodes, ChainConfig};
 
 mod upgrade;
-pub use upgrade::{BaseUpgrade, ContractUpgrade};
+pub use upgrade::{BaseUpgrade, BaseUpgradeExt};
 
 mod upgrades;
 pub use upgrades::Upgrades;

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -232,14 +232,8 @@ mod tests {
 
     #[test]
     fn contract_upgrade_parses_aliases() {
-        assert_eq!(
-            BaseUpgrade::from_contract_fork_name("base_azul"),
-            Some(BaseUpgrade::Azul)
-        );
-        assert_eq!(
-            BaseUpgrade::from_contract_fork_name("shanghai"),
-            Some(BaseUpgrade::Canyon)
-        );
+        assert_eq!(BaseUpgrade::from_contract_fork_name("base_azul"), Some(BaseUpgrade::Azul));
+        assert_eq!(BaseUpgrade::from_contract_fork_name("shanghai"), Some(BaseUpgrade::Canyon));
         assert_eq!(
             BaseUpgrade::from_contract_fork_name("pectra_blob_schedule"),
             Some(BaseUpgrade::PectraBlobSchedule)

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -1,107 +1,60 @@
-use core::str::FromStr;
-
-use alloy_hardforks::{EthereumHardfork, ForkCondition, hardfork};
-pub use base_common_genesis::ContractUpgrade;
+use alloy_hardforks::ForkCondition;
+pub use base_common_genesis::BaseUpgrade;
 use revm::primitives::hardfork::SpecId;
 
 use crate::{ChainConfig, Upgrades};
 
-hardfork!(
-    /// The name of a Base network upgrade.
-    ///
-    /// When building a list of upgrades for a chain, it's still expected to zip with
-    /// [`EthereumHardfork`](alloy_hardforks::EthereumHardfork).
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[derive(Default)]
-    BaseUpgrade {
-        /// Bedrock: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#bedrock>.
-        Bedrock,
-        /// Regolith: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#regolith>.
-        Regolith,
-        /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#canyon>.
-        Canyon,
-        /// Ecotone: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#ecotone>.
-        Ecotone,
-        /// Fjord: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#fjord>
-        Fjord,
-        /// Granite: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#granite>
-        Granite,
-        /// Holocene: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#holocene>
-        Holocene,
-        /// Isthmus: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/isthmus/overview.md>
-        Isthmus,
-        /// Jovian: Base network upgrade.
-        Jovian,
-        /// Azul: First Base-specific network upgrade.
-        #[default]
-        Azul,
-        /// Beryl: Second Base-specific network upgrade.
-        Beryl,
-        /// Cobalt: Third Base-specific network upgrade.
-        Cobalt,
-    }
-);
-
-impl BaseUpgrade {
-    /// Latest Base upgrade used by default.
-    pub const LATEST: Self = Self::Azul;
-
-    /// Returns the Base upgrade represented by a contract-backed upgrade, if any.
-    pub const fn from_contract_upgrade(upgrade: ContractUpgrade) -> Option<Self> {
-        match upgrade {
-            ContractUpgrade::Regolith => Some(Self::Regolith),
-            ContractUpgrade::Canyon => Some(Self::Canyon),
-            ContractUpgrade::Delta | ContractUpgrade::PectraBlobSchedule => None,
-            ContractUpgrade::Ecotone => Some(Self::Ecotone),
-            ContractUpgrade::Fjord => Some(Self::Fjord),
-            ContractUpgrade::Granite => Some(Self::Granite),
-            ContractUpgrade::Holocene => Some(Self::Holocene),
-            ContractUpgrade::Isthmus => Some(Self::Isthmus),
-            ContractUpgrade::Jovian => Some(Self::Jovian),
-            ContractUpgrade::Azul => Some(Self::Azul),
-            ContractUpgrade::Beryl => Some(Self::Beryl),
-            ContractUpgrade::Cobalt => Some(Self::Cobalt),
-        }
-    }
-
-    /// Returns the Base upgrade that carries the given Ethereum hardfork on Base.
-    pub const fn from_ethereum_hardfork(fork: EthereumHardfork) -> Option<Self> {
-        match fork {
-            EthereumHardfork::Shanghai => Some(Self::Canyon),
-            EthereumHardfork::Cancun => Some(Self::Ecotone),
-            EthereumHardfork::Prague => Some(Self::Isthmus),
-            EthereumHardfork::Osaka => Some(Self::Azul),
-            _ => None,
-        }
-    }
-
-    /// Returns the Ethereum execution hardfork activated alongside this Base upgrade, if any.
-    pub const fn execution_hardfork(self) -> Option<EthereumHardfork> {
-        match self {
-            Self::Canyon => Some(EthereumHardfork::Shanghai),
-            Self::Ecotone => Some(EthereumHardfork::Cancun),
-            Self::Isthmus => Some(EthereumHardfork::Prague),
-            Self::Azul => Some(EthereumHardfork::Osaka),
-            _ => None,
-        }
-    }
-
-    /// Returns the Base upgrade represented by an execution or Base fork name.
-    pub fn from_fork_name(name: &str) -> Option<Self> {
-        if let Ok(upgrade) = Self::from_str(name.trim()) {
-            return Some(upgrade);
-        }
-
-        // TODO: remove this once runtime override lookups stop passing fork names through strings.
-        Self::from_contract_upgrade(ContractUpgrade::from_fork_name(name)?)
-    }
-
+/// Execution-layer extension methods for [`BaseUpgrade`].
+///
+/// [`BaseUpgrade`] is defined in `base-common-genesis`, which cannot depend on `revm` or
+/// [`ChainConfig`]. These helpers, which map upgrades onto revm specs and Base chain schedules,
+/// therefore live here in `base-common-chains`. Bring this trait into scope to call them.
+pub trait BaseUpgradeExt: Sized {
     /// Converts the Base upgrade into its matching Ethereum execution spec.
-    pub const fn into_eth_spec(self) -> SpecId {
+    ///
+    /// The contract-only upgrades inherit the execution spec of the surrounding era: `Delta`
+    /// behaves like `Canyon` (Shanghai) and `PectraBlobSchedule` like `Holocene` (Cancun).
+    fn into_eth_spec(self) -> SpecId;
+
+    /// Returns the execution fork ladder with activation conditions for the given chain config.
+    fn forks_for(cfg: &ChainConfig) -> [(BaseUpgrade, ForkCondition); 12];
+
+    /// Base mainnet list of execution upgrades.
+    fn mainnet() -> [(BaseUpgrade, ForkCondition); 12] {
+        Self::forks_for(ChainConfig::mainnet())
+    }
+
+    /// Base Sepolia list of execution upgrades.
+    fn sepolia() -> [(BaseUpgrade, ForkCondition); 12] {
+        Self::forks_for(ChainConfig::sepolia())
+    }
+
+    /// Devnet list of execution upgrades.
+    fn devnet() -> [(BaseUpgrade, ForkCondition); 12] {
+        Self::forks_for(ChainConfig::devnet())
+    }
+
+    /// Base Zeronet list of execution upgrades.
+    fn zeronet() -> [(BaseUpgrade, ForkCondition); 12] {
+        Self::forks_for(ChainConfig::zeronet())
+    }
+
+    /// Returns the active Base upgrade at the given timestamp.
+    ///
+    /// This is intended for post-Bedrock timestamp-based fork resolution.
+    fn from_timestamp(chain_spec: impl Upgrades, timestamp: u64) -> BaseUpgrade;
+}
+
+impl BaseUpgradeExt for BaseUpgrade {
+    fn into_eth_spec(self) -> SpecId {
         match self {
             Self::Bedrock | Self::Regolith => SpecId::MERGE,
-            Self::Canyon => SpecId::SHANGHAI,
-            Self::Ecotone | Self::Fjord | Self::Granite | Self::Holocene => SpecId::CANCUN,
+            Self::Canyon | Self::Delta => SpecId::SHANGHAI,
+            Self::Ecotone
+            | Self::Fjord
+            | Self::Granite
+            | Self::Holocene
+            | Self::PectraBlobSchedule => SpecId::CANCUN,
             Self::Isthmus | Self::Jovian => SpecId::PRAGUE,
             // Azul, Beryl, Cobalt, and newer Base upgrades inherit the latest known Ethereum spec
             // until explicitly mapped.
@@ -109,10 +62,27 @@ impl BaseUpgrade {
         }
     }
 
-    /// Returns the active Base upgrade at the given timestamp.
-    ///
-    /// This is intended for post-Bedrock timestamp-based fork resolution.
-    pub fn from_timestamp(chain_spec: impl Upgrades, timestamp: u64) -> Self {
+    fn forks_for(cfg: &ChainConfig) -> [(BaseUpgrade, ForkCondition); 12] {
+        let azul = cfg.azul_timestamp.map_or(ForkCondition::Never, ForkCondition::Timestamp);
+        let beryl = cfg.beryl_timestamp.map_or(ForkCondition::Never, ForkCondition::Timestamp);
+        let cobalt = cfg.cobalt_timestamp.map_or(ForkCondition::Never, ForkCondition::Timestamp);
+        [
+            (Self::Bedrock, ForkCondition::Block(cfg.bedrock_block)),
+            (Self::Regolith, ForkCondition::Timestamp(cfg.regolith_timestamp)),
+            (Self::Canyon, ForkCondition::Timestamp(cfg.canyon_timestamp)),
+            (Self::Ecotone, ForkCondition::Timestamp(cfg.ecotone_timestamp)),
+            (Self::Fjord, ForkCondition::Timestamp(cfg.fjord_timestamp)),
+            (Self::Granite, ForkCondition::Timestamp(cfg.granite_timestamp)),
+            (Self::Holocene, ForkCondition::Timestamp(cfg.holocene_timestamp)),
+            (Self::Isthmus, ForkCondition::Timestamp(cfg.isthmus_timestamp)),
+            (Self::Jovian, ForkCondition::Timestamp(cfg.jovian_timestamp)),
+            (Self::Azul, azul),
+            (Self::Beryl, beryl),
+            (Self::Cobalt, cobalt),
+        ]
+    }
+
+    fn from_timestamp(chain_spec: impl Upgrades, timestamp: u64) -> BaseUpgrade {
         if chain_spec.is_cobalt_active_at_timestamp(timestamp) {
             Self::Cobalt
         } else if chain_spec.is_beryl_active_at_timestamp(timestamp) {
@@ -138,61 +108,6 @@ impl BaseUpgrade {
         } else {
             Self::Bedrock
         }
-    }
-
-    /// Returns the list of upgrades with their activation conditions for the given chain config.
-    pub const fn forks_for(cfg: &ChainConfig) -> [(Self, ForkCondition); 12] {
-        let azul = match cfg.azul_timestamp {
-            Some(ts) => ForkCondition::Timestamp(ts),
-            None => ForkCondition::Never,
-        };
-        let beryl = match cfg.beryl_timestamp {
-            Some(ts) => ForkCondition::Timestamp(ts),
-            None => ForkCondition::Never,
-        };
-        let cobalt = match cfg.cobalt_timestamp {
-            Some(ts) => ForkCondition::Timestamp(ts),
-            None => ForkCondition::Never,
-        };
-        [
-            (Self::Bedrock, ForkCondition::Block(cfg.bedrock_block)),
-            (Self::Regolith, ForkCondition::Timestamp(cfg.regolith_timestamp)),
-            (Self::Canyon, ForkCondition::Timestamp(cfg.canyon_timestamp)),
-            (Self::Ecotone, ForkCondition::Timestamp(cfg.ecotone_timestamp)),
-            (Self::Fjord, ForkCondition::Timestamp(cfg.fjord_timestamp)),
-            (Self::Granite, ForkCondition::Timestamp(cfg.granite_timestamp)),
-            (Self::Holocene, ForkCondition::Timestamp(cfg.holocene_timestamp)),
-            (Self::Isthmus, ForkCondition::Timestamp(cfg.isthmus_timestamp)),
-            (Self::Jovian, ForkCondition::Timestamp(cfg.jovian_timestamp)),
-            (Self::Azul, azul),
-            (Self::Beryl, beryl),
-            (Self::Cobalt, cobalt),
-        ]
-    }
-
-    /// Base mainnet list of upgrades.
-    pub const fn mainnet() -> [(Self, ForkCondition); 12] {
-        Self::forks_for(ChainConfig::mainnet())
-    }
-
-    /// Base Sepolia list of upgrades.
-    pub const fn sepolia() -> [(Self, ForkCondition); 12] {
-        Self::forks_for(ChainConfig::sepolia())
-    }
-
-    /// Devnet list of upgrades.
-    pub const fn devnet() -> [(Self, ForkCondition); 12] {
-        Self::forks_for(ChainConfig::devnet())
-    }
-
-    /// Base Zeronet list of upgrades.
-    pub const fn zeronet() -> [(Self, ForkCondition); 12] {
-        Self::forks_for(ChainConfig::zeronet())
-    }
-
-    /// Returns index of `self` in sorted canonical array.
-    pub const fn idx(&self) -> usize {
-        *self as usize
     }
 }
 
@@ -269,27 +184,26 @@ mod tests {
     #[test]
     fn contract_upgrade_aliases_resolve_consistently() {
         let aliases = [
-            (EthereumHardfork::Shanghai.name(), ContractUpgrade::Canyon),
-            (EthereumHardfork::Cancun.name(), ContractUpgrade::Ecotone),
-            (EthereumHardfork::Prague.name(), ContractUpgrade::Isthmus),
-            (EthereumHardfork::Osaka.name(), ContractUpgrade::Azul),
-            (BaseUpgrade::Beryl.name(), ContractUpgrade::Beryl),
-            ("v1", ContractUpgrade::Azul),
-            ("v2", ContractUpgrade::Beryl),
-            ("v3", ContractUpgrade::Cobalt),
+            (EthereumHardfork::Shanghai.name(), BaseUpgrade::Canyon),
+            (EthereumHardfork::Cancun.name(), BaseUpgrade::Ecotone),
+            (EthereumHardfork::Prague.name(), BaseUpgrade::Isthmus),
+            (EthereumHardfork::Osaka.name(), BaseUpgrade::Azul),
+            (BaseUpgrade::Beryl.name(), BaseUpgrade::Beryl),
+            ("v1", BaseUpgrade::Azul),
+            ("v2", BaseUpgrade::Beryl),
+            ("v3", BaseUpgrade::Cobalt),
         ];
 
         for (alias, upgrade) in aliases {
-            assert_eq!(ContractUpgrade::from_fork_name(alias), Some(upgrade));
-            assert_eq!(alias.parse::<ContractUpgrade>().unwrap(), upgrade);
+            assert_eq!(BaseUpgrade::from_contract_fork_name(alias), Some(upgrade));
         }
     }
 
     #[test]
     fn fork_names_are_trimmed_and_case_insensitive() {
-        assert_eq!(BaseUpgrade::from_fork_name("  shAnGhAi  "), Some(BaseUpgrade::Canyon));
-        assert_eq!(BaseUpgrade::from_fork_name("\tbase_azul\n"), Some(BaseUpgrade::Azul));
-        assert_eq!(BaseUpgrade::from_fork_name("\n bERyl\t"), Some(BaseUpgrade::Beryl));
+        assert_eq!(BaseUpgrade::from_contract_fork_name("  shAnGhAi  "), Some(BaseUpgrade::Canyon));
+        assert_eq!(BaseUpgrade::from_contract_fork_name("\tbase_azul\n"), Some(BaseUpgrade::Azul));
+        assert_eq!(BaseUpgrade::from_contract_fork_name("\n bERyl\t"), Some(BaseUpgrade::Beryl));
     }
 
     #[test]
@@ -298,10 +212,12 @@ mod tests {
             (BaseUpgrade::Bedrock, SpecId::MERGE),
             (BaseUpgrade::Regolith, SpecId::MERGE),
             (BaseUpgrade::Canyon, SpecId::SHANGHAI),
+            (BaseUpgrade::Delta, SpecId::SHANGHAI),
             (BaseUpgrade::Ecotone, SpecId::CANCUN),
             (BaseUpgrade::Fjord, SpecId::CANCUN),
             (BaseUpgrade::Granite, SpecId::CANCUN),
             (BaseUpgrade::Holocene, SpecId::CANCUN),
+            (BaseUpgrade::PectraBlobSchedule, SpecId::CANCUN),
             (BaseUpgrade::Isthmus, SpecId::PRAGUE),
             (BaseUpgrade::Jovian, SpecId::PRAGUE),
             (BaseUpgrade::Azul, SpecId::OSAKA),
@@ -316,19 +232,46 @@ mod tests {
 
     #[test]
     fn contract_upgrade_parses_aliases() {
-        assert_eq!("base_azul".parse::<ContractUpgrade>().unwrap(), ContractUpgrade::Azul);
-        assert_eq!("shanghai".parse::<ContractUpgrade>().unwrap(), ContractUpgrade::Canyon);
         assert_eq!(
-            "pectra_blob_schedule".parse::<ContractUpgrade>().unwrap(),
-            ContractUpgrade::PectraBlobSchedule
+            BaseUpgrade::from_contract_fork_name("base_azul"),
+            Some(BaseUpgrade::Azul)
+        );
+        assert_eq!(
+            BaseUpgrade::from_contract_fork_name("shanghai"),
+            Some(BaseUpgrade::Canyon)
+        );
+        assert_eq!(
+            BaseUpgrade::from_contract_fork_name("pectra_blob_schedule"),
+            Some(BaseUpgrade::PectraBlobSchedule)
         );
     }
 
     #[test]
+    fn bedrock_is_not_contract_backed() {
+        // Bedrock is block-activated and never signaled by the L1 contract.
+        assert!(!BaseUpgrade::Bedrock.is_contract_backed());
+        assert_eq!(BaseUpgrade::from_contract_fork_name("bedrock"), None);
+        assert!(!BaseUpgrade::CONTRACT_VARIANTS.contains(&BaseUpgrade::Bedrock));
+    }
+
+    #[test]
+    fn contract_only_upgrades_are_absent_from_execution_ladder() {
+        // Delta and PectraBlobSchedule are contract-backed config upgrades that do not change
+        // EVM execution, so they have no execution index and are excluded from the ladder.
+        for upgrade in [BaseUpgrade::Delta, BaseUpgrade::PectraBlobSchedule] {
+            assert!(!upgrade.is_execution());
+            assert_eq!(upgrade.execution_idx(), None);
+            assert!(upgrade.is_contract_backed());
+            assert!(!BaseUpgrade::EXECUTION_VARIANTS.contains(&upgrade));
+            assert!(BaseUpgrade::CONTRACT_VARIANTS.contains(&upgrade));
+        }
+    }
+
+    #[test]
     fn contract_upgrade_tracks_execution_companions() {
-        assert_eq!(ContractUpgrade::Canyon.execution_hardfork(), Some(EthereumHardfork::Shanghai));
-        assert_eq!(ContractUpgrade::Regolith.execution_hardfork(), None);
-        assert_eq!(ContractUpgrade::Delta.execution_hardfork(), None);
+        assert_eq!(BaseUpgrade::Canyon.execution_hardfork(), Some(EthereumHardfork::Shanghai));
+        assert_eq!(BaseUpgrade::Regolith.execution_hardfork(), None);
+        assert_eq!(BaseUpgrade::Delta.execution_hardfork(), None);
     }
 
     /// Reverse lookup to find the upgrade given a chain ID and block timestamp.

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -2,7 +2,7 @@ use alloy_hardforks::{EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
 use base_common_genesis::RollupConfig;
 
-use crate::{BaseUpgrade, ContractUpgrade};
+use crate::BaseUpgrade;
 
 /// Extends [`EthereumHardforks`] with Base upgrade helper methods.
 #[auto_impl::auto_impl(&, Arc)]
@@ -87,49 +87,52 @@ impl Upgrades for RollupConfig {
         match fork {
             BaseUpgrade::Bedrock => ForkCondition::Block(0),
             BaseUpgrade::Regolith => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Regolith)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Regolith)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Canyon)),
             BaseUpgrade::Canyon => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Canyon)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Canyon)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Ecotone)),
             BaseUpgrade::Ecotone => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Ecotone)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Ecotone)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Fjord)),
             BaseUpgrade::Fjord => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Fjord)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Fjord)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Granite)),
             BaseUpgrade::Granite => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Granite)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Granite)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Holocene)),
             BaseUpgrade::Holocene => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Holocene)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Holocene)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Isthmus)),
             BaseUpgrade::Isthmus => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Isthmus)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or_else(|| self.upgrade_activation(BaseUpgrade::Jovian)),
             BaseUpgrade::Jovian => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Jovian)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Jovian)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
             BaseUpgrade::Azul => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Azul)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Azul)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
             BaseUpgrade::Beryl => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Beryl)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Beryl)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
             BaseUpgrade::Cobalt => self
-                .contract_upgrade_activation_timestamp(ContractUpgrade::Cobalt)
+                .contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
+            // Contract-only upgrades (Delta, PectraBlobSchedule) and any future variants are
+            // absent from the execution fork ladder.
+            _ => ForkCondition::Never,
         }
     }
 }
@@ -181,12 +184,12 @@ mod tests {
         RuntimeUpgradeRegistry::clear_chain(CHAIN_ID);
         RuntimeUpgradeRegistry::set_activation_timestamp(
             CHAIN_ID,
-            ContractUpgrade::Azul,
+            BaseUpgrade::Azul,
             ACTIVATION,
         );
         RuntimeUpgradeRegistry::set_activation_timestamp(
             CHAIN_ID,
-            ContractUpgrade::Cobalt,
+            BaseUpgrade::Cobalt,
             ACTIVATION + 1,
         );
 

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -182,11 +182,7 @@ mod tests {
             ..RollupConfig::default()
         };
         RuntimeUpgradeRegistry::clear_chain(CHAIN_ID);
-        RuntimeUpgradeRegistry::set_activation_timestamp(
-            CHAIN_ID,
-            BaseUpgrade::Azul,
-            ACTIVATION,
-        );
+        RuntimeUpgradeRegistry::set_activation_timestamp(CHAIN_ID, BaseUpgrade::Azul, ACTIVATION);
         RuntimeUpgradeRegistry::set_activation_timestamp(
             CHAIN_ID,
             BaseUpgrade::Cobalt,

--- a/crates/common/evm/src/executor/block_executor.rs
+++ b/crates/common/evm/src/executor/block_executor.rs
@@ -316,7 +316,7 @@ mod tests {
     };
     use alloy_hardforks::ForkCondition;
     use alloy_primitives::{Address, Signature, U256, uint};
-    use base_common_chains::{BaseUpgrade, ChainUpgrades};
+    use base_common_chains::{BaseUpgrade, BaseUpgradeExt, ChainUpgrades};
     use base_common_consensus::{BaseTxEnvelope, Predeploys};
     use revm::{
         Context,

--- a/crates/common/evm/src/spec.rs
+++ b/crates/common/evm/src/spec.rs
@@ -1,7 +1,7 @@
 //! Contains the `[BaseSpecId]` type and its implementation.
 
 use alloy_consensus::BlockHeader;
-use base_common_chains::{BaseUpgrade, Upgrades};
+use base_common_chains::{BaseUpgrade, BaseUpgradeExt, Upgrades};
 use revm::primitives::hardfork::SpecId;
 
 /// EVM-facing Base spec id.
@@ -24,7 +24,7 @@ impl BaseSpecId {
     }
 
     /// Converts the [`BaseSpecId`] into a [`SpecId`].
-    pub const fn into_eth_spec(self) -> SpecId {
+    pub fn into_eth_spec(self) -> SpecId {
         self.0.into_eth_spec()
     }
 

--- a/crates/common/genesis/src/chain/mod.rs
+++ b/crates/common/genesis/src/chain/mod.rs
@@ -5,7 +5,7 @@ pub use addresses::AddressList;
 
 mod upgrade;
 pub use upgrade::{
-    BaseUpgradeConfig, ContractUpgrade, RuntimeUpgradeRegistry, UpgradeActivation,
+    BaseUpgrade, BaseUpgradeConfig, RuntimeUpgradeRegistry, UpgradeActivation,
     UpgradeActivationOverrides, UpgradeActivationSink, UpgradeConfig,
 };
 

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -2,12 +2,11 @@
 
 use alloc::{
     collections::BTreeMap,
-    format,
     string::{String, ToString},
 };
-use core::{fmt::Display, str::FromStr};
+use core::fmt::Display;
 
-use alloy_hardforks::{EthereumHardfork, ParseHardforkError};
+use alloy_hardforks::{EthereumHardfork, hardfork};
 use spin::{Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Upgrade configuration for Base-specific upgrades.
@@ -37,40 +36,89 @@ impl BaseUpgradeConfig {
     }
 }
 
-/// Contract-backed Base upgrade IDs.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum ContractUpgrade {
-    /// Regolith.
-    Regolith,
-    /// Canyon.
-    Canyon,
-    /// Delta.
-    Delta,
-    /// Ecotone.
-    Ecotone,
-    /// Fjord.
-    Fjord,
-    /// Granite.
-    Granite,
-    /// Holocene.
-    Holocene,
-    /// Pectra blob schedule.
-    PectraBlobSchedule,
-    /// Isthmus.
-    Isthmus,
-    /// Jovian.
-    Jovian,
-    /// Azul.
-    Azul,
-    /// Beryl.
-    Beryl,
-    /// Cobalt.
-    Cobalt,
-}
+hardfork!(
+    /// The canonical Base network upgrade.
+    ///
+    /// This single enum spans two domains:
+    /// - the **execution fork ladder** ([`BaseUpgrade::EXECUTION_VARIANTS`]) that maps onto the
+    ///   reth/revm hardfork schedule, and
+    /// - the **contract-backed upgrade set** ([`BaseUpgrade::CONTRACT_VARIANTS`]) that is keyed by
+    ///   the L1 upgrade-signal contract `hardforkId` strings and the genesis [`UpgradeConfig`]
+    ///   timestamp fields.
+    ///
+    /// Variants are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock) is
+    /// execution-only (block-activated, not contract-backed), while
+    /// [`Delta`](BaseUpgrade::Delta) and [`PectraBlobSchedule`](BaseUpgrade::PectraBlobSchedule)
+    /// are contract-backed config upgrades that do not change EVM execution and therefore never
+    /// enter the execution fork ladder.
+    ///
+    /// When building a list of upgrades for a chain, it's still expected to zip with
+    /// [`EthereumHardfork`](alloy_hardforks::EthereumHardfork).
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Default)]
+    BaseUpgrade {
+        /// Bedrock: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#bedrock>.
+        Bedrock,
+        /// Regolith: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#regolith>.
+        Regolith,
+        /// Canyon: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#canyon>.
+        Canyon,
+        /// Delta: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#delta>.
+        Delta,
+        /// Ecotone: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#ecotone>.
+        Ecotone,
+        /// Fjord: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#fjord>
+        Fjord,
+        /// Granite: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#granite>
+        Granite,
+        /// Holocene: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#holocene>
+        Holocene,
+        /// Pectra blob schedule: an optional fork present on Base Sepolia chains that observed the
+        /// L1 Pectra network upgrade with the reference node `<=v1.11.1` sequencing the network.
+        PectraBlobSchedule,
+        /// Isthmus: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/isthmus/overview.md>
+        Isthmus,
+        /// Jovian: Base network upgrade.
+        Jovian,
+        /// Azul: First Base-specific network upgrade.
+        #[default]
+        Azul,
+        /// Beryl: Second Base-specific network upgrade.
+        Beryl,
+        /// Cobalt: Third Base-specific network upgrade.
+        Cobalt,
+    }
+);
 
-impl ContractUpgrade {
-    /// All contract-backed Base upgrade IDs.
-    pub const ALL: [Self; 13] = [
+impl BaseUpgrade {
+    /// Latest Base upgrade used by default.
+    pub const LATEST: Self = Self::Azul;
+
+    /// The execution fork ladder, in activation order.
+    ///
+    /// These are the upgrades that participate in the reth/revm hardfork schedule. Excludes the
+    /// contract-only [`Delta`](Self::Delta) and [`PectraBlobSchedule`](Self::PectraBlobSchedule)
+    /// upgrades, which do not change EVM execution.
+    pub const EXECUTION_VARIANTS: [Self; 12] = [
+        Self::Bedrock,
+        Self::Regolith,
+        Self::Canyon,
+        Self::Ecotone,
+        Self::Fjord,
+        Self::Granite,
+        Self::Holocene,
+        Self::Isthmus,
+        Self::Jovian,
+        Self::Azul,
+        Self::Beryl,
+        Self::Cobalt,
+    ];
+
+    /// The contract-backed upgrade set, in activation order.
+    ///
+    /// These are the upgrades addressable by the L1 upgrade-signal contract and stored in the
+    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock).
+    pub const CONTRACT_VARIANTS: [Self; 13] = [
         Self::Regolith,
         Self::Canyon,
         Self::Delta,
@@ -86,9 +134,45 @@ impl ContractUpgrade {
         Self::Cobalt,
     ];
 
-    /// Returns the canonical contract upgrade name.
-    pub const fn name(self) -> &'static str {
+    /// Returns true if this upgrade participates in the execution fork ladder.
+    pub const fn is_execution(self) -> bool {
+        self.execution_idx().is_some()
+    }
+
+    /// Returns true if this upgrade is contract-backed (i.e. signaled by the L1 upgrade-signal
+    /// contract and stored in [`UpgradeConfig`]). False only for [`Bedrock`](Self::Bedrock).
+    pub const fn is_contract_backed(self) -> bool {
+        !matches!(self, Self::Bedrock)
+    }
+
+    /// Returns this upgrade's index within [`EXECUTION_VARIANTS`](Self::EXECUTION_VARIANTS), or
+    /// `None` for contract-only upgrades that are absent from the execution fork ladder.
+    pub const fn execution_idx(self) -> Option<usize> {
+        Some(match self {
+            Self::Bedrock => 0,
+            Self::Regolith => 1,
+            Self::Canyon => 2,
+            Self::Ecotone => 3,
+            Self::Fjord => 4,
+            Self::Granite => 5,
+            Self::Holocene => 6,
+            Self::Isthmus => 7,
+            Self::Jovian => 8,
+            Self::Azul => 9,
+            Self::Beryl => 10,
+            Self::Cobalt => 11,
+            Self::Delta | Self::PectraBlobSchedule => return None,
+        })
+    }
+
+    /// Returns the canonical `snake_case` contract upgrade ID used by the L1 upgrade-signal
+    /// contract and metrics.
+    ///
+    /// Note this differs from [`name`](Self::name) (`PascalCase`), which is the reth/execution
+    /// hardfork identity.
+    pub const fn contract_id(self) -> &'static str {
         match self {
+            Self::Bedrock => "bedrock",
             Self::Regolith => "regolith",
             Self::Canyon => "canyon",
             Self::Delta => "delta",
@@ -105,67 +189,57 @@ impl ContractUpgrade {
         }
     }
 
-    /// Returns the Ethereum execution hardfork activated by this contract upgrade, if any.
+    /// Returns the Ethereum execution hardfork activated by this upgrade, if any.
     pub const fn execution_hardfork(self) -> Option<EthereumHardfork> {
         match self {
             Self::Canyon => Some(EthereumHardfork::Shanghai),
             Self::Ecotone => Some(EthereumHardfork::Cancun),
             Self::Isthmus => Some(EthereumHardfork::Prague),
             Self::Azul => Some(EthereumHardfork::Osaka),
-            Self::Regolith
-            | Self::Delta
-            | Self::Fjord
-            | Self::Granite
-            | Self::Holocene
-            | Self::PectraBlobSchedule
-            | Self::Jovian
-            | Self::Beryl
-            | Self::Cobalt => None,
-        }
-    }
-
-    /// Returns the contract upgrade represented by an execution, Base, or contract alias name.
-    pub fn from_fork_name(name: &str) -> Option<Self> {
-        match Self::normalized_hardfork_id(name).as_str() {
-            "regolith" => Some(Self::Regolith),
-            "shanghai" | "canyon" => Some(Self::Canyon),
-            "delta" => Some(Self::Delta),
-            "cancun" | "ecotone" => Some(Self::Ecotone),
-            "fjord" => Some(Self::Fjord),
-            "granite" => Some(Self::Granite),
-            "holocene" => Some(Self::Holocene),
-            "pectrablobschedule" => Some(Self::PectraBlobSchedule),
-            "prague" | "isthmus" => Some(Self::Isthmus),
-            "jovian" => Some(Self::Jovian),
-            "osaka" | "azul" | "baseazul" | "v1" => Some(Self::Azul),
-            "beryl" | "baseberyl" | "v2" => Some(Self::Beryl),
-            "cobalt" | "basecobalt" | "v3" => Some(Self::Cobalt),
             _ => None,
         }
     }
 
-    /// Normalizes a contract upgrade ID for matching.
+    /// Returns the Base upgrade that carries the given Ethereum hardfork on Base.
+    pub const fn from_ethereum_hardfork(fork: EthereumHardfork) -> Option<Self> {
+        match fork {
+            EthereumHardfork::Shanghai => Some(Self::Canyon),
+            EthereumHardfork::Cancun => Some(Self::Ecotone),
+            EthereumHardfork::Prague => Some(Self::Isthmus),
+            EthereumHardfork::Osaka => Some(Self::Azul),
+            _ => None,
+        }
+    }
+
+    /// Returns the contract-backed upgrade represented by an execution, Base, or contract alias
+    /// name. Returns `None` for unknown names and for non-contract-backed upgrades (Bedrock).
+    pub fn from_contract_fork_name(name: &str) -> Option<Self> {
+        let upgrade = match Self::normalized_hardfork_id(name).as_str() {
+            "regolith" => Self::Regolith,
+            "shanghai" | "canyon" => Self::Canyon,
+            "delta" => Self::Delta,
+            "cancun" | "ecotone" => Self::Ecotone,
+            "fjord" => Self::Fjord,
+            "granite" => Self::Granite,
+            "holocene" => Self::Holocene,
+            "pectrablobschedule" => Self::PectraBlobSchedule,
+            "prague" | "isthmus" => Self::Isthmus,
+            "jovian" => Self::Jovian,
+            "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
+            "beryl" | "baseberyl" | "v2" => Self::Beryl,
+            "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
+            _ => return None,
+        };
+        Some(upgrade)
+    }
+
+    /// Normalizes a contract upgrade ID for matching (lowercase, stripping whitespace, `_`, `-`).
     pub fn normalized_hardfork_id(upgrade_id: &str) -> String {
         upgrade_id
             .bytes()
             .filter(|b| !b.is_ascii_whitespace() && !matches!(b, b'_' | b'-'))
             .map(|b| b.to_ascii_lowercase() as char)
             .collect()
-    }
-}
-
-impl FromStr for ContractUpgrade {
-    type Err = ParseHardforkError;
-
-    fn from_str(upgrade_id: &str) -> Result<Self, Self::Err> {
-        Self::from_fork_name(upgrade_id)
-            .ok_or_else(|| ParseHardforkError::new(format!("Unknown hardfork: {upgrade_id}")))
-    }
-}
-
-impl Display for ContractUpgrade {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(self.name())
     }
 }
 
@@ -210,7 +284,7 @@ pub trait UpgradeActivationSink {
     /// and was ignored.
     fn apply_activation(
         &mut self,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error>;
 
@@ -224,7 +298,7 @@ pub trait UpgradeActivationSink {
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct UpgradeActivationOverrides {
     /// Upgrade activations keyed by canonical contract upgrade ID.
-    pub activations: BTreeMap<ContractUpgrade, UpgradeActivation>,
+    pub activations: BTreeMap<BaseUpgrade, UpgradeActivation>,
 }
 
 impl UpgradeActivationOverrides {
@@ -239,27 +313,27 @@ impl UpgradeActivationOverrides {
     }
 
     /// Returns the runtime activation override for a contract upgrade ID.
-    pub fn activation(&self, upgrade_id: ContractUpgrade) -> Option<UpgradeActivation> {
+    pub fn activation(&self, upgrade_id: BaseUpgrade) -> Option<UpgradeActivation> {
         self.activations.get(&upgrade_id).copied()
     }
 
     /// Removes the runtime activation override for a contract upgrade ID.
-    pub fn remove_activation(&mut self, upgrade_id: ContractUpgrade) -> bool {
+    pub fn remove_activation(&mut self, upgrade_id: BaseUpgrade) -> bool {
         self.activations.remove(&upgrade_id).is_some()
     }
 
     /// Sets the runtime activation override for a contract upgrade ID.
-    pub fn set_activation(&mut self, upgrade_id: ContractUpgrade, activation: UpgradeActivation) {
+    pub fn set_activation(&mut self, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
         self.activations.insert(upgrade_id, activation);
     }
 
     /// Sets a runtime timestamp activation override for a contract upgrade ID.
-    pub fn set_activation_timestamp(&mut self, upgrade_id: ContractUpgrade, timestamp: u64) {
+    pub fn set_activation_timestamp(&mut self, upgrade_id: BaseUpgrade, timestamp: u64) {
         self.set_activation(upgrade_id, UpgradeActivation::Timestamp(timestamp))
     }
 
     /// Sets a runtime override that clears an upgrade activation.
-    pub fn clear_activation_timestamp(&mut self, upgrade_id: ContractUpgrade) {
+    pub fn clear_activation_timestamp(&mut self, upgrade_id: BaseUpgrade) {
         self.set_activation(upgrade_id, UpgradeActivation::Never)
     }
 }
@@ -293,7 +367,7 @@ impl RuntimeUpgradeRegistry {
     }
 
     /// Returns the runtime activation override for a chain and contract upgrade ID.
-    pub fn activation(chain_id: u64, upgrade_id: ContractUpgrade) -> Option<UpgradeActivation> {
+    pub fn activation(chain_id: u64, upgrade_id: BaseUpgrade) -> Option<UpgradeActivation> {
         Self::read_registry().get(&chain_id).and_then(|overrides| overrides.activation(upgrade_id))
     }
 
@@ -313,7 +387,7 @@ impl RuntimeUpgradeRegistry {
     }
 
     /// Removes one runtime activation override for a chain and contract upgrade ID.
-    pub fn remove_activation_override(chain_id: u64, upgrade_id: ContractUpgrade) -> bool {
+    pub fn remove_activation_override(chain_id: u64, upgrade_id: BaseUpgrade) -> bool {
         let mut registry = Self::write_registry();
         let Some(overrides) = registry.get_mut(&chain_id) else {
             return false;
@@ -325,7 +399,7 @@ impl RuntimeUpgradeRegistry {
     /// Sets one runtime activation override for a chain and contract upgrade ID.
     pub fn set_activation(
         chain_id: u64,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) {
         let mut registry = Self::write_registry();
@@ -334,12 +408,12 @@ impl RuntimeUpgradeRegistry {
     }
 
     /// Sets one runtime timestamp activation override for a chain and contract upgrade ID.
-    pub fn set_activation_timestamp(chain_id: u64, upgrade_id: ContractUpgrade, timestamp: u64) {
+    pub fn set_activation_timestamp(chain_id: u64, upgrade_id: BaseUpgrade, timestamp: u64) {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Timestamp(timestamp))
     }
 
     /// Sets one runtime override that clears a chain upgrade activation.
-    pub fn clear_activation_timestamp(chain_id: u64, upgrade_id: ContractUpgrade) {
+    pub fn clear_activation_timestamp(chain_id: u64, upgrade_id: BaseUpgrade) {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Never)
     }
 }
@@ -448,28 +522,29 @@ impl UpgradeConfig {
     }
 
     /// Clears a timestamp-based activation time by contract upgrade ID.
-    pub const fn clear_activation_timestamp(&mut self, upgrade_id: ContractUpgrade) {
+    pub const fn clear_activation_timestamp(&mut self, upgrade_id: BaseUpgrade) {
         match upgrade_id {
-            ContractUpgrade::Regolith => self.regolith_time = None,
-            ContractUpgrade::Canyon => self.canyon_time = None,
-            ContractUpgrade::Delta => self.delta_time = None,
-            ContractUpgrade::Ecotone => self.ecotone_time = None,
-            ContractUpgrade::Fjord => self.fjord_time = None,
-            ContractUpgrade::Granite => self.granite_time = None,
-            ContractUpgrade::Holocene => self.holocene_time = None,
-            ContractUpgrade::PectraBlobSchedule => self.pectra_blob_schedule_time = None,
-            ContractUpgrade::Isthmus => self.isthmus_time = None,
-            ContractUpgrade::Jovian => self.jovian_time = None,
-            ContractUpgrade::Azul => self.base.azul = None,
-            ContractUpgrade::Beryl => self.base.beryl = None,
-            ContractUpgrade::Cobalt => self.base.cobalt = None,
+            BaseUpgrade::Bedrock => {}
+            BaseUpgrade::Regolith => self.regolith_time = None,
+            BaseUpgrade::Canyon => self.canyon_time = None,
+            BaseUpgrade::Delta => self.delta_time = None,
+            BaseUpgrade::Ecotone => self.ecotone_time = None,
+            BaseUpgrade::Fjord => self.fjord_time = None,
+            BaseUpgrade::Granite => self.granite_time = None,
+            BaseUpgrade::Holocene => self.holocene_time = None,
+            BaseUpgrade::PectraBlobSchedule => self.pectra_blob_schedule_time = None,
+            BaseUpgrade::Isthmus => self.isthmus_time = None,
+            BaseUpgrade::Jovian => self.jovian_time = None,
+            BaseUpgrade::Azul => self.base.azul = None,
+            BaseUpgrade::Beryl => self.base.beryl = None,
+            BaseUpgrade::Cobalt => self.base.cobalt = None,
         }
     }
 
     /// Applies an upgrade activation override by contract upgrade ID.
     pub const fn set_activation(
         &mut self,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) {
         match activation {
@@ -488,47 +563,49 @@ impl UpgradeConfig {
     }
 
     /// Returns the activation for a timestamp-based contract upgrade ID.
-    pub const fn activation(&self, upgrade_id: ContractUpgrade) -> UpgradeActivation {
+    pub const fn activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
         let timestamp = match upgrade_id {
-            ContractUpgrade::Regolith => self.regolith_time,
-            ContractUpgrade::Canyon => self.canyon_time,
-            ContractUpgrade::Delta => self.delta_time,
-            ContractUpgrade::Ecotone => self.ecotone_time,
-            ContractUpgrade::Fjord => self.fjord_time,
-            ContractUpgrade::Granite => self.granite_time,
-            ContractUpgrade::Holocene => self.holocene_time,
-            ContractUpgrade::PectraBlobSchedule => self.pectra_blob_schedule_time,
-            ContractUpgrade::Isthmus => self.isthmus_time,
-            ContractUpgrade::Jovian => self.jovian_time,
-            ContractUpgrade::Azul => self.base.azul,
-            ContractUpgrade::Beryl => self.base.beryl,
-            ContractUpgrade::Cobalt => self.base.cobalt,
+            BaseUpgrade::Bedrock => None,
+            BaseUpgrade::Regolith => self.regolith_time,
+            BaseUpgrade::Canyon => self.canyon_time,
+            BaseUpgrade::Delta => self.delta_time,
+            BaseUpgrade::Ecotone => self.ecotone_time,
+            BaseUpgrade::Fjord => self.fjord_time,
+            BaseUpgrade::Granite => self.granite_time,
+            BaseUpgrade::Holocene => self.holocene_time,
+            BaseUpgrade::PectraBlobSchedule => self.pectra_blob_schedule_time,
+            BaseUpgrade::Isthmus => self.isthmus_time,
+            BaseUpgrade::Jovian => self.jovian_time,
+            BaseUpgrade::Azul => self.base.azul,
+            BaseUpgrade::Beryl => self.base.beryl,
+            BaseUpgrade::Cobalt => self.base.cobalt,
         };
 
         UpgradeActivation::from_timestamp(timestamp)
     }
 
     /// Returns the activation timestamp for a timestamp-based contract upgrade ID.
-    pub const fn activation_timestamp(&self, upgrade_id: ContractUpgrade) -> Option<u64> {
+    pub const fn activation_timestamp(&self, upgrade_id: BaseUpgrade) -> Option<u64> {
         self.activation(upgrade_id).timestamp()
     }
 
     /// Sets a timestamp-based activation time by contract upgrade ID.
-    pub const fn set_activation_timestamp(&mut self, upgrade_id: ContractUpgrade, timestamp: u64) {
+    pub const fn set_activation_timestamp(&mut self, upgrade_id: BaseUpgrade, timestamp: u64) {
         match upgrade_id {
-            ContractUpgrade::Regolith => self.regolith_time = Some(timestamp),
-            ContractUpgrade::Canyon => self.canyon_time = Some(timestamp),
-            ContractUpgrade::Delta => self.delta_time = Some(timestamp),
-            ContractUpgrade::Ecotone => self.ecotone_time = Some(timestamp),
-            ContractUpgrade::Fjord => self.fjord_time = Some(timestamp),
-            ContractUpgrade::Granite => self.granite_time = Some(timestamp),
-            ContractUpgrade::Holocene => self.holocene_time = Some(timestamp),
-            ContractUpgrade::PectraBlobSchedule => self.pectra_blob_schedule_time = Some(timestamp),
-            ContractUpgrade::Isthmus => self.isthmus_time = Some(timestamp),
-            ContractUpgrade::Jovian => self.jovian_time = Some(timestamp),
-            ContractUpgrade::Azul => self.base.azul = Some(timestamp),
-            ContractUpgrade::Beryl => self.base.beryl = Some(timestamp),
-            ContractUpgrade::Cobalt => self.base.cobalt = Some(timestamp),
+            BaseUpgrade::Bedrock => {}
+            BaseUpgrade::Regolith => self.regolith_time = Some(timestamp),
+            BaseUpgrade::Canyon => self.canyon_time = Some(timestamp),
+            BaseUpgrade::Delta => self.delta_time = Some(timestamp),
+            BaseUpgrade::Ecotone => self.ecotone_time = Some(timestamp),
+            BaseUpgrade::Fjord => self.fjord_time = Some(timestamp),
+            BaseUpgrade::Granite => self.granite_time = Some(timestamp),
+            BaseUpgrade::Holocene => self.holocene_time = Some(timestamp),
+            BaseUpgrade::PectraBlobSchedule => self.pectra_blob_schedule_time = Some(timestamp),
+            BaseUpgrade::Isthmus => self.isthmus_time = Some(timestamp),
+            BaseUpgrade::Jovian => self.jovian_time = Some(timestamp),
+            BaseUpgrade::Azul => self.base.azul = Some(timestamp),
+            BaseUpgrade::Beryl => self.base.beryl = Some(timestamp),
+            BaseUpgrade::Cobalt => self.base.cobalt = Some(timestamp),
         }
     }
 
@@ -687,11 +764,11 @@ mod tests {
     fn test_set_activation_timestamp_by_upgrade_id() {
         let mut upgrades = UpgradeConfig::default();
 
-        upgrades.set_activation_timestamp(ContractUpgrade::Regolith, 1);
-        upgrades.set_activation_timestamp(ContractUpgrade::PectraBlobSchedule, 2);
-        upgrades.set_activation_timestamp(ContractUpgrade::Azul, 3);
-        upgrades.set_activation_timestamp(ContractUpgrade::Beryl, 4);
-        upgrades.set_activation_timestamp(ContractUpgrade::Cobalt, 5);
+        upgrades.set_activation_timestamp(BaseUpgrade::Regolith, 1);
+        upgrades.set_activation_timestamp(BaseUpgrade::PectraBlobSchedule, 2);
+        upgrades.set_activation_timestamp(BaseUpgrade::Azul, 3);
+        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 4);
+        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 5);
 
         assert_eq!(upgrades.regolith_time, Some(1));
         assert_eq!(upgrades.pectra_blob_schedule_time, Some(2));
@@ -699,7 +776,7 @@ mod tests {
         assert_eq!(upgrades.base.beryl, Some(4));
         assert_eq!(upgrades.base.cobalt, Some(5));
 
-        upgrades.clear_activation_timestamp(ContractUpgrade::Azul);
+        upgrades.clear_activation_timestamp(BaseUpgrade::Azul);
         assert_eq!(upgrades.base.azul, None);
         assert_eq!(upgrades.base.beryl, Some(4));
         assert_eq!(upgrades.base.cobalt, Some(5));
@@ -719,20 +796,20 @@ mod runtime_tests {
         let chain_id = 9_100_001;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
 
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Azul, 42);
-        RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, ContractUpgrade::Beryl);
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Cobalt, 84);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
+        RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Beryl);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
 
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Azul),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Beryl),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
             Some(UpgradeActivation::Never)
         );
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Cobalt),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Cobalt),
             Some(UpgradeActivation::Timestamp(84))
         );
 
@@ -744,9 +821,9 @@ mod runtime_tests {
         let mut upgrades = UpgradeConfig { canyon_time: Some(10), ..Default::default() };
         let mut overrides = UpgradeActivationOverrides::new();
 
-        overrides.clear_activation_timestamp(ContractUpgrade::Canyon);
-        overrides.set_activation_timestamp(ContractUpgrade::Azul, 42);
-        overrides.set_activation_timestamp(ContractUpgrade::Cobalt, 84);
+        overrides.clear_activation_timestamp(BaseUpgrade::Canyon);
+        overrides.set_activation_timestamp(BaseUpgrade::Azul, 42);
+        overrides.set_activation_timestamp(BaseUpgrade::Cobalt, 84);
 
         upgrades.apply_activation_overrides(&overrides);
 

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -397,11 +397,7 @@ impl RuntimeUpgradeRegistry {
     }
 
     /// Sets one runtime activation override for a chain and contract upgrade ID.
-    pub fn set_activation(
-        chain_id: u64,
-        upgrade_id: BaseUpgrade,
-        activation: UpgradeActivation,
-    ) {
+    pub fn set_activation(chain_id: u64, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
         let mut registry = Self::write_registry();
         let overrides = registry.entry(chain_id).or_default();
         overrides.set_activation(upgrade_id, activation)
@@ -542,11 +538,7 @@ impl UpgradeConfig {
     }
 
     /// Applies an upgrade activation override by contract upgrade ID.
-    pub const fn set_activation(
-        &mut self,
-        upgrade_id: BaseUpgrade,
-        activation: UpgradeActivation,
-    ) {
+    pub const fn set_activation(&mut self, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
         match activation {
             UpgradeActivation::Never => self.clear_activation_timestamp(upgrade_id),
             UpgradeActivation::Timestamp(timestamp) => {

--- a/crates/common/genesis/src/lib.rs
+++ b/crates/common/genesis/src/lib.rs
@@ -29,8 +29,8 @@ pub use system::{
 
 mod chain;
 pub use chain::{
-    AddressList, BaseUpgradeConfig, ContractUpgrade, Roles, RuntimeUpgradeRegistry,
-    UpgradeActivation, UpgradeActivationOverrides, UpgradeActivationSink, UpgradeConfig,
+    AddressList, BaseUpgrade, BaseUpgradeConfig, Roles, RuntimeUpgradeRegistry, UpgradeActivation,
+    UpgradeActivationOverrides, UpgradeActivationSink, UpgradeConfig,
 };
 
 mod genesis;

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -197,10 +197,7 @@ impl RollupConfig {
     }
 
     /// Returns this rollup config's runtime-aware activation timestamp for a contract upgrade ID.
-    pub fn contract_upgrade_activation_timestamp(
-        &self,
-        upgrade_id: BaseUpgrade,
-    ) -> Option<u64> {
+    pub fn contract_upgrade_activation_timestamp(&self, upgrade_id: BaseUpgrade) -> Option<u64> {
         self.contract_upgrade_activation(upgrade_id).timestamp()
     }
 
@@ -896,20 +893,9 @@ mod tests {
 
         assert!(cfg.is_canyon_active(10));
 
-        crate::RuntimeUpgradeRegistry::clear_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Canyon,
-        );
-        crate::RuntimeUpgradeRegistry::set_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Azul,
-            42,
-        );
-        crate::RuntimeUpgradeRegistry::set_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Cobalt,
-            84,
-        );
+        crate::RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Canyon);
+        crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
+        crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
 
         assert!(!cfg.is_canyon_active(10));
         assert!(cfg.is_base_azul_active(42));

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -5,7 +5,7 @@ use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
 
 use crate::{
-    ChainGenesis, ContractUpgrade, FeeConfig, RuntimeUpgradeRegistry, UpgradeActivation,
+    BaseUpgrade, ChainGenesis, FeeConfig, RuntimeUpgradeRegistry, UpgradeActivation,
     UpgradeActivationSink, UpgradeConfig,
 };
 
@@ -132,32 +132,32 @@ impl EthereumHardforks for RollupConfig {
         } else if fork <= EthereumHardfork::Shanghai {
             // Canyon activates Shanghai; cascade through later Base upgrades if unset.
             cascade(&[
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Canyon),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Ecotone),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Fjord),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Granite),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Holocene),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Isthmus),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Jovian),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Canyon),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Ecotone),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Fjord),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Granite),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Holocene),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Jovian),
             ])
         } else if fork <= EthereumHardfork::Cancun {
             // Ecotone activates Cancun; cascade through later Base upgrades if unset.
             cascade(&[
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Ecotone),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Fjord),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Granite),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Holocene),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Isthmus),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Jovian),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Ecotone),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Fjord),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Granite),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Holocene),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Jovian),
             ])
         } else if fork <= EthereumHardfork::Prague {
             // Isthmus activates Prague; cascade through later Base upgrades if unset.
             cascade(&[
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Isthmus),
-                self.contract_upgrade_activation_timestamp(ContractUpgrade::Jovian),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus),
+                self.contract_upgrade_activation_timestamp(BaseUpgrade::Jovian),
             ])
         } else if fork <= EthereumHardfork::Osaka {
-            self.contract_upgrade_activation_timestamp(ContractUpgrade::Azul)
+            self.contract_upgrade_activation_timestamp(BaseUpgrade::Azul)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never)
         } else {
@@ -191,7 +191,7 @@ macro_rules! rollup_fork_methods {
 
 impl RollupConfig {
     /// Returns this rollup config's runtime-aware activation for a contract upgrade ID.
-    pub fn contract_upgrade_activation(&self, upgrade_id: ContractUpgrade) -> UpgradeActivation {
+    pub fn contract_upgrade_activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
         RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
             .unwrap_or_else(|| self.upgrades.activation(upgrade_id))
     }
@@ -199,7 +199,7 @@ impl RollupConfig {
     /// Returns this rollup config's runtime-aware activation timestamp for a contract upgrade ID.
     pub fn contract_upgrade_activation_timestamp(
         &self,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
     ) -> Option<u64> {
         self.contract_upgrade_activation(upgrade_id).timestamp()
     }
@@ -224,14 +224,14 @@ impl RollupConfig {
     }
 
     /// Clears a timestamp-based upgrade activation time by contract upgrade ID.
-    pub const fn clear_upgrade_activation_timestamp(&mut self, upgrade_id: ContractUpgrade) {
+    pub const fn clear_upgrade_activation_timestamp(&mut self, upgrade_id: BaseUpgrade) {
         self.upgrades.clear_activation_timestamp(upgrade_id)
     }
 
     /// Sets a timestamp-based upgrade activation time by contract upgrade ID.
     pub const fn set_upgrade_activation_timestamp(
         &mut self,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
         timestamp: u64,
     ) {
         self.upgrades.set_activation_timestamp(upgrade_id, timestamp)
@@ -240,7 +240,7 @@ impl RollupConfig {
     /// Applies an upgrade activation by contract upgrade ID.
     pub const fn apply_upgrade_activation(
         &mut self,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) {
         match activation {
@@ -254,75 +254,75 @@ impl RollupConfig {
     rollup_fork_methods! {
         is_regolith_active,
         is_first_regolith_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Regolith)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Regolith)],
         "Regolith",
         implies is_canyon_active;
 
         is_canyon_active,
         is_first_canyon_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Canyon)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Canyon)],
         "Canyon",
         implies is_delta_active;
 
         is_delta_active,
         is_first_delta_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Delta)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Delta)],
         "Delta",
         implies is_ecotone_active;
 
         is_ecotone_active,
         is_first_ecotone_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Ecotone)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Ecotone)],
         "Ecotone",
         implies is_fjord_active;
 
         is_fjord_active,
         is_first_fjord_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Fjord)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Fjord)],
         "Fjord",
         implies is_granite_active;
 
         is_granite_active,
         is_first_granite_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Granite)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Granite)],
         "Granite",
         implies is_holocene_active;
 
         is_holocene_active,
         is_first_holocene_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Holocene)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Holocene)],
         "Holocene",
         implies is_isthmus_active;
 
         is_pectra_blob_schedule_active,
         is_first_pectra_blob_schedule_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::PectraBlobSchedule)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::PectraBlobSchedule)],
         "pectra blob schedule";
 
         is_isthmus_active,
         is_first_isthmus_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Isthmus)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus)],
         "Isthmus",
         implies is_jovian_active;
 
         is_jovian_active,
         is_first_jovian_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Jovian)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Jovian)],
         "Jovian";
 
         is_base_azul_active,
         is_first_base_azul_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Azul)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Azul)],
         "Base Azul";
 
         is_beryl_active,
         is_first_beryl_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Beryl)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Beryl)],
         "Beryl";
 
         is_cobalt_active,
         is_first_cobalt_block,
-        [contract_upgrade_activation_timestamp(ContractUpgrade::Cobalt)],
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)],
         "Cobalt";
     }
 
@@ -439,7 +439,7 @@ impl UpgradeActivationSink for RollupConfig {
 
     fn apply_activation(
         &mut self,
-        upgrade_id: ContractUpgrade,
+        upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
         self.apply_upgrade_activation(upgrade_id, activation);
@@ -870,7 +870,7 @@ mod tests {
     fn set_upgrade_activation_timestamp_updates_osaka_activation() {
         let mut cfg = RollupConfig::default();
 
-        cfg.set_upgrade_activation_timestamp(ContractUpgrade::Azul, 700);
+        cfg.set_upgrade_activation_timestamp(BaseUpgrade::Azul, 700);
 
         assert_eq!(cfg.upgrades.base.azul, Some(700));
         assert!(cfg.is_base_azul_active(700));
@@ -898,16 +898,16 @@ mod tests {
 
         crate::RuntimeUpgradeRegistry::clear_activation_timestamp(
             chain_id,
-            ContractUpgrade::Canyon,
+            BaseUpgrade::Canyon,
         );
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(
             chain_id,
-            ContractUpgrade::Azul,
+            BaseUpgrade::Azul,
             42,
         );
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(
             chain_id,
-            ContractUpgrade::Cobalt,
+            BaseUpgrade::Cobalt,
             84,
         );
 

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 
 use alloy_evm::precompiles::PrecompilesMap;
 use alloy_primitives::Address;
-use base_common_chains::BaseUpgrade;
+use base_common_chains::{BaseUpgrade, BaseUpgradeExt};
 use revm::{
     context::Cfg,
     context_interface::ContextTr,
@@ -37,9 +37,12 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             BaseUpgrade::Bedrock
             | BaseUpgrade::Regolith
             | BaseUpgrade::Canyon
+            | BaseUpgrade::Delta
             | BaseUpgrade::Ecotone => Precompiles::new(Self::eth_spec(spec.upgrade()).into()),
             BaseUpgrade::Fjord => Self::fjord(),
-            BaseUpgrade::Granite | BaseUpgrade::Holocene => Self::granite(),
+            BaseUpgrade::Granite | BaseUpgrade::Holocene | BaseUpgrade::PectraBlobSchedule => {
+                Self::granite()
+            }
             BaseUpgrade::Isthmus => Self::isthmus(),
             BaseUpgrade::Jovian => Self::jovian(),
             BaseUpgrade::Azul => Self::azul(),
@@ -71,7 +74,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     }
 
     /// Converts a Base upgrade into its Ethereum precompile spec.
-    pub const fn eth_spec(upgrade: BaseUpgrade) -> SpecId {
+    pub fn eth_spec(upgrade: BaseUpgrade) -> SpecId {
         upgrade.into_eth_spec()
     }
 

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -6,7 +6,7 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
 use alloy_primitives::{Address, B256, U256};
-use base_common_chains::{BaseUpgrade, ChainConfig, ContractUpgrade, Upgrades};
+use base_common_chains::{BaseUpgrade, BaseUpgradeExt, ChainConfig, Upgrades};
 use base_common_consensus::Predeploys;
 use base_common_genesis::{RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationSink};
 use derive_more::{Constructor, Deref, Into};
@@ -292,7 +292,7 @@ impl BaseChainSpec {
 
     /// Returns a runtime upgrade override for an execution fork condition.
     pub fn runtime_fork_condition<H: Hardfork + ?Sized>(&self, fork: &H) -> Option<ForkCondition> {
-        let upgrade_id = ContractUpgrade::from_fork_name(fork.name())?;
+        let upgrade_id = BaseUpgrade::from_contract_fork_name(fork.name())?;
         RuntimeUpgradeRegistry::activation(self.chain().id(), upgrade_id).map(|activation| {
             match activation {
                 UpgradeActivation::Never => ForkCondition::Never,
@@ -362,7 +362,7 @@ impl BaseChainSpec {
 
     /// Clears all timestamp-based Base hardfork activation conditions.
     pub fn clear_hardfork_activation_timestamps(&mut self) {
-        for hardfork_id in ContractUpgrade::ALL {
+        for hardfork_id in BaseUpgrade::CONTRACT_VARIANTS {
             Self::set_hardfork_activation_condition_for(
                 &mut self.inner.hardforks,
                 hardfork_id,
@@ -372,14 +372,14 @@ impl BaseChainSpec {
     }
 
     /// Clears a timestamp-based hardfork activation condition by contract hardfork ID.
-    pub fn clear_hardfork_activation_timestamp(&mut self, hardfork_id: ContractUpgrade) -> bool {
+    pub fn clear_hardfork_activation_timestamp(&mut self, hardfork_id: BaseUpgrade) -> bool {
         self.try_clear_hardfork_activation_timestamp(hardfork_id).unwrap_or(false)
     }
 
     /// Clears a timestamp-based hardfork activation condition by contract hardfork ID.
     pub fn try_clear_hardfork_activation_timestamp(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
     ) -> Result<bool, BaseChainSpecError> {
         self.try_set_hardfork_activation_condition(hardfork_id, ForkCondition::Never)
     }
@@ -387,7 +387,7 @@ impl BaseChainSpec {
     /// Sets a timestamp-based hardfork activation condition by contract hardfork ID.
     pub fn set_hardfork_activation_timestamp(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         timestamp: u64,
     ) -> bool {
         self.try_set_hardfork_activation_timestamp(hardfork_id, timestamp).unwrap_or(false)
@@ -396,7 +396,7 @@ impl BaseChainSpec {
     /// Sets a timestamp-based hardfork activation condition by contract hardfork ID.
     pub fn try_set_hardfork_activation_timestamp(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         timestamp: u64,
     ) -> Result<bool, BaseChainSpecError> {
         self.try_set_hardfork_activation_condition(hardfork_id, ForkCondition::Timestamp(timestamp))
@@ -405,7 +405,7 @@ impl BaseChainSpec {
     /// Sets a hardfork activation condition by contract hardfork ID.
     pub fn set_hardfork_activation_condition(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         condition: ForkCondition,
     ) -> bool {
         self.try_set_hardfork_activation_condition(hardfork_id, condition).unwrap_or(false)
@@ -414,7 +414,7 @@ impl BaseChainSpec {
     /// Sets a hardfork activation condition by contract hardfork ID after validating invariants.
     pub fn try_set_hardfork_activation_condition(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         condition: ForkCondition,
     ) -> Result<bool, BaseChainSpecError> {
         let mut hardforks = self.inner.hardforks.clone();
@@ -435,7 +435,7 @@ impl BaseChainSpec {
     /// Sets a hardfork activation condition by contract hardfork ID on a hardfork collection.
     pub fn set_hardfork_activation_condition_for(
         hardforks: &mut ChainHardforks,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         condition: ForkCondition,
     ) -> bool {
         let mut inserted = false;
@@ -444,8 +444,10 @@ impl BaseChainSpec {
             hardforks.insert(execution_hardfork, condition);
             inserted = true;
         }
-        if let Some(base_upgrade) = BaseUpgrade::from_contract_upgrade(hardfork_id) {
-            hardforks.insert(base_upgrade, condition);
+        // Only execution-ladder upgrades enter the reth hardfork schedule; contract-only
+        // upgrades (Delta, PectraBlobSchedule) are ignored here.
+        if hardfork_id.is_execution() {
+            hardforks.insert(hardfork_id, condition);
             inserted = true;
         }
 
@@ -458,7 +460,7 @@ impl UpgradeActivationSink for BaseChainSpec {
 
     fn apply_activation(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
         match activation {
@@ -660,7 +662,7 @@ mod tests {
     use alloy_genesis::{ChainConfig as AlloyChainConfig, Genesis};
     use alloy_hardforks::Hardfork;
     use alloy_primitives::{Address, B256, U256, address, b256};
-    use base_common_chains::{BaseUpgrade, ChainConfig, ContractUpgrade, Upgrades};
+    use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
     use base_common_genesis::RuntimeUpgradeRegistry;
     use base_common_rpc_types::FeeInfo;
     use reth_chainspec::{
@@ -859,15 +861,15 @@ mod tests {
         assert_eq!(spec.fork(BaseUpgrade::Azul), ForkCondition::Never);
         assert_eq!(spec.fork(BaseUpgrade::Cobalt), ForkCondition::Never);
 
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Azul, 42);
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Cobalt, 84);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
 
         assert_eq!(spec.fork(EthereumHardfork::Osaka), ForkCondition::Timestamp(42));
         assert_eq!(spec.fork(BaseUpgrade::Azul), ForkCondition::Timestamp(42));
         assert_eq!(spec.fork(BaseUpgrade::Cobalt), ForkCondition::Timestamp(84));
 
-        RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, ContractUpgrade::Azul);
-        RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, ContractUpgrade::Cobalt);
+        RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Azul);
+        RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Cobalt);
 
         assert_eq!(spec.fork(EthereumHardfork::Osaka), ForkCondition::Never);
         assert_eq!(spec.fork(BaseUpgrade::Azul), ForkCondition::Never);
@@ -888,8 +890,8 @@ mod tests {
             .with_fork(BaseUpgrade::Cobalt, ForkCondition::Never)
             .build();
 
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Azul, 42);
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Cobalt, 84);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
 
         assert_eq!(spec.fork_id(&Head { number: 0, timestamp: 41, ..Default::default() }).next, 42);
         assert_eq!(spec.fork(BaseUpgrade::Cobalt), ForkCondition::Timestamp(84));
@@ -910,7 +912,7 @@ mod tests {
         assert_eq!(spec.fork(BaseUpgrade::Regolith), ForkCondition::Never);
         assert!(!spec.is_regolith_active_at_timestamp(42));
 
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Regolith, 42);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Regolith, 42);
 
         assert_eq!(spec.fork(BaseUpgrade::Regolith), ForkCondition::Timestamp(42));
         assert!(!spec.is_regolith_active_at_timestamp(41));
@@ -934,12 +936,12 @@ mod tests {
 
         RuntimeUpgradeRegistry::set_activation_timestamp(
             chain_id,
-            ContractUpgrade::Canyon,
+            BaseUpgrade::Canyon,
             timestamp,
         );
         RuntimeUpgradeRegistry::set_activation_timestamp(
             chain_id,
-            ContractUpgrade::Ecotone,
+            BaseUpgrade::Ecotone,
             timestamp,
         );
 
@@ -1253,8 +1255,8 @@ mod tests {
         chain_spec.set_fork(EthereumHardfork::Osaka, ForkCondition::Never);
         chain_spec.set_fork(BaseUpgrade::Azul, ForkCondition::Never);
         chain_spec.set_fork(BaseUpgrade::Cobalt, ForkCondition::Never);
-        assert!(chain_spec.set_hardfork_activation_timestamp(ContractUpgrade::Azul, 42));
-        assert!(chain_spec.set_hardfork_activation_timestamp(ContractUpgrade::Cobalt, 84));
+        assert!(chain_spec.set_hardfork_activation_timestamp(BaseUpgrade::Azul, 42));
+        assert!(chain_spec.set_hardfork_activation_timestamp(BaseUpgrade::Cobalt, 84));
 
         assert_eq!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Timestamp(42));
         assert_eq!(chain_spec.fork(BaseUpgrade::Azul), ForkCondition::Timestamp(42));
@@ -1272,13 +1274,13 @@ mod tests {
         let mut chain_spec = BaseChainSpec::devnet();
         let ecotone = chain_spec.fork(BaseUpgrade::Ecotone);
 
-        assert!(!chain_spec.set_hardfork_activation_timestamp(ContractUpgrade::Delta, 42));
+        assert!(!chain_spec.set_hardfork_activation_timestamp(BaseUpgrade::Delta, 42));
         assert!(
-            !chain_spec.set_hardfork_activation_timestamp(ContractUpgrade::PectraBlobSchedule, 84,)
+            !chain_spec.set_hardfork_activation_timestamp(BaseUpgrade::PectraBlobSchedule, 84,)
         );
-        assert!(!chain_spec.clear_hardfork_activation_timestamp(ContractUpgrade::Delta));
+        assert!(!chain_spec.clear_hardfork_activation_timestamp(BaseUpgrade::Delta));
         assert!(
-            !chain_spec.clear_hardfork_activation_timestamp(ContractUpgrade::PectraBlobSchedule)
+            !chain_spec.clear_hardfork_activation_timestamp(BaseUpgrade::PectraBlobSchedule)
         );
 
         assert_eq!(chain_spec.fork(BaseUpgrade::Ecotone), ecotone);
@@ -1289,11 +1291,11 @@ mod tests {
         let mut chain_spec = BaseChainSpec::from(ChainSpec::default());
 
         let err = chain_spec
-            .try_set_hardfork_activation_timestamp(ContractUpgrade::Beryl, 42)
+            .try_set_hardfork_activation_timestamp(BaseUpgrade::Beryl, 42)
             .expect_err("Beryl schedule without activation admin should be rejected");
 
         assert!(matches!(err, BaseChainSpecError::MissingActivationAdminAddress { .. }));
-        assert!(!chain_spec.set_hardfork_activation_timestamp(ContractUpgrade::Beryl, 42));
+        assert!(!chain_spec.set_hardfork_activation_timestamp(BaseUpgrade::Beryl, 42));
         assert_eq!(chain_spec.fork(BaseUpgrade::Beryl), ForkCondition::Never);
     }
 

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -934,16 +934,8 @@ mod tests {
         let static_blob_params = spec.inner.blob_params_at_timestamp(timestamp);
         let static_next_base_fee = spec.inner.next_block_base_fee(parent, timestamp);
 
-        RuntimeUpgradeRegistry::set_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Canyon,
-            timestamp,
-        );
-        RuntimeUpgradeRegistry::set_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Ecotone,
-            timestamp,
-        );
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Canyon, timestamp);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Ecotone, timestamp);
 
         let runtime_chain_spec = spec.runtime_chain_spec();
 
@@ -1279,9 +1271,7 @@ mod tests {
             !chain_spec.set_hardfork_activation_timestamp(BaseUpgrade::PectraBlobSchedule, 84,)
         );
         assert!(!chain_spec.clear_hardfork_activation_timestamp(BaseUpgrade::Delta));
-        assert!(
-            !chain_spec.clear_hardfork_activation_timestamp(BaseUpgrade::PectraBlobSchedule)
-        );
+        assert!(!chain_spec.clear_hardfork_activation_timestamp(BaseUpgrade::PectraBlobSchedule));
 
         assert_eq!(chain_spec.fork(BaseUpgrade::Ecotone), ecotone);
     }

--- a/crates/execution/chainspec/src/upgrades.rs
+++ b/crates/execution/chainspec/src/upgrades.rs
@@ -88,6 +88,8 @@ impl ChainUpgradesExt for ChainUpgrades {
 
 #[cfg(test)]
 mod tests {
+    use base_common_chains::BaseUpgradeExt;
+
     use super::*;
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/args.rs
+++ b/crates/utilities/upgrade-signal/src/config/args.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, U256};
-use base_common_genesis::ContractUpgrade;
+use base_common_genesis::BaseUpgrade;
 use url::Url;
 
 use super::{
@@ -82,9 +82,9 @@ impl UpgradeSignalArgs {
     /// Returns the configured hardfork IDs, or the default contract-backed hardfork schedule.
     pub fn configured_hardfork_ids(
         hardfork_ids: &[String],
-    ) -> Result<Vec<ContractUpgrade>, UpgradeSignalConfigError> {
+    ) -> Result<Vec<BaseUpgrade>, UpgradeSignalConfigError> {
         if hardfork_ids.is_empty() {
-            return Ok(ContractUpgrade::ALL.to_vec());
+            return Ok(BaseUpgrade::CONTRACT_VARIANTS.to_vec());
         }
 
         let source = hardfork_ids.iter().map(String::as_str).collect::<Vec<_>>();
@@ -94,7 +94,7 @@ impl UpgradeSignalArgs {
             if hardfork_id.is_empty() {
                 return Err(UpgradeSignalConfigError::EmptyHardforkId);
             }
-            let hardfork_id = hardfork_id.parse().map_err(|_| {
+            let hardfork_id = BaseUpgrade::from_contract_fork_name(hardfork_id).ok_or_else(|| {
                 UpgradeSignalConfigError::UnknownHardforkId(hardfork_id.to_string())
             })?;
             if !ids.contains(&hardfork_id) {
@@ -110,9 +110,9 @@ impl UpgradeSignalArgs {
     /// Every apply hardfork ID must also be a read hardfork ID, since only read signals can be
     /// applied. A non-subset apply ID is rejected rather than silently ignored.
     pub fn configured_apply_hardfork_ids(
-        hardfork_ids: &[ContractUpgrade],
+        hardfork_ids: &[BaseUpgrade],
         apply_hardfork_ids: &[String],
-    ) -> Result<Vec<ContractUpgrade>, UpgradeSignalConfigError> {
+    ) -> Result<Vec<BaseUpgrade>, UpgradeSignalConfigError> {
         if apply_hardfork_ids.is_empty() {
             return Ok(hardfork_ids.to_vec());
         }
@@ -121,7 +121,7 @@ impl UpgradeSignalArgs {
         for apply_hardfork_id in &apply_hardfork_ids {
             if !hardfork_ids.contains(apply_hardfork_id) {
                 return Err(UpgradeSignalConfigError::ApplyHardforkIdNotRead(
-                    apply_hardfork_id.to_string(),
+                    apply_hardfork_id.contract_id().to_string(),
                 ));
             }
         }
@@ -146,7 +146,7 @@ pub struct UpgradeSignalL1RpcArgs {
 mod tests {
     use alloy_primitives::address;
     use alloy_rpc_types_eth::BlockNumberOrTag;
-    use base_common_genesis::ContractUpgrade;
+    use base_common_genesis::BaseUpgrade;
 
     use super::*;
 
@@ -166,8 +166,8 @@ mod tests {
 
         let config = args.config().unwrap().unwrap();
 
-        assert_eq!(config.hardfork_ids, ContractUpgrade::ALL.to_vec());
-        assert_eq!(config.apply_hardfork_ids, ContractUpgrade::ALL.to_vec());
+        assert_eq!(config.hardfork_ids, BaseUpgrade::CONTRACT_VARIANTS.to_vec());
+        assert_eq!(config.apply_hardfork_ids, BaseUpgrade::CONTRACT_VARIANTS.to_vec());
         assert_eq!(config.mode, UpgradeSignalMode::MetricsOnly);
     }
 
@@ -206,8 +206,8 @@ mod tests {
         let config = args.config().unwrap().unwrap();
 
         assert_eq!(config.contract_address, contract);
-        assert_eq!(config.hardfork_ids, [ContractUpgrade::Azul]);
-        assert_eq!(config.apply_hardfork_ids, [ContractUpgrade::Azul]);
+        assert_eq!(config.hardfork_ids, [BaseUpgrade::Azul]);
+        assert_eq!(config.apply_hardfork_ids, [BaseUpgrade::Azul]);
         assert_eq!(config.mode, UpgradeSignalMode::StartupApply);
         assert_eq!(
             config.node_protocol_version,
@@ -227,8 +227,8 @@ mod tests {
 
         let config = args.config().unwrap().unwrap();
 
-        assert_eq!(config.hardfork_ids, [ContractUpgrade::Azul, ContractUpgrade::Beryl]);
-        assert_eq!(config.apply_hardfork_ids, [ContractUpgrade::Beryl]);
+        assert_eq!(config.hardfork_ids, [BaseUpgrade::Azul, BaseUpgrade::Beryl]);
+        assert_eq!(config.apply_hardfork_ids, [BaseUpgrade::Beryl]);
         assert_eq!(config.mode, UpgradeSignalMode::RuntimeAdmin);
     }
 

--- a/crates/utilities/upgrade-signal/src/config/args.rs
+++ b/crates/utilities/upgrade-signal/src/config/args.rs
@@ -94,9 +94,10 @@ impl UpgradeSignalArgs {
             if hardfork_id.is_empty() {
                 return Err(UpgradeSignalConfigError::EmptyHardforkId);
             }
-            let hardfork_id = BaseUpgrade::from_contract_fork_name(hardfork_id).ok_or_else(|| {
-                UpgradeSignalConfigError::UnknownHardforkId(hardfork_id.to_string())
-            })?;
+            let hardfork_id =
+                BaseUpgrade::from_contract_fork_name(hardfork_id).ok_or_else(|| {
+                    UpgradeSignalConfigError::UnknownHardforkId(hardfork_id.to_string())
+                })?;
             if !ids.contains(&hardfork_id) {
                 ids.push(hardfork_id);
             }

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::BlockNumberOrTag;
-use base_common_genesis::ContractUpgrade;
+use base_common_genesis::BaseUpgrade;
 use tracing::info;
 
 use super::{UpgradeSignalDefaults, UpgradeSignalMode};
@@ -17,9 +17,9 @@ pub struct UpgradeSignalConfig {
     /// L1 upgrade signal contract or proxy address.
     pub contract_address: Address,
     /// Contract-backed upgrades to pass to the contract.
-    pub hardfork_ids: Vec<ContractUpgrade>,
+    pub hardfork_ids: Vec<BaseUpgrade>,
     /// Contract-backed upgrades allowed to mutate local fork schedules.
-    pub apply_hardfork_ids: Vec<ContractUpgrade>,
+    pub apply_hardfork_ids: Vec<BaseUpgrade>,
     /// Local schedule mutation mode.
     pub mode: UpgradeSignalMode,
     /// L1 block tag used to read the contract.
@@ -30,7 +30,7 @@ pub struct UpgradeSignalConfig {
 
 impl UpgradeSignalConfig {
     /// Creates a new schedule read configuration for one contract-backed upgrade.
-    pub fn new(contract_address: Address, hardfork_id: ContractUpgrade) -> Self {
+    pub fn new(contract_address: Address, hardfork_id: BaseUpgrade) -> Self {
         Self {
             contract_address,
             hardfork_ids: vec![hardfork_id],
@@ -62,7 +62,7 @@ impl UpgradeSignalConfig {
     ) -> Result<(), UpgradeSignalError> {
         if signal.activation_timestamp > 0 && signal.protocol_version == U256::ZERO {
             return Err(UpgradeSignalError::missing_protocol_version(
-                signal.hardfork_id.to_string(),
+                signal.hardfork_id.contract_id().to_string(),
             ));
         }
 
@@ -86,7 +86,7 @@ impl UpgradeSignalConfig {
         }
 
         Err(UpgradeSignalError::unsupported_protocol_version(
-            signal.hardfork_id.to_string(),
+            signal.hardfork_id.contract_id().to_string(),
             signal.protocol_version,
             self.node_protocol_version,
         ))
@@ -149,7 +149,7 @@ impl UpgradeSignalConfig {
             info!(
                 target: "upgrade_signal",
                 context = log_context,
-                hardfork_id = %signal.hardfork_id,
+                hardfork_id = %signal.hardfork_id.contract_id(),
                 activation_timestamp = signal.activation_timestamp,
                 minimum_protocol_version = %signal.protocol_version,
                 node_protocol_version = %self.node_protocol_version,
@@ -175,8 +175,8 @@ mod tests {
     use super::*;
     use crate::state::{UpgradeSignal, UpgradeSignalSchedule};
 
-    fn upgrade(hardfork_id: &str) -> ContractUpgrade {
-        hardfork_id.parse().unwrap()
+    fn upgrade(hardfork_id: &str) -> BaseUpgrade {
+        BaseUpgrade::from_contract_fork_name(hardfork_id).unwrap()
     }
 
     #[rstest]
@@ -193,7 +193,7 @@ mod tests {
 
     fn signal(protocol_version: U256) -> UpgradeSignal {
         UpgradeSignal {
-            hardfork_id: ContractUpgrade::Azul,
+            hardfork_id: BaseUpgrade::Azul,
             activation_timestamp: 42,
             protocol_version,
             l1_block_number: 1,
@@ -249,7 +249,7 @@ mod tests {
         UpgradeSignalSchedule::new(vec![
             signal(config.node_protocol_version),
             UpgradeSignal {
-                hardfork_id: ContractUpgrade::Beryl,
+                hardfork_id: BaseUpgrade::Beryl,
                 activation_timestamp: 5,
                 protocol_version: U256::ZERO,
                 l1_block_number: 1,
@@ -261,7 +261,7 @@ mod tests {
     fn read_validation_rejects_missing_protocol_version_on_read_only_fork() {
         let config = UpgradeSignalConfig::new(
             address!("0000000000000000000000000000000000000001"),
-            ContractUpgrade::Azul,
+            BaseUpgrade::Azul,
         );
         let schedule = malformed_read_only_schedule(&config);
 
@@ -275,18 +275,18 @@ mod tests {
     fn applied_validation_allows_unsupported_version_on_read_only_fork() {
         let config = UpgradeSignalConfig::new(
             address!("0000000000000000000000000000000000000001"),
-            ContractUpgrade::Azul,
+            BaseUpgrade::Azul,
         );
 
         let schedule = UpgradeSignalSchedule::new(vec![
             UpgradeSignal {
-                hardfork_id: ContractUpgrade::Azul,
+                hardfork_id: BaseUpgrade::Azul,
                 activation_timestamp: 42,
                 protocol_version: config.node_protocol_version,
                 l1_block_number: 1,
             },
             UpgradeSignal {
-                hardfork_id: ContractUpgrade::Beryl,
+                hardfork_id: BaseUpgrade::Beryl,
                 activation_timestamp: 42,
                 protocol_version: config.node_protocol_version + U256::from(1),
                 l1_block_number: 1,

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -107,12 +107,16 @@ impl AlloyUpgradeSignalReader {
     ) -> Result<UpgradeSignal, UpgradeSignalError> {
         let (timestamp_output, version_output) = try_join(
             self.call_at_block(
-                IUpgradeSignal::getTimestampCall { hardforkId: hardfork_id.contract_id().to_string() },
+                IUpgradeSignal::getTimestampCall {
+                    hardforkId: hardfork_id.contract_id().to_string(),
+                },
                 l1_block,
                 "getTimestamp failed",
             ),
             self.call_at_block(
-                IUpgradeSignal::getProtocolVersionCall { hardforkId: hardfork_id.contract_id().to_string() },
+                IUpgradeSignal::getProtocolVersionCall {
+                    hardforkId: hardfork_id.contract_id().to_string(),
+                },
                 l1_block,
                 "getProtocolVersion failed",
             ),

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, TransactionInput, TransactionRequest};
 use alloy_sol_types::{SolCall, sol};
-use base_common_genesis::ContractUpgrade;
+use base_common_genesis::BaseUpgrade;
 use futures::future::{join_all, try_join};
 use tokio::time::sleep;
 use tracing::warn;
@@ -101,18 +101,18 @@ impl AlloyUpgradeSignalReader {
     /// Reads one hardfork signal using a previously observed L1 block ID.
     pub async fn read_signal_at_l1_block(
         &self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         l1_block_number: u64,
         l1_block: BlockId,
     ) -> Result<UpgradeSignal, UpgradeSignalError> {
         let (timestamp_output, version_output) = try_join(
             self.call_at_block(
-                IUpgradeSignal::getTimestampCall { hardforkId: hardfork_id.to_string() },
+                IUpgradeSignal::getTimestampCall { hardforkId: hardfork_id.contract_id().to_string() },
                 l1_block,
                 "getTimestamp failed",
             ),
             self.call_at_block(
-                IUpgradeSignal::getProtocolVersionCall { hardforkId: hardfork_id.to_string() },
+                IUpgradeSignal::getProtocolVersionCall { hardforkId: hardfork_id.contract_id().to_string() },
                 l1_block,
                 "getProtocolVersion failed",
             ),
@@ -135,7 +135,7 @@ impl AlloyUpgradeSignalReader {
     /// Reads the upgrade signal for `hardfork_id`.
     pub async fn read_signal(
         &self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
     ) -> Result<UpgradeSignal, UpgradeSignalError> {
         let (l1_block_number, l1_block) = self.pinned_l1_block_id().await?;
         self.read_signal_at_l1_block(hardfork_id, l1_block_number, l1_block).await
@@ -147,7 +147,7 @@ impl AlloyUpgradeSignalReader {
     /// only the failing hardfork ID if a per-hardfork contract call fails.
     pub async fn read_schedule(
         &self,
-        hardfork_ids: &[ContractUpgrade],
+        hardfork_ids: &[BaseUpgrade],
     ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
         let (l1_block_number, l1_block) = match self.pinned_l1_block_id().await {
             Ok(block) => block,
@@ -192,7 +192,7 @@ impl AlloyUpgradeSignalReader {
     /// outright; after `max_attempts` failures the last error is returned (fail-fast).
     pub async fn read_schedule_with_retries(
         &self,
-        hardfork_ids: &[ContractUpgrade],
+        hardfork_ids: &[BaseUpgrade],
         max_attempts: u32,
         backoff: Duration,
     ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
@@ -224,7 +224,7 @@ impl AlloyUpgradeSignalReader {
     /// schedule (or the node) because a single fork read failed.
     pub async fn read_schedule_tolerant(
         &self,
-        hardfork_ids: &[ContractUpgrade],
+        hardfork_ids: &[BaseUpgrade],
     ) -> UpgradeSignalSchedule {
         let (l1_block_number, l1_block) = match self.pinned_l1_block_id().await {
             Ok(block) => block,
@@ -254,7 +254,7 @@ impl AlloyUpgradeSignalReader {
                     UpgradeSignalMetrics::record_l1_read_error(hardfork_id);
                     warn!(
                         target: "upgrade_signal",
-                        hardfork_id = %hardfork_id,
+                        hardfork_id = %hardfork_id.contract_id(),
                         error = %error,
                         "failed to read live L1 upgrade signal for hardfork"
                     );

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Metrics for upgrade signal schedule reads.
 
 use alloy_primitives::U256;
-use base_common_genesis::ContractUpgrade;
+use base_common_genesis::BaseUpgrade;
 
 use crate::{UpgradeSignal, UpgradeSignalSchedule};
 
@@ -36,7 +36,7 @@ impl UpgradeSignalMetrics {
     /// Records all metrics derived from a successfully read signal.
     pub fn record_signal(signal: &UpgradeSignal) {
         Self::init();
-        let hardfork_id = signal.hardfork_id.to_string();
+        let hardfork_id = signal.hardfork_id.contract_id().to_string();
 
         Self::activation_timestamp(hardfork_id.clone()).set(signal.activation_timestamp as f64);
         Self::expected_protocol_version(hardfork_id.clone())
@@ -45,23 +45,23 @@ impl UpgradeSignalMetrics {
     }
 
     /// Records a failed L1 read for one hardfork ID.
-    pub fn record_l1_read_error(hardfork_id: ContractUpgrade) {
+    pub fn record_l1_read_error(hardfork_id: BaseUpgrade) {
         Self::init();
-        Self::l1_read_errors_total(hardfork_id.to_string()).increment(1);
+        Self::l1_read_errors_total(hardfork_id.contract_id().to_string()).increment(1);
     }
 
     /// Records failed L1 reads for all configured hardfork IDs.
-    pub fn record_l1_read_errors(hardfork_ids: &[ContractUpgrade]) {
+    pub fn record_l1_read_errors(hardfork_ids: &[BaseUpgrade]) {
         Self::init();
         for hardfork_id in hardfork_ids {
-            Self::l1_read_errors_total(hardfork_id.to_string()).increment(1);
+            Self::l1_read_errors_total(hardfork_id.contract_id().to_string()).increment(1);
         }
     }
 
     /// Records a live L1 signal value update for one hardfork ID.
-    pub fn record_signal_update(hardfork_id: ContractUpgrade) {
+    pub fn record_signal_update(hardfork_id: BaseUpgrade) {
         Self::init();
-        Self::signal_updates_total(hardfork_id.to_string()).increment(1);
+        Self::signal_updates_total(hardfork_id.contract_id().to_string()).increment(1);
     }
 
     /// Converts a protocol version to a metric gauge value.

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -1,5 +1,5 @@
 use base_common_genesis::{
-    ContractUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationOverrides,
+    BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationOverrides,
     UpgradeActivationSink,
 };
 
@@ -27,7 +27,7 @@ impl UpgradeActivationSink for RuntimeRegistrySink {
 
     fn apply_activation(
         &mut self,
-        hardfork_id: ContractUpgrade,
+        hardfork_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
         self.updates.set_activation(hardfork_id, activation);
@@ -85,7 +85,7 @@ impl UpgradeSignalRuntimeApplier {
             }
 
             summary.changes.push(UpgradeSignalApplyChange {
-                hardfork_id: signal.hardfork_id.to_string(),
+                hardfork_id: signal.hardfork_id.contract_id().to_string(),
                 action,
                 activation_timestamp: signal.activation_timestamp,
                 minimum_protocol_version: signal.protocol_version.to_string(),
@@ -114,13 +114,13 @@ impl UpgradeSignalRuntimeApplier {
 mod tests {
     use alloy_primitives::U256;
     use base_common_genesis::{
-        ContractUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationSink,
+        BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationSink,
     };
 
     use super::{RuntimeRegistrySink, UpgradeSignalRuntimeApplier};
     use crate::{UpgradeSignal, UpgradeSignalSchedule};
 
-    fn schedule(signals: &[(ContractUpgrade, u64)]) -> UpgradeSignalSchedule {
+    fn schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
             signals
                 .iter()
@@ -142,9 +142,9 @@ mod tests {
         let summary = UpgradeSignalRuntimeApplier::apply_schedule(
             chain_id,
             &schedule(&[
-                (ContractUpgrade::Azul, 42),
-                (ContractUpgrade::Beryl, 0),
-                (ContractUpgrade::Cobalt, 10),
+                (BaseUpgrade::Azul, 42),
+                (BaseUpgrade::Beryl, 0),
+                (BaseUpgrade::Cobalt, 10),
             ]),
         );
 
@@ -152,15 +152,15 @@ mod tests {
         assert_eq!(summary.cleared_hardforks, 1);
         assert_eq!(summary.ignored_hardforks, 0);
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Azul),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Beryl),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
             Some(UpgradeActivation::Never)
         );
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Cobalt),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Cobalt),
             Some(UpgradeActivation::Timestamp(10))
         );
 
@@ -169,8 +169,8 @@ mod tests {
 
     #[derive(Debug, Clone, Default, Eq, PartialEq)]
     struct RecordingSink {
-        applied: Vec<(ContractUpgrade, UpgradeActivation)>,
-        fail_on_hardfork_id: Option<ContractUpgrade>,
+        applied: Vec<(BaseUpgrade, UpgradeActivation)>,
+        fail_on_hardfork_id: Option<BaseUpgrade>,
     }
 
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -181,7 +181,7 @@ mod tests {
 
         fn apply_activation(
             &mut self,
-            hardfork_id: ContractUpgrade,
+            hardfork_id: BaseUpgrade,
             activation: UpgradeActivation,
         ) -> Result<bool, Self::Error> {
             if self.fail_on_hardfork_id == Some(hardfork_id) {
@@ -196,13 +196,13 @@ mod tests {
     #[test]
     fn apply_schedule_to_sink_is_transactional() {
         let mut sink = RecordingSink {
-            applied: vec![(ContractUpgrade::Regolith, UpgradeActivation::Timestamp(1))],
-            fail_on_hardfork_id: Some(ContractUpgrade::Beryl),
+            applied: vec![(BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1))],
+            fail_on_hardfork_id: Some(BaseUpgrade::Beryl),
         };
 
         let error = UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
             9_000_007,
-            &schedule(&[(ContractUpgrade::Azul, 42), (ContractUpgrade::Beryl, 84)]),
+            &schedule(&[(BaseUpgrade::Azul, 42), (BaseUpgrade::Beryl, 84)]),
             &mut sink,
         )
         .unwrap_err();
@@ -210,7 +210,7 @@ mod tests {
         assert_eq!(error, RecordingSinkError);
         assert_eq!(
             sink.applied,
-            vec![(ContractUpgrade::Regolith, UpgradeActivation::Timestamp(1))]
+            vec![(BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1))]
         );
     }
 
@@ -220,14 +220,14 @@ mod tests {
         RuntimeUpgradeRegistry::clear_chain(chain_id);
         let mut sink = RuntimeRegistrySink::new(chain_id);
 
-        sink.apply_activation(ContractUpgrade::Azul, UpgradeActivation::Timestamp(42)).unwrap();
+        sink.apply_activation(BaseUpgrade::Azul, UpgradeActivation::Timestamp(42)).unwrap();
 
-        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Azul), None);
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
 
         sink.finalize().unwrap();
 
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Azul),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
 
@@ -238,17 +238,17 @@ mod tests {
     fn runtime_registry_sink_replaces_existing_overrides() {
         let chain_id = 9_000_009;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, ContractUpgrade::Cobalt, 84);
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
 
         let mut sink = RuntimeRegistrySink::new(chain_id);
-        sink.apply_activation(ContractUpgrade::Azul, UpgradeActivation::Timestamp(42)).unwrap();
+        sink.apply_activation(BaseUpgrade::Azul, UpgradeActivation::Timestamp(42)).unwrap();
         sink.finalize().unwrap();
 
         assert_eq!(
-            RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Azul),
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
-        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, ContractUpgrade::Cobalt), None);
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Cobalt), None);
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
     }

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -208,10 +208,7 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, RecordingSinkError);
-        assert_eq!(
-            sink.applied,
-            vec![(BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1))]
-        );
+        assert_eq!(sink.applied, vec![(BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1))]);
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use alloy_primitives::U256;
-use base_common_genesis::ContractUpgrade;
+use base_common_genesis::BaseUpgrade;
 
 use crate::{AlloyUpgradeSignalReader, UpgradeSignalMetrics};
 
@@ -11,7 +11,7 @@ use crate::{AlloyUpgradeSignalReader, UpgradeSignalMetrics};
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UpgradeSignal {
     /// Contract-backed upgrade passed to the L1 contract.
-    pub hardfork_id: ContractUpgrade,
+    pub hardfork_id: BaseUpgrade,
     /// L2 activation timestamp announced on L1.
     pub activation_timestamp: u64,
     /// Minimum node protocol version announced on L1.
@@ -48,7 +48,7 @@ impl UpgradeSignalSchedule {
     }
 
     /// Returns a copy of this schedule containing only the requested upgrades.
-    pub fn filtered_to_hardfork_ids(&self, hardfork_ids: &[ContractUpgrade]) -> Self {
+    pub fn filtered_to_hardfork_ids(&self, hardfork_ids: &[BaseUpgrade]) -> Self {
         let signals = self
             .signals
             .iter()
@@ -103,12 +103,12 @@ impl UpgradeSignalState {
 #[derive(Debug, Clone)]
 pub struct UpgradeSignalMonitor {
     /// Live metrics state by contract-backed upgrade.
-    pub states: BTreeMap<ContractUpgrade, UpgradeSignalState>,
+    pub states: BTreeMap<BaseUpgrade, UpgradeSignalState>,
 }
 
 impl UpgradeSignalMonitor {
     /// Creates a monitor for the provided hardfork IDs.
-    pub fn new(hardfork_ids: &[ContractUpgrade]) -> Self {
+    pub fn new(hardfork_ids: &[BaseUpgrade]) -> Self {
         UpgradeSignalMetrics::init();
         let mut states = BTreeMap::new();
         for hardfork_id in hardfork_ids {
@@ -124,7 +124,7 @@ impl UpgradeSignalMonitor {
     pub async fn poll(
         &mut self,
         reader: &AlloyUpgradeSignalReader,
-        hardfork_ids: &[ContractUpgrade],
+        hardfork_ids: &[BaseUpgrade],
     ) -> usize {
         let schedule = reader.read_schedule_tolerant(hardfork_ids).await;
         self.update_schedule(schedule)
@@ -163,7 +163,7 @@ mod tests {
 
     fn signal(timestamp: u64) -> UpgradeSignal {
         UpgradeSignal {
-            hardfork_id: ContractUpgrade::Azul,
+            hardfork_id: BaseUpgrade::Azul,
             activation_timestamp: timestamp,
             protocol_version: U256::from(7),
             l1_block_number: 1,
@@ -213,16 +213,16 @@ mod tests {
         let schedule = UpgradeSignalSchedule::new(vec![
             signal(42),
             UpgradeSignal {
-                hardfork_id: ContractUpgrade::Beryl,
+                hardfork_id: BaseUpgrade::Beryl,
                 activation_timestamp: 43,
                 protocol_version: U256::from(7),
                 l1_block_number: 1,
             },
         ]);
 
-        let filtered = schedule.filtered_to_hardfork_ids(&[ContractUpgrade::Azul]);
+        let filtered = schedule.filtered_to_hardfork_ids(&[BaseUpgrade::Azul]);
 
         assert_eq!(filtered.signals.len(), 1);
-        assert_eq!(filtered.signals[0].hardfork_id, ContractUpgrade::Azul);
+        assert_eq!(filtered.signals[0].hardfork_id, BaseUpgrade::Azul);
     }
 }


### PR DESCRIPTION
Unifies the duplicated upgrade enums into a single canonical BaseUpgrade defined in base-common-genesis, removing the parallel ContractUpgrade type that existed only to work around the dependency graph. Everything downstream now depends on the one enum and dispatches through exhaustive typed matches instead of matching upgrades by string.

BaseUpgrade is generated via alloy_hardforks::hardfork! and spans two domains: the execution fork ladder (EXECUTION_VARIANTS) that maps onto the reth/revm hardfork schedule, and the contract-backed upgrade set (CONTRACT_VARIANTS) keyed by the L1 upgrade-signal contract ids and genesis UpgradeConfig timestamps. Bedrock is execution-only, while Delta and PectraBlobSchedule are contract-only and excluded from the execution ladder. snake_case contract ids come from contract_id(), kept separate from the PascalCase hardfork name().

Execution-layer behavior that cannot live in genesis (revm specs, ChainConfig schedules) is added through a BaseUpgradeExt trait in base-common-chains. ChainUpgrades now indexes a fixed-size array by execution_idx() rather than relying on enum discriminant ordering, so adding a future non-execution variant cannot silently shift the ladder.

Validated with tests and clippy across genesis, chains, chainspec, upgrade-signal, evm, and precompiles, plus a check build across dependent consensus, protocol, execution, builder, and cli crates.
