### PR TITLE
feat(batcher): Add Channel Byte Metrics

### DIFF
--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -302,6 +302,10 @@ impl BatchEncoder {
         BatcherMetrics::channel_closed_total(close_reason).increment(1);
         BatcherMetrics::channel_duration_blocks().record(duration_blocks as f64);
         BatcherMetrics::l2_blocks_per_channel().record(blocks_added as f64);
+        BatcherMetrics::input_bytes(BatcherMetrics::STAGE_CLOSED).set(input_bytes as f64);
+        BatcherMetrics::output_bytes().set(compressed_bytes as f64);
+        BatcherMetrics::input_bytes_total().increment(input_bytes);
+        BatcherMetrics::output_bytes_total().increment(closed_da_backlog_bytes);
         if input_bytes > 0 {
             let ratio = compressed_bytes as f64 / input_bytes as f64;
             BatcherMetrics::channel_compression_ratio().record(ratio);
@@ -567,6 +571,8 @@ impl BatchPipeline for BatchEncoder {
                     Ok(()) => {
                         open.blocks_added += 1;
                         open.da_backlog_bytes += block_da_backlog_bytes;
+                        BatcherMetrics::input_bytes(BatcherMetrics::STAGE_ADDED)
+                            .set(open.out.input_bytes() as f64);
                         self.block_cursor += 1;
 
                         debug!(

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -18,6 +18,15 @@ base_metrics::define_metrics! {
     da_bytes_submitted_total: counter,
     #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
     blob_used_bytes_total: counter,
+    #[describe("Number of input bytes to a channel")]
+    #[label(name = "stage", default = ["added", "closed"])]
+    input_bytes: gauge,
+    #[describe("Number of compressed output bytes from a channel")]
+    output_bytes: gauge,
+    #[describe("Total number of input bytes to channels")]
+    input_bytes_total: counter,
+    #[describe("Total number of compressed output bytes from channels")]
+    output_bytes_total: counter,
     #[describe("Number of frames currently waiting for L1 submission")]
     pending_frames: gauge,
     #[describe("Number of L2 blocks buffered in the encoder input queue")]
@@ -44,6 +53,12 @@ impl BatcherMetrics {
 
     /// Channel discarded without producing frames because the span batch exceeded limits.
     pub const REASON_DISCARD: &'static str = "discard";
+
+    /// Channel input bytes after blocks have been added.
+    pub const STAGE_ADDED: &'static str = "added";
+
+    /// Channel input bytes after the channel has been closed.
+    pub const STAGE_CLOSED: &'static str = "closed";
 
     /// Submission accepted and handed to the tx manager.
     pub const OUTCOME_SUBMITTED: &'static str = "submitted";


### PR DESCRIPTION
## Summary

This adds batcher channel input and output byte metrics that mirror the op-batcher channel byte counters and gauges. The encoder now records channel-close input bytes, compressed output bytes, and cumulative totals so dashboards can compare Base batcher throughput against op-batcher output.