### PR TITLE
refactor(registrar): clean up errors

### DIFF
--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -25,39 +25,21 @@ pub enum RegistrarError {
 
     /// ZK proof generation failed.
     #[error("proof generation failed")]
-    ProofGeneration(#[source] Box<dyn std::error::Error + Send + Sync>),
+    ProofGeneration(#[from] ProverError),
 
-    /// On-chain registry operation failed.
-    #[error("registry error")]
-    Registry(#[source] Box<dyn std::error::Error + Send + Sync>),
-
-    /// An onchain registry contract call failed.
-    #[error("registry call failed: {context}")]
-    RegistryCall {
-        /// Description of the call that failed (e.g. `"isValidSigner(0x1234…)"`).
+    /// An onchain contract call failed.
+    #[error("contract call failed: {context}")]
+    ContractCall {
+        /// Description of the call that failed (e.g. `"registry.isValidSigner(0x1234…)"`).
         context: String,
         /// The underlying contract call error.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-
-    /// An onchain `NitroEnclaveVerifier` contract call failed.
-    #[error("nitro verifier call failed: {context}")]
-    NitroVerifierCall {
-        /// Description of the call that failed (e.g. `"revokedCerts(0x…)"`).
-        context: String,
-        /// The underlying contract call error.
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    /// Transaction signing or submission failed.
-    #[error("signing error")]
-    Signing(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// Transaction submission or confirmation failed (RPC, nonce, fee, timeout).
     #[error("transaction error")]
-    Transaction(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Transaction(#[from] TxManagerError),
 
     /// Configuration is invalid.
     #[error("config error: {0}")]
@@ -72,17 +54,5 @@ pub enum RegistrarError {
     Crl(#[from] crate::crl::CrlError),
 }
 
-impl From<ProverError> for RegistrarError {
-    fn from(e: ProverError) -> Self {
-        Self::ProofGeneration(Box::new(e))
-    }
-}
-
-impl From<TxManagerError> for RegistrarError {
-    fn from(e: TxManagerError) -> Self {
-        Self::Transaction(Box::new(e))
-    }
-}
-
 /// Convenience result alias for registrar operations.
-pub type Result<T, E = RegistrarError> = std::result::Result<T, E>;
+pub type Result<T> = std::result::Result<T, RegistrarError>;

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use base_proof_tee_nitro_attestation_prover::ProverError;
 use base_tx_manager::TxManagerError;
 use thiserror::Error;
@@ -40,6 +41,13 @@ pub enum RegistrarError {
     /// Transaction submission or confirmation failed (RPC, nonce, fee, timeout).
     #[error("transaction error")]
     Transaction(#[from] TxManagerError),
+
+    /// Registration transaction was mined but reverted.
+    #[error("registration transaction {tx_hash} reverted")]
+    ReceiptReverted {
+        /// Hash of the reverted transaction.
+        tx_hash: B256,
+    },
 
     /// Configuration is invalid.
     #[error("config error: {0}")]

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -233,9 +233,13 @@ where
                 "registration transaction reverted onchain",
             );
             self.proof_provider.block_recovery_for_signer(signer_address);
-            return Err(RegistrarError::Transaction(
-                format!("registration transaction {} reverted", receipt.transaction_hash).into(),
-            ));
+            return Err(RegistrarError::Transaction(TxManagerError::ExecutionReverted {
+                reason: Some(format!(
+                    "registration transaction {} reverted",
+                    receipt.transaction_hash
+                )),
+                data: None,
+            }));
         }
 
         info!(

--- a/crates/proof/tee/registrar/src/proof_handler.rs
+++ b/crates/proof/tee/registrar/src/proof_handler.rs
@@ -233,13 +233,7 @@ where
                 "registration transaction reverted onchain",
             );
             self.proof_provider.block_recovery_for_signer(signer_address);
-            return Err(RegistrarError::Transaction(TxManagerError::ExecutionReverted {
-                reason: Some(format!(
-                    "registration transaction {} reverted",
-                    receipt.transaction_hash
-                )),
-                data: None,
-            }));
+            return Err(RegistrarError::ReceiptReverted { tx_hash: receipt.transaction_hash });
         }
 
         info!(
@@ -577,7 +571,10 @@ mod tests {
 
         let result = handle_proof(&harness, &CancellationToken::new()).await;
 
-        assert!(result.is_err(), "reverted receipt should fail registration");
+        assert!(
+            matches!(result, Err(RegistrarError::ReceiptReverted { tx_hash }) if tx_hash == tx.receipt.transaction_hash),
+            "reverted receipt should fail with ReceiptReverted: {result:?}"
+        );
         assert_eq!(tx.send_count(), 1, "should submit exactly one tx");
         assert_eq!(harness.proof_provider.blocked_signers(), vec![TEST_SIGNER]);
     }

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -42,9 +42,9 @@ impl RegistryContractClient {
     }
 }
 
-/// Converts a [`ContractError`] into a [`RegistrarError::RegistryCall`].
+/// Converts a [`ContractError`] into a [`RegistrarError::ContractCall`].
 fn map_contract_error(e: ContractError) -> RegistrarError {
-    RegistrarError::RegistryCall { context: e.to_string(), source: Box::new(e) }
+    RegistrarError::ContractCall { context: e.to_string(), source: Box::new(e) }
 }
 
 #[async_trait]

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -3,13 +3,11 @@
 //! Wraps [`TEEProverRegistryContractClient`] from `base-proof-contracts` with
 //! registrar-specific error types. The [`RegistryClient`] trait uses
 //! [`RegistrarError`] to integrate with the registrar's error handling,
-//! while the underlying contract bindings use [`ContractError`].
+//! while the underlying contract bindings use their own error types.
 
 use alloy_primitives::Address;
 use async_trait::async_trait;
-use base_proof_contracts::{
-    ContractError, TEEProverRegistryClient as _, TEEProverRegistryContractClient,
-};
+use base_proof_contracts::{TEEProverRegistryClient as _, TEEProverRegistryContractClient};
 use url::Url;
 
 use crate::{RegistrarError, Result};
@@ -42,18 +40,19 @@ impl RegistryContractClient {
     }
 }
 
-/// Converts a [`ContractError`] into a [`RegistrarError::ContractCall`].
-fn map_contract_error(e: ContractError) -> RegistrarError {
-    RegistrarError::ContractCall { context: e.to_string(), source: Box::new(e) }
-}
-
 #[async_trait]
 impl RegistryClient for RegistryContractClient {
     async fn is_registered(&self, signer: Address) -> Result<bool> {
-        self.inner.is_registered_signer(signer).await.map_err(map_contract_error)
+        self.inner.is_registered_signer(signer).await.map_err(|e| RegistrarError::ContractCall {
+            context: format!("registry.isRegisteredSigner({signer})"),
+            source: Box::new(e),
+        })
     }
 
     async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-        self.inner.get_registered_signers().await.map_err(map_contract_error)
+        self.inner.get_registered_signers().await.map_err(|e| RegistrarError::ContractCall {
+            context: "registry.getRegisteredSigners()".into(),
+            source: Box::new(e),
+        })
     }
 }

--- a/crates/proof/tee/registrar/src/verifier.rs
+++ b/crates/proof/tee/registrar/src/verifier.rs
@@ -47,8 +47,8 @@ impl NitroVerifierClient for NitroVerifierContractClient {
     }
 
     async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool> {
-        self.inner.is_revoked(cert_hash).await.map_err(|e| RegistrarError::NitroVerifierCall {
-            context: format!("revokedCerts({cert_hash:#x})"),
+        self.inner.is_revoked(cert_hash).await.map_err(|e| RegistrarError::ContractCall {
+            context: format!("nitro verifier.revokedCerts({cert_hash:#x})"),
             source: Box::new(e),
         })
     }

--- a/crates/proof/tee/registrar/src/verifier.rs
+++ b/crates/proof/tee/registrar/src/verifier.rs
@@ -48,7 +48,7 @@ impl NitroVerifierClient for NitroVerifierContractClient {
 
     async fn is_revoked(&self, cert_hash: FixedBytes<32>) -> Result<bool> {
         self.inner.is_revoked(cert_hash).await.map_err(|e| RegistrarError::ContractCall {
-            context: format!("nitro verifier.revokedCerts({cert_hash:#x})"),
+            context: format!("nitro_verifier.revokedCerts({cert_hash:#x})"),
             source: Box::new(e),
         })
     }


### PR DESCRIPTION
### What changed? Why?

Simplifies registrar error handling by replacing separate registry and Nitro verifier call variants with a shared contract-call variant, deriving conversions for prover and transaction-manager errors, and preserving reverted registration receipts as structured transaction errors.

### Notes to reviewers

Focus review on whether the consolidated contract-call error keeps enough context for registry and Nitro verifier failures. No behavior changes are intended outside error typing and messages.

### How has it been tested?

- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar`
- `cargo test -p base-proof-tee-registrar` was attempted first, but this local machine lacks Xcode's `metal` utility required by `risc0-sys`.