### PR TITLE
refactor(proposer): clean up admin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5987,7 +5987,6 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "metrics-util",
- "reqwest 0.13.4",
  "rstest",
  "rustls 0.23.40",
  "serde",

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -38,7 +38,7 @@ base-prover-service-protocol.workspace = true
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }
 
 # JSON-RPC
-jsonrpsee = { workspace = true, features = ["server", "macros"] }
+jsonrpsee = { workspace = true, features = ["server"] }
 
 # Async
 tokio.workspace = true
@@ -79,7 +79,6 @@ rstest.workspace = true
 serde_json.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-eth.workspace = true
-reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["test-util"] }
 metrics-util = { workspace = true, features = ["debugging"] }
 base-common-genesis = { workspace = true, features = ["serde"] }

--- a/crates/proof/proposer/src/admin.rs
+++ b/crates/proof/proposer/src/admin.rs
@@ -25,8 +25,10 @@ impl ProposerAdminApiServerImpl {
     ) -> eyre::Result<ServerHandle> {
         let server =
             Server::builder().build(addr).await.wrap_err("failed to bind admin RPC server")?;
+        let local_addr =
+            server.local_addr().wrap_err("failed to get admin server local address")?;
         let module = Self::module(driver)?;
-        info!(addr = %addr, "admin RPC server listening");
+        info!(addr = %local_addr, "admin RPC server listening");
         Ok(server.start(module))
     }
 

--- a/crates/proof/proposer/src/admin.rs
+++ b/crates/proof/proposer/src/admin.rs
@@ -1,231 +1,118 @@
 //! Optional admin JSON-RPC handler.
 //!
-//! Provides `POST /` JSON-RPC admin methods for proposer control:
-//! - `admin_startProposer`   — start the driver loop
-//! - `admin_stopProposer`    — stop the driver loop
-//! - `admin_proposerRunning` — query whether the driver is running
 
 use std::{net::SocketAddr, sync::Arc};
 
 use eyre::Context;
 use jsonrpsee::{
-    core::{RpcResult, async_trait},
-    proc_macros::rpc,
-    server::{Server, ServerHandle},
+    core::RpcResult,
+    server::{RpcModule, Server, ServerHandle},
     types::ErrorObjectOwned,
 };
 use tracing::info;
 
 use crate::driver::ProposerDriverControl;
 
-#[rpc(server, namespace = "admin")]
-pub trait ProposerAdminApi {
-    /// Start the proving pipeline.
-    #[method(name = "startProposer")]
-    async fn start_proposer(&self) -> RpcResult<()>;
-
-    /// Stop the proving pipeline.
-    #[method(name = "stopProposer")]
-    async fn stop_proposer(&self) -> RpcResult<()>;
-
-    /// Returns whether the proving pipeline is currently running.
-    #[method(name = "proposerRunning")]
-    async fn proposer_running(&self) -> RpcResult<bool>;
-}
-
-/// Concrete implementation of [`ProposerAdminApiServer`] backed by a
-/// [`ProposerDriverControl`] handle.
-pub struct ProposerAdminApiServerImpl {
-    driver: Arc<dyn ProposerDriverControl>,
-}
-
-impl std::fmt::Debug for ProposerAdminApiServerImpl {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProposerAdminApiServerImpl")
-            .field("driver", &"<dyn ProposerDriverControl>")
-            .finish()
-    }
-}
+/// Admin JSON-RPC server backed by a [`ProposerDriverControl`] handle.
+#[derive(Debug)]
+pub struct ProposerAdminApiServerImpl;
 
 impl ProposerAdminApiServerImpl {
-    fn driver_error(msg: String) -> ErrorObjectOwned {
-        ErrorObjectOwned::owned(-32000, msg, None::<()>)
-    }
-}
-
-#[async_trait]
-impl ProposerAdminApiServer for ProposerAdminApiServerImpl {
-    async fn start_proposer(&self) -> RpcResult<()> {
-        self.driver.start_proposer().await.map_err(Self::driver_error)
-    }
-
-    async fn stop_proposer(&self) -> RpcResult<()> {
-        self.driver.stop_proposer().await.map_err(Self::driver_error)
-    }
-
-    async fn proposer_running(&self) -> RpcResult<bool> {
-        Ok(self.driver.is_running())
-    }
-}
-
-/// A running admin JSON-RPC HTTP server.
-///
-/// Holds the jsonrpsee [`ServerHandle`] for the server's lifetime.
-/// Dropping this value stops the server from accepting new connections.
-pub struct AdminServer {
-    handle: ServerHandle,
-    addr: SocketAddr,
-}
-
-impl std::fmt::Debug for AdminServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AdminServer").field("addr", &self.addr).finish()
-    }
-}
-
-impl AdminServer {
     /// Bind and start the admin server on the given socket address.
     pub async fn spawn(
         addr: SocketAddr,
         driver: Arc<dyn ProposerDriverControl>,
-    ) -> eyre::Result<Self> {
+    ) -> eyre::Result<ServerHandle> {
         let server =
             Server::builder().build(addr).await.wrap_err("failed to bind admin RPC server")?;
-        let addr = server.local_addr().wrap_err("failed to get admin server local address")?;
-        let module = ProposerAdminApiServerImpl { driver }.into_rpc();
-        let handle = server.start(module);
+        let module = Self::module(driver)?;
         info!(addr = %addr, "admin RPC server listening");
-        Ok(Self { handle, addr })
+        Ok(server.start(module))
     }
 
-    /// Returns the local address the server is bound to.
-    pub const fn local_addr(&self) -> SocketAddr {
-        self.addr
+    /// Build the admin RPC module.
+    pub fn module(driver: Arc<dyn ProposerDriverControl>) -> eyre::Result<RpcModule<()>> {
+        let mut module = RpcModule::new(());
+
+        let start_driver = Arc::clone(&driver);
+        module
+            .register_async_method("admin_startProposer", move |_, _, _| {
+                let driver = Arc::clone(&start_driver);
+                async move { driver.start_proposer().await.map_err(Self::rpc_error) }
+            })
+            .wrap_err("failed to register admin_startProposer")?;
+
+        let stop_driver = Arc::clone(&driver);
+        module
+            .register_async_method("admin_stopProposer", move |_, _, _| {
+                let driver = Arc::clone(&stop_driver);
+                async move { driver.stop_proposer().await.map_err(Self::rpc_error) }
+            })
+            .wrap_err("failed to register admin_stopProposer")?;
+
+        module
+            .register_method("admin_proposerRunning", move |_, _, _| {
+                RpcResult::Ok(driver.is_running())
+            })
+            .wrap_err("failed to register admin_proposerRunning")?;
+
+        Ok(module)
     }
 
-    /// Initiate graceful shutdown and wait for all in-flight connections to
-    /// close.
-    pub async fn shutdown(self) {
-        let _ = self.handle.stop();
-        self.handle.stopped().await;
+    /// Convert a driver control error into a JSON-RPC error object.
+    pub fn rpc_error(msg: String) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(-32000, msg, None::<()>)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use async_trait::async_trait;
 
     use super::*;
-    use crate::driver::ProposerDriverControl;
 
-    struct MockDriverControl {
+    #[derive(Debug, Default)]
+    struct MockDriver {
         running: AtomicBool,
     }
 
-    impl MockDriverControl {
-        fn new() -> Self {
-            Self { running: AtomicBool::new(false) }
-        }
-    }
-
     #[async_trait]
-    impl ProposerDriverControl for MockDriverControl {
+    impl ProposerDriverControl for MockDriver {
         async fn start_proposer(&self) -> Result<(), String> {
-            if self.running.load(Ordering::SeqCst) {
-                return Err("already running".into());
-            }
-            self.running.store(true, Ordering::SeqCst);
+            self.running.store(true, Ordering::Release);
             Ok(())
         }
 
         async fn stop_proposer(&self) -> Result<(), String> {
-            if !self.running.load(Ordering::SeqCst) {
-                return Err("not running".into());
-            }
-            self.running.store(false, Ordering::SeqCst);
+            self.running.store(false, Ordering::Release);
             Ok(())
         }
 
         fn is_running(&self) -> bool {
-            self.running.load(Ordering::SeqCst)
+            self.running.load(Ordering::Acquire)
         }
     }
 
     #[tokio::test]
-    async fn test_admin_start_stop() {
-        let driver: Arc<dyn ProposerDriverControl> = Arc::new(MockDriverControl::new());
-        let server =
-            AdminServer::spawn("127.0.0.1:0".parse().unwrap(), Arc::clone(&driver)).await.unwrap();
-        let addr = server.local_addr();
-        let client = reqwest::Client::new();
+    async fn module_registers_admin_methods() {
+        let driver: Arc<dyn ProposerDriverControl> = Arc::new(MockDriver::default());
+        let module = ProposerAdminApiServerImpl::module(driver).unwrap();
+        let params = Vec::<()>::new();
 
-        // Start the proposer.
-        let resp = client
-            .post(format!("http://{addr}/"))
-            .json(&serde_json::json!({
-                "jsonrpc": "2.0",
-                "method": "admin_startProposer",
-                "id": 1
-            }))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), 200);
-        let body: serde_json::Value = resp.json().await.unwrap();
-        assert!(body["error"].is_null());
-        assert!(driver.is_running());
+        let running: bool = module.call("admin_proposerRunning", params.clone()).await.unwrap();
+        assert!(!running);
 
-        // Check running status.
-        let resp = client
-            .post(format!("http://{addr}/"))
-            .json(&serde_json::json!({
-                "jsonrpc": "2.0",
-                "method": "admin_proposerRunning",
-                "id": 2
-            }))
-            .send()
-            .await
-            .unwrap();
-        let body: serde_json::Value = resp.json().await.unwrap();
-        assert_eq!(body["result"], true);
+        let _: () = module.call("admin_startProposer", params.clone()).await.unwrap();
+        let running: bool = module.call("admin_proposerRunning", params.clone()).await.unwrap();
+        assert!(running);
 
-        // Stop the proposer.
-        let resp = client
-            .post(format!("http://{addr}/"))
-            .json(&serde_json::json!({
-                "jsonrpc": "2.0",
-                "method": "admin_stopProposer",
-                "id": 3
-            }))
-            .send()
-            .await
-            .unwrap();
-        let body: serde_json::Value = resp.json().await.unwrap();
-        assert!(body["error"].is_null());
-        assert!(!driver.is_running());
-    }
-
-    #[tokio::test]
-    async fn test_admin_unknown_method() {
-        let driver: Arc<dyn ProposerDriverControl> = Arc::new(MockDriverControl::new());
-        let server = AdminServer::spawn("127.0.0.1:0".parse().unwrap(), driver).await.unwrap();
-        let addr = server.local_addr();
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(format!("http://{addr}/"))
-            .json(&serde_json::json!({
-                "jsonrpc": "2.0",
-                "method": "admin_doesNotExist",
-                "id": 1
-            }))
-            .send()
-            .await
-            .unwrap();
-        let body: serde_json::Value = resp.json().await.unwrap();
-        assert_eq!(body["error"]["code"], -32601);
-        assert!(body["error"]["message"].as_str().unwrap().contains("not found"));
+        let _: () = module.call("admin_stopProposer", params.clone()).await.unwrap();
+        let running: bool = module.call("admin_proposerRunning", params).await.unwrap();
+        assert!(!running);
     }
 }

--- a/crates/proof/proposer/src/admin.rs
+++ b/crates/proof/proposer/src/admin.rs
@@ -1,5 +1,7 @@
 //! Optional admin JSON-RPC handler.
 //!
+//! Provides `admin_startProposer`, `admin_stopProposer`, and `admin_proposerRunning` JSON-RPC
+//! methods for controlling the proposer driver at runtime.
 
 use std::{net::SocketAddr, sync::Arc};
 

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -93,7 +93,7 @@ pub struct RecoveredState {
 /// This is the type-erased interface consumed by the admin JSON-RPC server.
 /// [`PipelineHandle`] is the concrete implementation.
 #[async_trait]
-pub trait ProposerDriverControl: Send + Sync {
+pub trait ProposerDriverControl: std::fmt::Debug + Send + Sync {
     /// Start the proving pipeline.
     async fn start_proposer(&self) -> Result<(), String>;
     /// Stop the proving pipeline.

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -93,7 +93,7 @@ pub struct RecoveredState {
 /// This is the type-erased interface consumed by the admin JSON-RPC server.
 /// [`PipelineHandle`] is the concrete implementation.
 #[async_trait]
-pub trait ProposerDriverControl: std::fmt::Debug + Send + Sync {
+pub trait ProposerDriverControl: Send + Sync {
     /// Start the proving pipeline.
     async fn start_proposer(&self) -> Result<(), String>;
     /// Stop the proving pipeline.

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -59,7 +59,7 @@ mod error;
 pub use error::{ProposerError, ProposerResult};
 
 mod admin;
-pub use admin::{AdminServer, ProposerAdminApiServer, ProposerAdminApiServerImpl};
+pub use admin::ProposerAdminApiServerImpl;
 
 mod metrics;
 pub use metrics::Metrics;

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -248,7 +248,7 @@ impl ProposerService {
         let admin_server = if let Some(admin_addr) = config.admin_addr {
             info!("Admin RPC enabled");
             let driver = Arc::clone(&driver_handle);
-            Some(crate::admin::AdminServer::spawn(admin_addr, driver).await?)
+            Some(crate::admin::ProposerAdminApiServerImpl::spawn(admin_addr, driver).await?)
         } else {
             None
         };
@@ -279,7 +279,8 @@ impl ProposerService {
         }
 
         if let Some(admin_server) = admin_server {
-            admin_server.shutdown().await;
+            let _ = admin_server.stop();
+            admin_server.stopped().await;
         }
 
         match health_handle.await {


### PR DESCRIPTION
### What changed? Why?

Simplifies the proposer admin JSON-RPC setup by registering the three admin methods directly on a jsonrpsee RpcModule. This removes the proc macro generated server trait, the custom AdminServer wrapper, and the reqwest-based integration test dependency while preserving the existing admin_startProposer, admin_stopProposer, and admin_proposerRunning methods.

### Notes to reviewers

The service now keeps the jsonrpsee ServerHandle returned by ProposerAdminApiServerImpl::spawn and performs shutdown directly through that handle.

### How has it been tested?

cargo test -p base-proposer