### PR TITLE
feat(eip8130): EVM-integration foundation (journal storage provider + tx plumbing)

### DIFF
--- a/crates/common/evm/src/lib.rs
+++ b/crates/common/evm/src/lib.rs
@@ -19,7 +19,8 @@ pub use l1block::L1BlockInfo;
 mod transaction;
 pub use transaction::{
     BaseTransaction, BaseTransactionBuilder, BaseTransactionError, BaseTxTr, BuildError,
-    DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts,
+    DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts, EIP8130_TRANSACTION_TYPE,
+    Eip8130TransactionParts,
 };
 
 mod handler;

--- a/crates/common/evm/src/transaction/builder.rs
+++ b/crates/common/evm/src/transaction/builder.rs
@@ -108,7 +108,12 @@ impl BaseTransactionBuilder {
 
         let base = self.base.build_fill();
 
-        BaseTransaction { base, enveloped_tx: self.enveloped_tx, deposit: self.deposit }
+        BaseTransaction {
+            base,
+            enveloped_tx: self.enveloped_tx,
+            deposit: self.deposit,
+            eip8130: None,
+        }
     }
 
     /// Build the [`BaseTransaction`] instance, return error if the transaction is not valid.
@@ -135,6 +140,11 @@ impl BaseTransactionBuilder {
 
         let base = self.base.build()?;
 
-        Ok(BaseTransaction { base, enveloped_tx: self.enveloped_tx, deposit: self.deposit })
+        Ok(BaseTransaction {
+            base,
+            enveloped_tx: self.enveloped_tx,
+            deposit: self.deposit,
+            eip8130: None,
+        })
     }
 }

--- a/crates/common/evm/src/transaction/core.rs
+++ b/crates/common/evm/src/transaction/core.rs
@@ -12,7 +12,10 @@ use revm::{
     primitives::{Address, B256, Bytes, TxKind, U256},
 };
 
-use crate::{BaseTransactionBuilder, BaseTxTr, DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts};
+use crate::{
+    BaseTransactionBuilder, BaseTxTr, DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts,
+    EIP8130_TRANSACTION_TYPE, Eip8130TransactionParts,
+};
 
 /// Base transaction.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -28,6 +31,12 @@ pub struct BaseTransaction<T: Transaction> {
     pub enveloped_tx: Option<Bytes>,
     /// Deposit transaction parts.
     pub deposit: DepositTransactionParts,
+    /// EIP-8130 account-abstraction transaction parts.
+    ///
+    /// `Some` only for EIP-8130 transactions, carrying the full signed envelope
+    /// the handler needs to run the authorize → apply → execute pipeline (the
+    /// `base` `TxEnv` is only a placeholder projection for such transactions).
+    pub eip8130: Option<Eip8130TransactionParts>,
 }
 
 impl<T: Transaction> AsRef<T> for BaseTransaction<T> {
@@ -39,7 +48,12 @@ impl<T: Transaction> AsRef<T> for BaseTransaction<T> {
 impl<T: Transaction> BaseTransaction<T> {
     /// Create a new Base transaction.
     pub fn new(base: T) -> Self {
-        Self { base, enveloped_tx: None, deposit: DepositTransactionParts::default() }
+        Self {
+            base,
+            enveloped_tx: None,
+            deposit: DepositTransactionParts::default(),
+            eip8130: None,
+        }
     }
 }
 
@@ -56,6 +70,7 @@ impl Default for BaseTransaction<TxEnv> {
             base: TxEnv::default(),
             enveloped_tx: Some(vec![0x00].into()),
             deposit: DepositTransactionParts::default(),
+            eip8130: None,
         }
     }
 }
@@ -89,6 +104,8 @@ impl<T: Transaction> Transaction for BaseTransaction<T> {
         // If this is a deposit transaction (has source_hash set), return deposit type
         if self.deposit.source_hash != B256::ZERO {
             DEPOSIT_TRANSACTION_TYPE
+        } else if self.eip8130.is_some() {
+            EIP8130_TRANSACTION_TYPE
         } else {
             self.base.tx_type()
         }
@@ -103,18 +120,41 @@ impl<T: Transaction> Transaction for BaseTransaction<T> {
     }
 
     fn value(&self) -> U256 {
+        // EIP-8130 transactions have no top-level value; the base env is a
+        // placeholder and any per-call value lives in the signed envelope.
+        debug_assert!(
+            self.eip8130.is_none(),
+            "value() called on an EIP-8130 transaction; use the signed envelope"
+        );
         self.base.value()
     }
 
     fn input(&self) -> &Bytes {
+        // EIP-8130 transactions have no top-level input; see `value`.
+        debug_assert!(
+            self.eip8130.is_none(),
+            "input() called on an EIP-8130 transaction; use the signed envelope"
+        );
         self.base.input()
     }
 
     fn nonce(&self) -> u64 {
+        // EIP-8130 transactions use a 2D nonce; the base env carries only
+        // `nonce_sequence` and drops `nonce_key`, so this is a misleading
+        // placeholder (see `value`). Use the signed envelope.
+        debug_assert!(
+            self.eip8130.is_none(),
+            "nonce() called on an EIP-8130 transaction; use the signed envelope"
+        );
         self.base.nonce()
     }
 
     fn kind(&self) -> TxKind {
+        // EIP-8130 transactions have no single call target; see `value`.
+        debug_assert!(
+            self.eip8130.is_none(),
+            "kind() called on an EIP-8130 transaction; use the signed envelope"
+        );
         self.base.kind()
     }
 
@@ -182,6 +222,10 @@ impl<T: Transaction> BaseTxTr for BaseTransaction<T> {
     fn is_system_transaction(&self) -> bool {
         self.deposit.is_system_transaction
     }
+
+    fn eip8130_parts(&self) -> Option<&Eip8130TransactionParts> {
+        self.eip8130.as_ref()
+    }
 }
 
 impl<T> IntoTxEnv<Self> for BaseTransaction<T>
@@ -222,24 +266,62 @@ impl FromTxWithEncoded<BaseTxEnvelope> for BaseTransaction<TxEnv> {
                 base: TxEnv::from_recovered_tx(tx.tx(), caller),
                 enveloped_tx: Some(encoded),
                 deposit: Default::default(),
+                eip8130: None,
             },
             BaseTxEnvelope::Eip1559(tx) => Self {
                 base: TxEnv::from_recovered_tx(tx.tx(), caller),
                 enveloped_tx: Some(encoded),
                 deposit: Default::default(),
+                eip8130: None,
             },
             BaseTxEnvelope::Eip2930(tx) => Self {
                 base: TxEnv::from_recovered_tx(tx.tx(), caller),
                 enveloped_tx: Some(encoded),
                 deposit: Default::default(),
+                eip8130: None,
             },
             BaseTxEnvelope::Eip7702(tx) => Self {
                 base: TxEnv::from_recovered_tx(tx.tx(), caller),
                 enveloped_tx: Some(encoded),
                 deposit: Default::default(),
+                eip8130: None,
             },
-            BaseTxEnvelope::Eip8130(_) => {
-                unimplemented!("EVM execution for EIP-8130 BaseTxEnvelope is not yet implemented")
+            BaseTxEnvelope::Eip8130(signed) => {
+                // An EIP-8130 transaction has no single call to project into a
+                // `TxEnv`. The `base` env is a placeholder carrying only the
+                // fields shared by every transaction (caller, gas, fee caps,
+                // chain id); execution is driven from the signed envelope in
+                // `eip8130` by [`Eip8130Executor`], not from this `TxEnv`.
+                //
+                // Consequently the `Transaction` accessors backed by the base
+                // env that have no EIP-8130 analogue — `kind`, `value`, and
+                // `input` — return `TxEnv` defaults (a zero-address call, zero
+                // value, empty input) for an 8130 transaction and must not be
+                // relied on for execution; `effective_gas_price` stays correct
+                // because the fee caps are projected above. The handler routes
+                // 8130 transactions to the executor before any of these are hit
+                // (see `BaseEvm::transact_raw`).
+                //
+                // `signed.clone()` is required because `from_encoded_tx` borrows
+                // the envelope by shared reference (signature inherited from
+                // alloy-evm). The clone deep-copies the account-change and call
+                // vectors; the auth blobs are ref-counted `Bytes`.
+                let inner = signed.tx();
+                let base = TxEnv {
+                    caller,
+                    gas_limit: inner.gas_limit,
+                    gas_price: inner.max_fee_per_gas,
+                    gas_priority_fee: Some(inner.max_priority_fee_per_gas),
+                    chain_id: Some(inner.chain_id),
+                    nonce: inner.nonce_sequence,
+                    ..Default::default()
+                };
+                Self {
+                    base,
+                    enveloped_tx: Some(encoded),
+                    deposit: Default::default(),
+                    eip8130: Some(Eip8130TransactionParts::new(signed.clone())),
+                }
             }
             BaseTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
         }
@@ -261,15 +343,17 @@ impl FromTxWithEncoded<TxDeposit> for BaseTransaction<TxEnv> {
             mint: Some(tx.mint),
             is_system_transaction: tx.is_system_transaction,
         };
-        Self { base, enveloped_tx: Some(encoded), deposit }
+        Self { base, enveloped_tx: Some(encoded), deposit, eip8130: None }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_eips::Encodable2718;
+    use base_common_consensus::{BaseTxEnvelope, Eip8130Signed, TxEip8130};
     use revm::{
         context_interface::Transaction,
-        primitives::{Address, B256},
+        primitives::{Address, B256, Bytes},
     };
 
     use super::*;
@@ -294,5 +378,37 @@ mod tests {
         // Verify gas related calculations - deposit transactions use gas_price for effective gas price
         assert_eq!(base_tx.effective_gas_price(90), 100);
         assert_eq!(base_tx.max_fee_per_gas(), 100);
+    }
+
+    /// An EIP-8130 envelope projects to a placeholder `TxEnv` carrying the shared
+    /// fields, reports the EIP-8130 transaction type, and retains the full signed
+    /// envelope in `eip8130` for the handler.
+    #[test]
+    fn from_encoded_eip8130_populates_parts() {
+        let inner = TxEip8130 {
+            chain_id: 8453,
+            gas_limit: 250_000,
+            max_fee_per_gas: 5_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            nonce_sequence: 7,
+            ..Default::default()
+        };
+        let signed = Eip8130Signed::new(inner, Bytes::from(vec![0u8; 65]), Bytes::new());
+        let envelope = BaseTxEnvelope::Eip8130(signed.clone());
+        let caller = Address::with_last_byte(0xab);
+        let encoded: Bytes = envelope.encoded_2718().into();
+
+        let tx = BaseTransaction::from_encoded_tx(&envelope, caller, encoded);
+
+        assert_eq!(tx.tx_type(), EIP8130_TRANSACTION_TYPE);
+        assert!(tx.is_eip8130());
+        assert_eq!(tx.eip8130_parts().map(|p| &p.signed), Some(&signed));
+        assert_eq!(tx.caller(), caller);
+        assert_eq!(tx.gas_limit(), 250_000);
+        assert_eq!(tx.chain_id(), Some(8453));
+        assert_eq!(tx.max_fee_per_gas(), 5_000_000_000);
+        // `nonce()` is a guarded placeholder for 8130 (it drops `nonce_key`);
+        // assert the projection on the base env directly to avoid the guard.
+        assert_eq!(tx.base.nonce(), 7);
     }
 }

--- a/crates/common/evm/src/transaction/eip8130.rs
+++ b/crates/common/evm/src/transaction/eip8130.rs
@@ -1,0 +1,31 @@
+//! Contains EIP-8130 account-abstraction transaction parts.
+pub use base_common_consensus::EIP8130_TX_TYPE_ID as EIP8130_TRANSACTION_TYPE;
+use base_common_consensus::Eip8130Signed;
+
+/// EIP-8130 account-abstraction transaction parts carried on a
+/// [`BaseTransaction`].
+///
+/// Unlike the other transaction types, an EIP-8130 transaction cannot be fully
+/// expressed as a revm `TxEnv`: it has a sender/payer split, a list of phased
+/// calls (`Vec<Vec<Call>>`), and account-configuration changes that are applied
+/// before execution. The `TxEnv` projection built by `from_encoded_tx` is only a
+/// placeholder; the full signed envelope is carried here so the handler can run
+/// the EIP-8130 authorize → apply → execute pipeline, which needs the
+/// sender/payer authentication blobs and the account changes the `TxEnv` cannot
+/// hold.
+///
+/// [`BaseTransaction`]: crate::BaseTransaction
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Eip8130TransactionParts {
+    /// The signed EIP-8130 envelope: the transaction body plus the sender and
+    /// (optional) payer authentication blobs.
+    pub signed: Eip8130Signed,
+}
+
+impl Eip8130TransactionParts {
+    /// Create new EIP-8130 transaction parts from a signed envelope.
+    pub const fn new(signed: Eip8130Signed) -> Self {
+        Self { signed }
+    }
+}

--- a/crates/common/evm/src/transaction/mod.rs
+++ b/crates/common/evm/src/transaction/mod.rs
@@ -12,6 +12,9 @@ pub use builder::BaseTransactionBuilder;
 mod deposit;
 pub use deposit::{DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts};
 
+mod eip8130;
+pub use eip8130::{EIP8130_TRANSACTION_TYPE, Eip8130TransactionParts};
+
 mod error;
 pub use error::{BaseTransactionError, BuildError};
 

--- a/crates/common/evm/src/transaction/traits.rs
+++ b/crates/common/evm/src/transaction/traits.rs
@@ -6,7 +6,7 @@ use revm::{
     primitives::{B256, Bytes},
 };
 
-use crate::DEPOSIT_TRANSACTION_TYPE;
+use crate::{DEPOSIT_TRANSACTION_TYPE, EIP8130_TRANSACTION_TYPE, Eip8130TransactionParts};
 
 /// Base Transaction trait.
 #[auto_impl(&, &mut, Box, Arc)]
@@ -23,8 +23,17 @@ pub trait BaseTxTr: Transaction {
     /// Whether the transaction is a system transaction
     fn is_system_transaction(&self) -> bool;
 
+    /// The EIP-8130 account-abstraction parts (the signed envelope), or `None`
+    /// for every other transaction type.
+    fn eip8130_parts(&self) -> Option<&Eip8130TransactionParts>;
+
     /// Returns `true` if transaction is of type [`DEPOSIT_TRANSACTION_TYPE`].
     fn is_deposit(&self) -> bool {
         self.tx_type() == DEPOSIT_TRANSACTION_TYPE
+    }
+
+    /// Returns `true` if transaction is of type [`EIP8130_TRANSACTION_TYPE`].
+    fn is_eip8130(&self) -> bool {
+        self.tx_type() == EIP8130_TRANSACTION_TYPE
     }
 }

--- a/crates/common/precompile-storage/src/journal.rs
+++ b/crates/common/precompile-storage/src/journal.rs
@@ -1,0 +1,265 @@
+//! Gas-free EVM-journal-backed [`PrecompileStorageProvider`].
+//!
+//! [`JournalStorageProvider`] wraps a live alloy-evm [`EvmInternals`] journal and
+//! implements [`PrecompileStorageProvider`] without metering any gas. It exists
+//! for the *enshrined* EIP-8130 execution path, which runs at block-executor
+//! level (around, not inside, an EVM call) and meters its own gas via the
+//! EIP-8130 intrinsic schedule. Using the metered [`EvmPrecompileStorageProvider`]
+//! there would double-count storage gas.
+//!
+//! Reads and writes go through the same [`EvmInternals`] journal that EVM opcodes
+//! use, so they observe state committed earlier in the block and persist to the
+//! state the subsequent EVM calls and the final commit see.
+//!
+//! [`EvmPrecompileStorageProvider`]: crate::EvmPrecompileStorageProvider
+
+use alloc::string::ToString;
+
+use alloy_evm::EvmInternals;
+use alloy_primitives::{Address, B256, Log, LogData, U256};
+use revm::{
+    // `Block` is imported only to bring its trait methods (e.g. `block_env().number()`)
+    // into scope; `as _` keeps it anonymous since it is never named directly.
+    context::{Block as _, journaled_state::JournalCheckpoint},
+    primitives::keccak256,
+    state::{AccountInfo, Bytecode},
+};
+
+use crate::{
+    error::{BasePrecompileError, Result},
+    provider::PrecompileStorageProvider,
+};
+
+/// Gas-free [`PrecompileStorageProvider`] backed by a live EVM journal.
+///
+/// Construct from an [`EvmInternals`] borrowed from the block-execution context
+/// (e.g. `EvmInternals::from_context(evm.ctx_mut())`) and pass `&mut self` to
+/// [`StorageCtx::enter`](crate::StorageCtx::enter) so `#[contract]` storage types
+/// read and write the real EVM journal. All gas accounting methods are no-ops:
+/// [`gas_limit`](PrecompileStorageProvider::gas_limit) reports [`u64::MAX`] and
+/// nothing is ever deducted.
+#[derive(Debug)]
+pub struct JournalStorageProvider<'a> {
+    internals: EvmInternals<'a>,
+    caller: Address,
+    block_number: u64,
+    timestamp: U256,
+    chain_id: u64,
+    beneficiary: Address,
+    origin: Address,
+}
+
+impl<'a> JournalStorageProvider<'a> {
+    /// Build a gas-free provider over `internals`, attributing storage access to
+    /// `caller`. Block metadata (number, timestamp, chain id, beneficiary,
+    /// origin) is snapshotted from the journal's block/transaction environment.
+    pub fn new(internals: EvmInternals<'a>, caller: Address) -> Self {
+        let block_number = internals.block_env().number().to::<u64>();
+        let timestamp = internals.block_env().timestamp();
+        let chain_id = internals.chain_id();
+        let beneficiary = internals.block_env().beneficiary();
+        let origin = internals.tx_origin();
+
+        Self { internals, caller, block_number, timestamp, chain_id, beneficiary, origin }
+    }
+}
+
+impl PrecompileStorageProvider for JournalStorageProvider<'_> {
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    fn timestamp(&self) -> U256 {
+        self.timestamp
+    }
+
+    fn beneficiary(&self) -> Address {
+        self.beneficiary
+    }
+
+    fn block_number(&self) -> u64 {
+        self.block_number
+    }
+
+    fn origin(&self) -> Address {
+        self.origin
+    }
+
+    fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()> {
+        self.internals
+            .set_code(address, code)
+            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
+    }
+
+    fn with_account_info(
+        &mut self,
+        address: Address,
+        f: &mut dyn FnMut(&AccountInfo),
+    ) -> Result<()> {
+        let info = {
+            let state_load = self
+                .internals
+                .load_account(address)
+                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+            state_load.data.info.clone()
+        };
+        f(&info);
+        Ok(())
+    }
+
+    fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
+        let s = self
+            .internals
+            .sload(address, key)
+            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+        Ok(s.data)
+    }
+
+    fn tload(&mut self, address: Address, key: U256) -> Result<U256> {
+        Ok(self.internals.tload(address, key))
+    }
+
+    fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
+        self.internals
+            .sstore(address, key, value)
+            .map(|_| ())
+            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
+    }
+
+    fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
+        self.internals.tstore(address, key, value);
+        Ok(())
+    }
+
+    fn emit_event(&mut self, address: Address, event: LogData) -> Result<()> {
+        self.internals.log(Log { address, data: event });
+        Ok(())
+    }
+
+    fn deduct_gas(&mut self, _gas: u64) -> Result<()> {
+        Ok(())
+    }
+
+    fn deduct_state_gas(&mut self, _gas: u64) -> Result<()> {
+        Ok(())
+    }
+
+    fn refund_gas(&mut self, _gas: i64) {}
+
+    fn gas_limit(&self) -> u64 {
+        u64::MAX
+    }
+
+    fn gas_used(&self) -> u64 {
+        0
+    }
+
+    fn state_gas_used(&self) -> u64 {
+        0
+    }
+
+    fn gas_refunded(&self) -> i64 {
+        0
+    }
+
+    fn reservoir(&self) -> u64 {
+        0
+    }
+
+    fn is_static(&self) -> bool {
+        false
+    }
+
+    fn call_value(&self) -> U256 {
+        U256::ZERO
+    }
+
+    fn caller(&self) -> Address {
+        self.caller
+    }
+
+    fn replace_caller(&mut self, caller: Address) -> Address {
+        core::mem::replace(&mut self.caller, caller)
+    }
+
+    fn checkpoint(&mut self) -> JournalCheckpoint {
+        self.internals.checkpoint()
+    }
+
+    fn checkpoint_commit(&mut self) {
+        self.internals.checkpoint_commit();
+    }
+
+    fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint) {
+        self.internals.checkpoint_revert(checkpoint);
+    }
+
+    fn metered_keccak256(&mut self, data: &[u8]) -> Result<B256> {
+        Ok(keccak256(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::{EvmInternals, eth::EthEvmContext};
+    use alloy_primitives::{Address, U256};
+    use revm::{database::EmptyDB, primitives::hardfork::SpecId, state::Bytecode};
+
+    use super::JournalStorageProvider;
+    use crate::provider::PrecompileStorageProvider;
+
+    const ADDR: Address = Address::repeat_byte(0x42);
+
+    /// A persistent write is visible to a later read through the same journal,
+    /// and neither charges any gas.
+    #[test]
+    fn sstore_then_sload_roundtrips_without_gas() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        let key = U256::from(7);
+        let value = U256::from(99);
+        provider.sstore(ADDR, key, value).unwrap();
+
+        assert_eq!(provider.sload(ADDR, key).unwrap(), value);
+        assert_eq!(provider.gas_used(), 0, "the gas-free provider must never charge gas");
+        assert_eq!(provider.gas_limit(), u64::MAX);
+        assert_eq!(provider.gas_refunded(), 0);
+    }
+
+    /// `set_code` persists and is reflected in the account's code hash, gas-free.
+    #[test]
+    fn set_code_persists_without_gas() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        let code = Bytecode::new_raw([0x60u8, 0x00].as_ref().into());
+        let expected_hash = code.hash_slow();
+        provider.set_code(ADDR, code).unwrap();
+
+        let mut observed = None;
+        provider.with_account_info(ADDR, &mut |info| observed = Some(info.code_hash)).unwrap();
+        assert_eq!(observed, Some(expected_hash));
+        assert_eq!(provider.gas_used(), 0);
+    }
+
+    /// Deducting gas is a no-op: it never fails and never advances the counter,
+    /// even when asked for more than the (nominal) limit.
+    #[test]
+    fn gas_deduction_is_a_noop() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        provider.deduct_gas(1_000_000).unwrap();
+        provider.deduct_state_gas(1_000_000).unwrap();
+        provider.refund_gas(500);
+
+        assert_eq!(provider.gas_used(), 0);
+        assert_eq!(provider.state_gas_used(), 0);
+        assert_eq!(provider.gas_refunded(), 0);
+        assert!(!provider.is_static());
+    }
+}

--- a/crates/common/precompile-storage/src/lib.rs
+++ b/crates/common/precompile-storage/src/lib.rs
@@ -36,6 +36,9 @@ pub use types::{
 mod evm;
 pub use evm::EvmPrecompileStorageProvider;
 
+mod journal;
+pub use journal::JournalStorageProvider;
+
 #[cfg(any(test, feature = "test-utils"))]
 mod hashmap;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/common/rpc-types/src/reth.rs
+++ b/crates/common/rpc-types/src/reth.rs
@@ -44,6 +44,7 @@ impl<Spec, Block: BlockEnvironment> TryIntoTxEnv<BaseRevm<TxEnv>, Spec, Block>
             base: self.as_ref().clone().try_into_tx_env(evm_env)?,
             enveloped_tx: Some(Bytes::new()),
             deposit: Default::default(),
+            eip8130: None,
         })
     }
 }


### PR DESCRIPTION
## Summary

First step of wiring EIP-8130 account-abstraction transactions into EVM execution. This PR lands only the **foundation** so it stays small and reviewable; nothing is reachable end-to-end yet (RPC/pool still reject `0x7B`).

- **Gas-free journal storage provider** (`base-precompile-storage::JournalStorageProvider`). The only existing `PrecompileStorageProvider` backed by the live revm journal is `EvmPrecompileStorageProvider`, which meters EIP-2929/2200 gas on every `sload`/`sstore` because it runs *inside* a precompile call. The enshrined EIP-8130 path runs at block-executor level and accounts gas via its own intrinsic schedule, so reusing the metered provider would **double-count gas**. `JournalStorageProvider` delegates to the same `EvmInternals` journal (reads see in-block state, writes persist) but meters nothing.
- **`BaseTransaction` EIP-8130 plumbing.** An 8130 transaction has a sender/payer split, phased calls, and account-config changes — it cannot be expressed as a single `TxEnv`. The new `Eip8130TransactionParts` carries the full signed envelope on `BaseTransaction`; `from_encoded_tx` now builds a placeholder `TxEnv` + parts instead of `unimplemented!()`-panicking; `tx_type()` reports `EIP8130_TRANSACTION_TYPE` (`0x7B`); and the handler can reach the envelope via the new `BaseTxTr::eip8130_parts` accessor.

### Why this shape

`BaseBlockExecutor` is generic over `E: Evm`, which doesn't expose the journal/context needed to mutate account-config state directly. Like deposit transactions, the 8130 state pipeline therefore belongs in `BaseHandler` (which has concrete context access) and is fed the signed envelope through `BaseTransaction`. These two pieces are the prerequisites for that handler work.

### Next PR (handler pre-call pipeline)

In `BaseHandler`: authorize → 2D-nonce validate + mark → intrinsic gas → fee-cap validate → resolve + debit payer → apply account changes (+ install deferred create/delegation code), backed by `JournalStorageProvider`. Phased call execution and full fee settlement / receipts follow after that.

## Test plan

- [x] `cargo test -p base-precompile-storage journal` — gas-free read/write round-trip, `set_code`, gas no-ops
- [x] `cargo test -p base-common-evm --lib transaction::` — 8130 `from_encoded_tx` populates parts, reports `0x7B`, projects shared fields
- [x] `cargo fmt` + `cargo clippy -p base-precompile-storage -p base-common-evm --all-targets` clean
- [x] Non-proof workspace consumers compile (`base-execution-evm`, `base-builder-core`, `base-execution-txpool`, `base-node-core`, `base-execution-rpc`, `base-common-rpc-types`). Proof crates not checked locally (blocked by missing Xcode Metal toolchain, unrelated to this change).