### PR TITLE
feat(devnet): Unify Docker Devnet Binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -186,21 +186,21 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          docker buildx bake -f etc/docker/docker-bake.hcl client \
-            --set client.tags=${{ env.REGISTRY_IMAGE }} \
-            --set client.platform=${{ matrix.settings.arch }} \
-            --set client.output=type=image,push-by-digest=true,name-canonical=true,push=true \
-            --set client.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max \
-            --set client.labels.org.opencontainers.image.source=${{ steps.image-labels.outputs.source }} \
-            --set client.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }} \
-            --set client.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }} \
-            --set client.labels.org.opencontainers.image.version=${{ steps.image-labels.outputs.version }} \
-            --metadata-file ${{ runner.temp }}/client-metadata.json
+          docker buildx bake -f etc/docker/docker-bake.hcl base \
+            --set base.tags=${{ env.REGISTRY_IMAGE }} \
+            --set base.platform=${{ matrix.settings.arch }} \
+            --set base.output=type=image,push-by-digest=true,name-canonical=true,push=true \
+            --set base.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max \
+            --set base.labels.org.opencontainers.image.source=${{ steps.image-labels.outputs.source }} \
+            --set base.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }} \
+            --set base.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }} \
+            --set base.labels.org.opencontainers.image.version=${{ steps.image-labels.outputs.version }} \
+            --metadata-file ${{ runner.temp }}/base-metadata.json
 
       - name: Export digest
         run: |
           mkdir -p ${{ runner.temp }}/digests
-          digest="$(jq -er '."client"."containerimage.digest"' ${{ runner.temp }}/client-metadata.json)"
+          digest="$(jq -er '."base"."containerimage.digest"' ${{ runner.temp }}/base-metadata.json)"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -254,7 +254,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker image
-        run: docker buildx bake -f etc/docker/docker-bake.hcl client --load
+        run: docker buildx bake -f etc/docker/docker-bake.hcl base --load
 
   test-musl-sigsegv:
     name: Test SIGSEGV (musl)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,20 +62,20 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          docker buildx bake -f etc/docker/docker-bake.hcl client \
-            --set client.tags=${{ env.REGISTRY_IMAGE }} \
-            --set client.platform=${{ matrix.settings.arch }} \
-            --set client.output=type=image,push-by-digest=true,name-canonical=true,push=true \
-            --set client.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max \
-            --set client.labels.org.opencontainers.image.source=${{ steps.image-labels.outputs.source }} \
-            --set client.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }} \
-            --set client.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }} \
-            --metadata-file ${{ runner.temp }}/client-metadata.json
+          docker buildx bake -f etc/docker/docker-bake.hcl base \
+            --set base.tags=${{ env.REGISTRY_IMAGE }} \
+            --set base.platform=${{ matrix.settings.arch }} \
+            --set base.output=type=image,push-by-digest=true,name-canonical=true,push=true \
+            --set base.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max \
+            --set base.labels.org.opencontainers.image.source=${{ steps.image-labels.outputs.source }} \
+            --set base.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }} \
+            --set base.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }} \
+            --metadata-file ${{ runner.temp }}/base-metadata.json
 
       - name: Export digest
         run: |
           mkdir -p ${{ runner.temp }}/digests
-          digest="$(jq -er '."client"."containerimage.digest"' ${{ runner.temp }}/client-metadata.json)"
+          digest="$(jq -er '."base"."containerimage.digest"' ${{ runner.temp }}/base-metadata.json)"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
@@ -89,7 +89,7 @@ jobs:
   warm-devnet-cache:
     strategy:
       matrix:
-        target: [builder, consensus, batcher]
+        target: [base, batcher]
 
     runs-on: ubuntu-24.04
 

--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -10,7 +10,7 @@ consensus node connects to that IPC endpoint internally.
 
 The execution CLI surface is shared with the standalone execution binaries through
 `base-execution-cli`. `base rpc` intentionally filters out flags for roles it does not run, including
-sequencer, builder, conductor, metering, and transaction-forwarding options.
+sequencer, builder, conductor, and transaction-forwarding options.
 
 Supported forms:
 
@@ -19,6 +19,7 @@ base rpc
 base --chain sepolia rpc
 base -c sepolia rpc
 base --chain zeronet rpc
+base --chain dev rpc
 base --chain ./chain.toml rpc
 base -c ./chain.toml rpc
 ```
@@ -29,6 +30,9 @@ for consensus chain resolution:
 ```text
 base rpc --execution-chain dev
 ```
+
+The command also accepts metering flags such as `--enable-metering` for trusted local devnet
+simulation nodes.
 
 ## `base sequencer`
 
@@ -45,6 +49,7 @@ Supported forms:
 ```text
 base sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.sequencer.key.path <path>
 base --chain sepolia sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.signer.endpoint <url>
+base --chain dev sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.sequencer.key.path <path>
 base --chain ./chain.toml sequencer --l1-eth-rpc <url> --l1-beacon <url> --p2p.sequencer.key.path <path>
 ```
 
@@ -77,7 +82,7 @@ base update --update-installer
 
 Chain selection supports:
 
-- built-in names: `mainnet`, `sepolia`, `zeronet`
+- built-in names: `mainnet`, `sepolia`, `zeronet`, `dev`
 - TOML files for custom chains:
 
 ```toml

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -432,8 +432,8 @@ mod tests {
 
         let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
 
-        assert!(launch_config.standard.enable_metering);
-        assert_eq!(launch_config.standard.metering_execution_time_us, Some(5_000_000));
+        assert!(launch_config.standard.metering.enable_metering);
+        assert_eq!(launch_config.standard.metering.metering_execution_time_us, Some(5_000_000));
     }
 
     #[test]

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -128,7 +128,11 @@ mod tests {
     use base_execution_chainspec::BaseChainSpec;
     use clap::Parser;
 
-    use crate::{cli::BaseCli, commands::BaseCommand, config::ChainArg};
+    use crate::{
+        cli::BaseCli,
+        commands::BaseCommand,
+        config::{BuiltInChain, ChainArg},
+    };
 
     const RPC_FORWARDING_ENDPOINT_ENV: &str = "OP_RETH_SEQUENCER_HTTP";
     const RPC_FORWARDING_ENDPOINT_ENV_CHILD_TEST: &str =
@@ -229,7 +233,7 @@ mod tests {
             "-vvv",
         ]);
 
-        assert!(matches!(cli.chain, ChainArg::File(_)));
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Dev)));
         let BaseCommand::Rpc(rpc) = cli.command else {
             panic!("expected rpc command");
         };
@@ -413,12 +417,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_rpc_metering_args() {
-        let err =
-            BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--enable-metering"])).unwrap_err();
+    fn parses_rpc_metering_args() {
+        let cli = BaseCli::parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--enable-metering",
+            "--metering.execution-time-us",
+            "5000000",
+        ]));
 
-        let rendered = err.to_string();
-        assert!(rendered.contains("--enable-metering"));
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
+
+        assert!(launch_config.standard.enable_metering);
+        assert_eq!(launch_config.standard.metering_execution_time_us, Some(5_000_000));
     }
 
     #[test]

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -29,6 +29,8 @@ pub(crate) enum BuiltInChain {
     Sepolia,
     /// Base zeronet.
     Zeronet,
+    /// Local Base devnet.
+    Dev,
 }
 
 impl BuiltInChain {
@@ -38,6 +40,7 @@ impl BuiltInChain {
             Self::Mainnet => "mainnet",
             Self::Sepolia => "sepolia",
             Self::Zeronet => "zeronet",
+            Self::Dev => "dev",
         }
     }
 
@@ -47,6 +50,7 @@ impl BuiltInChain {
             Self::Mainnet => BuiltInChainConfig::mainnet(),
             Self::Sepolia => BuiltInChainConfig::sepolia(),
             Self::Zeronet => BuiltInChainConfig::zeronet(),
+            Self::Dev => BuiltInChainConfig::devnet(),
         }
     }
 }
@@ -65,8 +69,9 @@ impl FromStr for BuiltInChain {
             "mainnet" => Ok(Self::Mainnet),
             "sepolia" => Ok(Self::Sepolia),
             "zeronet" => Ok(Self::Zeronet),
+            "dev" => Ok(Self::Dev),
             _ => Err(format!(
-                "unsupported built-in chain `{value}`; expected one of mainnet, sepolia, zeronet"
+                "unsupported built-in chain `{value}`; expected one of mainnet, sepolia, zeronet, dev"
             )),
         }
     }
@@ -273,6 +278,22 @@ mod tests {
             assert_eq!(resolved.name, "zeronet");
             assert_eq!(resolved.l2_chain_id, 763360);
             assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Zeronet));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn resolves_dev_builtin() {
+        with_cleared_env(|_| {
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Dev)).resolve().unwrap();
+
+            assert_eq!(resolved.name, "dev");
+            assert_eq!(resolved.l2_chain_id, 1337);
+            assert_eq!(resolved.l1_chain_id, 900);
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Dev));
 
             Ok(())
         });

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -19,8 +19,7 @@ pub use node::{
     ExecutionNodeRuntimeConfig,
 };
 /// Standard Base execution-node runner wiring.
-pub mod standard_node;
-
+mod standard_node;
 use std::{ffi::OsString, fmt, marker::PhantomData};
 
 pub use app::CliApp;
@@ -42,7 +41,9 @@ use reth_node_core::{
 // reporting
 use reth_node_metrics as _;
 use reth_rpc_server_types::{LenientRpcModuleValidator, RpcModuleValidator};
-pub use standard_node::{RpcStandardNodeArgs, StandardBaseRethNode, StandardNodeArgs};
+pub use standard_node::{
+    MeteringArgs, RpcStandardNodeArgs, StandardBaseRethNode, StandardNodeArgs,
+};
 mod upgrade_signal;
 pub use upgrade_signal::{
     ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalMetricsExtension,

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -20,7 +20,7 @@ use reth_node_core::{
 use reth_rpc_server_types::{LenientRpcModuleValidator, RpcModuleValidator};
 use tracing::info;
 
-use crate::{RpcStandardNodeArgs, StandardNodeArgs};
+use crate::{MeteringArgs, RpcStandardNodeArgs, StandardNodeArgs};
 
 const DEFAULT_BASE_MAX_INBOUND_EL_PEERS: usize = 80;
 const DEFAULT_BASE_MAX_OUTBOUND_EL_PEERS: usize = 80;
@@ -166,6 +166,10 @@ pub struct ExecutionNodeArgs {
     /// Standard Base execution-node extension arguments.
     #[command(flatten)]
     pub standard: RpcStandardNodeArgs,
+
+    /// Metering RPC and priority-fee resource budget arguments.
+    #[command(flatten)]
+    pub metering: MeteringArgs,
 }
 
 impl ExecutionNodeArgs {
@@ -174,7 +178,7 @@ impl ExecutionNodeArgs {
         let runtime = self.node.into_runtime_config(chain);
         ExecutionNodeLaunchConfig {
             node_config: runtime.node_config,
-            standard: self.standard.into(),
+            standard: StandardNodeArgs::from(self.standard).with_metering(self.metering),
             with_unused_ports: runtime.with_unused_ports,
             upgrade_signal_startup: runtime.upgrade_signal_startup,
         }
@@ -369,6 +373,25 @@ mod tests {
             args.standard.flashblocks_url.as_ref().map(Url::as_str),
             Some("wss://example.com/ws")
         );
+        assert!(!args.metering.enable_metering);
+    }
+
+    #[test]
+    fn standard_execution_args_parse_metering_separately() {
+        let args = CommandParser::<ExecutionNodeArgs>::parse_from([
+            "reth",
+            "--enable-metering",
+            "--metering.execution-time-us",
+            "5000000",
+        ])
+        .args;
+
+        assert!(args.metering.enable_metering);
+        assert_eq!(args.metering.metering_execution_time_us, Some(5_000_000));
+
+        let launch_config = args.into_launch_config(Arc::new(BaseChainSpec::devnet()));
+        assert!(launch_config.standard.metering.enable_metering);
+        assert_eq!(launch_config.standard.metering.metering_execution_time_us, Some(5_000_000));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -22,14 +22,9 @@ use crate::upgrade_signal::{
     ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalMetricsExtension,
 };
 
-/// CLI arguments for a standard Base execution node.
-#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
-#[command(next_help_heading = "Rollup")]
-pub struct StandardNodeArgs {
-    /// Shared execution node arguments.
-    #[command(flatten)]
-    pub rpc: RpcStandardNodeArgs,
-
+/// CLI arguments for metering RPC and priority-fee resource budgets.
+#[derive(Debug, Clone, PartialEq, Eq, Default, clap::Args)]
+pub struct MeteringArgs {
     /// Enable metering RPC for transaction bundle simulation
     #[arg(long = "enable-metering", value_name = "ENABLE_METERING")]
     pub enable_metering: bool,
@@ -70,6 +65,19 @@ pub struct StandardNodeArgs {
     /// (e.g., "SSTORE,SLOAD,KECCAK256"). Precompile gas is always tracked.
     #[arg(long = "metering.metered-opcodes", requires = "enable_metering", value_delimiter = ',')]
     pub metering_metered_opcodes: Vec<String>,
+}
+
+/// CLI arguments for a standard Base execution node.
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+#[command(next_help_heading = "Rollup")]
+pub struct StandardNodeArgs {
+    /// Shared execution node arguments.
+    #[command(flatten)]
+    pub rpc: RpcStandardNodeArgs,
+
+    /// Metering RPC and priority-fee resource budget arguments.
+    #[command(flatten)]
+    pub metering: MeteringArgs,
 
     /// Enable transaction forwarding for mempool nodes to builder RPC endpoints
     #[arg(
@@ -171,47 +179,6 @@ pub struct RpcStandardNodeArgs {
         value_name = "ENABLE_TRANSACTION_TRACING_LOGS"
     )]
     pub enable_transaction_tracing_logs: bool,
-
-    /// Enable metering RPC for transaction bundle simulation.
-    #[arg(long = "enable-metering", value_name = "ENABLE_METERING")]
-    pub enable_metering: bool,
-
-    /// Whole-block gas budget for priority fee estimation.
-    #[arg(
-        long = "metering.gas-limit",
-        requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
-    )]
-    pub metering_gas_limit: Option<u64>,
-
-    /// Per-flashblock execution time budget in microseconds for priority fee estimation.
-    #[arg(long = "metering.execution-time-us", requires = "enable_metering")]
-    pub metering_execution_time_us: Option<u64>,
-
-    /// Whole-block state root computation budget in microseconds for priority fee estimation.
-    #[arg(
-        long = "metering.state-root-time-us",
-        requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
-    )]
-    pub metering_state_root_time_us: Option<u64>,
-
-    /// Whole-block data availability byte budget for priority fee estimation.
-    #[arg(
-        long = "metering.da-bytes",
-        requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
-    )]
-    pub metering_da_bytes: Option<u64>,
-
-    /// Target number of tx-pool flashblocks the builder budgets per block.
-    ///
-    /// This excludes the base flashblock at index `0` and is required when gas, state root
-    /// time, or DA estimation is enabled.
-    #[arg(long = "metering.target-flashblocks-per-block", requires = "enable_metering")]
-    pub metering_target_flashblocks_per_block: Option<usize>,
-
-    /// Comma-separated list of EVM opcodes to track for gas metering
-    /// (e.g., "SSTORE,SLOAD,KECCAK256"). Precompile gas is always tracked.
-    #[arg(long = "metering.metered-opcodes", requires = "enable_metering", value_delimiter = ',')]
-    pub metering_metered_opcodes: Vec<String>,
 }
 
 impl From<RpcStandardNodeArgs> for StandardNodeArgs {
@@ -220,29 +187,23 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
             args.rollup_args.sequencer.clone_from(&args.rpc_forwarding_endpoint);
         }
 
-        let enable_metering = args.enable_metering;
-        let metering_gas_limit = args.metering_gas_limit;
-        let metering_execution_time_us = args.metering_execution_time_us;
-        let metering_state_root_time_us = args.metering_state_root_time_us;
-        let metering_da_bytes = args.metering_da_bytes;
-        let metering_target_flashblocks_per_block = args.metering_target_flashblocks_per_block;
-        let metering_metered_opcodes = args.metering_metered_opcodes.clone();
-
         Self {
             rpc: args,
-            enable_metering,
-            metering_gas_limit,
-            metering_execution_time_us,
-            metering_state_root_time_us,
-            metering_da_bytes,
-            metering_target_flashblocks_per_block,
-            metering_metered_opcodes,
+            metering: MeteringArgs::default(),
             enable_tx_forwarding: false,
             builder_rpc_urls: Vec::new(),
             tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
             tx_forwarding_batch_size: DEFAULT_MAX_BATCH_SIZE,
             tx_forwarding_max_rps: DEFAULT_MAX_RPS,
         }
+    }
+}
+
+impl StandardNodeArgs {
+    /// Sets the metering arguments on this standard node configuration.
+    pub fn with_metering(mut self, metering: MeteringArgs) -> Self {
+        self.metering = metering;
+        self
     }
 }
 
@@ -386,16 +347,16 @@ impl StandardBaseRethNode {
         });
 
         let resource_limits = MeteringResourceLimits {
-            gas_limit: args.metering_gas_limit,
-            execution_time_us: args.metering_execution_time_us,
-            state_root_time_us: args.metering_state_root_time_us,
-            da_bytes: args.metering_da_bytes,
+            gas_limit: args.metering.metering_gas_limit,
+            execution_time_us: args.metering.metering_execution_time_us,
+            state_root_time_us: args.metering.metering_state_root_time_us,
+            da_bytes: args.metering.metering_da_bytes,
         };
-        let metering_config = if args.enable_metering {
-            let metered_opcodes = if args.metering_metered_opcodes.is_empty() {
+        let metering_config = if args.metering.enable_metering {
+            let metered_opcodes = if args.metering.metering_metered_opcodes.is_empty() {
                 MeteredOpcodes::default()
             } else {
-                MeteredOpcodes::parse(&args.metering_metered_opcodes)?
+                MeteredOpcodes::parse(&args.metering.metering_metered_opcodes)?
             }
             .with_all_precompiles();
 
@@ -404,7 +365,9 @@ impl StandardBaseRethNode {
                 .map_or_else(MeteringConfig::enabled, MeteringConfig::with_flashblocks)
                 .with_resource_limits(resource_limits)
                 .with_metered_opcodes(metered_opcodes);
-            if let Some(target_flashblocks_per_block) = args.metering_target_flashblocks_per_block {
+            if let Some(target_flashblocks_per_block) =
+                args.metering.metering_target_flashblocks_per_block
+            {
                 config = config.with_target_flashblocks_per_block(target_flashblocks_per_block);
             }
             config
@@ -493,13 +456,6 @@ mod tests {
             flashblocks_ping_interval: Duration::from_secs(30),
             enable_transaction_tracing: false,
             enable_transaction_tracing_logs: false,
-            enable_metering: false,
-            metering_gas_limit: None,
-            metering_execution_time_us: None,
-            metering_state_root_time_us: None,
-            metering_da_bytes: None,
-            metering_target_flashblocks_per_block: None,
-            metering_metered_opcodes: Vec::new(),
         }
     }
 
@@ -610,5 +566,19 @@ mod tests {
         .expect_err("upgrade signal contract should require an explicit execution L1 RPC");
 
         assert!(error.to_string().contains("--upgrade-signal.l1-rpc"));
+    }
+
+    #[test]
+    fn test_standard_node_args_parses_metering_flags_once() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
+            "reth",
+            "--enable-metering",
+            "--metering.execution-time-us",
+            "5000000",
+        ])
+        .args;
+
+        assert!(args.metering.enable_metering);
+        assert_eq!(args.metering.metering_execution_time_us, Some(5_000_000));
     }
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -171,6 +171,47 @@ pub struct RpcStandardNodeArgs {
         value_name = "ENABLE_TRANSACTION_TRACING_LOGS"
     )]
     pub enable_transaction_tracing_logs: bool,
+
+    /// Enable metering RPC for transaction bundle simulation.
+    #[arg(long = "enable-metering", value_name = "ENABLE_METERING")]
+    pub enable_metering: bool,
+
+    /// Whole-block gas budget for priority fee estimation.
+    #[arg(
+        long = "metering.gas-limit",
+        requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
+    )]
+    pub metering_gas_limit: Option<u64>,
+
+    /// Per-flashblock execution time budget in microseconds for priority fee estimation.
+    #[arg(long = "metering.execution-time-us", requires = "enable_metering")]
+    pub metering_execution_time_us: Option<u64>,
+
+    /// Whole-block state root computation budget in microseconds for priority fee estimation.
+    #[arg(
+        long = "metering.state-root-time-us",
+        requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
+    )]
+    pub metering_state_root_time_us: Option<u64>,
+
+    /// Whole-block data availability byte budget for priority fee estimation.
+    #[arg(
+        long = "metering.da-bytes",
+        requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
+    )]
+    pub metering_da_bytes: Option<u64>,
+
+    /// Target number of tx-pool flashblocks the builder budgets per block.
+    ///
+    /// This excludes the base flashblock at index `0` and is required when gas, state root
+    /// time, or DA estimation is enabled.
+    #[arg(long = "metering.target-flashblocks-per-block", requires = "enable_metering")]
+    pub metering_target_flashblocks_per_block: Option<usize>,
+
+    /// Comma-separated list of EVM opcodes to track for gas metering
+    /// (e.g., "SSTORE,SLOAD,KECCAK256"). Precompile gas is always tracked.
+    #[arg(long = "metering.metered-opcodes", requires = "enable_metering", value_delimiter = ',')]
+    pub metering_metered_opcodes: Vec<String>,
 }
 
 impl From<RpcStandardNodeArgs> for StandardNodeArgs {
@@ -179,15 +220,23 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
             args.rollup_args.sequencer.clone_from(&args.rpc_forwarding_endpoint);
         }
 
+        let enable_metering = args.enable_metering;
+        let metering_gas_limit = args.metering_gas_limit;
+        let metering_execution_time_us = args.metering_execution_time_us;
+        let metering_state_root_time_us = args.metering_state_root_time_us;
+        let metering_da_bytes = args.metering_da_bytes;
+        let metering_target_flashblocks_per_block = args.metering_target_flashblocks_per_block;
+        let metering_metered_opcodes = args.metering_metered_opcodes.clone();
+
         Self {
             rpc: args,
-            enable_metering: false,
-            metering_gas_limit: None,
-            metering_execution_time_us: None,
-            metering_state_root_time_us: None,
-            metering_da_bytes: None,
-            metering_target_flashblocks_per_block: None,
-            metering_metered_opcodes: Vec::new(),
+            enable_metering,
+            metering_gas_limit,
+            metering_execution_time_us,
+            metering_state_root_time_us,
+            metering_da_bytes,
+            metering_target_flashblocks_per_block,
+            metering_metered_opcodes,
             enable_tx_forwarding: false,
             builder_rpc_urls: Vec::new(),
             tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
@@ -444,6 +493,13 @@ mod tests {
             flashblocks_ping_interval: Duration::from_secs(30),
             enable_transaction_tracing: false,
             enable_transaction_tracing_logs: false,
+            enable_metering: false,
+            metering_gas_limit: None,
+            metering_execution_time_us: None,
+            metering_state_root_time_us: None,
+            metering_da_bytes: None,
+            metering_target_flashblocks_per_block: None,
+            metering_metered_opcodes: Vec::new(),
         }
     }
 

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -110,12 +110,12 @@ pub struct ConductorNodeConfig {
     /// If set, the TUI can restart this container with `r`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docker_conductor: Option<String>,
-    /// Docker container name for the EL (execution layer) process.
+    /// Docker container name for the EL (execution layer) process or unified node.
     ///
     /// If set, the TUI can restart this container with `r`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docker_el: Option<String>,
-    /// Docker container name for the CL (consensus layer) process.
+    /// Docker container name for the CL (consensus layer) process or unified node.
     ///
     /// If set, the TUI can restart this container with `r`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -554,7 +554,7 @@ impl MonitoringConfig {
                     el_rpc: Some(Url::parse("http://localhost:7545").unwrap()),
                     docker_conductor: Some("op-conductor-0".to_string()),
                     docker_el: Some("base-builder".to_string()),
-                    docker_cl: Some("base-builder-cl".to_string()),
+                    docker_cl: Some("base-builder".to_string()),
                     flashblocks_ws: Some(Url::parse("ws://localhost:7111").unwrap()),
                 },
                 ConductorNodeConfig {
@@ -566,7 +566,7 @@ impl MonitoringConfig {
                     el_rpc: Some(Url::parse("http://localhost:10545").unwrap()),
                     docker_conductor: Some("op-conductor-1".to_string()),
                     docker_el: Some("base-sequencer-1".to_string()),
-                    docker_cl: Some("base-sequencer-1-cl".to_string()),
+                    docker_cl: Some("base-sequencer-1".to_string()),
                     flashblocks_ws: Some(Url::parse("ws://localhost:10111").unwrap()),
                 },
                 ConductorNodeConfig {
@@ -578,18 +578,18 @@ impl MonitoringConfig {
                     el_rpc: Some(Url::parse("http://localhost:11545").unwrap()),
                     docker_conductor: Some("op-conductor-2".to_string()),
                     docker_el: Some("base-sequencer-2".to_string()),
-                    docker_cl: Some("base-sequencer-2-cl".to_string()),
+                    docker_cl: Some("base-sequencer-2".to_string()),
                     flashblocks_ws: Some(Url::parse("ws://localhost:11111").unwrap()),
                 },
             ]),
             validators: Some(vec![
                 ValidatorNodeConfig {
                     name: "base-client".to_string(),
-                    binary: Some("/app/base-client + /app/base-consensus".to_string()),
+                    binary: Some("/app/base".to_string()),
                     cl_rpc: Url::parse("http://localhost:8549").unwrap(),
                     el_rpc: Some(Url::parse("http://localhost:8545").unwrap()),
                     docker_el: Some("base-client".to_string()),
-                    docker_cl: Some("base-client-cl".to_string()),
+                    docker_cl: Some("base-client".to_string()),
                 },
                 ValidatorNodeConfig {
                     name: "base-rpc".to_string(),
@@ -759,11 +759,11 @@ mod tests {
         let validators = devnet.validators.expect("devnet should include validator/RPC node");
         assert_eq!(validators.len(), 2);
         assert_eq!(validators[0].name, "base-client");
-        assert_eq!(validators[0].binary.as_deref(), Some("/app/base-client + /app/base-consensus"));
+        assert_eq!(validators[0].binary.as_deref(), Some("/app/base"));
         assert_eq!(validators[0].cl_rpc.as_str(), "http://localhost:8549/");
         assert_eq!(validators[0].el_rpc.as_ref().unwrap().as_str(), "http://localhost:8545/");
         assert_eq!(validators[0].docker_el.as_deref(), Some("base-client"));
-        assert_eq!(validators[0].docker_cl.as_deref(), Some("base-client-cl"));
+        assert_eq!(validators[0].docker_cl.as_deref(), Some("base-client"));
         assert_eq!(validators[1].name, "base-rpc");
         assert_eq!(validators[1].binary.as_deref(), Some("/app/base"));
         assert_eq!(validators[1].cl_rpc.as_str(), "http://localhost:8649/");

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -394,6 +394,22 @@ impl ConductorControl {
         )
     }
 
+    /// Returns docker containers to restart in dependency order, with duplicate names removed.
+    pub fn restart_containers(node: &ConductorNodeConfig) -> Vec<&str> {
+        let ordered = [
+            node.docker_el.as_deref(),
+            node.docker_cl.as_deref(),
+            node.docker_conductor.as_deref(),
+        ];
+        let mut containers = Vec::new();
+        for container in ordered.into_iter().flatten() {
+            if !containers.contains(&container) {
+                containers.push(container);
+            }
+        }
+        containers
+    }
+
     /// Pauses op-conductor's control loop on a single node.
     pub async fn pause_node(node: &ConductorNodeConfig) -> anyhow::Result<String> {
         const TIMEOUT: Duration = Duration::from_secs(5);
@@ -764,10 +780,7 @@ pub async fn restart_conductor_node(
     node: ConductorNodeConfig,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
-    // Dependency order: EL must be healthy before CL starts, CL before conductor.
-    let ordered: &[Option<&str>] =
-        &[node.docker_el.as_deref(), node.docker_cl.as_deref(), node.docker_conductor.as_deref()];
-    let containers: Vec<&str> = ordered.iter().filter_map(|c| *c).collect();
+    let containers = ConductorControl::restart_containers(&node);
 
     let outcome: anyhow::Result<String> = async {
         if containers.is_empty() {
@@ -1211,6 +1224,19 @@ mod tests {
         assert_eq!(nodes.len(), 2);
         assert_eq!(nodes[0].name, "op-conductor-0");
         assert_eq!(nodes[1].name, "op-conductor-1");
+    }
+
+    #[test]
+    fn restart_containers_deduplicates_unified_node_container() {
+        let mut node = node("op-conductor-0", "sequencer-0");
+        node.docker_el = Some("base-builder".to_string());
+        node.docker_cl = Some("base-builder".to_string());
+        node.docker_conductor = Some("op-conductor-0".to_string());
+
+        assert_eq!(
+            ConductorControl::restart_containers(&node),
+            vec!["base-builder", "op-conductor-0"]
+        );
     }
 
     #[test]

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -38,22 +38,6 @@ RUN set -eux; \
 FROM rust-builder-base AS source
 COPY . .
 
-FROM source AS client-builder
-ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=client-target,sharing=locked \
-    cargo build --profile $PROFILE \
-      --bin base-reth-node \
-      --bin base-consensus \
-      --bin basectl \
-      --bin snapshotter && \
-    target_dir="/app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")" && \
-    cp "$target_dir/base-reth-node" /app/base-client && \
-    cp "$target_dir/base-consensus" /app/base-consensus && \
-    cp "$target_dir/basectl" /app/basectl && \
-    cp "$target_dir/snapshotter" /app/snapshotter
-
 FROM source AS base-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
@@ -61,22 +45,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/target,id=base-target,sharing=locked \
     cargo build --profile $PROFILE --package base --bin base && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base /app/base
-
-FROM source AS builder-builder
-ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=builder-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
-    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-builder /app/base-builder
-
-FROM source AS consensus-builder
-ARG PROFILE=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=consensus-target,sharing=locked \
-    cargo build --profile $PROFILE --bin base-consensus && \
-    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-consensus /app/base-consensus
 
 FROM source AS proposer-builder
 ARG PROFILE=release
@@ -136,24 +104,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-FROM runtime-base AS client
-COPY --from=client-builder /app/base-client ./base-client
-COPY --from=client-builder /app/base-consensus ./base-consensus
-COPY --from=client-builder /app/basectl ./basectl
-COPY --from=client-builder /app/snapshotter ./snapshotter
-ENTRYPOINT ["./base-client"]
-
 FROM runtime-base AS base
 COPY --from=base-builder /app/base ./base
 ENTRYPOINT ["./base"]
-
-FROM runtime-base AS builder
-COPY --from=builder-builder /app/base-builder ./base-builder
-ENTRYPOINT ["./base-builder"]
-
-FROM runtime-base AS consensus
-COPY --from=consensus-builder /app/base-consensus ./base-consensus
-ENTRYPOINT ["./base-consensus"]
 
 FROM runtime-base AS proposer
 COPY --from=proposer-builder /app/base-proposer ./base-proposer

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -59,9 +59,9 @@ flashblocks:
 logs *containers:
     docker compose {{ _env }} {{ _ha }} logs -f {{ containers }}
 
-# Stream logs from the sequencer's execution (EL) and consensus (CL) layers
+# Stream logs from the primary unified sequencer
 sequencer-logs:
-    docker compose {{ _env }} {{ _ha }} logs -f base-builder base-builder-cl
+    docker compose {{ _env }} {{ _ha }} logs -f base-builder
 
 # Stream logs from the devnet ZK prover services
 zk-logs *containers:
@@ -72,7 +72,7 @@ zk-down:
     -docker compose {{ _env }} {{ _ha }} stop base-prover-zk zk-prover-postgres
     -docker compose {{ _env }} {{ _ha }} rm -f base-prover-zk zk-prover-postgres
 
-# Follow the active raft leader's CL logs, switching automatically on failover
+# Follow the active raft leader's unified sequencer logs, switching automatically on failover
 follow-leader:
     ./etc/scripts/devnet/follow-leader.sh
 
@@ -97,8 +97,8 @@ ingress-down:
 ingress-logs *containers:
     docker compose {{ _env }} {{ _ha }} -f etc/docker/docker-compose.ingress.yml logs -f {{ containers }}
 
-# Builds one of the shared Rust service images (default: client)
-build-image target='client' profile='dev':
+# Builds one of the shared Rust service images (default: base)
+build-image target='base' profile='dev':
     #!/usr/bin/env bash
     set -euo pipefail
     case "$(uname -m)" in

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -4,7 +4,7 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 
 ## Dockerfiles
 
-`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It bundles `base-consensus`, `basectl`, and `snapshotter`, while preserving the historical `base-client` entrypoint by copying the `base-reth-node` binary into the image under that compatible name.
+`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. The local devnet builds the unified `base` image for L2 bootnode, sequencer, and validator/RPC nodes.
 
 `Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) and setup scripts. This image bootstraps L1 and L2 chain configurations for local development.
 
@@ -15,8 +15,7 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 The `docker-compose.yml` orchestrates a complete local devnet environment with both L1 and L2 chains. It spins up:
 
 - An L1 execution client (Reth) and consensus client (Lighthouse) with a validator
-- The Base builder and client nodes on L2
-- Base consensus layer nodes (`base-consensus`) for both builder and client
+- Unified Base sequencer and validator/RPC nodes on L2
 - The `base-batcher` for submitting L2 data to L1
 - The `base-prover-zk` service in `SP1_PROVER=dry-run` mode with local Postgres storage
 
@@ -36,11 +35,11 @@ just devnet status # Check block numbers and sync status
 To build a specific Rust service image directly:
 
 ```bash
-just devnet build-image client release
+just devnet build-image base release
 ```
 
 Plain `docker build` still works if you prefer it:
 
 ```bash
-docker build -t base-reth-node -f etc/docker/Dockerfile.rust-services --target client .
+docker build -t base -f etc/docker/Dockerfile.rust-services --target base .
 ```

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -23,15 +23,12 @@ variable "PLATFORM_PAIR" {
 }
 
 group "default" {
-  targets = ["client"]
+  targets = ["base"]
 }
 
 group "rust-services" {
   targets = [
     "base",
-    "client",
-    "builder",
-    "consensus",
     "proposer",
     "websocket-proxy",
     "ingress-rpc",
@@ -42,14 +39,11 @@ group "rust-services" {
 }
 
 group "devnet" {
-  targets = ["builder", "consensus", "client", "base", "batcher", "zk-prover"]
+  targets = ["base", "batcher", "zk-prover"]
 }
 
 group "ingress" {
   targets = [
-    "builder",
-    "consensus",
-    "client",
     "base",
     "ingress-rpc",
     "audit-archiver",
@@ -67,36 +61,10 @@ target "_rust-service-common" {
   cache-from = ["type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}"]
 }
 
-target "client" {
-  inherits = ["_rust-service-common"]
-  target = "client"
-  tags = ["base-reth-node:local"]
-}
-
 target "base" {
   inherits = ["_rust-service-common"]
   target = "base"
   tags = ["base:local"]
-}
-
-target "builder" {
-  inherits = ["_rust-service-common"]
-  target = "builder"
-  tags = ["base-builder:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-builder-${PLATFORM_PAIR}",
-  ]
-}
-
-target "consensus" {
-  inherits = ["_rust-service-common"]
-  target = "consensus"
-  tags = ["base-consensus:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-consensus-${PLATFORM_PAIR}",
-  ]
 }
 
 target "proposer" {

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -1,28 +1,17 @@
-x-sequencer-el-base: &sequencer-el-base
-  image: base-builder:local
+x-sequencer-base: &sequencer-base
+  image: base:local
   build:
     context: ../..
     dockerfile: etc/docker/Dockerfile.rust-services
     args:
       PROFILE: "${CARGO_PROFILE:-dev}"
-    target: builder
-  entrypoint: /app/base-builder
+    target: base
+  entrypoint: /app/base
   depends_on:
     setup-l2:
       condition: service_completed_successfully
-    base-el-bootnode:
-      condition: service_started
-  restart: unless-stopped
-
-x-sequencer-cl-base: &sequencer-cl-base
-  image: base-consensus:local
-  build:
-    context: ../..
-    dockerfile: etc/docker/Dockerfile.rust-services
-    args:
-      PROFILE: "${CARGO_PROFILE:-dev}"
-    target: consensus
-  entrypoint: /app/base-consensus
+    base-bootnode:
+      condition: service_healthy
   restart: unless-stopped
 
 x-conductor-base: &conductor-base
@@ -45,58 +34,18 @@ services:
   setup-l2:
     volumes:
       - ../../.devnet/l2/sequencer-1:/data/l2-sequencer-1
-      - ../../.devnet/l2/sequencer-1-cl:/data/l2-sequencer-1-cl
       - ../../.devnet/l2/sequencer-2:/data/l2-sequencer-2
-      - ../../.devnet/l2/sequencer-2-cl:/data/l2-sequencer-2-cl
     environment:
       - SEQ1_P2P_KEY=${SEQ1_P2P_KEY}
       - SEQ2_P2P_KEY=${SEQ2_P2P_KEY}
 
-  base-builder-cl:
-    command:
-      - node
-      - --chain
-      - ${L2_CHAIN_ID}
-      - --l1-eth-rpc
-      - http://l1-el:${L1_HTTP_PORT}
-      - --l1-beacon
-      - http://l1-cl:${L1_CL_HTTP_PORT}
-      - --l2-engine-rpc
-      - ws://base-builder:${L2_BUILDER_AUTH_PORT}
-      - --l2-engine-jwt-secret
-      - /genesis/jwt.hex
-      - --l2-config-file
-      - /genesis/l2/rollup.json
-      - --l1-config-file
-      - /genesis/el/chain-config.json
-      - --l1-slot-duration-override
-      - "4"
-      - --rpc.port
-      - "${L2_BUILDER_CL_RPC_PORT}"
-      - --rpc.enable-admin
-      - --p2p.listen.tcp
-      - "${L2_BUILDER_CL_P2P_PORT}"
-      - --p2p.listen.udp
-      - "${L2_BUILDER_CL_P2P_PORT}"
-      - --p2p.advertise.ip
-      - base-builder-cl
-      - --p2p.priv.path
-      - /genesis/l2/builder-p2p-key.txt
-      - --p2p.bootnodes-file
-      - "${L2_CL_BOOTNODE_ENR_PATH}"
-      - --metrics.enabled
-      - --metrics.port
-      - "${L2_BUILDER_CL_METRICS_PORT}"
-      - --mode
-      - Sequencer
-      - --sequencer.l1-confs
-      - "0"
-      - --conductor.rpc
-      - http://op-conductor-0:${CONDUCTOR0_RPC_PORT}
-      - --p2p.sequencer.key
-      - ${SEQUENCER_KEY}
-      - --p2p.scoring
-      - Off
+  base-builder:
+    environment:
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+      - BASE_NODE_CONDUCTOR_RPC=http://op-conductor-0:${CONDUCTOR0_RPC_PORT}
+      - OTEL_SERVICE_NAME=base-builder
 
   base-batcher:
     depends_on:
@@ -126,7 +75,7 @@ services:
       - "${BATCHER_METRICS_PORT}"
 
   base-sequencer-1:
-    <<: *sequencer-el-base
+    <<: *sequencer-base
     container_name: base-sequencer-1
     ports:
       - "${L2_SEQ1_HTTP_PORT}:${L2_SEQ1_HTTP_PORT}"                     # HTTP RPC
@@ -136,18 +85,25 @@ services:
       - "${L2_SEQ1_P2P_PORT}:${L2_SEQ1_P2P_PORT}/udp"                   # Discovery
       - "${L2_SEQ1_FLASHBLOCKS_PORT}:${L2_SEQ1_FLASHBLOCKS_PORT}"       # Flashblocks
       - "${L2_SEQ1_METRICS_PORT}:${L2_SEQ1_METRICS_PORT}"               # Metrics
+      - "${L2_SEQ1_CL_RPC_PORT}:${L2_SEQ1_CL_RPC_PORT}"                 # Consensus RPC
+      - "${L2_SEQ1_CL_P2P_PORT}:${L2_SEQ1_CL_P2P_PORT}"                 # Consensus P2P TCP
+      - "${L2_SEQ1_CL_P2P_PORT}:${L2_SEQ1_CL_P2P_PORT}/udp"             # Consensus P2P UDP
     volumes:
       - ../../.devnet/l2/sequencer-1:/data
+      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
       - ../../.devnet/l1/configs:/genesis:ro
       - ../../.devnet/l2/configs:/genesis/l2:ro
     environment:
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
       - OTEL_SERVICE_NAME=base-sequencer-1
     command:
-      - node
-      - --chain=/genesis/l2/genesis.json
+      - sequencer
+      - --chain
+      - dev
+      - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
-      - --tracing-otlp=http://jaeger:4318
-      - --tracing-otlp.filter=debug,providers::state::overlay=off,trie=off
       - --telemetry.sampling-ratio=1
       - --http
       - --http.addr=0.0.0.0
@@ -162,6 +118,7 @@ services:
       - --authrpc.port=${L2_SEQ1_AUTH_PORT}
       - --authrpc.addr=0.0.0.0
       - --authrpc.jwtsecret=/genesis/jwt.hex
+      - --auth-ipc.path=/tmp/base-sequencer-1-engine.ipc
       - --port=${L2_SEQ1_P2P_PORT}
       - --discovery.port=${L2_SEQ1_P2P_PORT}
       - --nat=extip:${L2_SEQ1_ADVERTISE_IP}
@@ -185,47 +142,10 @@ services:
       - --txpool.max-batch-size=1024
       - --rpc.txfeecap=0
       - --rpc.gascap=600000000
-      - --color=never
-      - -vvv
-    healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/${L2_SEQ1_HTTP_PORT}"]
-      <<: *sequencer-healthcheck
-    networks:
-      default:
-        ipv4_address: ${L2_SEQ1_ADVERTISE_IP}
-
-  base-sequencer-1-cl:
-    <<: *sequencer-cl-base
-    container_name: base-sequencer-1-cl
-    depends_on:
-      base-sequencer-1:
-        condition: service_healthy
-      base-builder-cl:
-        condition: service_healthy
-      base-cl-bootnode:
-        condition: service_healthy
-    ports:
-      - "${L2_SEQ1_CL_RPC_PORT}:${L2_SEQ1_CL_RPC_PORT}"               # RPC
-      - "${L2_SEQ1_CL_P2P_PORT}:${L2_SEQ1_CL_P2P_PORT}"               # P2P TCP
-      - "${L2_SEQ1_CL_P2P_PORT}:${L2_SEQ1_CL_P2P_PORT}/udp"           # P2P UDP
-      - "${L2_SEQ1_CL_METRICS_PORT}:${L2_SEQ1_CL_METRICS_PORT}"       # Metrics
-    volumes:
-      - ../../.devnet/l2/sequencer-1-cl:/data
-      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
-    command:
-      - node
-      - --chain
-      - ${L2_CHAIN_ID}
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
       - http://l1-cl:${L1_CL_HTTP_PORT}
-      - --l2-engine-rpc
-      - ws://base-sequencer-1:${L2_SEQ1_AUTH_PORT}
-      - --l2-engine-jwt-secret
-      - /genesis/jwt.hex
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file
@@ -240,14 +160,11 @@ services:
       - --p2p.listen.udp
       - "${L2_SEQ1_CL_P2P_PORT}"
       - --p2p.advertise.ip
-      - base-sequencer-1-cl
+      - base-sequencer-1
       - --p2p.priv.path
       - /genesis/l2/sequencer-1-p2p-key.txt
-      - --metrics.enabled
-      - --metrics.port
-      - "${L2_SEQ1_CL_METRICS_PORT}"
-      - --mode
-      - Sequencer
+      - --p2p.bootnodes-file
+      - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --sequencer.l1-confs
       - "0"
       - --sequencer.stopped
@@ -255,16 +172,18 @@ services:
       - http://op-conductor-1:${CONDUCTOR1_RPC_PORT}
       - --p2p.sequencer.key
       - ${SEQUENCER_KEY}
-      - --p2p.bootnodes-file
-      - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --p2p.scoring
       - Off
+      - -vvv
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${L2_SEQ1_CL_RPC_PORT}/healthz"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_SEQ1_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_SEQ1_CL_RPC_PORT}/healthz >/dev/null"]
       <<: *sequencer-healthcheck
+    networks:
+      default:
+        ipv4_address: ${L2_SEQ1_ADVERTISE_IP}
 
   base-sequencer-2:
-    <<: *sequencer-el-base
+    <<: *sequencer-base
     container_name: base-sequencer-2
     ports:
       - "${L2_SEQ2_HTTP_PORT}:${L2_SEQ2_HTTP_PORT}"                     # HTTP RPC
@@ -274,18 +193,25 @@ services:
       - "${L2_SEQ2_P2P_PORT}:${L2_SEQ2_P2P_PORT}/udp"                   # Discovery
       - "${L2_SEQ2_FLASHBLOCKS_PORT}:${L2_SEQ2_FLASHBLOCKS_PORT}"       # Flashblocks
       - "${L2_SEQ2_METRICS_PORT}:${L2_SEQ2_METRICS_PORT}"               # Metrics
+      - "${L2_SEQ2_CL_RPC_PORT}:${L2_SEQ2_CL_RPC_PORT}"                 # Consensus RPC
+      - "${L2_SEQ2_CL_P2P_PORT}:${L2_SEQ2_CL_P2P_PORT}"                 # Consensus P2P TCP
+      - "${L2_SEQ2_CL_P2P_PORT}:${L2_SEQ2_CL_P2P_PORT}/udp"             # Consensus P2P UDP
     volumes:
       - ../../.devnet/l2/sequencer-2:/data
+      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
       - ../../.devnet/l1/configs:/genesis:ro
       - ../../.devnet/l2/configs:/genesis/l2:ro
     environment:
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
       - OTEL_SERVICE_NAME=base-sequencer-2
     command:
-      - node
-      - --chain=/genesis/l2/genesis.json
+      - sequencer
+      - --chain
+      - dev
+      - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
-      - --tracing-otlp=http://jaeger:4318
-      - --tracing-otlp.filter=debug,providers::state::overlay=off,trie=off
       - --telemetry.sampling-ratio=1
       - --http
       - --http.addr=0.0.0.0
@@ -300,6 +226,7 @@ services:
       - --authrpc.port=${L2_SEQ2_AUTH_PORT}
       - --authrpc.addr=0.0.0.0
       - --authrpc.jwtsecret=/genesis/jwt.hex
+      - --auth-ipc.path=/tmp/base-sequencer-2-engine.ipc
       - --port=${L2_SEQ2_P2P_PORT}
       - --discovery.port=${L2_SEQ2_P2P_PORT}
       - --nat=extip:${L2_SEQ2_ADVERTISE_IP}
@@ -323,47 +250,10 @@ services:
       - --txpool.max-batch-size=1024
       - --rpc.txfeecap=0
       - --rpc.gascap=600000000
-      - --color=never
-      - -vvv
-    healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/${L2_SEQ2_HTTP_PORT}"]
-      <<: *sequencer-healthcheck
-    networks:
-      default:
-        ipv4_address: ${L2_SEQ2_ADVERTISE_IP}
-
-  base-sequencer-2-cl:
-    <<: *sequencer-cl-base
-    container_name: base-sequencer-2-cl
-    depends_on:
-      base-sequencer-2:
-        condition: service_healthy
-      base-builder-cl:
-        condition: service_healthy
-      base-cl-bootnode:
-        condition: service_healthy
-    ports:
-      - "${L2_SEQ2_CL_RPC_PORT}:${L2_SEQ2_CL_RPC_PORT}"               # RPC
-      - "${L2_SEQ2_CL_P2P_PORT}:${L2_SEQ2_CL_P2P_PORT}"               # P2P TCP
-      - "${L2_SEQ2_CL_P2P_PORT}:${L2_SEQ2_CL_P2P_PORT}/udp"           # P2P UDP
-      - "${L2_SEQ2_CL_METRICS_PORT}:${L2_SEQ2_CL_METRICS_PORT}"       # Metrics
-    volumes:
-      - ../../.devnet/l2/sequencer-2-cl:/data
-      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
-    command:
-      - node
-      - --chain
-      - ${L2_CHAIN_ID}
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
       - http://l1-cl:${L1_CL_HTTP_PORT}
-      - --l2-engine-rpc
-      - ws://base-sequencer-2:${L2_SEQ2_AUTH_PORT}
-      - --l2-engine-jwt-secret
-      - /genesis/jwt.hex
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file
@@ -378,14 +268,11 @@ services:
       - --p2p.listen.udp
       - "${L2_SEQ2_CL_P2P_PORT}"
       - --p2p.advertise.ip
-      - base-sequencer-2-cl
+      - base-sequencer-2
       - --p2p.priv.path
       - /genesis/l2/sequencer-2-p2p-key.txt
-      - --metrics.enabled
-      - --metrics.port
-      - "${L2_SEQ2_CL_METRICS_PORT}"
-      - --mode
-      - Sequencer
+      - --p2p.bootnodes-file
+      - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --sequencer.l1-confs
       - "0"
       - --sequencer.stopped
@@ -393,19 +280,21 @@ services:
       - http://op-conductor-2:${CONDUCTOR2_RPC_PORT}
       - --p2p.sequencer.key
       - ${SEQUENCER_KEY}
-      - --p2p.bootnodes-file
-      - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --p2p.scoring
       - Off
+      - -vvv
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${L2_SEQ2_CL_RPC_PORT}/healthz"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_SEQ2_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_SEQ2_CL_RPC_PORT}/healthz >/dev/null"]
       <<: *sequencer-healthcheck
+    networks:
+      default:
+        ipv4_address: ${L2_SEQ2_ADVERTISE_IP}
 
   op-conductor-0:
     <<: *conductor-base
     container_name: op-conductor-0
     depends_on:
-      base-builder-cl:
+      base-builder:
         condition: service_healthy
     ports:
       - "${CONDUCTOR0_RPC_PORT}:${CONDUCTOR0_RPC_PORT}"           # RPC
@@ -422,7 +311,7 @@ services:
       - --consensus.addr=0.0.0.0
       - --consensus.port=${CONDUCTOR0_RAFT_PORT}
       - --consensus.advertised=op-conductor-0:${CONDUCTOR0_RAFT_PORT}
-      - --node.rpc=http://base-builder-cl:${L2_BUILDER_CL_RPC_PORT}
+      - --node.rpc=http://base-builder:${L2_BUILDER_CL_RPC_PORT}
       - --execution.rpc=http://base-builder:${L2_BUILDER_HTTP_PORT}
       - --healthcheck.interval=1
       - --healthcheck.unsafe-interval=30
@@ -441,7 +330,7 @@ services:
     <<: *conductor-base
     container_name: op-conductor-1
     depends_on:
-      base-sequencer-1-cl:
+      base-sequencer-1:
         condition: service_healthy
     ports:
       - "${CONDUCTOR1_RPC_PORT}:${CONDUCTOR1_RPC_PORT}"           # RPC
@@ -458,7 +347,7 @@ services:
       - --consensus.addr=0.0.0.0
       - --consensus.port=${CONDUCTOR1_RAFT_PORT}
       - --consensus.advertised=op-conductor-1:${CONDUCTOR1_RAFT_PORT}
-      - --node.rpc=http://base-sequencer-1-cl:${L2_SEQ1_CL_RPC_PORT}
+      - --node.rpc=http://base-sequencer-1:${L2_SEQ1_CL_RPC_PORT}
       - --execution.rpc=http://base-sequencer-1:${L2_SEQ1_HTTP_PORT}
       - --healthcheck.interval=1
       - --healthcheck.unsafe-interval=30
@@ -477,7 +366,7 @@ services:
     <<: *conductor-base
     container_name: op-conductor-2
     depends_on:
-      base-sequencer-2-cl:
+      base-sequencer-2:
         condition: service_healthy
     ports:
       - "${CONDUCTOR2_RPC_PORT}:${CONDUCTOR2_RPC_PORT}"           # RPC
@@ -494,7 +383,7 @@ services:
       - --consensus.addr=0.0.0.0
       - --consensus.port=${CONDUCTOR2_RAFT_PORT}
       - --consensus.advertised=op-conductor-2:${CONDUCTOR2_RAFT_PORT}
-      - --node.rpc=http://base-sequencer-2-cl:${L2_SEQ2_CL_RPC_PORT}
+      - --node.rpc=http://base-sequencer-2:${L2_SEQ2_CL_RPC_PORT}
       - --execution.rpc=http://base-sequencer-2:${L2_SEQ2_HTTP_PORT}
       - --healthcheck.interval=1
       - --healthcheck.unsafe-interval=30

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -18,7 +18,8 @@ x-conductor-base: &conductor-base
   image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-conductor:v0.9.2
   entrypoint: ["op-conductor"]
 
-x-sequencer-healthcheck: &sequencer-healthcheck
+x-node-healthcheck: &node-healthcheck
+  test: ["CMD-SHELL", "curl -sf -H 'Content-Type: application/json' --data '{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' \"http://localhost:$${NODE_HEALTHCHECK_HTTP_PORT}/\" >/dev/null && curl -sf \"http://localhost:$${NODE_HEALTHCHECK_CL_RPC_PORT}/healthz\" >/dev/null"]
   interval: 250ms
   timeout: 1s
   retries: 240
@@ -45,6 +46,8 @@ services:
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
       - BASE_NODE_CONDUCTOR_RPC=http://op-conductor-0:${CONDUCTOR0_RPC_PORT}
+      - NODE_HEALTHCHECK_HTTP_PORT=${L2_BUILDER_HTTP_PORT}
+      - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_BUILDER_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-builder
 
   base-batcher:
@@ -97,6 +100,8 @@ services:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+      - NODE_HEALTHCHECK_HTTP_PORT=${L2_SEQ1_HTTP_PORT}
+      - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_SEQ1_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-sequencer-1
     command:
       - sequencer
@@ -176,8 +181,7 @@ services:
       - Off
       - -vvv
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_SEQ1_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_SEQ1_CL_RPC_PORT}/healthz >/dev/null"]
-      <<: *sequencer-healthcheck
+      <<: *node-healthcheck
     networks:
       default:
         ipv4_address: ${L2_SEQ1_ADVERTISE_IP}
@@ -205,6 +209,8 @@ services:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+      - NODE_HEALTHCHECK_HTTP_PORT=${L2_SEQ2_HTTP_PORT}
+      - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_SEQ2_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-sequencer-2
     command:
       - sequencer
@@ -284,8 +290,7 @@ services:
       - Off
       - -vvv
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_SEQ2_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_SEQ2_CL_RPC_PORT}/healthz >/dev/null"]
-      <<: *sequencer-healthcheck
+      <<: *node-healthcheck
     networks:
       default:
         ipv4_address: ${L2_SEQ2_ADVERTISE_IP}

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -5,6 +5,13 @@ x-rust-service-build: &rust-service-build
     PROFILE: "${CARGO_PROFILE:-dev}"
     BASE_SUCCINCT_ELF_REQUIRE: "${BASE_SUCCINCT_ELF_REQUIRE:-0}"
 
+x-node-healthcheck: &node-healthcheck
+  test: ["CMD-SHELL", "curl -sf -H 'Content-Type: application/json' --data '{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' \"http://localhost:$${NODE_HEALTHCHECK_HTTP_PORT}/\" >/dev/null && curl -sf \"http://localhost:$${NODE_HEALTHCHECK_CL_RPC_PORT}/healthz\" >/dev/null"]
+  interval: 250ms
+  timeout: 1s
+  retries: 240
+  start_period: 250ms
+
 services:
   setup-l1:
     image: devnet-setup:local
@@ -257,6 +264,8 @@ services:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+      - NODE_HEALTHCHECK_HTTP_PORT=${L2_BUILDER_HTTP_PORT}
+      - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_BUILDER_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-builder
     entrypoint: /app/base
     command:
@@ -338,11 +347,7 @@ services:
       - Off
       - -vvv
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_BUILDER_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_BUILDER_CL_RPC_PORT}/healthz >/dev/null"]
-      interval: 250ms
-      timeout: 1s
-      retries: 240
-      start_period: 250ms
+      <<: *node-healthcheck
     networks:
       default:
         ipv4_address: ${L2_BUILDER_ADVERTISE_IP}
@@ -413,6 +418,8 @@ services:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+      - NODE_HEALTHCHECK_HTTP_PORT=${L2_CLIENT_HTTP_PORT}
+      - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_CLIENT_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-client
     entrypoint: /app/base
     command:
@@ -490,11 +497,7 @@ services:
       - "${BASE_NODE_VERIFIER_L1_CONFS}"
       - -vvv
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_CLIENT_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_CLIENT_CL_RPC_PORT}/healthz >/dev/null"]
-      interval: 250ms
-      timeout: 1s
-      retries: 240
-      start_period: 250ms
+      <<: *node-healthcheck
     networks:
       default:
         ipv4_address: ${L2_CLIENT_ADVERTISE_IP}
@@ -532,6 +535,8 @@ services:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+      - NODE_HEALTHCHECK_HTTP_PORT=${L2_BASE_RPC_HTTP_PORT}
+      - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_BASE_RPC_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-rpc
     entrypoint: /app/base
     command:
@@ -593,11 +598,7 @@ services:
       - "${BASE_NODE_VERIFIER_L1_CONFS}"
       - -vvv
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_BASE_RPC_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_BASE_RPC_CL_RPC_PORT}/healthz >/dev/null"]
-      interval: 250ms
-      timeout: 1s
-      retries: 240
-      start_period: 250ms
+      <<: *node-healthcheck
     networks:
       default:
         ipv4_address: ${L2_BASE_RPC_ADVERTISE_IP}

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -171,78 +171,53 @@ services:
       - L2_CL_BOOTNODE_ENR_PATH=${L2_CL_BOOTNODE_ENR_PATH}
     entrypoint: ["/usr/local/bin/setup-l2.sh"]
 
-  base-el-bootnode:
-    image: base-reth-node:local
+  base-bootnode:
+    image: base:local
     build:
       <<: *rust-service-build
-      target: client
-    container_name: base-el-bootnode
+      target: base
+    container_name: base-bootnode
     depends_on:
       setup-l2:
         condition: service_completed_successfully
     ports:
       - "${L2_EL_BOOTNODE_P2P_PORT}:${L2_EL_BOOTNODE_P2P_PORT}/udp" # Discovery
+      - "${L2_CL_BOOTNODE_P2P_PORT}:${L2_CL_BOOTNODE_P2P_PORT}"     # Consensus P2P TCP metadata
+      - "${L2_CL_BOOTNODE_P2P_PORT}:${L2_CL_BOOTNODE_P2P_PORT}/udp" # Consensus discovery
     volumes:
       - ../../.devnet/l2/el-bootnode:/data
-      - ../../.devnet/l2/configs:/genesis/l2:ro
-    entrypoint: /app/base-client
-    command:
-      - p2p
-      - bootnode
-      - --v4-addr=0.0.0.0:${L2_EL_BOOTNODE_P2P_PORT}
-      - --nat=extip:${L2_EL_BOOTNODE_ADVERTISE_IP}
-      - --p2p-secret-key=/genesis/l2/el-bootnode-p2p-key.txt
-      - --color=never
-      - -vvv
-    networks:
-      default:
-        ipv4_address: ${L2_EL_BOOTNODE_ADVERTISE_IP}
-    healthcheck:
-      test: ["CMD", "bash", "-c", "readlink /proc/1/exe | grep -q /app/base-client"]
-      interval: 250ms
-      timeout: 1s
-      retries: 240
-      start_period: 250ms
-    restart: unless-stopped
-
-  base-cl-bootnode:
-    image: base-consensus:local
-    build:
-      <<: *rust-service-build
-      target: consensus
-    container_name: base-cl-bootnode
-    depends_on:
-      setup-l2:
-        condition: service_completed_successfully
-    ports:
-      - "${L2_CL_BOOTNODE_P2P_PORT}:${L2_CL_BOOTNODE_P2P_PORT}"     # P2P TCP metadata
-      - "${L2_CL_BOOTNODE_P2P_PORT}:${L2_CL_BOOTNODE_P2P_PORT}/udp" # Discovery
-    volumes:
-      - ../../.devnet/l2/cl-bootnode:/data
       - ../../.devnet/l2/cl-bootnode-enr:/bootnodes
       - ../../.devnet/l2/configs:/genesis/l2:ro
-    entrypoint: /app/base-consensus
+    environment:
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
+    entrypoint: /app/base
     command:
       - bootnode
       - --chain
-      - ${L2_CHAIN_ID}
+      - dev
       - --l2-config-file
       - /genesis/l2/rollup.json
+      - --v4-addr=0.0.0.0:${L2_EL_BOOTNODE_P2P_PORT}
+      - --nat=extip:${L2_EL_BOOTNODE_ADVERTISE_IP}
+      - --p2p-secret-key=/genesis/l2/el-bootnode-p2p-key.txt
       - --p2p.listen.tcp
       - "${L2_CL_BOOTNODE_P2P_PORT}"
       - --p2p.listen.udp
       - "${L2_CL_BOOTNODE_P2P_PORT}"
       - --p2p.advertise.ip
-      - "${L2_CL_BOOTNODE_ADVERTISE_IP}"
+      - "${L2_EL_BOOTNODE_ADVERTISE_IP}"
       - --p2p.priv.path
       - /genesis/l2/cl-bootnode-p2p-key.txt
       - --p2p.bootstore
       - /data/bootstore.json
       - --p2p.enr-output
       - "${L2_CL_BOOTNODE_ENR_PATH}"
+      - -vvv
     networks:
       default:
-        ipv4_address: ${L2_CL_BOOTNODE_ADVERTISE_IP}
+        ipv4_address: ${L2_EL_BOOTNODE_ADVERTISE_IP}
     healthcheck:
       test: ["CMD", "test", "-s", "${L2_CL_BOOTNODE_ENR_PATH}"]
       interval: 250ms
@@ -252,16 +227,16 @@ services:
     restart: unless-stopped
 
   base-builder:
-    image: base-builder:local
+    image: base:local
     build:
       <<: *rust-service-build
-      target: builder
+      target: base
     container_name: base-builder
     depends_on:
       setup-l2:
         condition: service_completed_successfully
-      base-el-bootnode:
-        condition: service_started
+      base-bootnode:
+        condition: service_healthy
     ports:
       - "${L2_BUILDER_HTTP_PORT}:${L2_BUILDER_HTTP_PORT}"           # HTTP RPC
       - "${L2_BUILDER_WS_PORT}:${L2_BUILDER_WS_PORT}"               # WebSocket
@@ -270,19 +245,26 @@ services:
       - "${L2_BUILDER_P2P_PORT}:${L2_BUILDER_P2P_PORT}/udp"         # Discovery
       - "${L2_BUILDER_FLASHBLOCKS_PORT}:${L2_BUILDER_FLASHBLOCKS_PORT}"  # Flashblocks
       - "${L2_BUILDER_METRICS_PORT}:${L2_BUILDER_METRICS_PORT}"     # Metrics
+      - "${L2_BUILDER_CL_RPC_PORT}:${L2_BUILDER_CL_RPC_PORT}"       # Consensus RPC
+      - "${L2_BUILDER_CL_P2P_PORT}:${L2_BUILDER_CL_P2P_PORT}"       # Consensus P2P TCP
+      - "${L2_BUILDER_CL_P2P_PORT}:${L2_BUILDER_CL_P2P_PORT}/udp"   # Consensus P2P UDP
     volumes:
       - ../../.devnet/l2/builder:/data
+      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
       - ../../.devnet/l1/configs:/genesis:ro
       - ../../.devnet/l2/configs:/genesis/l2:ro
     environment:
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
       - OTEL_SERVICE_NAME=base-builder
-    entrypoint: /app/base-builder
+    entrypoint: /app/base
     command:
-      - node
-      - --chain=/genesis/l2/genesis.json
+      - sequencer
+      - --chain
+      - dev
+      - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
-      - --tracing-otlp=http://jaeger:4318
-      - --tracing-otlp.filter=debug,providers::state::overlay=off,trie=off
       - --telemetry.sampling-ratio=1
       - --http
       - --http.addr=0.0.0.0
@@ -297,6 +279,7 @@ services:
       - --authrpc.port=${L2_BUILDER_AUTH_PORT}
       - --authrpc.addr=0.0.0.0
       - --authrpc.jwtsecret=/genesis/jwt.hex
+      - --auth-ipc.path=/tmp/base-builder-engine.ipc
       - --port=${L2_BUILDER_P2P_PORT}
       - --discovery.port=${L2_BUILDER_P2P_PORT}
       - --nat=extip:${L2_BUILDER_ADVERTISE_IP}
@@ -324,53 +307,10 @@ services:
       - --txpool.max-batch-size=1024
       - --rpc.txfeecap=0
       - --rpc.gascap=600000000
-      - --color=never
-      - -vvv
-    healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/${L2_BUILDER_HTTP_PORT}"]
-      interval: 250ms
-      timeout: 1s
-      retries: 240
-      start_period: 250ms
-    networks:
-      default:
-        ipv4_address: ${L2_BUILDER_ADVERTISE_IP}
-    restart: unless-stopped
-
-  base-builder-cl:
-    image: base-consensus:local
-    build:
-      <<: *rust-service-build
-      target: consensus
-    container_name: base-builder-cl
-    depends_on:
-      base-builder:
-        condition: service_healthy
-      base-cl-bootnode:
-        condition: service_healthy
-    ports:
-      - "${L2_BUILDER_CL_RPC_PORT}:${L2_BUILDER_CL_RPC_PORT}"       # RPC
-      - "${L2_BUILDER_CL_P2P_PORT}:${L2_BUILDER_CL_P2P_PORT}"       # P2P TCP
-      - "${L2_BUILDER_CL_P2P_PORT}:${L2_BUILDER_CL_P2P_PORT}/udp"   # P2P UDP
-      - "${L2_BUILDER_CL_METRICS_PORT}:${L2_BUILDER_CL_METRICS_PORT}"  # Metrics
-    volumes:
-      - ../../.devnet/l2/builder-cl:/data
-      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
-    entrypoint: /app/base-consensus
-    command:
-      - node
-      - --chain
-      - ${L2_CHAIN_ID}
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
       - http://l1-cl:${L1_CL_HTTP_PORT}
-      - --l2-engine-rpc
-      - ws://base-builder:${L2_BUILDER_AUTH_PORT}
-      - --l2-engine-jwt-secret
-      - /genesis/jwt.hex
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file
@@ -385,28 +325,27 @@ services:
       - --p2p.listen.udp
       - "${L2_BUILDER_CL_P2P_PORT}"
       - --p2p.advertise.ip
-      - base-builder-cl
+      - base-builder
       - --p2p.priv.path
       - /genesis/l2/builder-p2p-key.txt
       - --p2p.bootnodes-file
       - "${L2_CL_BOOTNODE_ENR_PATH}"
-      - --metrics.enabled
-      - --metrics.port
-      - "${L2_BUILDER_CL_METRICS_PORT}"
-      - --mode
-      - Sequencer
       - --sequencer.l1-confs
       - "0"
       - --p2p.sequencer.key
       - ${SEQUENCER_KEY}
       - --p2p.scoring
       - Off
+      - -vvv
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${L2_BUILDER_CL_RPC_PORT}/healthz"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_BUILDER_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_BUILDER_CL_RPC_PORT}/healthz >/dev/null"]
       interval: 250ms
       timeout: 1s
       retries: 240
       start_period: 250ms
+    networks:
+      default:
+        ipv4_address: ${L2_BUILDER_ADVERTISE_IP}
     restart: unless-stopped
 
   base-batcher:
@@ -416,7 +355,7 @@ services:
       target: batcher
     container_name: base-batcher
     depends_on:
-      base-builder-cl:
+      base-builder:
         condition: service_healthy
     ports:
       - "${BATCHER_METRICS_PORT}:${BATCHER_METRICS_PORT}"   # Metrics
@@ -426,7 +365,7 @@ services:
       - --l2-rpc-url
       - http://base-builder:${L2_BUILDER_HTTP_PORT}
       - --rollup-rpc-url
-      - http://base-builder-cl:${L2_BUILDER_CL_RPC_PORT}
+      - http://base-builder:${L2_BUILDER_CL_RPC_PORT}
       - --private-key
       - ${BATCHER_KEY}
       - --max-channel-duration
@@ -445,16 +384,16 @@ services:
     restart: unless-stopped
 
   base-client:
-    image: base-reth-node:local
+    image: base:local
     build:
       <<: *rust-service-build
-      target: client
+      target: base
     container_name: base-client
     depends_on:
       setup-l2:
         condition: service_completed_successfully
-      base-el-bootnode:
-        condition: service_started
+      base-bootnode:
+        condition: service_healthy
     ports:
       - "${L2_CLIENT_HTTP_PORT}:${L2_CLIENT_HTTP_PORT}"     # HTTP RPC
       - "${L2_CLIENT_WS_PORT}:${L2_CLIENT_WS_PORT}"         # WebSocket
@@ -462,19 +401,26 @@ services:
       - "${L2_CLIENT_P2P_PORT}:${L2_CLIENT_P2P_PORT}"       # P2P
       - "${L2_CLIENT_P2P_PORT}:${L2_CLIENT_P2P_PORT}/udp"   # Discovery
       - "${L2_CLIENT_METRICS_PORT}:${L2_CLIENT_METRICS_PORT}"  # Metrics
+      - "${L2_CLIENT_CL_RPC_PORT}:${L2_CLIENT_CL_RPC_PORT}"     # Consensus RPC
+      - "${L2_CLIENT_CL_P2P_PORT}:${L2_CLIENT_CL_P2P_PORT}"     # Consensus P2P TCP
+      - "${L2_CLIENT_CL_P2P_PORT}:${L2_CLIENT_CL_P2P_PORT}/udp" # Consensus P2P UDP
     volumes:
       - ../../.devnet/l2/client:/data
+      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
       - ../../.devnet/l1/configs:/genesis:ro
       - ../../.devnet/l2/configs:/genesis/l2:ro
     environment:
+      - BASE_CHAIN_NAME=dev
+      - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
+      - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
       - OTEL_SERVICE_NAME=base-client
-    entrypoint: /app/base-client
+    entrypoint: /app/base
     command:
-      - node
-      - --chain=/genesis/l2/genesis.json
+      - rpc
+      - --chain
+      - dev
+      - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
-      - --tracing-otlp=http://jaeger:4318
-      - --tracing-otlp.filter=debug,providers::state::overlay=off,trie=off
       - --http
       - --http.addr=0.0.0.0
       - --http.port=${L2_CLIENT_HTTP_PORT}
@@ -490,6 +436,7 @@ services:
       - --authrpc.port=${L2_CLIENT_AUTH_PORT}
       - --authrpc.addr=0.0.0.0
       - --authrpc.jwtsecret=/genesis/jwt.hex
+      - --auth-ipc.path=/tmp/base-client-engine.ipc
       - --port=${L2_CLIENT_P2P_PORT}
       - --discovery.port=${L2_CLIENT_P2P_PORT}
       - --nat=extip:${L2_CLIENT_ADVERTISE_IP}
@@ -510,62 +457,17 @@ services:
       - --flashblocks-url=ws://base-builder:${L2_BUILDER_FLASHBLOCKS_PORT}
       - --bootnodes=${L2_EL_BOOTNODE_ENODE}
       - --rollup.discovery.v4
-      - --rollup.sequencer=http://base-builder:${L2_BUILDER_HTTP_PORT}
+      - --rpc.forwarding-endpoint=http://base-builder:${L2_BUILDER_HTTP_PORT}
       - --enable-metering
       - --metering.gas-limit=${METERING_GAS_LIMIT}
       - --metering.execution-time-us=${METERING_EXECUTION_TIME_US}
       - --metering.state-root-time-us=${METERING_STATE_ROOT_TIME_US}
       - --metering.da-bytes=${METERING_DA_BYTES}
       - --metering.target-flashblocks-per-block=${METERING_TARGET_FLASHBLOCKS_PER_BLOCK}
-      - --color=never
-      - -vvv
-    healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/${L2_CLIENT_HTTP_PORT}"]
-      interval: 250ms
-      timeout: 1s
-      retries: 240
-      start_period: 250ms
-    networks:
-      default:
-        ipv4_address: ${L2_CLIENT_ADVERTISE_IP}
-    restart: unless-stopped
-
-  base-client-cl:
-    image: base-consensus:local
-    build:
-      <<: *rust-service-build
-      target: consensus
-    container_name: base-client-cl
-    depends_on:
-      base-client:
-        condition: service_healthy
-      base-builder-cl:
-        condition: service_healthy
-      base-cl-bootnode:
-        condition: service_healthy
-    ports:
-      - "${L2_CLIENT_CL_RPC_PORT}:${L2_CLIENT_CL_RPC_PORT}"     # RPC
-      - "${L2_CLIENT_CL_P2P_PORT}:${L2_CLIENT_CL_P2P_PORT}"     # P2P TCP
-      - "${L2_CLIENT_CL_P2P_PORT}:${L2_CLIENT_CL_P2P_PORT}/udp" # P2P UDP
-      - "${L2_CLIENT_CL_METRICS_PORT}:${L2_CLIENT_CL_METRICS_PORT}"  # Metrics
-    volumes:
-      - ../../.devnet/l2/client-cl:/data
-      - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
-    entrypoint: /app/base-consensus
-    command:
-      - node
-      - --chain
-      - ${L2_CHAIN_ID}
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
       - http://l1-cl:${L1_CL_HTTP_PORT}
-      - --l2-engine-rpc
-      - ws://base-client:${L2_CLIENT_AUTH_PORT}
-      - --l2-engine-jwt-secret
-      - /genesis/jwt.hex
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file
@@ -579,22 +481,23 @@ services:
       - --p2p.listen.udp
       - "${L2_CLIENT_CL_P2P_PORT}"
       - --p2p.advertise.ip
-      - base-client-cl
-      - --metrics.enabled
-      - --metrics.port
-      - "${L2_CLIENT_CL_METRICS_PORT}"
+      - base-client
       - --p2p.bootnodes-file
       - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --p2p.scoring
       - Off
       - --l1.verifier-confs
       - "${BASE_NODE_VERIFIER_L1_CONFS}"
+      - -vvv
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${L2_CLIENT_CL_RPC_PORT}/healthz"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_CLIENT_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_CLIENT_CL_RPC_PORT}/healthz >/dev/null"]
       interval: 250ms
       timeout: 1s
       retries: 240
       start_period: 250ms
+    networks:
+      default:
+        ipv4_address: ${L2_CLIENT_ADVERTISE_IP}
     restart: unless-stopped
 
   base-rpc:
@@ -606,9 +509,9 @@ services:
     depends_on:
       setup-l2:
         condition: service_completed_successfully
-      base-el-bootnode:
-        condition: service_started
-      base-builder-cl:
+      base-bootnode:
+        condition: service_healthy
+      base-builder:
         condition: service_healthy
     ports:
       - "${L2_BASE_RPC_HTTP_PORT}:${L2_BASE_RPC_HTTP_PORT}"     # HTTP RPC
@@ -681,7 +584,7 @@ services:
       - --p2p.listen.udp
       - "${L2_BASE_RPC_CL_P2P_PORT}"
       - --p2p.advertise.ip
-      - base-rpc-cl
+      - base-rpc
       - --p2p.bootnodes-file
       - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --p2p.scoring
@@ -690,7 +593,7 @@ services:
       - "${BASE_NODE_VERIFIER_L1_CONFS}"
       - -vvv
     healthcheck:
-      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/${L2_BASE_RPC_HTTP_PORT}"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:${L2_BASE_RPC_HTTP_PORT} >/dev/null && curl -sf http://localhost:${L2_BASE_RPC_CL_RPC_PORT}/healthz >/dev/null"]
       interval: 250ms
       timeout: 1s
       retries: 240
@@ -698,8 +601,6 @@ services:
     networks:
       default:
         ipv4_address: ${L2_BASE_RPC_ADVERTISE_IP}
-        aliases:
-          - base-rpc-cl
     restart: unless-stopped
 
   zk-prover-postgres:

--- a/etc/scripts/devnet/follow-leader.sh
+++ b/etc/scripts/devnet/follow-leader.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Polls all op-conductor nodes to find the current raft leader, then streams
-# logs from the corresponding sequencer CL container. Automatically switches
+# logs from the corresponding unified sequencer container. Automatically switches
 # when leadership changes.
 set -euo pipefail
 
@@ -18,7 +18,7 @@ CONDUCTOR1_RPC_PORT="${CONDUCTOR1_RPC_PORT:-6546}"
 CONDUCTOR2_RPC_PORT="${CONDUCTOR2_RPC_PORT:-6547}"
 
 CONDUCTOR_PORTS=("$CONDUCTOR0_RPC_PORT" "$CONDUCTOR1_RPC_PORT" "$CONDUCTOR2_RPC_PORT")
-CONDUCTOR_CL_MAP=("base-builder-cl" "base-sequencer-1-cl" "base-sequencer-2-cl")
+CONDUCTOR_NODE_MAP=("base-builder" "base-sequencer-1" "base-sequencer-2")
 CONDUCTOR_NAMES=("op-conductor-0" "op-conductor-1" "op-conductor-2")
 
 POLL_INTERVAL="${FOLLOW_LEADER_POLL_INTERVAL:-2}"
@@ -72,7 +72,7 @@ while true; do
     continue
   fi
 
-  LEADER_CL="${CONDUCTOR_CL_MAP[$LEADER_IDX]}"
+  LEADER_NODE="${CONDUCTOR_NODE_MAP[$LEADER_IDX]}"
   CONDUCTOR_NAME="${CONDUCTOR_NAMES[$LEADER_IDX]}"
 
   if [ "$LEADER_IDX" != "$CURRENT_LEADER" ]; then
@@ -83,12 +83,12 @@ while true; do
 
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo " [$(date '+%H:%M:%S')] Leader: $CONDUCTOR_NAME → $LEADER_CL"
+    echo " [$(date '+%H:%M:%S')] Leader: $CONDUCTOR_NAME → $LEADER_NODE"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
 
     CURRENT_LEADER="$LEADER_IDX"
-    docker logs -f --tail=50 "$LEADER_CL" &
+    docker logs -f --tail=50 "$LEADER_NODE" &
     LOG_PID=$!
   fi
 

--- a/etc/scripts/devnet/prometheus.yml
+++ b/etc/scripts/devnet/prometheus.yml
@@ -11,17 +11,9 @@ scrape_configs:
     static_configs:
       - targets: ['base-builder:7090']
 
-  - job_name: 'l2_builder_cl'
-    static_configs:
-      - targets: ['base-builder-cl:7300']
-
   - job_name: 'l2_client'
     static_configs:
       - targets: ['base-client:8090']
-
-  - job_name: 'l2_client_cl'
-    static_configs:
-      - targets: ['base-client-cl:8300']
 
   - job_name: 'l2_base_rpc'
     static_configs:

--- a/etc/scripts/devnet/transfer-leader.sh
+++ b/etc/scripts/devnet/transfer-leader.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Simulates a sequencer failover: stops the active sequencer on the current
-# raft leader's CL node via admin_stopSequencer, then transfers raft leadership
+# raft leader's unified sequencer node via admin_stopSequencer, then transfers raft leadership
 # via op-conductor, and waits to confirm the new leader.
 #
 # Usage:
 #   transfer-leader.sh          # transfer to any available node
-#   transfer-leader.sh 0        # transfer to op-conductor-0 (base-builder-cl)
-#   transfer-leader.sh 1        # transfer to op-conductor-1 (base-sequencer-1-cl)
-#   transfer-leader.sh 2        # transfer to op-conductor-2 (base-sequencer-2-cl)
+#   transfer-leader.sh 0        # transfer to op-conductor-0 (base-builder)
+#   transfer-leader.sh 1        # transfer to op-conductor-1 (base-sequencer-1)
+#   transfer-leader.sh 2        # transfer to op-conductor-2 (base-sequencer-2)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,8 +32,7 @@ CONDUCTOR_PORTS=("$CONDUCTOR0_RPC_PORT" "$CONDUCTOR1_RPC_PORT" "$CONDUCTOR2_RPC_
 CONDUCTOR_SERVER_IDS=("sequencer-0" "sequencer-1" "sequencer-2")
 CONDUCTOR_RAFT_ADDRS=("op-conductor-0:$CONDUCTOR0_RAFT_PORT" "op-conductor-1:$CONDUCTOR1_RAFT_PORT" "op-conductor-2:$CONDUCTOR2_RAFT_PORT")
 CONDUCTOR_NAMES=("op-conductor-0" "op-conductor-1" "op-conductor-2")
-CONDUCTOR_CL_NAMES=("base-builder-cl" "base-sequencer-1-cl" "base-sequencer-2-cl")
-CONDUCTOR_CL_PORTS=("$L2_BUILDER_CL_RPC_PORT" "$L2_SEQ1_CL_RPC_PORT" "$L2_SEQ2_CL_RPC_PORT")
+CONDUCTOR_NODE_NAMES=("base-builder" "base-sequencer-1" "base-sequencer-2")
 
 TARGET="${1:-}"
 
@@ -41,9 +40,9 @@ if [ -n "$TARGET" ] && ! [[ "$TARGET" =~ ^[0-2]$ ]]; then
   echo "ERROR: target must be 0, 1, or 2 (got: $TARGET)"
   echo ""
   echo "Usage: $0 [0|1|2]"
-  echo "  0 → op-conductor-0 (base-builder-cl)"
-  echo "  1 → op-conductor-1 (base-sequencer-1-cl)"
-  echo "  2 → op-conductor-2 (base-sequencer-2-cl)"
+  echo "  0 → op-conductor-0 (base-builder)"
+  echo "  1 → op-conductor-1 (base-sequencer-1)"
+  echo "  2 → op-conductor-2 (base-sequencer-2)"
   exit 1
 fi
 
@@ -68,10 +67,10 @@ if [ -z "$LEADER_IDX" ]; then
 fi
 
 LEADER_CONDUCTOR_PORT="${CONDUCTOR_PORTS[$LEADER_IDX]}"
-LEADER_CL_NAME="${CONDUCTOR_CL_NAMES[$LEADER_IDX]}"
+LEADER_NODE_NAME="${CONDUCTOR_NODE_NAMES[$LEADER_IDX]}"
 LEADER_CONDUCTOR_NAME="${CONDUCTOR_NAMES[$LEADER_IDX]}"
 
-echo "Current leader: $LEADER_CONDUCTOR_NAME ($LEADER_CL_NAME)"
+echo "Current leader: $LEADER_CONDUCTOR_NAME ($LEADER_NODE_NAME)"
 
 if [ -n "$TARGET" ] && [ "$TARGET" = "$LEADER_IDX" ]; then
   echo "Target is already the leader, nothing to do."
@@ -91,10 +90,10 @@ if [ -z "$TARGET" ]; then
     "http://localhost:$LEADER_CONDUCTOR_PORT" >/dev/null
 else
   TARGET_NAME="${CONDUCTOR_NAMES[$TARGET]}"
-  TARGET_CL="${CONDUCTOR_CL_NAMES[$TARGET]}"
+  TARGET_NODE="${CONDUCTOR_NODE_NAMES[$TARGET]}"
   TARGET_SERVER_ID="${CONDUCTOR_SERVER_IDS[$TARGET]}"
   TARGET_RAFT_ADDR="${CONDUCTOR_RAFT_ADDRS[$TARGET]}"
-  echo "Transferring raft leadership to $TARGET_NAME ($TARGET_CL)..."
+  echo "Transferring raft leadership to $TARGET_NAME ($TARGET_NODE)..."
   curl -s --max-time 5 \
     -X POST -H "Content-Type: application/json" \
     --data "{\"jsonrpc\":\"2.0\",\"method\":\"conductor_transferLeaderToServer\",\"params\":[\"$TARGET_SERVER_ID\",\"$TARGET_RAFT_ADDR\"],\"id\":1}" \
@@ -115,7 +114,7 @@ for _ in $(seq 1 30); do
       | jq -r '.result // empty' 2>/dev/null || true)
     if [ "$result" = "true" ] && [ "$i" != "$LEADER_IDX" ]; then
       echo ""
-      echo "Leadership transferred: $LEADER_CONDUCTOR_NAME → ${CONDUCTOR_NAMES[$i]} (${CONDUCTOR_CL_NAMES[$i]})"
+      echo "Leadership transferred: $LEADER_CONDUCTOR_NAME → ${CONDUCTOR_NAMES[$i]} (${CONDUCTOR_NODE_NAMES[$i]})"
       exit 0
     fi
   done


### PR DESCRIPTION
## Summary

This migrates the local Docker devnet L2 nodes onto the unified `base` binary. Sequencer nodes now run `base sequencer`, validator and RPC nodes run `base rpc`, and the L2 bootnode runs `base bootnode`. The old local Docker build targets and service wiring for separate `base-reth-node`, `base-builder`, and `base-consensus` images are removed, with docs and helper scripts updated to match.