### PR TITLE
refactor(proposer): clean up proof adapter

### DIFF
--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -290,10 +290,8 @@ mod tests {
             ..Default::default()
         };
 
-        let proof_collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&proof_requester),
-            Arc::clone(&rollup),
-        );
+        let proof_collector =
+            ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup));
         let proof_dispatcher = ProofDispatcher::aws_nitro(
             Arc::clone(&proof_requester),
             Arc::clone(&l1),

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -292,7 +292,7 @@ mod tests {
 
         let proof_collector =
             ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup));
-        let proof_dispatcher = ProofDispatcher::aws_nitro(
+        let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
             Arc::clone(&l1),
             Arc::clone(&l2),

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -18,7 +18,7 @@ mod output_proposer;
 pub use output_proposer::{DryRunProposer, OutputProposer, ProposalSubmitter};
 
 mod proof_adapter;
-pub use proof_adapter::{DispatchedProof, ProofRequesterDispatcher, ProposerProofAdapter};
+pub use proof_adapter::ProposerProofAdapter;
 
 mod proposal_intervals;
 pub use proposal_intervals::ProposalIntervals;

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -240,7 +240,7 @@ mod tests {
             intermediate_block_interval: 100,
             ..Default::default()
         };
-        let proof_dispatcher = ProofDispatcher::aws_nitro(
+        let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
             Arc::clone(&l1),
             Arc::clone(&l2),

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -280,10 +280,8 @@ mod tests {
                 output_fetch_concurrency: config.recovery_scan_concurrency,
             },
         );
-        let proof_collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&proof_requester),
-            Arc::clone(&rollup),
-        );
+        let proof_collector =
+            ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup));
         let proof_collector_orchestrator = ProofCollectorOrchestrator::new(
             proof_collector,
             proof_dispatcher.clone(),

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -43,7 +43,7 @@ impl ProposerProofAdapter {
     }
 
     /// Builds a prover-service request for a TEE proposal proof with a caller-supplied session id.
-    pub fn tee_prove_block_range_request_with_session_id(
+    pub const fn tee_prove_block_range_request_with_session_id(
         request: PrimitiveProofRequest,
         session_id: String,
     ) -> ProveBlockRangeRequest {

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -60,24 +60,22 @@ impl ProposerProofAdapter {
 
     /// Converts a prover-service TEE proof result into the proposer proof result type.
     pub fn tee_proof_result(result: ProofResult) -> Result<PrimitiveProofResult, ProposerError> {
-        match result {
-            ProofResult::Tee(result) => {
-                if result.tee_kind != TeeKind::AwsNitro {
-                    return Err(ProposerError::Prover(format!(
-                        "expected TEE proof result from AwsNitro, got {:?}",
-                        result.tee_kind
-                    )));
-                }
-
-                Ok(PrimitiveProofResult::Tee {
-                    aggregate_proposal: result.aggregate_proposal,
-                    proposals: result.proposals,
-                })
-            }
-            ProofResult::Compressed(_) | ProofResult::SnarkGroth16(_) => Err(
-                ProposerError::Prover("expected TEE proof result, got non-TEE proof result".into()),
-            ),
+        let ProofResult::Tee(result) = result else {
+            return Err(ProposerError::Prover(
+                "expected TEE proof result, got non-TEE proof result".into(),
+            ));
+        };
+        if result.tee_kind != TeeKind::AwsNitro {
+            return Err(ProposerError::Prover(format!(
+                "expected TEE proof result from AwsNitro, got {:?}",
+                result.tee_kind
+            )));
         }
+
+        Ok(PrimitiveProofResult::Tee {
+            aggregate_proposal: result.aggregate_proposal,
+            proposals: result.proposals,
+        })
     }
 }
 
@@ -120,19 +118,14 @@ mod tests {
         let first = test_request(B256::repeat_byte(0xaa));
         let mut second = first.clone();
         second.l1_head_number += 1;
+        let retry_id = ProposerProofAdapter::tee_discard_retry_session_id(&first, 1);
 
         assert_ne!(
-            ProposerProofAdapter::tee_discard_retry_session_id(&first, 1),
+            retry_id,
             ProposerProofAdapter::tee_session_id_for_root(first.claimed_l2_output_root),
         );
-        assert_ne!(
-            ProposerProofAdapter::tee_discard_retry_session_id(&first, 1),
-            ProposerProofAdapter::tee_discard_retry_session_id(&first, 2),
-        );
-        assert_ne!(
-            ProposerProofAdapter::tee_discard_retry_session_id(&first, 1),
-            ProposerProofAdapter::tee_discard_retry_session_id(&second, 1),
-        );
+        assert_ne!(retry_id, ProposerProofAdapter::tee_discard_retry_session_id(&first, 2),);
+        assert_ne!(retry_id, ProposerProofAdapter::tee_discard_retry_session_id(&second, 1),);
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -45,7 +45,7 @@ impl ProposerProofAdapter {
     }
 
     /// Builds a prover-service request for a TEE proposal proof with a caller-supplied session id.
-    pub const fn tee_prove_block_range_request_with_session_id(
+    pub fn tee_prove_block_range_request_with_session_id(
         request: PrimitiveProofRequest,
         session_id: String,
     ) -> ProveBlockRangeRequest {
@@ -76,12 +76,9 @@ impl ProposerProofAdapter {
                     proposals: result.proposals,
                 })
             }
-            ProofResult::Compressed(_) => {
-                Err(ProposerError::Prover("expected TEE proof result, got Compressed".to_owned()))
-            }
-            ProofResult::SnarkGroth16(_) => {
-                Err(ProposerError::Prover("expected TEE proof result, got SnarkGroth16".to_owned()))
-            }
+            ProofResult::Compressed(_) | ProofResult::SnarkGroth16(_) => Err(
+                ProposerError::Prover("expected TEE proof result, got non-TEE proof result".into()),
+            ),
         }
     }
 }

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -60,10 +60,18 @@ impl ProposerProofAdapter {
 
     /// Converts a prover-service TEE proof result into the proposer proof result type.
     pub fn tee_proof_result(result: ProofResult) -> Result<PrimitiveProofResult, ProposerError> {
-        let ProofResult::Tee(result) = result else {
-            return Err(ProposerError::Prover(
-                "expected TEE proof result, got non-TEE proof result".into(),
-            ));
+        let result = match result {
+            ProofResult::Tee(result) => result,
+            ProofResult::Compressed(_) => {
+                return Err(ProposerError::Prover(
+                    "expected TEE proof result, got Compressed".into(),
+                ));
+            }
+            ProofResult::SnarkGroth16(_) => {
+                return Err(ProposerError::Prover(
+                    "expected TEE proof result, got SnarkGroth16".into(),
+                ));
+            }
         };
         if result.tee_kind != TeeKind::AwsNitro {
             return Err(ProposerError::Prover(format!(
@@ -83,9 +91,13 @@ impl ProposerProofAdapter {
 mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use base_proof_primitives::Proposal;
-    use base_prover_service_protocol::{ProofRequestKind, ProofResult, TeeKind, TeeProofResult};
+    use base_prover_service_protocol::{
+        ProofRequestKind, ProofResult, SnarkGroth16ProofResult, TeeKind, TeeProofResult,
+        ZkProofResult, ZkVm,
+    };
 
     use super::ProposerProofAdapter;
+    use crate::ProposerError;
 
     fn test_request(root: B256) -> base_proof_primitives::ProofRequest {
         base_proof_primitives::ProofRequest {
@@ -165,5 +177,31 @@ mod tests {
                 proposals: vec![proposal]
             }
         );
+    }
+
+    #[test]
+    fn tee_proof_result_reports_wrong_result_variant() {
+        for (result, expected) in [
+            (
+                ProofResult::Compressed(ZkProofResult {
+                    zk_vm: ZkVm::Sp1,
+                    proof: Bytes::from(vec![]),
+                }),
+                "expected TEE proof result, got Compressed",
+            ),
+            (
+                ProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+                    proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: Bytes::from(vec![]) },
+                }),
+                "expected TEE proof result, got SnarkGroth16",
+            ),
+        ] {
+            let err = ProposerProofAdapter::tee_proof_result(result).unwrap_err();
+            let ProposerError::Prover(message) = err else {
+                panic!("unexpected error: {err:?}");
+            };
+
+            assert_eq!(message, expected);
+        }
     }
 }

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -1,112 +1,15 @@
 //! Adapters between proposer proof types and the shared prover-service protocol.
 
-use std::{fmt, sync::Arc};
-
 use alloy_primitives::B256;
 use base_proof_primitives::{
     ProofRequest as PrimitiveProofRequest, ProofResult as PrimitiveProofResult,
 };
-use base_prover_service_client::ProofRequesterProvider;
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest, TeeKind,
     TeeProofRequest,
 };
-use tracing::debug;
 
 use crate::ProposerError;
-
-/// Proof request accepted by prover service for asynchronous collection.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct DispatchedProof {
-    /// Deterministic proof session identifier accepted by prover service.
-    pub session_id: String,
-}
-
-/// Async proof dispatcher backed by the prover-service requester API.
-#[derive(Clone)]
-pub struct ProofRequesterDispatcher {
-    requester: Arc<dyn ProofRequesterProvider>,
-    tee_kind: TeeKind,
-}
-
-impl ProofRequesterDispatcher {
-    /// Creates a dispatcher for AWS Nitro TEE proofs.
-    pub fn aws_nitro(requester: Arc<dyn ProofRequesterProvider>) -> Self {
-        Self { requester, tee_kind: TeeKind::AwsNitro }
-    }
-
-    /// Creates a dispatcher for the given TEE implementation.
-    pub const fn new(requester: Arc<dyn ProofRequesterProvider>, tee_kind: TeeKind) -> Self {
-        Self { requester, tee_kind }
-    }
-
-    /// Returns the TEE implementation used by this dispatcher.
-    pub const fn tee_kind(&self) -> TeeKind {
-        self.tee_kind
-    }
-
-    /// Submits a TEE proof request to prover service without waiting for completion.
-    pub async fn dispatch_tee(
-        &self,
-        request: PrimitiveProofRequest,
-    ) -> Result<DispatchedProof, ProposerError> {
-        let request = ProposerProofAdapter::tee_prove_block_range_request(request, self.tee_kind);
-        self.dispatch_prepared(request).await
-    }
-
-    /// Submits a TEE proof request under an explicit session id.
-    ///
-    /// Used for discard retries. The normal proposer session id is keyed only
-    /// by claimed output root so restarts can rediscover in-flight work, but a
-    /// discarded `Succeeded` session cannot be requeued by replaying that same
-    /// id. A retry-specific id lets the proposer obtain a genuinely fresh TEE
-    /// proof for the same output root.
-    pub async fn dispatch_tee_with_session_id(
-        &self,
-        request: PrimitiveProofRequest,
-        session_id: String,
-    ) -> Result<DispatchedProof, ProposerError> {
-        let request = ProposerProofAdapter::tee_prove_block_range_request_with_session_id(
-            request,
-            self.tee_kind,
-            session_id,
-        );
-        self.dispatch_prepared(request).await
-    }
-
-    async fn dispatch_prepared(
-        &self,
-        request: ProveBlockRangeRequest,
-    ) -> Result<DispatchedProof, ProposerError> {
-        let session_id = request.proof.session_id.clone();
-        let response = match self.requester.prove_block_range(request).await {
-            Ok(response) => response,
-            Err(e) if e.is_l1_head_conflict_for_session(&session_id) => {
-                debug!(
-                    session_id = %session_id,
-                    tee_kind = ?self.tee_kind,
-                    "prover-service already has this TEE proof session with a different l1_head"
-                );
-                return Ok(DispatchedProof { session_id });
-            }
-            Err(e) => return Err(ProposerError::Prover(e.to_string())),
-        };
-        debug!(
-            session_id = %response.session_id,
-            tee_kind = ?self.tee_kind,
-            "dispatched TEE proof request"
-        );
-        Ok(DispatchedProof { session_id: response.session_id })
-    }
-}
-
-impl fmt::Debug for ProofRequesterDispatcher {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProofRequesterDispatcher")
-            .field("tee_kind", &self.tee_kind)
-            .finish_non_exhaustive()
-    }
-}
 
 /// Conversion helpers for proposer proof requests and results.
 #[derive(Debug)]
@@ -116,77 +19,55 @@ impl ProposerProofAdapter {
     /// Namespace used to derive proposer proof session IDs.
     pub const SESSION_NAMESPACE: &'static [u8] = b"base/proposer/proof-session/v1";
 
-    /// Returns the session-ID proof subtype label for a TEE implementation.
-    pub const fn tee_session_label(tee_kind: TeeKind) -> &'static str {
-        match tee_kind {
-            TeeKind::AwsNitro => "tee/aws_nitro",
-        }
-    }
+    /// Session-ID proof subtype label for AWS Nitro TEE proofs.
+    pub const TEE_SESSION_LABEL: &'static str = "tee/aws_nitro";
 
     /// Derives an idempotent TEE proof session ID from proof subtype and claimed root.
-    ///
-    /// This intentionally follows the consolidation-plan derivation of
-    /// `proof type + root`. Other request fields are excluded so redeploys or
-    /// retries for the same proof identity re-use the same prover-service session.
-    pub fn tee_session_id(request: &PrimitiveProofRequest, tee_kind: TeeKind) -> String {
-        Self::tee_session_id_for_root(request.claimed_l2_output_root, tee_kind)
-    }
-
-    /// Derives an idempotent TEE proof session ID from proof subtype and claimed root.
-    pub fn tee_session_id_for_root(root: B256, tee_kind: TeeKind) -> String {
-        ProofSessionId::derive(Self::SESSION_NAMESPACE, Self::tee_session_label(tee_kind), root)
+    pub fn tee_session_id_for_root(root: B256) -> String {
+        ProofSessionId::derive(Self::SESSION_NAMESPACE, Self::TEE_SESSION_LABEL, root)
     }
 
     /// Derives a TEE proof retry session id for a discarded proof.
-    pub fn tee_discard_retry_session_id(
-        request: &PrimitiveProofRequest,
-        tee_kind: TeeKind,
-        attempt: u32,
-    ) -> String {
-        let label = Self::tee_session_label(tee_kind);
+    pub fn tee_discard_retry_session_id(request: &PrimitiveProofRequest, attempt: u32) -> String {
         let l1_head_number = request.l1_head_number.to_be_bytes();
         let attempt = attempt.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
-            label,
+            Self::TEE_SESSION_LABEL,
             &[request.claimed_l2_output_root.as_slice(), &l1_head_number, &attempt],
         )
     }
 
     /// Builds a prover-service request for a TEE proposal proof.
-    pub fn tee_prove_block_range_request(
-        request: PrimitiveProofRequest,
-        tee_kind: TeeKind,
-    ) -> ProveBlockRangeRequest {
-        let session_id = Self::tee_session_id(&request, tee_kind);
-        Self::tee_prove_block_range_request_with_session_id(request, tee_kind, session_id)
+    pub fn tee_prove_block_range_request(request: PrimitiveProofRequest) -> ProveBlockRangeRequest {
+        let session_id = Self::tee_session_id_for_root(request.claimed_l2_output_root);
+        Self::tee_prove_block_range_request_with_session_id(request, session_id)
     }
 
     /// Builds a prover-service request for a TEE proposal proof with a caller-supplied session id.
     pub const fn tee_prove_block_range_request_with_session_id(
         request: PrimitiveProofRequest,
-        tee_kind: TeeKind,
         session_id: String,
     ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
-                request: ProofRequestKind::Tee(TeeProofRequest { proof: request, tee_kind }),
+                request: ProofRequestKind::Tee(TeeProofRequest {
+                    proof: request,
+                    tee_kind: TeeKind::AwsNitro,
+                }),
             },
         }
     }
 
     /// Converts a prover-service TEE proof result into the proposer proof result type.
-    pub fn tee_proof_result(
-        result: ProofResult,
-        expected_tee_kind: TeeKind,
-    ) -> Result<PrimitiveProofResult, ProposerError> {
+    pub fn tee_proof_result(result: ProofResult) -> Result<PrimitiveProofResult, ProposerError> {
         match result {
             ProofResult::Tee(result) => {
-                let actual_tee_kind = result.tee_kind;
-                if actual_tee_kind != expected_tee_kind {
+                if result.tee_kind != TeeKind::AwsNitro {
                     return Err(ProposerError::Prover(format!(
-                        "expected TEE proof result from {expected_tee_kind:?}, got {actual_tee_kind:?}"
+                        "expected TEE proof result from AwsNitro, got {:?}",
+                        result.tee_kind
                     )));
                 }
 
@@ -207,84 +88,11 @@ impl ProposerProofAdapter {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use alloy_primitives::{Address, B256, Bytes};
-    use async_trait::async_trait;
     use base_proof_primitives::Proposal;
-    use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
-    use base_prover_service_protocol::{
-        GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-        ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult, ProveBlockRangeRequest,
-        ProveBlockRangeResponse, TeeKind, TeeProofResult,
-    };
-    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
+    use base_prover_service_protocol::{ProofRequestKind, ProofResult, TeeKind, TeeProofResult};
 
-    use super::{ProofRequesterDispatcher, ProposerProofAdapter};
-
-    #[derive(Debug, Default)]
-    struct MockProofRequester {
-        prove_requests: Mutex<Vec<ProveBlockRangeRequest>>,
-        get_requests: Mutex<Vec<GetProofRequest>>,
-    }
-
-    #[async_trait]
-    impl ProofRequesterProvider for MockProofRequester {
-        async fn prove_block_range(
-            &self,
-            request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            let session_id = request.proof.session_id.clone();
-            self.prove_requests.lock().unwrap().push(request);
-            Ok(ProveBlockRangeResponse { session_id })
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            unimplemented!("tests do not poll proofs")
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            unimplemented!("tests do not list proofs")
-        }
-    }
-
-    #[derive(Debug)]
-    struct L1HeadConflictRequester;
-
-    #[async_trait]
-    impl ProofRequesterProvider for L1HeadConflictRequester {
-        async fn prove_block_range(
-            &self,
-            request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            let session_id = request.proof.session_id;
-            Err(ProverServiceClientError::from(JsonRpcClientError::Call(ErrorObjectOwned::owned(
-                ProverServiceClientError::ERROR_FAILED_PRECONDITION,
-                ProofRequestIdCollisionMessage::for_field(session_id, "l1_head"),
-                None::<()>,
-            ))))
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            unimplemented!("tests do not poll proofs")
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            unimplemented!("tests do not list proofs")
-        }
-    }
+    use super::ProposerProofAdapter;
 
     fn test_request(root: B256) -> base_proof_primitives::ProofRequest {
         base_proof_primitives::ProofRequest {
@@ -313,23 +121,13 @@ mod tests {
     }
 
     #[test]
-    fn tee_session_id_is_stable_for_same_root() {
-        let request = test_request(B256::repeat_byte(0xaa));
-
-        assert_eq!(
-            ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro),
-            ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro)
-        );
-    }
-
-    #[test]
     fn tee_session_id_changes_for_different_roots() {
-        let first = test_request(B256::repeat_byte(0xaa));
-        let second = test_request(B256::repeat_byte(0xbb));
+        let first = B256::repeat_byte(0xaa);
+        let second = B256::repeat_byte(0xbb);
 
         assert_ne!(
-            ProposerProofAdapter::tee_session_id(&first, TeeKind::AwsNitro),
-            ProposerProofAdapter::tee_session_id(&second, TeeKind::AwsNitro)
+            ProposerProofAdapter::tee_session_id_for_root(first),
+            ProposerProofAdapter::tee_session_id_for_root(second)
         );
     }
 
@@ -348,50 +146,38 @@ mod tests {
         second.image_hash = B256::repeat_byte(0x14);
 
         assert_eq!(
-            ProposerProofAdapter::tee_session_id(&first, TeeKind::AwsNitro),
-            ProposerProofAdapter::tee_session_id(&second, TeeKind::AwsNitro)
+            ProposerProofAdapter::tee_prove_block_range_request(first).proof.session_id,
+            ProposerProofAdapter::tee_prove_block_range_request(second).proof.session_id
         );
     }
 
     #[test]
-    fn tee_discard_retry_session_id_differs_from_root_session() {
-        let request = test_request(B256::repeat_byte(0xaa));
-
-        assert_ne!(
-            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 1),
-            ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro),
-        );
-    }
-
-    #[test]
-    fn tee_discard_retry_session_id_changes_by_attempt() {
-        let request = test_request(B256::repeat_byte(0xaa));
-
-        assert_ne!(
-            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 1),
-            ProposerProofAdapter::tee_discard_retry_session_id(&request, TeeKind::AwsNitro, 2),
-        );
-    }
-
-    #[test]
-    fn tee_discard_retry_session_id_changes_by_l1_head_number() {
+    fn tee_discard_retry_session_id_varies_by_retry_identity() {
         let first = test_request(B256::repeat_byte(0xaa));
         let mut second = first.clone();
         second.l1_head_number += 1;
 
         assert_ne!(
-            ProposerProofAdapter::tee_discard_retry_session_id(&first, TeeKind::AwsNitro, 1),
-            ProposerProofAdapter::tee_discard_retry_session_id(&second, TeeKind::AwsNitro, 1),
+            ProposerProofAdapter::tee_discard_retry_session_id(&first, 1),
+            ProposerProofAdapter::tee_session_id_for_root(first.claimed_l2_output_root),
+        );
+        assert_ne!(
+            ProposerProofAdapter::tee_discard_retry_session_id(&first, 1),
+            ProposerProofAdapter::tee_discard_retry_session_id(&first, 2),
+        );
+        assert_ne!(
+            ProposerProofAdapter::tee_discard_retry_session_id(&first, 1),
+            ProposerProofAdapter::tee_discard_retry_session_id(&second, 1),
         );
     }
 
     #[test]
     fn tee_prove_block_range_request_wraps_primitive_request() {
-        let request = test_request(B256::repeat_byte(0xaa));
-        let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
+        let root = B256::repeat_byte(0xaa);
+        let request = test_request(root);
+        let expected_session_id = ProposerProofAdapter::tee_session_id_for_root(root);
 
-        let wrapped =
-            ProposerProofAdapter::tee_prove_block_range_request(request.clone(), TeeKind::AwsNitro);
+        let wrapped = ProposerProofAdapter::tee_prove_block_range_request(request.clone());
 
         assert_eq!(wrapped.proof.session_id, expected_session_id);
         match wrapped.proof.request {
@@ -413,7 +199,7 @@ mod tests {
             tee_kind: TeeKind::AwsNitro,
         });
 
-        let converted = ProposerProofAdapter::tee_proof_result(result, TeeKind::AwsNitro).unwrap();
+        let converted = ProposerProofAdapter::tee_proof_result(result).unwrap();
 
         assert_eq!(
             converted,
@@ -422,59 +208,5 @@ mod tests {
                 proposals: vec![proposal]
             }
         );
-    }
-
-    #[tokio::test]
-    async fn proof_requester_dispatcher_submits_without_polling() {
-        let requester = std::sync::Arc::new(MockProofRequester::default());
-        let dispatcher = ProofRequesterDispatcher::aws_nitro(
-            std::sync::Arc::clone(&requester) as std::sync::Arc<dyn ProofRequesterProvider>
-        );
-        let request = test_request(B256::repeat_byte(0xaa));
-        let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
-
-        let dispatched = dispatcher.dispatch_tee(request).await.unwrap();
-
-        assert_eq!(dispatched.session_id, expected_session_id);
-        assert_eq!(requester.prove_requests.lock().unwrap().len(), 1);
-        assert!(requester.get_requests.lock().unwrap().is_empty());
-    }
-
-    /// Restart/idempotency: dispatching the same proof request twice — e.g. after
-    /// a proposer restart re-discovers the same target — yields the same
-    /// deterministic session id. The prover service is expected to dedupe the
-    /// underlying session by id, but the proposer surfaces the same id either
-    /// way so that a subsequent `get_proof` call lands on the existing session.
-    #[tokio::test]
-    async fn proof_requester_dispatcher_is_idempotent_for_same_request() {
-        let requester = std::sync::Arc::new(MockProofRequester::default());
-        let dispatcher = ProofRequesterDispatcher::aws_nitro(
-            std::sync::Arc::clone(&requester) as std::sync::Arc<dyn ProofRequesterProvider>
-        );
-        let request = test_request(B256::repeat_byte(0xaa));
-        let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
-
-        let first = dispatcher.dispatch_tee(request.clone()).await.unwrap();
-        let second = dispatcher.dispatch_tee(request).await.unwrap();
-
-        assert_eq!(first.session_id, expected_session_id);
-        assert_eq!(second.session_id, expected_session_id);
-        let prove_requests = requester.prove_requests.lock().unwrap();
-        assert_eq!(prove_requests.len(), 2);
-        // Both calls carry the same session id and identical TEE proof payload.
-        assert_eq!(prove_requests[0].proof.session_id, expected_session_id);
-        assert_eq!(prove_requests[1].proof.session_id, expected_session_id);
-    }
-
-    #[tokio::test]
-    async fn proof_requester_dispatcher_accepts_existing_l1_head_conflict() {
-        let dispatcher =
-            ProofRequesterDispatcher::aws_nitro(std::sync::Arc::new(L1HeadConflictRequester));
-        let request = test_request(B256::repeat_byte(0xaa));
-        let expected_session_id = ProposerProofAdapter::tee_session_id(&request, TeeKind::AwsNitro);
-
-        let dispatched = dispatcher.dispatch_tee(request).await.unwrap();
-
-        assert_eq!(dispatched.session_id, expected_session_id);
     }
 }

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -12,7 +12,6 @@ use base_prover_service_protocol::{
 use crate::ProposerError;
 
 /// Conversion helpers for proposer proof requests and results.
-#[derive(Debug)]
 pub struct ProposerProofAdapter;
 
 impl ProposerProofAdapter {

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -12,6 +12,7 @@ use base_prover_service_protocol::{
 use crate::ProposerError;
 
 /// Conversion helpers for proposer proof requests and results.
+#[derive(Debug)]
 pub struct ProposerProofAdapter;
 
 impl ProposerProofAdapter {

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -16,11 +16,9 @@ use crate::ProposerError;
 pub struct ProposerProofAdapter;
 
 impl ProposerProofAdapter {
-    /// Namespace used to derive proposer proof session IDs.
-    pub const SESSION_NAMESPACE: &'static [u8] = b"base/proposer/proof-session/v1";
+    const SESSION_NAMESPACE: &'static [u8] = b"base/proposer/proof-session/v1";
 
-    /// Session-ID proof subtype label for AWS Nitro TEE proofs.
-    pub const TEE_SESSION_LABEL: &'static str = "tee/aws_nitro";
+    const TEE_SESSION_LABEL: &'static str = "tee/aws_nitro";
 
     /// Derives an idempotent TEE proof session ID from proof subtype and claimed root.
     pub fn tee_session_id_for_root(root: B256) -> String {
@@ -115,37 +113,6 @@ mod tests {
             prev_output_root: B256::repeat_byte(0x07),
             config_hash: B256::repeat_byte(0x08),
         }
-    }
-
-    #[test]
-    fn tee_session_id_changes_for_different_roots() {
-        let first = B256::repeat_byte(0xaa);
-        let second = B256::repeat_byte(0xbb);
-
-        assert_ne!(
-            ProposerProofAdapter::tee_session_id_for_root(first),
-            ProposerProofAdapter::tee_session_id_for_root(second)
-        );
-    }
-
-    #[test]
-    fn tee_session_id_ignores_non_root_request_fields() {
-        let root = B256::repeat_byte(0xaa);
-        let first = test_request(root);
-        let mut second = test_request(root);
-        second.l1_head = B256::repeat_byte(0x10);
-        second.agreed_l2_head_hash = B256::repeat_byte(0x11);
-        second.agreed_l2_output_root = B256::repeat_byte(0x12);
-        second.claimed_l2_block_number = 1200;
-        second.proposer = Address::repeat_byte(0x13);
-        second.intermediate_block_interval = 150;
-        second.l1_head_number = 2400;
-        second.image_hash = B256::repeat_byte(0x14);
-
-        assert_eq!(
-            ProposerProofAdapter::tee_prove_block_range_request(first).proof.session_id,
-            ProposerProofAdapter::tee_prove_block_range_request(second).proof.session_id
-        );
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -21,7 +21,7 @@ use base_proof_primitives::ProofResult;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_proof_submission::ProofSubmissionError;
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
-use base_prover_service_protocol::{GetProofRequest, GetProofResponse, ProofStatus, TeeKind};
+use base_prover_service_protocol::{GetProofRequest, GetProofResponse, ProofStatus};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -160,12 +160,11 @@ pub enum TargetPoll {
 pub struct ProofCollector<R> {
     proof_requester: Arc<dyn ProofRequesterProvider>,
     rollup_client: Arc<R>,
-    tee_kind: TeeKind,
 }
 
 impl<R> std::fmt::Debug for ProofCollector<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofCollector").field("tee_kind", &self.tee_kind).finish_non_exhaustive()
+        f.debug_struct("ProofCollector").finish_non_exhaustive()
     }
 }
 
@@ -175,21 +174,15 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
     ) -> Self {
-        Self::new(proof_requester, rollup_client, TeeKind::AwsNitro)
+        Self::new(proof_requester, rollup_client)
     }
 
-    /// Creates a proof collector for the given TEE implementation.
+    /// Creates a proof collector.
     pub const fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
-        tee_kind: TeeKind,
     ) -> Self {
-        Self { proof_requester, rollup_client, tee_kind }
-    }
-
-    /// Returns the TEE implementation this collector polls proofs for.
-    pub const fn tee_kind(&self) -> TeeKind {
-        self.tee_kind
+        Self { proof_requester, rollup_client }
     }
 
     /// Polls the prover service for the proof of `target_block`.
@@ -213,8 +206,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
             }
         };
 
-        let session_id =
-            ProposerProofAdapter::tee_session_id_for_root(output.output_root, self.tee_kind);
+        let session_id = ProposerProofAdapter::tee_session_id_for_root(output.output_root);
 
         let response = match self.get_proof(session_id.clone()).await {
             Ok(response) => response,
@@ -332,7 +324,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                         return TargetPoll::Failed { session_id, claimed_l2_output_root, error };
                     }
                 };
-                match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
+                match ProposerProofAdapter::tee_proof_result(result) {
                     Ok(proof) => TargetPoll::Ready { session_id, proof },
                     Err(decode_error) => {
                         let claimed_l2_output_root =
@@ -420,7 +412,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
                         return TargetPoll::Failed { session_id, claimed_l2_output_root, error };
                     }
                 };
-                match ProposerProofAdapter::tee_proof_result(result, self.tee_kind) {
+                match ProposerProofAdapter::tee_proof_result(result) {
                     Ok(proof) => TargetPoll::Ready { session_id, proof },
                     Err(error) => TargetPoll::Failed { session_id, claimed_l2_output_root, error },
                 }
@@ -888,10 +880,10 @@ where
         count_dispatch_failure: bool,
     ) -> bool {
         match self.dispatcher.dispatch_for(target_block, recovered, claimed_l2_output_root).await {
-            ProofDispatchAttempt::Accepted(dispatched) => {
+            ProofDispatchAttempt::Accepted(session_id) => {
                 info!(
                     target_block,
-                    session_id = %dispatched.session_id,
+                    session_id = %session_id,
                     from_block = recovered.l2_block_number,
                     "Proof request accepted by prover service"
                 );
@@ -975,46 +967,38 @@ where
                 return false;
             }
         };
-        let session_id = ProposerProofAdapter::tee_discard_retry_session_id(
-            &request,
-            self.collector.tee_kind(),
-            attempt,
-        );
+        let session_id = ProposerProofAdapter::tee_discard_retry_session_id(&request, attempt);
 
-        let dispatch_error = match self
-            .dispatcher
-            .requester_dispatcher()
-            .dispatch_tee_with_session_id(request, session_id.clone())
-            .await
-        {
-            Ok(dispatched) if dispatched.session_id == session_id => {
-                info!(
-                    target_block,
-                    session_id = %dispatched.session_id,
-                    attempt,
-                    "Discard retry proof request accepted by prover service"
-                );
-                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
-                state.discard_retry_counts.insert(target_block, attempt);
-                state.retry_sessions.insert(target_block, dispatched.session_id);
-                state.pending_discard_roots.remove(&target_block);
-                state.counted_failed_sessions.remove(&target_block);
-                None
-            }
-            Ok(dispatched) => {
-                error!(
-                    target_block,
-                    expected_session_id = %session_id,
-                    actual_session_id = %dispatched.session_id,
-                    "Prover service returned mismatched discard retry session id"
-                );
-                Some(ProposerError::Prover(format!(
-                    "prover service returned mismatched session_id: expected {}, got {}",
-                    session_id, dispatched.session_id
-                )))
-            }
-            Err(error) => Some(error),
-        };
+        let dispatch_error =
+            match self.dispatcher.dispatch_tee_with_session_id(request, session_id.clone()).await {
+                Ok(accepted_session_id) if accepted_session_id == session_id => {
+                    info!(
+                        target_block,
+                        session_id = %accepted_session_id,
+                        attempt,
+                        "Discard retry proof request accepted by prover service"
+                    );
+                    Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                    state.discard_retry_counts.insert(target_block, attempt);
+                    state.retry_sessions.insert(target_block, accepted_session_id);
+                    state.pending_discard_roots.remove(&target_block);
+                    state.counted_failed_sessions.remove(&target_block);
+                    None
+                }
+                Ok(accepted_session_id) => {
+                    error!(
+                        target_block,
+                        expected_session_id = %session_id,
+                        actual_session_id = %accepted_session_id,
+                        "Prover service returned mismatched discard retry session id"
+                    );
+                    Some(ProposerError::Prover(format!(
+                        "prover service returned mismatched session_id: expected {}, got {}",
+                        session_id, accepted_session_id
+                    )))
+                }
+                Err(error) => Some(error),
+            };
 
         if let Some(error) = dispatch_error {
             Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
@@ -1073,7 +1057,7 @@ mod tests {
     use super::*;
     use crate::{
         output_proposer::OutputProposer,
-        proof_adapter::{ProofRequesterDispatcher, ProposerProofAdapter},
+        proof_adapter::ProposerProofAdapter,
         proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
         proof_recovery::ProofRecoveryConfig,
         proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
@@ -1590,8 +1574,7 @@ mod tests {
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
-        let session_id =
-            ProposerProofAdapter::tee_session_id_for_root(claimed_root, TeeKind::AwsNitro);
+        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
         proof_requester
             .failed_sessions
             .lock()
@@ -1810,12 +1793,10 @@ mod tests {
             l1_head_number: 1000,
             image_hash: B256::repeat_byte(0x05),
         };
-        ProofRequesterDispatcher::aws_nitro(
-            Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>
-        )
-        .dispatch_tee(request)
-        .await
-        .expect("test setup should dispatch root session");
+        proof_requester
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(request))
+            .await
+            .expect("test setup should dispatch root session");
         let collector = ProofCollector::target_poller_aws_nitro(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
@@ -1870,8 +1851,7 @@ mod tests {
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
-        let session_id =
-            ProposerProofAdapter::tee_session_id_for_root(claimed_root, TeeKind::AwsNitro);
+        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
         proof_requester
             .failed_sessions
             .lock()
@@ -1946,9 +1926,8 @@ mod tests {
             max_safe_block: None,
         });
 
-        // First "run": dispatch a TEE proof for `target_block` via a dispatcher
-        // that shares the prover-service stub.
-        let dispatcher = ProofRequesterDispatcher::aws_nitro(Arc::clone(&proof_requester));
+        // First "run": dispatch a TEE proof for `target_block` against the shared
+        // prover-service stub.
         let proof_request = base_proof_primitives::ProofRequest {
             l1_head: B256::repeat_byte(0x01),
             agreed_l2_head_hash: B256::repeat_byte(0x02),
@@ -1960,11 +1939,11 @@ mod tests {
             l1_head_number: 1200,
             image_hash: B256::repeat_byte(0x05),
         };
-        let dispatched = dispatcher.dispatch_tee(proof_request).await.unwrap();
-        let expected_session_id = dispatched.session_id.clone();
-        // Drop the dispatcher to simulate the prior proposer process exiting.
-        drop(dispatcher);
-
+        let expected_session_id = proof_requester
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(proof_request))
+            .await
+            .unwrap()
+            .session_id;
         // "Restart": build a fresh collector with no in-memory dispatch state.
         // It must rederive the session id from the canonical chain root and
         // recover the in-flight session.

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1283,7 +1283,7 @@ mod tests {
         });
         let collector =
             ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             proof_requester,
             Arc::clone(&l1),
             l2,
@@ -1352,7 +1352,7 @@ mod tests {
         });
         let collector =
             ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             proof_requester,
             Arc::clone(&l1),
             l2,
@@ -1434,7 +1434,7 @@ mod tests {
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
         let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             requester,
             Arc::clone(&l1),
             l2,
@@ -1496,7 +1496,7 @@ mod tests {
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MismatchedProofRequester);
         let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             requester,
             Arc::clone(&l1),
             l2,
@@ -1571,7 +1571,7 @@ mod tests {
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
         );
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             l1,
             l2,
@@ -1630,7 +1630,7 @@ mod tests {
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
         let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             requester,
             Arc::clone(&l1),
             l2,
@@ -1694,7 +1694,7 @@ mod tests {
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
         let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             requester,
             Arc::clone(&l1),
             l2,
@@ -1777,7 +1777,7 @@ mod tests {
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
         );
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&l1),
             l2,
@@ -1842,7 +1842,7 @@ mod tests {
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
         );
-        let dispatcher = ProofDispatcher::aws_nitro(
+        let dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&l1),
             l2,

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -169,14 +169,6 @@ impl<R> std::fmt::Debug for ProofCollector<R> {
 }
 
 impl<R: RollupProvider + 'static> ProofCollector<R> {
-    /// Creates a TEE proof collector for single-target AWS Nitro polling.
-    pub fn target_poller_aws_nitro(
-        proof_requester: Arc<dyn ProofRequesterProvider>,
-        rollup_client: Arc<R>,
-    ) -> Self {
-        Self::new(proof_requester, rollup_client)
-    }
-
     /// Creates a proof collector.
     pub const fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
@@ -189,7 +181,7 @@ impl<R: RollupProvider + 'static> ProofCollector<R> {
     ///
     /// Returns a [`TargetPoll`] describing the next action the caller should
     /// take. The session ID is derived deterministically from the canonical
-    /// L2 output root at `target_block` and the configured TEE kind, so a
+    /// L2 output root at `target_block` and the AWS Nitro TEE label, so a
     /// freshly constructed collector can rediscover an in-flight session
     /// dispatched by a previous proposer instance.
     pub async fn poll(&self, target_block: u64) -> TargetPoll {
@@ -1289,10 +1281,8 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&proof_requester),
-            Arc::clone(&rollup_client),
-        );
+        let collector =
+            ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
         let dispatcher = ProofDispatcher::aws_nitro(
             proof_requester,
             Arc::clone(&l1),
@@ -1360,10 +1350,8 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&proof_requester),
-            Arc::clone(&rollup_client),
-        );
+        let collector =
+            ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
         let dispatcher = ProofDispatcher::aws_nitro(
             proof_requester,
             Arc::clone(&l1),
@@ -1445,10 +1433,7 @@ mod tests {
             max_safe_block: None,
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
-        let collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&requester),
-            Arc::clone(&rollup_client),
-        );
+        let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
         let dispatcher = ProofDispatcher::aws_nitro(
             requester,
             Arc::clone(&l1),
@@ -1510,10 +1495,7 @@ mod tests {
             max_safe_block: None,
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MismatchedProofRequester);
-        let collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&requester),
-            Arc::clone(&rollup_client),
-        );
+        let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
         let dispatcher = ProofDispatcher::aws_nitro(
             requester,
             Arc::clone(&l1),
@@ -1585,7 +1567,7 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let collector = ProofCollector::target_poller_aws_nitro(
+        let collector = ProofCollector::new(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
         );
@@ -1647,10 +1629,7 @@ mod tests {
             max_safe_block: None,
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
-        let collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&requester),
-            Arc::clone(&rollup_client),
-        );
+        let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
         let dispatcher = ProofDispatcher::aws_nitro(
             requester,
             Arc::clone(&l1),
@@ -1714,10 +1693,7 @@ mod tests {
             max_safe_block: None,
         });
         let requester: Arc<dyn ProofRequesterProvider> = Arc::new(RejectingProofRequester);
-        let collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&requester),
-            Arc::clone(&rollup_client),
-        );
+        let collector = ProofCollector::new(Arc::clone(&requester), Arc::clone(&rollup_client));
         let dispatcher = ProofDispatcher::aws_nitro(
             requester,
             Arc::clone(&l1),
@@ -1797,7 +1773,7 @@ mod tests {
             .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(request))
             .await
             .expect("test setup should dispatch root session");
-        let collector = ProofCollector::target_poller_aws_nitro(
+        let collector = ProofCollector::new(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
         );
@@ -1862,7 +1838,7 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let collector = ProofCollector::target_poller_aws_nitro(
+        let collector = ProofCollector::new(
             Arc::clone(&proof_requester) as Arc<dyn ProofRequesterProvider>,
             Arc::clone(&rollup_client),
         );
@@ -1947,8 +1923,7 @@ mod tests {
         // "Restart": build a fresh collector with no in-memory dispatch state.
         // It must rederive the session id from the canonical chain root and
         // recover the in-flight session.
-        let collector =
-            ProofCollector::target_poller_aws_nitro(Arc::clone(&proof_requester), rollup_client);
+        let collector = ProofCollector::new(Arc::clone(&proof_requester), rollup_client);
 
         match collector.poll(target_block).await {
             TargetPoll::Ready { session_id, .. } => {
@@ -1973,7 +1948,7 @@ mod tests {
             max_safe_block: None,
         });
 
-        let collector = ProofCollector::target_poller_aws_nitro(proof_requester, rollup_client);
+        let collector = ProofCollector::new(proof_requester, rollup_client);
         match collector.poll(target_block).await {
             TargetPoll::NotFound { session_id, claimed_l2_output_root } => {
                 assert!(!session_id.is_empty());

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -985,8 +985,7 @@ where
                         "Prover service returned mismatched discard retry session id"
                     );
                     Some(ProposerError::Prover(format!(
-                        "prover service returned mismatched session_id: expected {}, got {}",
-                        session_id, accepted_session_id
+                        "prover service returned mismatched session_id: expected {session_id}, got {accepted_session_id}"
                     )))
                 }
                 Err(error) => Some(error),

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -961,35 +961,38 @@ where
         };
         let session_id = ProposerProofAdapter::tee_discard_retry_session_id(&request, attempt);
 
-        let dispatch_error =
-            match self.dispatcher.dispatch_tee_with_session_id(request, session_id.clone()).await {
-                Ok(accepted_session_id) if accepted_session_id == session_id => {
-                    info!(
-                        target_block,
-                        session_id = %accepted_session_id,
-                        attempt,
-                        "Discard retry proof request accepted by prover service"
-                    );
-                    Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
-                    state.discard_retry_counts.insert(target_block, attempt);
-                    state.retry_sessions.insert(target_block, accepted_session_id);
-                    state.pending_discard_roots.remove(&target_block);
-                    state.counted_failed_sessions.remove(&target_block);
-                    None
-                }
-                Ok(accepted_session_id) => {
-                    error!(
-                        target_block,
-                        expected_session_id = %session_id,
-                        actual_session_id = %accepted_session_id,
-                        "Prover service returned mismatched discard retry session id"
-                    );
-                    Some(ProposerError::Prover(format!(
-                        "prover service returned mismatched session_id: expected {session_id}, got {accepted_session_id}"
-                    )))
-                }
-                Err(error) => Some(error),
-            };
+        let dispatch_error = match self
+            .dispatcher
+            .dispatch_tee_with_session_id(request, session_id.clone())
+            .await
+        {
+            Ok(accepted_session_id) if accepted_session_id == session_id => {
+                info!(
+                    target_block,
+                    session_id = %accepted_session_id,
+                    attempt,
+                    "Discard retry proof request accepted by prover service"
+                );
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                state.discard_retry_counts.insert(target_block, attempt);
+                state.retry_sessions.insert(target_block, accepted_session_id);
+                state.pending_discard_roots.remove(&target_block);
+                state.counted_failed_sessions.remove(&target_block);
+                None
+            }
+            Ok(accepted_session_id) => {
+                error!(
+                    target_block,
+                    expected_session_id = %session_id,
+                    actual_session_id = %accepted_session_id,
+                    "Prover service returned mismatched discard retry session id"
+                );
+                Some(ProposerError::Prover(format!(
+                    "prover service returned mismatched session_id: expected {session_id}, got {accepted_session_id}"
+                )))
+            }
+            Err(error) => Some(error),
+        };
 
         if let Some(error) = dispatch_error {
             Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -7,15 +7,12 @@ use alloy_primitives::{Address, B256};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::TeeKind;
+use base_prover_service_protocol::ProveBlockRangeRequest;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    Metrics,
-    driver::RecoveredState,
-    error::ProposerError,
-    proof_adapter::{DispatchedProof, ProofRequesterDispatcher, ProposerProofAdapter},
+    Metrics, driver::RecoveredState, error::ProposerError, proof_adapter::ProposerProofAdapter,
 };
 
 /// Static parameters needed to build proposer proof requests.
@@ -55,7 +52,7 @@ pub enum ProofDispatchOutcome {
 #[derive(Debug)]
 pub enum ProofDispatchAttempt {
     /// The request was accepted by prover-service.
-    Accepted(DispatchedProof),
+    Accepted(String),
     /// The request could not be built from local RPC data.
     BuildFailed(ProposerError),
     /// The request reached prover-service but dispatch failed.
@@ -73,7 +70,7 @@ where
     L2: L2Provider,
     R: RollupProvider,
 {
-    dispatcher: ProofRequesterDispatcher,
+    proof_requester: Arc<dyn ProofRequesterProvider>,
     l1_client: Arc<L1>,
     l2_client: Arc<L2>,
     rollup_client: Arc<R>,
@@ -87,10 +84,7 @@ where
     R: RollupProvider,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofDispatcher")
-            .field("dispatcher", &self.dispatcher)
-            .field("config", &self.config)
-            .finish_non_exhaustive()
+        f.debug_struct("ProofDispatcher").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
@@ -102,7 +96,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            dispatcher: self.dispatcher.clone(),
+            proof_requester: Arc::clone(&self.proof_requester),
             l1_client: Arc::clone(&self.l1_client),
             l2_client: Arc::clone(&self.l2_client),
             rollup_client: Arc::clone(&self.rollup_client),
@@ -125,18 +119,7 @@ where
         rollup_client: Arc<R>,
         config: ProofDispatcherConfig,
     ) -> Self {
-        Self {
-            dispatcher: ProofRequesterDispatcher::aws_nitro(proof_requester),
-            l1_client,
-            l2_client,
-            rollup_client,
-            config,
-        }
-    }
-
-    /// Returns the inner prover-service dispatcher.
-    pub const fn requester_dispatcher(&self) -> &ProofRequesterDispatcher {
-        &self.dispatcher
+        Self { proof_requester, l1_client, l2_client, rollup_client, config }
     }
 
     /// Builds a proof request for `target_block` using `recovered` as the agreed parent.
@@ -190,23 +173,21 @@ where
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
     ) -> ProofDispatchAttempt {
-        let expected_session_id = ProposerProofAdapter::tee_session_id_for_root(
-            claimed_l2_output_root,
-            self.dispatcher.tee_kind(),
-        );
+        let expected_session_id =
+            ProposerProofAdapter::tee_session_id_for_root(claimed_l2_output_root);
         let request =
             match self.build_request(target_block, recovered, claimed_l2_output_root).await {
                 Ok(request) => request,
                 Err(error) => return ProofDispatchAttempt::BuildFailed(error),
             };
 
-        match self.dispatcher.dispatch_tee(request).await {
-            Ok(dispatched) if dispatched.session_id == expected_session_id => {
-                ProofDispatchAttempt::Accepted(dispatched)
+        match self.dispatch_tee(request).await {
+            Ok(session_id) if session_id == expected_session_id => {
+                ProofDispatchAttempt::Accepted(session_id)
             }
-            Ok(dispatched) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
+            Ok(session_id) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
                 "prover service returned mismatched session_id: expected {}, got {}",
-                expected_session_id, dispatched.session_id
+                expected_session_id, session_id
             ))),
             Err(error) => ProofDispatchAttempt::DispatchFailed(error),
         }
@@ -218,7 +199,6 @@ where
         target_block: u64,
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
-        tee_kind: TeeKind,
         attempt: u32,
     ) -> ProofDispatchAttempt {
         let request =
@@ -226,20 +206,59 @@ where
                 Ok(request) => request,
                 Err(error) => return ProofDispatchAttempt::BuildFailed(error),
             };
-        let session_id =
-            ProposerProofAdapter::tee_discard_retry_session_id(&request, tee_kind, attempt);
+        let session_id = ProposerProofAdapter::tee_discard_retry_session_id(&request, attempt);
         let expected_session_id = session_id.clone();
 
-        match self.dispatcher.dispatch_tee_with_session_id(request, session_id).await {
-            Ok(dispatched) if dispatched.session_id == expected_session_id => {
-                ProofDispatchAttempt::Accepted(dispatched)
+        match self.dispatch_tee_with_session_id(request, session_id).await {
+            Ok(session_id) if session_id == expected_session_id => {
+                ProofDispatchAttempt::Accepted(session_id)
             }
-            Ok(dispatched) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
+            Ok(session_id) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
                 "prover service returned mismatched session_id: expected {}, got {}",
-                expected_session_id, dispatched.session_id
+                expected_session_id, session_id
             ))),
             Err(error) => ProofDispatchAttempt::DispatchFailed(error),
         }
+    }
+
+    /// Submits a TEE proof request under an explicit session id.
+    pub async fn dispatch_tee_with_session_id(
+        &self,
+        request: ProofRequest,
+        session_id: String,
+    ) -> Result<String, ProposerError> {
+        let request = ProposerProofAdapter::tee_prove_block_range_request_with_session_id(
+            request, session_id,
+        );
+        self.dispatch_prepared(request).await
+    }
+
+    async fn dispatch_tee(&self, request: ProofRequest) -> Result<String, ProposerError> {
+        let request = ProposerProofAdapter::tee_prove_block_range_request(request);
+        self.dispatch_prepared(request).await
+    }
+
+    async fn dispatch_prepared(
+        &self,
+        request: ProveBlockRangeRequest,
+    ) -> Result<String, ProposerError> {
+        let session_id = request.proof.session_id.clone();
+        let response = match self.proof_requester.prove_block_range(request).await {
+            Ok(response) => response,
+            Err(e) if e.is_l1_head_conflict_for_session(&session_id) => {
+                debug!(
+                    session_id = %session_id,
+                    "prover-service already has this TEE proof session with a different l1_head"
+                );
+                return Ok(session_id);
+            }
+            Err(e) => return Err(ProposerError::Prover(e.to_string())),
+        };
+        debug!(
+            session_id = %response.session_id,
+            "dispatched TEE proof request"
+        );
+        Ok(response.session_id)
     }
 
     /// Dispatches every target from the current dispatcher cursor up to `safe_head`.
@@ -326,10 +345,10 @@ where
         count_dispatch_failure: bool,
     ) -> ProofDispatchOutcome {
         match self.dispatch_for(target_block, recovered, claimed_l2_output_root).await {
-            ProofDispatchAttempt::Accepted(dispatched) => {
+            ProofDispatchAttempt::Accepted(session_id) => {
                 info!(
                     target_block,
-                    session_id = %dispatched.session_id,
+                    session_id = %session_id,
                     from_block = recovered.l2_block_number,
                     "Proof request accepted by prover service"
                 );
@@ -446,8 +465,9 @@ mod tests {
     use base_prover_service_client::ProverServiceClientError;
     use base_prover_service_protocol::{
         GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-        ProveBlockRangeRequest, ProveBlockRangeResponse,
+        ProofRequestIdCollisionMessage, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
+    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
     use super::*;
     use crate::test_utils::{
@@ -459,6 +479,9 @@ mod tests {
         session_id: String,
     }
 
+    #[derive(Debug)]
+    struct L1HeadConflictRequester;
+
     #[async_trait]
     impl ProofRequesterProvider for MismatchedProofRequester {
         async fn prove_block_range(
@@ -466,6 +489,35 @@ mod tests {
             _request: ProveBlockRangeRequest,
         ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
             Ok(ProveBlockRangeResponse { session_id: self.session_id.clone() })
+        }
+
+        async fn get_proof(
+            &self,
+            _request: GetProofRequest,
+        ) -> Result<GetProofResponse, ProverServiceClientError> {
+            unimplemented!("dispatcher tests do not poll proofs")
+        }
+
+        async fn list_proofs(
+            &self,
+            _request: ListProofsRequest,
+        ) -> Result<ListProofsResponse, ProverServiceClientError> {
+            unimplemented!("dispatcher tests do not list proofs")
+        }
+    }
+
+    #[async_trait]
+    impl ProofRequesterProvider for L1HeadConflictRequester {
+        async fn prove_block_range(
+            &self,
+            request: ProveBlockRangeRequest,
+        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
+            let session_id = request.proof.session_id;
+            Err(ProverServiceClientError::from(JsonRpcClientError::Call(ErrorObjectOwned::owned(
+                ProverServiceClientError::ERROR_FAILED_PRECONDITION,
+                ProofRequestIdCollisionMessage::for_field(session_id, "l1_head"),
+                None::<()>,
+            ))))
         }
 
         async fn get_proof(
@@ -528,15 +580,12 @@ mod tests {
         let claimed_root = B256::repeat_byte(0xaa);
 
         let outcome = dispatcher.dispatch_for(200, &recovered(), claimed_root).await;
-        let ProofDispatchAttempt::Accepted(dispatched) = outcome else {
+        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
             panic!("expected accepted dispatch")
         };
 
-        assert_eq!(
-            dispatched.session_id,
-            ProposerProofAdapter::tee_session_id_for_root(claimed_root, TeeKind::AwsNitro)
-        );
-        assert!(requester.requests.lock().unwrap().contains_key(&dispatched.session_id));
+        assert_eq!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
+        assert!(requester.requests.lock().unwrap().contains_key(&session_id));
     }
 
     #[tokio::test]
@@ -551,6 +600,19 @@ mod tests {
             panic!("expected mismatched session id to fail dispatch")
         };
         assert!(message.contains("mismatched session_id"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_for_accepts_existing_l1_head_conflict() {
+        let dispatcher = dispatcher_for_requester(Arc::new(L1HeadConflictRequester));
+        let claimed_root = B256::repeat_byte(0xaa);
+
+        let outcome = dispatcher.dispatch_for(200, &recovered(), claimed_root).await;
+
+        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
+            panic!("expected accepted dispatch")
+        };
+        assert_eq!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
     }
 
     #[tokio::test]
@@ -624,17 +686,12 @@ mod tests {
         let (dispatcher, _requester) = dispatcher();
         let claimed_root = B256::repeat_byte(0xaa);
 
-        let outcome = dispatcher
-            .dispatch_discard_retry(200, &recovered(), claimed_root, TeeKind::AwsNitro, 1)
-            .await;
-        let ProofDispatchAttempt::Accepted(dispatched) = outcome else {
+        let outcome = dispatcher.dispatch_discard_retry(200, &recovered(), claimed_root, 1).await;
+        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
             panic!("expected accepted dispatch")
         };
 
-        assert_ne!(
-            dispatched.session_id,
-            ProposerProofAdapter::tee_session_id_for_root(claimed_root, TeeKind::AwsNitro)
-        );
+        assert_ne!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -111,8 +111,8 @@ where
     L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
-    /// Creates an AWS Nitro TEE proof dispatcher.
-    pub fn aws_nitro(
+    /// Creates a proof dispatcher.
+    pub fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
         l1_client: Arc<L1>,
         l2_client: Arc<L2>,
@@ -553,7 +553,7 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        ProofDispatcher::aws_nitro(
+        ProofDispatcher::new(
             requester,
             l1,
             l2,

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -186,8 +186,7 @@ where
                 ProofDispatchAttempt::Accepted(session_id)
             }
             Ok(session_id) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {}, got {}",
-                expected_session_id, session_id
+                "prover service returned mismatched session_id: expected {expected_session_id}, got {session_id}"
             ))),
             Err(error) => ProofDispatchAttempt::DispatchFailed(error),
         }
@@ -214,8 +213,7 @@ where
                 ProofDispatchAttempt::Accepted(session_id)
             }
             Ok(session_id) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {}, got {}",
-                expected_session_id, session_id
+                "prover service returned mismatched session_id: expected {expected_session_id}, got {session_id}"
             ))),
             Err(error) => ProofDispatchAttempt::DispatchFailed(error),
         }

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -232,10 +232,8 @@ impl ProposerService {
             tee_image_hash: config.tee_image_hash,
             anchor_state_registry_address: config.anchor_state_registry_addr,
         };
-        let proof_collector = ProofCollector::target_poller_aws_nitro(
-            Arc::clone(&proof_requester),
-            Arc::clone(&rollup_client),
-        );
+        let proof_collector =
+            ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
         let proof_dispatcher = ProofDispatcher::aws_nitro(
             Arc::clone(&proof_requester),
             Arc::clone(&l1_client),

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -234,7 +234,7 @@ impl ProposerService {
         };
         let proof_collector =
             ProofCollector::new(Arc::clone(&proof_requester), Arc::clone(&rollup_client));
-        let proof_dispatcher = ProofDispatcher::aws_nitro(
+        let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
             Arc::clone(&l1_client),
             Arc::clone(&l2_client),


### PR DESCRIPTION
### What changed? Why?

Refactors the proof proposer TEE dispatch path so `ProofDispatcher` owns prover-service submission directly and `ProposerProofAdapter` only handles proof request/result conversion.

Removes the standalone proof requester dispatcher wrapper, returns accepted session IDs directly, and keeps AWS Nitro session ID derivation in the adapter.

### Notes to reviewers

The behavior this preserves is covered in the existing dispatcher/collector tests: root-derived sessions remain idempotent, discard retries still use retry-specific session IDs, and existing `l1_head` conflicts for the same session are accepted.

### How has it been tested?

- `git diff --check refactor/clean-pipeline...HEAD`
- `cargo test -p base-proposer`