### PR TITLE
feat(proof): wire zk host worker loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,10 +6187,16 @@ name = "base-prover-zk-host"
 version = "0.0.0"
 dependencies = [
  "base-cli-utils",
+ "base-proof-worker",
+ "base-proof-zk-backend",
+ "base-proof-zk-host",
+ "base-prover-service-client",
  "clap",
  "eyre",
  "serde",
+ "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/bin/prover/zk-host/Cargo.toml
+++ b/bin/prover/zk-host/Cargo.toml
@@ -16,10 +16,24 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-# CLI
-eyre.workspace = true
-tracing.workspace = true
+# base
 base-cli-utils.workspace = true
+base-proof-worker.workspace = true
+base-proof-zk-host.workspace = true
+base-proof-zk-backend.workspace = true
+base-prover-service-client.workspace = true
+
+# CLI / errors
+eyre.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 # Required by base-cli-utils logging and metrics macro expansions.
 serde = { workspace = true, features = ["derive", "std"] }
+
+# async
+tokio-util.workspace = true
+
+# misc
+uuid = { workspace = true, features = ["v4"] }
+
+# observability
+tracing.workspace = true

--- a/bin/prover/zk-host/README.md
+++ b/bin/prover/zk-host/README.md
@@ -3,5 +3,5 @@
 ZK prover-service worker host binary.
 
 This binary is the CLI entry point for the ZK worker host. The worker loop is
-intentionally wired in later PRs after the shared worker crate and ZK host
-orchestration are available.
+wired through `base-proof-zk-host` and currently supports the mock and dry-run
+ZK proving backends.

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -1,9 +1,23 @@
 //! CLI definition for the ZK prover-service worker host binary.
 
+use std::{fmt, sync::Arc, time::Duration};
+
 use base_cli_utils::{LogConfig, RuntimeManager};
+use base_proof_worker::{
+    DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
+};
+use base_proof_zk_backend::{DryRunZkProver, MockZkProver};
+use base_proof_zk_host::{
+    DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
+    DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, ProofGeneratorHeartbeatConfig,
+    ZkHost, ZkHostConfig, ZkProofClaimType, ZkProver,
+};
+use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::{Parser, ValueEnum};
-use eyre::eyre;
+use eyre::WrapErr;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
+use uuid::Uuid;
 
 base_cli_utils::define_log_args!("BASE_PROVER_ZK_HOST");
 base_cli_utils::define_metrics_args!("BASE_PROVER_ZK_HOST", 7303);
@@ -40,23 +54,31 @@ struct ZkHostArgs {
     worker_id: Option<String>,
 
     /// ZK proof type this worker should claim.
-    #[arg(long, env = "ZK_PROOF_TYPE", default_value = "compressed")]
+    #[arg(long, env = "PROOF_TYPE", value_enum, default_value = "compressed")]
     proof_type: ZkProofTypeArg,
 
-    /// ZK virtual machines this worker can execute.
-    #[arg(long, env = "ZK_VMS", value_delimiter = ',', default_value = "sp1")]
-    zk_vms: Vec<ZkVmArg>,
+    /// Proving backend to run.
+    #[arg(long, env = "ZK_BACKEND", value_enum)]
+    backend: ZkBackendArg,
 
     /// Delay after an empty or failed discovery attempt, in milliseconds.
     #[arg(long, env = "JOB_DISCOVERY_POLL_INTERVAL_MS", default_value_t = 5_000)]
     job_discovery_poll_interval_ms: u64,
 
     /// Requested claim lock duration in seconds. Zero uses the server default.
-    #[arg(long, env = "JOB_DISCOVERY_LOCK_DURATION_SECONDS", default_value_t = 0)]
+    #[arg(
+        long,
+        env = "JOB_DISCOVERY_LOCK_DURATION_SECONDS",
+        default_value_t = DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS
+    )]
     job_discovery_lock_duration_seconds: u32,
 
     /// Maximum number of claimed proof jobs generated concurrently.
-    #[arg(long, env = "JOB_DISCOVERY_MAX_CONCURRENT_JOBS", default_value_t = 1)]
+    #[arg(
+        long,
+        env = "JOB_DISCOVERY_MAX_CONCURRENT_JOBS",
+        default_value_t = DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS
+    )]
     job_discovery_max_concurrent_jobs: usize,
 
     /// Delay between worker API heartbeats while a ZK proof is being generated.
@@ -64,33 +86,67 @@ struct ZkHostArgs {
     proof_generator_heartbeat_interval_secs: u64,
 
     /// Requested heartbeat lock duration in seconds. Zero uses the server default.
-    #[arg(long, env = "PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS", default_value_t = 0)]
+    #[arg(
+        long,
+        env = "PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS",
+        default_value_t = DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS
+    )]
     proof_generator_heartbeat_lock_duration_seconds: u32,
+
+    /// Maximum consecutive retryable heartbeat failures before aborting generation.
+    #[arg(
+        long,
+        env = "PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES",
+        default_value_t = DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES
+    )]
+    proof_generator_max_consecutive_heartbeat_failures: u32,
 }
 
 /// ZK proof type argument.
-#[derive(Clone, Copy, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum ZkProofTypeArg {
     /// Claim compressed ZK proofs.
     Compressed,
     /// Claim SNARK Groth16 proofs.
+    #[value(alias = "snark_groth16", alias = "groth16")]
     SnarkGroth16,
 }
 
-impl ZkProofTypeArg {
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Compressed => "compressed",
-            Self::SnarkGroth16 => "snark-groth16",
+impl From<ZkProofTypeArg> for ZkProofClaimType {
+    fn from(proof_type: ZkProofTypeArg) -> Self {
+        match proof_type {
+            ZkProofTypeArg::Compressed => Self::Compressed,
+            ZkProofTypeArg::SnarkGroth16 => Self::SnarkGroth16,
         }
     }
 }
 
-/// ZK virtual machine argument.
-#[derive(Clone, Copy, Debug, ValueEnum)]
-enum ZkVmArg {
-    /// SP1 ZKVM.
-    Sp1,
+/// ZK proving backend argument.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum ZkBackendArg {
+    /// Return placeholder proof bytes without an external backend.
+    Mock,
+    /// Return empty proof bytes without an external backend.
+    #[value(alias = "dry_run", alias = "dryrun")]
+    DryRun,
+}
+
+impl ZkBackendArg {
+    fn prover(self) -> Arc<dyn ZkProver> {
+        match self {
+            Self::Mock => Arc::new(MockZkProver),
+            Self::DryRun => Arc::new(DryRunZkProver),
+        }
+    }
+}
+
+impl fmt::Display for ZkBackendArg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Mock => f.write_str("mock"),
+            Self::DryRun => f.write_str("dry_run"),
+        }
+    }
 }
 
 impl Cli {
@@ -102,27 +158,46 @@ impl Cli {
             base_cli_utils::register_version_metrics!();
         })?;
 
-        RuntimeManager::new().run_until_ctrl_c(async move { args.run().await })
+        RuntimeManager::new()
+            .with_thread_stack_size(8 * 1024 * 1024)
+            .run_until_shutdown(|cancel| async move { args.run(cancel).await })
     }
 }
 
 impl ZkHostArgs {
-    async fn run(self) -> eyre::Result<()> {
-        info!(
-            prover_service_endpoint = %self.prover_service_endpoint,
-            prover_service_request_timeout_secs = self.prover_service_request_timeout_secs,
-            worker_id = ?self.worker_id,
-            proof_type = %self.proof_type.as_str(),
-            zk_vms = ?self.zk_vms,
-            job_discovery_poll_interval_ms = self.job_discovery_poll_interval_ms,
-            job_discovery_lock_duration_seconds = self.job_discovery_lock_duration_seconds,
-            job_discovery_max_concurrent_jobs = self.job_discovery_max_concurrent_jobs,
-            proof_generator_heartbeat_interval_secs = self.proof_generator_heartbeat_interval_secs,
-            proof_generator_heartbeat_lock_duration_seconds =
-                self.proof_generator_heartbeat_lock_duration_seconds,
-            "zk worker host configuration loaded"
-        );
+    async fn run(self, cancel: CancellationToken) -> eyre::Result<()> {
+        let worker_id = self.worker_id.unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
+        let proof_type = ZkProofClaimType::from(self.proof_type);
+        let prover = self.backend.prover();
 
-        Err(eyre!("zk prover-service worker loop is not wired yet"))
+        let client_config = ProverServiceClientConfig::new(self.prover_service_endpoint.clone())
+            .with_request_timeout(Duration::from_secs(self.prover_service_request_timeout_secs));
+        let client = ProverWorkerClient::connect(&client_config)
+            .wrap_err("failed to connect to prover service")?;
+
+        let heartbeat = ProofGeneratorHeartbeatConfig::with_max_consecutive_failures(
+            Duration::from_secs(self.proof_generator_heartbeat_interval_secs),
+            self.proof_generator_heartbeat_lock_duration_seconds,
+            self.proof_generator_max_consecutive_heartbeat_failures,
+        );
+        let host_config = ZkHostConfig::sp1(worker_id.clone(), proof_type)
+            .with_job_discovery_poll_interval(Duration::from_millis(
+                self.job_discovery_poll_interval_ms,
+            ))
+            .with_job_discovery_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
+            .with_job_discovery_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
+            .with_proof_generator_heartbeat(heartbeat);
+        let host = ZkHost::new(client, prover, host_config);
+
+        info!(
+            worker_id = %worker_id,
+            prover_service_endpoint = %self.prover_service_endpoint,
+            proof_type = ?proof_type,
+            backend = %self.backend,
+            "starting zk prover host worker"
+        );
+        host.run_until_cancelled(cancel).await;
+
+        Ok(())
     }
 }

--- a/crates/proof/zk/host/README.md
+++ b/crates/proof/zk/host/README.md
@@ -3,12 +3,11 @@
 Host-side ZK proving worker for the prover service.
 
 This crate adapts the shared worker machinery for ZK proving jobs. It provides
-[`ProofGenerator`], which claims a ZK job, drives a [`ZkProver`] backend to
-completion, and hands the proof result to `base_proof_worker::ProofSubmitter`.
+[`ZkHost`] and [`ProofGenerator`], which claim ZK jobs, drive a [`ZkProver`]
+backend to completion, and hand proof results to `base_proof_worker::ProofSubmitter`.
 
-The concrete SP1 backend is wired separately. [`UnimplementedZkProver`] is a
-placeholder for early host wiring.
+Concrete SP1 proving backends are provided by `base-proof-zk-backend`.
 
+[`ZkHost`]: crate::ZkHost
 [`ProofGenerator`]: crate::ProofGenerator
 [`ZkProver`]: crate::ZkProver
-[`UnimplementedZkProver`]: crate::UnimplementedZkProver

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -1,0 +1,170 @@
+//! ZK host orchestration.
+
+use std::{sync::Arc, time::Duration};
+
+use base_proof_worker::{
+    DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
+    DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobDiscovery, JobDiscoveryConfig, ProofSubmitter,
+};
+use base_prover_service_client::ProverWorkerProvider;
+use tokio_util::sync::CancellationToken;
+
+use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkProofClaimType, ZkProver, ZkVm};
+
+/// Settings for running a ZK host against the prover service.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZkHostConfig {
+    worker_id: String,
+    proof_type: ZkProofClaimType,
+    zk_vms: Vec<ZkVm>,
+    job_discovery_poll_interval: Duration,
+    job_discovery_lock_duration_seconds: u32,
+    job_discovery_max_concurrent_jobs: usize,
+    proof_generator_heartbeat: ProofGeneratorHeartbeatConfig,
+}
+
+impl ZkHostConfig {
+    /// Creates a ZK host config with default timing settings.
+    pub fn new(
+        worker_id: impl Into<String>,
+        proof_type: ZkProofClaimType,
+        zk_vms: impl Into<Vec<ZkVm>>,
+    ) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            proof_type,
+            zk_vms: zk_vms.into(),
+            job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
+            job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
+            job_discovery_max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
+            proof_generator_heartbeat: ProofGeneratorHeartbeatConfig::default(),
+        }
+    }
+
+    /// Creates an SP1 ZK host config with default timing settings.
+    pub fn sp1(worker_id: impl Into<String>, proof_type: ZkProofClaimType) -> Self {
+        Self::new(worker_id, proof_type, vec![ZkVm::Sp1])
+    }
+
+    /// Returns the worker identifier used for prover-service claims.
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    /// Returns the proof type claimed by the worker.
+    pub const fn proof_type(&self) -> ZkProofClaimType {
+        self.proof_type
+    }
+
+    /// Returns the ZK VMs claimed by the worker.
+    pub fn zk_vms(&self) -> &[ZkVm] {
+        &self.zk_vms
+    }
+
+    /// Returns the heartbeat settings used while proofs are generated.
+    pub const fn proof_generator_heartbeat(&self) -> ProofGeneratorHeartbeatConfig {
+        self.proof_generator_heartbeat
+    }
+
+    /// Returns the configured delay after empty or failed discovery attempts.
+    pub const fn job_discovery_poll_interval(&self) -> Duration {
+        self.job_discovery_poll_interval
+    }
+
+    /// Returns the requested claim lock duration in seconds.
+    pub const fn job_discovery_lock_duration_seconds(&self) -> u32 {
+        self.job_discovery_lock_duration_seconds
+    }
+
+    /// Returns the maximum number of claimed proof jobs generated concurrently.
+    pub const fn job_discovery_max_concurrent_jobs(&self) -> usize {
+        self.job_discovery_max_concurrent_jobs
+    }
+
+    /// Sets the delay after empty or failed discovery attempts.
+    #[must_use]
+    pub const fn with_job_discovery_poll_interval(
+        mut self,
+        job_discovery_poll_interval: Duration,
+    ) -> Self {
+        self.job_discovery_poll_interval = job_discovery_poll_interval;
+        self
+    }
+
+    /// Sets the requested claim lock duration in seconds.
+    #[must_use]
+    pub const fn with_job_discovery_lock_duration_seconds(
+        mut self,
+        job_discovery_lock_duration_seconds: u32,
+    ) -> Self {
+        self.job_discovery_lock_duration_seconds = job_discovery_lock_duration_seconds;
+        self
+    }
+
+    /// Sets the maximum number of claimed proof jobs generated concurrently.
+    #[must_use]
+    pub const fn with_job_discovery_max_concurrent_jobs(
+        mut self,
+        job_discovery_max_concurrent_jobs: usize,
+    ) -> Self {
+        self.job_discovery_max_concurrent_jobs = job_discovery_max_concurrent_jobs;
+        self
+    }
+
+    /// Sets the heartbeat settings used while proofs are generated.
+    #[must_use]
+    pub const fn with_proof_generator_heartbeat(
+        mut self,
+        proof_generator_heartbeat: ProofGeneratorHeartbeatConfig,
+    ) -> Self {
+        self.proof_generator_heartbeat = proof_generator_heartbeat;
+        self
+    }
+
+    /// Builds the shared worker discovery config.
+    pub fn job_discovery_config(&self) -> JobDiscoveryConfig {
+        JobDiscoveryConfig::zk(self.worker_id.clone(), self.proof_type, self.zk_vms.clone())
+            .with_poll_interval(self.job_discovery_poll_interval)
+            .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
+            .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
+    }
+}
+
+/// Runs ZK proof generation jobs claimed from the prover service.
+#[derive(Debug)]
+pub struct ZkHost<Client> {
+    client: Client,
+    prover: Arc<dyn ZkProver>,
+    config: ZkHostConfig,
+}
+
+impl<Client> ZkHost<Client> {
+    /// Creates a ZK host from a prover-service client and ZK prover backend.
+    pub const fn new(client: Client, prover: Arc<dyn ZkProver>, config: ZkHostConfig) -> Self {
+        Self { client, prover, config }
+    }
+
+    /// Returns the host config.
+    pub const fn config(&self) -> &ZkHostConfig {
+        &self.config
+    }
+}
+
+impl<Client> ZkHost<Client>
+where
+    Client: Clone + ProverWorkerProvider + 'static,
+{
+    /// Runs the host until cancellation is requested.
+    pub async fn run_until_cancelled(self, cancel: CancellationToken) {
+        let submitter = ProofSubmitter::new(self.client.clone());
+        let proof_generator = Arc::new(ProofGenerator::new(
+            self.prover,
+            submitter,
+            self.config.proof_generator_heartbeat,
+        ));
+        let discovery =
+            JobDiscovery::new(self.client, proof_generator, self.config.job_discovery_config());
+
+        discovery.run_until_cancelled(cancel).await;
+    }
+}

--- a/crates/proof/zk/host/src/lib.rs
+++ b/crates/proof/zk/host/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 
+pub use base_proof_worker::ZkProofClaimType;
+pub use base_prover_service_protocol::ZkVm;
+
 mod prover;
 pub use prover::{
     UnimplementedZkProver, ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState,
@@ -21,3 +24,6 @@ pub use proof_generator::{
     MIN_PROOF_GENERATOR_POLL_INTERVAL, ProofGenerator, ProofGeneratorError,
     ProofGeneratorHeartbeatConfig, ProofGeneratorRequest,
 };
+
+mod host;
+pub use host::{ZkHost, ZkHostConfig};


### PR DESCRIPTION
## Summary

Wire the zk-host binary to the shared ZK host orchestration with mock and dry-run backends, so it can claim prover-service ZK jobs and run the worker loop while leaving real Succinct cluster/network backend construction for follow-up changes.