### PR TITLE
fix(registrar): reject attestation count mismatch

### DIFF
--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -17,8 +17,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, warn};
 
 use crate::{
-    CertManager, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet, ProverClient,
-    ProverInstance, RegistrarMetrics, Result, SignerClient, SignerManager,
+    CertManager, EnclaveEndpointClient, InstanceDiscovery, InstanceHealthStatus, ProofTaskSet,
+    ProverClient, ProverInstance, RegistrarMetrics, Result, SignerManager,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -114,7 +114,7 @@ impl<D, S, P, R, T> RegistrationDriver<D, S, P, R, T> {
 impl<D, S, P, R, T> RegistrationDriver<D, S, P, R, T>
 where
     D: InstanceDiscovery,
-    S: SignerClient,
+    S: EnclaveEndpointClient,
     T: TxManager,
 {
     /// Runs the registration loop until cancelled.
@@ -262,12 +262,12 @@ where
             }
         };
 
-        if all_attestations.len() < addresses.len() {
+        if all_attestations.len() != addresses.len() {
             warn!(
                 expected = addresses.len(),
                 actual = all_attestations.len(),
                 instance = %instance.instance_id,
-                "signer attestation count was lower than signer public key count"
+                "signer attestation count did not match signer public key count"
             );
             RegistrarMetrics::processing_errors_total().increment(1);
             outcome.unresolved_instance_ids.insert(instance.instance_id.clone());
@@ -373,8 +373,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, InstanceHealthStatus, RegistrarError,
-        Result, SignerClient,
+        DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, EnclaveEndpointClient,
+        InstanceHealthStatus, RegistrarError, Result,
         test_utils::{
             EP1, EP2, EP3, HARDHAT_KEY_0, HARDHAT_KEY_1, HARDHAT_KEY_2, NoopTxManager,
             TEST_REGISTRY_ADDRESS, healthy_prover_instance, prover_instance,
@@ -389,13 +389,13 @@ mod tests {
     }
 
     #[derive(Clone, Debug, Default)]
-    struct MockSignerClient {
+    struct MockEnclaveEndpointClient {
         keys: HashMap<Url, Vec<Vec<u8>>>,
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
     }
 
-    impl MockSignerClient {
+    impl MockEnclaveEndpointClient {
         fn from_keys(entries: &[(&str, &[u8; 32])]) -> Self {
             let keys = entries
                 .iter()
@@ -410,7 +410,7 @@ mod tests {
         }
     }
 
-    impl SignerClient for MockSignerClient {
+    impl EnclaveEndpointClient for MockEnclaveEndpointClient {
         async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
             self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
                 instance: endpoint.to_string(),
@@ -439,8 +439,8 @@ mod tests {
 
     type TestDriver = RegistrationDriver<
         Vec<ProverInstance>,
-        MockSignerClient,
-        MockSignerClient,
+        MockEnclaveEndpointClient,
+        MockEnclaveEndpointClient,
         (),
         NoopTxManager,
     >;
@@ -451,7 +451,7 @@ mod tests {
 
     fn cycle_driver(
         instances: Vec<ProverInstance>,
-        signer_client: MockSignerClient,
+        signer_client: MockEnclaveEndpointClient,
         cancel: CancellationToken,
     ) -> TestDriver {
         let signer_manager = Arc::new(SignerManager::new(
@@ -487,7 +487,7 @@ mod tests {
 
         let instance_under_test =
             prover_instance(EP1, InstanceHealthStatus::Unhealthy, launch_time);
-        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let signer_client = MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
 
         let driver = cycle_driver(
             vec![instance_under_test.clone()],
@@ -504,8 +504,11 @@ mod tests {
 
     #[tokio::test]
     async fn discover_and_resolve_allows_orphan_pass_when_discovery_is_empty() {
-        let driver =
-            cycle_driver(vec![], MockSignerClient::from_keys(&[]), CancellationToken::new());
+        let driver = cycle_driver(
+            vec![],
+            MockEnclaveEndpointClient::from_keys(&[]),
+            CancellationToken::new(),
+        );
 
         let resolution = driver.discover_and_resolve().await.unwrap();
         assert!(resolution.active_signers.is_empty());
@@ -522,7 +525,7 @@ mod tests {
             healthy_prover_instance(EP3),
         ];
 
-        let signer_client = MockSignerClient::from_keys(&[
+        let signer_client = MockEnclaveEndpointClient::from_keys(&[
             (EP1, &HARDHAT_KEY_0),
             (EP2, &HARDHAT_KEY_1),
             (EP3, &HARDHAT_KEY_2),
@@ -542,7 +545,8 @@ mod tests {
         let addr1 = signer_from_private_key(&HARDHAT_KEY_1);
 
         let instances = vec![prover_instance(EP1, InstanceHealthStatus::Draining, None)];
-        let signer_client = MockSignerClient::multi_enclave(EP1, &[&HARDHAT_KEY_0, &HARDHAT_KEY_1]);
+        let signer_client =
+            MockEnclaveEndpointClient::multi_enclave(EP1, &[&HARDHAT_KEY_0, &HARDHAT_KEY_1]);
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
@@ -564,7 +568,7 @@ mod tests {
         ];
 
         let signer_client =
-            MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
+            MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
@@ -576,25 +580,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_attestation_failure_keeps_signer_active_and_unresolved() {
+    async fn discover_and_resolve_bad_attestations_keep_signer_active_and_unresolved() {
         let signer_addr = signer_from_private_key(&HARDHAT_KEY_0);
         let inst = healthy_prover_instance(EP1);
-        let mut missing_attestation = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let mut missing_attestation =
+            MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
         missing_attestation.attestations.insert(endpoint_url(EP1), vec![]);
-        let mut failing_attestation = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let mut extra_attestation = MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        extra_attestation
+            .attestations
+            .insert(endpoint_url(EP1), vec![b"mock-attestation".to_vec(), b"extra".to_vec()]);
+        let mut failing_attestation =
+            MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
         failing_attestation.fail_attestation.insert(endpoint_url(EP1));
-        let signer_clients = [missing_attestation, failing_attestation];
+        let signer_clients = [
+            ("missing attestation", missing_attestation),
+            ("extra attestation", extra_attestation),
+            ("failing attestation", failing_attestation),
+        ];
 
-        for signer_client in signer_clients {
+        for (case, signer_client) in signer_clients {
             let driver = cycle_driver(vec![inst.clone()], signer_client, CancellationToken::new());
 
             let resolution = driver.discover_and_resolve().await.unwrap();
 
-            assert!(resolution.active_signers.contains(&signer_addr));
-            assert!(resolution.registerable.is_empty());
+            assert!(resolution.active_signers.contains(&signer_addr), "{case}");
+            assert!(resolution.registerable.is_empty(), "{case}");
             assert_eq!(
                 resolution.unresolved_instance_ids,
-                HashSet::from([inst.instance_id.clone()])
+                HashSet::from([inst.instance_id.clone()]),
+                "{case}"
             );
         }
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -280,7 +280,7 @@ where
         if let Some(cert_manager) = &self.cert_manager {
             let first_attestation = all_attestations
                 .first()
-                .expect("guarded by attestation count >= signer count >= 1");
+                .expect("guarded by attestation count == signer count >= 1");
             match cert_manager.check_and_revoke_crls(first_attestation, instance).await {
                 Ok(true) => {
                     warn!(

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -35,7 +35,7 @@ mod service;
 pub use service::RegistrarConfig;
 
 mod traits;
-pub use traits::{InstanceDiscovery, SignerClient};
+pub use traits::{EnclaveEndpointClient, InstanceDiscovery};
 
 mod types;
 pub use types::{InstanceHealthStatus, ProverInstance};

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -10,11 +10,11 @@ use k256::ecdsa::VerifyingKey;
 use tracing::debug;
 use url::Url;
 
-use crate::{RegistrarError, Result, SignerClient};
+use crate::{EnclaveEndpointClient, RegistrarError, Result};
 
 /// JSON-RPC client for prover instance signer endpoints.
 ///
-/// Implements [`SignerClient`] by making HTTP JSON-RPC calls to the prover's
+/// Implements [`EnclaveEndpointClient`] by making HTTP JSON-RPC calls to the prover's
 /// `enclave_signerPublicKey` and `enclave_signerAttestation` endpoints.
 ///
 /// The `timeout` is configured once at construction and applied to all requests.
@@ -52,7 +52,7 @@ impl ProverClient {
     }
 }
 
-impl SignerClient for ProverClient {
+impl EnclaveEndpointClient for ProverClient {
     async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
         debug!(endpoint = %endpoint, "fetching signer public keys");
         let client = self.build_client(endpoint)?;

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -20,12 +20,12 @@ pub trait InstanceDiscovery: Send + Sync {
 /// Fetches signer identity data from a prover instance endpoint.
 ///
 /// The primary implementation is [`ProverClient`](crate::ProverClient), which
-/// makes JSON-RPC calls to the prover's `enclave_signerPublicKey` and
-/// `enclave_signerAttestation` endpoints. Test code can substitute a mock
-/// to avoid real HTTP calls.
+/// adapts a discovered endpoint [`Url`] to the shared
+/// `base_proof_primitives::EnclaveApiClient` JSON-RPC surface. Test code can
+/// substitute a mock to avoid real HTTP calls.
 ///
 /// The `endpoint` parameter is a [`Url`] (e.g. `http://10.0.1.5:8000/`).
-pub trait SignerClient: Send + Sync {
+pub trait EnclaveEndpointClient: Send + Sync {
     /// Fetches the SEC1-encoded public key for each enclave signer at the given endpoint.
     fn signer_public_key<'a>(
         &'a self,


### PR DESCRIPTION
## Summary
- reject signer attestation responses unless the count exactly matches signer public keys
- keep mismatched instances active but unresolved so orphan deregistration remains protected while registration fails closed
- rename the registrar endpoint abstraction from `SignerClient` to `EnclaveEndpointClient` and document its relationship to the shared `EnclaveApiClient` RPC surface

## Test plan
- `cargo +nightly fmt --package base-proof-tee-registrar`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar`

## Notes
- `RISC0_SKIP_BUILD_KERNELS=1` is needed locally because `xcrun` cannot find `metal` when `risc0-sys` attempts to build Metal kernels.
- Attempted `RISC0_SKIP_BUILD_KERNELS=1 cargo clippy -p base-proof-tee-registrar --all-targets -- -D warnings`, but it timed out locally while compiling dependency `risc0-circuit-recursion` before reporting crate diagnostics.