### PR TITLE
feat(load-tester): bid more competitive fees on tx submission

### DIFF
--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -13,8 +13,8 @@ pub use utils::{BaselineError, Result};
 
 mod rpc;
 pub use rpc::{
-    BatchRpcClient, BatchSendResult, QueryProvider, RPC_TIMEOUT, RpcProviders, RpcResultExt,
-    TxpoolAdminClient, WalletProvider, create_wallet_provider,
+    BaseFeeExt, BatchRpcClient, BatchSendResult, QueryProvider, RPC_TIMEOUT, RpcProviders,
+    RpcResultExt, TxpoolAdminClient, WalletProvider, create_wallet_provider,
 };
 
 mod metrics;
@@ -36,10 +36,11 @@ mod runner;
 pub use runner::{
     AdaptiveBackoff, BatchTxError, BlockObservation, BlockReceipt, BlockWatcher,
     DEFAULT_MAX_GAS_PRICE, DisplaySnapshot, FlashblockInclusion, FlashblockWatcher, LoadConfig,
-    LoadRunner, LoadTestDisplay, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT, PipelineQueue,
-    PreparedBatch, PreparedTransaction, QueuedSubmitFailures, RateLimiter, RealTokenAcquisition,
-    RealTokenPairTokenSetup, RealTokenRecoverySummary, RealTokenSetup, ResultsTracker,
-    SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS,
-    SenderContext, SentTransaction, SignedBatch, SignedTransaction, SignerContext,
-    SubmissionPipeline, SubmitEvent, TxConfig, TxType,
+    LoadRunner, LoadTestDisplay, MAX_FEE_BASE_FEE_MULTIPLIER, MAX_SENDER_WORKER_COUNT,
+    MAX_SIGNER_WORKER_COUNT, PipelineQueue, PreparedBatch, PreparedTransaction,
+    QueuedSubmitFailures, RateLimiter, RealTokenAcquisition, RealTokenPairTokenSetup,
+    RealTokenRecoverySummary, RealTokenSetup, ResultsTracker, SENDER_WORKERS_PER_RPC,
+    SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
+    SentTransaction, SignedBatch, SignedTransaction, SignerContext, SubmissionPipeline,
+    SubmitEvent, TxConfig, TxType,
 };

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -52,6 +52,32 @@ impl RpcProviders {
     }
 }
 
+/// Extension trait for reading the latest base fee from a query provider.
+pub trait BaseFeeExt {
+    /// Returns the `baseFeePerGas` of the latest block.
+    ///
+    /// Base fee is the value that determines whether a `maxFeePerGas` is
+    /// includable, so fee estimation reads it directly rather than relying on
+    /// `eth_gasPrice` (which can lag or smooth on some clients).
+    fn get_base_fee(&self) -> impl std::future::Future<Output = Result<u128>> + Send;
+}
+
+impl BaseFeeExt for QueryProvider {
+    async fn get_base_fee(&self) -> Result<u128> {
+        let block = self
+            .get_block_by_number(alloy_rpc_types::BlockNumberOrTag::Latest)
+            .hashes()
+            .await
+            .rpc("get latest block for base fee")?
+            .ok_or_else(|| BaselineError::Rpc("latest block not found".to_string()))?;
+        block
+            .header
+            .base_fee_per_gas
+            .map(u128::from)
+            .ok_or_else(|| BaselineError::Rpc("latest block missing base fee".to_string()))
+    }
+}
+
 /// Extension trait for converting Alloy RPC results into load-test errors.
 pub trait RpcResultExt<T> {
     /// Converts an RPC result into the load-test result type with context.

--- a/crates/infra/load-tests/src/rpc/mod.rs
+++ b/crates/infra/load-tests/src/rpc/mod.rs
@@ -2,6 +2,6 @@
 
 mod client;
 pub use client::{
-    BatchRpcClient, BatchSendResult, QueryProvider, RPC_TIMEOUT, RpcProviders, RpcResultExt,
-    TxpoolAdminClient, WalletProvider, create_wallet_provider,
+    BaseFeeExt, BatchRpcClient, BatchSendResult, QueryProvider, RPC_TIMEOUT, RpcProviders,
+    RpcResultExt, TxpoolAdminClient, WalletProvider, create_wallet_provider,
 };

--- a/crates/infra/load-tests/src/runner/b20.rs
+++ b/crates/infra/load-tests/src/runner/b20.rs
@@ -14,13 +14,13 @@ use futures::{StreamExt, stream};
 use tracing::{debug, info, instrument, warn};
 
 use super::{
-    LoadRunner, TxType,
+    LoadRunner, SubmissionPipeline, TxType,
     load_runner::{BATCH_SIZE, FUNDING_CONCURRENCY},
 };
 use crate::{
     BaselineError, Result,
     config::WorkloadConfig,
-    rpc::{RpcResultExt, create_wallet_provider},
+    rpc::{BaseFeeExt, RpcResultExt, create_wallet_provider},
 };
 
 impl LoadRunner {
@@ -46,9 +46,10 @@ impl LoadRunner {
             Arc::new(create_wallet_provider(self.config.primary_submission_rpc().clone(), wallet));
         let chain_id = self.config.chain_id;
         let max_gas_price = self.config.max_gas_price;
-        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let base_fee = self.client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee =
+            SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
         let b20_gas_limit = 10_000_000u64;
 
         let mut nonce = funder_provider
@@ -318,9 +319,10 @@ impl LoadRunner {
 
         let chain_id = self.config.chain_id;
         let max_gas_price = self.config.max_gas_price;
-        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let base_fee = self.client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee =
+            SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
         let burn_gas_limit = 200_000u64;
 
         let sender_addresses: Vec<Address> =

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -41,7 +41,7 @@ use crate::{
     config::{OsakaTarget, WorkloadConfig},
     metrics::{ConfigSummary, MetricsCollector, MetricsSummary},
     rpc::{
-        BatchRpcClient, QueryProvider, RpcProviders, RpcResultExt, TxpoolAdminClient,
+        BaseFeeExt, BatchRpcClient, QueryProvider, RpcProviders, RpcResultExt, TxpoolAdminClient,
         create_wallet_provider,
     },
     workload::{
@@ -69,7 +69,7 @@ pub struct LoadRunner {
     nonce_managers: Arc<HashMap<Address, NonceManager<RootProvider<Ethereum>>>>,
     signers: Arc<HashMap<Address, PrivateKeySigner>>,
     submission_batch_rpcs: Arc<Vec<BatchRpcClient>>,
-    gas_price: u128,
+    base_fee: u128,
     display: Option<LoadTestDisplay>,
     snapshot_tx: Option<watch::Sender<DisplaySnapshot>>,
     last_total_eth: Option<String>,
@@ -145,7 +145,7 @@ impl LoadRunner {
             nonce_managers: Arc::new(HashMap::new()),
             signers,
             submission_batch_rpcs,
-            gas_price: 0,
+            base_fee: 0,
             display: None,
             snapshot_tx: None,
             last_total_eth: None,
@@ -388,12 +388,10 @@ impl LoadRunner {
         let funder_provider =
             Arc::new(create_wallet_provider(primary_submission_rpc.clone(), wallet));
 
-        let gas_price = client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        // Ensure max_fee >= max_priority_fee (EIP-1559 requirement).
-        // When gas_price is 0 (e.g. a fresh devnet), `gas_price * 2` would be 0
-        // while max_priority_fee=1, causing the transaction to be rejected.
-        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let base_fee = client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee =
+            SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
 
         // Phase 2: Early balance validation — abort before sending any TXs if
         // the funder cannot cover the total cost.
@@ -861,9 +859,10 @@ impl LoadRunner {
         let chain_id = self.config.chain_id;
         let max_gas_price = self.config.max_gas_price;
 
-        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let base_fee = self.client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee =
+            SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
 
         // Pre-flight balance check — abort before sending any TXs if the funder
         // cannot cover the total gas cost for needed token transfers.
@@ -990,8 +989,8 @@ impl LoadRunner {
         self.stop_flag.store(false, Ordering::SeqCst);
         self.cancel_token = CancellationToken::new();
 
-        self.gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
-        info!(gas_price = self.gas_price, "fetched current gas price");
+        self.base_fee = self.client.get_base_fee().await?;
+        info!(base_fee = self.base_fee, "fetched current base fee");
 
         for account in self.accounts.accounts() {
             if !self.nonce_managers.contains_key(&account.address) {
@@ -1079,10 +1078,12 @@ impl LoadRunner {
         let mut queued_per_sender: HashMap<Address, u64> =
             self.accounts.accounts().iter().map(|a| (a.address, 0)).collect();
 
-        let mut last_gas_price_refresh = Instant::now();
+        let mut last_base_fee_refresh = Instant::now();
         let mut last_rate_limiter_update = Instant::now();
         let mut last_progress_report = Instant::now();
-        const GAS_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+        // Refresh once per block so the cached base fee tracks the climb the load
+        // test itself induces; a stale fee mints underwater (unincludable) txs.
+        const BASE_FEE_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
         const RATE_LIMITER_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
         const PROGRESS_REPORT_INTERVAL: Duration = Duration::from_secs(5);
         const DISPLAY_RENDER_INTERVAL: Duration = Duration::from_millis(500);
@@ -1113,14 +1114,14 @@ impl LoadRunner {
         {
             // --- Housekeeping (runs once per batch iteration) ---
 
-            if last_gas_price_refresh.elapsed() >= GAS_PRICE_REFRESH_INTERVAL {
-                if let Ok(new_price) = self.client.get_gas_price().await.rpc("get gas price")
-                    && new_price != self.gas_price
+            if last_base_fee_refresh.elapsed() >= BASE_FEE_REFRESH_INTERVAL {
+                if let Ok(new_base_fee) = self.client.get_base_fee().await
+                    && new_base_fee != self.base_fee
                 {
-                    debug!(old_price = self.gas_price, new_price, "gas price updated");
-                    self.gas_price = new_price;
+                    debug!(old_base_fee = self.base_fee, new_base_fee, "base fee updated");
+                    self.base_fee = new_base_fee;
                 }
-                last_gas_price_refresh = Instant::now();
+                last_base_fee_refresh = Instant::now();
             }
 
             if last_rate_limiter_update.elapsed() >= RATE_LIMITER_UPDATE_INTERVAL {
@@ -1189,7 +1190,7 @@ impl LoadRunner {
                     pending,
                     total_queued,
                     senders_blocked,
-                    gas_price = self.gas_price,
+                    base_fee = self.base_fee,
                     p50_ms = p50.as_millis() as u64,
                     p99_ms = p99.as_millis() as u64,
                     block_receipt_delay_p50_ms = block_receipt_delay_p50.as_millis() as u64,
@@ -1272,8 +1273,7 @@ impl LoadRunner {
             let batch = std::mem::replace(&mut pending_batch, Vec::with_capacity(batch_size));
             let batch_id = next_submit_batch_id.fetch_add(1, Ordering::SeqCst);
             let batch_len = batch.len();
-            let submit_batch =
-                PreparedBatch { id: batch_id, gas_price: self.gas_price, txs: batch };
+            let submit_batch = PreparedBatch { id: batch_id, base_fee: self.base_fee, txs: batch };
             match submission_pipeline.enqueue_prepared(submit_batch).await {
                 Ok(()) => {
                     debug!(batch_id, batch_len, "queued submit batch");
@@ -1296,7 +1296,7 @@ impl LoadRunner {
             let final_batch_len = pending_batch.len();
             let batch_id = next_submit_batch_id.fetch_add(1, Ordering::SeqCst);
             let submit_batch =
-                PreparedBatch { id: batch_id, gas_price: self.gas_price, txs: pending_batch };
+                PreparedBatch { id: batch_id, base_fee: self.base_fee, txs: pending_batch };
             match submission_pipeline.enqueue_prepared(submit_batch).await {
                 Ok(()) => {
                     debug!(batch_id, batch_len = final_batch_len, "queued final submit batch");
@@ -1460,7 +1460,7 @@ impl LoadRunner {
             block_receipt_delay_p99,
             flashblocks_p50_latency: flashblocks_p50,
             flashblocks_p99_latency: flashblocks_p99,
-            gas_price_gwei: self.gas_price as f64 / 1e9,
+            gas_price_gwei: self.base_fee as f64 / 1e9,
             total_eth: self.last_total_eth.clone(),
             min_eth: self.last_min_eth.clone(),
             funds_low: self.last_funds_low,
@@ -1515,11 +1515,13 @@ impl LoadRunner {
         let primary_submission_rpc = self.config.primary_submission_rpc().clone();
         let chain_id = self.config.chain_id;
 
-        let gas_price = client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        // Ensure max_fee >= max_priority_fee (EIP-1559 requirement).
-        let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+        let base_fee = client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee = SubmissionPipeline::submission_max_fee(
+            base_fee,
+            max_priority_fee,
+            self.config.max_gas_price,
+        );
         let drain_gas_limit = 21_000u128;
         // L1 data fee on Base can be significant (0.0001-0.001 ETH depending on L1 gas prices).
         // Use 0.001 ETH (1e15 wei) buffer to be safe. We may leave dust in accounts.

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -25,10 +25,10 @@ pub use results_tracker::{
 
 mod submission;
 pub use submission::{
-    BatchTxError, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT, PipelineQueue, PreparedBatch,
-    PreparedTransaction, QueuedSubmitFailures, SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC,
-    SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext, SignedBatch, SignedTransaction,
-    SignerContext, SubmissionPipeline, SubmitEvent,
+    BatchTxError, MAX_FEE_BASE_FEE_MULTIPLIER, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT,
+    PipelineQueue, PreparedBatch, PreparedTransaction, QueuedSubmitFailures,
+    SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS,
+    SenderContext, SignedBatch, SignedTransaction, SignerContext, SubmissionPipeline, SubmitEvent,
 };
 
 mod status;

--- a/crates/infra/load-tests/src/runner/real_tokens.rs
+++ b/crates/infra/load-tests/src/runner/real_tokens.rs
@@ -13,12 +13,12 @@ use indicatif::ProgressBar;
 use tracing::{debug, info, instrument, warn};
 
 use super::{
-    RealTokenAcquisition, RealTokenRecoverySummary, RealTokenSetup,
+    RealTokenAcquisition, RealTokenRecoverySummary, RealTokenSetup, SubmissionPipeline,
     load_runner::{FUNDING_CONCURRENCY, LoadRunner},
 };
 use crate::{
     BaselineError, Result,
-    rpc::{QueryProvider, RpcResultExt, create_wallet_provider},
+    rpc::{BaseFeeExt, QueryProvider, RpcResultExt, create_wallet_provider},
 };
 
 const WETH_DEPOSIT_GAS_LIMIT: u64 = 100_000;
@@ -107,10 +107,13 @@ impl LoadRunner {
         }
         let approval_targets = self.collect_real_token_setup_approvals(setup);
 
-        let gas_price = self.client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+        let base_fee = self.client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee = SubmissionPipeline::submission_max_fee(
+            base_fee,
+            max_priority_fee,
+            self.config.max_gas_price,
+        );
 
         let account_data: Vec<_> =
             self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
@@ -365,10 +368,13 @@ impl LoadRunner {
         let primary_submission_rpc = self.config.primary_submission_rpc().clone();
         let chain_id = self.config.chain_id;
 
-        let gas_price = client.get_gas_price().await.rpc("get gas price")?;
-        let max_priority_fee = (gas_price / 10).max(1);
-        let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+        let base_fee = client.get_base_fee().await?;
+        let max_priority_fee = (base_fee / 10).max(1);
+        let max_fee = SubmissionPipeline::submission_max_fee(
+            base_fee,
+            max_priority_fee,
+            self.config.max_gas_price,
+        );
 
         let account_data: Vec<_> =
             self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -41,6 +41,12 @@ pub const MAX_SENDER_WORKER_COUNT: usize = 64;
 pub const SUBMIT_BATCH_QUEUE_BUFFER: usize = 4096;
 /// Maximum send attempts for signed transaction batches.
 pub const SUBMIT_MAX_ATTEMPTS: u32 = 5;
+/// Multiplier applied to the base fee when computing `maxFeePerGas`.
+///
+/// Base fee can rise at most 12.5% per block (EIP-1559); a 4x buffer tolerates
+/// ~11 full blocks (~24s on a 2s chain) of growth before a tx goes underwater.
+/// The `max_gas_price` cap bounds worst-case cost, so the headroom is cheap.
+pub const MAX_FEE_BASE_FEE_MULTIPLIER: u128 = 4;
 
 /// A transaction request ready for nonce assignment and signing.
 #[derive(Debug, Clone)]
@@ -110,8 +116,8 @@ pub struct SignedTransaction {
 pub struct PreparedBatch {
     /// Stable batch id used for logging and endpoint sharding.
     pub id: u64,
-    /// Gas price snapshot used while signing the batch.
-    pub gas_price: u128,
+    /// Latest base fee snapshot used to derive `maxFeePerGas` while signing.
+    pub base_fee: u128,
     /// Prepared transactions.
     pub txs: Vec<PreparedTransaction>,
 }
@@ -467,9 +473,16 @@ impl SubmissionPipeline {
         }
     }
 
-    /// Computes EIP-1559 max fee for submissions.
-    pub fn submission_max_fee(gas_price: u128, priority_fee: u128, max_gas_price: u128) -> u128 {
-        gas_price.saturating_mul(2).max(priority_fee).min(max_gas_price)
+    /// Computes EIP-1559 `maxFeePerGas` for submissions.
+    ///
+    /// The result is `min(target, max_gas_price)` but always at least `priority_fee`,
+    /// where `target = max(base_fee * MULTIPLIER, base_fee + priority_fee)`.
+    /// When `max_gas_price` is lower than the target, the tx may be unincludable.
+    pub fn submission_max_fee(base_fee: u128, priority_fee: u128, max_gas_price: u128) -> u128 {
+        let target = base_fee
+            .saturating_mul(MAX_FEE_BASE_FEE_MULTIPLIER)
+            .max(base_fee.saturating_add(priority_fee));
+        target.min(max_gas_price).max(priority_fee)
     }
 
     async fn signer_worker(
@@ -543,7 +556,7 @@ impl SubmissionPipeline {
     async fn sign_batch(ctx: &SignerContext, batch: PreparedBatch) -> Option<SignedBatch> {
         let mut signed_txs = Vec::with_capacity(batch.txs.len());
         for prepared in batch.txs {
-            if let Some(tx) = Self::sign_prepared(ctx, &prepared, batch.gas_price).await {
+            if let Some(tx) = Self::sign_prepared(ctx, &prepared, batch.base_fee).await {
                 signed_txs.push(tx);
             } else {
                 Self::release_prepared(&ctx.submit_event_tx, &prepared).await;
@@ -800,10 +813,10 @@ impl SubmissionPipeline {
     async fn sign_prepared(
         ctx: &SignerContext,
         prepared: &PreparedTransaction,
-        gas_price: u128,
+        base_fee: u128,
     ) -> Option<SignedTransaction> {
-        let priority_fee = (gas_price / 10).max(1);
-        let max_fee = Self::submission_max_fee(gas_price, priority_fee, ctx.max_gas_price);
+        let priority_fee = (base_fee / 10).max(1);
+        let max_fee = Self::submission_max_fee(base_fee, priority_fee, ctx.max_gas_price);
 
         let Some(signer) = ctx.signers.get(&prepared.from) else {
             warn!(from = %prepared.from, "no signer for sender");
@@ -904,8 +917,8 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::{
-        BatchTxError, PipelineQueue, PreparedBatch, PreparedTransaction, SignedBatch,
-        SignedTransaction, SubmissionPipeline, SubmitEvent,
+        BatchTxError, MAX_FEE_BASE_FEE_MULTIPLIER, PipelineQueue, PreparedBatch,
+        PreparedTransaction, SignedBatch, SignedTransaction, SubmissionPipeline, SubmitEvent,
     };
 
     #[test]
@@ -945,8 +958,25 @@ mod tests {
     #[test]
     fn submission_max_fee_is_at_least_priority_fee() {
         assert_eq!(SubmissionPipeline::submission_max_fee(0, 1, 1_000_000_000), 1);
-        assert_eq!(SubmissionPipeline::submission_max_fee(100, 10, 1_000_000_000), 200);
         assert_eq!(SubmissionPipeline::submission_max_fee(1_000, 10, 500), 500);
+    }
+
+    #[test]
+    fn submission_max_fee_applies_base_fee_multiplier() {
+        // 4x base fee dominates when it exceeds base_fee + priority_fee.
+        assert_eq!(SubmissionPipeline::submission_max_fee(100, 10, 1_000_000_000), 400);
+    }
+
+    #[test]
+    fn submission_max_fee_covers_base_fee_plus_tip() {
+        // Verifies a transaction is never minted underwater: max_fee always
+        // covers base_fee + priority_fee when the cap is not binding.
+        let base_fee = 1_000_000u128;
+        let priority_fee = 100u128;
+        let cap = 10_000_000_000u128;
+        let max_fee = SubmissionPipeline::submission_max_fee(base_fee, priority_fee, cap);
+        assert!(max_fee >= base_fee + priority_fee, "max_fee must cover base fee + tip");
+        assert_eq!(max_fee, base_fee * MAX_FEE_BASE_FEE_MULTIPLIER);
     }
 
     #[tokio::test]
@@ -964,7 +994,7 @@ mod tests {
         prepared_batch_tx
             .send(PreparedBatch {
                 id: 0,
-                gas_price: 1,
+                base_fee: 1,
                 txs: vec![PreparedTransaction {
                     from: sender,
                     to: None,


### PR DESCRIPTION
- Use base fee over gasPrice to determine amount to pay for tx
- `GAS_PRICE_REFRESH_INTERVAL` was previously set to 30s, that's an entire load test duration (30s), so prices won't update to reflect the demand (visually, we saw the base fee rise)
- Also introduce `MAX_FEE_BASE_FEE_MULTIPLIER` for more competitive bids

Before:
- We can send 10 blocks of 6k swaps/block before we start seeing our load test txs not go through

After:
- We can send the entire load test duration (30-40s) of 6k swaps/block