### PR TITLE
Simplify transaction event JSONL writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5239,7 +5239,6 @@ dependencies = [
  "eyre",
  "hex",
  "metrics",
- "once_cell",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,7 +5244,6 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "tracing-appender",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5239,6 +5239,7 @@ dependencies = [
  "eyre",
  "hex",
  "metrics",
+ "once_cell",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5246,6 +5246,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-appender",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,6 +452,7 @@ clap_builder = "4.5.57"
 tracing-appender = "0.2.4"
 tracing-subscriber = "0.3.22"
 tracing = { version = "0.1.43", default-features = false }
+once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 
 # Metrics
 ordered-float = "5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,7 +452,6 @@ clap_builder = "4.5.57"
 tracing-appender = "0.2.4"
 tracing-subscriber = "0.3.22"
 tracing = { version = "0.1.43", default-features = false }
-once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 
 # Metrics
 ordered-float = "5"

--- a/crates/common/observability-events/Cargo.toml
+++ b/crates/common/observability-events/Cargo.toml
@@ -22,8 +22,8 @@ serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "sync", "time"] }
 tracing = { workspace = true, features = ["std"] }
+tracing-appender.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/common/observability-events/Cargo.toml
+++ b/crates/common/observability-events/Cargo.toml
@@ -22,12 +22,13 @@ serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-appender.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [features]
 default = [ "metrics" ]

--- a/crates/common/observability-events/Cargo.toml
+++ b/crates/common/observability-events/Cargo.toml
@@ -22,13 +22,11 @@ serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-appender.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [features]
 default = [ "metrics" ]

--- a/crates/common/observability-events/Cargo.toml
+++ b/crates/common/observability-events/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { workspace = true, features = ["serde"] }
 eyre.workspace = true
 hex.workspace = true
 metrics = { workspace = true, optional = true }
-once_cell.workspace = true
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2.workspace = true

--- a/crates/common/observability-events/Cargo.toml
+++ b/crates/common/observability-events/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { workspace = true, features = ["serde"] }
 eyre.workspace = true
 hex.workspace = true
 metrics = { workspace = true, optional = true }
+once_cell.workspace = true
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2.workspace = true

--- a/crates/common/observability-events/README.md
+++ b/crates/common/observability-events/README.md
@@ -18,7 +18,7 @@ stdout/stderr and the normal Kubernetes log pipeline.
 - **`EventIdBuilder`**: Helper for deterministic event IDs so downstream ingest
   can deduplicate retries.
 - **`TransactionEventWriter`**: Non-blocking JSONL append writer with bounded
-  queueing, dropped-event metrics, write-error metrics, queue depth, and bytes
+  queueing, aggregate dropped-event metrics, write-error metrics, and bytes
   written metrics.
 - **`TransactionEventBuilder`** and **`transaction_event!`**: Helpers for
   producer call sites that use the process-global transaction event writer while

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -1,10 +1,9 @@
 //! Transaction event emission helpers and process-global writer access.
 
-use std::cell::Cell;
+use std::sync::{Mutex, OnceLock};
 
 use alloy_primitives::{B256, TxHash};
 use chrono::Utc;
-use once_cell::sync::OnceCell;
 use serde_json::{Map, Value};
 use tracing::debug;
 
@@ -13,7 +12,8 @@ use crate::{
     TransactionEventWriter, TransactionEventWriterConfig, WriteEventError,
 };
 
-static GLOBAL_TRANSACTION_EVENT_WRITER: OnceCell<TransactionEventWriter> = OnceCell::new();
+static GLOBAL_TRANSACTION_EVENT_WRITER: OnceLock<TransactionEventWriter> = OnceLock::new();
+static GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Result of initializing the process-global transaction event writer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,17 +51,20 @@ impl GlobalTransactionEventWriter {
             return Ok(GlobalTransactionEventWriterInitStatus::NotConfigured);
         }
 
-        let initialized = Cell::new(false);
-        GLOBAL_TRANSACTION_EVENT_WRITER.get_or_try_init(|| {
-            initialized.set(true);
-            TransactionEventWriter::from_config(config)
-        })?;
-
-        if initialized.get() {
-            Ok(GlobalTransactionEventWriterInitStatus::Initialized)
-        } else {
-            Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized)
+        if GLOBAL_TRANSACTION_EVENT_WRITER.get().is_some() {
+            return Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized);
         }
+
+        let _guard = GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK
+            .lock()
+            .map_err(|_| eyre::eyre!("transaction event writer init lock poisoned"))?;
+        if GLOBAL_TRANSACTION_EVENT_WRITER.get().is_some() {
+            return Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized);
+        }
+
+        let writer = TransactionEventWriter::from_config(config)?;
+        let _ = GLOBAL_TRANSACTION_EVENT_WRITER.set(writer);
+        Ok(GlobalTransactionEventWriterInitStatus::Initialized)
     }
 
     /// Returns the process-global transaction event writer, if configured.

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -1,11 +1,10 @@
 //! Transaction event emission helpers and process-global writer access.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use alloy_primitives::{B256, TxHash};
 use chrono::Utc;
 use serde_json::{Map, Value};
-use tokio::sync::OnceCell;
 use tracing::debug;
 
 use crate::{
@@ -13,7 +12,8 @@ use crate::{
     TransactionEventWriter, TransactionEventWriterConfig, WriteEventError,
 };
 
-static GLOBAL_TRANSACTION_EVENT_WRITER: OnceCell<TransactionEventWriter> = OnceCell::const_new();
+static GLOBAL_TRANSACTION_EVENT_WRITER: OnceLock<TransactionEventWriter> = OnceLock::new();
+static GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Result of initializing the process-global transaction event writer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,7 +41,7 @@ pub struct GlobalTransactionEventWriter;
 
 impl GlobalTransactionEventWriter {
     /// Initializes the process-global transaction event writer.
-    pub async fn init(
+    pub fn init(
         config: Option<TransactionEventWriterConfig>,
     ) -> eyre::Result<GlobalTransactionEventWriterInitStatus> {
         let Some(config) = config else {
@@ -55,19 +55,16 @@ impl GlobalTransactionEventWriter {
             return Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized);
         }
 
-        let initialized = AtomicBool::new(false);
-        GLOBAL_TRANSACTION_EVENT_WRITER
-            .get_or_try_init(|| async {
-                initialized.store(true, Ordering::Relaxed);
-                TransactionEventWriter::from_config(config).await
-            })
-            .await?;
-
-        if initialized.load(Ordering::Relaxed) {
-            Ok(GlobalTransactionEventWriterInitStatus::Initialized)
-        } else {
-            Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized)
+        let _guard = GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK
+            .lock()
+            .map_err(|_| eyre::eyre!("transaction event writer init lock poisoned"))?;
+        if GLOBAL_TRANSACTION_EVENT_WRITER.get().is_some() {
+            return Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized);
         }
+
+        let writer = TransactionEventWriter::from_config(config)?;
+        let _ = GLOBAL_TRANSACTION_EVENT_WRITER.set(writer);
+        Ok(GlobalTransactionEventWriterInitStatus::Initialized)
     }
 
     /// Returns the process-global transaction event writer, if configured.

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -1,9 +1,10 @@
 //! Transaction event emission helpers and process-global writer access.
 
-use std::sync::{Mutex, OnceLock};
+use std::cell::Cell;
 
 use alloy_primitives::{B256, TxHash};
 use chrono::Utc;
+use once_cell::sync::OnceCell;
 use serde_json::{Map, Value};
 use tracing::debug;
 
@@ -12,8 +13,7 @@ use crate::{
     TransactionEventWriter, TransactionEventWriterConfig, WriteEventError,
 };
 
-static GLOBAL_TRANSACTION_EVENT_WRITER: OnceLock<TransactionEventWriter> = OnceLock::new();
-static GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK: Mutex<()> = Mutex::new(());
+static GLOBAL_TRANSACTION_EVENT_WRITER: OnceCell<TransactionEventWriter> = OnceCell::new();
 
 /// Result of initializing the process-global transaction event writer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,20 +51,17 @@ impl GlobalTransactionEventWriter {
             return Ok(GlobalTransactionEventWriterInitStatus::NotConfigured);
         }
 
-        if GLOBAL_TRANSACTION_EVENT_WRITER.get().is_some() {
-            return Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized);
-        }
+        let initialized = Cell::new(false);
+        GLOBAL_TRANSACTION_EVENT_WRITER.get_or_try_init(|| {
+            initialized.set(true);
+            TransactionEventWriter::from_config(config)
+        })?;
 
-        let _guard = GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK
-            .lock()
-            .map_err(|_| eyre::eyre!("transaction event writer init lock poisoned"))?;
-        if GLOBAL_TRANSACTION_EVENT_WRITER.get().is_some() {
-            return Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized);
+        if initialized.get() {
+            Ok(GlobalTransactionEventWriterInitStatus::Initialized)
+        } else {
+            Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized)
         }
-
-        let writer = TransactionEventWriter::from_config(config)?;
-        let _ = GLOBAL_TRANSACTION_EVENT_WRITER.set(writer);
-        Ok(GlobalTransactionEventWriterInitStatus::Initialized)
     }
 
     /// Returns the process-global transaction event writer, if configured.

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -358,7 +358,7 @@ macro_rules! transaction_event {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, time::Duration};
+    use std::path::PathBuf;
 
     use alloy_primitives::{B256, TxHash};
     use serde_json::{Map, json};
@@ -374,7 +374,6 @@ mod tests {
             enabled: false,
             file_path: PathBuf::from("/tmp/transaction-events.jsonl"),
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
-            flush_interval: Duration::from_secs(1),
             required: false,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-devnet".to_string(),

--- a/crates/common/observability-events/src/event.rs
+++ b/crates/common/observability-events/src/event.rs
@@ -1,4 +1,4 @@
-use std::{fmt, time::Duration};
+use std::fmt;
 
 use alloy_primitives::{B256, TxHash};
 use chrono::{DateTime, Utc};
@@ -10,9 +10,6 @@ pub const SCHEMA_VERSION: &str = "transaction-event/v1";
 
 /// Default bounded channel capacity for the background writer.
 pub const DEFAULT_QUEUE_CAPACITY: usize = 16_384;
-
-/// Default background flush interval.
-pub const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 
 const MAX_DATA_VALIDATION_DEPTH: usize = 16;
 

--- a/crates/common/observability-events/src/metrics.rs
+++ b/crates/common/observability-events/src/metrics.rs
@@ -10,8 +10,6 @@ base_metrics::define_metrics! {
     #[describe("Transaction event journal write or flush errors")]
     #[label(name = "operation", default = ["write", "flush"])]
     write_errors: counter,
-    #[describe("Transaction event journal queue depth")]
-    queue_depth: gauge,
     #[describe("Transaction event journal bytes written")]
     bytes_written: counter,
 }

--- a/crates/common/observability-events/src/metrics.rs
+++ b/crates/common/observability-events/src/metrics.rs
@@ -2,8 +2,8 @@
 
 base_metrics::define_metrics! {
     transaction_events
-    #[describe("Transaction event journal entries accepted by the writer")]
-    emitted_events: counter,
+    #[describe("Transaction event journal entries submitted to the writer")]
+    submitted_events: counter,
     #[describe("Transaction event journal entries dropped before enqueue")]
     #[label(name = "reason", default = ["disabled", "backpressure", "closed", "serialization", "validation"])]
     dropped_events: counter,

--- a/crates/common/observability-events/src/metrics.rs
+++ b/crates/common/observability-events/src/metrics.rs
@@ -5,7 +5,7 @@ base_metrics::define_metrics! {
     #[describe("Transaction event journal entries submitted to the writer")]
     submitted_events: counter,
     #[describe("Transaction event journal entries dropped before enqueue")]
-    #[label(name = "reason", default = ["disabled", "backpressure", "closed", "serialization", "validation"])]
+    #[label(name = "reason", default = ["disabled", "backpressure", "serialization", "validation"])]
     dropped_events: counter,
     #[describe("Transaction event journal write or flush errors")]
     #[label(name = "operation", default = ["write", "flush"])]

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -27,7 +27,9 @@ pub struct TransactionEventWriterConfig {
     pub file_path: PathBuf,
     /// Bounded queue capacity before producers drop instead of blocking.
     pub queue_capacity: usize,
-    /// Periodic flush interval for the background file writer.
+    /// Preferred periodic flush interval for implementations that manage their
+    /// own flush loop. The current non-blocking appender flushes on its
+    /// internal cadence, so this is retained for config compatibility.
     pub flush_interval: Duration,
     /// If true, initialization errors are returned to the caller.
     pub required: bool,
@@ -204,6 +206,8 @@ impl TransactionEventWriter {
         let mut writer = writer.clone();
         if writer.write_all(&line).is_err() {
             Metrics::dropped_events("closed").increment(1);
+            self.observe_dropped_events();
+            return Err(WriteEventError::Closed);
         }
 
         self.observe_dropped_events();
@@ -221,13 +225,24 @@ impl TransactionEventWriter {
             return 0;
         };
 
-        let current = dropped.dropped_lines();
-        let previous = self.inner.observed_drops.swap(current, Ordering::Relaxed);
-        let delta = current.saturating_sub(previous);
-        if delta > 0 {
-            Metrics::dropped_events("backpressure").increment(delta as u64);
+        loop {
+            let current = dropped.dropped_lines();
+            let previous = self.inner.observed_drops.load(Ordering::Relaxed);
+            if current <= previous {
+                return 0;
+            }
+
+            if self
+                .inner
+                .observed_drops
+                .compare_exchange_weak(previous, current, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                let delta = current - previous;
+                Metrics::dropped_events("backpressure").increment(delta as u64);
+                return delta;
+            }
         }
-        delta
     }
 }
 
@@ -237,6 +252,9 @@ pub enum WriteEventError {
     /// Writer is disabled.
     #[error("transaction event writer is disabled")]
     Disabled,
+    /// Writer queue is closed.
+    #[error("transaction event writer is closed")]
+    Closed,
     /// Serialization failed.
     #[error("failed to serialize transaction event: {0}")]
     Serialize(serde_json::Error),

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -7,15 +7,14 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
-    time::Duration,
 };
 
 use tracing::warn;
 use tracing_appender::non_blocking::{ErrorCounter, NonBlocking, NonBlockingBuilder, WorkerGuard};
 
 use crate::{
-    DEFAULT_FLUSH_INTERVAL, DEFAULT_QUEUE_CAPACITY, Metrics, TransactionEvent,
-    TransactionEventProducer, TransactionEventValidationError,
+    DEFAULT_QUEUE_CAPACITY, Metrics, TransactionEvent, TransactionEventProducer,
+    TransactionEventValidationError,
 };
 
 /// Configuration for the dedicated transaction event JSONL writer.
@@ -27,10 +26,6 @@ pub struct TransactionEventWriterConfig {
     pub file_path: PathBuf,
     /// Bounded queue capacity before producers drop instead of blocking.
     pub queue_capacity: usize,
-    /// Preferred periodic flush interval for implementations that manage their
-    /// own flush loop. The current non-blocking appender flushes on its
-    /// internal cadence, so this is retained for config compatibility.
-    pub flush_interval: Duration,
     /// If true, initialization errors are returned to the caller.
     pub required: bool,
     /// Producer identity expected for events written through this handle.
@@ -50,7 +45,6 @@ impl TransactionEventWriterConfig {
             enabled: false,
             file_path: file_path.into(),
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
-            flush_interval: DEFAULT_FLUSH_INTERVAL,
             required: false,
             producer,
             network: network.into(),
@@ -317,7 +311,6 @@ mod tests {
             enabled: true,
             file_path: PathBuf::from("test.jsonl"),
             queue_capacity,
-            flush_interval: Duration::from_millis(10),
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
@@ -526,7 +519,6 @@ mod tests {
             enabled: true,
             file_path: path.clone(),
             queue_capacity: 8,
-            flush_interval: Duration::from_millis(10),
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
@@ -579,7 +571,6 @@ mod tests {
             enabled: true,
             file_path: path.clone(),
             queue_capacity: 8,
-            flush_interval: Duration::from_millis(10),
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
@@ -601,7 +592,6 @@ mod tests {
             enabled: true,
             file_path: path,
             queue_capacity: 8,
-            flush_interval: Duration::from_millis(10),
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -205,7 +205,7 @@ impl TransactionEventWriter {
         }
 
         self.observe_dropped_events();
-        Metrics::emitted_events().increment(1);
+        Metrics::submitted_events().increment(1);
         Ok(())
     }
 

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -197,13 +197,7 @@ impl TransactionEventWriter {
         })?;
         line.push(b'\n');
 
-        let mut writer = writer.clone();
-        if writer.write_all(&line).is_err() {
-            Metrics::dropped_events("closed").increment(1);
-            self.observe_dropped_events();
-            return Err(WriteEventError::Closed);
-        }
-
+        let _ = writer.clone().write_all(&line);
         self.observe_dropped_events();
         Metrics::submitted_events().increment(1);
         Ok(())
@@ -246,9 +240,6 @@ pub enum WriteEventError {
     /// Writer is disabled.
     #[error("transaction event writer is disabled")]
     Disabled,
-    /// Writer queue is closed.
-    #[error("transaction event writer is closed")]
-    Closed,
     /// Serialization failed.
     #[error("failed to serialize transaction event: {0}")]
     Serialize(serde_json::Error),

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -1,4 +1,7 @@
 use std::{
+    fmt,
+    fs::{File, OpenOptions, create_dir_all},
+    io::{self, Write},
     path::PathBuf,
     sync::{
         Arc,
@@ -7,14 +10,8 @@ use std::{
     time::Duration,
 };
 
-use tokio::{
-    fs::{OpenOptions, create_dir_all},
-    io::{AsyncWrite, AsyncWriteExt, BufWriter},
-    sync::mpsc,
-    task::JoinHandle,
-    time::{MissedTickBehavior, interval},
-};
-use tracing::{error, warn};
+use tracing::warn;
+use tracing_appender::non_blocking::{ErrorCounter, NonBlocking, NonBlockingBuilder, WorkerGuard};
 
 use crate::{
     DEFAULT_FLUSH_INTERVAL, DEFAULT_QUEUE_CAPACITY, Metrics, TransactionEvent,
@@ -60,24 +57,65 @@ impl TransactionEventWriterConfig {
 }
 
 /// Non-blocking handle for appending transaction events to JSONL.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TransactionEventWriter {
     inner: Arc<WriterInner>,
 }
 
-#[derive(Debug)]
 struct WriterInner {
-    tx: Option<mpsc::Sender<QueuedEvent>>,
-    queued: Arc<AtomicUsize>,
-    _task: Option<JoinHandle<()>>,
+    writer: Option<NonBlocking>,
+    dropped: Option<ErrorCounter>,
+    observed_drops: AtomicUsize,
+    _guard: Option<Arc<WorkerGuard>>,
     config: TransactionEventWriterConfig,
 }
 
+impl fmt::Debug for TransactionEventWriter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransactionEventWriter")
+            .field("enabled", &self.inner.writer.is_some())
+            .field("config", &self.inner.config)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug)]
-struct QueuedEvent {
-    event_id: String,
-    tx_hash: Option<String>,
-    line: Vec<u8>,
+struct MetricWriter<W> {
+    inner: W,
+}
+
+impl<W> MetricWriter<W> {
+    const fn new(inner: W) -> Self {
+        Self { inner }
+    }
+}
+
+impl<W> Write for MetricWriter<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.inner.write(buf) {
+            Ok(bytes) => {
+                Metrics::bytes_written().increment(bytes as u64);
+                Ok(bytes)
+            }
+            Err(err) => {
+                Metrics::write_errors("write").increment(1);
+                Err(err)
+            }
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.inner.flush() {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                Metrics::write_errors("flush").increment(1);
+                Err(err)
+            }
+        }
+    }
 }
 
 impl TransactionEventWriter {
@@ -92,13 +130,7 @@ impl TransactionEventWriter {
             return Ok(Self::disabled(config));
         }
 
-        let file = async {
-            if let Some(parent) = config.file_path.parent() {
-                create_dir_all(parent).await?;
-            }
-            OpenOptions::new().create(true).append(true).open(&config.file_path).await
-        }
-        .await;
+        let file = open_file(&config);
 
         let file = match file {
             Ok(file) => file,
@@ -120,20 +152,21 @@ impl TransactionEventWriter {
         };
 
         let queue_capacity = config.queue_capacity.max(1);
-        let flush_interval = if config.flush_interval.is_zero() {
-            DEFAULT_FLUSH_INTERVAL
-        } else {
-            config.flush_interval
-        };
-        let (tx, rx) = mpsc::channel(queue_capacity);
-        let queued = Arc::new(AtomicUsize::new(0));
-        let task_queued = Arc::clone(&queued);
-        let task = tokio::spawn(async move {
-            run_writer(BufWriter::new(file), rx, task_queued, flush_interval).await;
-        });
+        let (writer, guard) = NonBlockingBuilder::default()
+            .lossy(true)
+            .buffered_lines_limit(queue_capacity)
+            .thread_name("transaction-event-writer")
+            .finish(MetricWriter::new(file));
+        let dropped = writer.error_counter();
 
         Ok(Self {
-            inner: Arc::new(WriterInner { tx: Some(tx), queued, _task: Some(task), config }),
+            inner: Arc::new(WriterInner {
+                writer: Some(writer),
+                dropped: Some(dropped),
+                observed_drops: AtomicUsize::new(0),
+                _guard: Some(Arc::new(guard)),
+                config,
+            }),
         })
     }
 
@@ -141,9 +174,10 @@ impl TransactionEventWriter {
     pub fn disabled(config: TransactionEventWriterConfig) -> Self {
         Self {
             inner: Arc::new(WriterInner {
-                tx: None,
-                queued: Arc::new(AtomicUsize::new(0)),
-                _task: None,
+                writer: None,
+                dropped: None,
+                observed_drops: AtomicUsize::new(0),
+                _guard: None,
                 config,
             }),
         }
@@ -151,7 +185,7 @@ impl TransactionEventWriter {
 
     /// Attempts to enqueue one event without blocking the caller.
     pub fn try_write(&self, event: &TransactionEvent) -> Result<(), WriteEventError> {
-        let Some(tx) = &self.inner.tx else {
+        let Some(writer) = &self.inner.writer else {
             Metrics::dropped_events("disabled").increment(1);
             return Err(WriteEventError::Disabled);
         };
@@ -167,44 +201,33 @@ impl TransactionEventWriter {
         })?;
         line.push(b'\n');
 
-        let queued_event = QueuedEvent {
-            event_id: event.event_id.clone(),
-            tx_hash: event.tx_hash.map(|tx_hash| format!("{tx_hash:#x}")),
-            line,
-        };
-
-        self.inner.queued.fetch_add(1, Ordering::Relaxed);
-
-        match tx.try_send(queued_event) {
-            Ok(()) => {
-                let depth = self.inner.queued.load(Ordering::Relaxed);
-                Metrics::emitted_events().increment(1);
-                Metrics::queue_depth().set(depth as f64);
-                Ok(())
-            }
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                let depth = decrement_queued(&self.inner.queued);
-                Metrics::dropped_events("backpressure").increment(1);
-                Metrics::queue_depth().set(depth as f64);
-                Err(WriteEventError::Backpressure)
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                let depth = decrement_queued(&self.inner.queued);
-                Metrics::dropped_events("closed").increment(1);
-                Metrics::queue_depth().set(depth as f64);
-                Err(WriteEventError::Closed)
-            }
+        let mut writer = writer.clone();
+        if writer.write_all(&line).is_err() {
+            Metrics::dropped_events("closed").increment(1);
         }
-    }
 
-    /// Returns the approximate number of queued events.
-    pub fn queue_depth(&self) -> usize {
-        self.inner.queued.load(Ordering::Relaxed)
+        self.observe_dropped_events();
+        Metrics::emitted_events().increment(1);
+        Ok(())
     }
 
     /// Returns the configured network label for this writer.
     pub fn network(&self) -> &str {
         &self.inner.config.network
+    }
+
+    fn observe_dropped_events(&self) -> usize {
+        let Some(dropped) = &self.inner.dropped else {
+            return 0;
+        };
+
+        let current = dropped.dropped_lines();
+        let previous = self.inner.observed_drops.swap(current, Ordering::Relaxed);
+        let delta = current.saturating_sub(previous);
+        if delta > 0 {
+            Metrics::dropped_events("backpressure").increment(delta as u64);
+        }
+        delta
     }
 }
 
@@ -214,12 +237,6 @@ pub enum WriteEventError {
     /// Writer is disabled.
     #[error("transaction event writer is disabled")]
     Disabled,
-    /// Bounded queue is full.
-    #[error("transaction event writer queue is full")]
-    Backpressure,
-    /// Background writer task has stopped.
-    #[error("transaction event writer task is closed")]
-    Closed,
     /// Serialization failed.
     #[error("failed to serialize transaction event: {0}")]
     Serialize(serde_json::Error),
@@ -228,79 +245,25 @@ pub enum WriteEventError {
     Invalid(TransactionEventValidationError),
 }
 
-/// Drains queued events to the JSONL file.
-///
-/// Runtime write and flush failures are observable through metrics and logs but
-/// do not block or fail transaction-serving paths. A write failure permanently
-/// drops the affected queued event, and storage failures can leave a partial
-/// JSONL line on disk. Collectors should tolerate and skip malformed lines.
-/// Callers that require startup-time fail closed behavior should configure
-/// [`TransactionEventWriterConfig::required`].
-async fn run_writer<W>(
-    mut writer: BufWriter<W>,
-    mut rx: mpsc::Receiver<QueuedEvent>,
-    queued: Arc<AtomicUsize>,
-    flush_interval: Duration,
-) where
-    W: AsyncWrite + Unpin,
-{
-    let mut ticker = interval(flush_interval);
-    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-    loop {
-        tokio::select! {
-            maybe_event = rx.recv() => {
-                let Some(event) = maybe_event else {
-                    if let Err(err) = writer.flush().await {
-                        Metrics::write_errors("flush").increment(1);
-                        error!(error = %err, "failed to flush transaction event journal on shutdown");
-                    }
-                    Metrics::queue_depth().set(0.0);
-                    break;
-                };
-
-                let depth = decrement_queued(&queued);
-                Metrics::queue_depth().set(depth as f64);
-
-                let bytes = event.line.len();
-                match writer.write_all(&event.line).await {
-                    Ok(()) => Metrics::bytes_written().increment(bytes as u64),
-                    Err(err) => {
-                        Metrics::write_errors("write").increment(1);
-                        error!(
-                            error = %err,
-                            event_id = %event.event_id,
-                            tx_hash = ?event.tx_hash,
-                            "failed to write transaction event journal entry; queued event dropped"
-                        );
-                    }
-                }
-            }
-            _ = ticker.tick() => {
-                if let Err(err) = writer.flush().await {
-                    Metrics::write_errors("flush").increment(1);
-                    error!(error = %err, "failed to flush transaction event journal");
-                }
-            }
-        }
+fn open_file(config: &TransactionEventWriterConfig) -> io::Result<File> {
+    if let Some(parent) = config.file_path.parent() {
+        create_dir_all(parent)?;
     }
-}
-
-fn decrement_queued(queued: &AtomicUsize) -> usize {
-    queued
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| value.checked_sub(1))
-        .map(|previous| previous - 1)
-        .unwrap_or(0)
+    OpenOptions::new().create(true).append(true).open(&config.file_path)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, time::Duration};
+    use std::{
+        fs,
+        io::{self, ErrorKind},
+        thread,
+        time::Duration,
+    };
 
     use alloy_primitives::TxHash;
     use chrono::{DateTime, Utc};
     use serde_json::{Map, Value, json};
-    use tokio::io;
 
     use super::*;
     use crate::{
@@ -326,6 +289,37 @@ mod tests {
         .with_network("base-mainnet")
         .with_tx_hash(tx_hash)
         .with_data(Map::from_iter([("pool".to_string(), json!("pending"))]))
+    }
+
+    fn writer_with_sink<W>(sink: W, queue_capacity: usize) -> TransactionEventWriter
+    where
+        W: Write + Send + 'static,
+    {
+        let config = TransactionEventWriterConfig {
+            enabled: true,
+            file_path: PathBuf::from("test.jsonl"),
+            queue_capacity,
+            flush_interval: Duration::from_millis(10),
+            required: true,
+            producer: TransactionEventProducer::BaseRethNode,
+            network: "base-mainnet".to_string(),
+        };
+        let (writer, guard) = NonBlockingBuilder::default()
+            .lossy(true)
+            .buffered_lines_limit(queue_capacity)
+            .thread_name("transaction-event-writer-test")
+            .finish(MetricWriter::new(sink));
+        let dropped = writer.error_counter();
+
+        TransactionEventWriter {
+            inner: Arc::new(WriterInner {
+                writer: Some(writer),
+                dropped: Some(dropped),
+                observed_drops: AtomicUsize::new(0),
+                _guard: Some(Arc::new(guard)),
+                config,
+            }),
+        }
     }
 
     #[test]
@@ -523,9 +517,7 @@ mod tests {
         .unwrap();
 
         writer.try_write(&sample_event()).unwrap();
-        tokio::time::sleep(Duration::from_millis(50)).await;
         drop(writer);
-        tokio::time::sleep(Duration::from_millis(20)).await;
 
         let contents = fs::read_to_string(path).unwrap();
         let lines = contents.lines().collect::<Vec<_>>();
@@ -534,32 +526,32 @@ mod tests {
         assert_eq!(value["schema_version"], SCHEMA_VERSION);
     }
 
-    #[tokio::test]
-    async fn writer_drops_on_backpressure() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("transaction-events.jsonl");
-        let writer = TransactionEventWriter::from_config(TransactionEventWriterConfig {
-            enabled: true,
-            file_path: path,
-            queue_capacity: 1,
-            flush_interval: Duration::from_secs(30),
-            required: true,
-            producer: TransactionEventProducer::BaseRethNode,
-            network: "base-mainnet".to_string(),
-        })
-        .await
-        .unwrap();
+    #[test]
+    fn writer_observes_aggregate_backpressure_drops() {
+        struct SlowWriter;
 
-        writer.try_write(&sample_event()).unwrap();
-        let mut saw_backpressure = false;
+        impl Write for SlowWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                thread::sleep(Duration::from_millis(50));
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let writer = writer_with_sink(SlowWriter, 0);
+
         for _ in 0..10_000 {
-            if matches!(writer.try_write(&sample_event()), Err(WriteEventError::Backpressure)) {
-                saw_backpressure = true;
+            writer.try_write(&sample_event()).unwrap();
+            if writer.inner.observed_drops.load(Ordering::Relaxed) > 0 {
                 break;
             }
         }
 
-        assert!(saw_backpressure, "bounded writer should eventually reject without blocking");
+        let dropped = writer.inner.observed_drops.load(Ordering::Relaxed);
+        assert!(dropped > 0, "lossy writer should report aggregate drops under backpressure");
     }
 
     #[tokio::test]
@@ -579,7 +571,7 @@ mod tests {
         .unwrap();
 
         writer.try_write(&sample_event()).unwrap();
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(writer);
 
         assert!(path.exists());
     }
@@ -604,59 +596,26 @@ mod tests {
         assert!(err.to_string().contains("required transaction event writer"));
     }
 
-    #[tokio::test]
-    async fn runtime_write_failure_does_not_close_writer() {
+    #[test]
+    fn metric_writer_propagates_runtime_write_failure() {
         struct FailingWriter;
 
-        impl AsyncWrite for FailingWriter {
-            fn poll_write(
-                self: std::pin::Pin<&mut Self>,
-                _cx: &mut std::task::Context<'_>,
-                _buf: &[u8],
-            ) -> std::task::Poll<io::Result<usize>> {
-                std::task::Poll::Ready(Err(io::Error::other("disk full")))
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::other("disk full"))
             }
 
-            fn poll_flush(
-                self: std::pin::Pin<&mut Self>,
-                _cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<io::Result<()>> {
-                std::task::Poll::Ready(Ok(()))
-            }
-
-            fn poll_shutdown(
-                self: std::pin::Pin<&mut Self>,
-                _cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<io::Result<()>> {
-                std::task::Poll::Ready(Ok(()))
+            fn flush(&mut self) -> io::Result<()> {
+                Err(io::Error::other("flush failed"))
             }
         }
 
-        let (tx, rx) = mpsc::channel(2);
-        let queued = Arc::new(AtomicUsize::new(0));
-        let task = tokio::spawn(run_writer(
-            BufWriter::new(FailingWriter),
-            rx,
-            Arc::clone(&queued),
-            Duration::from_millis(10),
-        ));
+        let mut writer = MetricWriter::new(FailingWriter);
 
-        tx.send(QueuedEvent {
-            event_id: "event-1".to_string(),
-            tx_hash: None,
-            line: Vec::from(&b"{}\n"[..]),
-        })
-        .await
-        .unwrap();
-        tx.send(QueuedEvent {
-            event_id: "event-2".to_string(),
-            tx_hash: None,
-            line: Vec::from(&b"{}\n"[..]),
-        })
-        .await
-        .unwrap();
-        drop(tx);
+        let err = writer.write_all(b"{}\n").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Other);
 
-        task.await.unwrap();
+        let err = writer.flush().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Other);
     }
 }

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -127,7 +127,7 @@ impl TransactionEventWriter {
     /// metric. If initialization fails and `required = false`, returns the same
     /// disabled handle after recording the error. If `required = true`, returns
     /// the initialization error.
-    pub async fn from_config(config: TransactionEventWriterConfig) -> eyre::Result<Self> {
+    pub fn from_config(config: TransactionEventWriterConfig) -> eyre::Result<Self> {
         if !config.enabled {
             return Ok(Self::disabled(config));
         }
@@ -518,8 +518,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn writer_appends_jsonl() {
+    #[test]
+    fn writer_appends_jsonl() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("transaction-events.jsonl");
         let writer = TransactionEventWriter::from_config(TransactionEventWriterConfig {
@@ -531,7 +531,6 @@ mod tests {
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
         })
-        .await
         .unwrap();
 
         writer.try_write(&sample_event()).unwrap();
@@ -572,8 +571,8 @@ mod tests {
         assert!(dropped > 0, "lossy writer should report aggregate drops under backpressure");
     }
 
-    #[tokio::test]
-    async fn writer_creates_parent_directories() {
+    #[test]
+    fn writer_creates_parent_directories() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("missing").join("transaction-events.jsonl");
         let writer = TransactionEventWriter::from_config(TransactionEventWriterConfig {
@@ -585,7 +584,6 @@ mod tests {
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
         })
-        .await
         .unwrap();
 
         writer.try_write(&sample_event()).unwrap();
@@ -594,8 +592,8 @@ mod tests {
         assert!(path.exists());
     }
 
-    #[tokio::test]
-    async fn required_writer_fails_closed_on_init_error() {
+    #[test]
+    fn required_writer_fails_closed_on_init_error() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("transaction-events-dir");
         fs::create_dir(&path).unwrap();
@@ -608,7 +606,6 @@ mod tests {
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
         })
-        .await
         .unwrap_err();
 
         assert!(err.to_string().contains("required transaction event writer"));

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -68,7 +68,7 @@ struct WriterInner {
     writer: Option<NonBlocking>,
     dropped: Option<ErrorCounter>,
     observed_drops: AtomicUsize,
-    _guard: Option<Arc<WorkerGuard>>,
+    _guard: Option<WorkerGuard>,
     config: TransactionEventWriterConfig,
 }
 
@@ -166,7 +166,7 @@ impl TransactionEventWriter {
                 writer: Some(writer),
                 dropped: Some(dropped),
                 observed_drops: AtomicUsize::new(0),
-                _guard: Some(Arc::new(guard)),
+                _guard: Some(guard),
                 config,
             }),
         })
@@ -334,7 +334,7 @@ mod tests {
                 writer: Some(writer),
                 dropped: Some(dropped),
                 observed_drops: AtomicUsize::new(0),
-                _guard: Some(Arc::new(guard)),
+                _guard: Some(guard),
                 config,
             }),
         }

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -19,7 +19,6 @@ producer-specific prefix:
 | `enabled` | boolean | Enables transaction event journal writes. |
 | `file_path` | string | Dedicated JSONL file path tailed by Vector. |
 | `queue_capacity` | integer | Bounded in-process event queue size. Producers drop on backpressure instead of blocking transaction serving paths. |
-| `flush_interval` | duration | Background file flush interval. |
 | `required` | boolean | If true, fail service initialization when the file writer cannot open. Runtime write failures remain observable and non-fatal. |
 | `producer` | string | One of the producer identities below. |
 | `network` | string | Network label, for example `base-mainnet` or `base-sepolia`. |
@@ -31,7 +30,6 @@ For Go/proxyd, mirror the same names in TOML:
 enabled = true
 file_path = "/var/log/base/transaction-events.jsonl"
 queue_capacity = 16384
-flush_interval = "1s"
 required = false
 producer = "base-routing/proxyd"
 network = "base-mainnet"


### PR DESCRIPTION
## Summary
- replace the custom Tokio queue/background JSONL writer in `base-observability-events` with `tracing_appender::non_blocking`
- keep transaction events as raw one-envelope-per-line JSONL written to the dedicated transaction event file, separate from stdout/stderr and the normal Datadog application log path
- make `TransactionEventWriter::from_config` and `GlobalTransactionEventWriter::init` synchronous now that writer setup uses blocking file open plus the appender's own worker thread
- remove the unused `flush_interval` writer config field and the corresponding contract documentation now that flushing is owned by the non-blocking appender
- keep runtime write failures out of transaction-serving paths while reporting appender backpressure drops and write/flush errors through metrics
- remove exact queue-depth reporting because the appender owns the bounded queue internally
- clean up writer internals by avoiding redundant guard wrapping and narrowing dependencies now that Tokio is no longer needed by the shared writer crate

## Stack context
This PR is stacked on #3628 and only changes the shared writer implementation introduced there. Producer wiring PRs can continue to depend on the same writer API without routing transaction events through stdout/stderr or the normal Datadog application log path.

## Verification
- `cargo +nightly fmt --check`
- `cargo check -p base-observability-events --no-default-features --locked`
- `cargo test -p base-observability-events --locked`

type=routine
risk=low
impact=sev5
