### PR TITLE
crypto: extract shared base-common-crypto signature primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3726,6 +3726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-common-crypto"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "k256",
+ "p256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "base-common-evm"
 version = "0.0.0"
 dependencies = [
@@ -4488,6 +4498,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "base-common-consensus",
+ "base-common-crypto",
  "base-common-precompiles",
  "base-precompile-macros",
  "base-precompile-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ base-common-rpc-types = { path = "crates/common/rpc-types" }
 base-common-flashblocks = { path = "crates/common/flashblocks" }
 base-common-evm = { path = "crates/common/evm", default-features = false }
 base-common-flz = { path = "crates/common/flz", default-features = false }
+base-common-crypto = { path = "crates/common/crypto", default-features = false }
 base-precompile-macros = { path = "crates/common/precompile-macros" }
 base-common-genesis = { path = "crates/common/genesis", default-features = false }
 base-common-consensus = { path = "crates/common/consensus", default-features = false }

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "base-common-crypto"
+description = "Shared elliptic-curve signature primitives (secp256k1 recovery, P-256 verify) with EIP-2 / OpenZeppelin low-s enforcement"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# crypto
+k256 = { workspace = true, features = ["ecdsa"] }
+p256 = { workspace = true, features = ["ecdsa"] }
+
+# alloy
+alloy-primitives.workspace = true
+
+# misc
+thiserror.workspace = true

--- a/crates/common/crypto/README.md
+++ b/crates/common/crypto/README.md
@@ -1,0 +1,29 @@
+# base-common-crypto
+
+Shared elliptic-curve signature primitives used across the Base protocol.
+
+This crate is the single home for the raw signature operations that the EIP-8130
+enshrined authenticators rely on, so the heavy curve logic and — critically — the
+**malleability policy** live in exactly one audited place:
+
+- [`Secp256k1::recover`] — recovers the signer of a 32-byte prehash from a
+  65-byte `r || s || v` signature, requiring `v in {27, 28}` and enforcing
+  **EIP-2 low-`s`**.
+- [`Secp256r1::verify_prehash`] — verifies a P-256 signature `(r, s)` over a
+  prehash for the public key `(x, y)`, enforcing low-`s` to match OpenZeppelin
+  `P256.verify`.
+
+## Why not call the precompiles?
+
+Both operations bottom out in the same `k256` / `p256` crates the EVM precompiles
+use, but the precompile *wrappers* deliberately disagree on malleability:
+
+- the `ecrecover` precompile (`0x01`) **normalizes** a high-`s` signature and
+  accepts it;
+- the RIP-7212 `P256VERIFY` precompile does **not** enforce low-`s`.
+
+The EIP-8130 authenticators must instead **reject** malleable (high-`s`)
+signatures, both to preserve transaction-hash non-malleability and to stay
+byte-parity with the deployed `AccountConfiguration` / OpenZeppelin-based
+authenticator contracts. This crate provides that policy as a reusable primitive
+rather than re-deriving it at each call site.

--- a/crates/common/crypto/src/error.rs
+++ b/crates/common/crypto/src/error.rs
@@ -1,0 +1,21 @@
+//! Error type for the shared elliptic-curve signature primitives.
+
+/// Reason a signature primitive rejected its inputs.
+///
+/// Every variant is a hard rejection: nothing may be authenticated on the
+/// strength of an input that produced one of these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum CryptoError {
+    /// The signature payload was the wrong length for the routed primitive.
+    #[error("signature payload is malformed")]
+    MalformedSignature,
+
+    /// The signature failed to parse, was malleable (upper-half `s`), or did not
+    /// verify / recover against the supplied prehash and key.
+    #[error("signature verification failed")]
+    InvalidSignature,
+
+    /// The public key could not be decoded or does not lie on the curve.
+    #[error("invalid public key")]
+    InvalidPublicKey,
+}

--- a/crates/common/crypto/src/lib.rs
+++ b/crates/common/crypto/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod error;
+pub use error::CryptoError;
+
+mod secp256k1;
+pub use secp256k1::Secp256k1;
+
+mod secp256r1;
+pub use secp256r1::Secp256r1;

--- a/crates/common/crypto/src/secp256k1.rs
+++ b/crates/common/crypto/src/secp256k1.rs
@@ -1,0 +1,109 @@
+//! secp256k1 ECDSA signer recovery with EIP-2 low-`s` enforcement.
+
+use alloy_primitives::{Address, B256, keccak256};
+use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+
+use crate::CryptoError;
+
+/// secp256k1 ECDSA operations shared across the protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Secp256k1;
+
+impl Secp256k1 {
+    /// Recovers the Ethereum address that signed `hash` from a 65-byte
+    /// `r || s || v` signature, requiring `v in {27, 28}` and enforcing **EIP-2
+    /// low-`s`** (a malleable upper-half-`s` signature is rejected, not
+    /// canonicalized).
+    ///
+    /// This is the recovery semantics of the enshrined EIP-8130 k1 authenticator
+    /// and the deployed `AccountConfiguration` reference. It deliberately differs
+    /// from the EVM `ecrecover` precompile, which normalizes and accepts a
+    /// high-`s` signature.
+    ///
+    /// Returns [`CryptoError::MalformedSignature`] when `signature` is not 65
+    /// bytes, and [`CryptoError::InvalidSignature`] when `v` is out of range, the
+    /// signature is malleable, or recovery fails.
+    pub fn recover(hash: B256, signature: &[u8]) -> Result<Address, CryptoError> {
+        if signature.len() != 65 {
+            return Err(CryptoError::MalformedSignature);
+        }
+        let recovery = match signature[64] {
+            27 | 28 => signature[64] - 27,
+            _ => return Err(CryptoError::InvalidSignature),
+        };
+        let sig =
+            Signature::from_slice(&signature[..64]).map_err(|_| CryptoError::InvalidSignature)?;
+        // `normalize_s` returns `Some` only when `s` is in the upper half, i.e. a
+        // malleable high-`s` signature: reject it rather than canonicalizing.
+        if sig.normalize_s().is_some() {
+            return Err(CryptoError::InvalidSignature);
+        }
+        let recovery_id = RecoveryId::from_byte(recovery).ok_or(CryptoError::InvalidSignature)?;
+        let key = VerifyingKey::recover_from_prehash(hash.as_slice(), &sig, recovery_id)
+            .map_err(|_| CryptoError::InvalidSignature)?;
+        let encoded = key.to_encoded_point(false);
+        // encoded = 0x04 || x(32) || y(32); address = keccak256(x || y)[12..].
+        Ok(Address::from_slice(&keccak256(&encoded.as_bytes()[1..])[12..]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use k256::ecdsa::{Signature as K256Signature, SigningKey};
+
+    use super::*;
+
+    const HASH: B256 = B256::repeat_byte(0x42);
+
+    fn signing_key() -> SigningKey {
+        SigningKey::from_slice(&[0x11u8; 32]).unwrap()
+    }
+
+    fn address_of(key: &SigningKey) -> Address {
+        let point = key.verifying_key().to_encoded_point(false);
+        Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+    }
+
+    /// 65-byte `r || s || v` signature over `hash`, `v` in `{27, 28}` (low-s).
+    fn sign(key: &SigningKey, hash: B256) -> [u8; 65] {
+        let (sig, recid) = key.sign_prehash_recoverable(hash.as_slice()).unwrap();
+        let mut out = [0u8; 65];
+        out[..64].copy_from_slice(&sig.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    #[test]
+    fn recovers_the_signer_address() {
+        let key = signing_key();
+        let recovered = Secp256k1::recover(HASH, &sign(&key, HASH)).unwrap();
+        assert_eq!(recovered, address_of(&key));
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert_eq!(Secp256k1::recover(HASH, &[0u8; 64]), Err(CryptoError::MalformedSignature));
+    }
+
+    #[test]
+    fn rejects_v_not_27_or_28() {
+        let mut sig = sign(&signing_key(), HASH);
+        sig[64] -= 27; // 0 or 1: invalid for the EVM ecrecover sentinel.
+        assert_eq!(Secp256k1::recover(HASH, &sig), Err(CryptoError::InvalidSignature));
+    }
+
+    #[test]
+    fn rejects_high_s() {
+        // The malleable upper-half-`s` counterpart (negate `s`, flip recovery
+        // parity) recovers the same signer but MUST be rejected.
+        let key = signing_key();
+        let (sig, recid) = key.sign_prehash_recoverable(HASH.as_slice()).unwrap();
+        let s_high = -*sig.s();
+        let high = K256Signature::from_scalars(sig.r().to_bytes(), s_high.to_bytes()).unwrap();
+        let mut bytes = [0u8; 65];
+        bytes[..64].copy_from_slice(&high.to_bytes());
+        bytes[64] = (recid.to_byte() ^ 1) + 27;
+        assert_eq!(Secp256k1::recover(HASH, &bytes), Err(CryptoError::InvalidSignature));
+    }
+}

--- a/crates/common/crypto/src/secp256r1.rs
+++ b/crates/common/crypto/src/secp256r1.rs
@@ -1,0 +1,122 @@
+//! secp256r1 (P-256) ECDSA verification with low-`s` enforcement.
+
+use p256::ecdsa::{Signature, VerifyingKey, signature::hazmat::PrehashVerifier};
+
+use crate::CryptoError;
+
+/// secp256r1 (P-256) ECDSA operations shared across the protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Secp256r1;
+
+impl Secp256r1 {
+    /// Verifies a P-256 signature `(r, s)` over the `prehash` for the public key
+    /// `(x, y)`, enforcing low-`s` to match `OpenZeppelin` `P256.verify` (the
+    /// malleability check the deployed EIP-8130 P-256 and `WebAuthn`
+    /// authenticators perform).
+    ///
+    /// Each of `r`, `s`, `x`, and `y` must be exactly 32 bytes. Returns
+    /// [`CryptoError::InvalidPublicKey`] when `(x, y)` is the wrong length or not
+    /// on the curve, and [`CryptoError::InvalidSignature`] when `(r, s)` is the
+    /// wrong length, malleable, or does not verify.
+    pub fn verify_prehash(
+        prehash: &[u8],
+        r: &[u8],
+        s: &[u8],
+        x: &[u8],
+        y: &[u8],
+    ) -> Result<(), CryptoError> {
+        if x.len() != 32 || y.len() != 32 {
+            return Err(CryptoError::InvalidPublicKey);
+        }
+        if r.len() != 32 || s.len() != 32 {
+            return Err(CryptoError::InvalidSignature);
+        }
+
+        let mut sec1 = [0u8; 65];
+        sec1[0] = 0x04;
+        sec1[1..33].copy_from_slice(x);
+        sec1[33..65].copy_from_slice(y);
+        let key =
+            VerifyingKey::from_sec1_bytes(&sec1).map_err(|_| CryptoError::InvalidPublicKey)?;
+
+        let mut rs = [0u8; 64];
+        rs[..32].copy_from_slice(r);
+        rs[32..].copy_from_slice(s);
+        let signature = Signature::from_slice(&rs).map_err(|_| CryptoError::InvalidSignature)?;
+        // Reject a malleable upper-half-`s` signature rather than canonicalizing.
+        if signature.normalize_s().is_some() {
+            return Err(CryptoError::InvalidSignature);
+        }
+        key.verify_prehash(prehash, &signature).map_err(|_| CryptoError::InvalidSignature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p256::ecdsa::{Signature as P256Sig, SigningKey, signature::hazmat::PrehashSigner};
+
+    use super::*;
+
+    const PREHASH: &[u8; 32] = &[0x42u8; 32];
+
+    fn signing_key() -> SigningKey {
+        SigningKey::from_slice(&[0x22u8; 32]).unwrap()
+    }
+
+    fn public_xy(key: &SigningKey) -> ([u8; 32], [u8; 32]) {
+        let point = key.verifying_key().to_encoded_point(false);
+        let bytes = point.as_bytes();
+        (bytes[1..33].try_into().unwrap(), bytes[33..65].try_into().unwrap())
+    }
+
+    /// Low-`s`-normalized `(r, s)` over `prehash`.
+    fn sign(key: &SigningKey, prehash: &[u8]) -> [u8; 64] {
+        let sig: P256Sig = key.sign_prehash(prehash).unwrap();
+        sig.normalize_s().unwrap_or(sig).to_bytes().into()
+    }
+
+    #[test]
+    fn verifies_a_valid_signature() {
+        let key = signing_key();
+        let (x, y) = public_xy(&key);
+        let rs = sign(&key, PREHASH);
+        assert_eq!(Secp256r1::verify_prehash(PREHASH, &rs[..32], &rs[32..], &x, &y), Ok(()));
+    }
+
+    #[test]
+    fn rejects_a_tampered_prehash() {
+        let key = signing_key();
+        let (x, y) = public_xy(&key);
+        let rs = sign(&key, PREHASH);
+        let other = [0x99u8; 32];
+        assert_eq!(
+            Secp256r1::verify_prehash(&other, &rs[..32], &rs[32..], &x, &y),
+            Err(CryptoError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn rejects_high_s() {
+        // Force the upper-half-`s` (malleable) counterpart of a valid signature.
+        let key = signing_key();
+        let (x, y) = public_xy(&key);
+        let sig: P256Sig = key.sign_prehash(PREHASH).unwrap();
+        let low = sig.normalize_s().unwrap_or(sig);
+        let high = P256Sig::from_scalars(low.r(), -low.s()).unwrap();
+        let rs: [u8; 64] = high.to_bytes().into();
+        assert_eq!(
+            Secp256r1::verify_prehash(PREHASH, &rs[..32], &rs[32..], &x, &y),
+            Err(CryptoError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_length_public_key() {
+        let rs = [0u8; 64];
+        assert_eq!(
+            Secp256r1::verify_prehash(PREHASH, &rs[..32], &rs[32..], &[0u8; 31], &[0u8; 32]),
+            Err(CryptoError::InvalidPublicKey),
+        );
+    }
+}

--- a/crates/execution/eip8130/Cargo.toml
+++ b/crates/execution/eip8130/Cargo.toml
@@ -17,14 +17,13 @@ workspace = true
 # crypto
 sha2.workspace = true
 base64.workspace = true
-k256 = { workspace = true, features = ["ecdsa"] }
-p256 = { workspace = true, features = ["ecdsa"] }
 
 # alloy
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 
 # base
+base-common-crypto.workspace = true
 base-precompile-macros.workspace = true
 base-precompile-storage.workspace = true
 base-common-precompiles.workspace = true
@@ -37,6 +36,8 @@ revm.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+k256 = { workspace = true, features = ["ecdsa"] }
+p256 = { workspace = true, features = ["ecdsa"] }
 base-precompile-storage = { workspace = true, features = ["test-utils"] }
 
 [features]

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -5,10 +5,7 @@ use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_sol_types::{SolValue, sol};
 use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use p256::ecdsa::{
-    Signature as P256Signature, VerifyingKey as P256VerifyingKey,
-    signature::hazmat::PrehashVerifier,
-};
+use base_common_crypto::Secp256r1;
 use sha2::{Digest, Sha256};
 
 use crate::{AuthError, DispatchOutcome, RecoveredActorId};
@@ -131,34 +128,8 @@ impl AuthenticatorDispatch {
             return Err(AuthError::MalformedAuth);
         }
         let (r, s, x, y) = (&data[0..32], &data[32..64], &data[64..96], &data[96..128]);
-        Self::p256_verify(hash.as_slice(), r, s, x, y)?;
+        Secp256r1::verify_prehash(hash.as_slice(), r, s, x, y)?;
         Ok(keccak256([x, y].concat()))
-    }
-
-    /// Verify a P-256 signature `(r, s)` over `prehash` for public key `(x, y)`.
-    /// Enforces low-`s` to match `OpenZeppelin` `P256.verify` (malleability check).
-    fn p256_verify(
-        prehash: &[u8],
-        r: &[u8],
-        s: &[u8],
-        x: &[u8],
-        y: &[u8],
-    ) -> Result<(), AuthError> {
-        let mut sec1 = [0u8; 65];
-        sec1[0] = 0x04;
-        sec1[1..33].copy_from_slice(x);
-        sec1[33..65].copy_from_slice(y);
-        let key =
-            P256VerifyingKey::from_sec1_bytes(&sec1).map_err(|_| AuthError::InvalidPublicKey)?;
-
-        let mut rs = [0u8; 64];
-        rs[..32].copy_from_slice(r);
-        rs[32..].copy_from_slice(s);
-        let signature = P256Signature::from_slice(&rs).map_err(|_| AuthError::InvalidSignature)?;
-        if signature.normalize_s().is_some() {
-            return Err(AuthError::InvalidSignature);
-        }
-        key.verify_prehash(prehash, &signature).map_err(|_| AuthError::InvalidSignature)
     }
 
     /// `WebAuthn` authenticator. `data = abi.encode(WebAuthnAuth, x, y)`.
@@ -199,7 +170,7 @@ impl AuthenticatorDispatch {
         signed.update(client_hash);
         let signed = signed.finalize();
 
-        Self::p256_verify(
+        Secp256r1::verify_prehash(
             signed.as_slice(),
             auth.r.as_slice(),
             auth.s.as_slice(),

--- a/crates/execution/eip8130/src/error.rs
+++ b/crates/execution/eip8130/src/error.rs
@@ -1,6 +1,7 @@
 //! Errors returned by EIP-8130 authenticator dispatch.
 
 use alloy_primitives::Address;
+use base_common_crypto::CryptoError;
 
 /// Reason an authentication blob was rejected during dispatch.
 ///
@@ -32,4 +33,18 @@ pub enum AuthError {
     /// The supplied P-256 public-key coordinates do not lie on the curve.
     #[error("invalid public key")]
     InvalidPublicKey,
+}
+
+impl From<CryptoError> for AuthError {
+    /// Maps a low-level [`CryptoError`] from [`base_common_crypto`] onto the
+    /// dispatch-level rejection, preserving the existing wire-error semantics: a
+    /// wrong-length payload is a malformed blob, everything else is an invalid
+    /// signature or public key.
+    fn from(err: CryptoError) -> Self {
+        match err {
+            CryptoError::MalformedSignature => Self::MalformedAuth,
+            CryptoError::InvalidSignature => Self::InvalidSignature,
+            CryptoError::InvalidPublicKey => Self::InvalidPublicKey,
+        }
+    }
 }

--- a/crates/execution/eip8130/src/recovered.rs
+++ b/crates/execution/eip8130/src/recovered.rs
@@ -1,9 +1,9 @@
 //! Proof-of-recovery actor id: a recovered secp256k1 signer that can only be
 //! produced by a verified signature recovery.
 
-use alloy_primitives::{Address, B256, keccak256};
+use alloy_primitives::{Address, B256};
 use base_common_consensus::Eip8130Signed;
-use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
+use base_common_crypto::Secp256k1;
 
 use crate::AuthError;
 
@@ -34,29 +34,12 @@ impl RecoveredActorId {
     /// k1 path through here, so the two stay byte-parity with the deployed
     /// `AccountConfiguration` reference by construction.
     ///
+    /// The recovery itself is delegated to [`base_common_crypto::Secp256k1`], the
+    /// single home for the low-`s` policy shared with the rest of the protocol.
+    ///
     /// [`AuthenticatorDispatch`]: crate::AuthenticatorDispatch
     pub fn recover_k1(hash: B256, signature: &[u8]) -> Result<Self, AuthError> {
-        if signature.len() != 65 {
-            return Err(AuthError::MalformedAuth);
-        }
-        let recovery = match signature[64] {
-            27 | 28 => signature[64] - 27,
-            _ => return Err(AuthError::InvalidSignature),
-        };
-        let sig =
-            K256Signature::from_slice(&signature[..64]).map_err(|_| AuthError::InvalidSignature)?;
-        // `normalize_s` returns `Some` only when `s` is in the upper half, i.e. a
-        // malleable high-`s` signature: reject it rather than canonicalizing.
-        if sig.normalize_s().is_some() {
-            return Err(AuthError::InvalidSignature);
-        }
-        let recovery_id = RecoveryId::from_byte(recovery).ok_or(AuthError::InvalidSignature)?;
-        let key = K256VerifyingKey::recover_from_prehash(hash.as_slice(), &sig, recovery_id)
-            .map_err(|_| AuthError::InvalidSignature)?;
-        let encoded = key.to_encoded_point(false);
-        // encoded = 0x04 || x(32) || y(32); address = keccak256(x || y)[12..].
-        let address = Address::from_slice(&keccak256(&encoded.as_bytes()[1..])[12..]);
-        Ok(Self { address })
+        Ok(Self { address: Secp256k1::recover(hash, signature)? })
     }
 
     /// Recovers the EOA sender of a signed transaction — the empty-`sender` wire


### PR DESCRIPTION
## Summary

Stacked on top of #3586.

Extracts the secp256k1 recovery and P-256 verification used by the EIP-8130 enshrined authenticators into a new `base-common-crypto` crate, so the curve logic and — crucially — the **low-`s` malleability policy** live in one audited place instead of being re-derived at each call site.

- New `crates/common/crypto` exposing:
  - `Secp256k1::recover(hash, sig)` — 65-byte `r‖s‖v`, `v ∈ {27,28}`, **EIP-2 low-`s` enforced**.
  - `Secp256r1::verify_prehash(prehash, r, s, x, y)` — low-`s` enforced to match OpenZeppelin `P256.verify`.
  - `CryptoError` with a `From<CryptoError> for AuthError` mapping in eip8130.
- `AuthenticatorDispatch` (p256 + webauthn) and `RecoveredActorId::recover_k1` now delegate to the shared primitives.
- `k256` / `p256` move to `dev-dependencies` of `base-execution-eip8130` (remaining uses are test-only).

### Why a shared crate instead of calling the precompiles

Both the precompiles and EIP-8130 already bottom out in the same `k256`/`p256` crates, but the precompile wrappers deliberately disagree on malleability: `ecrecover` (`0x01`) normalizes and accepts high-`s`, and the RIP-7212 `P256VERIFY` precompile does not enforce low-`s`. EIP-8130 must **reject** high-`s` to preserve transaction-hash non-malleability and stay byte-parity with the deployed `AccountConfiguration` / OZ-based authenticator contracts. Reusing the precompile entry points directly would silently change those semantics (a security-control downgrade), so we share the *primitive* and keep the policy in one place.

No behavior change: error mapping and low-`s` rejection are preserved.

## Test plan

- [x] `cargo test -p base-common-crypto` (8 tests: recover, low-`s` rejection, `v` range, length, p256 verify/tamper/length)
- [x] `cargo test -p base-execution-eip8130` (92 tests, unchanged)
- [x] `cargo clippy -p base-common-crypto -p base-execution-eip8130 --all-targets` clean