### PR TITLE
fix(prover-service): allow tee intermediate intervals

### DIFF
--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -1,5 +1,6 @@
 use base_prover_service_db::{
-    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, canonical_session_id,
+    ApiProofType, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    canonical_session_id,
 };
 use base_prover_service_protocol::{ProveBlockRangeRequest, ProveBlockRangeResponse};
 use jsonrpsee::core::RpcResult;
@@ -43,19 +44,11 @@ impl ProverServiceServer {
             "Attempting to prove base block(s)",
         );
 
-        if let Some(interval) = db_request.intermediate_root_interval {
-            if interval == 0 {
-                return Err(invalid_argument(
-                    "Invalid intermediate_root_interval: must be greater than 0",
-                ));
-            }
-            if !db_request.number_of_blocks_to_prove.is_multiple_of(interval) {
-                return Err(invalid_argument(format!(
-                    "Invalid number_of_blocks_to_prove ({}): must be a multiple of intermediate_root_interval ({})",
-                    db_request.number_of_blocks_to_prove, interval,
-                )));
-            }
-        }
+        validate_intermediate_root_interval(
+            db_request.api_proof_type,
+            db_request.number_of_blocks_to_prove,
+            db_request.intermediate_root_interval,
+        )?;
 
         let outcome = self
             .repo
@@ -125,12 +118,38 @@ fn parse_session_id(session_id: &str) -> RpcResult<String> {
     canonical_session_id(session_id).map_err(|e| invalid_argument(format!("{e}")))
 }
 
+fn validate_intermediate_root_interval(
+    api_proof_type: ApiProofType,
+    number_of_blocks_to_prove: u64,
+    intermediate_root_interval: Option<u64>,
+) -> RpcResult<()> {
+    if api_proof_type == ApiProofType::Tee {
+        return Ok(());
+    }
+
+    if let Some(interval) = intermediate_root_interval {
+        if interval == 0 {
+            return Err(invalid_argument(
+                "Invalid intermediate_root_interval: must be greater than 0",
+            ));
+        }
+        if !number_of_blocks_to_prove.is_multiple_of(interval) {
+            return Err(invalid_argument(format!(
+                "Invalid number_of_blocks_to_prove ({}): must be a multiple of intermediate_root_interval ({})",
+                number_of_blocks_to_prove, interval,
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use base_prover_service_db::{ApiProofType, ProofType};
     use uuid::Uuid;
 
-    use super::parse_session_id;
+    use super::{parse_session_id, validate_intermediate_root_interval};
     use crate::metrics;
 
     #[test]
@@ -178,5 +197,19 @@ mod tests {
         let parsed = parse_session_id(session_id).unwrap();
 
         assert_eq!(parsed, session_id);
+    }
+
+    #[test]
+    fn zkp_request_rejects_non_multiple_intermediate_root_interval() {
+        let result = validate_intermediate_root_interval(ApiProofType::Compressed, 1, Some(30));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tee_request_accepts_intermediate_block_interval() {
+        let result = validate_intermediate_root_interval(ApiProofType::Tee, 1, Some(30));
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -136,8 +136,7 @@ fn validate_intermediate_root_interval(
         }
         if !number_of_blocks_to_prove.is_multiple_of(interval) {
             return Err(invalid_argument(format!(
-                "Invalid number_of_blocks_to_prove ({}): must be a multiple of intermediate_root_interval ({})",
-                number_of_blocks_to_prove, interval,
+                "Invalid number_of_blocks_to_prove ({number_of_blocks_to_prove}): must be a multiple of intermediate_root_interval ({interval})",
             )));
         }
     }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -123,8 +123,9 @@ fn validate_intermediate_root_interval(
     number_of_blocks_to_prove: u64,
     intermediate_root_interval: Option<u64>,
 ) -> RpcResult<()> {
-    if api_proof_type == ApiProofType::Tee {
-        return Ok(());
+    match api_proof_type {
+        ApiProofType::Tee => return Ok(()),
+        ApiProofType::Compressed | ApiProofType::SnarkGroth16 => {}
     }
 
     if let Some(interval) = intermediate_root_interval {


### PR DESCRIPTION
### What changed? Why?

Prover-service now skips the ZK-only `number_of_blocks_to_prove % intermediate_root_interval == 0` validation for TEE proof requests. TEE proposer requests carry the onchain intermediate block interval in the protocol payload, but prover-service stores TEE requests as a single target block job. On zeronet that produced `number_of_blocks_to_prove=1` and `intermediate_root_interval=30`, so requests were rejected before reaching the worker queue.

### Notes to reviewers

The validation still applies to compressed and SNARK ZK proof requests. TEE requests keep the interval in the original request payload for workers; this change only prevents the requester API from applying the ZK range validation to TEE jobs.

### How has it been tested?

- `cargo test -p base-prover-service intermediate`