### PR TITLE
refactor(proposer): clean up cli

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -230,4 +230,31 @@ mod tests {
         assert_eq!(cli.proposer.rpc_retry_initial_delay, Duration::from_millis(100));
         assert_eq!(cli.proposer.rpc_retry_max_delay, Duration::from_secs(10));
     }
+
+    #[test]
+    fn test_recovery_scan_concurrency_zero_rejected() {
+        let result = Cli::try_parse_from([
+            "proposer",
+            "--prover-rpc",
+            "http://localhost:8080",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l2-eth-rpc",
+            "http://localhost:9545",
+            "--anchor-state-registry-addr",
+            "0x1234567890123456789012345678901234567890",
+            "--dispute-game-factory-addr",
+            "0x2234567890123456789012345678901234567890",
+            "--game-type",
+            "1",
+            "--tee-image-hash",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "--rollup-rpc",
+            "http://localhost:7545",
+            "--recovery-scan-concurrency",
+            "0",
+        ]);
+
+        assert!(result.is_err());
+    }
 }

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -1,10 +1,10 @@
 //! CLI argument definitions for proposer.
 
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use alloy_primitives::{Address, B256};
 use base_cli_utils::CliStyles;
-use clap::Parser;
+use clap::{Args, Parser};
 use url::Url;
 
 use crate::constants::RECOVERY_SCAN_CONCURRENCY;
@@ -17,7 +17,7 @@ base_tx_manager::define_signer_cli!("BASE_PROPOSER");
 base_tx_manager::define_tx_manager_cli!("BASE_PROPOSER", tx_send_timeout_default = "10m");
 
 /// Proposer - TEE-based output proposal generation for Base.
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Parser)]
 #[command(name = "proposer")]
 #[command(version, about, long_about = None)]
 #[command(styles = CliStyles::init())]
@@ -44,19 +44,15 @@ pub struct Cli {
 }
 
 /// Core proposer configuration arguments.
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Args)]
 #[command(next_help_heading = "Proposer")]
 pub struct ProposerArgs {
-    /// Dry-run mode: source proofs but do not submit transactions on-chain.
-    #[arg(long = "dry-run", env = cli_env!("DRY_RUN"), default_value = "false")]
+    /// Dry-run mode: source proofs but do not submit transactions onchain.
+    #[arg(long = "dry-run", env = cli_env!("DRY_RUN"))]
     pub dry_run: bool,
 
     /// Allow proposals based on non-finalized L1 data.
-    #[arg(
-        long = "allow-non-finalized",
-        env = cli_env!("ALLOW_NON_FINALIZED"),
-        default_value = "false"
-    )]
+    #[arg(long = "allow-non-finalized", env = cli_env!("ALLOW_NON_FINALIZED"))]
     pub allow_non_finalized: bool,
 
     /// URL of the prover RPC endpoint.
@@ -119,15 +115,11 @@ pub struct ProposerArgs {
     pub rollup_rpc: Url,
 
     /// Skip TLS certificate verification.
-    #[arg(
-        long = "skip-tls-verify",
-        env = cli_env!("SKIP_TLS_VERIFY"),
-        default_value = "false"
-    )]
+    #[arg(long = "skip-tls-verify", env = cli_env!("SKIP_TLS_VERIFY"))]
     pub skip_tls_verify: bool,
 
     /// Maximum number of retry attempts for RPC operations.
-    #[arg(long = "rpc-max-retries", env = cli_env!("RPC_MAX_RETRIES"), default_value = "5")]
+    #[arg(long = "rpc-max-retries", env = cli_env!("RPC_MAX_RETRIES"), default_value_t = 5)]
     pub rpc_max_retries: u32,
 
     /// Initial delay for exponential backoff (e.g., "100ms", "1s").
@@ -156,12 +148,13 @@ pub struct ProposerArgs {
     #[arg(
         long = "recovery-scan-concurrency",
         env = cli_env!("RECOVERY_SCAN_CONCURRENCY"),
-        default_value_t = RECOVERY_SCAN_CONCURRENCY
+        default_value_t = NonZeroUsize::new(RECOVERY_SCAN_CONCURRENCY).unwrap(),
+        value_parser = clap::value_parser!(NonZeroUsize)
     )]
-    pub recovery_scan_concurrency: usize,
+    pub recovery_scan_concurrency: NonZeroUsize,
 
     /// Address of the `TEEProverRegistry` contract on L1.
-    /// When set, the proposer validates signers before on-chain submission.
+    /// When set, the proposer validates signers before onchain submission.
     #[arg(
         long = "tee-prover-registry-address",
         env = cli_env!("TEE_PROVER_REGISTRY_ADDRESS")
@@ -174,67 +167,37 @@ pub struct ProposerArgs {
 }
 
 /// Admin RPC server configuration arguments.
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Args)]
 #[command(next_help_heading = "Admin RPC")]
 pub struct AdminArgs {
     /// Enable the admin RPC server.
-    #[arg(
-        id = "rpc_enable_admin",
-        long = "rpc.enable-admin",
-        env = cli_env!("RPC_ENABLE_ADMIN"),
-        default_value = "false"
-    )]
-    pub enabled: bool,
+    #[arg(long = "rpc.enable-admin", env = cli_env!("RPC_ENABLE_ADMIN"))]
+    pub admin_enabled: bool,
 
     /// Admin RPC server bind address.
     #[arg(
-        id = "rpc_addr",
         long = "rpc.addr",
         default_value = "127.0.0.1",
         env = cli_env!("RPC_ADDR")
     )]
-    pub addr: std::net::IpAddr,
+    pub admin_addr: std::net::IpAddr,
 
     /// Admin RPC server port.
     #[arg(
-        id = "rpc_port",
         long = "rpc.port",
-        default_value = "8545",
+        default_value_t = 8545,
         env = cli_env!("RPC_PORT")
     )]
-    pub port: u16,
-}
-
-impl Default for AdminArgs {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            addr: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-            port: 8545,
-        }
-    }
-}
-
-impl AdminArgs {
-    /// Returns the configured socket address.
-    pub const fn socket_addr(&self) -> std::net::SocketAddr {
-        std::net::SocketAddr::new(self.addr, self.port)
-    }
+    pub admin_port: u16,
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
-
-    use base_cli_utils::LogFormat;
-
     use super::*;
-    use crate::constants::PROPOSAL_TIMEOUT;
 
     #[test]
     fn test_cli_defaults() {
-        // Test that we can construct minimal CLI args (requires all required fields)
-        let args = vec![
+        let cli = Cli::try_parse_from([
             "proposer",
             "--prover-rpc",
             "http://localhost:8080",
@@ -252,99 +215,19 @@ mod tests {
             "0x0000000000000000000000000000000000000000000000000000000000000001",
             "--rollup-rpc",
             "http://localhost:7545",
-        ];
-        let cli = Cli::try_parse_from(args).unwrap();
+        ])
+        .unwrap();
 
-        // Check defaults
-        assert!(!cli.proposer.dry_run);
-        assert!(!cli.proposer.allow_non_finalized);
         assert_eq!(cli.proposer.prover_timeout, Duration::from_secs(70 * 60));
         assert_eq!(cli.proposer.poll_interval, Duration::from_secs(12));
         assert_eq!(cli.proposer.rpc_timeout, Duration::from_secs(30));
-        assert_eq!(cli.proposer.rollup_rpc.as_str(), "http://localhost:7545/");
-        assert!(!cli.proposer.skip_tls_verify);
-        assert_eq!(cli.proposer.game_type, 1);
 
-        assert_eq!(cli.logging.level, 3);
-        assert_eq!(cli.logging.stdout_format, LogFormat::Full);
-        assert!(!cli.logging.stdout_quiet);
+        assert!(!cli.admin.admin_enabled);
+        assert_eq!(cli.admin.admin_addr, std::net::Ipv4Addr::LOCALHOST);
+        assert_eq!(cli.admin.admin_port, 8545);
 
-        assert!(!cli.metrics.enabled);
-        assert_eq!(cli.metrics.addr, "0.0.0.0".parse::<IpAddr>().unwrap());
-        assert_eq!(cli.metrics.port, 7300);
-
-        assert!(!cli.admin.enabled);
-        assert_eq!(cli.admin.addr, "127.0.0.1".parse::<IpAddr>().unwrap());
-        assert_eq!(cli.admin.port, 8545);
-        assert_eq!(cli.health.addr, "0.0.0.0".parse::<IpAddr>().unwrap());
-        assert_eq!(cli.health.port, 8080);
-
-        // Check retry defaults
         assert_eq!(cli.proposer.rpc_max_retries, 5);
         assert_eq!(cli.proposer.rpc_retry_initial_delay, Duration::from_millis(100));
         assert_eq!(cli.proposer.rpc_retry_max_delay, Duration::from_secs(10));
-        assert_eq!(cli.proposer.tx_manager.tx_send_timeout, PROPOSAL_TIMEOUT);
-
-        // Check signing defaults (all None)
-        assert!(cli.proposer.signer.private_key.is_none());
-        assert!(cli.proposer.signer.signer_endpoint.is_none());
-        assert!(cli.proposer.signer.signer_address.is_none());
-    }
-
-    #[test]
-    fn test_cli_missing_required() {
-        // Test that missing required fields cause an error
-        let args = vec!["proposer"];
-        assert!(Cli::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn test_cli_preserves_explicit_zero_tx_send_timeout() {
-        let args = vec![
-            "proposer",
-            "--prover-rpc",
-            "http://localhost:8080",
-            "--l1-eth-rpc",
-            "http://localhost:8545",
-            "--l2-eth-rpc",
-            "http://localhost:9545",
-            "--anchor-state-registry-addr",
-            "0x1234567890123456789012345678901234567890",
-            "--dispute-game-factory-addr",
-            "0x2234567890123456789012345678901234567890",
-            "--game-type",
-            "1",
-            "--tee-image-hash",
-            "0x0000000000000000000000000000000000000000000000000000000000000001",
-            "--rollup-rpc",
-            "http://localhost:7545",
-            "--tx-manager.tx-send-timeout",
-            "0s",
-        ];
-        let cli = Cli::try_parse_from(args).unwrap();
-
-        assert!(cli.proposer.tx_manager.tx_send_timeout.is_zero());
-    }
-
-    #[test]
-    fn test_cli_missing_rollup_rpc() {
-        let args = vec![
-            "proposer",
-            "--prover-rpc",
-            "http://localhost:8080",
-            "--l1-eth-rpc",
-            "http://localhost:8545",
-            "--l2-eth-rpc",
-            "http://localhost:9545",
-            "--anchor-state-registry-addr",
-            "0x1234567890123456789012345678901234567890",
-            "--dispute-game-factory-addr",
-            "0x2234567890123456789012345678901234567890",
-            "--game-type",
-            "1",
-            "--tee-image-hash",
-            "0x0000000000000000000000000000000000000000000000000000000000000001",
-        ];
-        assert!(Cli::try_parse_from(args).is_err());
     }
 }

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -40,7 +40,7 @@ pub enum ConfigError {
 /// Validated proposer configuration.
 #[derive(Debug)]
 pub struct ProposerConfig {
-    /// Dry-run mode: source proofs but do not submit transactions on-chain.
+    /// Dry-run mode: source proofs but do not submit transactions onchain.
     pub dry_run: bool,
     /// Allow proposals based on non-finalized L1 data.
     pub allow_non_finalized: bool,
@@ -87,7 +87,7 @@ pub struct ProposerConfig {
     /// Maximum number of concurrent RPC calls during the recovery scan.
     pub recovery_scan_concurrency: usize,
     /// Optional address of the `TEEProverRegistry` contract on L1.
-    /// When set, the proposer validates signers before on-chain submission.
+    /// When set, the proposer validates signers before onchain submission.
     pub tee_prover_registry_address: Option<Address>,
 }
 
@@ -100,14 +100,6 @@ impl ProposerConfig {
         validate_url(&proposer.l1_eth_rpc, "l1-eth-rpc")?;
         validate_url(&proposer.l2_eth_rpc, "l2-eth-rpc")?;
         validate_url(&proposer.rollup_rpc, "rollup-rpc")?;
-
-        if proposer.recovery_scan_concurrency == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "recovery-scan-concurrency",
-                constraint: "at least 1",
-                value: "0",
-            });
-        }
 
         // A zero address would be indistinguishable from an unconfigured value,
         // and is used as the "no parent" sentinel for the first game from anchor state.
@@ -151,7 +143,7 @@ impl ProposerConfig {
             });
         }
 
-        if admin.enabled && admin.port == 0 {
+        if admin.admin_enabled && admin.admin_port == 0 {
             return Err(ConfigError::OutOfRange {
                 field: "admin-port",
                 constraint: "non-zero when admin is enabled",
@@ -189,11 +181,13 @@ impl ProposerConfig {
             log: LogConfig::from(logging),
             metrics: metrics.into(),
             health_addr: health.socket_addr(),
-            admin_addr: admin.enabled.then(|| admin.socket_addr()),
+            admin_addr: admin
+                .admin_enabled
+                .then(|| SocketAddr::new(admin.admin_addr, admin.admin_port)),
             retry,
             signing,
             tx_manager,
-            recovery_scan_concurrency: proposer.recovery_scan_concurrency,
+            recovery_scan_concurrency: proposer.recovery_scan_concurrency.get(),
             tee_prover_registry_address: proposer.tee_prover_registry_address,
         })
     }
@@ -219,6 +213,8 @@ impl From<&ProposerArgs> for RetryConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use base_cli_utils::LogFormat;
 
     use super::*;
@@ -261,7 +257,7 @@ mod tests {
                     signer_endpoint: None,
                     signer_address: None,
                 },
-                recovery_scan_concurrency: 8,
+                recovery_scan_concurrency: NonZeroUsize::new(8).unwrap(),
                 tee_prover_registry_address: None,
                 tx_manager: TxManagerCli::default(),
             },
@@ -278,7 +274,11 @@ mod tests {
                 ..Default::default()
             },
             health: HealthArgs::default(),
-            admin: AdminArgs::default(),
+            admin: AdminArgs {
+                admin_enabled: false,
+                admin_addr: "127.0.0.1".parse().unwrap(),
+                admin_port: 8545,
+            },
         }
     }
 
@@ -350,8 +350,8 @@ mod tests {
     #[test]
     fn test_admin_port_zero_when_admin_enabled() {
         let mut cli = minimal_cli();
-        cli.admin.enabled = true;
-        cli.admin.port = 0;
+        cli.admin.admin_enabled = true;
+        cli.admin.admin_port = 0;
         let result = ProposerConfig::from_cli(cli);
         assert!(matches!(result, Err(ConfigError::OutOfRange { field: "admin-port", .. })));
     }
@@ -359,8 +359,8 @@ mod tests {
     #[test]
     fn test_admin_port_zero_when_admin_disabled() {
         let mut cli = minimal_cli();
-        cli.admin.enabled = false;
-        cli.admin.port = 0;
+        cli.admin.admin_enabled = false;
+        cli.admin.admin_port = 0;
         // Should be fine since admin is disabled
         let result = ProposerConfig::from_cli(cli);
         assert!(result.is_ok());
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn test_admin_addr_some_when_enabled() {
         let mut cli = minimal_cli();
-        cli.admin.enabled = true;
+        cli.admin.admin_enabled = true;
         let config = ProposerConfig::from_cli(cli).unwrap();
         assert!(config.admin_addr.is_some());
         let addr = config.admin_addr.unwrap();
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn test_admin_addr_none_when_disabled() {
         let mut cli = minimal_cli();
-        cli.admin.enabled = false;
+        cli.admin.admin_enabled = false;
         let config = ProposerConfig::from_cli(cli).unwrap();
         assert!(config.admin_addr.is_none());
     }
@@ -443,20 +443,9 @@ mod tests {
     }
 
     #[test]
-    fn test_recovery_scan_concurrency_zero_rejected() {
-        let mut cli = minimal_cli();
-        cli.proposer.recovery_scan_concurrency = 0;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(
-            result,
-            Err(ConfigError::OutOfRange { field: "recovery-scan-concurrency", .. })
-        ));
-    }
-
-    #[test]
     fn test_recovery_scan_concurrency_custom() {
         let mut cli = minimal_cli();
-        cli.proposer.recovery_scan_concurrency = 4;
+        cli.proposer.recovery_scan_concurrency = NonZeroUsize::new(4).unwrap();
         let config = ProposerConfig::from_cli(cli).unwrap();
         assert_eq!(config.recovery_scan_concurrency, 4);
     }


### PR DESCRIPTION
### What changed? Why?

Simplifies proposer CLI argument definitions and config mapping by using clap `Args`, typed defaults, and parser-level `NonZeroUsize` for recovery scan concurrency. Renames admin arg fields to match the flattened CLI names and constructs the admin socket address directly in config.

### Notes to reviewers

The recovery scan concurrency zero check moved from config validation to clap parsing through `NonZeroUsize`; runtime config still stores the value as `usize`.

### How has it been tested?

- `cargo test -p base-proposer`