### PR TITLE
refactor(proposer): clean up errors

### DIFF
--- a/crates/proof/proposer/src/error.rs
+++ b/crates/proof/proposer/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for the proposer.
 
 use base_proof_rpc::RpcError;
-use base_proof_submission::{KnownRevert, ProofSubmissionError};
+use base_proof_submission::ProofSubmissionError;
 use thiserror::Error;
 
 /// Main error type for the proposer.
@@ -19,29 +19,9 @@ pub enum ProposerError {
     #[error("contract error: {0}")]
     Contract(String),
 
-    /// Transaction was included but reverted on-chain.
-    #[error("transaction reverted: {0}")]
-    TxReverted(String),
-
-    /// The dispute game already exists for the given parameters.
-    #[error("game already exists")]
-    GameAlreadyExists,
-
-    /// A proof of this type has already been attached to the dispute game.
-    #[error("proof already verified")]
-    ProofAlreadyVerified,
-
-    /// The proof's L1 origin is older than the EIP-2935 history window.
-    #[error("l1 origin too old")]
-    L1OriginTooOld,
-
-    /// The parent game is no longer valid on-chain (`AggregateVerifier.InvalidParentGame()`).
-    #[error("invalid parent game")]
-    InvalidParentGame,
-
-    /// The proof signer is not valid on-chain (`TEEVerifier.InvalidSigner(address)`).
-    #[error("invalid signer")]
-    InvalidSigner,
+    /// Proof submission error.
+    #[error(transparent)]
+    Submission(#[from] ProofSubmissionError),
 
     /// Configuration error.
     #[error("config error: {0}")]
@@ -50,109 +30,18 @@ pub enum ProposerError {
     /// Internal logic error.
     #[error("internal error: {0}")]
     Internal(String),
-
-    /// Transaction manager error (nonce, fees, signing, etc.).
-    #[error(transparent)]
-    TxManager(base_tx_manager::TxManagerError),
-}
-
-impl From<ProofSubmissionError> for ProposerError {
-    fn from(err: ProofSubmissionError) -> Self {
-        match err {
-            ProofSubmissionError::GameAlreadyExists => Self::GameAlreadyExists,
-            ProofSubmissionError::ProofAlreadyVerified => Self::ProofAlreadyVerified,
-            ProofSubmissionError::L1OriginTooOld => Self::L1OriginTooOld,
-            ProofSubmissionError::InvalidParentGame => Self::InvalidParentGame,
-            ProofSubmissionError::InvalidSigner => Self::InvalidSigner,
-            ProofSubmissionError::TxReverted(tx_hash) => {
-                Self::TxReverted(format!("transaction {tx_hash} reverted"))
-            }
-            ProofSubmissionError::TxManager(err) => Self::TxManager(err),
-        }
-    }
-}
-
-impl From<KnownRevert> for ProposerError {
-    fn from(revert: KnownRevert) -> Self {
-        match revert {
-            KnownRevert::GameAlreadyExists => Self::GameAlreadyExists,
-            KnownRevert::ProofAlreadyVerified => Self::ProofAlreadyVerified,
-            KnownRevert::L1OriginTooOld => Self::L1OriginTooOld,
-            KnownRevert::InvalidParentGame => Self::InvalidParentGame,
-            KnownRevert::InvalidSigner => Self::InvalidSigner,
-        }
-    }
 }
 
 impl ProposerError {
-    /// Metric label for RPC errors.
-    pub const ERROR_TYPE_RPC: &str = "rpc";
-    /// Metric label for prover errors.
-    pub const ERROR_TYPE_PROVER: &str = "prover";
-    /// Metric label for contract interaction errors.
-    pub const ERROR_TYPE_CONTRACT: &str = "contract";
-    /// Metric label for reverted transactions.
-    pub const ERROR_TYPE_TX_REVERTED: &str = "tx_reverted";
-    /// Metric label for configuration errors.
-    pub const ERROR_TYPE_CONFIG: &str = "config";
-    /// Metric label for internal errors.
-    pub const ERROR_TYPE_INTERNAL: &str = "internal";
-    /// Metric label for transaction manager errors.
-    pub const ERROR_TYPE_TX_MANAGER: &str = "tx_manager";
-    /// Metric label for duplicate game errors.
-    pub const ERROR_TYPE_GAME_ALREADY_EXISTS: &str = "game_already_exists";
-    /// Metric label for already-verified proof errors.
-    pub const ERROR_TYPE_PROOF_ALREADY_VERIFIED: &str = "proof_already_verified";
-    /// Metric label for stale L1 origin errors.
-    pub const ERROR_TYPE_L1_ORIGIN_TOO_OLD: &str = "l1_origin_too_old";
-    /// Metric label for invalid parent game rejections.
-    pub const ERROR_TYPE_INVALID_PARENT_GAME: &str = "invalid_parent_game";
-    /// Metric label for invalid proof signer rejections.
-    pub const ERROR_TYPE_INVALID_SIGNER: &str = "invalid_signer";
-
-    /// Returns true if this error indicates the game already exists.
-    pub const fn is_game_already_exists(&self) -> bool {
-        matches!(self, Self::GameAlreadyExists)
-    }
-
-    /// Returns true if this error indicates the proof was already attached.
-    pub const fn is_proof_already_verified(&self) -> bool {
-        matches!(self, Self::ProofAlreadyVerified)
-    }
-
-    /// Returns true if this error indicates the proof's L1 origin is too old.
-    pub const fn is_l1_origin_too_old(&self) -> bool {
-        matches!(self, Self::L1OriginTooOld)
-    }
-
-    /// Returns true if this error indicates the parent game is no longer valid on-chain.
-    pub const fn is_invalid_parent_game(&self) -> bool {
-        matches!(self, Self::InvalidParentGame)
-    }
-
-    /// Returns true if this error indicates the proof signer is not valid on-chain.
-    pub const fn is_invalid_signer(&self) -> bool {
-        matches!(self, Self::InvalidSigner)
-    }
-
     /// Returns the metrics label for this error variant.
     pub const fn metric_label(&self) -> &'static str {
         match self {
-            Self::Rpc(_) => Self::ERROR_TYPE_RPC,
-            Self::Prover(_) => Self::ERROR_TYPE_PROVER,
-            Self::Contract(_) => Self::ERROR_TYPE_CONTRACT,
-            Self::TxReverted(_) => Self::ERROR_TYPE_TX_REVERTED,
-            Self::GameAlreadyExists => Self::ERROR_TYPE_GAME_ALREADY_EXISTS,
-            Self::ProofAlreadyVerified => Self::ERROR_TYPE_PROOF_ALREADY_VERIFIED,
-            Self::L1OriginTooOld => Self::ERROR_TYPE_L1_ORIGIN_TOO_OLD,
-            Self::InvalidParentGame => Self::ERROR_TYPE_INVALID_PARENT_GAME,
-            Self::InvalidSigner => Self::ERROR_TYPE_INVALID_SIGNER,
-            Self::Config(_) => Self::ERROR_TYPE_CONFIG,
-            Self::Internal(_) => Self::ERROR_TYPE_INTERNAL,
-            Self::TxManager(_) => Self::ERROR_TYPE_TX_MANAGER,
+            Self::Rpc(_) => "rpc",
+            Self::Prover(_) => "prover",
+            Self::Contract(_) => "contract",
+            Self::Submission(err) => err.metric_label(),
+            Self::Config(_) => "config",
+            Self::Internal(_) => "internal",
         }
     }
 }
-
-/// Result type alias for proposer operations.
-pub type ProposerResult<T> = Result<T, ProposerError>;

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -50,7 +50,7 @@ mod pipeline;
 pub use pipeline::{PipelineConfig, ProvingPipeline};
 
 mod error;
-pub use error::{ProposerError, ProposerResult};
+pub use error::ProposerError;
 
 mod admin;
 pub use admin::ProposerAdminApiServerImpl;

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -8,7 +8,9 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{encode_create_calldata, encode_extra_data};
 use base_proof_primitives::{ProofEncoder, Proposal};
-use base_proof_submission::{AggregateProofSubmitter, KnownRevert, VerifyProposalProofSubmission};
+use base_proof_submission::{
+    AggregateProofSubmitter, ProofSubmissionError, VerifyProposalProofSubmission,
+};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::info;
 
@@ -127,15 +129,17 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
             "Creating dispute game"
         );
 
-        let receipt = self.tx_manager.send(candidate).await.map_err(|err| {
-            KnownRevert::from_tx_manager_error(&err)
-                .map_or_else(|| ProposerError::TxManager(err), ProposerError::from)
-        })?;
+        let receipt = self
+            .tx_manager
+            .send(candidate)
+            .await
+            .map_err(ProofSubmissionError::from)
+            .map_err(ProposerError::from)?;
 
         let tx_hash = receipt.transaction_hash;
 
         if !receipt.inner.status() {
-            return Err(ProposerError::TxReverted(format!("transaction {tx_hash} reverted")));
+            return Err(ProofSubmissionError::TxReverted(tx_hash).into());
         }
 
         info!(
@@ -349,7 +353,7 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xBB);
         let submitter = test_submitter(Ok(receipt_with_status(false, tx_hash)));
         let err = submitter.propose_output(&test_proposal(), Address::ZERO, &[]).await.unwrap_err();
-        assert!(matches!(err, ProposerError::TxReverted(_)));
+        assert!(matches!(err, ProposerError::Submission(ProofSubmissionError::TxReverted(_))));
     }
 
     #[tokio::test]
@@ -357,40 +361,13 @@ mod tests {
         let submitter = test_submitter(Err(TxManagerError::NonceTooLow));
         let err = submitter.propose_output(&test_proposal(), Address::ZERO, &[]).await.unwrap_err();
         assert!(
-            matches!(err, ProposerError::TxManager(TxManagerError::NonceTooLow)),
+            matches!(
+                err,
+                ProposerError::Submission(ProofSubmissionError::TxManager(
+                    TxManagerError::NonceTooLow
+                ))
+            ),
             "expected TxManager(NonceTooLow), got {err:?}",
         );
-    }
-
-    #[rstest]
-    #[case::game_already_exists(ProposerError::GameAlreadyExists, true)]
-    #[case::other_error(ProposerError::Contract("other".into()), false)]
-    fn test_is_game_already_exists(#[case] err: ProposerError, #[case] expected: bool) {
-        assert_eq!(err.is_game_already_exists(), expected);
-    }
-
-    #[rstest]
-    #[case::l1_origin_too_old(ProposerError::L1OriginTooOld, true)]
-    #[case::other_error(ProposerError::Contract("other".into()), false)]
-    fn test_is_l1_origin_too_old(#[case] err: ProposerError, #[case] expected: bool) {
-        assert_eq!(err.is_l1_origin_too_old(), expected);
-    }
-
-    #[rstest]
-    #[case::invalid_parent_game(ProposerError::InvalidParentGame, true)]
-    #[case::game_already_exists(ProposerError::GameAlreadyExists, false)]
-    #[case::l1_origin_too_old(ProposerError::L1OriginTooOld, false)]
-    #[case::other_error(ProposerError::Contract("other".into()), false)]
-    fn test_is_invalid_parent_game(#[case] err: ProposerError, #[case] expected: bool) {
-        assert_eq!(err.is_invalid_parent_game(), expected);
-    }
-
-    #[rstest]
-    #[case::invalid_signer(ProposerError::InvalidSigner, true)]
-    #[case::invalid_parent_game(ProposerError::InvalidParentGame, false)]
-    #[case::l1_origin_too_old(ProposerError::L1OriginTooOld, false)]
-    #[case::other_error(ProposerError::Contract("other".into()), false)]
-    fn test_is_invalid_signer(#[case] err: ProposerError, #[case] expected: bool) {
-        assert_eq!(err.is_invalid_signer(), expected);
     }
 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -503,7 +503,7 @@ where
     /// counter, and refreshes the recovery cache
     /// incrementally. Submit failures are transient by default — they do not
     /// count against the per-target retry budget — except `RootMismatch` and
-    /// `Failed { is_invalid_parent_game }`, which drop the cached recovery
+    /// `InvalidParentGame` failures, which drop the cached recovery
     /// so the next iteration re-walks the chain.
     #[cfg(test)]
     async fn submit_inline(
@@ -708,6 +708,7 @@ mod tests {
     use async_trait::async_trait;
     use base_proof_primitives::{ProofResult, Proposal};
     use base_proof_rpc::RpcError;
+    use base_proof_submission::ProofSubmissionError;
     use base_prover_service_client::ProverServiceClientError;
     use base_prover_service_protocol::{
         GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofStatus,
@@ -922,7 +923,7 @@ mod tests {
             _parent_address: Address,
             _intermediate_roots: &[B256],
         ) -> Result<(), ProposerError> {
-            Err(ProposerError::L1OriginTooOld)
+            Err(ProposerError::Submission(ProofSubmissionError::L1OriginTooOld))
         }
     }
 
@@ -937,7 +938,7 @@ mod tests {
             _parent_address: Address,
             _intermediate_roots: &[B256],
         ) -> Result<(), ProposerError> {
-            Err(ProposerError::InvalidSigner)
+            Err(ProposerError::Submission(ProofSubmissionError::InvalidSigner))
         }
     }
 
@@ -992,7 +993,12 @@ mod tests {
             pipeline.validate_and_submit(&proof_result, SUBMIT_BLOCK_INTERVAL, Address::ZERO).await;
 
         assert!(
-            matches!(result, Err(SubmitAction::Discard(ProposerError::L1OriginTooOld))),
+            matches!(
+                result,
+                Err(SubmitAction::Discard(ProposerError::Submission(
+                    ProofSubmissionError::L1OriginTooOld
+                )))
+            ),
             "stale L1 origin should discard the proof, got {result:?}"
         );
     }
@@ -1013,7 +1019,12 @@ mod tests {
             pipeline.validate_and_submit(&proof_result, SUBMIT_BLOCK_INTERVAL, Address::ZERO).await;
 
         assert!(
-            matches!(result, Err(SubmitAction::Discard(ProposerError::InvalidSigner))),
+            matches!(
+                result,
+                Err(SubmitAction::Discard(ProposerError::Submission(
+                    ProofSubmissionError::InvalidSigner
+                )))
+            ),
             "invalid signer should discard the proof, got {result:?}"
         );
     }
@@ -1127,7 +1138,7 @@ mod tests {
             _: Address,
             _: &[B256],
         ) -> Result<(), ProposerError> {
-            Err(ProposerError::InvalidParentGame)
+            Err(ProposerError::Submission(ProofSubmissionError::InvalidParentGame))
         }
     }
 

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -19,6 +19,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use alloy_primitives::B256;
 use base_proof_primitives::ProofResult;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
+use base_proof_submission::ProofSubmissionError;
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{GetProofRequest, GetProofResponse, ProofStatus, TeeKind};
 use futures::{StreamExt, stream};
@@ -1070,7 +1071,10 @@ where
             Ok(Err(SubmitAction::Failed(error))) => {
                 submit_timer.disarm();
                 Metrics::errors_total(error.metric_label()).increment(1);
-                if error.is_invalid_parent_game() {
+                if matches!(
+                    error,
+                    ProposerError::Submission(ProofSubmissionError::InvalidParentGame)
+                ) {
                     warn!(
                         target_block,
                         error = %error,
@@ -1348,7 +1352,7 @@ mod tests {
             _parent_address: Address,
             _intermediate_roots: &[B256],
         ) -> Result<(), ProposerError> {
-            Err(ProposerError::L1OriginTooOld)
+            Err(ProposerError::Submission(ProofSubmissionError::L1OriginTooOld))
         }
     }
 

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -29,6 +29,7 @@ use base_proof_contracts::{
 };
 use base_proof_primitives::{ProofJournal, ProofResult, Proposal};
 use base_proof_rpc::{L1Provider, RollupProvider};
+use base_proof_submission::ProofSubmissionError;
 use futures::{StreamExt, stream};
 use tracing::{debug, info, instrument, warn};
 
@@ -313,7 +314,7 @@ where
                 Ok(())
             }
             Err(e) => {
-                if e.is_game_already_exists() {
+                if matches!(e, ProposerError::Submission(ProofSubmissionError::GameAlreadyExists)) {
                     drop(propose_timer);
                     info!(target_block, "Game already exists, checking fresh state from chain");
                     let raced_game = self
@@ -340,7 +341,10 @@ where
                         "Game already exists, next tick will load fresh state from chain"
                     );
                     Err(SubmitAction::GameAlreadyExists)
-                } else if e.is_l1_origin_too_old() {
+                } else if matches!(
+                    e,
+                    ProposerError::Submission(ProofSubmissionError::L1OriginTooOld)
+                ) {
                     propose_timer.disarm();
                     warn!(
                         error = %e,
@@ -348,7 +352,10 @@ where
                         "Proof L1 origin is too old, discarding proof to re-prove"
                     );
                     Err(SubmitAction::Discard(e))
-                } else if e.is_invalid_signer() {
+                } else if matches!(
+                    e,
+                    ProposerError::Submission(ProofSubmissionError::InvalidSigner)
+                ) {
                     propose_timer.disarm();
                     warn!(
                         error = %e,
@@ -402,7 +409,12 @@ where
                 Metrics::l2_output_proposals_total().increment(1);
                 Ok(())
             }
-            Err(e) if e.is_proof_already_verified() => {
+            Err(e)
+                if matches!(
+                    e,
+                    ProposerError::Submission(ProofSubmissionError::ProofAlreadyVerified)
+                ) =>
+            {
                 drop(attach_timer);
                 info!(
                     target_block,
@@ -411,7 +423,9 @@ where
                 );
                 Ok(())
             }
-            Err(e) if e.is_l1_origin_too_old() => {
+            Err(e)
+                if matches!(e, ProposerError::Submission(ProofSubmissionError::L1OriginTooOld)) =>
+            {
                 attach_timer.disarm();
                 warn!(
                     error = %e,
@@ -421,7 +435,9 @@ where
                 );
                 Err(SubmitAction::Discard(e))
             }
-            Err(e) if e.is_invalid_signer() => {
+            Err(e)
+                if matches!(e, ProposerError::Submission(ProofSubmissionError::InvalidSigner)) =>
+            {
                 attach_timer.disarm();
                 warn!(
                     error = %e,
@@ -731,7 +747,8 @@ mod tests {
     async fn submit_attaches_proof_after_game_already_exists_race() {
         let game_address = Address::repeat_byte(0xAA);
         let output = Arc::new(RecordingOutputProposer::default());
-        *output.create_error.lock().unwrap() = Some(ProposerError::GameAlreadyExists);
+        *output.create_error.lock().unwrap() =
+            Some(ProposerError::Submission(ProofSubmissionError::GameAlreadyExists));
         let submitter = submitter_with_factory(
             Arc::clone(&output),
             Arc::new(SequentialGameFactory::new([Address::ZERO, game_address])),
@@ -773,16 +790,16 @@ mod tests {
 
     #[rstest]
     #[case::already_verified(
-        ProposerError::ProofAlreadyVerified,
+        ProposerError::Submission(ProofSubmissionError::ProofAlreadyVerified),
         ExpectedAttachErrorAction::Success
     )]
     #[case::l1_origin_too_old(
-        ProposerError::L1OriginTooOld,
-        ExpectedAttachErrorAction::Discard(ProposerError::ERROR_TYPE_L1_ORIGIN_TOO_OLD)
+        ProposerError::Submission(ProofSubmissionError::L1OriginTooOld),
+        ExpectedAttachErrorAction::Discard("l1_origin_too_old")
     )]
     #[case::invalid_signer(
-        ProposerError::InvalidSigner,
-        ExpectedAttachErrorAction::Discard(ProposerError::ERROR_TYPE_INVALID_SIGNER)
+        ProposerError::Submission(ProofSubmissionError::InvalidSigner),
+        ExpectedAttachErrorAction::Discard("invalid_signer")
     )]
     #[tokio::test]
     async fn submit_handles_existing_game_attach_error(

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -428,9 +428,7 @@ where
                 );
                 Err(SubmitAction::Discard(e))
             }
-            Err(e)
-                if matches!(e, ProposerError::Submission(ProofSubmissionError::InvalidSigner)) =>
-            {
+            Err(e @ ProposerError::Submission(ProofSubmissionError::InvalidSigner)) => {
                 attach_timer.disarm();
                 warn!(
                     error = %e,

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -409,12 +409,7 @@ where
                 Metrics::l2_output_proposals_total().increment(1);
                 Ok(())
             }
-            Err(e)
-                if matches!(
-                    e,
-                    ProposerError::Submission(ProofSubmissionError::ProofAlreadyVerified)
-                ) =>
-            {
+            Err(ProposerError::Submission(ProofSubmissionError::ProofAlreadyVerified)) => {
                 drop(attach_timer);
                 info!(
                     target_block,
@@ -423,9 +418,7 @@ where
                 );
                 Ok(())
             }
-            Err(e)
-                if matches!(e, ProposerError::Submission(ProofSubmissionError::L1OriginTooOld)) =>
-            {
+            Err(e @ ProposerError::Submission(ProofSubmissionError::L1OriginTooOld)) => {
                 attach_timer.disarm();
                 warn!(
                     error = %e,

--- a/crates/proof/submission/src/error.rs
+++ b/crates/proof/submission/src/error.rs
@@ -19,19 +19,56 @@ pub enum ProofSubmissionError {
     #[error("l1 origin too old")]
     L1OriginTooOld,
 
-    /// The parent game is no longer valid on-chain.
+    /// The parent game is no longer valid onchain.
     #[error("invalid parent game")]
     InvalidParentGame,
 
-    /// The proof signer is not valid on-chain.
+    /// The proof signer is not valid onchain.
     #[error("invalid signer")]
     InvalidSigner,
 
-    /// The transaction was included but reverted on-chain.
+    /// The transaction was included but reverted onchain.
     #[error("transaction {0} reverted")]
     TxReverted(B256),
 
     /// Transaction manager error while submitting the proof transaction.
     #[error(transparent)]
     TxManager(TxManagerError),
+}
+
+impl ProofSubmissionError {
+    /// Returns the metrics label for this error variant.
+    pub const fn metric_label(&self) -> &'static str {
+        match self {
+            Self::GameAlreadyExists => "game_already_exists",
+            Self::ProofAlreadyVerified => "proof_already_verified",
+            Self::L1OriginTooOld => "l1_origin_too_old",
+            Self::InvalidParentGame => "invalid_parent_game",
+            Self::InvalidSigner => "invalid_signer",
+            Self::TxReverted(_) => "tx_reverted",
+            Self::TxManager(_) => "tx_manager",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_label_returns_stable_labels() {
+        let cases = [
+            (ProofSubmissionError::GameAlreadyExists, "game_already_exists"),
+            (ProofSubmissionError::ProofAlreadyVerified, "proof_already_verified"),
+            (ProofSubmissionError::L1OriginTooOld, "l1_origin_too_old"),
+            (ProofSubmissionError::InvalidParentGame, "invalid_parent_game"),
+            (ProofSubmissionError::InvalidSigner, "invalid_signer"),
+            (ProofSubmissionError::TxReverted(B256::ZERO), "tx_reverted"),
+            (ProofSubmissionError::TxManager(TxManagerError::NonceTooLow), "tx_manager"),
+        ];
+
+        for (error, label) in cases {
+            assert_eq!(error.metric_label(), label);
+        }
+    }
 }


### PR DESCRIPTION
### What changed? Why?

Simplifies proposer and proof submission error handling by consolidating error variants and updating callers to use the cleaned-up error types.

### Notes to reviewers

The diff is limited to proposer error cleanup and proof submission error conversion updates.

### How has it been tested?

- `cargo check -p base-proposer -p base-proof-submission`