### PR TITLE
feat(consensus): Add Upgrade Countdown Metric

### DIFF
--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -46,13 +46,14 @@ impl BaseCli {
             .init_tracing_subscriber()
             .wrap_err("failed to initialize tracing")?;
 
+        let metrics_enabled = metrics.enabled;
         MetricsConfig::from(metrics)
             .init_with(|| {
                 base_cli_utils::register_version_metrics!();
             })
             .wrap_err("failed to install Prometheus recorder")?;
 
-        command.run(ChainResolver::new(chain))
+        command.run(ChainResolver::new(chain), metrics_enabled)
     }
 }
 #[cfg(test)]

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -28,16 +28,22 @@ pub(crate) struct BootnodeCommand {
 
 impl BootnodeCommand {
     /// Runs both discovery-only bootnodes.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics_enabled: bool,
+    ) -> eyre::Result<()> {
         let consensus_chain = resolved_chain.consensus_chain_args();
         let rollup_config = self.l2_config.load(&consensus_chain.l2_chain_id)?;
 
-        CliMetrics::init_rollup_config(&rollup_config);
-        CliMetrics::init_bootnode_p2p(&self.consensus);
+        if metrics_enabled {
+            CliMetrics::init_rollup_config(&rollup_config);
+            CliMetrics::init_bootnode_p2p(&self.consensus);
+        }
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|_| async move {
-            let _upgrade_countdown_metrics =
-                CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone());
+            let _upgrade_countdown_metrics = metrics_enabled
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let chain_id = rollup_config.l2_chain_id.id();
             self.consensus.check_ports()?;
 

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -43,7 +43,7 @@ impl BootnodeCommand {
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|_| async move {
             let _upgrade_countdown_metrics = metrics_enabled
-                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(&rollup_config));
             let chain_id = rollup_config.l2_chain_id.id();
             self.consensus.check_ports()?;
 

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -43,7 +43,7 @@ impl BootnodeCommand {
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|_| async move {
             let _upgrade_countdown_metrics = metrics_enabled
-                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(&rollup_config));
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let chain_id = rollup_config.l2_chain_id.id();
             self.consensus.check_ports()?;
 

--- a/bin/base/src/commands/bootnode.rs
+++ b/bin/base/src/commands/bootnode.rs
@@ -36,6 +36,8 @@ impl BootnodeCommand {
         CliMetrics::init_bootnode_p2p(&self.consensus);
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|_| async move {
+            let _upgrade_countdown_metrics =
+                CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone());
             let chain_id = rollup_config.l2_chain_id.id();
             self.consensus.check_ports()?;
 

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -37,8 +37,10 @@ impl BaseCommand {
     ) -> eyre::Result<()> {
         match self {
             Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?, metrics_enabled),
-            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?),
-            Self::Sequencer(sequencer) => (*sequencer).run(chain_resolver.resolve()?),
+            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?, metrics_enabled),
+            Self::Sequencer(sequencer) => {
+                (*sequencer).run(chain_resolver.resolve()?, metrics_enabled)
+            }
             Self::Update(update) => (*update).run(),
         }
     }

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -30,9 +30,13 @@ pub(crate) enum BaseCommand {
 
 impl BaseCommand {
     /// Runs the selected top-level command.
-    pub(crate) fn run(self, chain_resolver: ChainResolver) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        chain_resolver: ChainResolver,
+        metrics_enabled: bool,
+    ) -> eyre::Result<()> {
         match self {
-            Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?),
+            Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?, metrics_enabled),
             Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?),
             Self::Sequencer(sequencer) => (*sequencer).run(chain_resolver.resolve()?),
             Self::Update(update) => (*update).run(),

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -3,7 +3,7 @@
 use std::{path::Path, sync::Arc};
 
 use base_consensus_cli::{
-    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
+    CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedConsensusNodeConfigArgs,
 };
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{ExecutionNodeArgs, chainspec::chain_value_parser};
@@ -43,7 +43,11 @@ pub(crate) struct RpcCommand {
 
 impl RpcCommand {
     /// Runs the `rpc` flavor.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics_enabled: bool,
+    ) -> eyre::Result<()> {
         let execution_chain = match self.execution_chain {
             Some(chain) => chain,
             None => resolved_chain.execution_chain_spec()?,
@@ -51,11 +55,16 @@ impl RpcCommand {
         let consensus_chain = resolved_chain.consensus_chain_args();
         let consensus_args = ConsensusNodeArgs::new(consensus_chain, self.consensus.into());
         let rollup_config = consensus_args.load_rollup_config()?;
+        if metrics_enabled {
+            CliMetrics::init_rollup_config(&rollup_config);
+        }
 
         let execution = self.execution.into_launch_config(execution_chain).with_auth_ipc();
         let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
+            let _upgrade_countdown_metrics = metrics_enabled
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let task_executor = ctx.task_executor.clone();
             let launched = execution.launch_default(ctx).await?;
             let handle = launched.handle;

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -64,7 +64,7 @@ impl RpcCommand {
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
             let _upgrade_countdown_metrics = metrics_enabled
-                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(&rollup_config));
             let task_executor = ctx.task_executor.clone();
             let launched = execution.launch_default(ctx).await?;
             let handle = launched.handle;

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -64,7 +64,7 @@ impl RpcCommand {
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
             let _upgrade_countdown_metrics = metrics_enabled
-                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(&rollup_config));
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let task_executor = ctx.task_executor.clone();
             let launched = execution.launch_default(ctx).await?;
             let handle = launched.handle;

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -6,7 +6,7 @@ use base_builder_cli::Args as BuilderArgs;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
 use base_consensus_cli::{
-    ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
+    CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
 };
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{ExecutionNodeConfigArgs, chainspec::chain_value_parser};
@@ -40,7 +40,11 @@ pub(crate) struct SequencerCommand {
 
 impl SequencerCommand {
     /// Runs the `sequencer` flavor with execution, builder, and consensus in one process.
-    pub(crate) fn run(self, resolved_chain: ResolvedChainConfig) -> eyre::Result<()> {
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics_enabled: bool,
+    ) -> eyre::Result<()> {
         let execution_chain = match self.execution_chain {
             Some(chain) => chain,
             None => resolved_chain.execution_chain_spec()?,
@@ -48,6 +52,9 @@ impl SequencerCommand {
         let consensus_chain = resolved_chain.consensus_chain_args();
         let consensus_args = ConsensusNodeArgs::new(consensus_chain, self.consensus.into());
         let rollup_config = consensus_args.load_rollup_config()?;
+        if metrics_enabled {
+            CliMetrics::init_rollup_config(&rollup_config);
+        }
 
         let rollup_args = self.builder.rollup_args.clone();
         let sequencer_rpc = rollup_args.sequencer.clone();
@@ -61,6 +68,8 @@ impl SequencerCommand {
         let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
+            let _upgrade_countdown_metrics = metrics_enabled
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let task_executor = ctx.task_executor.clone();
             let builder = execution.into_default_node_builder(ctx)?;
             let mut runner = BaseNodeRunner::new(rollup_args)

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -69,7 +69,7 @@ impl SequencerCommand {
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
             let _upgrade_countdown_metrics = metrics_enabled
-                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(&rollup_config));
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let task_executor = ctx.task_executor.clone();
             let builder = execution.into_default_node_builder(ctx)?;
             let mut runner = BaseNodeRunner::new(rollup_args)

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -69,7 +69,7 @@ impl SequencerCommand {
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
             let _upgrade_countdown_metrics = metrics_enabled
-                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(&rollup_config));
             let task_executor = ctx.task_executor.clone();
             let builder = execution.into_default_node_builder(ctx)?;
             let mut runner = BaseNodeRunner::new(rollup_args)

--- a/crates/consensus/cli/src/bootnode.rs
+++ b/crates/consensus/cli/src/bootnode.rs
@@ -73,6 +73,8 @@ impl Bootnode {
 
     /// Runs the discovery-only bootnode.
     pub async fn exec(self, cfg: RollupConfig) -> eyre::Result<()> {
+        let _upgrade_countdown_metrics =
+            self.metrics.enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
         let chain_id = cfg.l2_chain_id.id();
         self.p2p.check_ports()?;
 

--- a/crates/consensus/cli/src/bootnode.rs
+++ b/crates/consensus/cli/src/bootnode.rs
@@ -74,7 +74,7 @@ impl Bootnode {
     /// Runs the discovery-only bootnode.
     pub async fn exec(self, cfg: RollupConfig) -> eyre::Result<()> {
         let _upgrade_countdown_metrics =
-            self.metrics.enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(&cfg));
+            self.metrics.enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
         let chain_id = cfg.l2_chain_id.id();
         self.p2p.check_ports()?;
 

--- a/crates/consensus/cli/src/bootnode.rs
+++ b/crates/consensus/cli/src/bootnode.rs
@@ -74,7 +74,7 @@ impl Bootnode {
     /// Runs the discovery-only bootnode.
     pub async fn exec(self, cfg: RollupConfig) -> eyre::Result<()> {
         let _upgrade_countdown_metrics =
-            self.metrics.enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
+            self.metrics.enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(&cfg));
         let chain_id = cfg.l2_chain_id.id();
         self.p2p.check_ports()?;
 

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -49,12 +49,19 @@ impl ConsensusFollowNodeCommand {
         })?;
 
         let args = ConsensusFollowNodeArgs::new(chain, self.args);
-        if self.metrics.enabled {
+        let metrics_config = if self.metrics.enabled {
             let cfg = args.load_rollup_config()?;
             CliMetrics::init_rollup_config(&cfg);
-        }
+            Some(cfg)
+        } else {
+            None
+        };
 
-        RuntimeManager::new().run_until_ctrl_c(args.start())
+        RuntimeManager::new().run_until_ctrl_c(async move {
+            let _upgrade_countdown_metrics =
+                metrics_config.map(CliMetrics::spawn_upgrade_countdown_recorder);
+            args.start().await
+        })
     }
 }
 

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -59,7 +59,7 @@ impl ConsensusFollowNodeCommand {
 
         RuntimeManager::new().run_until_ctrl_c(async move {
             let _upgrade_countdown_metrics =
-                metrics_config.map(CliMetrics::spawn_upgrade_countdown_recorder);
+                metrics_config.as_ref().map(CliMetrics::spawn_upgrade_countdown_recorder);
             args.start().await
         })
     }

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -59,7 +59,7 @@ impl ConsensusFollowNodeCommand {
 
         RuntimeManager::new().run_until_ctrl_c(async move {
             let _upgrade_countdown_metrics =
-                metrics_config.as_ref().map(CliMetrics::spawn_upgrade_countdown_recorder);
+                metrics_config.map(CliMetrics::spawn_upgrade_countdown_recorder);
             args.start().await
         })
     }

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -2,11 +2,11 @@
 
 use std::{
     collections::BTreeSet,
-    thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use base_common_genesis::{BaseUpgrade, RollupConfig};
+use tokio::task::JoinHandle;
 
 use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
 
@@ -184,20 +184,24 @@ impl CliMetrics {
             let time: f64 = activation_time.map(|t| t as f64).unwrap_or(-1f64);
             metrics::gauge!(Self::UPGRADE_ACTIVATION_TIMES, "upgrade" => upgrade_name).set(time);
         }
-
-        Self::spawn_upgrade_countdown_recorder(config.clone());
     }
 
-    fn spawn_upgrade_countdown_recorder(config: RollupConfig) {
-        thread::spawn(move || {
+    /// Starts the periodic recorder for the next scheduled upgrade countdown metric.
+    ///
+    /// This must be called from an active Tokio runtime. The static rollup config metrics are
+    /// initialized before the runtime exists in some CLI paths, so the dynamic countdown recorder is
+    /// started separately by the async command entrypoints.
+    pub fn spawn_upgrade_countdown_recorder(config: RollupConfig) -> JoinHandle<()> {
+        tokio::spawn(async move {
             let mut observed_upgrades = BTreeSet::new();
+            let mut interval = tokio::time::interval(UPGRADE_COUNTDOWN_REFRESH_INTERVAL);
 
             loop {
+                interval.tick().await;
                 let now = current_unix_timestamp();
                 Self::record_seconds_until_next_upgrade(&config, now, &mut observed_upgrades);
-                thread::sleep(UPGRADE_COUNTDOWN_REFRESH_INTERVAL);
             }
-        });
+        })
     }
 
     fn record_seconds_until_next_upgrade(
@@ -215,15 +219,23 @@ impl CliMetrics {
                 .set(seconds_until_activation as f64);
         }
 
-        for upgrade in observed_upgrades.difference(&current_upgrades) {
+        let stale_upgrades =
+            observed_upgrades.difference(&current_upgrades).copied().collect::<Vec<_>>();
+
+        for upgrade in &stale_upgrades {
             metrics::gauge!(Self::SECONDS_UNTIL_NEXT_UPGRADE, "upgrade" => *upgrade)
                 .set(NO_UPCOMING_UPGRADE_SECONDS);
+        }
+        for upgrade in stale_upgrades {
+            observed_upgrades.remove(upgrade);
         }
     }
 }
 
 const UPGRADE_COUNTDOWN_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 const UPGRADE_ACTIVATION_GRACE_SECONDS: u64 = 15 * 60;
+// Use a large reset value, not `-1`, so Datadog `<= 1d/1h/0` countdown monitors recover after the
+// activation grace window instead of alerting on an unscheduled sentinel.
 const NO_UPCOMING_UPGRADE_SECONDS: f64 = 4_294_967_295.0;
 
 fn current_unix_timestamp() -> u64 {
@@ -332,5 +344,30 @@ mod tests {
         };
 
         assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("azul", 100), ("beryl", 100)]);
+    }
+
+    #[test]
+    fn record_seconds_until_next_upgrade_drains_stale_upgrades() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: base_common_genesis::BaseUpgradeConfig {
+                    beryl: Some(1_000),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut observed_upgrades = BTreeSet::new();
+
+        CliMetrics::record_seconds_until_next_upgrade(&config, 900, &mut observed_upgrades);
+        assert!(observed_upgrades.contains("beryl"));
+
+        CliMetrics::record_seconds_until_next_upgrade(
+            &config,
+            1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1,
+            &mut observed_upgrades,
+        );
+        assert!(observed_upgrades.is_empty());
     }
 }

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use base_common_genesis::{BaseUpgrade, RollupConfig};
+use base_common_genesis::{BaseUpgrade, RollupConfig, UpgradeConfig};
 use tokio::task::JoinHandle;
 
 use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
@@ -272,24 +272,19 @@ fn seconds_until_next_upgrades(config: &RollupConfig, now: u64) -> Vec<(&'static
         .collect()
 }
 
-const fn upgrade_metric_label(upgrade: BaseUpgrade) -> &'static str {
-    match upgrade {
-        BaseUpgrade::Bedrock => "Bedrock",
-        BaseUpgrade::Regolith => "Regolith",
-        BaseUpgrade::Canyon => "Canyon",
-        BaseUpgrade::Delta => "Delta",
-        BaseUpgrade::Ecotone => "Ecotone",
-        BaseUpgrade::Fjord => "Fjord",
-        BaseUpgrade::Granite => "Granite",
-        BaseUpgrade::Holocene => "Holocene",
-        BaseUpgrade::PectraBlobSchedule => "Pectra Blob Schedule",
-        BaseUpgrade::Isthmus => "Isthmus",
-        BaseUpgrade::Jovian => "Jovian",
-        BaseUpgrade::Azul => "Azul",
-        BaseUpgrade::Beryl => "Beryl",
-        BaseUpgrade::Cobalt => "Cobalt",
-        _ => upgrade.name(),
-    }
+fn upgrade_metric_label(upgrade: BaseUpgrade) -> &'static str {
+    let config = UpgradeConfig::default();
+    BaseUpgrade::CONTRACT_VARIANTS
+        .into_iter()
+        .zip(config.iter().map(|(label, _)| label))
+        .find_map(|(candidate, label)| (candidate == upgrade).then_some(label))
+        .expect("contract upgrade metric label exists")
+}
+
+#[cfg(test)]
+fn upgrade_metric_labels() -> Vec<(BaseUpgrade, &'static str)> {
+    let config = UpgradeConfig::default();
+    BaseUpgrade::CONTRACT_VARIANTS.into_iter().zip(config.iter().map(|(label, _)| label)).collect()
 }
 
 #[cfg(test)]
@@ -395,14 +390,12 @@ mod tests {
 
     #[test]
     fn upgrade_metric_label_matches_upgrade_activation_time_labels() {
-        let labels = BaseUpgrade::CONTRACT_VARIANTS
-            .into_iter()
-            .map(upgrade_metric_label)
-            .collect::<Vec<_>>();
+        let labels = upgrade_metric_labels();
+        assert_eq!(labels.len(), BaseUpgrade::CONTRACT_VARIANTS.len());
 
         let config_labels =
             UpgradeConfig::default().iter().map(|(label, _)| label).collect::<Vec<_>>();
 
-        assert_eq!(labels, config_labels);
+        assert_eq!(labels.iter().map(|(_, label)| *label).collect::<Vec<_>>(), config_labels);
     }
 }

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -190,10 +190,9 @@ impl CliMetrics {
     ///
     /// This must be called from an active Tokio runtime. The static rollup config metrics are
     /// initialized before the runtime exists in some CLI paths, so the dynamic countdown recorder is
-    /// started separately by the async command entrypoints.
-    pub fn spawn_upgrade_countdown_recorder(config: &RollupConfig) -> JoinHandle<()> {
-        let schedule = UpgradeCountdownSchedule::from_rollup_config(config);
-
+    /// started separately by the async command entrypoints. The recorder owns its rollup config so
+    /// it can re-query runtime-aware activation timestamps on each tick.
+    pub fn spawn_upgrade_countdown_recorder(config: RollupConfig) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut observed_upgrades = BTreeSet::new();
             let mut interval = tokio::time::interval(UPGRADE_COUNTDOWN_REFRESH_INTERVAL);
@@ -202,17 +201,17 @@ impl CliMetrics {
             loop {
                 interval.tick().await;
                 let now = current_unix_timestamp();
-                Self::record_seconds_until_next_upgrade(&schedule, now, &mut observed_upgrades);
+                Self::record_seconds_until_next_upgrade(&config, now, &mut observed_upgrades);
             }
         })
     }
 
     fn record_seconds_until_next_upgrade(
-        schedule: &UpgradeCountdownSchedule,
+        config: &RollupConfig,
         now: u64,
         observed_upgrades: &mut BTreeSet<&'static str>,
     ) {
-        let countdowns = seconds_until_next_upgrades(schedule, now);
+        let countdowns = seconds_until_next_upgrades(config, now);
         let current_upgrades =
             countdowns.iter().map(|(upgrade, _)| *upgrade).collect::<BTreeSet<_>>();
 
@@ -245,48 +244,33 @@ fn current_unix_timestamp() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
 }
 
-struct UpgradeCountdownSchedule {
-    activations: Vec<(&'static str, u64)>,
-}
-
-impl UpgradeCountdownSchedule {
-    fn from_rollup_config(config: &RollupConfig) -> Self {
-        let activations = BaseUpgrade::CONTRACT_VARIANTS
-            .into_iter()
-            .filter_map(|upgrade| {
-                let label = upgrade_metric_label(upgrade)?;
-                let activation_time = config.contract_upgrade_activation_timestamp(upgrade)?;
-                Some((label, activation_time))
-            })
-            .collect();
-
-        Self { activations }
-    }
-}
-
-fn seconds_until_next_upgrades(
-    schedule: &UpgradeCountdownSchedule,
-    now: u64,
-) -> Vec<(&'static str, u64)> {
-    let next_activation = schedule
-        .activations
-        .iter()
-        .filter(|(_, activation_time)| {
-            activation_time.saturating_add(UPGRADE_ACTIVATION_GRACE_SECONDS) >= now
+fn seconds_until_next_upgrades(config: &RollupConfig, now: u64) -> Vec<(&'static str, u64)> {
+    let next_activation = BaseUpgrade::CONTRACT_VARIANTS
+        .into_iter()
+        .filter_map(|upgrade| {
+            config
+                .contract_upgrade_activation_timestamp(upgrade)
+                .filter(|activation_time| {
+                    activation_time.saturating_add(UPGRADE_ACTIVATION_GRACE_SECONDS) >= now
+                })
+                .map(|activation_time| (upgrade, activation_time))
         })
-        .map(|(_, activation_time)| *activation_time)
-        .min();
+        .min_by_key(|(_, activation_time)| *activation_time);
 
-    let Some(next_activation_time) = next_activation else {
+    let Some((_, next_activation_time)) = next_activation else {
         return Vec::new();
     };
 
-    schedule
-        .activations
-        .iter()
-        .filter_map(|(label, activation_time)| {
-            (*activation_time == next_activation_time)
-                .then_some((*label, activation_time.saturating_sub(now)))
+    BaseUpgrade::CONTRACT_VARIANTS
+        .into_iter()
+        .filter_map(|upgrade| {
+            config
+                .contract_upgrade_activation_timestamp(upgrade)
+                .filter(|activation_time| *activation_time == next_activation_time)
+                .and_then(|activation_time| {
+                    upgrade_metric_label(upgrade)
+                        .map(|label| (label, activation_time.saturating_sub(now)))
+                })
         })
         .collect()
 }
@@ -314,19 +298,14 @@ fn upgrade_metric_label(upgrade: BaseUpgrade) -> Option<&'static str> {
 }
 
 #[cfg(test)]
-fn upgrade_metric_labels() -> Vec<(BaseUpgrade, &'static str)> {
-    UPGRADE_METRIC_LABELS.to_vec()
-}
-
-#[cfg(test)]
 mod tests {
-    use base_common_genesis::UpgradeConfig;
+    use alloy_chains::Chain;
+    use base_common_genesis::{RuntimeUpgradeRegistry, UpgradeConfig};
 
     use super::*;
 
-    fn countdowns(config: &RollupConfig, now: u64) -> Vec<(&'static str, u64)> {
-        let schedule = UpgradeCountdownSchedule::from_rollup_config(config);
-        seconds_until_next_upgrades(&schedule, now)
+    fn upgrade_metric_labels() -> Vec<(BaseUpgrade, &'static str)> {
+        UPGRADE_METRIC_LABELS.to_vec()
     }
 
     #[test]
@@ -343,7 +322,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(countdowns(&config, 800), vec![("Azul", 200)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 800), vec![("Azul", 200)]);
     }
 
     #[test]
@@ -359,8 +338,8 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(countdowns(&config, 1_000), vec![("Beryl", 0)]);
-        assert_eq!(countdowns(&config, 1_100), vec![("Beryl", 0)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 1_000), vec![("Beryl", 0)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 1_100), vec![("Beryl", 0)]);
     }
 
     #[test]
@@ -376,7 +355,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(countdowns(&config, 1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1).is_empty());
+        assert!(
+            seconds_until_next_upgrades(&config, 1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1)
+                .is_empty()
+        );
     }
 
     #[test]
@@ -393,7 +375,24 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(countdowns(&config, 900), vec![("Azul", 100), ("Beryl", 100)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("Azul", 100), ("Beryl", 100)]);
+    }
+
+    #[test]
+    fn seconds_until_next_upgrades_reflects_runtime_registry_updates() {
+        let chain_id = 9_200_001;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+        let config = RollupConfig { l2_chain_id: Chain::from_id(chain_id), ..Default::default() };
+
+        assert!(seconds_until_next_upgrades(&config, 900).is_empty());
+
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Beryl, 1_000);
+        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("Beryl", 100)]);
+
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Beryl, 2_000);
+        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("Beryl", 1_100)]);
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 
     #[test]
@@ -408,14 +407,13 @@ mod tests {
             },
             ..Default::default()
         };
-        let schedule = UpgradeCountdownSchedule::from_rollup_config(&config);
         let mut observed_upgrades = BTreeSet::new();
 
-        CliMetrics::record_seconds_until_next_upgrade(&schedule, 900, &mut observed_upgrades);
+        CliMetrics::record_seconds_until_next_upgrade(&config, 900, &mut observed_upgrades);
         assert!(observed_upgrades.contains("Beryl"));
 
         CliMetrics::record_seconds_until_next_upgrade(
-            &schedule,
+            &config,
             1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1,
             &mut observed_upgrades,
         );

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -1,6 +1,12 @@
 //! CLI Options Metrics
 
-use base_common_genesis::RollupConfig;
+use std::{
+    collections::BTreeSet,
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use base_common_genesis::{BaseUpgrade, RollupConfig};
 
 use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
 
@@ -68,6 +74,9 @@ impl CliMetrics {
 
     /// Upgrade activation times.
     pub const UPGRADE_ACTIVATION_TIMES: &'static str = "base_node_upgrades";
+
+    /// Seconds until the next scheduled upgrade activation.
+    pub const SECONDS_UNTIL_NEXT_UPGRADE: &'static str = "base_node_seconds_until_next_upgrade";
 
     /// Top-level rollup config settings.
     pub const ROLLUP_CONFIG: &'static str = "base_node_rollup_config";
@@ -144,6 +153,10 @@ impl CliMetrics {
             Self::UPGRADE_ACTIVATION_TIMES,
             "Activation times for upgrades in Base"
         );
+        metrics::describe_gauge!(
+            Self::SECONDS_UNTIL_NEXT_UPGRADE,
+            "Seconds until the next scheduled Base upgrade activation"
+        );
 
         metrics::gauge!(
             Self::ROLLUP_CONFIG,
@@ -171,5 +184,153 @@ impl CliMetrics {
             let time: f64 = activation_time.map(|t| t as f64).unwrap_or(-1f64);
             metrics::gauge!(Self::UPGRADE_ACTIVATION_TIMES, "upgrade" => upgrade_name).set(time);
         }
+
+        Self::spawn_upgrade_countdown_recorder(config.clone());
+    }
+
+    fn spawn_upgrade_countdown_recorder(config: RollupConfig) {
+        thread::spawn(move || {
+            let mut observed_upgrades = BTreeSet::new();
+
+            loop {
+                let now = current_unix_timestamp();
+                Self::record_seconds_until_next_upgrade(&config, now, &mut observed_upgrades);
+                thread::sleep(UPGRADE_COUNTDOWN_REFRESH_INTERVAL);
+            }
+        });
+    }
+
+    fn record_seconds_until_next_upgrade(
+        config: &RollupConfig,
+        now: u64,
+        observed_upgrades: &mut BTreeSet<&'static str>,
+    ) {
+        let countdowns = seconds_until_next_upgrades(config, now);
+        let current_upgrades =
+            countdowns.iter().map(|(upgrade, _)| *upgrade).collect::<BTreeSet<_>>();
+
+        for (upgrade, seconds_until_activation) in countdowns {
+            observed_upgrades.insert(upgrade);
+            metrics::gauge!(Self::SECONDS_UNTIL_NEXT_UPGRADE, "upgrade" => upgrade)
+                .set(seconds_until_activation as f64);
+        }
+
+        for upgrade in observed_upgrades.difference(&current_upgrades) {
+            metrics::gauge!(Self::SECONDS_UNTIL_NEXT_UPGRADE, "upgrade" => *upgrade)
+                .set(NO_UPCOMING_UPGRADE_SECONDS);
+        }
+    }
+}
+
+const UPGRADE_COUNTDOWN_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+const UPGRADE_ACTIVATION_GRACE_SECONDS: u64 = 15 * 60;
+const NO_UPCOMING_UPGRADE_SECONDS: f64 = 4_294_967_295.0;
+
+fn current_unix_timestamp() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+fn seconds_until_next_upgrades(config: &RollupConfig, now: u64) -> Vec<(&'static str, u64)> {
+    let next_activation = BaseUpgrade::CONTRACT_VARIANTS
+        .into_iter()
+        .filter_map(|upgrade| {
+            config
+                .contract_upgrade_activation_timestamp(upgrade)
+                .filter(|activation_time| {
+                    activation_time.saturating_add(UPGRADE_ACTIVATION_GRACE_SECONDS) >= now
+                })
+                .map(|activation_time| (upgrade, activation_time))
+        })
+        .min_by_key(|(_, activation_time)| *activation_time);
+
+    let Some((_, next_activation_time)) = next_activation else {
+        return Vec::new();
+    };
+
+    BaseUpgrade::CONTRACT_VARIANTS
+        .into_iter()
+        .filter_map(|upgrade| {
+            config
+                .contract_upgrade_activation_timestamp(upgrade)
+                .filter(|activation_time| *activation_time == next_activation_time)
+                .map(|activation_time| (upgrade.contract_id(), activation_time.saturating_sub(now)))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::UpgradeConfig;
+
+    use super::*;
+
+    #[test]
+    fn seconds_until_next_upgrades_returns_future_countdown() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: base_common_genesis::BaseUpgradeConfig {
+                    azul: Some(1_000),
+                    beryl: Some(2_000),
+                    cobalt: Some(3_000),
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(seconds_until_next_upgrades(&config, 800), vec![("azul", 200)]);
+    }
+
+    #[test]
+    fn seconds_until_next_upgrades_returns_zero_during_activation_grace() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: base_common_genesis::BaseUpgradeConfig {
+                    beryl: Some(1_000),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(seconds_until_next_upgrades(&config, 1_000), vec![("beryl", 0)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 1_100), vec![("beryl", 0)]);
+    }
+
+    #[test]
+    fn seconds_until_next_upgrades_ignores_activations_after_grace() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: base_common_genesis::BaseUpgradeConfig {
+                    beryl: Some(1_000),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(
+            seconds_until_next_upgrades(&config, 1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn seconds_until_next_upgrades_returns_all_simultaneous_next_upgrades() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: base_common_genesis::BaseUpgradeConfig {
+                    azul: Some(1_000),
+                    beryl: Some(1_000),
+                    cobalt: Some(2_000),
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("azul", 100), ("beryl", 100)]);
     }
 }

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use base_common_genesis::{BaseUpgrade, RollupConfig, UpgradeConfig};
+use base_common_genesis::{BaseUpgrade, RollupConfig};
 use tokio::task::JoinHandle;
 
 use crate::{P2PArgs, bootnode::BootnodeP2PArgs};
@@ -265,26 +265,39 @@ fn seconds_until_next_upgrades(config: &RollupConfig, now: u64) -> Vec<(&'static
             config
                 .contract_upgrade_activation_timestamp(upgrade)
                 .filter(|activation_time| *activation_time == next_activation_time)
-                .map(|activation_time| {
-                    (upgrade_metric_label(upgrade), activation_time.saturating_sub(now))
+                .and_then(|activation_time| {
+                    upgrade_metric_label(upgrade)
+                        .map(|label| (label, activation_time.saturating_sub(now)))
                 })
         })
         .collect()
 }
 
-fn upgrade_metric_label(upgrade: BaseUpgrade) -> &'static str {
-    let config = UpgradeConfig::default();
-    BaseUpgrade::CONTRACT_VARIANTS
-        .into_iter()
-        .zip(config.iter().map(|(label, _)| label))
-        .find_map(|(candidate, label)| (candidate == upgrade).then_some(label))
-        .expect("contract upgrade metric label exists")
+const UPGRADE_METRIC_LABELS: [(BaseUpgrade, &str); BaseUpgrade::CONTRACT_VARIANTS.len()] = [
+    (BaseUpgrade::Regolith, "Regolith"),
+    (BaseUpgrade::Canyon, "Canyon"),
+    (BaseUpgrade::Delta, "Delta"),
+    (BaseUpgrade::Ecotone, "Ecotone"),
+    (BaseUpgrade::Fjord, "Fjord"),
+    (BaseUpgrade::Granite, "Granite"),
+    (BaseUpgrade::Holocene, "Holocene"),
+    (BaseUpgrade::PectraBlobSchedule, "Pectra Blob Schedule"),
+    (BaseUpgrade::Isthmus, "Isthmus"),
+    (BaseUpgrade::Jovian, "Jovian"),
+    (BaseUpgrade::Azul, "Azul"),
+    (BaseUpgrade::Beryl, "Beryl"),
+    (BaseUpgrade::Cobalt, "Cobalt"),
+];
+
+fn upgrade_metric_label(upgrade: BaseUpgrade) -> Option<&'static str> {
+    UPGRADE_METRIC_LABELS
+        .iter()
+        .find_map(|(candidate, label)| (*candidate == upgrade).then_some(*label))
 }
 
 #[cfg(test)]
 fn upgrade_metric_labels() -> Vec<(BaseUpgrade, &'static str)> {
-    let config = UpgradeConfig::default();
-    BaseUpgrade::CONTRACT_VARIANTS.into_iter().zip(config.iter().map(|(label, _)| label)).collect()
+    UPGRADE_METRIC_LABELS.to_vec()
 }
 
 #[cfg(test)]

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -191,25 +191,28 @@ impl CliMetrics {
     /// This must be called from an active Tokio runtime. The static rollup config metrics are
     /// initialized before the runtime exists in some CLI paths, so the dynamic countdown recorder is
     /// started separately by the async command entrypoints.
-    pub fn spawn_upgrade_countdown_recorder(config: RollupConfig) -> JoinHandle<()> {
+    pub fn spawn_upgrade_countdown_recorder(config: &RollupConfig) -> JoinHandle<()> {
+        let schedule = UpgradeCountdownSchedule::from_rollup_config(config);
+
         tokio::spawn(async move {
             let mut observed_upgrades = BTreeSet::new();
             let mut interval = tokio::time::interval(UPGRADE_COUNTDOWN_REFRESH_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             loop {
                 interval.tick().await;
                 let now = current_unix_timestamp();
-                Self::record_seconds_until_next_upgrade(&config, now, &mut observed_upgrades);
+                Self::record_seconds_until_next_upgrade(&schedule, now, &mut observed_upgrades);
             }
         })
     }
 
     fn record_seconds_until_next_upgrade(
-        config: &RollupConfig,
+        schedule: &UpgradeCountdownSchedule,
         now: u64,
         observed_upgrades: &mut BTreeSet<&'static str>,
     ) {
-        let countdowns = seconds_until_next_upgrades(config, now);
+        let countdowns = seconds_until_next_upgrades(schedule, now);
         let current_upgrades =
             countdowns.iter().map(|(upgrade, _)| *upgrade).collect::<BTreeSet<_>>();
 
@@ -242,33 +245,48 @@ fn current_unix_timestamp() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
 }
 
-fn seconds_until_next_upgrades(config: &RollupConfig, now: u64) -> Vec<(&'static str, u64)> {
-    let next_activation = BaseUpgrade::CONTRACT_VARIANTS
-        .into_iter()
-        .filter_map(|upgrade| {
-            config
-                .contract_upgrade_activation_timestamp(upgrade)
-                .filter(|activation_time| {
-                    activation_time.saturating_add(UPGRADE_ACTIVATION_GRACE_SECONDS) >= now
-                })
-                .map(|activation_time| (upgrade, activation_time))
-        })
-        .min_by_key(|(_, activation_time)| *activation_time);
+struct UpgradeCountdownSchedule {
+    activations: Vec<(&'static str, u64)>,
+}
 
-    let Some((_, next_activation_time)) = next_activation else {
+impl UpgradeCountdownSchedule {
+    fn from_rollup_config(config: &RollupConfig) -> Self {
+        let activations = BaseUpgrade::CONTRACT_VARIANTS
+            .into_iter()
+            .filter_map(|upgrade| {
+                let label = upgrade_metric_label(upgrade)?;
+                let activation_time = config.contract_upgrade_activation_timestamp(upgrade)?;
+                Some((label, activation_time))
+            })
+            .collect();
+
+        Self { activations }
+    }
+}
+
+fn seconds_until_next_upgrades(
+    schedule: &UpgradeCountdownSchedule,
+    now: u64,
+) -> Vec<(&'static str, u64)> {
+    let next_activation = schedule
+        .activations
+        .iter()
+        .filter(|(_, activation_time)| {
+            activation_time.saturating_add(UPGRADE_ACTIVATION_GRACE_SECONDS) >= now
+        })
+        .map(|(_, activation_time)| *activation_time)
+        .min();
+
+    let Some(next_activation_time) = next_activation else {
         return Vec::new();
     };
 
-    BaseUpgrade::CONTRACT_VARIANTS
-        .into_iter()
-        .filter_map(|upgrade| {
-            config
-                .contract_upgrade_activation_timestamp(upgrade)
-                .filter(|activation_time| *activation_time == next_activation_time)
-                .and_then(|activation_time| {
-                    upgrade_metric_label(upgrade)
-                        .map(|label| (label, activation_time.saturating_sub(now)))
-                })
+    schedule
+        .activations
+        .iter()
+        .filter_map(|(label, activation_time)| {
+            (*activation_time == next_activation_time)
+                .then_some((*label, activation_time.saturating_sub(now)))
         })
         .collect()
 }
@@ -306,6 +324,11 @@ mod tests {
 
     use super::*;
 
+    fn countdowns(config: &RollupConfig, now: u64) -> Vec<(&'static str, u64)> {
+        let schedule = UpgradeCountdownSchedule::from_rollup_config(config);
+        seconds_until_next_upgrades(&schedule, now)
+    }
+
     #[test]
     fn seconds_until_next_upgrades_returns_future_countdown() {
         let config = RollupConfig {
@@ -320,7 +343,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(seconds_until_next_upgrades(&config, 800), vec![("Azul", 200)]);
+        assert_eq!(countdowns(&config, 800), vec![("Azul", 200)]);
     }
 
     #[test]
@@ -336,8 +359,8 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(seconds_until_next_upgrades(&config, 1_000), vec![("Beryl", 0)]);
-        assert_eq!(seconds_until_next_upgrades(&config, 1_100), vec![("Beryl", 0)]);
+        assert_eq!(countdowns(&config, 1_000), vec![("Beryl", 0)]);
+        assert_eq!(countdowns(&config, 1_100), vec![("Beryl", 0)]);
     }
 
     #[test]
@@ -353,10 +376,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(
-            seconds_until_next_upgrades(&config, 1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1)
-                .is_empty()
-        );
+        assert!(countdowns(&config, 1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1).is_empty());
     }
 
     #[test]
@@ -373,7 +393,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("Azul", 100), ("Beryl", 100)]);
+        assert_eq!(countdowns(&config, 900), vec![("Azul", 100), ("Beryl", 100)]);
     }
 
     #[test]
@@ -388,13 +408,14 @@ mod tests {
             },
             ..Default::default()
         };
+        let schedule = UpgradeCountdownSchedule::from_rollup_config(&config);
         let mut observed_upgrades = BTreeSet::new();
 
-        CliMetrics::record_seconds_until_next_upgrade(&config, 900, &mut observed_upgrades);
+        CliMetrics::record_seconds_until_next_upgrade(&schedule, 900, &mut observed_upgrades);
         assert!(observed_upgrades.contains("Beryl"));
 
         CliMetrics::record_seconds_until_next_upgrade(
-            &config,
+            &schedule,
             1_000 + UPGRADE_ACTIVATION_GRACE_SECONDS + 1,
             &mut observed_upgrades,
         );

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -265,9 +265,31 @@ fn seconds_until_next_upgrades(config: &RollupConfig, now: u64) -> Vec<(&'static
             config
                 .contract_upgrade_activation_timestamp(upgrade)
                 .filter(|activation_time| *activation_time == next_activation_time)
-                .map(|activation_time| (upgrade.contract_id(), activation_time.saturating_sub(now)))
+                .map(|activation_time| {
+                    (upgrade_metric_label(upgrade), activation_time.saturating_sub(now))
+                })
         })
         .collect()
+}
+
+const fn upgrade_metric_label(upgrade: BaseUpgrade) -> &'static str {
+    match upgrade {
+        BaseUpgrade::Bedrock => "Bedrock",
+        BaseUpgrade::Regolith => "Regolith",
+        BaseUpgrade::Canyon => "Canyon",
+        BaseUpgrade::Delta => "Delta",
+        BaseUpgrade::Ecotone => "Ecotone",
+        BaseUpgrade::Fjord => "Fjord",
+        BaseUpgrade::Granite => "Granite",
+        BaseUpgrade::Holocene => "Holocene",
+        BaseUpgrade::PectraBlobSchedule => "Pectra Blob Schedule",
+        BaseUpgrade::Isthmus => "Isthmus",
+        BaseUpgrade::Jovian => "Jovian",
+        BaseUpgrade::Azul => "Azul",
+        BaseUpgrade::Beryl => "Beryl",
+        BaseUpgrade::Cobalt => "Cobalt",
+        _ => upgrade.name(),
+    }
 }
 
 #[cfg(test)]
@@ -290,7 +312,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(seconds_until_next_upgrades(&config, 800), vec![("azul", 200)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 800), vec![("Azul", 200)]);
     }
 
     #[test]
@@ -306,8 +328,8 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(seconds_until_next_upgrades(&config, 1_000), vec![("beryl", 0)]);
-        assert_eq!(seconds_until_next_upgrades(&config, 1_100), vec![("beryl", 0)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 1_000), vec![("Beryl", 0)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 1_100), vec![("Beryl", 0)]);
     }
 
     #[test]
@@ -343,7 +365,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("azul", 100), ("beryl", 100)]);
+        assert_eq!(seconds_until_next_upgrades(&config, 900), vec![("Azul", 100), ("Beryl", 100)]);
     }
 
     #[test]
@@ -361,7 +383,7 @@ mod tests {
         let mut observed_upgrades = BTreeSet::new();
 
         CliMetrics::record_seconds_until_next_upgrade(&config, 900, &mut observed_upgrades);
-        assert!(observed_upgrades.contains("beryl"));
+        assert!(observed_upgrades.contains("Beryl"));
 
         CliMetrics::record_seconds_until_next_upgrade(
             &config,
@@ -369,5 +391,18 @@ mod tests {
             &mut observed_upgrades,
         );
         assert!(observed_upgrades.is_empty());
+    }
+
+    #[test]
+    fn upgrade_metric_label_matches_upgrade_activation_time_labels() {
+        let labels = BaseUpgrade::CONTRACT_VARIANTS
+            .into_iter()
+            .map(upgrade_metric_label)
+            .collect::<Vec<_>>();
+
+        let config_labels =
+            UpgradeConfig::default().iter().map(|(label, _)| label).collect::<Vec<_>>();
+
+        assert_eq!(labels, config_labels);
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -65,7 +65,12 @@ impl ConsensusNodeCommand {
             CliMetrics::init_p2p(&args.config.p2p_flags);
         }
 
-        RuntimeManager::new().run_until_ctrl_c(args.start_with_overrides(cfg, Default::default()))
+        let metrics_enabled = self.metrics.enabled;
+        RuntimeManager::new().run_until_ctrl_c(async move {
+            let _upgrade_countdown_metrics =
+                metrics_enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
+            args.start_with_overrides(cfg, Default::default()).await
+        })
     }
 }
 

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -68,7 +68,7 @@ impl ConsensusNodeCommand {
         let metrics_enabled = self.metrics.enabled;
         RuntimeManager::new().run_until_ctrl_c(async move {
             let _upgrade_countdown_metrics =
-                metrics_enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
+                metrics_enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(&cfg));
             args.start_with_overrides(cfg, Default::default()).await
         })
     }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -68,7 +68,7 @@ impl ConsensusNodeCommand {
         let metrics_enabled = self.metrics.enabled;
         RuntimeManager::new().run_until_ctrl_c(async move {
             let _upgrade_countdown_metrics =
-                metrics_enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(&cfg));
+                metrics_enabled.then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
             args.start_with_overrides(cfg, Default::default()).await
         })
     }


### PR DESCRIPTION
## Summary

This adds a consensus metric that reports the seconds until the next scheduled upgrade activation. The metric uses runtime-aware upgrade activation timestamps, emits zero during a short activation grace window, and resets previously observed upgrade series after the next activation window passes. The included tests cover future countdowns, activation behavior, expired activations, and simultaneous upgrade timestamps.