### PR TITLE
refactor(registrar): clean up types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5847,7 +5847,6 @@ dependencies = [
  "metrics",
  "rand 0.9.4",
  "reqwest 0.13.4",
- "rstest",
  "rustls 0.23.40",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -77,7 +77,6 @@ url.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-rstest.workspace = true
 hex-literal.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -16,4 +16,4 @@ to detect new Nitro enclave instances, fetches their attestation documents via
 - **`prover`** — [`ProverClient`] JSON-RPC client for polling prover signer endpoints.
 - **`signer_manager`** — [`SignerManager`] lifecycle management for signer proof tasks and registration execution.
 - **`traits`** — [`InstanceDiscovery`] and attestation proof provider trait usage.
-- **`types`** — Core domain types: [`ProverInstance`], [`RegisteredSigner`].
+- **`types`** — Core domain types: [`ProverInstance`].

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -103,7 +103,12 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             let health_status = desc
                 .target_health()
                 .and_then(|h| h.state())
-                .map(|s| InstanceHealthStatus::from_aws_state(s.as_str()))
+                .map(|s| match s.as_str() {
+                    "initial" => InstanceHealthStatus::Initial,
+                    "healthy" => InstanceHealthStatus::Healthy,
+                    "draining" => InstanceHealthStatus::Draining,
+                    _ => InstanceHealthStatus::Unhealthy,
+                })
                 .unwrap_or(InstanceHealthStatus::Unhealthy);
 
             health_map.entry(instance_id.to_string()).or_insert(health_status);

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -213,7 +213,11 @@ where
                 lt.elapsed()
                     .is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
             });
-        if !instance.health_status.should_register() && !recently_launched_unhealthy {
+        if !matches!(
+            instance.health_status,
+            InstanceHealthStatus::Initial | InstanceHealthStatus::Healthy
+        ) && !recently_launched_unhealthy
+        {
             debug!(
                 status = ?instance.health_status,
                 instance = %instance.instance_id,

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -38,7 +38,7 @@ mod traits;
 pub use traits::{InstanceDiscovery, SignerClient};
 
 mod types;
-pub use types::{InstanceHealthStatus, ProverInstance, RegisteredSigner};
+pub use types::{InstanceHealthStatus, ProverInstance};
 
 mod verifier;
 pub use verifier::{NitroVerifierClient, NitroVerifierContractClient};

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -1,6 +1,5 @@
 use std::time::SystemTime;
 
-use alloy_primitives::{Address, B256};
 use url::Url;
 
 /// A prover instance discovered from the infrastructure layer.
@@ -28,63 +27,4 @@ pub enum InstanceHealthStatus {
     Unhealthy,
     /// ALB is draining connections from this instance.
     Draining,
-}
-
-impl InstanceHealthStatus {
-    /// Returns `true` if the instance should be registered onchain.
-    ///
-    /// Both `Initial` (AWS warm-up) and `Healthy` instances are candidates for
-    /// registration. `Unhealthy` and `Draining` instances are not.
-    pub const fn should_register(&self) -> bool {
-        matches!(self, Self::Initial | Self::Healthy)
-    }
-
-    /// Maps an AWS ELB target health state string to [`InstanceHealthStatus`].
-    ///
-    /// Used by `AwsTargetGroupDiscovery` to convert `describe_target_health` responses.
-    pub fn from_aws_state(state: &str) -> Self {
-        match state {
-            "initial" => Self::Initial,
-            "healthy" => Self::Healthy,
-            "draining" => Self::Draining,
-            _ => Self::Unhealthy,
-        }
-    }
-}
-
-/// A signer currently registered onchain via `TEEProverRegistry`.
-#[derive(Debug, Clone)]
-pub struct RegisteredSigner {
-    /// The signer's Ethereum address.
-    pub address: Address,
-    /// The `keccak256(PCR0)` measurement hash the signer was registered under.
-    pub pcr0: B256,
-}
-
-#[cfg(test)]
-mod tests {
-    use rstest::rstest;
-
-    use super::*;
-
-    #[rstest]
-    #[case::initial(InstanceHealthStatus::Initial, true)]
-    #[case::healthy(InstanceHealthStatus::Healthy, true)]
-    #[case::unhealthy(InstanceHealthStatus::Unhealthy, false)]
-    #[case::draining(InstanceHealthStatus::Draining, false)]
-    fn should_register(#[case] status: InstanceHealthStatus, #[case] expected: bool) {
-        assert_eq!(status.should_register(), expected);
-    }
-
-    #[rstest]
-    #[case::initial("initial", InstanceHealthStatus::Initial)]
-    #[case::healthy("healthy", InstanceHealthStatus::Healthy)]
-    #[case::draining("draining", InstanceHealthStatus::Draining)]
-    #[case::unhealthy("unhealthy", InstanceHealthStatus::Unhealthy)]
-    #[case::unavailable("unavailable", InstanceHealthStatus::Unhealthy)]
-    #[case::empty("", InstanceHealthStatus::Unhealthy)]
-    #[case::bogus("bogus", InstanceHealthStatus::Unhealthy)]
-    fn from_aws_state(#[case] input: &str, #[case] expected: InstanceHealthStatus) {
-        assert_eq!(InstanceHealthStatus::from_aws_state(input), expected);
-    }
 }


### PR DESCRIPTION
### What changed? Why?

Removes the unused `RegisteredSigner` type and export from the registrar crate, along with the now-unused `rstest` dev dependency.

Keeps `InstanceHealthStatus` as a plain domain enum by moving AWS state mapping and registration eligibility checks to the call sites that use them.

### Notes to reviewers

Behavior should be unchanged: `initial` and `healthy` instances remain registerable, `draining` and `unhealthy` instances are skipped, and unknown AWS target states still map to `Unhealthy`.

### How has it been tested?

- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar` (39 passed)
- A plain `cargo test -p base-proof-tee-registrar` failed before tests because local `xcrun` could not find the Metal compiler utility.
