### PR TITLE
refactor(proposer): clean up output proposer

### DIFF
--- a/crates/proof/primitives/src/proposal.rs
+++ b/crates/proof/primitives/src/proposal.rs
@@ -108,14 +108,22 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{address, b256};
+    use rstest::rstest;
 
     use super::*;
 
-    #[cfg(feature = "serde")]
+    const PROOF_DATA_V_INDEX: usize = 1 + 32 + 32 + ECDSA_SIGNATURE_LENGTH - 1;
+
+    fn signature_with_v(v: u8) -> Bytes {
+        let mut signature = vec![0xab; ECDSA_SIGNATURE_LENGTH];
+        signature[ECDSA_SIGNATURE_LENGTH - 1] = v;
+        Bytes::from(signature)
+    }
+
     fn sample_proposal() -> Proposal {
         Proposal {
             output_root: b256!("0000000000000000000000000000000000000000000000000000000000000001"),
-            signature: Bytes::from(vec![0xab; 65]),
+            signature: signature_with_v(0),
             l1_origin_hash: b256!(
                 "0000000000000000000000000000000000000000000000000000000000000002"
             ),
@@ -170,6 +178,28 @@ mod tests {
 
         let json = serde_json::to_string(&proposal).unwrap();
         assert!(json.contains("\"l2_block_number\":0"));
+    }
+
+    fn proposal_with_v(v: u8) -> Proposal {
+        Proposal { signature: signature_with_v(v), ..sample_proposal() }
+    }
+
+    #[rstest]
+    #[case::v_zero_adjusted_to_27(0, Some(27))]
+    #[case::v_one_adjusted_to_28(1, Some(28))]
+    #[case::v_27_unchanged(27, Some(27))]
+    #[case::v_28_unchanged(28, Some(28))]
+    #[case::v_5_rejected(5, None)]
+    fn test_build_proof_data_v_value(#[case] input_v: u8, #[case] expected_v: Option<u8>) {
+        match (expected_v, proposal_with_v(input_v).build_proof_data()) {
+            (Some(expected_v), Ok(proof)) => {
+                assert_eq!(proof[PROOF_DATA_V_INDEX], expected_v);
+            }
+            (None, Err(CryptoError::InvalidVValue(v))) => {
+                assert_eq!(v, input_v);
+            }
+            (expected, result) => panic!("expected {expected:?}, got {result:?}"),
+        }
     }
 
     fn test_journal() -> ProofJournal {

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -8,9 +8,7 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{encode_create_calldata, encode_extra_data};
 use base_proof_primitives::{ProofEncoder, Proposal};
-use base_proof_submission::{
-    AggregateProofSubmitter, ProofSubmissionError, VerifyProposalProofSubmission,
-};
+use base_proof_submission::{AggregateProofSubmitter, ProofSubmissionError};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::info;
 
@@ -32,12 +30,7 @@ pub trait OutputProposer: Send + Sync {
         &self,
         game_address: Address,
         proposal: &Proposal,
-    ) -> Result<(), ProposerError> {
-        Err(ProposerError::Internal(format!(
-            "verify_proposal_proof not implemented for game {game_address} at block {}",
-            proposal.l2_block_number
-        )))
-    }
+    ) -> Result<(), ProposerError>;
 }
 
 /// No-op output proposer that logs proposals without submitting transactions.
@@ -86,7 +79,7 @@ pub struct ProposalSubmitter<T> {
     init_bond: U256,
 }
 
-impl<T: TxManager> ProposalSubmitter<T> {
+impl<T> ProposalSubmitter<T> {
     /// Creates a new [`ProposalSubmitter`] backed by the given transaction manager.
     pub const fn new(
         tx_manager: T,
@@ -129,21 +122,14 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
             "Creating dispute game"
         );
 
-        let receipt = self
-            .tx_manager
-            .send(candidate)
-            .await
-            .map_err(ProofSubmissionError::from)
-            .map_err(ProposerError::from)?;
+        let receipt = self.tx_manager.send(candidate).await.map_err(ProofSubmissionError::from)?;
 
-        let tx_hash = receipt.transaction_hash;
-
-        if !receipt.inner.status() {
-            return Err(ProofSubmissionError::TxReverted(tx_hash).into());
+        if !receipt.status() {
+            return Err(ProofSubmissionError::TxReverted(receipt.transaction_hash).into());
         }
 
         info!(
-            %tx_hash,
+            tx_hash = %receipt.transaction_hash,
             l2_block_number,
             block_number = receipt.block_number,
             "Proposal transaction confirmed"
@@ -168,12 +154,11 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
         );
 
         let receipt = AggregateProofSubmitter::new(&self.tx_manager)
-            .verify_proposal_proof(VerifyProposalProofSubmission::new(game_address, proof_bytes))
+            .verify_proposal_proof(game_address, proof_bytes)
             .await?;
-        let tx_hash = receipt.transaction_hash;
 
         info!(
-            %tx_hash,
+            tx_hash = %receipt.transaction_hash,
             l2_block_number,
             game_address = %game_address,
             block_number = receipt.block_number,
@@ -186,56 +171,14 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, Bloom, Bytes};
+    use alloy_primitives::{Address, Bloom};
     use alloy_rpc_types_eth::TransactionReceipt;
-    use base_proof_primitives::PROOF_TYPE_TEE;
     use base_tx_manager::{SendHandle, SendResponse, TxManagerError};
-    use rstest::rstest;
 
     use super::*;
+    use crate::test_utils::test_proposal;
 
-    /// The expected length of encoded proof data:
-    /// 1 (type) + 32 (l1OriginHash) + 32 (l1OriginNumber) + 65 (sig) = 130.
-    const EXPECTED_PROOF_DATA_LEN: usize = 130;
-
-    /// Index of the v-value byte within the encoded proof data.
-    const V_VALUE_BYTE_INDEX: usize = EXPECTED_PROOF_DATA_LEN - 1;
-
-    /// Test game type for `ProposalSubmitter` tests.
-    const TEST_GAME_TYPE: u32 = 1;
-
-    /// Test init bond value.
-    const TEST_INIT_BOND: u64 = 100;
-
-    /// Test L2 block number used in proposal tests.
-    const TEST_L2_BLOCK: u64 = 200;
-
-    fn test_proposal() -> Proposal {
-        Proposal {
-            output_root: B256::repeat_byte(0x01),
-            signature: {
-                let mut sig = vec![0xab; 65];
-                sig[64] = 1;
-                Bytes::from(sig)
-            },
-            l1_origin_hash: B256::repeat_byte(0x02),
-            l1_origin_number: 300,
-            l2_block_number: TEST_L2_BLOCK,
-            prev_output_root: B256::repeat_byte(0x03),
-            config_hash: B256::repeat_byte(0x04),
-        }
-    }
-
-    fn proposal_with_v(v: u8) -> Proposal {
-        let mut proposal = test_proposal();
-        let mut sig = proposal.signature.to_vec();
-        sig[64] = v;
-        proposal.signature = Bytes::from(sig);
-        proposal
-    }
-
-    /// Builds a minimal [`TransactionReceipt`] with the given status and hash.
-    fn receipt_with_status(success: bool, tx_hash: B256) -> TransactionReceipt {
+    fn receipt_with_status(success: bool) -> TransactionReceipt {
         let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
             receipt: Receipt {
                 status: Eip658Value::Eip658(success),
@@ -246,7 +189,7 @@ mod tests {
         });
         TransactionReceipt {
             inner,
-            transaction_hash: tx_hash,
+            transaction_hash: B256::ZERO,
             transaction_index: Some(0),
             block_hash: Some(B256::ZERO),
             block_number: Some(1),
@@ -262,28 +205,21 @@ mod tests {
 
     fn test_submitter(response: SendResponse) -> ProposalSubmitter<MockTxManager> {
         ProposalSubmitter::new(
-            MockTxManager::new(response),
+            MockTxManager { response },
             Address::repeat_byte(0x01),
-            TEST_GAME_TYPE,
-            U256::from(TEST_INIT_BOND),
+            1,
+            U256::from(100_u64),
         )
     }
 
-    /// Mock transaction manager for testing.
     #[derive(Debug)]
     struct MockTxManager {
-        response: std::sync::Mutex<Option<SendResponse>>,
-    }
-
-    impl MockTxManager {
-        fn new(response: SendResponse) -> Self {
-            Self { response: std::sync::Mutex::new(Some(response)) }
-        }
+        response: SendResponse,
     }
 
     impl TxManager for MockTxManager {
         async fn send(&self, _candidate: TxCandidate) -> SendResponse {
-            self.response.lock().unwrap().take().expect("MockTxManager response already consumed")
+            self.response.clone()
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
@@ -295,71 +231,19 @@ mod tests {
         }
     }
 
-    // ========================================================================
-    // Proof data encoding tests
-    // ========================================================================
-
-    #[test]
-    fn test_build_proof_data_length() {
-        let proof = test_proposal().build_proof_data().unwrap();
-        assert_eq!(proof.len(), EXPECTED_PROOF_DATA_LEN);
-    }
-
-    #[test]
-    fn test_build_proof_data_type_byte() {
-        let proof = test_proposal().build_proof_data().unwrap();
-        assert_eq!(proof[0], PROOF_TYPE_TEE);
-    }
-
-    #[rstest]
-    #[case::v_zero_adjusted_to_27(0, Some(27))]
-    #[case::v_one_adjusted_to_28(1, Some(28))]
-    #[case::v_27_unchanged(27, Some(27))]
-    #[case::v_28_unchanged(28, Some(28))]
-    #[case::v_5_rejected(5, None)]
-    fn test_build_proof_data_v_value(#[case] v_input: u8, #[case] expected: Option<u8>) {
-        let proposal = proposal_with_v(v_input);
-        let result = proposal.build_proof_data();
-
-        match expected {
-            Some(v) => {
-                let proof = result.unwrap();
-                assert_eq!(proof[V_VALUE_BYTE_INDEX], v);
-            }
-            None => {
-                assert!(result.is_err());
-                assert!(
-                    result.unwrap_err().to_string().contains("invalid ECDSA v-value"),
-                    "expected 'invalid ECDSA v-value' error"
-                );
-            }
-        }
-    }
-
-    // ========================================================================
-    // ProposalSubmitter tests
-    // ========================================================================
-
-    #[tokio::test]
-    async fn propose_output_success() {
-        let tx_hash = B256::repeat_byte(0xAA);
-        let submitter = test_submitter(Ok(receipt_with_status(true, tx_hash)));
-        let result = submitter.propose_output(&test_proposal(), Address::ZERO, &[]).await;
-        assert!(result.is_ok());
-    }
-
     #[tokio::test]
     async fn propose_output_reverted() {
-        let tx_hash = B256::repeat_byte(0xBB);
-        let submitter = test_submitter(Ok(receipt_with_status(false, tx_hash)));
-        let err = submitter.propose_output(&test_proposal(), Address::ZERO, &[]).await.unwrap_err();
+        let submitter = test_submitter(Ok(receipt_with_status(false)));
+        let err =
+            submitter.propose_output(&test_proposal(200), Address::ZERO, &[]).await.unwrap_err();
         assert!(matches!(err, ProposerError::Submission(ProofSubmissionError::TxReverted(_))));
     }
 
     #[tokio::test]
     async fn propose_output_tx_manager_error() {
         let submitter = test_submitter(Err(TxManagerError::NonceTooLow));
-        let err = submitter.propose_output(&test_proposal(), Address::ZERO, &[]).await.unwrap_err();
+        let err =
+            submitter.propose_output(&test_proposal(200), Address::ZERO, &[]).await.unwrap_err();
         assert!(
             matches!(
                 err,

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -124,7 +124,7 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
 
         let receipt = self.tx_manager.send(candidate).await.map_err(ProofSubmissionError::from)?;
 
-        if !receipt.status() {
+        if !receipt.inner.status() {
             return Err(ProofSubmissionError::TxReverted(receipt.transaction_hash).into());
         }
 

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -910,6 +910,15 @@ mod tests {
             tokio::time::sleep(self.delay).await;
             Ok(())
         }
+
+        async fn verify_proposal_proof(
+            &self,
+            _game_address: Address,
+            _proposal: &Proposal,
+        ) -> Result<(), ProposerError> {
+            tokio::time::sleep(self.delay).await;
+            Ok(())
+        }
     }
 
     #[derive(Debug)]
@@ -925,6 +934,14 @@ mod tests {
         ) -> Result<(), ProposerError> {
             Err(ProposerError::Submission(ProofSubmissionError::L1OriginTooOld))
         }
+
+        async fn verify_proposal_proof(
+            &self,
+            _game_address: Address,
+            _proposal: &Proposal,
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::Submission(ProofSubmissionError::L1OriginTooOld))
+        }
     }
 
     #[derive(Debug)]
@@ -937,6 +954,14 @@ mod tests {
             _proposal: &Proposal,
             _parent_address: Address,
             _intermediate_roots: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::Submission(ProofSubmissionError::InvalidSigner))
+        }
+
+        async fn verify_proposal_proof(
+            &self,
+            _game_address: Address,
+            _proposal: &Proposal,
         ) -> Result<(), ProposerError> {
             Err(ProposerError::Submission(ProofSubmissionError::InvalidSigner))
         }
@@ -1140,6 +1165,14 @@ mod tests {
         ) -> Result<(), ProposerError> {
             Err(ProposerError::Submission(ProofSubmissionError::InvalidParentGame))
         }
+
+        async fn verify_proposal_proof(
+            &self,
+            _: Address,
+            _: &Proposal,
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::Submission(ProofSubmissionError::InvalidParentGame))
+        }
     }
 
     /// Output proposer that always rejects with a transient internal error.
@@ -1153,6 +1186,14 @@ mod tests {
             _: &Proposal,
             _: Address,
             _: &[B256],
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::Internal("simulated transient failure".into()))
+        }
+
+        async fn verify_proposal_proof(
+            &self,
+            _: Address,
+            _: &Proposal,
         ) -> Result<(), ProposerError> {
             Err(ProposerError::Internal("simulated transient failure".into()))
         }
@@ -1254,6 +1295,15 @@ mod tests {
             _: &Proposal,
             _: Address,
             _: &[B256],
+        ) -> Result<(), ProposerError> {
+            self.submitted_games.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn verify_proposal_proof(
+            &self,
+            _: Address,
+            _: &Proposal,
         ) -> Result<(), ProposerError> {
             self.submitted_games.fetch_add(1, Ordering::SeqCst);
             Ok(())

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1354,6 +1354,14 @@ mod tests {
         ) -> Result<(), ProposerError> {
             Err(ProposerError::Submission(ProofSubmissionError::L1OriginTooOld))
         }
+
+        async fn verify_proposal_proof(
+            &self,
+            _game_address: Address,
+            _proposal: &Proposal,
+        ) -> Result<(), ProposerError> {
+            Err(ProposerError::Submission(ProofSubmissionError::L1OriginTooOld))
+        }
     }
 
     #[async_trait]

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -32,6 +32,12 @@ use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwn
 
 use crate::{error::ProposerError, output_proposer::OutputProposer};
 
+const TEST_SIGNATURE: [u8; 65] = {
+    let mut signature = [0xab; 65];
+    signature[64] = 1;
+    signature
+};
+
 /// Mock L1 provider for tests.
 #[derive(Debug)]
 pub struct MockL1 {
@@ -407,7 +413,7 @@ pub fn test_anchor_root(block_number: u64) -> AnchorRoot {
 pub fn test_proposal(block_number: u64) -> Proposal {
     Proposal {
         output_root: B256::repeat_byte(block_number as u8),
-        signature: Bytes::from_static(&[0xab; 65]),
+        signature: Bytes::from_static(&TEST_SIGNATURE),
         l1_origin_hash: B256::repeat_byte(0x02),
         l1_origin_number: 100 + block_number,
         l2_block_number: block_number,
@@ -512,6 +518,14 @@ impl OutputProposer for MockOutputProposer {
         _proposal: &Proposal,
         _parent_address: Address,
         _intermediate_roots: &[B256],
+    ) -> Result<(), ProposerError> {
+        Ok(())
+    }
+
+    async fn verify_proposal_proof(
+        &self,
+        _game_address: Address,
+        _proposal: &Proposal,
     ) -> Result<(), ProposerError> {
         Ok(())
     }

--- a/crates/proof/submission/src/lib.rs
+++ b/crates/proof/submission/src/lib.rs
@@ -13,9 +13,7 @@ mod classifier;
 pub use classifier::KnownRevert;
 
 mod submission;
-pub use submission::{
-    ChallengeProofSubmission, NullifyProofSubmission, VerifyProposalProofSubmission,
-};
+pub use submission::{ChallengeProofSubmission, NullifyProofSubmission};
 
 mod submitter;
 pub use submitter::AggregateProofSubmitter;

--- a/crates/proof/submission/src/submission.rs
+++ b/crates/proof/submission/src/submission.rs
@@ -1,30 +1,7 @@
 //! Aggregate verifier proof transaction inputs.
 
 use alloy_primitives::{Address, B256, Bytes};
-use base_proof_contracts::{
-    encode_challenge_calldata, encode_nullify_calldata, encode_verify_proposal_proof_calldata,
-};
-
-/// Inputs for `AggregateVerifier.verifyProposalProof(bytes)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VerifyProposalProofSubmission {
-    /// Dispute game contract address.
-    pub game_address: Address,
-    /// Type-prefixed proof bytes accepted by the dispute game.
-    pub proof_bytes: Bytes,
-}
-
-impl VerifyProposalProofSubmission {
-    /// Creates a proposal proof submission.
-    pub const fn new(game_address: Address, proof_bytes: Bytes) -> Self {
-        Self { game_address, proof_bytes }
-    }
-
-    /// Encodes calldata for `AggregateVerifier.verifyProposalProof(bytes)`.
-    pub fn calldata(&self) -> Bytes {
-        encode_verify_proposal_proof_calldata(self.proof_bytes.clone())
-    }
-}
+use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 
 /// Inputs for dispute-game `challenge(bytes,uint256,bytes32)`.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/proof/submission/src/submitter.rs
+++ b/crates/proof/submission/src/submitter.rs
@@ -4,10 +4,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_types_eth::TransactionReceipt;
 use base_tx_manager::{TxCandidate, TxManager};
 
-use crate::{
-    ChallengeProofSubmission, NullifyProofSubmission, ProofSubmissionError,
-    VerifyProposalProofSubmission,
-};
+use crate::{ChallengeProofSubmission, NullifyProofSubmission, ProofSubmissionError};
 
 /// Submits proof bytes to an existing aggregate verifier dispute game.
 #[derive(Debug)]
@@ -29,9 +26,14 @@ impl<'a, T: TxManager> AggregateProofSubmitter<'a, T> {
     /// Submits `AggregateVerifier.verifyProposalProof(bytes)` to an existing game.
     pub async fn verify_proposal_proof(
         &self,
-        submission: VerifyProposalProofSubmission,
+        game_address: Address,
+        proof_bytes: Bytes,
     ) -> Result<TransactionReceipt, ProofSubmissionError> {
-        self.submit_calldata(submission.game_address, submission.calldata()).await
+        self.submit_calldata(
+            game_address,
+            base_proof_contracts::encode_verify_proposal_proof_calldata(proof_bytes),
+        )
+        .await
     }
 
     /// Submits `AggregateVerifier.challenge(bytes,uint256,bytes32)` to an existing game.
@@ -83,10 +85,7 @@ mod tests {
     use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError};
 
     use super::AggregateProofSubmitter;
-    use crate::{
-        ChallengeProofSubmission, NullifyProofSubmission, ProofSubmissionError,
-        VerifyProposalProofSubmission,
-    };
+    use crate::{ChallengeProofSubmission, NullifyProofSubmission, ProofSubmissionError};
 
     fn receipt_with_status(success: bool, tx_hash: B256) -> TransactionReceipt {
         let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
@@ -155,9 +154,8 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xaa);
         let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
         let submitter = AggregateProofSubmitter::new(&tx_manager);
-        let submission = VerifyProposalProofSubmission::new(game_address, proof_bytes.clone());
 
-        let receipt = submitter.verify_proposal_proof(submission).await;
+        let receipt = submitter.verify_proposal_proof(game_address, proof_bytes.clone()).await;
 
         assert_eq!(receipt.unwrap().transaction_hash, tx_hash);
         let candidate = tx_manager.take_candidate().unwrap();
@@ -216,9 +214,8 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xdd);
         let tx_manager = MockTxManager::new(Ok(receipt_with_status(false, tx_hash)));
         let submitter = AggregateProofSubmitter::new(&tx_manager);
-        let submission = VerifyProposalProofSubmission::new(Address::ZERO, proof_bytes());
 
-        let err = submitter.verify_proposal_proof(submission).await.unwrap_err();
+        let err = submitter.verify_proposal_proof(Address::ZERO, proof_bytes()).await.unwrap_err();
 
         assert!(matches!(err, ProofSubmissionError::TxReverted(hash) if hash == tx_hash));
     }
@@ -230,9 +227,8 @@ mod tests {
             data: None,
         }));
         let submitter = AggregateProofSubmitter::new(&tx_manager);
-        let submission = VerifyProposalProofSubmission::new(Address::ZERO, proof_bytes());
 
-        let err = submitter.verify_proposal_proof(submission).await.unwrap_err();
+        let err = submitter.verify_proposal_proof(Address::ZERO, proof_bytes()).await.unwrap_err();
 
         assert!(matches!(err, ProofSubmissionError::ProofAlreadyVerified));
     }


### PR DESCRIPTION
### What changed? Why?

This cleans up output proposer proof submission by making proposal-proof verification an explicit `OutputProposer` requirement instead of a default internal-error implementation.

It also simplifies aggregate proof submission by passing the game address and proof bytes directly to `AggregateProofSubmitter::verify_proposal_proof`, which removes the extra `VerifyProposalProofSubmission` wrapper type.

The tests now reuse shared proposer test utilities and keep output proposer coverage focused on submission errors.

### Notes to reviewers

None.

### How has it been tested?

cargo test -p base-proposer -p base-proof-submission