### PR TITLE
fix(registrar): back off tx submission retries

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -180,7 +180,7 @@ pub(crate) struct Cli {
     #[arg(long, env = cli_env!("MAX_TX_RETRIES"), default_value_t = DEFAULT_MAX_TX_RETRIES)]
     max_tx_retries: u32,
 
-    /// Transaction submission retry delay in seconds.
+    /// Initial transaction submission retry delay in seconds.
     #[arg(
         long = "tx-retry-delay-secs",
         env = cli_env!("TX_RETRY_DELAY_SECS"),

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -55,7 +55,7 @@ pub struct RegistrarConfig {
     pub max_concurrency: usize,
     /// Maximum number of transaction submission retries for transient errors.
     pub max_tx_retries: u32,
-    /// Delay between transaction submission retries.
+    /// Initial delay between transaction submission retries.
     pub tx_retry_delay: Duration,
     /// Grace window for registering recently launched unhealthy instances.
     pub unhealthy_registration_window: Duration,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -30,6 +30,9 @@ pub const DEFAULT_MAX_TX_RETRIES: u32 = 3;
 /// Default initial delay between transaction submission retries in seconds.
 pub const DEFAULT_TX_RETRY_DELAY_SECS: u64 = 5;
 
+/// Maximum exponential backoff delay between transaction submission retries.
+const MAX_TX_RETRY_BACKOFF_DELAY: Duration = Duration::from_secs(60);
+
 /// State for a proof-generation task currently in-flight.
 ///
 /// One entry per signer address. The pending map is keyed by [`Address`] so
@@ -78,12 +81,6 @@ impl<P, R, T> SignerManager<P, R, T> {
             max_tx_retries,
             tx_retry_delay,
         }
-    }
-
-    /// Returns the exponential backoff delay before the next retry attempt.
-    fn tx_retry_backoff_delay(&self, retry: u32) -> Duration {
-        let multiplier = 1_u32.checked_shl(retry.saturating_sub(1)).unwrap_or(u32::MAX);
-        self.tx_retry_delay.saturating_mul(multiplier)
     }
 }
 
@@ -318,7 +315,11 @@ where
                         }
 
                         let retry = retry + 1;
-                        let retry_delay = self.tx_retry_backoff_delay(retry);
+                        let max_retry_delay = MAX_TX_RETRY_BACKOFF_DELAY.max(self.tx_retry_delay);
+                        let retry_delay = self
+                            .tx_retry_delay
+                            .saturating_mul(2_u32.saturating_pow(retry - 1))
+                            .min(max_retry_delay);
                         warn!(
                             error = %e,
                             signer = %signer_address,
@@ -888,6 +889,31 @@ mod tests {
         assert!(result.is_ok(), "retryable errors should eventually succeed: {result:?}");
         assert_eq!(manager.tx_manager.send_count(), 4);
         assert_eq!(start.elapsed(), Duration::from_secs(7));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_caps_exponential_backoff_between_tx_retries() {
+        let manager = SignerManager::new(
+            RecordingProofProvider::default(),
+            MockRegistry::default(),
+            RecordingTxManager::with_errors(vec![
+                TxManagerError::Rpc("transient 1".into()),
+                TxManagerError::Rpc("transient 2".into()),
+                TxManagerError::Rpc("transient 3".into()),
+                TxManagerError::Rpc("transient 4".into()),
+            ]),
+            TEST_REGISTRY_ADDRESS,
+            DEFAULT_MAX_CONCURRENCY,
+            4,
+            Duration::from_secs(30),
+        );
+        let start = tokio::time::Instant::now();
+
+        let result = register(&manager, &CancellationToken::new()).await;
+
+        assert!(result.is_ok(), "retryable errors should eventually succeed: {result:?}");
+        assert_eq!(manager.tx_manager.send_count(), 5);
+        assert_eq!(start.elapsed(), Duration::from_secs(210));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -27,7 +27,7 @@ use crate::{DiscoveryResolution, RegistrarError, RegistrarMetrics, Result};
 /// errors before giving up.
 pub const DEFAULT_MAX_TX_RETRIES: u32 = 3;
 
-/// Default delay between transaction submission retries in seconds.
+/// Default initial delay between transaction submission retries in seconds.
 pub const DEFAULT_TX_RETRY_DELAY_SECS: u64 = 5;
 
 /// State for a proof-generation task currently in-flight.
@@ -78,6 +78,12 @@ impl<P, R, T> SignerManager<P, R, T> {
             max_tx_retries,
             tx_retry_delay,
         }
+    }
+
+    /// Returns the exponential backoff delay before the next retry attempt.
+    fn tx_retry_backoff_delay(&self, retry: u32) -> Duration {
+        let multiplier = 1_u32.checked_shl(retry.saturating_sub(1)).unwrap_or(u32::MAX);
+        self.tx_retry_delay.saturating_mul(multiplier)
     }
 }
 
@@ -312,16 +318,18 @@ where
                         }
 
                         let retry = retry + 1;
+                        let retry_delay = self.tx_retry_backoff_delay(retry);
                         warn!(
                             error = %e,
                             signer = %signer_address,
                             retry,
                             max_retries = self.max_tx_retries,
+                            delay = ?retry_delay,
                             "tx submission failed, retrying with same proof"
                         );
 
                         if signer_cancel
-                            .run_until_cancelled(tokio::time::sleep(self.tx_retry_delay))
+                            .run_until_cancelled(tokio::time::sleep(retry_delay))
                             .await
                             .is_none()
                         {
@@ -856,6 +864,30 @@ mod tests {
                 manager.tx_manager.take_sent().into_iter().map(|(_, data)| data).collect();
             assert!(sent.windows(2).all(|w| w[0] == w[1]), "calldata mismatch: {sent:?}");
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn register_signer_uses_exponential_backoff_between_tx_retries() {
+        let manager = SignerManager::new(
+            RecordingProofProvider::default(),
+            MockRegistry::default(),
+            RecordingTxManager::with_errors(vec![
+                TxManagerError::Rpc("transient 1".into()),
+                TxManagerError::Rpc("transient 2".into()),
+                TxManagerError::Rpc("transient 3".into()),
+            ]),
+            TEST_REGISTRY_ADDRESS,
+            DEFAULT_MAX_CONCURRENCY,
+            3,
+            Duration::from_secs(1),
+        );
+        let start = tokio::time::Instant::now();
+
+        let result = register(&manager, &CancellationToken::new()).await;
+
+        assert!(result.is_ok(), "retryable errors should eventually succeed: {result:?}");
+        assert_eq!(manager.tx_manager.send_count(), 4);
+        assert_eq!(start.elapsed(), Duration::from_secs(7));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -868,52 +868,35 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn register_signer_uses_exponential_backoff_between_tx_retries() {
-        let manager = SignerManager::new(
-            RecordingProofProvider::default(),
-            MockRegistry::default(),
-            RecordingTxManager::with_errors(vec![
-                TxManagerError::Rpc("transient 1".into()),
-                TxManagerError::Rpc("transient 2".into()),
-                TxManagerError::Rpc("transient 3".into()),
-            ]),
-            TEST_REGISTRY_ADDRESS,
-            DEFAULT_MAX_CONCURRENCY,
-            3,
-            Duration::from_secs(1),
-        );
-        let start = tokio::time::Instant::now();
+    async fn register_signer_backs_off_between_tx_retries() {
+        for (case, max_retries, retry_delay, errors, expected_sends, expected_elapsed) in [
+            ("exponential", 3, Duration::from_secs(1), 3, 4, Duration::from_secs(7)),
+            ("capped", 4, Duration::from_secs(30), 4, 5, Duration::from_secs(210)),
+        ] {
+            let manager = SignerManager::new(
+                RecordingProofProvider::default(),
+                MockRegistry::default(),
+                RecordingTxManager::with_errors(
+                    (1..=errors)
+                        .map(|retry| TxManagerError::Rpc(format!("transient {retry}")))
+                        .collect(),
+                ),
+                TEST_REGISTRY_ADDRESS,
+                DEFAULT_MAX_CONCURRENCY,
+                max_retries,
+                retry_delay,
+            );
+            let start = tokio::time::Instant::now();
 
-        let result = register(&manager, &CancellationToken::new()).await;
+            let result = register(&manager, &CancellationToken::new()).await;
 
-        assert!(result.is_ok(), "retryable errors should eventually succeed: {result:?}");
-        assert_eq!(manager.tx_manager.send_count(), 4);
-        assert_eq!(start.elapsed(), Duration::from_secs(7));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn register_signer_caps_exponential_backoff_between_tx_retries() {
-        let manager = SignerManager::new(
-            RecordingProofProvider::default(),
-            MockRegistry::default(),
-            RecordingTxManager::with_errors(vec![
-                TxManagerError::Rpc("transient 1".into()),
-                TxManagerError::Rpc("transient 2".into()),
-                TxManagerError::Rpc("transient 3".into()),
-                TxManagerError::Rpc("transient 4".into()),
-            ]),
-            TEST_REGISTRY_ADDRESS,
-            DEFAULT_MAX_CONCURRENCY,
-            4,
-            Duration::from_secs(30),
-        );
-        let start = tokio::time::Instant::now();
-
-        let result = register(&manager, &CancellationToken::new()).await;
-
-        assert!(result.is_ok(), "retryable errors should eventually succeed: {result:?}");
-        assert_eq!(manager.tx_manager.send_count(), 5);
-        assert_eq!(start.elapsed(), Duration::from_secs(210));
+            assert!(
+                result.is_ok(),
+                "{case}: retryable errors should eventually succeed: {result:?}"
+            );
+            assert_eq!(manager.tx_manager.send_count(), expected_sends, "{case}");
+            assert_eq!(start.elapsed(), expected_elapsed, "{case}");
+        }
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary
- use exponential backoff for retryable registrar registration tx submission errors
- treat the existing tx retry delay config as the initial backoff delay
- include the selected retry delay in retry warning logs
- clarify CLI/config docs that the retry delay is now the initial delay

## Test plan
- `cargo +nightly fmt --package base-proof-tee-registrar --package base-proof-tee-registrar-bin`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar signer_manager::tests::register_signer`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo clippy -p base-proof-tee-registrar --all-targets -- -D warnings`