### PR TITLE
refactor(registrar): simplify signer attestation trait

### DIFF
--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -242,7 +242,7 @@ where
         );
         let all_attestations = match self
             .signer_client
-            .signer_attestation(&instance.endpoint, None, Some(nonce.to_vec()))
+            .signer_attestation(&instance.endpoint, Some(nonce.to_vec()))
             .await
         {
             Ok(attestations) => attestations,
@@ -417,7 +417,6 @@ mod tests {
         async fn signer_attestation(
             &self,
             endpoint: &Url,
-            _user_data: Option<Vec<u8>>,
             _nonce: Option<Vec<u8>>,
         ) -> Result<Vec<Vec<u8>>> {
             if self.fail_attestation.contains(endpoint) {

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -65,13 +65,13 @@ impl SignerClient for ProverClient {
     async fn signer_attestation(
         &self,
         endpoint: &Url,
-        user_data: Option<Vec<u8>>,
         nonce: Option<Vec<u8>>,
     ) -> Result<Vec<Vec<u8>>> {
         debug!(endpoint = %endpoint, "fetching signer attestations");
         let client = self.build_client(endpoint)?;
-        client.signer_attestation(user_data, nonce).await.map_err(|e| {
-            RegistrarError::ProverClient { instance: endpoint.to_string(), source: Box::new(e) }
+        client.signer_attestation(None, nonce).await.map_err(|e| RegistrarError::ProverClient {
+            instance: endpoint.to_string(),
+            source: Box::new(e),
         })
     }
 }

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -34,12 +34,10 @@ pub trait SignerClient: Send + Sync {
 
     /// Fetches the raw Nitro attestation document for each enclave signer at the given endpoint.
     ///
-    /// Optional `user_data` and `nonce` bind the attestation to a specific
-    /// request (e.g. a random nonce for replay protection).
+    /// The optional nonce binds the attestation to a specific request for replay protection.
     fn signer_attestation<'a>(
         &'a self,
         endpoint: &'a Url,
-        user_data: Option<Vec<u8>>,
         nonce: Option<Vec<u8>>,
     ) -> impl Future<Output = Result<Vec<Vec<u8>>>> + Send + 'a;
 }


### PR DESCRIPTION
### What changed? Why?

Removes the unused `user_data` parameter from the registrar `SignerClient::signer_attestation` trait so callers and test implementations only pass the nonce used for replay protection. The prover client still calls the lower-level signer attestation API with `None` for user data.

### Notes to reviewers

No behavior change intended; this only narrows the registrar trait boundary and updates its call sites.

### How has it been tested?

`RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar`