### PR TITLE
fix(docker): use cargo-chef for dependency caching in CI

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -63,11 +63,22 @@ FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-# Pre-build workspace dependencies (cached until Cargo.toml/Cargo.lock change)
+# Pre-build non-ZK workspace dependencies (cached until Cargo.toml/Cargo.lock change)
 FROM chef AS deps
 ARG PROFILE=release
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json \
+    --package base-reth-node \
+    --package base \
+    --package base-builder-bin \
+    --package base-consensus \
+    --package base-proposer-bin \
+    --package base-challenger-bin \
+    --package websocket-proxy-bin \
+    --package ingress-rpc \
+    --package audit-archiver \
+    --package base-batcher-bin \
+    --package base-da-server-bin
 
 # Full source on top of pre-built deps
 FROM deps AS source
@@ -140,7 +151,8 @@ COPY --from=chef /usr/local/cargo/bin/cargo-chef /usr/local/cargo/bin/cargo-chef
 FROM zk-chef AS zk-deps
 ARG PROFILE=release
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json \
+    --package base-prover-zk
 
 FROM zk-deps AS zk-source
 COPY . .

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -57,7 +57,7 @@ RUN set -eux; \
 # dependency build entirely.
 
 FROM rust-builder-base AS chef
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef@0.1.77 --locked
 
 FROM chef AS planner
 COPY . .

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -102,6 +102,11 @@ ARG PROFILE=release
 RUN cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-proposer /app/base-proposer
 
+FROM source AS challenger-builder
+ARG PROFILE=release
+RUN cargo build --profile $PROFILE --package base-challenger-bin --bin base-challenger && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-challenger /app/base-challenger
+
 FROM source AS websocket-proxy-builder
 ARG PROFILE=release
 RUN cargo build --profile $PROFILE --package websocket-proxy-bin --bin websocket-proxy && \
@@ -174,6 +179,10 @@ FROM runtime-base AS proposer
 COPY --from=proposer-builder /app/base-proposer ./base-proposer
 EXPOSE 9090
 ENTRYPOINT ["./base-proposer"]
+
+FROM runtime-base AS challenger
+COPY --from=challenger-builder /app/base-challenger ./base-challenger
+ENTRYPOINT ["./base-challenger"]
 
 FROM runtime-base AS websocket-proxy
 COPY --from=websocket-proxy-builder /app/websocket-proxy ./websocket-proxy

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.93
+ARG RUST_VERSION=1.94
 FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-base
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -51,108 +51,102 @@ RUN set -eux; \
     unzip /tmp/protoc.zip -d /usr/local; \
     rm /tmp/protoc.zip
 
-FROM rust-builder-base AS source
+# ---- cargo-chef: dependency caching ----
+# Dependencies are pre-compiled in a layer that only invalidates when
+# Cargo.toml or Cargo.lock change.  Source-only changes skip the expensive
+# dependency build entirely.
+
+FROM rust-builder-base AS chef
+RUN cargo install cargo-chef --locked
+
+FROM chef AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Pre-build workspace dependencies (cached until Cargo.toml/Cargo.lock change)
+FROM chef AS deps
+ARG PROFILE=release
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
+
+# Full source on top of pre-built deps
+FROM deps AS source
+COPY . .
+
+# ---- service builder stages ----
+# Each stage only recompiles workspace crates; external deps are already built
+# in the `deps` layer above.
 
 FROM source AS client-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=client-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
+RUN cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-reth-node /app/base-client
 
 FROM source AS base-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=base-target,sharing=locked \
-    cargo build --profile $PROFILE --package base --bin base && \
+RUN cargo build --profile $PROFILE --package base --bin base && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base /app/base
 
 FROM source AS builder-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=builder-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
+RUN cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-builder /app/base-builder
 
 FROM source AS consensus-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=consensus-target,sharing=locked \
-    cargo build --profile $PROFILE --bin base-consensus && \
+RUN cargo build --profile $PROFILE --bin base-consensus && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-consensus /app/base-consensus
 
 FROM source AS proposer-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=proposer-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
+RUN cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-proposer /app/base-proposer
-
-FROM source AS challenger-builder
-ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=challenger-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-challenger-bin --bin base-challenger && \
-    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-challenger /app/base-challenger
 
 FROM source AS websocket-proxy-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=websocket-proxy-target,sharing=locked \
-    cargo build --profile $PROFILE --package websocket-proxy-bin --bin websocket-proxy && \
+RUN cargo build --profile $PROFILE --package websocket-proxy-bin --bin websocket-proxy && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/websocket-proxy /app/websocket-proxy
 
 FROM source AS ingress-rpc-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=ingress-rpc-target,sharing=locked \
-    cargo build --profile $PROFILE --package ingress-rpc --bin ingress-rpc && \
+RUN cargo build --profile $PROFILE --package ingress-rpc --bin ingress-rpc && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/ingress-rpc /app/ingress-rpc
 
 FROM source AS audit-archiver-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=audit-archiver-target,sharing=locked \
-    cargo build --profile $PROFILE --package audit-archiver --bin audit-archiver && \
+RUN cargo build --profile $PROFILE --package audit-archiver --bin audit-archiver && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/audit-archiver /app/audit-archiver
 
 FROM source AS batcher-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=batcher-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-batcher-bin --bin base-batcher && \
+RUN cargo build --profile $PROFILE --package base-batcher-bin --bin base-batcher && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-batcher /app/base-batcher
 
 FROM source AS da-server-builder
 ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=da-server-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-da-server-bin --bin base-da-server && \
+RUN cargo build --profile $PROFILE --package base-da-server-bin --bin base-da-server && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-da-server /app/base-da-server
 
-FROM zk-builder-base AS zk-source
+# ---- zk-prover (needs Go + protoc from zk-builder-base) ----
+
+FROM zk-builder-base AS zk-chef
+RUN cargo install cargo-chef --locked
+
+FROM zk-chef AS zk-deps
+ARG PROFILE=release
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
+
+FROM zk-deps AS zk-source
 COPY . .
 
 FROM zk-source AS zk-prover-builder
 ARG PROFILE=release
 ARG BASE_SUCCINCT_ELF_REQUIRE=1
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=zk-prover-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
+RUN cargo build --profile $PROFILE --package base-prover-zk --bin base-prover-zk && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-zk /app/base-prover-zk
+
+# ---- runtime images ----
 
 FROM public.ecr.aws/docker/library/debian:trixie-slim AS runtime-base
 RUN apt-get update && \
@@ -180,10 +174,6 @@ FROM runtime-base AS proposer
 COPY --from=proposer-builder /app/base-proposer ./base-proposer
 EXPOSE 9090
 ENTRYPOINT ["./base-proposer"]
-
-FROM runtime-base AS challenger
-COPY --from=challenger-builder /app/base-challenger ./base-challenger
-ENTRYPOINT ["./base-challenger"]
 
 FROM runtime-base AS websocket-proxy
 COPY --from=websocket-proxy-builder /app/websocket-proxy ./websocket-proxy

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -135,7 +135,7 @@ RUN cargo build --profile $PROFILE --package base-da-server-bin --bin base-da-se
 # ---- zk-prover (needs Go + protoc from zk-builder-base) ----
 
 FROM zk-builder-base AS zk-chef
-RUN cargo install cargo-chef --locked
+COPY --from=chef /usr/local/cargo/bin/cargo-chef /usr/local/cargo/bin/cargo-chef
 
 FROM zk-chef AS zk-deps
 ARG PROFILE=release

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -33,6 +33,7 @@ group "rust-services" {
     "builder",
     "consensus",
     "proposer",
+    "challenger",
     "websocket-proxy",
     "ingress-rpc",
     "audit-archiver",
@@ -49,7 +50,7 @@ group "devnet" {
 # L3 dev-multiproof services, built only on the `up-l3` path (alongside nitro-host-local).
 # Kept out of the shared `devnet` group so the default eth-l1 devnet does not build them.
 group "devnet-l3" {
-  targets = ["proposer"]
+  targets = ["proposer", "challenger"]
 }
 
 group "ingress" {
@@ -110,6 +111,12 @@ target "proposer" {
   inherits = ["_rust-service-common"]
   target = "proposer"
   tags = ["base-proposer:local"]
+}
+
+target "challenger" {
+  inherits = ["_rust-service-common"]
+  target = "challenger"
+  tags = ["base-challenger:local"]
 }
 
 target "websocket-proxy" {

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -33,7 +33,6 @@ group "rust-services" {
     "builder",
     "consensus",
     "proposer",
-    "challenger",
     "websocket-proxy",
     "ingress-rpc",
     "audit-archiver",
@@ -50,7 +49,7 @@ group "devnet" {
 # L3 dev-multiproof services, built only on the `up-l3` path (alongside nitro-host-local).
 # Kept out of the shared `devnet` group so the default eth-l1 devnet does not build them.
 group "devnet-l3" {
-  targets = ["proposer", "challenger"]
+  targets = ["proposer"]
 }
 
 group "ingress" {
@@ -111,12 +110,6 @@ target "proposer" {
   inherits = ["_rust-service-common"]
   target = "proposer"
   tags = ["base-proposer:local"]
-}
-
-target "challenger" {
-  inherits = ["_rust-service-common"]
-  target = "challenger"
-  tags = ["base-challenger:local"]
 }
 
 target "websocket-proxy" {

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "ZK_PROVER_PROFILE" {
 }
 
 variable "RUST_VERSION" {
-  default = "1.93"
+  default = "1.94"
 }
 
 variable "BASE_SUCCINCT_ELF_REQUIRE" {

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -878,7 +878,7 @@ services:
 
   # base-proposer: sole game creator for L3 dev multiproof. Talks directly to nitro-local over
   # JSON-RPC (--direct-prover-rpc), creates AggregateVerifier games (type 621), and submits the
-  # TEE-signed output root. It does NOT resolve games — the challenger does. setup-dispute-service.sh
+  # TEE-signed output root. setup-dispute-service.sh
   # sources the DisputeGameFactory + AnchorStateRegistry addresses from l1-addresses.json (only
   # known post-deploy) and exports them before exec'ing the binary. L3 (base-l1) only.
   base-proposer:
@@ -912,40 +912,6 @@ services:
       - BASE_PROPOSER_POLL_INTERVAL=6s
       - BASE_PROPOSER_NUM_CONFIRMATIONS=1
     entrypoint: ["/bin/bash", "/setup-dispute-service.sh", "proposer"]
-    restart: unless-stopped
-
-  # base-challenger: sole resolver, running in --no-dispute mode (no proving). It drives the
-  # post-game bond/anchor lifecycle (resolve -> claimCredit -> setAnchorState) for games whose
-  # bond recipient is the proposer (BOND_CLAIM_ADDRESSES). no-dispute validation forbids the
-  # zk-/tee-rpc-url flags and requires bond-claim-addresses. setup-dispute-service.sh sources the
-  # L1 dispute addresses like the proposer. L3 (base-l1) only.
-  base-challenger:
-    image: base-challenger:local
-    build:
-      <<: *rust-service-build
-      target: challenger
-    container_name: base-challenger
-    profiles: ["base-l1"]
-    depends_on:
-      base-rpc:
-        condition: service_healthy
-      register-aggregate-verifier:
-        condition: service_completed_successfully
-      base-proposer:
-        condition: service_started
-    volumes:
-      - ../../.devnet/l2/configs:/devnet/l2/configs:ro
-      - ../../etc/scripts/devnet/setup-dispute-service.sh:/setup-dispute-service.sh:ro
-    environment:
-      - ADDRESSES_FILE=/devnet/l2/configs/l1-addresses.json
-      - BASE_CHALLENGER_L1_ETH_RPC=http://l1-el:${L1_HTTP_PORT}
-      - BASE_CHALLENGER_L2_ETH_RPC=http://base-rpc:${L2_BASE_RPC_HTTP_PORT}
-      - BASE_CHALLENGER_NO_DISPUTE=true
-      - BASE_CHALLENGER_BOND_CLAIM_ADDRESSES=${PROPOSER_ADDR}
-      - BASE_CHALLENGER_PRIVATE_KEY=${CHALLENGER_KEY}
-      - BASE_CHALLENGER_POLL_INTERVAL=6s
-      - BASE_CHALLENGER_NUM_CONFIRMATIONS=1
-    entrypoint: ["/bin/bash", "/setup-dispute-service.sh", "challenger"]
     restart: unless-stopped
 
   zk-prover-postgres:

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -878,7 +878,7 @@ services:
 
   # base-proposer: sole game creator for L3 dev multiproof. Talks directly to nitro-local over
   # JSON-RPC (--direct-prover-rpc), creates AggregateVerifier games (type 621), and submits the
-  # TEE-signed output root. setup-dispute-service.sh
+  # TEE-signed output root. It does NOT resolve games — the challenger does. setup-dispute-service.sh
   # sources the DisputeGameFactory + AnchorStateRegistry addresses from l1-addresses.json (only
   # known post-deploy) and exports them before exec'ing the binary. L3 (base-l1) only.
   base-proposer:
@@ -912,6 +912,40 @@ services:
       - BASE_PROPOSER_POLL_INTERVAL=6s
       - BASE_PROPOSER_NUM_CONFIRMATIONS=1
     entrypoint: ["/bin/bash", "/setup-dispute-service.sh", "proposer"]
+    restart: unless-stopped
+
+  # base-challenger: sole resolver, running in --no-dispute mode (no proving). It drives the
+  # post-game bond/anchor lifecycle (resolve -> claimCredit -> setAnchorState) for games whose
+  # bond recipient is the proposer (BOND_CLAIM_ADDRESSES). no-dispute validation forbids the
+  # zk-/tee-rpc-url flags and requires bond-claim-addresses. setup-dispute-service.sh sources the
+  # L1 dispute addresses like the proposer. L3 (base-l1) only.
+  base-challenger:
+    image: base-challenger:local
+    build:
+      <<: *rust-service-build
+      target: challenger
+    container_name: base-challenger
+    profiles: ["base-l1"]
+    depends_on:
+      base-rpc:
+        condition: service_healthy
+      register-aggregate-verifier:
+        condition: service_completed_successfully
+      base-proposer:
+        condition: service_started
+    volumes:
+      - ../../.devnet/l2/configs:/devnet/l2/configs:ro
+      - ../../etc/scripts/devnet/setup-dispute-service.sh:/setup-dispute-service.sh:ro
+    environment:
+      - ADDRESSES_FILE=/devnet/l2/configs/l1-addresses.json
+      - BASE_CHALLENGER_L1_ETH_RPC=http://l1-el:${L1_HTTP_PORT}
+      - BASE_CHALLENGER_L2_ETH_RPC=http://base-rpc:${L2_BASE_RPC_HTTP_PORT}
+      - BASE_CHALLENGER_NO_DISPUTE=true
+      - BASE_CHALLENGER_BOND_CLAIM_ADDRESSES=${PROPOSER_ADDR}
+      - BASE_CHALLENGER_PRIVATE_KEY=${CHALLENGER_KEY}
+      - BASE_CHALLENGER_POLL_INTERVAL=6s
+      - BASE_CHALLENGER_NUM_CONFIRMATIONS=1
+    entrypoint: ["/bin/bash", "/setup-dispute-service.sh", "challenger"]
     restart: unless-stopped
 
   zk-prover-postgres:


### PR DESCRIPTION
## Problem

The Docker L3 CI build cache is not working — every push recompiles all Rust dependencies from scratch (~30+ min builds).

**Root cause**: Two issues compound:

1. **`COPY . .` invalidates the source layer on every commit.** The `source` stage copies the entire repo, so any file change produces a different layer hash. All downstream `cargo build` layers miss the registry cache.

2. **`--mount=type=cache,target=/app/target` is ephemeral on GHA.** These BuildKit cache mounts persist on the local daemon, but GHA spins a fresh runner per job — the mounts are always empty.

## Solution

Replace the single-stage source copy with [cargo-chef](https://github.com/LukeMathWalker/cargo-chef)'s three-stage caching pattern:

| Stage | Purpose |
|---|---|
| `planner` | `cargo chef prepare` → produces `recipe.json` (deterministic from Cargo.toml/lock) |
| `deps` | `cargo chef cook` → compiles all external deps into a cacheable layer |
| `source` | `COPY . .` on top of pre-built deps |

### Cache behavior after this change

**Source-only change** (most commits):
- `recipe.json` unchanged → `deps` layer **hits registry cache** → dependency compilation skipped entirely
- Builder stages only recompile workspace crates (~5-10 min)

**Cargo.toml/lock change** (dep updates):
- `recipe.json` changes → `deps` layer rebuilds → full dep compile (unavoidable)

The zk-prover gets its own `zk-deps` cook stage since it requires Go + protoc from `zk-builder-base`.

## Impact

- **L3 CI**: Source-only builds drop from ~30+ min to ~5-10 min
- **Main branch** (`docker.yml`): Also benefits since it uses the same Dockerfile
- **Local builds**: No regression — `docker buildx bake` works identically