### PR TITLE
feat(PRIV-2002): publish base-challenger image via docker-l3 CI

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [client, base, builder, consensus, proposer, batcher, da-server, zk-prover]
+        target: [client, base, builder, consensus, proposer, challenger, batcher, da-server, zk-prover]
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
## Summary

Add `challenger` to the `docker-l3.yml` build matrix so the `base-challenger`
image is built and published alongside the other L3 images. The challenger
compose service added in #3609 (PRIV-2001) needs a published image to run.

Stacked on `l3`. Closes PRIV-2002.

## Changes
- `.github/workflows/docker-l3.yml`: add `challenger` to the build matrix.