### PR TITLE
Backport PR #3603 to releases/v1.1.0

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1,7 +1,10 @@
 use core::time::Duration;
 use std::{
     ops::{Div, Rem},
-    sync::{Arc, Mutex},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Instant,
 };
 
@@ -72,6 +75,26 @@ type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
     >,
 >;
 
+#[derive(Debug, Default)]
+struct LastEmittedFlashblockId {
+    block_number: AtomicU64,
+    index: AtomicU64,
+}
+
+impl LastEmittedFlashblockId {
+    fn load(&self) -> FlashblockId {
+        FlashblockId {
+            block_number: self.block_number.load(Ordering::Relaxed),
+            index: self.index.load(Ordering::Relaxed),
+        }
+    }
+
+    fn store(&self, flashblock_id: FlashblockId) {
+        self.block_number.store(flashblock_id.block_number, Ordering::Relaxed);
+        self.index.store(flashblock_id.index, Ordering::Relaxed);
+    }
+}
+
 /// Base payload builder
 #[derive(Debug, Clone)]
 pub(super) struct BasePayloadBuilder<Pool, Client> {
@@ -92,7 +115,7 @@ pub(super) struct BasePayloadBuilder<Pool, Client> {
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
     /// Last flashblock emitted by this builder instance.
-    pub last_emitted_flashblock_id: Arc<Mutex<Option<FlashblockId>>>,
+    last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
 }
 
 impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
@@ -114,33 +137,16 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
             ws_pub,
             config,
             rejected_tx_sender,
-            last_emitted_flashblock_id: Arc::new(Mutex::new(None)),
+            last_emitted_flashblock_id: Arc::default(),
         }
     }
 
-    fn previous_flashblock_id(&self) -> Result<FlashblockId, PayloadBuilderError> {
-        let last_emitted = self.last_emitted_flashblock_id.lock().map_err(|_| {
-            PayloadBuilderError::other(std::io::Error::other(
-                "last emitted flashblock id lock poisoned",
-            ))
-        })?;
-
-        Ok(last_emitted.unwrap_or_default())
+    fn previous_flashblock_id(&self) -> FlashblockId {
+        self.last_emitted_flashblock_id.load()
     }
 
-    fn record_emitted_flashblock(
-        &self,
-        block_number: u64,
-        index: u64,
-    ) -> Result<(), PayloadBuilderError> {
-        let mut last_emitted = self.last_emitted_flashblock_id.lock().map_err(|_| {
-            PayloadBuilderError::other(std::io::Error::other(
-                "last emitted flashblock id lock poisoned",
-            ))
-        })?;
-
-        *last_emitted = Some(FlashblockId { block_number, index });
-        Ok(())
+    fn record_emitted_flashblock(&self, block_number: u64, index: u64) {
+        self.last_emitted_flashblock_id.store(FlashblockId { block_number, index });
     }
 }
 
@@ -294,7 +300,7 @@ where
 
         let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
 
-        let prev_flashblock_id = self.previous_flashblock_id()?;
+        let prev_flashblock_id = self.previous_flashblock_id();
         let (payload, fb_payload) = build_block(
             &mut state,
             &ctx,
@@ -324,7 +330,7 @@ where
                 .ws_pub
                 .publish(&fb_payload, ctx.block_number(), 0)
                 .map_err(PayloadBuilderError::other)?;
-            self.record_emitted_flashblock(ctx.block_number(), 0)?;
+            self.record_emitted_flashblock(ctx.block_number(), 0);
             BuilderMetrics::flashblock_byte_size_histogram().record(flashblock_byte_size as f64);
             BuilderMetrics::first_flashblock_time_offset()
                 .record(first_flashblock_offset.as_millis() as f64);
@@ -683,7 +689,7 @@ where
             .set(payload_transaction_simulation_time);
 
         let total_block_built_duration = Instant::now();
-        let prev_flashblock_id = self.previous_flashblock_id()?;
+        let prev_flashblock_id = self.previous_flashblock_id();
         let build_result =
             build_block(state, ctx, info, prev_flashblock_id, ctx.attributes().no_tx_pool);
         let total_block_built_duration = total_block_built_duration.elapsed();
@@ -713,7 +719,7 @@ where
                             .ws_pub
                             .publish(&fb_payload, ctx.block_number(), flashblock_index)
                             .wrap_err("failed to publish flashblock via websocket")?;
-                        self.record_emitted_flashblock(ctx.block_number(), flashblock_index)?;
+                        self.record_emitted_flashblock(ctx.block_number(), flashblock_index);
                         (false, size)
                     }
                 };

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 use std::{
     ops::{Div, Rem},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Instant,
 };
 
@@ -18,7 +18,8 @@ use base_bundles::RejectedTransaction;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
 use base_common_flashblocks::{
-    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblockId, FlashblocksPayloadV1,
+    Metadata,
 };
 use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
 use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
@@ -90,11 +91,13 @@ pub(super) struct BasePayloadBuilder<Pool, Client> {
     pub config: BuilderConfig,
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+    /// Last flashblock emitted by this builder instance.
+    pub last_emitted_flashblock_id: Arc<Mutex<Option<FlashblockId>>>,
 }
 
 impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
     /// `BasePayloadBuilder` constructor.
-    pub(super) const fn new(
+    pub(super) fn new(
         evm_config: BaseEvmConfig,
         pool: Pool,
         client: Client,
@@ -103,7 +106,41 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
         ws_pub: Arc<WebSocketPublisher>,
         rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
     ) -> Self {
-        Self { evm_config, pool, client, payload_tx, ws_pub, config, rejected_tx_sender }
+        Self {
+            evm_config,
+            pool,
+            client,
+            payload_tx,
+            ws_pub,
+            config,
+            rejected_tx_sender,
+            last_emitted_flashblock_id: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn previous_flashblock_id(&self) -> Result<FlashblockId, PayloadBuilderError> {
+        let last_emitted = self.last_emitted_flashblock_id.lock().map_err(|_| {
+            PayloadBuilderError::other(std::io::Error::other(
+                "last emitted flashblock id lock poisoned",
+            ))
+        })?;
+
+        Ok(last_emitted.unwrap_or_default())
+    }
+
+    fn record_emitted_flashblock(
+        &self,
+        block_number: u64,
+        index: u64,
+    ) -> Result<(), PayloadBuilderError> {
+        let mut last_emitted = self.last_emitted_flashblock_id.lock().map_err(|_| {
+            PayloadBuilderError::other(std::io::Error::other(
+                "last emitted flashblock id lock poisoned",
+            ))
+        })?;
+
+        *last_emitted = Some(FlashblockId { block_number, index });
+        Ok(())
     }
 }
 
@@ -257,10 +294,12 @@ where
 
         let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
 
+        let prev_flashblock_id = self.previous_flashblock_id()?;
         let (payload, fb_payload) = build_block(
             &mut state,
             &ctx,
             &mut info,
+            prev_flashblock_id,
             skip_flashblocks_building, // need to calculate state root for CL sync or if not building flashblocks
         )?;
 
@@ -285,6 +324,7 @@ where
                 .ws_pub
                 .publish(&fb_payload, ctx.block_number(), 0)
                 .map_err(PayloadBuilderError::other)?;
+            self.record_emitted_flashblock(ctx.block_number(), 0)?;
             BuilderMetrics::flashblock_byte_size_histogram().record(flashblock_byte_size as f64);
             BuilderMetrics::first_flashblock_time_offset()
                 .record(first_flashblock_offset.as_millis() as f64);
@@ -643,7 +683,9 @@ where
             .set(payload_transaction_simulation_time);
 
         let total_block_built_duration = Instant::now();
-        let build_result = build_block(state, ctx, info, ctx.attributes().no_tx_pool);
+        let prev_flashblock_id = self.previous_flashblock_id()?;
+        let build_result =
+            build_block(state, ctx, info, prev_flashblock_id, ctx.attributes().no_tx_pool);
         let total_block_built_duration = total_block_built_duration.elapsed();
         BuilderMetrics::total_block_built_duration().record(total_block_built_duration);
         BuilderMetrics::total_block_built_gauge().set(total_block_built_duration);
@@ -671,6 +713,7 @@ where
                             .ws_pub
                             .publish(&fb_payload, ctx.block_number(), flashblock_index)
                             .wrap_err("failed to publish flashblock via websocket")?;
+                        self.record_emitted_flashblock(ctx.block_number(), flashblock_index)?;
                         (false, size)
                     }
                 };
@@ -822,7 +865,7 @@ where
         let start_time = Instant::now();
 
         // Build the final block WITH state root computed
-        let (final_payload, _) = build_block(state, ctx, info, true)?;
+        let (final_payload, _) = build_block(state, ctx, info, FlashblockId::default(), true)?;
 
         ctx.flush_rejected_txs(info);
 
@@ -904,12 +947,13 @@ where
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
 struct FlashblocksMetadata {
+    /// Metadata fields consumed by flashblock clients.
+    #[serde(flatten)]
+    metadata: Metadata,
     /// Receipts for transactions in this flashblock (removed in Base 1.0)
     receipts: Option<HashMap<B256, BaseReceipt>>,
     /// Changed account balances (removed in Base 1.0)
     new_account_balances: Option<HashMap<Address, U256>>,
-    /// The block number this flashblock belongs to
-    block_number: u64,
     /// The flashblock access list
     access_list: Option<FlashblockAccessList>,
 }
@@ -937,6 +981,7 @@ pub(crate) fn build_block<DB, P>(
     state: &mut State<DB>,
     ctx: &BasePayloadBuilderCtx,
     info: &mut ExecutionInfo,
+    prev_flashblock_id: FlashblockId,
     calculate_state_root: bool,
 ) -> Result<(BaseBuiltPayload, FlashblocksPayloadV1), PayloadBuilderError>
 where
@@ -1112,14 +1157,14 @@ where
     let metadata: FlashblocksMetadata =
         if ctx.chain_spec.is_azul_active_at_timestamp(ctx.attributes().timestamp()) {
             FlashblocksMetadata {
-                block_number: ctx.parent().number + 1,
+                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
                 access_list: None,
                 receipts: None,
                 new_account_balances: None,
             }
         } else {
             FlashblocksMetadata {
-                block_number: ctx.parent().number + 1,
+                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
                 access_list: None,
                 new_account_balances: Some(new_account_balances),
                 receipts: Some(receipts_with_hash),
@@ -1186,7 +1231,7 @@ mod tests {
     use alloy_consensus::{Header, Receipt};
     use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
     use base_common_consensus::BaseReceipt;
-    use base_common_flashblocks::Metadata;
+    use base_common_flashblocks::{FlashblockId, Metadata};
     use base_execution_chainspec::BaseChainSpec;
     use reth_chainspec::ChainSpec;
     use reth_primitives_traits::SealedHeader;
@@ -1238,9 +1283,14 @@ mod tests {
         let mut state = State::builder().with_database(db).with_bundle_update().build();
         let mut info = ExecutionInfo::default();
 
-        let (payload, fb_payload) =
-            build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
-                .expect("build_block should succeed for an empty block");
+        let (payload, fb_payload) = build_block::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut info,
+            FlashblockId::default(),
+            false,
+        )
+        .expect("build_block should succeed for an empty block");
 
         // Block number must be parent + 1.
         assert_eq!(payload.block().number, parent.number + 1, "block number should be parent + 1");
@@ -1270,9 +1320,14 @@ mod tests {
         let mut state = State::builder().with_database(db).with_bundle_update().build();
         let mut info = ExecutionInfo::default();
 
-        let (payload, _fb_payload) =
-            build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, true)
-                .expect("build_block with state root should succeed");
+        let (payload, _fb_payload) = build_block::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut info,
+            FlashblockId::default(),
+            true,
+        )
+        .expect("build_block with state root should succeed");
 
         // NoopProvider returns B256::default() for all state root queries,
         // which equals B256::ZERO.
@@ -1306,8 +1361,14 @@ mod tests {
         let mut state = State::builder().with_database(db).with_bundle_update().build();
         let mut info = ExecutionInfo::default();
 
-        let err = build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
-            .expect_err("build_block should fail on block number mismatch");
+        let err = build_block::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut info,
+            FlashblockId::default(),
+            false,
+        )
+        .expect_err("build_block should fail on block number mismatch");
 
         let msg = err.to_string();
         assert!(
@@ -1335,8 +1396,14 @@ mod tests {
         let mut state = State::builder().with_database(db).with_bundle_update().build();
         let mut info = ExecutionInfo::default();
 
-        let err = build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
-            .expect_err("build_block should fail without beacon block root");
+        let err = build_block::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut info,
+            FlashblockId::default(),
+            false,
+        )
+        .expect_err("build_block should fail without beacon block root");
 
         let msg = err.to_string();
         assert!(
@@ -1370,7 +1437,10 @@ mod tests {
         let metadata = FlashblocksMetadata {
             receipts: Some(receipts),
             new_account_balances: Some(balances),
-            block_number: 42,
+            metadata: Metadata {
+                block_number: 42,
+                prev_flashblock_id: FlashblockId { block_number: 41, index: 10 },
+            },
             access_list: None,
         };
 
@@ -1382,12 +1452,13 @@ mod tests {
         keys.sort();
         assert_eq!(
             keys,
-            vec!["block_number", "new_account_balances", "receipts"],
+            vec!["block_number", "new_account_balances", "prev_flashblock_id", "receipts",],
             "metadata field names changed"
         );
 
         // block_number is a plain integer, not hex-encoded
         assert_eq!(obj["block_number"], serde_json::json!(42));
+        assert_eq!(obj["prev_flashblock_id"], serde_json::json!("41-10"));
 
         // receipts is a map keyed by tx hash
         let receipts_obj = obj["receipts"].as_object().unwrap();
@@ -1411,7 +1482,10 @@ mod tests {
         let metadata = FlashblocksMetadata {
             receipts: Some(HashMap::default()),
             new_account_balances: Some(HashMap::default()),
-            block_number: 99,
+            metadata: Metadata {
+                block_number: 99,
+                prev_flashblock_id: FlashblockId { block_number: 98, index: 10 },
+            },
             access_list: None,
         };
 
@@ -1419,6 +1493,10 @@ mod tests {
         let client_metadata: Metadata =
             serde_json::from_value(json).expect("client Metadata must parse builder metadata");
         assert_eq!(client_metadata.block_number, 99);
+        assert_eq!(
+            client_metadata.prev_flashblock_id,
+            FlashblockId { block_number: 98, index: 10 }
+        );
     }
 
     /// The v0.4.1 metadata format (only `block_number`) must still deserialize
@@ -1428,5 +1506,6 @@ mod tests {
         let json = serde_json::json!({"block_number": 123});
         let metadata: Metadata = serde_json::from_value(json).expect("v0.4.1 metadata must parse");
         assert_eq!(metadata.block_number, 123);
+        assert_eq!(metadata.prev_flashblock_id, FlashblockId::default());
     }
 }

--- a/crates/common/flashblocks/src/lib.rs
+++ b/crates/common/flashblocks/src/lib.rs
@@ -14,7 +14,7 @@ mod error;
 pub use error::FlashblockDecodeError;
 
 mod metadata;
-pub use metadata::Metadata;
+pub use metadata::{FlashblockId, Metadata};
 
 mod payload;
 pub use payload::{

--- a/crates/common/flashblocks/src/lib.rs
+++ b/crates/common/flashblocks/src/lib.rs
@@ -14,7 +14,7 @@ mod error;
 pub use error::FlashblockDecodeError;
 
 mod metadata;
-pub use metadata::{FlashblockId, Metadata};
+pub use metadata::{FlashblockId, FlashblockIdParseError, Metadata};
 
 mod payload;
 pub use payload::{

--- a/crates/common/flashblocks/src/metadata.rs
+++ b/crates/common/flashblocks/src/metadata.rs
@@ -1,8 +1,9 @@
 //! Contains the [`Metadata`] type used in Flashblocks.
 
-use std::{fmt, str::FromStr};
+use std::{fmt, num::ParseIntError, str::FromStr};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use thiserror::Error;
 
 /// Identifies a flashblock within a canonical block build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -13,6 +14,37 @@ pub struct FlashblockId {
     pub index: u64,
 }
 
+/// Error returned when parsing a [`FlashblockId`] from its compact string form.
+#[derive(Debug, Error)]
+pub enum FlashblockIdParseError {
+    /// The input did not use the expected `<block_number>-<index>` format.
+    #[error("invalid flashblock id '{value}': expected '<block_number>-<index>' format")]
+    InvalidFormat {
+        /// Original input value.
+        value: String,
+    },
+    /// The block number component was not a valid integer.
+    #[error("invalid flashblock id '{value}': block number '{block_number}' must be an integer")]
+    InvalidBlockNumber {
+        /// Original input value.
+        value: String,
+        /// Block number component.
+        block_number: String,
+        /// Parse error for the block number component.
+        source: ParseIntError,
+    },
+    /// The flashblock index component was not a valid integer.
+    #[error("invalid flashblock id '{value}': index '{index}' must be an integer")]
+    InvalidIndex {
+        /// Original input value.
+        value: String,
+        /// Index component.
+        index: String,
+        /// Parse error for the index component.
+        source: ParseIntError,
+    },
+}
+
 impl fmt::Display for FlashblockId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}-{}", self.block_number, self.index)
@@ -20,18 +52,26 @@ impl fmt::Display for FlashblockId {
 }
 
 impl FromStr for FlashblockId {
-    type Err = &'static str;
+    type Err = FlashblockIdParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let Some((block_number, index)) = value.split_once('-') else {
-            return Err("flashblock id must use '<block_number>-<index>' format");
+            return Err(FlashblockIdParseError::InvalidFormat { value: value.to_owned() });
         };
 
         Ok(Self {
-            block_number: block_number
-                .parse()
-                .map_err(|_| "flashblock id block number must be an integer")?,
-            index: index.parse().map_err(|_| "flashblock id index must be an integer")?,
+            block_number: block_number.parse().map_err(|source| {
+                FlashblockIdParseError::InvalidBlockNumber {
+                    value: value.to_owned(),
+                    block_number: block_number.to_owned(),
+                    source,
+                }
+            })?,
+            index: index.parse().map_err(|source| FlashblockIdParseError::InvalidIndex {
+                value: value.to_owned(),
+                index: index.to_owned(),
+                source,
+            })?,
         })
     }
 }

--- a/crates/common/flashblocks/src/metadata.rs
+++ b/crates/common/flashblocks/src/metadata.rs
@@ -1,10 +1,107 @@
 //! Contains the [`Metadata`] type used in Flashblocks.
 
-use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+/// Identifies a flashblock within a canonical block build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FlashblockId {
+    /// Canonical block number this flashblock belongs to.
+    pub block_number: u64,
+    /// Index of the flashblock within the block.
+    pub index: u64,
+}
+
+impl fmt::Display for FlashblockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.block_number, self.index)
+    }
+}
+
+impl FromStr for FlashblockId {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let Some((block_number, index)) = value.split_once('-') else {
+            return Err("flashblock id must use '<block_number>-<index>' format");
+        };
+
+        Ok(Self {
+            block_number: block_number
+                .parse()
+                .map_err(|_| "flashblock id block number must be an integer")?,
+            index: index.parse().map_err(|_| "flashblock id index must be an integer")?,
+        })
+    }
+}
+
+impl From<FlashblockId> for String {
+    fn from(value: FlashblockId) -> Self {
+        value.to_string()
+    }
+}
+
+impl Serialize for FlashblockId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for FlashblockId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?.parse().map_err(de::Error::custom)
+    }
+}
 
 /// Metadata associated with a flashblock.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct Metadata {
     /// Block number this flashblock belongs to.
     pub block_number: u64,
+    /// Identifier of the previously emitted flashblock.
+    #[serde(default)]
+    pub prev_flashblock_id: FlashblockId,
+}
+
+impl Metadata {
+    /// Creates metadata for legacy tests and callers that only need a block number.
+    pub const fn new(block_number: u64) -> Self {
+        Self { block_number, prev_flashblock_id: FlashblockId { block_number: 0, index: 0 } }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FlashblockId, Metadata};
+
+    #[test]
+    fn flashblock_id_serializes_as_compact_key() {
+        let json = serde_json::to_value(FlashblockId { block_number: 123, index: 4 })
+            .expect("flashblock id should serialize");
+
+        assert_eq!(json, serde_json::json!("123-4"));
+    }
+
+    #[test]
+    fn flashblock_id_deserializes_from_compact_key() {
+        let id: FlashblockId = serde_json::from_value(serde_json::json!("123-4"))
+            .expect("flashblock id should deserialize");
+
+        assert_eq!(id, FlashblockId { block_number: 123, index: 4 });
+    }
+
+    #[test]
+    fn metadata_deserializes_missing_flashblock_id_as_default() {
+        let metadata: Metadata = serde_json::from_value(serde_json::json!({"block_number": 123}))
+            .expect("legacy metadata should deserialize");
+
+        assert_eq!(metadata.prev_flashblock_id, FlashblockId::default());
+    }
 }

--- a/crates/execution/engine-tree/src/cached_execution.rs
+++ b/crates/execution/engine-tree/src/cached_execution.rs
@@ -334,7 +334,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
             },
-            metadata: Metadata { block_number },
+            metadata: Metadata::new(block_number),
         }
     }
 

--- a/crates/execution/flashblocks-node/benches/pending_state.rs
+++ b/crates/execution/flashblocks-node/benches/pending_state.rs
@@ -240,7 +240,7 @@ fn base_flashblock(
             transactions: vec![BLOCK_INFO_TXN],
             blob_gas_used: Default::default(),
         },
-        metadata: Metadata { block_number },
+        metadata: Metadata::new(block_number),
     }
 }
 
@@ -272,7 +272,7 @@ fn transaction_flashblock(
             transactions: tx_bytes,
             blob_gas_used: Default::default(),
         },
-        metadata: Metadata { block_number },
+        metadata: Metadata::new(block_number),
     }
 }
 

--- a/crates/execution/flashblocks-node/src/test_harness.rs
+++ b/crates/execution/flashblocks-node/src/test_harness.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_consensus::{Receipt, Transaction};
+use alloy_consensus::{BlockHeader, Receipt, Transaction};
 use alloy_eips::{BlockHashOrNumber, Decodable2718, Encodable2718};
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, hex::FromHex, map::HashMap};
 use alloy_rpc_types_engine::PayloadId;
@@ -288,6 +288,11 @@ impl FlashblocksHarness {
         Self::with_options(false).await
     }
 
+    /// Get a reference to the inner [`TestHarness`]
+    pub const fn inner(&self) -> &TestHarness {
+        &self.inner
+    }
+
     /// Get a handle to the in-memory Flashblocks state backing the harness.
     pub fn flashblocks_state(&self) -> Arc<FlashblocksState> {
         self.parts.state()
@@ -356,6 +361,11 @@ impl FlashblocksBuilderTestHarness {
         flashblocks.on_canonical_block_received(genesis_block);
 
         Self { node, provider, flashblocks }
+    }
+
+    /// Get a reference to the inner [`FlashblocksHarness`]
+    pub const fn inner(&self) -> &FlashblocksHarness {
+        &self.node
     }
 
     /// Decode a private key from an account.
@@ -577,7 +587,9 @@ impl<'a> FlashblockBuilder<'a> {
 
         let base = if self.index == 0 {
             Some(ExecutionPayloadBaseV1 {
-                parent_beacon_block_root: current_block.hash(),
+                parent_beacon_block_root: current_block
+                    .parent_beacon_block_root()
+                    .unwrap_or_default(),
                 parent_hash: current_block.hash(),
                 fee_recipient: Address::random(),
                 prev_randao: B256::random(),
@@ -611,7 +623,7 @@ impl<'a> FlashblockBuilder<'a> {
                 transactions,
                 blob_gas_used: Default::default(),
             },
-            metadata: Metadata { block_number: canonical_block_num },
+            metadata: Metadata::new(canonical_block_num),
         }
     }
 }

--- a/crates/execution/flashblocks-node/tests/eip7702_tests.rs
+++ b/crates/execution/flashblocks-node/tests/eip7702_tests.rs
@@ -140,7 +140,7 @@ fn create_base_flashblock(setup: &TestSetup) -> Flashblock {
             transactions: vec![L1_BLOCK_INFO_DEPOSIT_TX, setup.account_deploy_tx.clone()],
             ..Default::default()
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata::new(1),
     }
 }
 
@@ -160,7 +160,7 @@ fn create_eip7702_flashblock(eip7702_tx: Bytes, cumulative_gas: u64) -> Flashblo
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata::new(1),
     }
 }
 
@@ -265,7 +265,7 @@ async fn test_eip7702_multiple_delegations_same_flashblock() -> Result<()> {
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata::new(1),
     };
 
     setup.send_flashblock(flashblock).await?;
@@ -383,7 +383,7 @@ async fn test_eip7702_delegation_then_execution() -> Result<()> {
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata::new(1),
     };
 
     setup.send_flashblock(execution_flashblock).await?;

--- a/crates/execution/flashblocks-node/tests/eth_call_erc20.rs
+++ b/crates/execution/flashblocks-node/tests/eth_call_erc20.rs
@@ -90,7 +90,7 @@ impl Erc20TestSetup {
                 transactions: vec![L1_BLOCK_INFO_DEPOSIT_TX],
                 ..Default::default()
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata::new(1),
         }
     }
 
@@ -116,7 +116,7 @@ impl Erc20TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata::new(1),
         }
     }
 
@@ -137,7 +137,7 @@ impl Erc20TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata::new(1),
         }
     }
 

--- a/crates/execution/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/execution/flashblocks-node/tests/flashblocks_rpc.rs
@@ -3,27 +3,37 @@
 use std::str::FromStr;
 
 use DoubleCounter::DoubleCounterInstance;
+use ParentBlockhashGuard::ParentBlockhashGuardInstance;
 use alloy_consensus::{Transaction, constants::EMPTY_WITHDRAWALS};
-use alloy_eips::{BlockNumberOrTag, eip7685::EMPTY_REQUESTS_HASH};
+use alloy_eips::{
+    BlockHashOrNumber, BlockNumberOrTag, Decodable2718, eip7685::EMPTY_REQUESTS_HASH,
+};
 use alloy_network::{ReceiptResponse, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, TxHash, U256, address, b256, bytes};
-use alloy_provider::Provider;
+use alloy_provider::{MulticallItem, Provider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::simulate::{SimBlock, SimulatePayload};
 use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::{TransactionInput, error::EthRpcErrorCode};
+use base_common_consensus::{BaseTransactionSigned, BaseTxEnvelope};
 use base_common_flashblocks::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
 };
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
-use base_flashblocks_node::test_harness::FlashblocksHarness;
+use base_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
+use base_flashblocks_node::test_harness::{
+    FlashblockBuilder, FlashblocksBuilderTestHarness, FlashblocksHarness,
+};
 use base_node_runner::test_utils::L1_BLOCK_INFO_DEPOSIT_TX;
-use base_test_utils::{Account, DoubleCounter};
+use base_test_utils::{Account, DoubleCounter, ParentBlockhashGuard};
 use eyre::Result;
 use futures::{SinkExt, StreamExt};
+use reth_primitives_traits::Block;
+use reth_provider::BlockReader;
 use reth_revm::context::TransactionType;
 use reth_rpc_eth_api::RpcReceipt;
+use reth_transaction_pool::test_utils::TransactionBuilder;
 use serde_json::json;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
@@ -286,7 +296,7 @@ impl TestSetup {
                 withdrawals_root: EMPTY_WITHDRAWALS,
                 ..Default::default()
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata::new(1),
         }
     }
 
@@ -318,7 +328,7 @@ impl TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: EMPTY_WITHDRAWALS,
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata::new(1),
         }
     }
 
@@ -501,6 +511,80 @@ async fn test_get_transaction_receipt_pending() -> Result<()> {
         .await?
         .expect("receipt expected");
     assert_eq!(receipt.gas_used(), 21000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_blockhash_dependent_transaction_receipt_pending() -> Result<()> {
+    let mut builder_setup = FlashblocksBuilderTestHarness::new().await;
+    let mut client_setup = FlashblocksBuilderTestHarness::new().await;
+
+    let builder_provider = builder_setup.node.provider();
+    let client_provider = client_setup.node.provider();
+
+    // Step 1. Deploy the ParentBlockhashGuard contract in canon block 1
+    let (deployment_tx, guard_address, _) = Account::Deployer
+        .create_deployment_tx(ParentBlockhashGuard::BYTECODE.clone(), 0)
+        .expect("should be able to sign ParentBlockhashGuard deployment txn");
+    let deployment_tx = BaseTxEnvelope::decode_2718(&mut deployment_tx.as_ref())?;
+    builder_setup.new_canonical_block_without_processing(vec![deployment_tx.clone()]).await;
+    assert_eq!(builder_provider.get_block_number().await?, 1);
+    client_setup.new_canonical_block_without_processing(vec![deployment_tx]).await;
+    assert_eq!(client_provider.get_block_number().await?, 1);
+
+    // Step 2. Random flashblocks for canon block 2
+    // Created by builder_setup, but inserted into client_setup
+    let block_two_fb_base = FlashblockBuilder::new_base(&builder_setup).build();
+    let block_two_fb_one = FlashblockBuilder::new(&builder_setup, 1).build();
+    let block_two_fb_two = FlashblockBuilder::new(&builder_setup, 2).build();
+    client_setup.send_flashblock(block_two_fb_base.clone()).await;
+    client_setup.send_flashblock(block_two_fb_one).await;
+    client_setup.send_flashblock(block_two_fb_two).await;
+    builder_setup
+        .node
+        .build_block_from_transactions(block_two_fb_base.diff.transactions)
+        .await
+        .expect("able to build canon block 2");
+    let canon_block_two = builder_setup
+        .provider
+        .block(BlockHashOrNumber::Number(2))
+        .expect("able to load block 2")
+        .expect("block 2 should be available")
+        .try_into_recovered()
+        .expect("able to recover block 2");
+
+    // Step 3. Builder builds flashblocks for block 3
+    // that contain a call to the contract
+    // It is processed by client before client has canon block 2
+    let guard = ParentBlockhashGuardInstance::new(guard_address, builder_provider.clone());
+    let txn = TransactionBuilder::default()
+        .signer(Account::Deployer.signer_b256())
+        .chain_id(builder_provider.get_chain_id().await?)
+        .to(guard_address)
+        .nonce(1)
+        .input(guard.succeedsOnlyWhenParentBlockHashIsCanonical(canon_block_two.hash()).input())
+        .gas_limit(200_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000_000)
+        .into_eip1559()
+        .as_eip1559()
+        .unwrap()
+        .clone();
+    let flashblock = FlashblockBuilder::new_base(&builder_setup).build();
+    client_setup.send_flashblock(flashblock).await;
+    client_setup.flashblocks.on_canonical_block_received(canon_block_two);
+    let flashblock = FlashblockBuilder::new(&builder_setup, 1)
+        .with_transactions(vec![BaseTransactionSigned::Eip1559(txn.clone())])
+        .build();
+    client_setup.send_flashblock(flashblock).await;
+
+    let receipt = client_setup
+        .flashblocks
+        .get_pending_blocks()
+        .get_transaction_receipt(*txn.hash())
+        .expect("blockhash-dependent receipt expected");
+    assert!(!receipt.status(), "transaction should see the canonical parent block hash and revert");
 
     Ok(())
 }

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -752,7 +752,7 @@ async fn test_progress_canonical_blocks_without_flashblocks() {
 
     let block_one = test.node.latest_block();
     assert_eq!(block_one.number, 1);
-    assert_eq!(block_one.transaction_count(), 2);
+    assert_eq!(block_one.transaction_count(), 1);
     assert!(test.flashblocks.get_pending_blocks().get_block(true).is_none());
 
     test.new_canonical_block(vec![
@@ -763,7 +763,7 @@ async fn test_progress_canonical_blocks_without_flashblocks() {
 
     let block_two = test.node.latest_block();
     assert_eq!(block_two.number, 2);
-    assert_eq!(block_two.transaction_count(), 3);
+    assert_eq!(block_two.transaction_count(), 2);
     assert!(test.flashblocks.get_pending_blocks().get_block(true).is_none());
 }
 

--- a/crates/execution/flashblocks/src/block_assembler.rs
+++ b/crates/execution/flashblocks/src/block_assembler.rs
@@ -202,7 +202,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
             },
-            metadata: Metadata { block_number: 100 },
+            metadata: Metadata::new(100),
         }
     }
 

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -109,7 +109,7 @@ mod tests {
             index,
             base: None,
             diff: ExecutionPayloadFlashblockDeltaV1::default(),
-            metadata: Metadata { block_number },
+            metadata: Metadata::new(block_number),
         }
     }
 

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -893,7 +893,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
             },
-            metadata: Metadata { block_number },
+            metadata: Metadata::new(block_number),
         }
     }
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -350,6 +350,7 @@ where
             pending_blocks.latest_flashblock_index(),
             flashblock.metadata.block_number,
             flashblock.index,
+            flashblock.metadata.prev_flashblock_id,
         );
 
         match validation_result {
@@ -380,13 +381,29 @@ where
                 self.clear_live_state();
                 Ok(None)
             }
-            SequenceValidationResult::NonSequentialGap { expected: _, actual: _ } => {
-                // We have received a non-sequential Flashblock for the current block
+            SequenceValidationResult::NonSequentialGap { expected, actual } => {
                 Metrics::unexpected_block_order().increment(1);
                 error!(
-                    message = "Received non-sequential Flashblock for current block, zeroing Flashblocks until we receive a base Flashblock",
                     curr_block = %pending_blocks.latest_block_number(),
+                    expected_flashblock_index = %expected,
+                    actual_flashblock_index = %actual,
+                    "received non-sequential flashblock index for current block"
+                );
+                self.clear_live_state();
+                Ok(None)
+            }
+            SequenceValidationResult::NonSequentialPredecessor { expected, actual } => {
+                Metrics::unexpected_block_order().increment(1);
+                error!(
+                    curr_block = %pending_blocks.latest_block_number(),
+                    curr_flashblock_index = %pending_blocks.latest_flashblock_index(),
                     new_block = %flashblock.metadata.block_number,
+                    new_flashblock_index = %flashblock.index,
+                    expected_prev_block = %expected.block_number,
+                    expected_prev_index = %expected.index,
+                    actual_prev_block = %actual.block_number,
+                    actual_prev_index = %actual.index,
+                    "received flashblock with non-sequential predecessor link"
                 );
                 self.clear_live_state();
                 Ok(None)
@@ -412,7 +429,7 @@ where
         let latest_flashblock_tx_start = prev_pending_blocks.pending_transaction_count();
 
         let mut live_state = self.lock_live_state();
-        let Some(LivePendingState { db, state_overrides }) = live_state.take() else {
+        let Some(LivePendingState { mut db, state_overrides }) = live_state.take() else {
             warn!(
                 message = "live pending state unavailable, falling back to full rebuild",
                 block_number = flashblock.metadata.block_number,
@@ -431,6 +448,8 @@ where
         let latest_block_header =
             BlockAssembler::refresh_same_block_header(&latest_header, &latest_block_flashblocks)?;
 
+        db.block_hashes.insert(latest_block_base.block_number - 1, latest_block_base.parent_hash);
+
         let evm_config = BaseEvmConfig::base(self.client.chain_spec());
         let evm_env = evm_config
             .evm_env(&latest_header)
@@ -440,6 +459,7 @@ where
         let previous_block_transaction_count = prev_pending_blocks.latest_block_transaction_count();
         let pending_block = Block {
             header: Header {
+                parent_hash: latest_block_base.parent_hash,
                 number: latest_block_base.block_number,
                 timestamp: latest_block_base.timestamp,
                 gas_limit: latest_block_base.gas_limit,
@@ -549,7 +569,7 @@ where
         };
 
         let mut live_state = self.lock_live_state();
-        let Some(LivePendingState { db, state_overrides }) = live_state.take() else {
+        let Some(LivePendingState { mut db, state_overrides }) = live_state.take() else {
             warn!(
                 message = "live pending state unavailable, falling back to full rebuild",
                 block_number = flashblock.metadata.block_number,
@@ -568,6 +588,7 @@ where
         let AssembledBlock { block: assembled_block, header: assembled_header, .. } = current_block;
         let pending_block = Block {
             header: Header {
+                parent_hash: base.parent_hash,
                 number: base.block_number,
                 timestamp: base.timestamp,
                 gas_limit: base.gas_limit,
@@ -576,6 +597,8 @@ where
             },
             body: assembled_block.body,
         };
+
+        db.block_hashes.insert(base.block_number - 1, base.parent_hash);
 
         let evm_config = BaseEvmConfig::base(self.client.chain_spec());
         let block_env_attributes = BaseNextBlockEnvAttributes {
@@ -616,10 +639,8 @@ where
             l1_block_info.clone(),
             state_overrides,
         );
-        pending_state_builder.apply_pre_execution_changes(
-            previous_header.hash_slow(),
-            Some(base.parent_beacon_block_root),
-        )?;
+        pending_state_builder
+            .apply_pre_execution_changes(base.parent_hash, Some(base.parent_beacon_block_root))?;
 
         for (idx, (transaction, sender)) in txs_with_senders.into_iter().enumerate() {
             let tx_hash = transaction.tx_hash();
@@ -727,6 +748,9 @@ where
                 extra_data: assembled.base.extra_data.clone(),
             };
 
+            db.block_hashes
+                .insert(latest_block_base.block_number - 1, latest_block_base.parent_hash);
+
             let evm_env = evm_config
                 .next_evm_env(&last_block_header, &block_env_attributes)
                 .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
@@ -757,7 +781,7 @@ where
             // Clone header before moving block to avoid cloning the entire block
             let block_header = assembled.block.header.clone();
 
-            let parent_hash = last_block_header.hash_slow();
+            let parent_block_hash = assembled.base.parent_hash;
             let parent_beacon_block_root = Some(assembled.base.parent_beacon_block_root);
 
             let mut pending_state_builder = PendingStateBuilder::new(
@@ -770,7 +794,7 @@ where
             );
 
             pending_state_builder
-                .apply_pre_execution_changes(parent_hash, parent_beacon_block_root)?;
+                .apply_pre_execution_changes(parent_block_hash, parent_beacon_block_root)?;
 
             for (idx, (transaction, sender)) in txs_with_senders.into_iter().enumerate() {
                 let tx_hash = transaction.tx_hash();

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -636,7 +636,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
             },
-            metadata: Metadata { block_number: header.number },
+            metadata: Metadata::new(header.number),
         }]);
         pending_blocks_builder.with_receipt(tx_hash, first_result.receipt.clone());
         pending_blocks_builder.with_transaction_state(tx_hash, first_result.state.clone());
@@ -926,7 +926,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
             },
-            metadata: Metadata { block_number: header.number },
+            metadata: Metadata::new(header.number),
         }]);
         pending_blocks_builder.with_transaction_sender(tx_a_hash, sender);
         pending_blocks_builder.with_receipt(tx_a_hash, first_result.receipt.clone());

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -3,6 +3,7 @@
 //! Provides stateless validation logic for flashblock sequencing and chain reorg detection.
 
 use alloy_primitives::B256;
+use base_common_flashblocks::FlashblockId;
 
 /// Result of validating a flashblock's position in the sequence.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,6 +28,13 @@ pub enum SequenceValidationResult {
         /// The invalid (non-zero) index received.
         index: u64,
     },
+    /// Incoming flashblock does not link back to the currently tracked latest flashblock.
+    NonSequentialPredecessor {
+        /// Expected predecessor flashblock id.
+        expected: FlashblockId,
+        /// Actual predecessor flashblock id reported by the incoming flashblock.
+        actual: FlashblockId,
+    },
 }
 
 /// Stateless validator for flashblock sequence ordering.
@@ -34,43 +42,53 @@ pub enum SequenceValidationResult {
 pub struct FlashblockSequenceValidator;
 
 impl FlashblockSequenceValidator {
-    /// Validates whether an incoming flashblock follows the expected sequence.
-    ///
-    /// Returns the appropriate [`SequenceValidationResult`] based on:
-    /// - Same block, index + 1 → `NextInSequence`
-    /// - Next block, index 0 → `FirstOfNextBlock`
-    /// - Same block and index → `Duplicate`
-    /// - Same block, wrong index → `NonSequentialGap`
-    /// - Different block, non-zero index or block gap → `InvalidNewBlockIndex`
-    pub const fn validate(
+    /// Validates whether an incoming flashblock links to the current latest flashblock.
+    pub fn validate(
         latest_block_number: u64,
         latest_flashblock_index: u64,
         incoming_block_number: u64,
         incoming_index: u64,
+        incoming_prev_flashblock_id: FlashblockId,
     ) -> SequenceValidationResult {
-        // Next flashblock within the current block
-        if incoming_block_number == latest_block_number
-            && incoming_index == latest_flashblock_index + 1
+        let latest_flashblock_id =
+            FlashblockId { block_number: latest_block_number, index: latest_flashblock_index };
+
+        if incoming_block_number == latest_block_number && incoming_index == latest_flashblock_index
         {
-            SequenceValidationResult::NextInSequence
-        // First flashblock of the next block
-        } else if incoming_block_number == latest_block_number + 1 && incoming_index == 0 {
-            SequenceValidationResult::FirstOfNextBlock
-        // New block with non-zero index or block gap
-        } else if incoming_block_number != latest_block_number {
-            SequenceValidationResult::InvalidNewBlockIndex {
-                block_number: incoming_block_number,
-                index: incoming_index,
-            }
-        } else if incoming_index == latest_flashblock_index {
-            // Duplicate flashblock
-            SequenceValidationResult::Duplicate
-        } else {
-            // Non-sequential index within the same block
-            SequenceValidationResult::NonSequentialGap {
-                expected: latest_flashblock_index + 1,
+            return SequenceValidationResult::Duplicate;
+        }
+
+        // We can remove this `incoming_prev_flashblock_id != FlashblockId::default()` check later
+        // but it is currently necessary as client nodes may be updated before the builder is
+        // and they need to be able to handle the lack of `prev_flashblock_id` in the stream
+        if incoming_prev_flashblock_id != FlashblockId::default()
+            && incoming_prev_flashblock_id != latest_flashblock_id
+        {
+            return SequenceValidationResult::NonSequentialPredecessor {
+                expected: latest_flashblock_id,
+                actual: incoming_prev_flashblock_id,
+            };
+        }
+
+        let next_flashblock_index = latest_flashblock_index.saturating_add(1);
+        if incoming_block_number == latest_block_number && incoming_index == next_flashblock_index {
+            return SequenceValidationResult::NextInSequence;
+        }
+
+        if incoming_block_number == latest_block_number + 1 && incoming_index == 0 {
+            return SequenceValidationResult::FirstOfNextBlock;
+        }
+
+        if incoming_block_number == latest_block_number {
+            return SequenceValidationResult::NonSequentialGap {
+                expected: next_flashblock_index,
                 actual: incoming_index,
-            }
+            };
+        }
+
+        SequenceValidationResult::InvalidNewBlockIndex {
+            block_number: incoming_block_number,
+            index: incoming_index,
         }
     }
 }
@@ -197,37 +215,60 @@ mod tests {
     // ==================== FlashblockSequenceValidator Tests ====================
 
     #[rstest]
-    // NextInSequence: consecutive indices within the same block
-    #[case(100, 2, 100, 3, SequenceValidationResult::NextInSequence)]
-    #[case(100, 0, 100, 1, SequenceValidationResult::NextInSequence)]
-    #[case(100, 999, 100, 1000, SequenceValidationResult::NextInSequence)]
-    #[case(0, 0, 0, 1, SequenceValidationResult::NextInSequence)]
-    #[case(100, u64::MAX - 1, 100, u64::MAX, SequenceValidationResult::NextInSequence)]
-    // FirstOfNextBlock: index 0 of the next block
-    #[case(0, 0, 1, 0, SequenceValidationResult::FirstOfNextBlock)]
-    #[case(100, 5, 101, 0, SequenceValidationResult::FirstOfNextBlock)]
-    #[case(100, 0, 101, 0, SequenceValidationResult::FirstOfNextBlock)]
-    #[case(999999, 10, 1000000, 0, SequenceValidationResult::FirstOfNextBlock)]
-    #[case(0, 5, 1, 0, SequenceValidationResult::FirstOfNextBlock)]
-    #[case(u64::MAX - 1, 0, u64::MAX, 0, SequenceValidationResult::FirstOfNextBlock)]
-    // Duplicate: same block and index
-    #[case(100, 5, 100, 5, SequenceValidationResult::Duplicate)]
-    #[case(100, 0, 100, 0, SequenceValidationResult::Duplicate)]
-    // NonSequentialGap: non-consecutive indices within the same block
-    #[case(100, 2, 100, 4, SequenceValidationResult::NonSequentialGap { expected: 3, actual: 4 })]
-    #[case(100, 0, 100, 10, SequenceValidationResult::NonSequentialGap { expected: 1, actual: 10 })]
-    #[case(100, 5, 100, 3, SequenceValidationResult::NonSequentialGap { expected: 6, actual: 3 })]
-    // InvalidNewBlockIndex: new block with non-zero index or block gap
-    #[case(100, 5, 101, 1, SequenceValidationResult::InvalidNewBlockIndex { block_number: 101, index: 1 })]
-    #[case(100, 5, 105, 3, SequenceValidationResult::InvalidNewBlockIndex { block_number: 105, index: 3 })]
-    #[case(100, 5, 102, 0, SequenceValidationResult::InvalidNewBlockIndex { block_number: 102, index: 0 })]
-    #[case(100, 5, 99, 0, SequenceValidationResult::InvalidNewBlockIndex { block_number: 99, index: 0 })]
-    #[case(100, 5, 99, 5, SequenceValidationResult::InvalidNewBlockIndex { block_number: 99, index: 5 })]
+    #[case(100, 5, 100, 6, FlashblockId { block_number: 100, index: 5 }, SequenceValidationResult::NextInSequence)]
+    #[case(100, 5, 100, 6, FlashblockId::default(), SequenceValidationResult::NextInSequence)]
+    #[case(100, 5, 101, 0, FlashblockId { block_number: 100, index: 5 }, SequenceValidationResult::FirstOfNextBlock)]
+    #[case(100, 5, 101, 0, FlashblockId::default(), SequenceValidationResult::FirstOfNextBlock)]
+    #[case(100, 5, 100, 5, FlashblockId::default(), SequenceValidationResult::Duplicate)]
+    #[case(
+        100,
+        5,
+        100,
+        7,
+        FlashblockId { block_number: 100, index: 5 },
+        SequenceValidationResult::NonSequentialGap { expected: 6, actual: 7 }
+    )]
+    #[case(
+        100,
+        5,
+        101,
+        3,
+        FlashblockId { block_number: 100, index: 5 },
+        SequenceValidationResult::InvalidNewBlockIndex { block_number: 101, index: 3 }
+    )]
+    #[case(
+        100,
+        5,
+        105,
+        0,
+        FlashblockId { block_number: 100, index: 5 },
+        SequenceValidationResult::InvalidNewBlockIndex { block_number: 105, index: 0 }
+    )]
+    #[case(
+        100,
+        5,
+        101,
+        0,
+        FlashblockId { block_number: 100, index: 4 },
+        SequenceValidationResult::NonSequentialPredecessor {
+            expected: FlashblockId { block_number: 100, index: 5 },
+            actual: FlashblockId { block_number: 100, index: 4 },
+        }
+    )]
+    #[case(
+        100,
+        5,
+        99,
+        0,
+        FlashblockId { block_number: 100, index: 5 },
+        SequenceValidationResult::InvalidNewBlockIndex { block_number: 99, index: 0 }
+    )]
     fn test_sequence_validator(
         #[case] latest_block: u64,
         #[case] latest_idx: u64,
         #[case] incoming_block: u64,
         #[case] incoming_idx: u64,
+        #[case] incoming_prev_flashblock_id: FlashblockId,
         #[case] expected: SequenceValidationResult,
     ) {
         let result = FlashblockSequenceValidator::validate(
@@ -235,6 +276,7 @@ mod tests {
             latest_idx,
             incoming_block,
             incoming_idx,
+            incoming_prev_flashblock_id,
         );
         assert_eq!(result, expected);
     }

--- a/crates/execution/metering/src/collector.rs
+++ b/crates/execution/metering/src/collector.rs
@@ -403,7 +403,7 @@ mod tests {
                     withdrawals_root: B256::ZERO,
                     blob_gas_used: None,
                 },
-                metadata: Metadata { block_number: 100 },
+                metadata: Metadata::new(100),
             };
 
             builder.with_flashblocks([flashblock]);

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -625,6 +625,7 @@ mod tests {
         ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
     };
     use base_flashblocks::{FlashblocksConfig, PendingBlocksBuilder};
+    use base_node_runner::test_utils::L1_BLOCK_INFO_DEPOSIT_TX;
     use base_node_runner::test_utils::TestHarness;
     use base_test_utils::Account;
     use reth_transaction_pool::test_utils::TransactionBuilder;
@@ -658,6 +659,7 @@ mod tests {
 
     async fn generate_txs_for_block(chain_id: u64) -> Vec<Bytes> {
         vec![
+            L1_BLOCK_INFO_DEPOSIT_TX,
             TransactionBuilder::default()
                 .signer(Account::Charlie.signer_b256())
                 .chain_id(chain_id)

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -625,8 +625,7 @@ mod tests {
         ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
     };
     use base_flashblocks::{FlashblocksConfig, PendingBlocksBuilder};
-    use base_node_runner::test_utils::L1_BLOCK_INFO_DEPOSIT_TX;
-    use base_node_runner::test_utils::TestHarness;
+    use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, TestHarness};
     use base_test_utils::Account;
     use reth_transaction_pool::test_utils::TransactionBuilder;
     use url::Url;

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -1057,7 +1057,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: Some(0),
             },
-            metadata: Metadata { block_number: 2 },
+            metadata: Metadata::new(2),
         };
 
         // Build PendingBlocks with zero-hash header

--- a/crates/execution/runner/benches/fcu_unsafe.rs
+++ b/crates/execution/runner/benches/fcu_unsafe.rs
@@ -26,7 +26,7 @@ use std::{
 
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockNumberOrTag;
-use base_node_runner::test_utils::{PreparedBlock, TestHarness};
+use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, PreparedBlock, TestHarness};
 use criterion::{Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
@@ -61,7 +61,7 @@ fn fcu_unsafe_benches(c: &mut Criterion) {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
                     let PreparedBlock { new_block_hash, .. } = harness
-                        .prepare_unsafe_block(vec![])
+                        .prepare_unsafe_block(vec![L1_BLOCK_INFO_DEPOSIT_TX])
                         .await
                         .expect("prepare_unsafe_block should succeed");
 

--- a/crates/execution/runner/src/test_utils/harness.rs
+++ b/crates/execution/runner/src/test_utils/harness.rs
@@ -23,8 +23,7 @@ use tokio::time::sleep;
 use crate::{
     BaseNodeExtension, FromExtensionConfig,
     test_utils::{
-        BLOCK_BUILD_DELAY_MS, BLOCK_TIME_SECONDS, GAS_LIMIT, L1_BLOCK_INFO_DEPOSIT_TX,
-        NODE_STARTUP_DELAY_MS,
+        BLOCK_BUILD_DELAY_MS, BLOCK_TIME_SECONDS, GAS_LIMIT, NODE_STARTUP_DELAY_MS,
         engine::{EngineApi, IpcEngine},
         node::{LocalNode, LocalNodeProvider},
         tracing::init_silenced_tracing,
@@ -158,14 +157,7 @@ impl TestHarness {
     /// Returns the parent hash and the new block hash so callers can issue the
     /// final FCU themselves — useful for benchmarks that want to time only the
     /// canonical FCU step.
-    pub async fn prepare_unsafe_block(
-        &self,
-        mut transactions: Vec<Bytes>,
-    ) -> Result<PreparedBlock> {
-        if transactions.first().is_none_or(|tx| tx != &L1_BLOCK_INFO_DEPOSIT_TX) {
-            transactions.insert(0, L1_BLOCK_INFO_DEPOSIT_TX);
-        }
-
+    pub async fn prepare_unsafe_block(&self, transactions: Vec<Bytes>) -> Result<PreparedBlock> {
         let latest_block = self
             .provider()
             .get_block_by_number(BlockNumberOrTag::Latest)
@@ -259,7 +251,8 @@ impl TestHarness {
         Ok(())
     }
 
-    async fn wait_for_header(&self, block_hash: B256, block_number: u64) -> Result<()> {
+    /// Wait for a given block to become available
+    pub async fn wait_for_header(&self, block_hash: B256, block_number: u64) -> Result<()> {
         const HEADER_PERSIST_TIMEOUT: Duration = Duration::from_secs(5);
         const HEADER_PERSIST_POLL_INTERVAL: Duration = Duration::from_millis(10);
 

--- a/crates/utilities/test-utils/contracts/src/ParentBlockhashGuard.sol
+++ b/crates/utilities/test-utils/contracts/src/ParentBlockhashGuard.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract ParentBlockhashGuard {
+    error ParentBlockHashWasCanonical(bytes32 actual);
+
+    function succeedsOnlyWhenParentBlockHashIsCanonical(
+        bytes32 canonicalParentBlockHash
+    ) external view returns (bytes32) {
+        bytes32 parentBlockHash = blockhash(block.number - 1);
+
+        if (parentBlockHash == canonicalParentBlockHash) {
+            revert ParentBlockHashWasCanonical(parentBlockHash);
+        }
+
+        return parentBlockHash;
+    }
+}

--- a/crates/utilities/test-utils/src/contracts.rs
+++ b/crates/utilities/test-utils/src/contracts.rs
@@ -62,6 +62,15 @@ sol!(
 
 sol!(
     #[sol(rpc)]
+    ParentBlockhashGuard,
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/contracts/out/ParentBlockhashGuard.sol/ParentBlockhashGuard.json"
+    )
+);
+
+sol!(
+    #[sol(rpc)]
     Logic,
     concat!(env!("CARGO_MANIFEST_DIR"), "/contracts/out/Proxy.sol/Logic.json")
 );

--- a/crates/utilities/test-utils/src/lib.rs
+++ b/crates/utilities/test-utils/src/lib.rs
@@ -18,5 +18,5 @@ pub use genesis::{
 mod contracts;
 pub use contracts::{
     AccessListContract, ContractFactory, DoubleCounter, Logic, Logic2, Minimal7702Account,
-    MockERC20, Proxy, SimpleStorage, TransparentUpgradeableProxy,
+    MockERC20, ParentBlockhashGuard, Proxy, SimpleStorage, TransparentUpgradeableProxy,
 };


### PR DESCRIPTION
## Summary
- Backports #3603 to the v1.1 release line.
- Fixes pending Flashblocks EVM `BLOCKHASH` divergence by wiring parent block hashes into pending execution.
- Adds Flashblock sequence linkage hardening with `prev_flashblock_id` metadata while preserving the release branch metadata shape.
- Targets `releases/v1.1.1` because `releases/v1.1.0` is finalized and the release CI intentionally rejects PRs into finalized branches.

## Verification
- `cargo test -p base-common-flashblocks -p base-flashblocks -p base-builder-core`
- `lychee --config ./lychee.toml docs/guides/UPGRADES.md`