### PR TITLE
fix(batcher): Prevent Batcher P2P Metrics

### DIFF
--- a/crates/batcher/service/Cargo.toml
+++ b/crates/batcher/service/Cargo.toml
@@ -41,7 +41,6 @@ jsonrpsee = { workspace = true, features = ["http-client", "macros"] }
 metrics = [
 	"base-batcher-core/metrics",
 	"base-batcher-encoder/metrics",
-	"base-consensus-rpc/metrics",
 	"base-tx-manager/metrics",
 ]
 


### PR DESCRIPTION
## Summary

This removes the consensus RPC metrics feature from the batcher service metrics feature set. The batcher still uses consensus RPC clients, but no longer initializes consensus gossip gauges that can make non-P2P batcher pods emit zero peer-count metrics. This prevents the shadow batcher from matching low P2P peer-count monitors as a false signal.