### PR TITLE
fix(proposer): handle prover session l1 head conflicts

### DIFF
--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -78,11 +78,19 @@ impl ProofRequesterDispatcher {
         &self,
         request: ProveBlockRangeRequest,
     ) -> Result<DispatchedProof, ProposerError> {
-        let response = self
-            .requester
-            .prove_block_range(request)
-            .await
-            .map_err(|e| ProposerError::Prover(e.to_string()))?;
+        let session_id = request.proof.session_id.clone();
+        let response = match self.requester.prove_block_range(request).await {
+            Ok(response) => response,
+            Err(e) if e.is_l1_head_conflict_for_session(&session_id) => {
+                debug!(
+                    session_id = %session_id,
+                    tee_kind = ?self.tee_kind,
+                    "prover-service already has this TEE proof session with a different l1_head"
+                );
+                return Ok(DispatchedProof { session_id });
+            }
+            Err(e) => return Err(ProposerError::Prover(e.to_string())),
+        };
         debug!(
             session_id = %response.session_id,
             tee_kind = ?self.tee_kind,
@@ -209,6 +217,7 @@ mod tests {
         GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofRequestKind,
         ProofResult, ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
     };
+    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
     use super::{ProofRequesterDispatcher, ProposerProofAdapter};
 
@@ -227,6 +236,38 @@ mod tests {
             let session_id = request.proof.session_id.clone();
             self.prove_requests.lock().unwrap().push(request);
             Ok(ProveBlockRangeResponse { session_id })
+        }
+
+        async fn get_proof(
+            &self,
+            _request: GetProofRequest,
+        ) -> Result<GetProofResponse, ProverServiceClientError> {
+            unimplemented!("tests do not poll proofs")
+        }
+
+        async fn list_proofs(
+            &self,
+            _request: ListProofsRequest,
+        ) -> Result<ListProofsResponse, ProverServiceClientError> {
+            unimplemented!("tests do not list proofs")
+        }
+    }
+
+    #[derive(Debug)]
+    struct L1HeadConflictRequester;
+
+    #[async_trait]
+    impl ProofRequesterProvider for L1HeadConflictRequester {
+        async fn prove_block_range(
+            &self,
+            request: ProveBlockRangeRequest,
+        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
+            let session_id = request.proof.session_id;
+            Err(ProverServiceClientError::from(JsonRpcClientError::Call(ErrorObjectOwned::owned(
+                ProverServiceClientError::ERROR_FAILED_PRECONDITION,
+                format!("session_id {session_id} already exists with a different l1_head"),
+                None::<()>,
+            ))))
         }
 
         async fn get_proof(
@@ -422,5 +463,17 @@ mod tests {
         // Both calls carry the same session id and identical TEE proof payload.
         assert_eq!(prove_requests[0].proof.session_id, expected_session_id);
         assert_eq!(prove_requests[1].proof.session_id, expected_session_id);
+    }
+
+    #[tokio::test]
+    async fn proof_requester_dispatcher_accepts_existing_l1_head_conflict() {
+        let dispatcher =
+            ProofRequesterDispatcher::aws_nitro(std::sync::Arc::new(L1HeadConflictRequester));
+        let request = test_request(B256::repeat_byte(0xaa));
+        let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
+
+        let dispatched = dispatcher.dispatch_tee(request).await.unwrap();
+
+        assert_eq!(dispatched.session_id, expected_session_id);
     }
 }

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -75,6 +75,16 @@ impl ProverServiceClientError {
         call.code() == Self::ERROR_NOT_FOUND && call.message() == PROOF_REQUEST_NOT_FOUND_MESSAGE
     }
 
+    /// Returns `true` when prover-service rejected a replay because the same
+    /// session id is already bound to a request with a different L1 head.
+    #[must_use]
+    pub fn is_l1_head_conflict_for_session(&self, session_id: &str) -> bool {
+        let Self::RpcTransport(JsonRpcClientError::Call(call)) = self else { return false };
+        call.code() == Self::ERROR_FAILED_PRECONDITION
+            && call.message()
+                == format!("session_id {session_id} already exists with a different l1_head")
+    }
+
     /// Returns `true` when the JSON-RPC error is classified as transient.
     #[must_use]
     pub fn is_retryable_rpc_error(err: &JsonRpcClientError) -> bool {
@@ -184,5 +194,21 @@ mod tests {
 
         let timeout = ProverServiceClientError::Timeout("not ready".into());
         assert!(!timeout.is_not_found());
+    }
+
+    #[test]
+    fn is_l1_head_conflict_matches_only_exact_session_conflict() {
+        let session_id = "e89da79a-8b92-5274-ba97-54a90170cee7";
+        let conflict = rpc_call_error(
+            ProverServiceClientError::ERROR_FAILED_PRECONDITION,
+            &format!("session_id {session_id} already exists with a different l1_head"),
+        );
+
+        assert!(conflict.is_l1_head_conflict_for_session(session_id));
+        assert!(!conflict.is_l1_head_conflict_for_session("other-session"));
+
+        let other_precondition =
+            rpc_call_error(ProverServiceClientError::ERROR_FAILED_PRECONDITION, "lease mismatch");
+        assert!(!other_precondition.is_l1_head_conflict_for_session(session_id));
     }
 }


### PR DESCRIPTION
### What changed? Why?

The proposer now treats prover-service `session_id ... already exists with a different l1_head` responses as an existing accepted proof session when the error matches the session id it just requested. This prevents the dispatcher from repeatedly retrying a deterministic root-derived session after finalized L1 advances, while still letting the collector poll and submit the existing prover-service session.

The prover-service client has a small classifier for this exact failed-precondition response so unrelated failed preconditions still surface as dispatch failures.

### Notes to reviewers

This keeps the existing root-derived TEE session id behavior intact. The dispatcher only stops treating this specific idempotency conflict as fatal; the collector remains responsible for waiting on queued/running proofs, submitting succeeded proofs, and creating retry-specific sessions when a proof is discarded.

### How has it been tested?

- `cargo test -p base-proposer proof_requester_dispatcher_accepts_existing_l1_head_conflict`
- `cargo test -p base-prover-service-client is_l1_head_conflict_matches_only_exact_session_conflict`