### PR TITLE
refactor(proposer): clean up driver

### DIFF
--- a/crates/proof/proposer/src/admin.rs
+++ b/crates/proof/proposer/src/admin.rs
@@ -5,6 +5,8 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
+use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
+use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use eyre::Context;
 use jsonrpsee::{
     core::RpcResult,
@@ -13,18 +15,25 @@ use jsonrpsee::{
 };
 use tracing::info;
 
-use crate::driver::ProposerDriverControl;
+use crate::driver::PipelineHandle;
 
-/// Admin JSON-RPC server backed by a [`ProposerDriverControl`] handle.
+/// Admin JSON-RPC server backed by a [`PipelineHandle`].
 #[derive(Debug)]
 pub struct ProposerAdminApiServerImpl;
 
 impl ProposerAdminApiServerImpl {
     /// Bind and start the admin server on the given socket address.
-    pub async fn spawn(
+    pub async fn spawn<L1, L2, R, ASR, F>(
         addr: SocketAddr,
-        driver: Arc<dyn ProposerDriverControl>,
-    ) -> eyre::Result<ServerHandle> {
+        driver: Arc<PipelineHandle<L1, L2, R, ASR, F>>,
+    ) -> eyre::Result<ServerHandle>
+    where
+        L1: L1Provider + 'static,
+        L2: L2Provider + 'static,
+        R: RollupProvider + 'static,
+        ASR: AnchorStateRegistryClient + 'static,
+        F: DisputeGameFactoryClient + 'static,
+    {
         let server =
             Server::builder().build(addr).await.wrap_err("failed to bind admin RPC server")?;
         let local_addr =
@@ -35,7 +44,16 @@ impl ProposerAdminApiServerImpl {
     }
 
     /// Build the admin RPC module.
-    pub fn module(driver: Arc<dyn ProposerDriverControl>) -> eyre::Result<RpcModule<()>> {
+    pub fn module<L1, L2, R, ASR, F>(
+        driver: Arc<PipelineHandle<L1, L2, R, ASR, F>>,
+    ) -> eyre::Result<RpcModule<()>>
+    where
+        L1: L1Provider + 'static,
+        L2: L2Provider + 'static,
+        R: RollupProvider + 'static,
+        ASR: AnchorStateRegistryClient + 'static,
+        F: DisputeGameFactoryClient + 'static,
+    {
         let mut module = RpcModule::new(());
 
         let start_driver = Arc::clone(&driver);
@@ -55,8 +73,9 @@ impl ProposerAdminApiServerImpl {
             .wrap_err("failed to register admin_stopProposer")?;
 
         module
-            .register_method("admin_proposerRunning", move |_, _, _| {
-                RpcResult::Ok(driver.is_running())
+            .register_async_method("admin_proposerRunning", move |_, _, _| {
+                let driver = Arc::clone(&driver);
+                async move { RpcResult::Ok(driver.is_running().await) }
             })
             .wrap_err("failed to register admin_proposerRunning")?;
 
@@ -64,59 +83,7 @@ impl ProposerAdminApiServerImpl {
     }
 
     /// Convert a driver control error into a JSON-RPC error object.
-    pub fn rpc_error(msg: String) -> ErrorObjectOwned {
+    pub fn rpc_error(msg: &'static str) -> ErrorObjectOwned {
         ErrorObjectOwned::owned(-32000, msg, None::<()>)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    };
-
-    use async_trait::async_trait;
-
-    use super::*;
-
-    #[derive(Debug, Default)]
-    struct MockDriver {
-        running: AtomicBool,
-    }
-
-    #[async_trait]
-    impl ProposerDriverControl for MockDriver {
-        async fn start_proposer(&self) -> Result<(), String> {
-            self.running.store(true, Ordering::Release);
-            Ok(())
-        }
-
-        async fn stop_proposer(&self) -> Result<(), String> {
-            self.running.store(false, Ordering::Release);
-            Ok(())
-        }
-
-        fn is_running(&self) -> bool {
-            self.running.load(Ordering::Acquire)
-        }
-    }
-
-    #[tokio::test]
-    async fn module_registers_admin_methods() {
-        let driver: Arc<dyn ProposerDriverControl> = Arc::new(MockDriver::default());
-        let module = ProposerAdminApiServerImpl::module(driver).unwrap();
-        let params = Vec::<()>::new();
-
-        let running: bool = module.call("admin_proposerRunning", params.clone()).await.unwrap();
-        assert!(!running);
-
-        let _: () = module.call("admin_startProposer", params.clone()).await.unwrap();
-        let running: bool = module.call("admin_proposerRunning", params.clone()).await.unwrap();
-        assert!(running);
-
-        let _: () = module.call("admin_stopProposer", params.clone()).await.unwrap();
-        let running: bool = module.call("admin_proposerRunning", params).await.unwrap();
-        assert!(!running);
     }
 }

--- a/crates/proof/proposer/src/admin.rs
+++ b/crates/proof/proposer/src/admin.rs
@@ -73,9 +73,8 @@ impl ProposerAdminApiServerImpl {
             .wrap_err("failed to register admin_stopProposer")?;
 
         module
-            .register_async_method("admin_proposerRunning", move |_, _, _| {
-                let driver = Arc::clone(&driver);
-                async move { RpcResult::Ok(driver.is_running().await) }
+            .register_method("admin_proposerRunning", move |_, _, _| {
+                RpcResult::Ok(driver.is_running())
             })
             .wrap_err("failed to register admin_proposerRunning")?;
 

--- a/crates/proof/proposer/src/admin.rs
+++ b/crates/proof/proposer/src/admin.rs
@@ -86,3 +86,36 @@ impl ProposerAdminApiServerImpl {
         ErrorObjectOwned::owned(-32000, msg, None::<()>)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::test_utils::test_pipeline_handle;
+
+    #[tokio::test]
+    async fn module_registers_admin_methods() {
+        let cancel = CancellationToken::new();
+        let driver = Arc::new(test_pipeline_handle(cancel));
+        let module = ProposerAdminApiServerImpl::module(Arc::clone(&driver)).unwrap();
+        let methods = module.method_names().collect::<Vec<_>>();
+
+        assert!(methods.contains(&"admin_startProposer"));
+        assert!(methods.contains(&"admin_stopProposer"));
+        assert!(methods.contains(&"admin_proposerRunning"));
+
+        let running: bool = module.call("admin_proposerRunning", Vec::<()>::new()).await.unwrap();
+        assert!(!running);
+
+        module.call::<_, ()>("admin_startProposer", Vec::<()>::new()).await.unwrap();
+        let running: bool = module.call("admin_proposerRunning", Vec::<()>::new()).await.unwrap();
+        assert!(running);
+
+        module.call::<_, ()>("admin_stopProposer", Vec::<()>::new()).await.unwrap();
+        let running: bool = module.call("admin_proposerRunning", Vec::<()>::new()).await.unwrap();
+        assert!(!running);
+    }
+}

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -158,9 +158,9 @@ where
     pub async fn stop_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        if !self.running.load(Ordering::Acquire)
-            || !session.as_ref().is_some_and(|(_, task)| !task.is_finished())
-        {
+        let is_active = self.running.load(Ordering::Acquire)
+            && session.as_ref().is_some_and(|(_, task)| !task.is_finished());
+        if !is_active {
             return Err("proposer is not running");
         }
 
@@ -179,7 +179,7 @@ where
     }
 
     /// Returns whether the proving pipeline is currently running.
-    pub async fn is_running(&self) -> bool {
+    pub fn is_running(&self) -> bool {
         self.running.load(Ordering::Acquire)
     }
 }
@@ -270,13 +270,13 @@ mod tests {
         let cancel = CancellationToken::new();
         let handle = test_pipeline_handle(cancel);
 
-        assert!(!handle.is_running().await);
+        assert!(!handle.is_running());
         handle.start_proposer().await.unwrap();
         handle.stop_proposer().await.unwrap();
         handle.start_proposer().await.unwrap();
-        assert!(handle.is_running().await);
+        assert!(handle.is_running());
         handle.stop_proposer().await.unwrap();
-        assert!(!handle.is_running().await);
+        assert!(!handle.is_running());
     }
 
     #[tokio::test]
@@ -285,26 +285,10 @@ mod tests {
         let handle = test_pipeline_handle(cancel.clone());
 
         handle.start_proposer().await.unwrap();
-        assert!(handle.is_running().await);
+        assert!(handle.is_running());
 
         cancel.cancel();
         tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(!handle.is_running().await);
-    }
-
-    #[tokio::test]
-    async fn test_pipeline_handle_running_check_does_not_wait_on_session_lock() {
-        let cancel = CancellationToken::new();
-        let handle = test_pipeline_handle(cancel);
-
-        handle.start_proposer().await.unwrap();
-        let session = handle.session.lock().await;
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), handle.is_running()).await.unwrap()
-        );
-
-        drop(session);
-        handle.stop_proposer().await.unwrap();
+        assert!(!handle.is_running());
     }
 }

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -184,66 +184,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
+    use std::time::Duration;
 
-    use alloy_primitives::B256;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
-    use crate::{
-        pipeline::PipelineConfig,
-        test_utils::{
-            MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
-            MockOutputProposer, MockProofRequester, MockRollupClient, test_anchor_root,
-            test_sync_status,
-        },
-    };
-
-    fn test_pipeline_handle(
-        global_cancel: CancellationToken,
-    ) -> PipelineHandle<
-        MockL1,
-        MockL2,
-        MockRollupClient,
-        MockAnchorStateRegistry,
-        MockDisputeGameFactory,
-    > {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
-        let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(200, B256::ZERO),
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        let anchor_registry = Arc::new(MockAnchorStateRegistry {
-            anchor_root: test_anchor_root(0),
-            anchor_game: Address::ZERO,
-        });
-        let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
-
-        let pipeline = ProvingPipeline::new(
-            PipelineConfig {
-                submit_timeout: Some(std::time::Duration::from_secs(60)),
-                max_retries: 3,
-                recovery_scan_concurrency: 8,
-                tee_prover_registry_address: None,
-                driver: DriverConfig {
-                    poll_interval: Duration::from_secs(3600),
-                    ..Default::default()
-                },
-            },
-            Arc::new(MockProofRequester::default()),
-            l1,
-            l2,
-            rollup,
-            anchor_registry,
-            factory,
-            Arc::new(MockAggregateVerifier::default()),
-            Arc::new(MockOutputProposer),
-            global_cancel.child_token(),
-        );
-        PipelineHandle::new(pipeline, global_cancel)
-    }
+    use crate::test_utils::test_pipeline_handle;
 
     #[tokio::test]
     async fn test_pipeline_handle_double_start_errors() {

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -80,7 +80,6 @@ pub struct RecoveredState {
 
 /// Manages the lifecycle of a [`ProvingPipeline`], allowing it to be started
 /// and stopped at runtime (e.g. via the admin RPC).
-#[derive(Debug)]
 pub struct PipelineHandle<L1, L2, R, ASR, F>
 where
     L1: L1Provider + 'static,
@@ -93,6 +92,21 @@ where
     session: TokioMutex<Option<(CancellationToken, JoinHandle<Result<()>>)>>,
     global_cancel: CancellationToken,
     running: Arc<AtomicBool>,
+}
+
+impl<L1, L2, R, ASR, F> std::fmt::Debug for PipelineHandle<L1, L2, R, ASR, F>
+where
+    L1: L1Provider + 'static,
+    L2: L2Provider + 'static,
+    R: RollupProvider + 'static,
+    ASR: AnchorStateRegistryClient + 'static,
+    F: DisputeGameFactoryClient + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PipelineHandle")
+            .field("running", &self.running.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
 }
 
 impl<L1, L2, R, ASR, F> PipelineHandle<L1, L2, R, ASR, F>

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -158,9 +158,7 @@ where
     pub async fn stop_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        let is_active = self.running.load(Ordering::Acquire)
-            && session.as_ref().is_some_and(|(_, task)| !task.is_finished());
-        if !is_active {
+        if session.is_none() {
             return Err("proposer is not running");
         }
 
@@ -277,6 +275,35 @@ mod tests {
         assert!(handle.is_running());
         handle.stop_proposer().await.unwrap();
         assert!(!handle.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_handle_stop_recovers_after_panic() {
+        let cancel = CancellationToken::new();
+        let handle = test_pipeline_handle(cancel);
+
+        {
+            let mut session = handle.session.lock().await;
+            let task: tokio::task::JoinHandle<Result<()>> = tokio::spawn(async {
+                panic!("pipeline task panic");
+            });
+            handle.running.store(true, Ordering::Release);
+            *session = Some((CancellationToken::new(), task));
+        }
+
+        loop {
+            let session = handle.session.lock().await;
+            if session.as_ref().is_some_and(|(_, task)| task.is_finished()) {
+                break;
+            }
+            drop(session);
+            tokio::task::yield_now().await;
+        }
+
+        handle.stop_proposer().await.unwrap();
+        assert!(!handle.is_running());
+        handle.start_proposer().await.unwrap();
+        handle.stop_proposer().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -2,19 +2,11 @@
 //!
 //! Contains configuration types ([`DriverConfig`], [`RecoveredState`]) shared
 //! by the [`crate::ProvingPipeline`], and the [`PipelineHandle`] that wraps a
-//! pipeline with start/stop/is-running semantics exposed through the
-//! [`ProposerDriverControl`] trait for the admin JSON-RPC server.
+//! pipeline with start/stop/is-running semantics for the admin JSON-RPC server.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::time::Duration;
 
 use alloy_primitives::{Address, B256};
-use async_trait::async_trait;
 use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use eyre::Result;
@@ -23,10 +15,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::pipeline::ProvingPipeline;
-
-// ---------------------------------------------------------------------------
-// Core types
-// ---------------------------------------------------------------------------
 
 /// Driver configuration.
 #[derive(Debug, Clone)]
@@ -42,7 +30,7 @@ pub struct DriverConfig {
     /// If true, use `safe_l2` (derived from L1 but L1 not yet finalized).
     /// If false (default), use `finalized_l2` (derived from finalized L1).
     pub allow_non_finalized: bool,
-    /// Address of the proposer that submits proof transactions on-chain.
+    /// Address of the proposer that submits proof transactions onchain.
     /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
     pub proposer_address: Address,
     /// Keccak256 hash of the expected enclave PCR0 measurement.
@@ -69,7 +57,7 @@ impl Default for DriverConfig {
     }
 }
 
-/// On-chain state recovered by the pipeline.
+/// Onchain state recovered by the pipeline.
 ///
 /// This is either a game found in the `DisputeGameFactory` or the
 /// anchor root from the `AnchorStateRegistry` when no games exist.
@@ -84,33 +72,9 @@ pub struct RecoveredState {
     pub l2_block_number: u64,
 }
 
-// ---------------------------------------------------------------------------
-// Lifecycle management
-// ---------------------------------------------------------------------------
-
-/// Trait for controlling the proposer at runtime.
-///
-/// This is the type-erased interface consumed by the admin JSON-RPC server.
-/// [`PipelineHandle`] is the concrete implementation.
-#[async_trait]
-pub trait ProposerDriverControl: Send + Sync {
-    /// Start the proving pipeline.
-    async fn start_proposer(&self) -> Result<(), String>;
-    /// Stop the proving pipeline.
-    async fn stop_proposer(&self) -> Result<(), String>;
-    /// Returns whether the proving pipeline is currently running.
-    fn is_running(&self) -> bool;
-}
-
-/// Active session state: the cancellation token and spawned task for a running
-/// pipeline.
-struct Session {
-    cancel: CancellationToken,
-    task: Option<JoinHandle<Result<()>>>,
-}
-
 /// Manages the lifecycle of a [`ProvingPipeline`], allowing it to be started
 /// and stopped at runtime (e.g. via the admin RPC).
+#[derive(Debug)]
 pub struct PipelineHandle<L1, L2, R, ASR, F>
 where
     L1: L1Provider + 'static,
@@ -120,24 +84,8 @@ where
     F: DisputeGameFactoryClient + 'static,
 {
     pipeline: ProvingPipeline<L1, L2, R, ASR, F>,
-    session: TokioMutex<Session>,
+    session: TokioMutex<Option<(CancellationToken, JoinHandle<Result<()>>)>>,
     global_cancel: CancellationToken,
-    running: Arc<AtomicBool>,
-}
-
-impl<L1, L2, R, ASR, F> std::fmt::Debug for PipelineHandle<L1, L2, R, ASR, F>
-where
-    L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
-    R: RollupProvider + 'static,
-    ASR: AnchorStateRegistryClient + 'static,
-    F: DisputeGameFactoryClient + 'static,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PipelineHandle")
-            .field("running", &self.running.load(Ordering::Relaxed))
-            .finish_non_exhaustive()
-    }
 }
 
 impl<L1, L2, R, ASR, F> PipelineHandle<L1, L2, R, ASR, F>
@@ -153,35 +101,20 @@ where
         pipeline: ProvingPipeline<L1, L2, R, ASR, F>,
         global_cancel: CancellationToken,
     ) -> Self {
-        let session = Session { cancel: global_cancel.child_token(), task: None };
-        Self {
-            pipeline,
-            session: TokioMutex::new(session),
-            global_cancel,
-            running: Arc::new(AtomicBool::new(false)),
-        }
+        Self { pipeline, session: TokioMutex::new(None), global_cancel }
     }
-}
 
-#[async_trait]
-impl<L1, L2, R, ASR, F> ProposerDriverControl for PipelineHandle<L1, L2, R, ASR, F>
-where
-    L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
-    R: RollupProvider + 'static,
-    ASR: AnchorStateRegistryClient + 'static,
-    F: DisputeGameFactoryClient + 'static,
-{
-    async fn start_proposer(&self) -> Result<(), String> {
+    /// Start the proving pipeline.
+    pub async fn start_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        if self.running.load(Ordering::Acquire) {
-            return Err("proposer is already running".into());
+        if session.as_ref().is_some_and(|(_, task)| !task.is_finished()) {
+            return Err("proposer is already running");
         }
 
         // Drain any stale task from a self-terminated pipeline run so panics
         // are surfaced and the JoinHandle resources are properly reclaimed.
-        if let Some(task) = session.task.take() {
+        if let Some((_, task)) = session.take() {
             match task.await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => warn!(error = %e, "previous pipeline run exited with error"),
@@ -189,36 +122,28 @@ where
             }
         }
 
-        self.running.store(true, Ordering::Release);
-
         let cancel = self.global_cancel.child_token();
         let mut pipeline = self.pipeline.clone();
         pipeline.set_cancel(cancel.clone());
 
-        let running = Arc::clone(&self.running);
-        let handle = tokio::spawn(async move {
-            let result = pipeline.run().await;
-            running.store(false, Ordering::Release);
-            result
-        });
+        let handle = tokio::spawn(async move { pipeline.run().await });
 
-        session.cancel = cancel;
-        session.task = Some(handle);
+        *session = Some((cancel, handle));
 
         info!("proving pipeline started");
         Ok(())
     }
 
-    async fn stop_proposer(&self) -> Result<(), String> {
+    /// Stop the proving pipeline.
+    pub async fn stop_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        if !self.running.load(Ordering::Acquire) {
-            return Err("proposer is not running".into());
+        if !session.as_ref().is_some_and(|(_, task)| !task.is_finished()) {
+            return Err("proposer is not running");
         }
 
-        session.cancel.cancel();
-
-        if let Some(task) = session.task.take() {
+        if let Some((cancel, task)) = session.take() {
+            cancel.cancel();
             match task.await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => warn!(error = %e, "proving pipeline exited with error"),
@@ -226,13 +151,13 @@ where
             }
         }
 
-        self.running.store(false, Ordering::Release);
         info!("proving pipeline stopped");
         Ok(())
     }
 
-    fn is_running(&self) -> bool {
-        self.running.load(Ordering::Acquire)
+    /// Returns whether the proving pipeline is currently running.
+    pub async fn is_running(&self) -> bool {
+        self.session.lock().await.as_ref().is_some_and(|(_, task)| !task.is_finished())
     }
 }
 
@@ -283,8 +208,6 @@ mod tests {
                 tee_prover_registry_address: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_secs(3600),
-                    block_interval: 512,
-                    intermediate_block_interval: 512,
                     ..Default::default()
                 },
             },
@@ -302,26 +225,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pipeline_handle_start_stop() {
-        let cancel = CancellationToken::new();
-        let handle = test_pipeline_handle(cancel);
-
-        assert!(!handle.is_running());
-        handle.start_proposer().await.unwrap();
-        assert!(handle.is_running());
-        handle.stop_proposer().await.unwrap();
-        assert!(!handle.is_running());
-    }
-
-    #[tokio::test]
     async fn test_pipeline_handle_double_start_errors() {
         let cancel = CancellationToken::new();
         let handle = test_pipeline_handle(cancel);
 
         handle.start_proposer().await.unwrap();
-        let result = handle.start_proposer().await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("already running"));
+        assert!(handle.start_proposer().await.unwrap_err().contains("already running"));
         handle.stop_proposer().await.unwrap();
     }
 
@@ -330,9 +239,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let handle = test_pipeline_handle(cancel);
 
-        let result = handle.stop_proposer().await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not running"));
+        assert!(handle.stop_proposer().await.unwrap_err().contains("not running"));
     }
 
     #[tokio::test]
@@ -340,12 +247,13 @@ mod tests {
         let cancel = CancellationToken::new();
         let handle = test_pipeline_handle(cancel);
 
+        assert!(!handle.is_running().await);
         handle.start_proposer().await.unwrap();
         handle.stop_proposer().await.unwrap();
         handle.start_proposer().await.unwrap();
-        assert!(handle.is_running());
+        assert!(handle.is_running().await);
         handle.stop_proposer().await.unwrap();
-        assert!(!handle.is_running());
+        assert!(!handle.is_running().await);
     }
 
     #[tokio::test]
@@ -354,20 +262,10 @@ mod tests {
         let handle = test_pipeline_handle(cancel.clone());
 
         handle.start_proposer().await.unwrap();
-        assert!(handle.is_running());
+        assert!(handle.is_running().await);
 
         cancel.cancel();
         tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(!handle.is_running());
-    }
-
-    #[tokio::test]
-    async fn test_pipeline_handle_debug() {
-        let cancel = CancellationToken::new();
-        let handle = test_pipeline_handle(cancel);
-
-        let debug = format!("{handle:?}");
-        assert!(debug.contains("PipelineHandle"));
-        assert!(debug.contains("running"));
+        assert!(!handle.is_running().await);
     }
 }

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -4,7 +4,13 @@
 //! by the [`crate::ProvingPipeline`], and the [`PipelineHandle`] that wraps a
 //! pipeline with start/stop/is-running semantics for the admin JSON-RPC server.
 
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
@@ -86,6 +92,7 @@ where
     pipeline: ProvingPipeline<L1, L2, R, ASR, F>,
     session: TokioMutex<Option<(CancellationToken, JoinHandle<Result<()>>)>>,
     global_cancel: CancellationToken,
+    running: Arc<AtomicBool>,
 }
 
 impl<L1, L2, R, ASR, F> PipelineHandle<L1, L2, R, ASR, F>
@@ -101,14 +108,21 @@ where
         pipeline: ProvingPipeline<L1, L2, R, ASR, F>,
         global_cancel: CancellationToken,
     ) -> Self {
-        Self { pipeline, session: TokioMutex::new(None), global_cancel }
+        Self {
+            pipeline,
+            session: TokioMutex::new(None),
+            global_cancel,
+            running: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     /// Start the proving pipeline.
     pub async fn start_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        if session.as_ref().is_some_and(|(_, task)| !task.is_finished()) {
+        if self.running.load(Ordering::Acquire)
+            || session.as_ref().is_some_and(|(_, task)| !task.is_finished())
+        {
             return Err("proposer is already running");
         }
 
@@ -126,7 +140,13 @@ where
         let mut pipeline = self.pipeline.clone();
         pipeline.set_cancel(cancel.clone());
 
-        let handle = tokio::spawn(async move { pipeline.run().await });
+        self.running.store(true, Ordering::Release);
+        let running = Arc::clone(&self.running);
+        let handle = tokio::spawn(async move {
+            let result = pipeline.run().await;
+            running.store(false, Ordering::Release);
+            result
+        });
 
         *session = Some((cancel, handle));
 
@@ -138,7 +158,9 @@ where
     pub async fn stop_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        if !session.as_ref().is_some_and(|(_, task)| !task.is_finished()) {
+        if !self.running.load(Ordering::Acquire)
+            || !session.as_ref().is_some_and(|(_, task)| !task.is_finished())
+        {
             return Err("proposer is not running");
         }
 
@@ -151,13 +173,14 @@ where
             }
         }
 
+        self.running.store(false, Ordering::Release);
         info!("proving pipeline stopped");
         Ok(())
     }
 
     /// Returns whether the proving pipeline is currently running.
     pub async fn is_running(&self) -> bool {
-        self.session.lock().await.as_ref().is_some_and(|(_, task)| !task.is_finished())
+        self.running.load(Ordering::Acquire)
     }
 }
 
@@ -267,5 +290,21 @@ mod tests {
         cancel.cancel();
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(!handle.is_running().await);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_handle_running_check_does_not_wait_on_session_lock() {
+        let cancel = CancellationToken::new();
+        let handle = test_pipeline_handle(cancel);
+
+        handle.start_proposer().await.unwrap();
+        let session = handle.session.lock().await;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), handle.is_running()).await.unwrap()
+        );
+
+        drop(session);
+        handle.stop_proposer().await.unwrap();
     }
 }

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -158,7 +158,9 @@ where
     pub async fn stop_proposer(&self) -> std::result::Result<(), &'static str> {
         let mut session = self.session.lock().await;
 
-        if session.is_none() {
+        if !self.running.load(Ordering::Acquire)
+            && session.as_ref().is_none_or(|(_, task)| task.is_finished())
+        {
             return Err("proposer is not running");
         }
 
@@ -263,5 +265,31 @@ mod tests {
         cancel.cancel();
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(!handle.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_handle_stop_after_self_terminated_errors() {
+        let cancel = CancellationToken::new();
+        let handle = test_pipeline_handle(cancel.clone());
+
+        handle.start_proposer().await.unwrap();
+        cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let task_finished = {
+                    let session = handle.session.lock().await;
+                    session.as_ref().is_some_and(|(_, task)| task.is_finished())
+                };
+                if !handle.is_running() && task_finished {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        assert!(handle.stop_proposer().await.unwrap_err().contains("not running"));
     }
 }

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -44,7 +44,7 @@ mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};
 
 mod driver;
-pub use driver::{DriverConfig, PipelineHandle, ProposerDriverControl, RecoveredState};
+pub use driver::{DriverConfig, PipelineHandle, RecoveredState};
 
 mod pipeline;
 pub use pipeline::{PipelineConfig, ProvingPipeline};

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -32,7 +32,7 @@ use tracing::{info, warn};
 use crate::{
     Metrics,
     config::ProposerConfig,
-    driver::{DriverConfig, PipelineHandle, ProposerDriverControl},
+    driver::{DriverConfig, PipelineHandle},
     output_proposer::ProposalSubmitter,
     pipeline::{PipelineConfig, ProvingPipeline},
 };
@@ -243,8 +243,7 @@ impl ProposerService {
             cancel.child_token(),
         );
         info!("Proving pipeline initialized");
-        let driver_handle: Arc<dyn ProposerDriverControl> =
-            Arc::new(PipelineHandle::new(pipeline, cancel.clone()));
+        let driver_handle = Arc::new(PipelineHandle::new(pipeline, cancel.clone()));
 
         let ready = Arc::new(AtomicBool::new(false));
         let health_handle: JoinHandle<Result<()>> = {
@@ -281,7 +280,7 @@ impl ProposerService {
 
         ready.store(false, Ordering::SeqCst);
 
-        if driver_handle.is_running()
+        if driver_handle.is_running().await
             && let Err(e) = driver_handle.stop_proposer().await
         {
             warn!(error = %e, "Error stopping proposer driver");

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -280,7 +280,7 @@ impl ProposerService {
 
         ready.store(false, Ordering::SeqCst);
 
-        if driver_handle.is_running().await
+        if driver_handle.is_running()
             && let Err(e) = driver_handle.stop_proposer().await
         {
             warn!(error = %e, "Error stopping proposer driver");

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -6,6 +6,7 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    time::Duration,
 };
 
 use alloy_eips::BlockNumberOrTag;
@@ -29,8 +30,14 @@ use base_prover_service_protocol::{
     TeeKind, TeeProofResult,
 };
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
+use tokio_util::sync::CancellationToken;
 
-use crate::{error::ProposerError, output_proposer::OutputProposer};
+use crate::{
+    driver::{DriverConfig, PipelineHandle},
+    error::ProposerError,
+    output_proposer::OutputProposer,
+    pipeline::{PipelineConfig, ProvingPipeline},
+};
 
 /// Mock L1 provider for tests.
 #[derive(Debug)]
@@ -515,4 +522,43 @@ impl OutputProposer for MockOutputProposer {
     ) -> Result<(), ProposerError> {
         Ok(())
     }
+}
+
+/// Creates a test pipeline handle with a long poll interval.
+pub fn test_pipeline_handle(
+    global_cancel: CancellationToken,
+) -> PipelineHandle<MockL1, MockL2, MockRollupClient, MockAnchorStateRegistry, MockDisputeGameFactory>
+{
+    let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+    let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
+    let rollup = Arc::new(MockRollupClient {
+        sync_status: test_sync_status(200, B256::ZERO),
+        output_roots: HashMap::new(),
+        max_safe_block: None,
+    });
+    let anchor_registry = Arc::new(MockAnchorStateRegistry {
+        anchor_root: test_anchor_root(0),
+        anchor_game: Address::ZERO,
+    });
+    let factory = Arc::new(MockDisputeGameFactory::with_games(vec![]));
+
+    let pipeline = ProvingPipeline::new(
+        PipelineConfig {
+            submit_timeout: Some(Duration::from_secs(60)),
+            max_retries: 3,
+            recovery_scan_concurrency: 8,
+            tee_prover_registry_address: None,
+            driver: DriverConfig { poll_interval: Duration::from_secs(3600), ..Default::default() },
+        },
+        Arc::new(MockProofRequester::default()),
+        l1,
+        l2,
+        rollup,
+        anchor_registry,
+        factory,
+        Arc::new(MockAggregateVerifier::default()),
+        Arc::new(MockOutputProposer),
+        global_cancel.child_token(),
+    );
+    PipelineHandle::new(pipeline, global_cancel)
 }


### PR DESCRIPTION
### What changed? Why?

Simplifies proposer driver lifecycle control by removing the type-erased `ProposerDriverControl` trait and wiring the admin RPC and service directly to `PipelineHandle`. The handle now tracks the running pipeline task in its mutex-protected session state instead of maintaining separate atomic running state.

### Notes to reviewers

The admin `admin_proposerRunning` method is now async because `PipelineHandle::is_running` reads the session state under the async mutex. This also removes the standalone admin mock test that existed only for the erased trait path; driver lifecycle coverage remains colocated with the handle implementation.

### How has it been tested?

- `cargo test -p base-proposer`