### PR TITLE
feat(proof): generalize aggregate proof submission

### DIFF
--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{encode_create_calldata, encode_extra_data};
 use base_proof_primitives::{ProofEncoder, Proposal};
-use base_proof_submission::{AggregateProofSubmitter, KnownRevert};
+use base_proof_submission::{AggregateProofSubmitter, KnownRevert, VerifyProposalProofSubmission};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::info;
 
@@ -164,7 +164,7 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
         );
 
         let receipt = AggregateProofSubmitter::new(&self.tx_manager)
-            .verify_proposal_proof(game_address, proof_bytes)
+            .verify_proposal_proof(VerifyProposalProofSubmission::new(game_address, proof_bytes))
             .await?;
         let tx_hash = receipt.transaction_hash;
 

--- a/crates/proof/submission/README.md
+++ b/crates/proof/submission/README.md
@@ -5,9 +5,10 @@ Shared proof submission helpers for Base dispute games.
 ## Overview
 
 This crate contains the reusable pieces needed to attach proof bytes to an
-existing `AggregateVerifier` dispute game:
+existing dispute game:
 
 - Submitting `AggregateVerifier.verifyProposalProof(bytes)` through the shared transaction manager.
+- Submitting proof-bearing `challenge()` and `nullify()` transactions.
 - Classifying known non-retryable revert selectors into structured errors.
 
 Proof byte encoding lives in `base-proof-primitives::ProofEncoder` so callers can

--- a/crates/proof/submission/src/lib.rs
+++ b/crates/proof/submission/src/lib.rs
@@ -12,5 +12,10 @@ pub use error::ProofSubmissionError;
 mod classifier;
 pub use classifier::KnownRevert;
 
+mod submission;
+pub use submission::{
+    ChallengeProofSubmission, NullifyProofSubmission, VerifyProposalProofSubmission,
+};
+
 mod submitter;
 pub use submitter::AggregateProofSubmitter;

--- a/crates/proof/submission/src/submission.rs
+++ b/crates/proof/submission/src/submission.rs
@@ -1,0 +1,95 @@
+//! Aggregate verifier proof transaction inputs.
+
+use alloy_primitives::{Address, B256, Bytes};
+use base_proof_contracts::{
+    encode_challenge_calldata, encode_nullify_calldata, encode_verify_proposal_proof_calldata,
+};
+
+/// Inputs for `AggregateVerifier.verifyProposalProof(bytes)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyProposalProofSubmission {
+    /// Dispute game contract address.
+    pub game_address: Address,
+    /// Type-prefixed proof bytes accepted by the dispute game.
+    pub proof_bytes: Bytes,
+}
+
+impl VerifyProposalProofSubmission {
+    /// Creates a proposal proof submission.
+    pub const fn new(game_address: Address, proof_bytes: Bytes) -> Self {
+        Self { game_address, proof_bytes }
+    }
+
+    /// Encodes calldata for `AggregateVerifier.verifyProposalProof(bytes)`.
+    pub fn calldata(&self) -> Bytes {
+        encode_verify_proposal_proof_calldata(self.proof_bytes.clone())
+    }
+}
+
+/// Inputs for dispute-game `challenge(bytes,uint256,bytes32)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChallengeProofSubmission {
+    /// Dispute game contract address.
+    pub game_address: Address,
+    /// Type-prefixed proof bytes accepted by the dispute game.
+    pub proof_bytes: Bytes,
+    /// Zero-based intermediate root index being challenged.
+    pub intermediate_root_index: u64,
+    /// Correct intermediate root to prove for the challenged index.
+    pub intermediate_root_to_prove: B256,
+}
+
+impl ChallengeProofSubmission {
+    /// Creates a challenge proof submission.
+    pub const fn new(
+        game_address: Address,
+        proof_bytes: Bytes,
+        intermediate_root_index: u64,
+        intermediate_root_to_prove: B256,
+    ) -> Self {
+        Self { game_address, proof_bytes, intermediate_root_index, intermediate_root_to_prove }
+    }
+
+    /// Encodes calldata for `AggregateVerifier.challenge(bytes,uint256,bytes32)`.
+    pub fn calldata(&self) -> Bytes {
+        encode_challenge_calldata(
+            self.proof_bytes.clone(),
+            self.intermediate_root_index,
+            self.intermediate_root_to_prove,
+        )
+    }
+}
+
+/// Inputs for dispute-game `nullify(bytes,uint256,bytes32)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NullifyProofSubmission {
+    /// Dispute game contract address.
+    pub game_address: Address,
+    /// Type-prefixed proof bytes accepted by the dispute game.
+    pub proof_bytes: Bytes,
+    /// Zero-based intermediate root index being nullified.
+    pub intermediate_root_index: u64,
+    /// Correct intermediate root to prove for the nullified index.
+    pub intermediate_root_to_prove: B256,
+}
+
+impl NullifyProofSubmission {
+    /// Creates a nullify proof submission.
+    pub const fn new(
+        game_address: Address,
+        proof_bytes: Bytes,
+        intermediate_root_index: u64,
+        intermediate_root_to_prove: B256,
+    ) -> Self {
+        Self { game_address, proof_bytes, intermediate_root_index, intermediate_root_to_prove }
+    }
+
+    /// Encodes calldata for `AggregateVerifier.nullify(bytes,uint256,bytes32)`.
+    pub fn calldata(&self) -> Bytes {
+        encode_nullify_calldata(
+            self.proof_bytes.clone(),
+            self.intermediate_root_index,
+            self.intermediate_root_to_prove,
+        )
+    }
+}

--- a/crates/proof/submission/src/submitter.rs
+++ b/crates/proof/submission/src/submitter.rs
@@ -1,11 +1,13 @@
-//! Aggregate verifier proof transaction submission.
+//! Aggregate verifier proof transaction submitter.
 
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_types_eth::TransactionReceipt;
-use base_proof_contracts::encode_verify_proposal_proof_calldata;
 use base_tx_manager::{TxCandidate, TxManager};
 
-use crate::ProofSubmissionError;
+use crate::{
+    ChallengeProofSubmission, NullifyProofSubmission, ProofSubmissionError,
+    VerifyProposalProofSubmission,
+};
 
 /// Submits proof bytes to an existing aggregate verifier dispute game.
 #[derive(Debug)]
@@ -19,14 +21,40 @@ impl<'a, T: TxManager> AggregateProofSubmitter<'a, T> {
         Self { tx_manager }
     }
 
+    /// Returns the address that will submit transactions on-chain.
+    pub fn sender_address(&self) -> Address {
+        self.tx_manager.sender_address()
+    }
+
     /// Submits `AggregateVerifier.verifyProposalProof(bytes)` to an existing game.
-    /// Callers provide already-encoded TEE or ZK proof bytes.
     pub async fn verify_proposal_proof(
         &self,
-        game_address: Address,
-        proof_bytes: Bytes,
+        submission: VerifyProposalProofSubmission,
     ) -> Result<TransactionReceipt, ProofSubmissionError> {
-        let calldata = encode_verify_proposal_proof_calldata(proof_bytes);
+        self.submit_calldata(submission.game_address, submission.calldata()).await
+    }
+
+    /// Submits `AggregateVerifier.challenge(bytes,uint256,bytes32)` to an existing game.
+    pub async fn challenge(
+        &self,
+        submission: ChallengeProofSubmission,
+    ) -> Result<TransactionReceipt, ProofSubmissionError> {
+        self.submit_calldata(submission.game_address, submission.calldata()).await
+    }
+
+    /// Submits `AggregateVerifier.nullify(bytes,uint256,bytes32)` to an existing game.
+    pub async fn nullify(
+        &self,
+        submission: NullifyProofSubmission,
+    ) -> Result<TransactionReceipt, ProofSubmissionError> {
+        self.submit_calldata(submission.game_address, submission.calldata()).await
+    }
+
+    async fn submit_calldata(
+        &self,
+        game_address: Address,
+        calldata: Bytes,
+    ) -> Result<TransactionReceipt, ProofSubmissionError> {
         let candidate = TxCandidate {
             tx_data: calldata,
             to: Some(game_address),
@@ -55,7 +83,10 @@ mod tests {
     use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError};
 
     use super::AggregateProofSubmitter;
-    use crate::ProofSubmissionError;
+    use crate::{
+        ChallengeProofSubmission, NullifyProofSubmission, ProofSubmissionError,
+        VerifyProposalProofSubmission,
+    };
 
     fn receipt_with_status(success: bool, tx_hash: B256) -> TransactionReceipt {
         let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
@@ -113,15 +144,20 @@ mod tests {
         }
     }
 
+    fn proof_bytes() -> Bytes {
+        Bytes::from_static(&[0x00, 0xab, 0xcd])
+    }
+
     #[tokio::test]
     async fn verify_proposal_proof_sends_encoded_calldata_to_game() {
         let game_address = Address::repeat_byte(0x11);
-        let proof_bytes = Bytes::from_static(&[0x00, 0xab, 0xcd]);
+        let proof_bytes = proof_bytes();
         let tx_hash = B256::repeat_byte(0xaa);
         let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
         let submitter = AggregateProofSubmitter::new(&tx_manager);
+        let submission = VerifyProposalProofSubmission::new(game_address, proof_bytes.clone());
 
-        let receipt = submitter.verify_proposal_proof(game_address, proof_bytes.clone()).await;
+        let receipt = submitter.verify_proposal_proof(submission).await;
 
         assert_eq!(receipt.unwrap().transaction_hash, tx_hash);
         let candidate = tx_manager.take_candidate().unwrap();
@@ -134,15 +170,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verify_proposal_proof_maps_reverted_receipt() {
+    async fn challenge_sends_encoded_calldata_to_game() {
         let tx_hash = B256::repeat_byte(0xbb);
+        let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+        let submitter = AggregateProofSubmitter::new(&tx_manager);
+        let submission = ChallengeProofSubmission::new(
+            Address::repeat_byte(0x11),
+            proof_bytes(),
+            7,
+            B256::repeat_byte(0x22),
+        );
+
+        let receipt = submitter.challenge(submission.clone()).await;
+
+        assert_eq!(receipt.unwrap().transaction_hash, tx_hash);
+        let candidate = tx_manager.take_candidate().unwrap();
+        assert_eq!(candidate.to, Some(submission.game_address));
+        assert_eq!(candidate.value, U256::ZERO);
+        assert_eq!(candidate.tx_data, submission.calldata());
+    }
+
+    #[tokio::test]
+    async fn nullify_sends_encoded_calldata_to_game() {
+        let tx_hash = B256::repeat_byte(0xcc);
+        let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+        let submitter = AggregateProofSubmitter::new(&tx_manager);
+        let submission = NullifyProofSubmission::new(
+            Address::repeat_byte(0x11),
+            proof_bytes(),
+            7,
+            B256::repeat_byte(0x22),
+        );
+
+        let receipt = submitter.nullify(submission.clone()).await;
+
+        assert_eq!(receipt.unwrap().transaction_hash, tx_hash);
+        let candidate = tx_manager.take_candidate().unwrap();
+        assert_eq!(candidate.to, Some(submission.game_address));
+        assert_eq!(candidate.value, U256::ZERO);
+        assert_eq!(candidate.tx_data, submission.calldata());
+    }
+
+    #[tokio::test]
+    async fn verify_proposal_proof_maps_reverted_receipt() {
+        let tx_hash = B256::repeat_byte(0xdd);
         let tx_manager = MockTxManager::new(Ok(receipt_with_status(false, tx_hash)));
         let submitter = AggregateProofSubmitter::new(&tx_manager);
+        let submission = VerifyProposalProofSubmission::new(Address::ZERO, proof_bytes());
 
-        let err = submitter
-            .verify_proposal_proof(Address::ZERO, Bytes::from_static(&[0x00]))
-            .await
-            .unwrap_err();
+        let err = submitter.verify_proposal_proof(submission).await.unwrap_err();
 
         assert!(matches!(err, ProofSubmissionError::TxReverted(hash) if hash == tx_hash));
     }
@@ -154,11 +230,9 @@ mod tests {
             data: None,
         }));
         let submitter = AggregateProofSubmitter::new(&tx_manager);
+        let submission = VerifyProposalProofSubmission::new(Address::ZERO, proof_bytes());
 
-        let err = submitter
-            .verify_proposal_proof(Address::ZERO, Bytes::from_static(&[0x00]))
-            .await
-            .unwrap_err();
+        let err = submitter.verify_proposal_proof(submission).await.unwrap_err();
 
         assert!(matches!(err, ProofSubmissionError::ProofAlreadyVerified));
     }


### PR DESCRIPTION
## Summary
Add explicit submission inputs and functions for AggregateVerifier verifyProposalProof(), challenge(), and nullify() calls.

This will be useful for the fork-test harness