### PR TITLE
feat(batcher): Add Channel Frame Metric

### DIFF
--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -306,6 +306,7 @@ impl BatchEncoder {
         BatcherMetrics::output_bytes().set(compressed_bytes as f64);
         BatcherMetrics::input_bytes_total().increment(input_bytes);
         BatcherMetrics::output_bytes_total().increment(closed_da_backlog_bytes);
+        BatcherMetrics::channel_num_frames().set(frame_count as f64);
         if input_bytes > 0 {
             let ratio = compressed_bytes as f64 / input_bytes as f64;
             BatcherMetrics::channel_compression_ratio().record(ratio);

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -27,6 +27,8 @@ base_metrics::define_metrics! {
     input_bytes_total: counter,
     #[describe("Total number of compressed output bytes from channels")]
     output_bytes_total: counter,
+    #[describe("Total number of frames in the closed channel")]
+    channel_num_frames: gauge,
     #[describe("Number of frames currently waiting for L1 submission")]
     pending_frames: gauge,
     #[describe("Number of L2 blocks buffered in the encoder input queue")]


### PR DESCRIPTION
## Summary

This adds a batcher channel frame-count gauge that mirrors the op-batcher channel_num_frames metric. The encoder now records the number of frames in each closed channel so dashboards can compare channel shape between the Base batcher and op-batcher.