### PR TITLE
refactor(proposer): clean up config

### DIFF
--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -5,43 +5,14 @@ use std::{net::SocketAddr, time::Duration};
 use alloy_primitives::{Address, B256};
 use base_cli_utils::{LogConfig, MetricsConfig};
 use base_retry::RetryConfig;
-use thiserror::Error;
+use eyre::{Result, WrapErr};
 use url::Url;
 
-use crate::cli::{Cli, ProposerArgs};
-
-/// Errors that can occur during configuration validation.
-#[derive(Debug, Error)]
-pub enum ConfigError {
-    /// Invalid URL format.
-    #[error("invalid {field} URL: missing host")]
-    InvalidUrl {
-        /// The field name that contains the invalid URL.
-        field: &'static str,
-    },
-    /// A field value is out of the allowed range.
-    #[error("{field} must be {constraint}, got {value}")]
-    OutOfRange {
-        /// The field name that is out of range.
-        field: &'static str,
-        /// The constraint description.
-        constraint: &'static str,
-        /// The actual value.
-        value: &'static str,
-    },
-    /// Invalid signing configuration.
-    #[error("invalid signing config: {0}")]
-    Signing(base_tx_manager::ConfigError),
-    /// Invalid transaction manager configuration.
-    #[error("invalid tx manager config: {0}")]
-    TxManager(base_tx_manager::ConfigError),
-}
+use crate::cli::Cli;
 
 /// Validated proposer configuration.
 #[derive(Debug)]
 pub struct ProposerConfig {
-    /// Dry-run mode: source proofs but do not submit transactions onchain.
-    pub dry_run: bool,
     /// Allow proposals based on non-finalized L1 data.
     pub allow_non_finalized: bool,
     /// URL of the prover RPC endpoint.
@@ -93,78 +64,62 @@ pub struct ProposerConfig {
 
 impl ProposerConfig {
     /// Create a validated configuration from CLI arguments.
-    pub fn from_cli(cli: Cli) -> Result<Self, ConfigError> {
+    pub fn from_cli(cli: Cli) -> Result<Self> {
         let Cli { proposer, logging, metrics, health, admin } = cli;
 
-        validate_url(&proposer.prover_rpc, "prover-rpc")?;
-        validate_url(&proposer.l1_eth_rpc, "l1-eth-rpc")?;
-        validate_url(&proposer.l2_eth_rpc, "l2-eth-rpc")?;
-        validate_url(&proposer.rollup_rpc, "rollup-rpc")?;
+        for (url, message) in [
+            (&proposer.prover_rpc, "invalid prover-rpc URL: missing host"),
+            (&proposer.l1_eth_rpc, "invalid l1-eth-rpc URL: missing host"),
+            (&proposer.l2_eth_rpc, "invalid l2-eth-rpc URL: missing host"),
+            (&proposer.rollup_rpc, "invalid rollup-rpc URL: missing host"),
+        ] {
+            if url.host().is_none() {
+                eyre::bail!(message);
+            }
+        }
 
         // A zero address would be indistinguishable from an unconfigured value,
         // and is used as the "no parent" sentinel for the first game from anchor state.
         if proposer.anchor_state_registry_addr == Address::ZERO {
-            return Err(ConfigError::OutOfRange {
-                field: "anchor-state-registry-addr",
-                constraint: "non-zero address",
-                value: "0x0000000000000000000000000000000000000000",
-            });
+            eyre::bail!("anchor-state-registry-addr must be non-zero address");
         }
 
         if proposer.prover_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "prover-timeout",
-                constraint: "greater than 0",
-                value: "0",
-            });
+            eyre::bail!("prover-timeout must be greater than 0");
         }
 
         if proposer.poll_interval.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "poll-interval",
-                constraint: "greater than 0",
-                value: "0",
-            });
+            eyre::bail!("poll-interval must be greater than 0");
         }
 
         if metrics.enabled && metrics.port == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "metrics-port",
-                constraint: "non-zero when metrics are enabled",
-                value: "0",
-            });
+            eyre::bail!("metrics-port must be non-zero when metrics are enabled");
         }
 
         if health.port == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "health-port",
-                constraint: "non-zero",
-                value: "0",
-            });
+            eyre::bail!("health-port must be non-zero");
         }
 
         if admin.admin_enabled && admin.admin_port == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "admin-port",
-                constraint: "non-zero when admin is enabled",
-                value: "0",
-            });
+            eyre::bail!("admin-port must be non-zero when admin is enabled");
         }
-
-        let retry = RetryConfig::from(&proposer);
 
         let (signing, tx_manager) = if proposer.dry_run {
             (None, None)
         } else {
-            let s = base_tx_manager::SignerConfig::try_from(proposer.signer)
-                .map_err(ConfigError::Signing)?;
-            let t = base_tx_manager::TxManagerConfig::try_from(proposer.tx_manager)
-                .map_err(ConfigError::TxManager)?;
-            (Some(s), Some(t))
+            (
+                Some(
+                    base_tx_manager::SignerConfig::try_from(proposer.signer)
+                        .wrap_err("invalid signing config")?,
+                ),
+                Some(
+                    base_tx_manager::TxManagerConfig::try_from(proposer.tx_manager)
+                        .wrap_err("invalid tx manager config")?,
+                ),
+            )
         };
 
         Ok(Self {
-            dry_run: proposer.dry_run,
             allow_non_finalized: proposer.allow_non_finalized,
             prover_rpc: proposer.prover_rpc,
             prover_timeout: proposer.prover_timeout,
@@ -183,8 +138,12 @@ impl ProposerConfig {
             health_addr: health.socket_addr(),
             admin_addr: admin
                 .admin_enabled
-                .then(|| SocketAddr::new(admin.admin_addr, admin.admin_port)),
-            retry,
+                .then_some(SocketAddr::new(admin.admin_addr, admin.admin_port)),
+            retry: RetryConfig::new(
+                proposer.rpc_max_retries,
+                proposer.rpc_retry_initial_delay,
+                proposer.rpc_retry_max_delay,
+            ),
             signing,
             tx_manager,
             recovery_scan_concurrency: proposer.recovery_scan_concurrency.get(),
@@ -193,223 +152,97 @@ impl ProposerConfig {
     }
 }
 
-/// Validate that a URL has a host component.
-///
-/// Scheme is guaranteed present by `url::Url::parse`, but host can be absent
-/// (e.g. `file:///path`).
-fn validate_url(url: &Url, field: &'static str) -> Result<(), ConfigError> {
-    if url.host().is_none() {
-        return Err(ConfigError::InvalidUrl { field });
-    }
-
-    Ok(())
-}
-
-impl From<&ProposerArgs> for RetryConfig {
-    fn from(args: &ProposerArgs) -> Self {
-        Self::new(args.rpc_max_retries, args.rpc_retry_initial_delay, args.rpc_retry_max_delay)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
-
-    use base_cli_utils::LogFormat;
+    use clap::Parser;
 
     use super::*;
-    use crate::{
-        cli::{
-            AdminArgs, Cli, HealthArgs, LogArgs, MetricsArgs, ProposerArgs, SignerCli, TxManagerCli,
-        },
-        constants::PROPOSAL_TIMEOUT,
-    };
+    use crate::cli::{Cli, SignerCli};
 
     fn minimal_cli() -> Cli {
-        Cli {
-            proposer: ProposerArgs {
-                dry_run: false,
-                allow_non_finalized: false,
-                prover_rpc: Url::parse("http://localhost:8080").unwrap(),
-                l1_eth_rpc: Url::parse("http://localhost:8545").unwrap(),
-                l2_eth_rpc: Url::parse("http://localhost:9545").unwrap(),
-                anchor_state_registry_addr: "0x1234567890123456789012345678901234567890"
-                    .parse()
-                    .unwrap(),
-                dispute_game_factory_addr: "0x2234567890123456789012345678901234567890"
-                    .parse()
-                    .unwrap(),
-                game_type: 1,
-                tee_image_hash: B256::repeat_byte(0x01),
-                prover_timeout: Duration::from_secs(70 * 60),
-                poll_interval: Duration::from_secs(12),
-                rpc_timeout: Duration::from_secs(30),
-                rollup_rpc: Url::parse("http://localhost:7545").unwrap(),
-                skip_tls_verify: false,
-                rpc_max_retries: 5,
-                rpc_retry_initial_delay: Duration::from_millis(100),
-                rpc_retry_max_delay: Duration::from_secs(10),
-                signer: SignerCli {
-                    private_key: Some(
-                        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-                            .to_string(),
-                    ),
-                    signer_endpoint: None,
-                    signer_address: None,
+        Cli::try_parse_from([
+            "proposer",
+            "--prover-rpc",
+            "http://localhost:8080",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l2-eth-rpc",
+            "http://localhost:9545",
+            "--anchor-state-registry-addr",
+            "0x1234567890123456789012345678901234567890",
+            "--dispute-game-factory-addr",
+            "0x2234567890123456789012345678901234567890",
+            "--game-type",
+            "1",
+            "--tee-image-hash",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "--rollup-rpc",
+            "http://localhost:7545",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        ])
+        .unwrap()
+    }
+
+    fn assert_invalid_after(mutate: impl FnOnce(&mut Cli), expected: &'static str) {
+        let mut cli = minimal_cli();
+        mutate(&mut cli);
+        assert_eq!(ProposerConfig::from_cli(cli).unwrap_err().to_string(), expected);
+    }
+
+    #[test]
+    fn test_invalid_values() {
+        let cases: [(fn(&mut Cli), &str); 6] = [
+            (
+                |cli| cli.proposer.prover_timeout = Duration::ZERO,
+                "prover-timeout must be greater than 0",
+            ),
+            (
+                |cli| cli.proposer.poll_interval = Duration::ZERO,
+                "poll-interval must be greater than 0",
+            ),
+            (
+                |cli| {
+                    cli.metrics.enabled = true;
+                    cli.metrics.port = 0;
                 },
-                recovery_scan_concurrency: NonZeroUsize::new(8).unwrap(),
-                tee_prover_registry_address: None,
-                tx_manager: TxManagerCli::default(),
-            },
-            logging: LogArgs {
-                level: 3,
-                stdout_quiet: false,
-                stdout_format: LogFormat::Full,
-                ..Default::default()
-            },
-            metrics: MetricsArgs {
-                enabled: false,
-                addr: "0.0.0.0".parse().unwrap(),
-                port: 7300,
-                ..Default::default()
-            },
-            health: HealthArgs::default(),
-            admin: AdminArgs {
-                admin_enabled: false,
-                admin_addr: "127.0.0.1".parse().unwrap(),
-                admin_port: 8545,
-            },
+                "metrics-port must be non-zero when metrics are enabled",
+            ),
+            (|cli| cli.health.port = 0, "health-port must be non-zero"),
+            (
+                |cli| {
+                    cli.admin.admin_enabled = true;
+                    cli.admin.admin_port = 0;
+                },
+                "admin-port must be non-zero when admin is enabled",
+            ),
+            (
+                |cli| cli.proposer.anchor_state_registry_addr = Address::ZERO,
+                "anchor-state-registry-addr must be non-zero address",
+            ),
+        ];
+
+        for (mutate, expected) in cases {
+            assert_invalid_after(mutate, expected);
         }
     }
 
     #[test]
-    fn test_valid_config() {
-        let cli = minimal_cli();
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(!config.dry_run);
-        assert!(!config.allow_non_finalized);
-        assert_eq!(config.game_type, 1);
-        assert_eq!(config.prover_timeout, Duration::from_secs(70 * 60));
-        assert_eq!(config.poll_interval, Duration::from_secs(12));
-        assert_eq!(config.rpc_timeout, Duration::from_secs(30));
-        assert_eq!(config.tx_manager.as_ref().unwrap().tx_send_timeout, PROPOSAL_TIMEOUT);
-    }
-
-    #[test]
-    fn test_explicit_zero_tx_send_timeout_disables_tx_manager_timeout() {
-        let mut cli = minimal_cli();
-        cli.proposer.tx_manager.tx_send_timeout = Duration::ZERO;
-        let config = ProposerConfig::from_cli(cli).unwrap();
-
-        assert_eq!(config.tx_manager.as_ref().unwrap().tx_send_timeout, Duration::ZERO);
-    }
-
-    #[test]
-    fn test_zero_prover_timeout() {
-        let mut cli = minimal_cli();
-        cli.proposer.prover_timeout = Duration::ZERO;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "prover-timeout", .. })));
-    }
-
-    #[test]
-    fn test_zero_poll_interval() {
-        let mut cli = minimal_cli();
-        cli.proposer.poll_interval = Duration::ZERO;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "poll-interval", .. })));
-    }
-
-    #[test]
-    fn test_metrics_port_zero_when_enabled() {
-        let mut cli = minimal_cli();
-        cli.metrics.enabled = true;
-        cli.metrics.port = 0;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "metrics-port", .. })));
-    }
-
-    #[test]
-    fn test_metrics_port_zero_when_disabled() {
+    fn test_disabled_servers_allow_zero_ports() {
         let mut cli = minimal_cli();
         cli.metrics.enabled = false;
         cli.metrics.port = 0;
-        // Should be fine since metrics are disabled
-        let result = ProposerConfig::from_cli(cli);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_health_port_zero_rejected() {
-        let mut cli = minimal_cli();
-        cli.health.port = 0;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "health-port", .. })));
-    }
-
-    #[test]
-    fn test_admin_port_zero_when_admin_enabled() {
-        let mut cli = minimal_cli();
-        cli.admin.admin_enabled = true;
-        cli.admin.admin_port = 0;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "admin-port", .. })));
-    }
-
-    #[test]
-    fn test_admin_port_zero_when_admin_disabled() {
-        let mut cli = minimal_cli();
         cli.admin.admin_enabled = false;
         cli.admin.admin_port = 0;
-        // Should be fine since admin is disabled
-        let result = ProposerConfig::from_cli(cli);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_admin_addr_some_when_enabled() {
-        let mut cli = minimal_cli();
-        cli.admin.admin_enabled = true;
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(config.admin_addr.is_some());
-        let addr = config.admin_addr.unwrap();
-        assert_eq!(addr.ip(), "127.0.0.1".parse::<std::net::IpAddr>().unwrap());
-        assert_eq!(addr.port(), 8545);
-    }
-
-    #[test]
-    fn test_admin_addr_none_when_disabled() {
-        let mut cli = minimal_cli();
-        cli.admin.admin_enabled = false;
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(config.admin_addr.is_none());
+        assert!(ProposerConfig::from_cli(cli).is_ok());
     }
 
     #[test]
     fn test_url_without_host() {
-        // Create URL that parses but has no host (file:// URLs for instance)
-        let url = Url::parse("file:///some/path").unwrap();
-        let result = validate_url(&url, "test-field");
-        assert!(matches!(result, Err(ConfigError::InvalidUrl { field: "test-field", .. })));
-    }
-
-    #[test]
-    fn test_signing_config_local() {
-        let cli = minimal_cli();
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(matches!(config.signing, Some(base_tx_manager::SignerConfig::Local { .. })));
-    }
-
-    #[test]
-    fn test_signing_config_remote() {
-        let mut cli = minimal_cli();
-        cli.proposer.signer = SignerCli {
-            private_key: None,
-            signer_endpoint: Some(Url::parse("http://localhost:8546").unwrap()),
-            signer_address: Some("0x1234567890123456789012345678901234567890".parse().unwrap()),
-        };
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(matches!(config.signing, Some(base_tx_manager::SignerConfig::Remote { .. })));
+        assert_invalid_after(
+            |cli| cli.proposer.prover_rpc = Url::parse("file:///some/path").unwrap(),
+            "invalid prover-rpc URL: missing host",
+        );
     }
 
     #[test]
@@ -418,7 +251,7 @@ mod tests {
         cli.proposer.signer =
             SignerCli { private_key: None, signer_endpoint: None, signer_address: None };
         let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::Signing(_))));
+        assert_eq!(result.unwrap_err().to_string(), "invalid signing config");
     }
 
     #[test]
@@ -428,36 +261,7 @@ mod tests {
         cli.proposer.signer =
             SignerCli { private_key: None, signer_endpoint: None, signer_address: None };
         let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(config.dry_run);
         assert!(config.signing.is_none());
         assert!(config.tx_manager.is_none());
-    }
-
-    #[test]
-    fn test_retry_config_from_args() {
-        let cli = minimal_cli();
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.retry.max_attempts, Some(5));
-        assert_eq!(config.retry.initial_delay, Duration::from_millis(100));
-        assert_eq!(config.retry.max_delay, Duration::from_secs(10));
-    }
-
-    #[test]
-    fn test_recovery_scan_concurrency_custom() {
-        let mut cli = minimal_cli();
-        cli.proposer.recovery_scan_concurrency = NonZeroUsize::new(4).unwrap();
-        let config = ProposerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.recovery_scan_concurrency, 4);
-    }
-
-    #[test]
-    fn test_anchor_state_registry_zero_rejected() {
-        let mut cli = minimal_cli();
-        cli.proposer.anchor_state_registry_addr = Address::ZERO;
-        let result = ProposerConfig::from_cli(cli);
-        assert!(matches!(
-            result,
-            Err(ConfigError::OutOfRange { field: "anchor-state-registry-addr", .. })
-        ));
     }
 }

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -13,6 +13,8 @@ use crate::cli::Cli;
 /// Validated proposer configuration.
 #[derive(Debug)]
 pub struct ProposerConfig {
+    /// Dry-run mode: source proofs but do not submit transactions onchain.
+    pub dry_run: bool,
     /// Allow proposals based on non-finalized L1 data.
     pub allow_non_finalized: bool,
     /// URL of the prover RPC endpoint.
@@ -120,6 +122,7 @@ impl ProposerConfig {
         };
 
         Ok(Self {
+            dry_run: proposer.dry_run,
             allow_non_finalized: proposer.allow_non_finalized,
             prover_rpc: proposer.prover_rpc,
             prover_timeout: proposer.prover_timeout,
@@ -193,6 +196,26 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_config_maps_cli_fields() {
+        let mut cli = minimal_cli();
+        cli.proposer.allow_non_finalized = true;
+        cli.proposer.rpc_max_retries = 7;
+        cli.proposer.recovery_scan_concurrency = 4.try_into().unwrap();
+        cli.admin.admin_enabled = true;
+
+        let config = ProposerConfig::from_cli(cli).unwrap();
+
+        assert!(!config.dry_run);
+        assert!(config.allow_non_finalized);
+        assert_eq!(config.game_type, 1);
+        assert_eq!(config.retry.max_attempts, Some(7));
+        assert_eq!(config.recovery_scan_concurrency, 4);
+        assert_eq!(config.admin_addr.unwrap().port(), 8545);
+        assert!(matches!(config.signing, Some(base_tx_manager::SignerConfig::Local { .. })));
+        assert!(config.tx_manager.is_some());
+    }
+
+    #[test]
     fn test_invalid_values() {
         let cases: [InvalidCase; 6] = [
             (
@@ -263,6 +286,7 @@ mod tests {
         cli.proposer.signer =
             SignerCli { private_key: None, signer_endpoint: None, signer_address: None };
         let config = ProposerConfig::from_cli(cli).unwrap();
+        assert!(config.dry_run);
         assert!(config.signing.is_none());
         assert!(config.tx_manager.is_none());
     }

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -159,6 +159,8 @@ mod tests {
     use super::*;
     use crate::cli::{Cli, SignerCli};
 
+    type InvalidCase = (fn(&mut Cli), &'static str);
+
     fn minimal_cli() -> Cli {
         Cli::try_parse_from([
             "proposer",
@@ -192,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_invalid_values() {
-        let cases: [(fn(&mut Cli), &str); 6] = [
+        let cases: [InvalidCase; 6] = [
             (
                 |cli| cli.proposer.prover_timeout = Duration::ZERO,
                 "prover-timeout must be greater than 0",

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -12,7 +12,7 @@ pub use cli::{
 };
 
 mod config;
-pub use config::{ConfigError, ProposerConfig};
+pub use config::ProposerConfig;
 
 mod constants;
 pub use constants::{

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -46,11 +46,9 @@ impl ProposerService {
         // Required by rustls 0.23+ when custom TLS configs are used (e.g. skip_tls_verify).
         let _ = rustls::crypto::ring::default_provider().install_default();
 
-        let dry_run = config.signing.is_none();
-
         info!(version = env!("CARGO_PKG_VERSION"), "Proposer starting");
         info!(
-            dry_run,
+            dry_run = config.dry_run,
             allow_non_finalized = config.allow_non_finalized,
             anchor_state_registry = %config.anchor_state_registry_addr,
             dispute_game_factory = %config.dispute_game_factory_addr,
@@ -151,7 +149,7 @@ impl ProposerService {
         });
 
         let (output_proposer, proposer_address): (Arc<dyn crate::OutputProposer>, Option<Address>) =
-            if dry_run {
+            if config.dry_run {
                 info!("Dry-run mode enabled - proofs will be sourced but NOT submitted onchain");
                 (Arc::new(crate::DryRunProposer), None)
             } else {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -46,9 +46,11 @@ impl ProposerService {
         // Required by rustls 0.23+ when custom TLS configs are used (e.g. skip_tls_verify).
         let _ = rustls::crypto::ring::default_provider().install_default();
 
+        let dry_run = config.signing.is_none();
+
         info!(version = env!("CARGO_PKG_VERSION"), "Proposer starting");
         info!(
-            dry_run = config.dry_run,
+            dry_run,
             allow_non_finalized = config.allow_non_finalized,
             anchor_state_registry = %config.anchor_state_registry_addr,
             dispute_game_factory = %config.dispute_game_factory_addr,
@@ -138,7 +140,7 @@ impl ProposerService {
             init_bond = %init_bond,
             impl_address = %impl_address,
             game_type = config.game_type,
-            "Read on-chain config from AggregateVerifier and DisputeGameFactory"
+            "Read onchain config from AggregateVerifier and DisputeGameFactory"
         );
 
         let factory_client = Arc::new(factory_client);
@@ -149,8 +151,8 @@ impl ProposerService {
         });
 
         let (output_proposer, proposer_address): (Arc<dyn crate::OutputProposer>, Option<Address>) =
-            if config.dry_run {
-                info!("Dry-run mode enabled — proofs will be sourced but NOT submitted on-chain");
+            if dry_run {
+                info!("Dry-run mode enabled - proofs will be sourced but NOT submitted onchain");
                 (Arc::new(crate::DryRunProposer), None)
             } else {
                 let signing = config.signing.ok_or_else(|| {


### PR DESCRIPTION
### What changed? Why?

Simplifies proposer config validation by returning `eyre::Result` directly instead of a local `ConfigError` enum.

Builds retry config inline, keeps dry-run sourced from the CLI flag while making signing and transaction manager config optional in dry-run, and updates config tests to parse minimal real CLI arguments.

### Notes to reviewers

The validation behavior is intended to stay the same while removing the extra error wrapper and duplicated test setup.

### How has it been tested?

`cargo test -p base-proposer config`