### PR TITLE
fix(release): release notes can be too long and cause errors

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -362,7 +362,7 @@ jobs:
           if gh release view "$TAG" > /dev/null 2>&1; then
             echo "GitHub Release $TAG already exists, skipping creation"
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes --draft
+            gh release create "$TAG" --title "$TAG" --notes "" --draft
           fi
 
       - name: Download binary artifacts


### PR DESCRIPTION
## Summary
Create draft GitHub releases with an empty body instead of generated notes, fixes an error where release notes can be too large and cause errors.