### PR TITLE
feat(batcher): Add Batcher Balance Metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ dependencies = [
  "alloy-rpc-types-eth 2.0.5",
  "alloy-signer-local 2.0.5",
  "async-trait",
+ "base-balance-monitor",
  "base-batcher-admin",
  "base-batcher-core",
  "base-batcher-encoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4101,11 +4101,11 @@ dependencies = [
  "lru 0.16.4",
  "metrics",
  "multihash",
- "openssl",
  "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_repr",
+ "sha2 0.10.9",
  "snap",
  "tempfile",
  "thiserror 2.0.18",
@@ -14009,15 +14009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14025,7 +14016,6 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -292,6 +292,7 @@ impl BatcherArgs {
             l2_ws_url: self.l2_ws_url,
             rollup_rpc_url: self.rollup_rpc_url,
             batcher_private_key: Some(self.private_key),
+            metrics_enabled: self.metrics.enabled,
             poll_interval: Duration::from_secs(self.poll_interval_secs),
             encoder_config,
             max_pending_transactions: self.max_pending_transactions,
@@ -381,6 +382,14 @@ mod tests {
         let config = cli.args.into_config().expect("config should build");
 
         assert_eq!(config.encoder_config.batch_type, base_protocol::BatchType::Single);
+    }
+
+    #[test]
+    fn into_config_sets_metrics_enabled() {
+        let cli = parse_cli(&["--metrics.enabled"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert!(config.metrics_enabled);
     }
 
     #[test]

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -18,9 +18,9 @@ base_metrics::define_metrics! {
     da_bytes_submitted_total: counter,
     #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
     blob_used_bytes_total: counter,
-    #[describe("Batcher signer account balance in ether")]
+    #[describe("Batcher signer account balance in wei")]
     #[no_zero]
-    balance: gauge,
+    account_balance_wei: gauge,
     #[describe("Number of input bytes to a channel")]
     #[label(name = "stage", default = ["added", "closed"])]
     input_bytes: gauge,

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -18,6 +18,9 @@ base_metrics::define_metrics! {
     da_bytes_submitted_total: counter,
     #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
     blob_used_bytes_total: counter,
+    #[describe("Batcher signer account balance in ether")]
+    #[no_zero]
+    balance: gauge,
     #[describe("Number of input bytes to a channel")]
     #[label(name = "stage", default = ["added", "closed"])]
     input_bytes: gauge,

--- a/crates/batcher/service/Cargo.toml
+++ b/crates/batcher/service/Cargo.toml
@@ -20,6 +20,7 @@ async-trait.workspace = true
 base-tx-manager.workspace = true
 base-batcher-core.workspace = true
 base-batcher-admin.workspace = true
+base-balance-monitor.workspace = true
 base-common-network.workspace = true
 alloy-signer-local.workspace = true
 base-batcher-source.workspace = true

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -50,6 +50,10 @@ pub struct BatcherConfig {
     /// Must be `Some` before the batcher is started; a `None` value will cause
     /// startup to fail with a clear error rather than proceeding with a random key.
     pub batcher_private_key: Option<PrivateKeySigner>,
+    /// Whether Prometheus metrics are enabled for this service.
+    ///
+    /// When enabled, the service starts the signer account balance monitor.
+    pub metrics_enabled: bool,
     /// L2 block polling interval.
     pub poll_interval: Duration,
     /// Encoder configuration.
@@ -112,6 +116,7 @@ impl Default for BatcherConfig {
             l2_ws_url: None,
             rollup_rpc_url: vec!["http://localhost:7545".parse().expect("valid default URL")],
             batcher_private_key: None,
+            metrics_enabled: false,
             poll_interval: Duration::from_secs(1),
             encoder_config: EncoderConfig::default(),
             max_pending_transactions: 1,

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -2,14 +2,15 @@
 
 use std::sync::Arc;
 
-use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_provider::{Provider, ProviderBuilder, ProviderLayer, RootProvider};
 use alloy_rpc_types_eth::BlockNumberOrTag;
+use base_balance_monitor::BalanceMonitorLayer;
 use base_batcher_admin::AdminServer;
 use base_batcher_core::{
     AdminHandle, BatchDriver, DaThrottle, NoopThrottleClient, ThrottleClient, ThrottleConfig,
     ThrottleController, ThrottleStrategy,
 };
-use base_batcher_encoder::BatchEncoder;
+use base_batcher_encoder::{BatchEncoder, BatcherMetrics};
 use base_batcher_source::{BlockSubscription, HybridBlockSource, HybridL1HeadSource, SourceError};
 use base_common_consensus::BaseBlock;
 use base_common_network::Base;
@@ -27,6 +28,8 @@ use crate::{
     RecentTxScanner, RpcL1HeadPollingSource, RpcPollingSource, RpcThrottleClient, SafeHeadPoller,
     WsBlockSubscription, WsL1HeadSubscription,
 };
+
+const WEI_PER_ETHER: f64 = 1_000_000_000_000_000_000.0;
 
 /// Service-internal throttle client variant: either a no-op or an RPC client.
 ///
@@ -394,6 +397,13 @@ impl BatcherService {
             eyre::bail!("at least one rollup RPC endpoint is required");
         }
 
+        let batcher_address = self
+            .config
+            .batcher_private_key
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("batcher_private_key must be set before starting"))?
+            .address();
+
         info!(
             l1_rpc_count = self.config.l1_rpc_url.len(),
             l2_rpc_count = self.config.l2_rpc_url.len(),
@@ -503,17 +513,29 @@ impl BatcherService {
             })
             .await?;
 
+        if self.config.metrics_enabled {
+            let (layer, mut balance_rx) = BalanceMonitorLayer::new(
+                batcher_address,
+                runtime.token().clone(),
+                BalanceMonitorLayer::DEFAULT_POLL_INTERVAL,
+            );
+            let _ = layer.layer(l1_provider.clone());
+            tokio::spawn(async move {
+                while balance_rx.changed().await.is_ok() {
+                    let balance_ether = f64::from(*balance_rx.borrow_and_update()) / WEI_PER_ETHER;
+                    BatcherMetrics::balance().set(balance_ether);
+                }
+            });
+            info!(
+                address = %batcher_address,
+                "batcher balance monitor started"
+            );
+        }
+
         // Optionally scan recent L1 blocks to find the highest L2 block already
         // submitted but not yet reflected in the safe head, preventing re-submissions
-        // after an unclean restart. Peek at the batcher address from the private key
-        // (without consuming it) only when the scan is requested.
+        // after an unclean restart.
         let scanned_highest = if self.config.check_recent_txs_depth > 0 {
-            let batcher_address = self
-                .config
-                .batcher_private_key
-                .as_ref()
-                .ok_or_else(|| eyre::eyre!("batcher_private_key must be set before starting"))?
-                .address();
             RecentTxScanner::highest_submitted_l2_block(
                 &l1_provider,
                 batcher_address,

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use alloy_provider::{Provider, ProviderBuilder, ProviderLayer, RootProvider};
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use base_balance_monitor::BalanceMonitorLayer;
 use base_batcher_admin::AdminServer;
@@ -28,8 +28,6 @@ use crate::{
     RecentTxScanner, RpcL1HeadPollingSource, RpcPollingSource, RpcThrottleClient, SafeHeadPoller,
     WsBlockSubscription, WsL1HeadSubscription,
 };
-
-const WEI_PER_ETHER: f64 = 1_000_000_000_000_000_000.0;
 
 /// Service-internal throttle client variant: either a no-op or an RPC client.
 ///
@@ -519,11 +517,14 @@ impl BatcherService {
                 runtime.token().clone(),
                 BalanceMonitorLayer::DEFAULT_POLL_INTERVAL,
             );
-            let _ = layer.layer(l1_provider.clone());
+            let _provider = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .layer(layer)
+                .connect_provider(l1_provider.clone());
             tokio::spawn(async move {
                 while balance_rx.changed().await.is_ok() {
-                    let balance_ether = f64::from(*balance_rx.borrow_and_update()) / WEI_PER_ETHER;
-                    BatcherMetrics::balance().set(balance_ether);
+                    BatcherMetrics::account_balance_wei()
+                        .set(f64::from(*balance_rx.borrow_and_update()));
                 }
             });
             info!(

--- a/crates/consensus/gossip/Cargo.toml
+++ b/crates/consensus/gossip/Cargo.toml
@@ -35,12 +35,12 @@ futures.workspace = true
 libp2p-stream.workspace = true
 ipnet = { workspace = true, features = ["serde"] }
 discv5 = { workspace = true, features = ["libp2p"] }
-openssl = { workspace = true, features = ["vendored"] }
 libp2p-identity = { workspace = true, features = ["secp256k1"] }
 libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "dns", "noise", "gossipsub", "ping", "yamux", "identify"] }
 
 # Misc
 lru.workspace = true
+sha2.workspace = true
 tokio.workspace = true
 serde_repr.workspace = true
 serde = { workspace = true, features = ["std"] }

--- a/crates/consensus/gossip/src/config.rs
+++ b/crates/consensus/gossip/src/config.rs
@@ -6,7 +6,7 @@ use libp2p::{
     connection_limits::ConnectionLimits,
     gossipsub::{Config, ConfigBuilder, Message, MessageId},
 };
-use openssl::sha::Sha256;
+use sha2::{Digest, Sha256};
 use snap::raw::Decoder;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -236,7 +236,7 @@ fn message_id_hash(msg: &Message, domain: &[u8; 4], data: &[u8]) -> Vec<u8> {
     hasher.update(topic);
     hasher.update(data);
 
-    hasher.finish()[..20].to_vec()
+    hasher.finalize()[..20].to_vec()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This adds a batcher balance gauge that mirrors the op-batcher account balance metric. The batcher now starts the existing balance monitor when Prometheus metrics are enabled and records the signer account balance in ether.