### PR TITLE
feat(eip8130): EIP-8130 rpc extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,17 +4513,21 @@ dependencies = [
 name = "base-execution-eip8130-rpc"
 version = "0.0.0"
 dependencies = [
+ "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types 2.0.5",
+ "base-common-chains",
  "base-common-consensus",
  "base-common-network",
  "base-common-precompiles",
  "jsonrpsee",
  "jsonrpsee-types",
+ "reth-chainspec",
  "reth-provider",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
+ "reth-storage-api",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,6 +4509,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-execution-eip8130-rpc"
+version = "0.0.0"
+dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types 2.0.5",
+ "base-common-consensus",
+ "base-common-network",
+ "base-common-precompiles",
+ "jsonrpsee-types",
+ "reth-provider",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+]
+
+[[package]]
 name = "base-execution-evm"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,6 +4409,7 @@ dependencies = [
  "base-common-genesis",
  "base-execution-chainspec",
  "base-execution-consensus",
+ "base-execution-eip8130-rpc-node",
  "base-execution-evm",
  "base-execution-trie",
  "base-flashblocks",
@@ -4523,6 +4524,15 @@ dependencies = [
  "reth-provider",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
+ "tracing",
+]
+
+[[package]]
+name = "base-execution-eip8130-rpc-node"
+version = "0.0.0"
+dependencies = [
+ "base-execution-eip8130-rpc",
+ "base-node-runner",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,6 +4799,7 @@ dependencies = [
  "base-common-rpc-types",
  "base-common-rpc-types-engine",
  "base-execution-chainspec",
+ "base-execution-eip8130-rpc",
  "base-execution-evm",
  "base-execution-rpc",
  "base-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,8 +4535,15 @@ dependencies = [
 name = "base-execution-eip8130-rpc-node"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-client 2.0.5",
+ "base-common-consensus",
+ "base-execution-chainspec",
  "base-execution-eip8130-rpc",
  "base-node-runner",
+ "base-test-utils",
+ "eyre",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,10 +4518,12 @@ dependencies = [
  "base-common-consensus",
  "base-common-network",
  "base-common-precompiles",
+ "jsonrpsee",
  "jsonrpsee-types",
  "reth-provider",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ base-execution-payload-builder = { path = "crates/execution/payload" }
 base-flashblocks-node = { path = "crates/execution/flashblocks-node" }
 base-execution-eip8130 = { path = "crates/execution/eip8130", default-features = false }
 base-execution-eip8130-rpc = { path = "crates/execution/eip8130-rpc" }
+base-execution-eip8130-rpc-node = { path = "crates/execution/eip8130-rpc-node" }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ base-txpool-tracing = { path = "crates/execution/txpool-tracing" }
 base-execution-payload-builder = { path = "crates/execution/payload" }
 base-flashblocks-node = { path = "crates/execution/flashblocks-node" }
 base-execution-eip8130 = { path = "crates/execution/eip8130", default-features = false }
+base-execution-eip8130-rpc = { path = "crates/execution/eip8130-rpc" }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, B256, U256, address};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result, StorageKey};
 
 use crate::INonceManager;
 
@@ -50,6 +50,14 @@ impl NonceManagerStorage<'_> {
     /// system precompiles).
     pub const ADDRESS: Address = address!("813000000000000000000000000000000000aa01");
 
+    /// Base storage slot of the `nonces` mapping under this contract's
+    /// ERC-7201 namespace.
+    ///
+    /// Re-exported from the macro-generated `slots` module so off-chain
+    /// readers (e.g. RPC) can derive `nonces[account][nonce_key]` slots
+    /// without instantiating the precompile. Pair with [`Self::nonce_slot`].
+    pub const NONCES_BASE_SLOT: U256 = slots::NONCES;
+
     /// Capacity of the expiring-nonce ring buffer.
     ///
     /// Sized to absorb a sustained burst (~10k TPS for ~30s) so that, by the time
@@ -75,6 +83,26 @@ impl NonceManagerStorage<'_> {
             return Err(BasePrecompileError::revert(INonceManager::ProtocolNonceNotSupported {}));
         }
         self.nonces.at(&account).at(&nonce_key).read()
+    }
+
+    /// Returns the EVM storage slot that holds the 2D channel nonce for
+    /// `nonces[account][nonce_key]`.
+    ///
+    /// Off-chain dual of [`Self::get_nonce`]: same preconditions, same error
+    /// for `nonce_key == 0`, but does not read storage. Intended for off-chain
+    /// readers (e.g. an RPC `eth_getTransactionCount` extension) that want to
+    /// look up a channel nonce via `storage_at` without instantiating the
+    /// precompile. The decoded value at this slot is a `u64` right-aligned in
+    /// the slot's low 8 bytes.
+    ///
+    /// # Errors
+    /// - [`INonceManager::ProtocolNonceNotSupported`] — `nonce_key` is `0`, the
+    ///   protocol nonce, which is stored in account state and must be read from there.
+    pub fn nonce_slot(account: Address, nonce_key: U256) -> Result<U256> {
+        if nonce_key == Self::PROTOCOL_NONCE_KEY {
+            return Err(BasePrecompileError::revert(INonceManager::ProtocolNonceNotSupported {}));
+        }
+        Ok(nonce_key.mapping_slot(account.mapping_slot(Self::NONCES_BASE_SLOT)))
     }
 
     /// Increments the 2D nonce for `account` at `nonce_key`, returning the new
@@ -215,7 +243,7 @@ impl NonceManagerStorage<'_> {
 mod tests {
     use alloy_primitives::{Address, B256, U256, address};
     use base_precompile_storage::{
-        BasePrecompileError, Handler, HashMapStorageProvider, StorageCtx,
+        BasePrecompileError, Handler, HashMapStorageProvider, StorageCtx, StorageKey,
     };
 
     use crate::{INonceManager, nonce::storage::NonceManagerStorage};
@@ -401,5 +429,56 @@ mod tests {
             mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0x88), valid_before).unwrap();
             assert_eq!(mgr.expiring_nonce_ring_ptr.read().unwrap(), 1);
         });
+    }
+
+    #[test]
+    fn nonce_slot_matches_handler_chain() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let nonce_key = U256::from(42);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mgr = NonceManagerStorage::new(ctx);
+            let inner_base = mgr.nonces.at(&ACCOUNT_A).slot();
+            let expected = nonce_key.mapping_slot(inner_base);
+            assert_eq!(NonceManagerStorage::nonce_slot(ACCOUNT_A, nonce_key).unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn nonce_slot_locates_value_written_via_precompile() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let nonce_key = U256::from(7);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut mgr = NonceManagerStorage::new(ctx);
+            for _ in 0..3 {
+                mgr.increment_nonce(ACCOUNT_A, nonce_key).unwrap();
+            }
+        });
+
+        let slot = NonceManagerStorage::nonce_slot(ACCOUNT_A, nonce_key).unwrap();
+        StorageCtx::enter(&mut storage, |ctx| {
+            let word = ctx.sload(NonceManagerStorage::ADDRESS, slot).unwrap();
+            // u64 leaf is right-aligned in the slot (Solidity packing).
+            let bytes = word.to_be_bytes::<32>();
+            let nonce = u64::from_be_bytes(bytes[24..32].try_into().unwrap());
+            assert_eq!(nonce, 3);
+        });
+    }
+
+    #[test]
+    fn nonce_slot_distinct_per_account_and_key() {
+        let key_a = U256::from(1);
+        let key_b = U256::from(2);
+        let slot_a1 = NonceManagerStorage::nonce_slot(ACCOUNT_A, key_a).unwrap();
+        let slot_a2 = NonceManagerStorage::nonce_slot(ACCOUNT_A, key_b).unwrap();
+        let slot_b1 = NonceManagerStorage::nonce_slot(ACCOUNT_B, key_a).unwrap();
+        assert_ne!(slot_a1, slot_a2);
+        assert_ne!(slot_a1, slot_b1);
+        assert_ne!(slot_a2, slot_b1);
+    }
+
+    #[test]
+    fn nonce_slot_rejects_protocol_nonce() {
+        let err = NonceManagerStorage::nonce_slot(ACCOUNT_A, U256::ZERO).unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(INonceManager::ProtocolNonceNotSupported {}));
     }
 }

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -46,6 +46,7 @@ base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-execution-trie.workspace = true
+base-execution-eip8130-rpc-node.workspace = true
 base-bundle-extension.workspace = true
 base-proofs-extension.workspace = true
 base-execution-chainspec.workspace = true

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -378,7 +378,6 @@ impl StandardBaseRethNode {
         runner.install_ext::<TxForwardingExtension>((&args).into());
         runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
         Self::install_upgrade_signal_metrics_extension(&mut runner, &rollup_args)?;
-        let flashblocks_enabled = flashblocks_config.is_some();
         let eip8130_rpc_mode = if flashblocks_config.is_some() {
             Eip8130RpcMode::Defer
         } else {

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -3,7 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use base_bundle_extension::BundleExtension;
-use base_execution_eip8130_rpc_node::Eip8130RpcExtension;
+use base_execution_eip8130_rpc_node::{Eip8130RpcExtension, Eip8130RpcMode};
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringResourceLimits};
@@ -327,7 +327,17 @@ impl StandardBaseRethNode {
         // Create flashblocks config first so we can share its state with metering.
         let flashblocks_config: Option<FlashblocksConfig> = (&args).into();
 
-        // Feature extensions (FlashblocksExtension must be last - uses replace_configured).
+        // Feature extensions. Several use `replace_configured` (which is overwrite,
+        // not compose) on overlapping RPC methods, so install order would otherwise
+        // silently decide which one wins. Coordination is enforced by self-gating:
+        //   - FlashblocksExtension: registers eth_getTransactionCount (and others)
+        //     iff flashblocks is enabled.
+        //   - Eip8130RpcExtension: registers eth_getTransactionCount iff flashblocks
+        //     is NOT (see `Eip8130RpcMode` below).
+        //   - ProofsHistoryExtension: registers eth_getProof variants (disjoint from
+        //     the above, so it can sit anywhere in the chain).
+        // New extensions touching the same RPC methods MUST be added to this
+        // coordination scheme rather than relying on install order.
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig {
             sequencer_rpc: args.rpc.rollup_args.sequencer.clone(),
         });
@@ -369,8 +379,13 @@ impl StandardBaseRethNode {
         runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
         Self::install_upgrade_signal_metrics_extension(&mut runner, &rollup_args)?;
         let flashblocks_enabled = flashblocks_config.is_some();
+        let eip8130_rpc_mode = if flashblocks_config.is_some() {
+            Eip8130RpcMode::Defer
+        } else {
+            Eip8130RpcMode::Register
+        };
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
-        runner.install_ext::<Eip8130RpcExtension>(!flashblocks_enabled);
+        runner.install_ext::<Eip8130RpcExtension>(eip8130_rpc_mode);
         Ok(runner)
     }
 

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -3,6 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use base_bundle_extension::BundleExtension;
+use base_execution_eip8130_rpc_node::Eip8130RpcExtension;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringResourceLimits};
@@ -367,8 +368,9 @@ impl StandardBaseRethNode {
         runner.install_ext::<TxForwardingExtension>((&args).into());
         runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
         Self::install_upgrade_signal_metrics_extension(&mut runner, &rollup_args)?;
+        let flashblocks_enabled = flashblocks_config.is_some();
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
-
+        runner.install_ext::<Eip8130RpcExtension>(!flashblocks_enabled);
         Ok(runner)
     }
 

--- a/crates/execution/eip8130-rpc-node/Cargo.toml
+++ b/crates/execution/eip8130-rpc-node/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "base-execution-eip8130-rpc-node"
+description = "BaseNodeExtension wiring for the standalone EIP-8130 eth_getTransactionCount override"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# base
+base-node-runner.workspace = true
+base-execution-eip8130-rpc.workspace = true
+
+# misc
+tracing = { workspace = true, features = ["std"] }

--- a/crates/execution/eip8130-rpc-node/Cargo.toml
+++ b/crates/execution/eip8130-rpc-node/Cargo.toml
@@ -20,3 +20,18 @@ base-execution-eip8130-rpc.workspace = true
 
 # misc
 tracing = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+# base
+base-test-utils.workspace = true
+base-common-consensus.workspace = true
+base-execution-chainspec.workspace = true
+base-node-runner = { workspace = true, features = ["test-utils"] }
+
+# alloy
+alloy-primitives.workspace = true
+alloy-rpc-client.workspace = true
+
+# misc
+eyre.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/execution/eip8130-rpc-node/README.md
+++ b/crates/execution/eip8130-rpc-node/README.md
@@ -4,11 +4,12 @@
 `eth_getTransactionCount` override defined in
 [`base-execution-eip8130-rpc`].
 
-Self-gates on a boolean: if flashblocks is enabled, this extension does
+Self-gates via [`Eip8130RpcMode`]: when `Defer`, this extension does
 nothing (flashblocks's own override already extends
 `eth_getTransactionCount` with the EIP-8130 `nonce_key` parameter, and
-`jsonrpsee`'s `replace_configured` is overwrite). If flashblocks
-is disabled, this extension registers `Eip8130EthApiExt` so non-zero
-`nonce_key` lookups still work on standalone nodes.
+`jsonrpsee`'s `replace_configured` is overwrite). When `Register`, this
+extension registers `Eip8130EthApiExt` so non-zero `nonce_key` lookups
+still work on standalone nodes.
 
-The node-assembly site is the source of truth for which path is active. It passes `flashblocks_config.is_none()` as the enable flag.
+The node-assembly site is the source of truth for which mode is active.
+It constructs the mode from the flashblocks config.

--- a/crates/execution/eip8130-rpc-node/README.md
+++ b/crates/execution/eip8130-rpc-node/README.md
@@ -1,0 +1,14 @@
+# base-execution-eip8130-rpc-node
+
+`BaseNodeExtension` wiring for the standalone EIP-8130
+`eth_getTransactionCount` override defined in
+[`base-execution-eip8130-rpc`].
+
+Self-gates on a boolean: if flashblocks is enabled, this extension does
+nothing (flashblocks's own override already extends
+`eth_getTransactionCount` with the EIP-8130 `nonce_key` parameter, and
+`jsonrpsee`'s `replace_configured` is overwrite). If flashblocks
+is disabled, this extension registers `Eip8130EthApiExt` so non-zero
+`nonce_key` lookups still work on standalone nodes.
+
+The node-assembly site is the source of truth for which path is active. It passes `flashblocks_config.is_none()` as the enable flag.

--- a/crates/execution/eip8130-rpc-node/src/extension.rs
+++ b/crates/execution/eip8130-rpc-node/src/extension.rs
@@ -5,9 +5,20 @@ use base_execution_eip8130_rpc::{Eip8130EthApiExt, Eip8130EthApiOverrideServer};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tracing::info;
 
+/// Whether [`Eip8130RpcExtension`] should register the standalone EIP-8130
+/// `eth_getTransactionCount` override, or defer to another extension
+/// (flashblocks) that owns the same RPC method.
+///
+/// Both this extension and the flashblocks extension call
+/// `ctx.modules.replace_configured` on `eth_getTransactionCount`, and
+/// `replace_configured` is overwrite, so the node-assembly site must
+/// designate exactly one owner via this mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Eip8130RpcMode {
+    /// Register the standalone override. Use on nodes without flashblocks.
     Register,
+    /// Skip registration. Use on nodes where flashblocks is registering
+    /// `eth_getTransactionCount` and thereby owning the EIP-8130 RPC surface.
     Defer,
 }
 

--- a/crates/execution/eip8130-rpc-node/src/extension.rs
+++ b/crates/execution/eip8130-rpc-node/src/extension.rs
@@ -5,43 +5,49 @@ use base_execution_eip8130_rpc::{Eip8130EthApiExt, Eip8130EthApiOverrideServer};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tracing::info;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Eip8130RpcMode {
+    Register,
+    Defer,
+}
+
 /// Wires the standalone EIP-8130 `eth_getTransactionCount` override
-/// into the node, gated on whether flashblocks is registering the same
-/// RPC method.
+/// into the node, gated by [`Eip8130RpcMode`].
 #[derive(Debug)]
 pub struct Eip8130RpcExtension {
-    enabled: bool,
+    mode: Eip8130RpcMode,
 }
 
 impl Eip8130RpcExtension {
-    /// Creates a new extension. `enabled` should be `true` only on nodes
-    /// where flashblocks is NOT registering its `eth_getTransactionCount`
-    /// override.
-    pub const fn new(enabled: bool) -> Self {
-        Self { enabled }
+    /// Creates a new extension. Pass [`Eip8130RpcMode::Register`] on
+    /// nodes without flashblocks; pass [`Eip8130RpcMode::Defer`] when
+    /// flashblocks is already registering the override.
+    pub const fn new(mode: Eip8130RpcMode) -> Self {
+        Self { mode }
     }
 }
 
 impl BaseNodeExtension for Eip8130RpcExtension {
     fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
-        if !self.enabled {
-            info!(message = "EIP-8130 RPC override skipped (flashblocks is registering it)");
-            return hooks;
+        match self.mode {
+            Eip8130RpcMode::Defer => {
+                info!(message = "EIP-8130 RPC override deferred to flashblocks");
+                hooks
+            }
+            Eip8130RpcMode::Register => hooks.add_rpc_module(|ctx| {
+                info!(message = "Starting standalone EIP-8130 RPC override");
+                let api_ext = Eip8130EthApiExt::new(ctx.registry.eth_api().clone());
+                ctx.modules.replace_configured(api_ext.into_rpc())?;
+                Ok(())
+            }),
         }
-
-        hooks.add_rpc_module(|ctx| {
-            info!(message = "Starting standalone EIP-8130 RPC override");
-            let api_ext = Eip8130EthApiExt::new(ctx.registry.eth_api().clone());
-            ctx.modules.replace_configured(api_ext.into_rpc())?;
-            Ok(())
-        })
     }
 }
 
 impl FromExtensionConfig for Eip8130RpcExtension {
-    type Config = bool;
+    type Config = Eip8130RpcMode;
 
-    fn from_config(enabled: bool) -> Self {
-        Self::new(enabled)
+    fn from_config(mode: Eip8130RpcMode) -> Self {
+        Self::new(mode)
     }
 }

--- a/crates/execution/eip8130-rpc-node/src/extension.rs
+++ b/crates/execution/eip8130-rpc-node/src/extension.rs
@@ -1,0 +1,47 @@
+//! `BaseNodeExtension` that registers the standalone EIP-8130
+//! `eth_getTransactionCount` override when flashblocks is not.
+
+use base_execution_eip8130_rpc::{Eip8130EthApiExt, Eip8130EthApiOverrideServer};
+use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use tracing::info;
+
+/// Wires the standalone EIP-8130 `eth_getTransactionCount` override
+/// into the node, gated on whether flashblocks is registering the same
+/// RPC method.
+#[derive(Debug)]
+pub struct Eip8130RpcExtension {
+    enabled: bool,
+}
+
+impl Eip8130RpcExtension {
+    /// Creates a new extension. `enabled` should be `true` only on nodes
+    /// where flashblocks is NOT registering its `eth_getTransactionCount`
+    /// override.
+    pub const fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+}
+
+impl BaseNodeExtension for Eip8130RpcExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        if !self.enabled {
+            info!(message = "EIP-8130 RPC override skipped (flashblocks is registering it)");
+            return hooks;
+        }
+
+        hooks.add_rpc_module(|ctx| {
+            info!(message = "Starting standalone EIP-8130 RPC override");
+            let api_ext = Eip8130EthApiExt::new(ctx.registry.eth_api().clone());
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+            Ok(())
+        })
+    }
+}
+
+impl FromExtensionConfig for Eip8130RpcExtension {
+    type Config = bool;
+
+    fn from_config(enabled: bool) -> Self {
+        Self::new(enabled)
+    }
+}

--- a/crates/execution/eip8130-rpc-node/src/lib.rs
+++ b/crates/execution/eip8130-rpc-node/src/lib.rs
@@ -1,4 +1,4 @@
 #![doc = include_str!("../README.md")]
 
 mod extension;
-pub use extension::Eip8130RpcExtension;
+pub use extension::{Eip8130RpcExtension, Eip8130RpcMode};

--- a/crates/execution/eip8130-rpc-node/src/lib.rs
+++ b/crates/execution/eip8130-rpc-node/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod extension;
+pub use extension::Eip8130RpcExtension;

--- a/crates/execution/eip8130-rpc-node/tests/rpc.rs
+++ b/crates/execution/eip8130-rpc-node/tests/rpc.rs
@@ -1,0 +1,61 @@
+//! Behavioural regression tests for the standalone EIP-8130
+//! `eth_getTransactionCount` override.
+//!
+//! These tests pin the two special-case dispatch branches in
+//! `ChannelNonceReader::read` — protocol-nonce delegation for `nonce_key == 0`
+//! and `INVALID_PARAMS` for the `NONCE_KEY_MAX` sentinel — by exercising the
+//! full RPC path against a Cobalt-activated test harness.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, U256};
+use alloy_rpc_client::RpcClient;
+use base_common_consensus::Eip8130Constants;
+use base_execution_chainspec::BaseChainSpec;
+use base_execution_eip8130_rpc_node::{Eip8130RpcExtension, Eip8130RpcMode};
+use base_node_runner::test_utils::TestHarness;
+use base_test_utils::{Account, build_test_genesis_cobalt};
+
+async fn setup() -> eyre::Result<(TestHarness, RpcClient)> {
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_cobalt()));
+    let harness = TestHarness::builder()
+        .with_chain_spec(chain_spec)
+        .with_ext::<Eip8130RpcExtension>(Eip8130RpcMode::Register)
+        .build()
+        .await?;
+    let client = harness.rpc_client()?;
+    Ok((harness, client))
+}
+
+/// `nonce_key == 0` must delegate to the standard protocol-nonce path
+/// (`EthState::transaction_count`) rather than reading the precompile.
+#[tokio::test]
+async fn nonce_key_zero_returns_protocol_nonce() -> eyre::Result<()> {
+    let (_harness, client) = setup().await?;
+    let alice: Address = Account::Alice.address();
+
+    let legacy: U256 = client.request("eth_getTransactionCount", (alice, "latest")).await?;
+    let with_key: U256 =
+        client.request("eth_getTransactionCount", (alice, "latest", U256::ZERO)).await?;
+
+    assert_eq!(with_key, legacy, "nonce_key=0 must return the same value as the legacy 2-arg call");
+    Ok(())
+}
+
+/// `nonce_key == NONCE_KEY_MAX` must return `INVALID_PARAMS` because the
+/// expiring-nonce sentinel has no per-channel counter; replay protection
+/// there relies on `expiry`, not a sequence number.
+#[tokio::test]
+async fn nonce_key_max_returns_invalid_params() -> eyre::Result<()> {
+    let (_harness, client) = setup().await?;
+    let alice: Address = Account::Alice.address();
+
+    let result: Result<U256, _> = client
+        .request("eth_getTransactionCount", (alice, "latest", Eip8130Constants::NONCE_KEY_MAX))
+        .await;
+
+    let err = result.expect_err("NONCE_KEY_MAX must error");
+    let err_str = err.to_string();
+    assert!(err_str.contains("-32602"), "expected INVALID_PARAMS (-32602), got: {err_str}");
+    Ok(())
+}

--- a/crates/execution/eip8130-rpc/Cargo.toml
+++ b/crates/execution/eip8130-rpc/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "base-execution-eip8130-rpc"
+description = "RPC-layer helpers for EIP-8130 2D nonce reads"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# base
+base-common-network.workspace = true
+base-common-consensus.workspace = true
+base-common-precompiles.workspace = true
+
+# reth
+reth-provider.workspace = true
+reth-rpc-eth-api.workspace = true
+reth-rpc-eth-types.workspace = true
+
+# alloy
+alloy-eips.workspace = true
+alloy-rpc-types.workspace = true
+alloy-primitives.workspace = true
+
+# rpc
+jsonrpsee-types.workspace = true
+
+[dev-dependencies]
+alloy-rpc-types = { workspace = true }

--- a/crates/execution/eip8130-rpc/Cargo.toml
+++ b/crates/execution/eip8130-rpc/Cargo.toml
@@ -30,7 +30,11 @@ alloy-rpc-types.workspace = true
 alloy-primitives.workspace = true
 
 # rpc
+jsonrpsee.workspace = true
 jsonrpsee-types.workspace = true
+
+# misc
+tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 alloy-rpc-types = { workspace = true }

--- a/crates/execution/eip8130-rpc/Cargo.toml
+++ b/crates/execution/eip8130-rpc/Cargo.toml
@@ -39,6 +39,3 @@ jsonrpsee-types.workspace = true
 
 # misc
 tracing = { workspace = true, features = ["std"] }
-
-[dev-dependencies]
-alloy-rpc-types = { workspace = true }

--- a/crates/execution/eip8130-rpc/Cargo.toml
+++ b/crates/execution/eip8130-rpc/Cargo.toml
@@ -18,9 +18,12 @@ workspace = true
 base-common-network.workspace = true
 base-common-consensus.workspace = true
 base-common-precompiles.workspace = true
+base-common-chains.workspace = true
 
 # reth
 reth-provider.workspace = true
+reth-chainspec.workspace = true
+reth-storage-api.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-rpc-eth-types.workspace = true
 
@@ -28,6 +31,7 @@ reth-rpc-eth-types.workspace = true
 alloy-eips.workspace = true
 alloy-rpc-types.workspace = true
 alloy-primitives.workspace = true
+alloy-consensus.workspace = true
 
 # rpc
 jsonrpsee.workspace = true

--- a/crates/execution/eip8130-rpc/README.md
+++ b/crates/execution/eip8130-rpc/README.md
@@ -1,0 +1,26 @@
+# base-execution-eip8130-rpc
+
+RPC-layer helpers for EIP-8130 2D nonce reads.
+
+Exposes [`ChannelNonceReader`], which resolves a `(address, nonce_key)` channel
+nonce against a state snapshot at a given block, optionally honoring
+state overrides (e.g. flashblocks pending state).
+
+Behavior by `nonce_key`:
+
+- `nonce_key == 0`: delegates to the standard protocol nonce path
+  (`EthState::transaction_count`), since the protocol nonce lives in
+  `account.nonce`, not in the Nonce Manager precompile's storage.
+- `nonce_key == NONCE_KEY_MAX`: returns an `INVALID_PARAMS` RPC error.
+  This sentinel value selects the expiring-nonce / nonce-free channel,
+  which has no per-channel counter — replay protection there relies on
+  `expiry` instead.
+- otherwise: derives the precompile storage slot via
+  `NonceManagerStorage::nonce_slot`, consults any provided state overrides
+  for that slot, falls back to a raw `StateProvider::storage` lookup
+  against the requested block, and decodes the resulting u64 from the
+  slot's low 8 bytes.
+
+This avoids the cost of an `eth_call` to the precompile's `getNonce` for
+the common `nonce_key != 0` case while keeping layout ownership inside
+`base-common-precompiles` (via `NonceManagerStorage::nonce_slot`).

--- a/crates/execution/eip8130-rpc/src/cobalt_gate.rs
+++ b/crates/execution/eip8130-rpc/src/cobalt_gate.rs
@@ -1,0 +1,78 @@
+//! Cobalt fork-activation gate for EIP-8130 RPC reads.
+
+use alloy_consensus::BlockHeader;
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use base_common_chains::Upgrades;
+use base_common_network::Base;
+use jsonrpsee_types::{ErrorObjectOwned, error::INVALID_PARAMS_CODE};
+use reth_chainspec::ChainSpecProvider;
+use reth_rpc_eth_api::{RpcNodeCore, helpers::FullEthApi};
+use reth_storage_api::BlockReaderIdExt;
+
+/// Rejects EIP-8130 RPC reads issued before the Cobalt hard fork has
+/// activated at the requested block.
+///
+/// Mirrors the txpool's Cobalt gate (which rejects EIP-8130 transactions
+/// with `TxTypeNotSupported` pre-activation) on the read side: an RPC
+/// `eth_getTransactionCount` call carrying any `nonce_key` is using the
+/// EIP-8130 RPC surface, regardless of value, and should error pre-Cobalt
+/// rather than silently delegating to the legacy path.
+///
+/// The block-of-query timestamp drives the gate, so historical queries
+/// against pre-Cobalt blocks are gated even when Cobalt is currently active.
+#[derive(Debug)]
+pub struct Eip8130CobaltGate;
+
+impl Eip8130CobaltGate {
+    /// Errors with `INVALID_PARAMS` if Cobalt is not active at `block_id`'s
+    /// timestamp. Resolves `Pending` and `Latest` block ids to the head
+    /// block's timestamp.
+    pub fn check<Eth>(eth_api: &Eth, block_id: BlockId) -> Result<(), ErrorObjectOwned>
+    where
+        Eth: FullEthApi<NetworkTypes = Base>,
+        <Eth as RpcNodeCore>::Provider: ChainSpecProvider + BlockReaderIdExt,
+        <<Eth as RpcNodeCore>::Provider as ChainSpecProvider>::ChainSpec: Upgrades,
+    {
+        let provider = eth_api.provider();
+        let timestamp = Self::resolve_timestamp(provider, block_id)?;
+        if !provider.chain_spec().is_cobalt_active_at_timestamp(timestamp) {
+            return Err(ErrorObjectOwned::owned(
+                INVALID_PARAMS_CODE,
+                "EIP-8130 RPC features are not active before the Cobalt hard fork; the `nonce_key` parameter is not supported at this block",
+                None::<()>,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Resolves a `BlockId` to a block timestamp via the provider's
+    /// header lookup, falling back to the latest sealed header for
+    /// `Pending`.
+    fn resolve_timestamp<P>(provider: &P, block_id: BlockId) -> Result<u64, ErrorObjectOwned>
+    where
+        P: BlockReaderIdExt,
+    {
+        let header = match block_id {
+            BlockId::Number(BlockNumberOrTag::Pending) => {
+                provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest)
+            }
+            BlockId::Number(tag) => provider.sealed_header_by_number_or_tag(tag),
+            BlockId::Hash(hash) => provider.sealed_header_by_hash(hash.block_hash),
+        }
+        .map_err(|err| {
+            ErrorObjectOwned::owned(
+                INVALID_PARAMS_CODE,
+                format!("failed to resolve block: {err}"),
+                None::<()>,
+            )
+        })?
+        .ok_or_else(|| {
+            ErrorObjectOwned::owned(
+                INVALID_PARAMS_CODE,
+                format!("block not found: {block_id:?}"),
+                None::<()>,
+            )
+        })?;
+        Ok(header.timestamp())
+    }
+}

--- a/crates/execution/eip8130-rpc/src/cobalt_gate.rs
+++ b/crates/execution/eip8130-rpc/src/cobalt_gate.rs
@@ -17,10 +17,11 @@ use tracing::warn;
 /// activated at the requested block.
 ///
 /// Mirrors the txpool's Cobalt gate (which rejects EIP-8130 transactions
-/// with `TxTypeNotSupported` pre-activation) on the read side: an RPC
-/// `eth_getTransactionCount` call carrying any `nonce_key` is using the
-/// EIP-8130 RPC surface, regardless of value, and should error pre-Cobalt
-/// rather than silently delegating to the legacy path.
+/// with `TxTypeNotSupported` pre-activation) on the read side. Callers
+/// invoke this only on paths that actually consult the precompile (i.e.
+/// `nonce_key != 0`); requests with no `nonce_key` or `Some(0)` are
+/// indistinguishable from a legacy `eth_getTransactionCount` and bypass
+/// the gate to keep the hot path free of a sync header resolution.
 ///
 /// The block-of-query timestamp drives the gate, so historical queries
 /// against pre-Cobalt blocks are gated even when Cobalt is currently active.

--- a/crates/execution/eip8130-rpc/src/cobalt_gate.rs
+++ b/crates/execution/eip8130-rpc/src/cobalt_gate.rs
@@ -74,7 +74,7 @@ impl Eip8130CobaltGate {
         .ok_or_else(|| {
             ErrorObjectOwned::owned(
                 INVALID_PARAMS_CODE,
-                format!("block not found: {block_id:?}"),
+                format!("block not found: {block_id}"),
                 None::<()>,
             )
         })?;

--- a/crates/execution/eip8130-rpc/src/cobalt_gate.rs
+++ b/crates/execution/eip8130-rpc/src/cobalt_gate.rs
@@ -4,10 +4,14 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use base_common_chains::Upgrades;
 use base_common_network::Base;
-use jsonrpsee_types::{ErrorObjectOwned, error::INVALID_PARAMS_CODE};
+use jsonrpsee_types::{
+    ErrorObjectOwned,
+    error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE},
+};
 use reth_chainspec::ChainSpecProvider;
 use reth_rpc_eth_api::{RpcNodeCore, helpers::FullEthApi};
 use reth_storage_api::BlockReaderIdExt;
+use tracing::warn;
 
 /// Rejects EIP-8130 RPC reads issued before the Cobalt hard fork has
 /// activated at the requested block.
@@ -60,11 +64,12 @@ impl Eip8130CobaltGate {
             BlockId::Hash(hash) => provider.sealed_header_by_hash(hash.block_hash),
         }
         .map_err(|err| {
-            ErrorObjectOwned::owned(
-                INVALID_PARAMS_CODE,
-                format!("failed to resolve block: {err}"),
-                None::<()>,
-            )
+            warn!(
+                error = %err,
+                block_id = ?block_id,
+                "cobalt gate: failed to resolve block header"
+            );
+            ErrorObjectOwned::owned(INTERNAL_ERROR_CODE, "failed to resolve block", None::<()>)
         })?
         .ok_or_else(|| {
             ErrorObjectOwned::owned(

--- a/crates/execution/eip8130-rpc/src/eth.rs
+++ b/crates/execution/eip8130-rpc/src/eth.rs
@@ -1,0 +1,101 @@
+//! Standalone `eth_getTransactionCount` override that adds EIP-8130
+//! `nonce_key` support on nodes without flashblocks.
+
+use alloy_eips::BlockId;
+use alloy_primitives::{Address, U256};
+use base_common_network::Base;
+use jsonrpsee::{
+    core::{RpcResult, async_trait},
+    proc_macros::rpc,
+};
+use reth_rpc_eth_api::{
+    EthApiTypes,
+    helpers::{EthState, FullEthApi},
+};
+use tracing::debug;
+
+use crate::ChannelNonceReader;
+
+/// Eth API override trait that adds EIP-8130 `nonce_key` support to
+/// `eth_getTransactionCount`.
+///
+/// Registered only on nodes where the flashblocks override is not
+/// registering, since flashblocks's override already extends the same
+/// method with `nonce_key` plus its own pending-state semantics.
+#[rpc(server, namespace = "eth")]
+pub trait Eip8130EthApiOverride {
+    /// Returns transaction count for an address.
+    ///
+    /// `nonce_key`: when omitted or zero, returns the protocol nonce from
+    /// account state (the standard reth resolution). When non-zero,
+    /// returns the 2D channel nonce `nonces[address][nonce_key]` from the
+    /// Nonce Manager precompile. `nonce_key == NONCE_KEY_MAX` returns
+    /// `INVALID_PARAMS`.
+    ///
+    /// No pending-flashblock state is consulted here; this override is for
+    /// nodes running without flashblocks. Use the flashblocks override if
+    /// pending-state semantics are required.
+    #[method(name = "getTransactionCount")]
+    async fn get_transaction_count(
+        &self,
+        address: Address,
+        block_number: Option<BlockId>,
+        nonce_key: Option<U256>,
+    ) -> RpcResult<U256>;
+}
+
+/// Standalone EIP-8130 `eth_getTransactionCount` extension.
+#[derive(Debug)]
+pub struct Eip8130EthApiExt<Eth: EthApiTypes> {
+    eth_api: Eth,
+}
+
+impl<Eth: EthApiTypes> Eip8130EthApiExt<Eth> {
+    /// Creates a new standalone EIP-8130 `eth_getTransactionCount`
+    /// extension over the supplied Eth API.
+    pub const fn new(eth_api: Eth) -> Self {
+        Self { eth_api }
+    }
+}
+
+#[async_trait]
+impl<Eth> Eip8130EthApiOverrideServer for Eip8130EthApiExt<Eth>
+where
+    Eth: FullEthApi<NetworkTypes = Base> + Send + Sync + 'static,
+    jsonrpsee_types::error::ErrorObject<'static>: From<Eth::Error>,
+{
+    async fn get_transaction_count(
+        &self,
+        address: Address,
+        block_number: Option<BlockId>,
+        nonce_key: Option<U256>,
+    ) -> RpcResult<U256> {
+        debug!(
+            message = "rpc::eip8130::get_transaction_count",
+            address = %address,
+            nonce_key = ?nonce_key,
+        );
+
+        // 2D channel path. `Some(0)` is the protocol nonce by EIP-8130's
+        // reservation and is semantically identical to omitting the param,
+        // so fall through to the standard resolution for that case.
+        if let Some(key) = nonce_key
+            && key != U256::ZERO
+        {
+            return ChannelNonceReader::read(
+                &self.eth_api,
+                address,
+                key,
+                block_number.unwrap_or_default(),
+                None,
+            )
+            .await;
+        }
+
+        // Protocol nonce path. Standard reth resolution against
+        // `account.nonce` at the requested block. No flashblocks
+        // pending-state delta. This override only registers when
+        // flashblocks is disabled.
+        EthState::transaction_count(&self.eth_api, address, block_number).await.map_err(Into::into)
+    }
+}

--- a/crates/execution/eip8130-rpc/src/eth.rs
+++ b/crates/execution/eip8130-rpc/src/eth.rs
@@ -3,18 +3,21 @@
 
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, U256};
+use base_common_chains::Upgrades;
 use base_common_network::Base;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
 };
+use reth_chainspec::ChainSpecProvider;
 use reth_rpc_eth_api::{
-    EthApiTypes,
+    EthApiTypes, RpcNodeCore,
     helpers::{EthState, FullEthApi},
 };
+use reth_storage_api::BlockReaderIdExt;
 use tracing::debug;
 
-use crate::ChannelNonceReader;
+use crate::{ChannelNonceReader, Eip8130CobaltGate};
 
 /// Eth API override trait that adds EIP-8130 `nonce_key` support to
 /// `eth_getTransactionCount`.
@@ -62,6 +65,8 @@ impl<Eth: EthApiTypes> Eip8130EthApiExt<Eth> {
 impl<Eth> Eip8130EthApiOverrideServer for Eip8130EthApiExt<Eth>
 where
     Eth: FullEthApi<NetworkTypes = Base> + Send + Sync + 'static,
+    <Eth as RpcNodeCore>::Provider: ChainSpecProvider + BlockReaderIdExt,
+    <<Eth as RpcNodeCore>::Provider as ChainSpecProvider>::ChainSpec: Upgrades,
     jsonrpsee_types::error::ErrorObject<'static>: From<Eth::Error>,
 {
     async fn get_transaction_count(
@@ -76,20 +81,20 @@ where
             nonce_key = ?nonce_key,
         );
 
-        // 2D channel path. `Some(0)` is the protocol nonce by EIP-8130's
-        // reservation and is semantically identical to omitting the param,
-        // so fall through to the standard resolution for that case.
-        if let Some(key) = nonce_key
-            && key != U256::ZERO
-        {
-            return ChannelNonceReader::read(
-                &self.eth_api,
-                address,
-                key,
-                block_number.unwrap_or_default(),
-                None,
-            )
-            .await;
+        let block_id = block_number.unwrap_or_default();
+
+        // EIP-8130 surface. Any `nonce_key` (including `Some(0)`) is the
+        // client using the EIP-8130 RPC extension, so we gate the whole
+        // surface on Cobalt. Mirrors the txpool's `TxTypeNotSupported`
+        // rejection of EIP-8130 transactions pre-activation.
+        if let Some(key) = nonce_key {
+            Eip8130CobaltGate::check(&self.eth_api, block_id)?;
+
+            // Post-Cobalt: `Some(0)` is the protocol nonce by EIP-8130's
+            // reservation. Fall through to the standard resolution.
+            if key != U256::ZERO {
+                return ChannelNonceReader::read(&self.eth_api, address, key, block_id, None).await;
+            }
         }
 
         // Protocol nonce path. Standard reth resolution against

--- a/crates/execution/eip8130-rpc/src/eth.rs
+++ b/crates/execution/eip8130-rpc/src/eth.rs
@@ -83,18 +83,17 @@ where
 
         let block_id = block_number.unwrap_or_default();
 
-        // EIP-8130 surface. Any `nonce_key` (including `Some(0)`) is the
-        // client using the EIP-8130 RPC extension, so we gate the whole
-        // surface on Cobalt. Mirrors the txpool's `TxTypeNotSupported`
-        // rejection of EIP-8130 transactions pre-activation.
-        if let Some(key) = nonce_key {
+        // EIP-8130 channel read. Only `nonce_key != 0` uses the precompile
+        // path; `Some(0)` is the protocol nonce by EIP-8130's reservation
+        // and falls through to the standard resolution. The Cobalt gate
+        // lives here (not above) so the default hot path — absent
+        // `nonce_key` and `Some(0)` — is not slowed down by a sync header
+        // resolution.
+        if let Some(key) = nonce_key
+            && key != U256::ZERO
+        {
             Eip8130CobaltGate::check(&self.eth_api, block_id)?;
-
-            // Post-Cobalt: `Some(0)` is the protocol nonce by EIP-8130's
-            // reservation. Fall through to the standard resolution.
-            if key != U256::ZERO {
-                return ChannelNonceReader::read(&self.eth_api, address, key, block_id, None).await;
-            }
+            return ChannelNonceReader::read(&self.eth_api, address, key, block_id, None).await;
         }
 
         // Protocol nonce path. Standard reth resolution against

--- a/crates/execution/eip8130-rpc/src/lib.rs
+++ b/crates/execution/eip8130-rpc/src/lib.rs
@@ -2,3 +2,6 @@
 
 mod nonce_reader;
 pub use nonce_reader::ChannelNonceReader;
+
+mod eth;
+pub use eth::{Eip8130EthApiExt, Eip8130EthApiOverrideServer};

--- a/crates/execution/eip8130-rpc/src/lib.rs
+++ b/crates/execution/eip8130-rpc/src/lib.rs
@@ -3,5 +3,8 @@
 mod nonce_reader;
 pub use nonce_reader::ChannelNonceReader;
 
+mod cobalt_gate;
+pub use cobalt_gate::Eip8130CobaltGate;
+
 mod eth;
 pub use eth::{Eip8130EthApiExt, Eip8130EthApiOverrideServer};

--- a/crates/execution/eip8130-rpc/src/lib.rs
+++ b/crates/execution/eip8130-rpc/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod nonce_reader;
+pub use nonce_reader::ChannelNonceReader;

--- a/crates/execution/eip8130-rpc/src/nonce_reader.rs
+++ b/crates/execution/eip8130-rpc/src/nonce_reader.rs
@@ -72,8 +72,13 @@ impl ChannelNonceReader {
 
         // Real 2D channel. Derive slot, consult overrides, then fall back to
         // the canonical state at `block_id`.
-        let slot = NonceManagerStorage::nonce_slot(address, nonce_key)
-            .expect("nonce_key checked non-zero above");
+        let slot = NonceManagerStorage::nonce_slot(address, nonce_key).map_err(|err| {
+            ErrorObjectOwned::owned(
+                INVALID_PARAMS_CODE,
+                format!("failed to derive nonce slot for nonce_key: {err}"),
+                None::<()>,
+            )
+        })?;
         let slot_b256 = B256::from(slot);
 
         if let Some(value) =

--- a/crates/execution/eip8130-rpc/src/nonce_reader.rs
+++ b/crates/execution/eip8130-rpc/src/nonce_reader.rs
@@ -1,0 +1,237 @@
+//! 2D channel-nonce reader used by `eth_getTransactionCount` extensions.
+
+use alloy_eips::BlockId;
+use alloy_primitives::{Address, B256, U256};
+use alloy_rpc_types::state::StateOverride;
+use base_common_consensus::Eip8130Constants;
+use base_common_network::Base;
+use base_common_precompiles::NonceManagerStorage;
+use jsonrpsee_types::{ErrorObjectOwned, error::INVALID_PARAMS_CODE};
+use reth_provider::StateProvider;
+use reth_rpc_eth_api::helpers::{EthState, FullEthApi};
+use reth_rpc_eth_types::EthApiError;
+
+/// Reads 2D channel nonces (`nonces[account][nonce_key]`) from the Nonce Manager
+/// precompile, with optional state-override support.
+///
+/// See the crate-level docs for behavior across the three `nonce_key` regimes
+/// (protocol nonce, expiring-nonce sentinel, real 2D channel).
+#[derive(Debug)]
+pub struct ChannelNonceReader;
+
+impl ChannelNonceReader {
+    /// Resolves the channel nonce for `(address, nonce_key)` at `block_id`,
+    /// honoring `state_overrides` if provided.
+    ///
+    /// `state_overrides` lets callers stack pending-state writes on top of the
+    /// canonical block — e.g. flashblocks passes its accumulated
+    /// [`StateOverride`] here so a 2D nonce incremented inside the pending
+    /// flashblock is visible. The override's `state` field, if present,
+    /// fully replaces the precompile's storage view; otherwise `state_diff`
+    /// is consulted slot-by-slot and the canonical storage is used for slots
+    /// the diff doesn't mention.
+    ///
+    /// # Errors
+    /// - [`Eip8130Constants::NONCE_KEY_MAX`] returns an `INVALID_PARAMS` RPC
+    ///   error: the expiring-nonce channel has no per-channel counter and
+    ///   replay protection there relies on `expiry`, not a sequence number.
+    /// - Any error from the underlying `eth_api` (e.g. unknown block, state
+    ///   read failure) propagates as an `ErrorObjectOwned`.
+    pub async fn read<Eth>(
+        eth_api: &Eth,
+        address: Address,
+        nonce_key: U256,
+        block_id: BlockId,
+        state_overrides: Option<&StateOverride>,
+    ) -> Result<U256, ErrorObjectOwned>
+    where
+        Eth: FullEthApi<NetworkTypes = Base> + Send + Sync + 'static,
+        ErrorObjectOwned: From<Eth::Error>,
+    {
+        // Protocol nonce. Lives in account state, not the precompile.
+        // Delegate to the standard `eth_getTransactionCount` resolution path.
+        if nonce_key == U256::ZERO {
+            return EthState::transaction_count(eth_api, address, Some(block_id))
+                .await
+                .map_err(Into::into);
+        }
+
+        // Expiring-nonce sentinel. No per-channel counter exists for this key.
+        if nonce_key == Eip8130Constants::NONCE_KEY_MAX {
+            return Err(ErrorObjectOwned::owned(
+                INVALID_PARAMS_CODE,
+                "nonce_key NONCE_KEY_MAX selects the expiring-nonce channel which has no per-channel counter",
+                None::<()>,
+            ));
+        }
+
+        // Real 2D channel. Derive slot, consult overrides, then fall back to
+        // the canonical state at `block_id`.
+        let slot = NonceManagerStorage::nonce_slot(address, nonce_key)
+            .expect("nonce_key checked non-zero above");
+        let slot_b256 = B256::from(slot);
+
+        if let Some(value) =
+            Self::override_for_slot(state_overrides, NonceManagerStorage::ADDRESS, slot_b256)
+        {
+            return Ok(Self::decode_channel_nonce(value));
+        }
+
+        let state = eth_api.state_at_block_id(block_id).await.map_err(Into::into)?;
+        let word = state
+            .storage(NonceManagerStorage::ADDRESS, slot_b256)
+            .map_err(|err| EthApiError::from(err).into())?
+            .unwrap_or_default();
+        Ok(Self::decode_channel_nonce(word))
+    }
+
+    /// Looks up a single storage slot in a [`StateOverride`], if one was
+    /// provided and overrides `address`.
+    ///
+    /// Honors `state` (full replacement: missing slots read as zero) ahead of
+    /// `state_diff` (partial merge: missing slots fall through). Returns
+    /// `None` if no override applies; callers should fall back to the
+    /// canonical state in that case.
+    pub fn override_for_slot(
+        state_overrides: Option<&StateOverride>,
+        address: Address,
+        slot: B256,
+    ) -> Option<U256> {
+        let account_override = state_overrides?.get(&address)?;
+        if let Some(state) = account_override.state.as_ref() {
+            return Some(state.get(&slot).copied().map(b256_to_u256).unwrap_or_default());
+        }
+        let state_diff = account_override.state_diff.as_ref()?;
+        state_diff.get(&slot).copied().map(b256_to_u256)
+    }
+
+    /// Decodes a Solidity-packed `u64` (the channel nonce) from the low 8
+    /// bytes of an EVM storage slot, returning it widened to [`U256`].
+    ///
+    /// Widening to `U256` matches the return type of
+    /// [`EthState::transaction_count`] so all three `nonce_key` branches of
+    /// [`Self::read`] return the same shape.
+    pub fn decode_channel_nonce(slot_value: U256) -> U256 {
+        let bytes = slot_value.to_be_bytes::<32>();
+        let nonce = u64::from_be_bytes(bytes[24..32].try_into().expect("8 bytes"));
+        U256::from(nonce)
+    }
+}
+
+fn b256_to_u256(value: B256) -> U256 {
+    U256::from_be_bytes(value.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+    use alloy_rpc_types::state::AccountOverride;
+
+    use super::*;
+
+    const ADDR: Address = address!("0x1111111111111111111111111111111111111111");
+    const OTHER_ADDR: Address = address!("0x2222222222222222222222222222222222222222");
+    const SLOT: B256 = B256::repeat_byte(0xAB);
+    const OTHER_SLOT: B256 = B256::repeat_byte(0xCD);
+
+    fn override_with(account_override: AccountOverride) -> StateOverride {
+        let mut o = StateOverride::default();
+        o.insert(ADDR, account_override);
+        o
+    }
+
+    fn slot_to_b256(value: u64) -> B256 {
+        let mut bytes = [0u8; 32];
+        bytes[24..32].copy_from_slice(&value.to_be_bytes());
+        B256::from(bytes)
+    }
+
+    #[test]
+    fn decode_zero_slot() {
+        assert_eq!(ChannelNonceReader::decode_channel_nonce(U256::ZERO), U256::ZERO);
+    }
+
+    #[test]
+    fn decode_low_byte_value() {
+        // Slot containing the u64 `42` right-aligned (Solidity packing).
+        let slot_value = U256::from(42u64);
+        assert_eq!(ChannelNonceReader::decode_channel_nonce(slot_value), U256::from(42u64));
+    }
+
+    #[test]
+    fn decode_at_u64_max() {
+        let slot_value = U256::from(u64::MAX);
+        assert_eq!(ChannelNonceReader::decode_channel_nonce(slot_value), U256::from(u64::MAX));
+    }
+
+    #[test]
+    fn decode_ignores_high_bits() {
+        // A correctly-packed u64 only uses the low 8 bytes. Bits above bit 64
+        // are not part of the channel-nonce value; the decoder should ignore
+        // them so a malformed slot can't pollute the result.
+        let slot_value = (U256::from(1u64) << 200) | U256::from(7u64);
+        assert_eq!(ChannelNonceReader::decode_channel_nonce(slot_value), U256::from(7u64));
+    }
+
+    #[test]
+    fn override_lookup_returns_none_when_no_overrides() {
+        assert_eq!(ChannelNonceReader::override_for_slot(None, ADDR, SLOT), None);
+    }
+
+    #[test]
+    fn override_lookup_returns_none_when_address_not_overridden() {
+        let overrides = override_with(AccountOverride {
+            state_diff: Some([(SLOT, slot_to_b256(5))].into_iter().collect()),
+            ..Default::default()
+        });
+        assert_eq!(ChannelNonceReader::override_for_slot(Some(&overrides), OTHER_ADDR, SLOT), None);
+    }
+
+    #[test]
+    fn override_lookup_reads_state_diff_hit() {
+        let overrides = override_with(AccountOverride {
+            state_diff: Some([(SLOT, slot_to_b256(9))].into_iter().collect()),
+            ..Default::default()
+        });
+        assert_eq!(
+            ChannelNonceReader::override_for_slot(Some(&overrides), ADDR, SLOT),
+            Some(U256::from(9u64))
+        );
+    }
+
+    #[test]
+    fn override_lookup_falls_through_on_state_diff_miss() {
+        // state_diff is a merge: missing slots fall through to the canonical
+        // state, not zero.
+        let overrides = override_with(AccountOverride {
+            state_diff: Some([(OTHER_SLOT, slot_to_b256(5))].into_iter().collect()),
+            ..Default::default()
+        });
+        assert_eq!(ChannelNonceReader::override_for_slot(Some(&overrides), ADDR, SLOT), None);
+    }
+
+    #[test]
+    fn override_lookup_reads_full_state_hit() {
+        let overrides = override_with(AccountOverride {
+            state: Some([(SLOT, slot_to_b256(11))].into_iter().collect()),
+            ..Default::default()
+        });
+        assert_eq!(
+            ChannelNonceReader::override_for_slot(Some(&overrides), ADDR, SLOT),
+            Some(U256::from(11u64))
+        );
+    }
+
+    #[test]
+    fn override_lookup_returns_zero_on_full_state_miss() {
+        // `state` is a *replacement* — missing slots are zero, NOT a fall-through.
+        let overrides = override_with(AccountOverride {
+            state: Some([(OTHER_SLOT, slot_to_b256(5))].into_iter().collect()),
+            ..Default::default()
+        });
+        assert_eq!(
+            ChannelNonceReader::override_for_slot(Some(&overrides), ADDR, SLOT),
+            Some(U256::ZERO)
+        );
+    }
+}

--- a/crates/execution/eip8130-rpc/src/nonce_reader.rs
+++ b/crates/execution/eip8130-rpc/src/nonce_reader.rs
@@ -109,10 +109,16 @@ impl ChannelNonceReader {
     ) -> Option<U256> {
         let account_override = state_overrides?.get(&address)?;
         if let Some(state) = account_override.state.as_ref() {
-            return Some(state.get(&slot).copied().map(b256_to_u256).unwrap_or_default());
+            return Some(
+                state
+                    .get(&slot)
+                    .copied()
+                    .map(|value| U256::from_be_bytes(value.0))
+                    .unwrap_or_default(),
+            );
         }
         let state_diff = account_override.state_diff.as_ref()?;
-        state_diff.get(&slot).copied().map(b256_to_u256)
+        state_diff.get(&slot).copied().map(|value| U256::from_be_bytes(value.0))
     }
 
     /// Decodes a Solidity-packed `u64` (the channel nonce) from the low 64
@@ -124,10 +130,6 @@ impl ChannelNonceReader {
     pub fn decode_channel_nonce(slot_value: U256) -> U256 {
         slot_value & U256::from(u64::MAX)
     }
-}
-
-const fn b256_to_u256(value: B256) -> U256 {
-    U256::from_be_bytes(value.0)
 }
 
 #[cfg(test)]

--- a/crates/execution/eip8130-rpc/src/nonce_reader.rs
+++ b/crates/execution/eip8130-rpc/src/nonce_reader.rs
@@ -123,7 +123,7 @@ impl ChannelNonceReader {
     }
 }
 
-fn b256_to_u256(value: B256) -> U256 {
+const fn b256_to_u256(value: B256) -> U256 {
     U256::from_be_bytes(value.0)
 }
 

--- a/crates/execution/eip8130-rpc/src/nonce_reader.rs
+++ b/crates/execution/eip8130-rpc/src/nonce_reader.rs
@@ -115,16 +115,14 @@ impl ChannelNonceReader {
         state_diff.get(&slot).copied().map(b256_to_u256)
     }
 
-    /// Decodes a Solidity-packed `u64` (the channel nonce) from the low 8
-    /// bytes of an EVM storage slot, returning it widened to [`U256`].
+    /// Decodes a Solidity-packed `u64` (the channel nonce) from the low 64
+    /// bits of an EVM storage slot, returning it widened to [`U256`].
     ///
     /// Widening to `U256` matches the return type of
     /// [`EthState::transaction_count`] so all three `nonce_key` branches of
     /// [`Self::read`] return the same shape.
     pub fn decode_channel_nonce(slot_value: U256) -> U256 {
-        let bytes = slot_value.to_be_bytes::<32>();
-        let nonce = u64::from_be_bytes(bytes[24..32].try_into().expect("8 bytes"));
-        U256::from(nonce)
+        slot_value & U256::from(u64::MAX)
     }
 }
 

--- a/crates/execution/eip8130-rpc/src/nonce_reader.rs
+++ b/crates/execution/eip8130-rpc/src/nonce_reader.rs
@@ -16,6 +16,11 @@ use reth_rpc_eth_types::EthApiError;
 ///
 /// See the crate-level docs for behavior across the three `nonce_key` regimes
 /// (protocol nonce, expiring-nonce sentinel, real 2D channel).
+///
+/// **Fork-agnostic on purpose.** This helper does not check that the
+/// Cobalt fork has activated. Callers must enforce that themselves
+/// (typically via [`crate::Eip8130CobaltGate`]) before invoking
+/// [`Self::read`].
 #[derive(Debug)]
 pub struct ChannelNonceReader;
 

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 base-common-flashblocks.workspace = true
 alloy-evm = { workspace = true, features = ["std"] }
 base-common-evm = { workspace = true, features = ["std"] }
+base-execution-eip8130-rpc.workspace = true
 
 # reth
 reth-rpc.workspace = true

--- a/crates/execution/flashblocks/src/rpc/eth.rs
+++ b/crates/execution/flashblocks/src/rpc/eth.rs
@@ -62,6 +62,7 @@ use alloy_rpc_types::{
 use alloy_rpc_types_eth::{Filter, Log};
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
+use base_execution_eip8130_rpc::ChannelNonceReader;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
@@ -111,6 +112,7 @@ pub trait EthApiOverride {
         &self,
         address: Address,
         block_number: Option<BlockId>,
+        nonce_key: Option<U256>,
     ) -> RpcResult<U256>;
 
     /// Returns transaction by hash, checking flashblocks first.
@@ -264,13 +266,45 @@ where
         &self,
         address: Address,
         block_number: Option<BlockId>,
+        nonce_key: Option<U256>,
     ) -> RpcResult<U256> {
         debug!(
             message = "rpc::get_transaction_count",
             address = %address,
+            nonce_key = ?nonce_key,
         );
 
         let block_id = block_number.unwrap_or_default();
+
+        // 2D channel path. `nonce_key == 0` is the protocol nonce and
+        // semantically identical to omitting the parameter, so fall through to
+        // the legacy path for that case (flashblocks tracks the protocol
+        // nonce's pending delta but does not track per-channel deltas).
+        if let Some(key) = nonce_key
+            && key != U256::ZERO
+        {
+            Metrics::rpc_get_transaction_count().increment(1);
+            let (resolved_block, overrides) = if block_id.is_pending() {
+                let pending_blocks = self.flashblocks_state.get_pending_blocks();
+                (
+                    pending_blocks.get_canonical_block_number().into(),
+                    pending_blocks.get_state_overrides(),
+                )
+            } else {
+                (block_id, None)
+            };
+            return ChannelNonceReader::read(
+                &self.eth_api,
+                address,
+                key,
+                resolved_block,
+                overrides.as_ref(),
+            )
+            .await;
+        }
+
+        // Protocol nonce path. `canon + flashblock_delta` on pending,
+        // standard resolution otherwise.
         if block_id.is_pending() {
             Metrics::rpc_get_transaction_count().increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();

--- a/crates/execution/flashblocks/src/rpc/eth.rs
+++ b/crates/execution/flashblocks/src/rpc/eth.rs
@@ -280,37 +280,30 @@ where
 
         let block_id = block_number.unwrap_or_default();
 
-        // EIP-8130 surface. Any `nonce_key` (including `Some(0)`) is the
-        // client using the EIP-8130 RPC extension, so we gate the whole
-        // surface on Cobalt. Mirrors the txpool's `TxTypeNotSupported`
-        // rejection of EIP-8130 transactions pre-activation.
-        if let Some(key) = nonce_key {
+        // EIP-8130 channel read. Only `nonce_key != 0` uses the precompile
+        // path.
+        if let Some(key) = nonce_key
+            && key != U256::ZERO
+        {
             Eip8130CobaltGate::check(&self.eth_api, block_id)?;
-
-            // Post-Cobalt: `Some(0)` is the protocol nonce by EIP-8130's
-            // reservation. Fall through to the legacy path so the
-            // flashblock pending delta is added (flashblocks does not
-            // track per-channel deltas).
-            if key != U256::ZERO {
-                Metrics::rpc_get_transaction_count().increment(1);
-                let (resolved_block, overrides) = if block_id.is_pending() {
-                    let pending_blocks = self.flashblocks_state.get_pending_blocks();
-                    (
-                        pending_blocks.get_canonical_block_number().into(),
-                        pending_blocks.get_state_overrides(),
-                    )
-                } else {
-                    (block_id, None)
-                };
-                return ChannelNonceReader::read(
-                    &self.eth_api,
-                    address,
-                    key,
-                    resolved_block,
-                    overrides.as_ref(),
+            Metrics::rpc_get_transaction_count().increment(1);
+            let (resolved_block, overrides) = if block_id.is_pending() {
+                let pending_blocks = self.flashblocks_state.get_pending_blocks();
+                (
+                    pending_blocks.get_canonical_block_number().into(),
+                    pending_blocks.get_state_overrides(),
                 )
-                .await;
-            }
+            } else {
+                (block_id, None)
+            };
+            return ChannelNonceReader::read(
+                &self.eth_api,
+                address,
+                key,
+                resolved_block,
+                overrides.as_ref(),
+            )
+            .await;
         }
 
         // Protocol nonce path. `canon + flashblock_delta` on pending,

--- a/crates/execution/flashblocks/src/rpc/eth.rs
+++ b/crates/execution/flashblocks/src/rpc/eth.rs
@@ -62,7 +62,7 @@ use alloy_rpc_types::{
 use alloy_rpc_types_eth::{Filter, Log};
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
-use base_execution_eip8130_rpc::ChannelNonceReader;
+use base_execution_eip8130_rpc::{ChannelNonceReader, Eip8130CobaltGate};
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
@@ -186,6 +186,10 @@ impl<Eth: EthApiTypes, FB> EthApiExt<Eth, FB> {
 impl<Eth, FB> EthApiOverrideServer for EthApiExt<Eth, FB>
 where
     Eth: FullEthApi<NetworkTypes = Base> + Send + Sync + 'static,
+    <Eth as reth_rpc_eth_api::RpcNodeCore>::Provider:
+        reth_chainspec::ChainSpecProvider + reth_provider::BlockReaderIdExt,
+    <<Eth as reth_rpc_eth_api::RpcNodeCore>::Provider as reth_chainspec::ChainSpecProvider>::ChainSpec:
+        base_common_chains::Upgrades,
     FB: FlashblocksAPI + Send + Sync + 'static,
     jsonrpsee_types::error::ErrorObject<'static>: From<Eth::Error>,
 {
@@ -276,31 +280,37 @@ where
 
         let block_id = block_number.unwrap_or_default();
 
-        // 2D channel path. `nonce_key == 0` is the protocol nonce and
-        // semantically identical to omitting the parameter, so fall through to
-        // the legacy path for that case (flashblocks tracks the protocol
-        // nonce's pending delta but does not track per-channel deltas).
-        if let Some(key) = nonce_key
-            && key != U256::ZERO
-        {
-            Metrics::rpc_get_transaction_count().increment(1);
-            let (resolved_block, overrides) = if block_id.is_pending() {
-                let pending_blocks = self.flashblocks_state.get_pending_blocks();
-                (
-                    pending_blocks.get_canonical_block_number().into(),
-                    pending_blocks.get_state_overrides(),
+        // EIP-8130 surface. Any `nonce_key` (including `Some(0)`) is the
+        // client using the EIP-8130 RPC extension, so we gate the whole
+        // surface on Cobalt. Mirrors the txpool's `TxTypeNotSupported`
+        // rejection of EIP-8130 transactions pre-activation.
+        if let Some(key) = nonce_key {
+            Eip8130CobaltGate::check(&self.eth_api, block_id)?;
+
+            // Post-Cobalt: `Some(0)` is the protocol nonce by EIP-8130's
+            // reservation. Fall through to the legacy path so the
+            // flashblock pending delta is added (flashblocks does not
+            // track per-channel deltas).
+            if key != U256::ZERO {
+                Metrics::rpc_get_transaction_count().increment(1);
+                let (resolved_block, overrides) = if block_id.is_pending() {
+                    let pending_blocks = self.flashblocks_state.get_pending_blocks();
+                    (
+                        pending_blocks.get_canonical_block_number().into(),
+                        pending_blocks.get_state_overrides(),
+                    )
+                } else {
+                    (block_id, None)
+                };
+                return ChannelNonceReader::read(
+                    &self.eth_api,
+                    address,
+                    key,
+                    resolved_block,
+                    overrides.as_ref(),
                 )
-            } else {
-                (block_id, None)
-            };
-            return ChannelNonceReader::read(
-                &self.eth_api,
-                address,
-                key,
-                resolved_block,
-                overrides.as_ref(),
-            )
-            .await;
+                .await;
+            }
         }
 
         // Protocol nonce path. `canon + flashblock_delta` on pending,

--- a/crates/utilities/test-utils/src/genesis.rs
+++ b/crates/utilities/test-utils/src/genesis.rs
@@ -111,3 +111,23 @@ pub fn build_test_genesis_azul() -> Genesis {
     genesis.config.extra_fields.insert("base".to_string(), serde_json::json!({ "azul": 0 }));
     genesis
 }
+
+/// Builds a test genesis with Base Azul, Beryl, and Cobalt all enabled at
+/// timestamp 0.
+///
+/// Extends [`build_test_genesis_azul`] with:
+/// - Base Beryl and Cobalt activation at timestamp 0
+/// - `activationAdminAddress` set to the [`Account::Deployer`] address (required
+///   once Beryl is active)
+pub fn build_test_genesis_cobalt() -> Genesis {
+    let mut genesis = build_test_genesis_azul();
+    genesis
+        .config
+        .extra_fields
+        .insert("base".to_string(), serde_json::json!({ "azul": 0, "beryl": 0, "cobalt": 0 }));
+    genesis.config.extra_fields.insert(
+        "activationAdminAddress".to_string(),
+        serde_json::json!(Account::Deployer.address()),
+    );
+    genesis
+}

--- a/crates/utilities/test-utils/src/lib.rs
+++ b/crates/utilities/test-utils/src/lib.rs
@@ -13,6 +13,7 @@ pub use accounts::Account;
 mod genesis;
 pub use genesis::{
     DEVNET_CHAIN_ID, GENESIS_GAS_LIMIT, build_test_genesis, build_test_genesis_azul,
+    build_test_genesis_cobalt,
 };
 
 mod contracts;


### PR DESCRIPTION
## Summary

Extends `eth_getTransactionCount` with an optional EIP-8130 `nonce_key` (uint256) parameter as a third positional argument, enabling RPC clients to query 2D nonce channels from the Nonce Manager precompile.

Behavior by `nonce_key`:
- **omitted** → existing protocol-nonce behavior (backwards-compatible).
- **`0`** → protocol nonce (collapses with omitted post-Cobalt, per EIP-8130's reservation of key 0).
- **non-zero `k`** → 2D channel nonce from `nonces[address][k]` in the precompile's storage.
- **`NONCE_KEY_MAX`** → `INVALID_PARAMS` (expiring-nonce channel has no per-channel counter).
- **any value pre-Cobalt** → `INVALID_PARAMS` (gate mirrors the txpool's `TxTypeNotSupported` rejection of EIP-8130 txs pre-activation).

## Design

**Single owner for `eth_getTransactionCount`**. Both the existing flashblocks override and a new standalone override register the same method via jsonrpsee's overwrite-semantics `replace_configured`. Resolved by self-gating at the node-assembly site in `standard_node.rs`: `flashblocks_config.is_some()` determines which extension installs, so exactly one owns the method.

| Node config | Owner | Behavior on pending |
|---|---|---|
| Flashblocks enabled | flashblocks override | protocol nonce: `canon + flashblock_delta`; channel: precompile slot read with flashblocks `StateOverride` layered on canonical state |
| Flashblocks disabled | standalone `Eip8130EthApiExt` | standard reth resolution + raw precompile slot read |

**Channel read avoids `eth_call`**. `NonceManagerStorage::nonce_slot(addr, key)` (new) derives the slot via the same Solidity-compatible math the precompile's typed handler chain uses internally, and the RPC reader does a single `StateProvider::storage` lookup. This is ~10× faster than an `eth_call` to the precompile's `getNonce` while keeping layout ownership inside `base-common-precompiles` (the precompile crate is the single source of truth; off-chain readers go through the typed helper).

**Cobalt gate on `nonce_key.is_some()`**. Gates the whole EIP-8130 RPC surface on Cobalt activation, including explicit `Some(0)`. A client probing for EIP-8130 support by sending `nonce_key = 0` gets an unambiguous "feature not active" pre-Cobalt instead of silently delegating. Block-of-query timestamp drives the gate.

## Changes by crate

- **`base-common-precompiles`**: `NonceManagerStorage::nonce_slot()` static helper + `NONCES_BASE_SLOT` const.
- **`base-execution-eip8130-rpc`** *(new)*: `ChannelNonceReader` (slot derivation + override-aware read), `Eip8130CobaltGate` (fork gate), `Eip8130EthApiOverride` trait + `Eip8130EthApiExt<Eth>` impl (standalone non-flashblocks override).
- **`base-execution-eip8130-rpc-node`** *(new)*: `Eip8130RpcExtension` (`BaseNodeExtension` wiring with self-gating bool).
- **`base-flashblocks`**: flashblocks's `EthApiOverride::get_transaction_count` extended with `nonce_key: Option<U256>` parameter; routes through `ChannelNonceReader` for the non-zero case, layering `pending_blocks.get_state_overrides()` for the pending path.
- **`base-execution-cli`**: installs `Eip8130RpcExtension` after `FlashblocksExtension`, gated on `!flashblocks_config.is_some()`.

## Wire compatibility

JSON-RPC change is fully backwards-compatible. `jsonrpsee` deserializes a missing trailing `Option<U256>` as `None`, so existing 2-arg `eth_getTransactionCount(address, blockNumber)` calls continue to behave identically (route through the legacy path with no gate).

## Test plan

- [x] Unit tests for `nonce_slot()` (4): handler-chain consistency, end-to-end sload-and-decode, distinct slots per (account, key), protocol-nonce rejection.
- [x] Unit tests for override lookup + u64 decode (10): all override shapes, sentinel/edge values, high-bit ignoring.
- [x] `cargo check -p base-execution-cli --tests` clean. Verifies the whole assembly chain (cli + flashblocks-node + the 2 new crates) compiles together.
- [x] `cargo test -p base-flashblocks --lib` (111 tests). No regression on flashblocks's existing override behavior.
- [ ] **Node-level integration tests deferred.** Across the existing EIP-8130 implementation (validator, txpool admission, precompile dispatch, span batches) there are zero integration tests in any `tests/` directory. The whole feature relies on colocated unit tests. Building a Cobalt-activated test harness + EIP-8130 tx-submission helpers is meaningful work that benefits the entire feature, not just our RPC slice. Tracked as a follow-up; coverage profile matches the rest of EIP-8130 in the meantime.

## Open items for follow-up

1. **EIP-8130 integration test infrastructure**. Cobalt-activated genesis builder, `FlashblocksHarness` chain-spec parameterization (or new non-flashblocks harness), EIP-8130 tx-submission helpers, raw 3-arg `eth_getTransactionCount` plumbing. Reusable across the whole feature.
2. **`NONCE_KEY_MAX` RPC semantics**. Using `INVALID_PARAMS` ("no per-channel counter") based on the spec's framing of NONCE_KEY_MAX as the expiring-nonce sentinel.
3. **`state` vs `state_diff` precedence** in `override_for_slot`. Geth's `eth_call` overrides extension doesn't formally spec precedence when both are set. Current behavior: `state` (full replacement) takes precedence over `state_diff` (merge). No test asserts this (intentionally, since it's underspecified).