### PR TITLE
fix(prover-service, challenger): close metric gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6084,6 +6084,7 @@ dependencies = [
  "chrono",
  "jsonrpsee",
  "metrics",
+ "metrics-util",
  "rstest",
  "serde_json",
  "tokio",

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -420,8 +420,12 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         //   starting_block + interval * (i + 1)
         let checkpoint_block = candidate.checkpoint_start_block(challenged_index + 1)?;
 
-        let expected_root = match self.validator.compute_output_root(checkpoint_block).await {
-            Ok(root) => root,
+        let validation = match self
+            .validator
+            .validate_claimed_root_at_block(game_address, checkpoint_block, on_chain_root)
+            .await
+        {
+            Ok(result) => result,
             Err(ValidatorError::BlockNotAvailable { .. }) => {
                 debug!(
                     game = %game_address,
@@ -443,12 +447,12 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
         // If the onchain root at the challenged index does not match the
         // locally computed root, the ZK challenge was legitimate — skip.
-        if on_chain_root != expected_root {
+        if !validation.is_valid {
             debug!(
                 game = %game_address,
                 challenged_index = challenged_index,
                 on_chain = %on_chain_root,
-                expected = %expected_root,
+                expected = %validation.expected_root,
                 "ZK challenge is legitimate (challenged root was wrong), skipping"
             );
             return Ok(());
@@ -463,8 +467,13 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
         ChallengerMetrics::fraudulent_zk_challenge_detected_total().increment(1);
 
-        self.initiate_zk_proof(candidate, challenged_index, on_chain_root, DisputeIntent::Nullify)
-            .await
+        self.initiate_zk_proof(
+            candidate,
+            challenged_index,
+            validation.expected_root,
+            DisputeIntent::Nullify,
+        )
+        .await
     }
 
     /// Attempts TEE-first proof sourcing with ZK fallback.

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -265,18 +265,18 @@ impl<L2: L2Provider> OutputValidator<L2> {
         Ok(None)
     }
 
-    /// Validates the final output root of a candidate dispute game.
+    /// Validates one claimed output root at a specific L2 block.
     ///
     /// Fetches the L2 header and `L2ToL1MessagePasser` storage proof at the
-    /// game's L2 block number, computes the expected output root, and compares
-    /// it against the game's `rootClaim`.
-    pub async fn validate_final_root(
+    /// provided L2 block number, computes the expected output root, and compares
+    /// it against the claimed root.
+    pub async fn validate_claimed_root_at_block(
         &self,
         game_address: Address,
         l2_block_number: u64,
         claimed_root: B256,
     ) -> Result<ValidationResult, ValidatorError> {
-        info!(game = %game_address, block = l2_block_number, "validating final output root");
+        info!(game = %game_address, block = l2_block_number, "validating claimed output root");
 
         let checkpoint = Checkpoint { block: l2_block_number, claimed_root };
         let mismatch = self.validate_output_roots(game_address, &[checkpoint]).await?;
@@ -401,6 +401,11 @@ mod tests {
     use alloy_consensus::Header as ConsensusHeader;
     use alloy_primitives::{Address, B256};
     use alloy_rpc_types_eth::Header as RpcHeader;
+    #[cfg(feature = "metrics")]
+    use metrics_util::{
+        MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
     use rstest::rstest;
 
     use super::*;
@@ -431,7 +436,7 @@ mod tests {
     #[case::valid(None, true)]
     #[case::invalid(Some(B256::repeat_byte(0xFF)), false)]
     #[tokio::test]
-    async fn test_validate_final_root(
+    async fn test_validate_claimed_root_at_block(
         #[case] wrong_root: Option<B256>,
         #[case] expect_valid: bool,
     ) {
@@ -441,7 +446,10 @@ mod tests {
         let game_address = Address::repeat_byte(0x01);
         let claimed_root = wrong_root.unwrap_or(expected_root);
 
-        let result = validator.validate_final_root(game_address, 100, claimed_root).await.unwrap();
+        let result = validator
+            .validate_claimed_root_at_block(game_address, 100, claimed_root)
+            .await
+            .unwrap();
 
         assert_eq!(result.is_valid, expect_valid);
         assert_eq!(result.expected_root, expected_root);
@@ -519,7 +527,7 @@ mod tests {
 
         // Final root validation succeeds
         let final_result =
-            validator.validate_final_root(game_address, 100, roots[1]).await.unwrap();
+            validator.validate_claimed_root_at_block(game_address, 100, roots[1]).await.unwrap();
         assert!(final_result.is_valid);
 
         // Intermediate root validation fails (corrupt index 0)
@@ -554,7 +562,7 @@ mod tests {
         let validator = OutputValidator::new(Arc::new(provider));
         let game_address = Address::repeat_byte(0x06);
 
-        let result = validator.validate_final_root(game_address, 100, B256::ZERO).await;
+        let result = validator.validate_claimed_root_at_block(game_address, 100, B256::ZERO).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -772,7 +780,7 @@ mod tests {
         let validator = OutputValidator::new(Arc::new(provider));
         let game_address = Address::repeat_byte(0x0B);
 
-        let result = validator.validate_final_root(game_address, 100, B256::ZERO).await;
+        let result = validator.validate_claimed_root_at_block(game_address, 100, B256::ZERO).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -812,7 +820,7 @@ mod tests {
         let validator = OutputValidator::new(Arc::new(provider));
         let game_address = Address::repeat_byte(0x0F);
 
-        let result = validator.validate_final_root(game_address, 100, B256::ZERO).await;
+        let result = validator.validate_claimed_root_at_block(game_address, 100, B256::ZERO).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -839,7 +847,8 @@ mod tests {
         let validator = OutputValidator::new(Arc::new(provider));
         let game_address = Address::repeat_byte(0x10);
 
-        let result = validator.validate_final_root(game_address, 100, substituted_root).await;
+        let result =
+            validator.validate_claimed_root_at_block(game_address, 100, substituted_root).await;
 
         let err = result.expect_err("substituted account proof should be rejected");
         match err {
@@ -852,5 +861,54 @@ mod tests {
             }
             other => panic!("expected AccountProofFailed, got: {other:?}"),
         }
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn validate_claimed_root_at_block_emits_shared_validation_metrics() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let (provider, roots) = mock_with_blocks(&[100]);
+        let validator = OutputValidator::new(Arc::new(provider));
+        let game_address = Address::repeat_byte(0x11);
+        let wrong_root = B256::repeat_byte(0xFF);
+
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            rt.block_on(async {
+                let result = validator
+                    .validate_claimed_root_at_block(game_address, 100, wrong_root)
+                    .await
+                    .expect("validation should complete");
+
+                assert!(!result.is_valid);
+                assert_eq!(result.expected_root, roots[0]);
+                assert_eq!(result.invalid_intermediate_index, None);
+            });
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert_eq!(
+            snapshot.iter().find_map(|(ck, _, _, value)| {
+                if ck.kind() != MetricKind::Counter
+                    || ck.key().name() != "base_challenger.games_invalid_total"
+                {
+                    return None;
+                }
+                match value {
+                    DebugValue::Counter(value) => Some(*value),
+                    _ => None,
+                }
+            }),
+            Some(1),
+        );
+        assert!(
+            snapshot.iter().any(|(ck, _, _, value)| {
+                ck.kind() == MetricKind::Histogram
+                    && ck.key().name() == "base_challenger.validation_latency_seconds"
+                    && matches!(value, DebugValue::Histogram(_))
+            }),
+            "checkpoint validation should record latency",
+        );
     }
 }

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace = true
 rstest.workspace = true
 chrono.workspace = true
 jsonrpsee = { workspace = true, features = ["http-client"] }
+metrics-util = { workspace = true, features = ["debugging"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 base-prover-service-protocol = { workspace = true, features = ["rpc-client"] }
 

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -197,12 +197,12 @@ impl TryFrom<&str> for SessionType {
 }
 
 /// Outcome of attempting to retry or fail a stuck proof request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum RetryOutcome {
     /// Request was reset to CREATED with incremented `retry_count`.
     Retried,
     /// Request was permanently marked FAILED (max retries exceeded).
-    PermanentlyFailed,
+    PermanentlyFailed(Box<ProofJob>),
     /// Request was no longer in PENDING state (already claimed or transitioned).
     Skipped,
 }
@@ -1048,8 +1048,10 @@ pub struct CompleteClaimedProofJob {
 /// Outcome of attempting to complete a worker proof job.
 #[derive(Debug, Clone)]
 pub enum SubmitProofOutcome {
-    /// Submit succeeded.
+    /// Submit succeeded and transitioned the job to terminal success.
     Completed(ProofJob),
+    /// Submit replayed an already completed result from the same worker/lock.
+    AlreadyCompleted(ProofJob),
     /// The submitted result does not match the claimed job's proof type or
     /// capability discriminator. The stored job is left unchanged.
     ResultMismatch {

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -645,7 +645,7 @@ impl ProofRequestRepo {
                 serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
 
             return Ok(if existing.result_payload.as_ref() == Some(&result_payload) {
-                SubmitProofOutcome::Completed(existing)
+                SubmitProofOutcome::AlreadyCompleted(existing)
             } else {
                 SubmitProofOutcome::ResultConflict { job: existing }
             });
@@ -725,7 +725,7 @@ impl ProofRequestRepo {
             }
 
             return Ok(if job.result_payload.as_ref() == Some(&result_payload) {
-                SubmitProofOutcome::Completed(job)
+                SubmitProofOutcome::AlreadyCompleted(job)
             } else {
                 SubmitProofOutcome::ResultConflict { job }
             });
@@ -852,7 +852,8 @@ impl ProofRequestRepo {
         .await?;
 
         if retry_count >= max_retries {
-            sqlx::query(
+            let columns = PROOF_JOB_RETURNING_COLUMNS;
+            let sql = format!(
                 r#"
                 UPDATE proof_requests
                 SET status = $1,
@@ -865,16 +866,22 @@ impl ProofRequestRepo {
                     claimed_at = NULL,
                     last_heartbeat_at = NULL
                 WHERE id = $3
+                RETURNING {columns}
                 "#,
-            )
-            .bind(ProofStatus::Failed.as_str())
-            .bind(format!("{error_message} (max retries exceeded after {retry_count} attempts)"))
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
+            );
+
+            let row = sqlx::query(&sql)
+                .bind(ProofStatus::Failed.as_str())
+                .bind(format!(
+                    "{error_message} (max retries exceeded after {retry_count} attempts)"
+                ))
+                .bind(id)
+                .fetch_one(&mut *tx)
+                .await?;
+            let job = row_to_proof_job(&row)?;
 
             tx.commit().await?;
-            return Ok(RetryOutcome::PermanentlyFailed);
+            return Ok(RetryOutcome::PermanentlyFailed(Box::new(job)));
         }
 
         sqlx::query(

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -842,7 +842,7 @@ async fn test_retry_or_fail_stuck_request_retries() {
     .unwrap();
 
     let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::Retried);
+    assert!(matches!(outcome, RetryOutcome::Retried));
 
     let req = repo.get(id).await.unwrap().unwrap();
     assert_eq!(req.status, ProofStatus::Created);
@@ -872,7 +872,7 @@ async fn test_retry_or_fail_stuck_request_retries_tee_request() {
     );
 
     let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck in PENDING").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::Retried);
+    assert!(matches!(outcome, RetryOutcome::Retried));
 
     let req = repo.get(id).await.unwrap().unwrap();
     assert_eq!(req.status, ProofStatus::Created);
@@ -892,7 +892,7 @@ async fn test_retry_or_fail_stuck_request_exhausted() {
     for i in 0..3 {
         repo.atomic_claim_task(id).await.unwrap();
         let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
-        assert_eq!(outcome, RetryOutcome::Retried, "retry {i} should succeed");
+        assert!(matches!(outcome, RetryOutcome::Retried), "retry {i} should succeed");
     }
 
     // retry_count is now 3, claim once more
@@ -900,7 +900,12 @@ async fn test_retry_or_fail_stuck_request_exhausted() {
 
     // This time should permanently fail (retry_count >= max_retries)
     let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::PermanentlyFailed);
+    let RetryOutcome::PermanentlyFailed(job) = outcome else {
+        panic!("expected permanent failure outcome");
+    };
+    assert_eq!(job.id, id);
+    assert_eq!(job.job_status, ProofJobStatus::Failed);
+    assert!(job.completed_at.is_some());
 
     let req = repo.get(id).await.unwrap().unwrap();
     assert_eq!(req.status, ProofStatus::Failed);
@@ -918,7 +923,7 @@ async fn test_retry_or_fail_stuck_request_wrong_state() {
 
     // Request is RUNNING, not PENDING — should be skipped
     let outcome = repo.retry_or_fail_stuck_request(id, 3, "stuck").await.unwrap();
-    assert_eq!(outcome, RetryOutcome::Skipped);
+    assert!(matches!(outcome, RetryOutcome::Skipped));
 
     let req = repo.get(id).await.unwrap().unwrap();
     assert_eq!(req.status, ProofStatus::Running); // unchanged
@@ -965,7 +970,7 @@ async fn test_retry_or_fail_stuck_request_requeues_migration_parked_running_requ
     let outcome =
         repo.retry_or_fail_stuck_request(id, 3, "migration-parked RUNNING request").await.unwrap();
 
-    assert_eq!(outcome, RetryOutcome::Retried);
+    assert!(matches!(outcome, RetryOutcome::Retried));
 
     let req = repo.get(id).await.unwrap().unwrap();
     assert_eq!(req.status, ProofStatus::Created);
@@ -1661,7 +1666,7 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
         })
         .await
         .unwrap();
-    let SubmitProofOutcome::Completed(replayed) = replay else {
+    let SubmitProofOutcome::AlreadyCompleted(replayed) = replay else {
         panic!("identical retry should be idempotent");
     };
     assert_eq!(replayed.job_status, ProofJobStatus::Succeeded);

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -2,11 +2,12 @@
 
 mod metrics;
 pub use metrics::{
-    PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, ProverMetrics, REQUESTS,
-    RESPONSE_LATENCY_MS, RETRIED_REQUESTS, STUCK_REQUESTS, WITNESS_GENERATION_DURATION_MS,
-    WORKER_JOBS_FAILED, api_proof_type_label, inc_proof_requests_completed, inc_requests,
-    inc_retried_requests, inc_stuck_requests, inc_worker_jobs_failed, proof_type_label,
-    record_proof_request_duration, record_response_latency, record_witness_generation_duration,
+    PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, PROOF_STATUS_FAILED,
+    PROOF_STATUS_SUCCEEDED, ProverMetrics, REQUESTS, RESPONSE_LATENCY_MS, RETRIED_REQUESTS,
+    STUCK_REQUESTS, WITNESS_GENERATION_DURATION_MS, WORKER_JOBS_FAILED, api_proof_type_label,
+    inc_proof_requests_completed, inc_requests, inc_retried_requests, inc_stuck_requests,
+    inc_worker_jobs_failed, proof_type_label, record_proof_request_duration,
+    record_response_latency, record_terminal_proof_job, record_witness_generation_duration,
 };
 
 mod metadata;

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -3,7 +3,7 @@
 //! Uses the `metrics` crate facade (`counter!`, `histogram!`) so the exporter
 //! backend is determined by the binary (e.g. Prometheus, `DogStatsD`).
 
-use base_prover_service_db::{ApiProofType, ProofType};
+use base_prover_service_db::{ApiProofType, ProofJob, ProofType};
 use metrics::{counter, describe_counter, describe_histogram, histogram};
 
 // ---------------------------------------------------------------------------
@@ -27,6 +27,11 @@ pub const STUCK_REQUESTS: &str = "prover_service.stuck_requests";
 pub const RETRIED_REQUESTS: &str = "prover_service.retried_requests";
 /// Worker jobs terminally failed by a background reaper. Tags: `reason`, `proof_type`
 pub const WORKER_JOBS_FAILED: &str = "prover_service.worker_jobs_failed";
+
+/// Terminal success status label.
+pub const PROOF_STATUS_SUCCEEDED: &str = "succeeded";
+/// Terminal failure status label.
+pub const PROOF_STATUS_FAILED: &str = "failed";
 
 // ---------------------------------------------------------------------------
 // ProverMetrics — metric descriptions (called once at init)
@@ -129,6 +134,23 @@ pub fn inc_worker_jobs_failed(reason: &str, proof_type: &str) {
     .increment(1);
 }
 
+/// Record terminal outcome and duration metrics for a proof job.
+pub fn record_terminal_proof_job(status: &str, job: &ProofJob) {
+    let proof_type = api_proof_type_label(job.api_proof_type);
+    inc_proof_requests_completed(status, proof_type);
+
+    if let Some(completed_at) = job.completed_at {
+        let duration_ms = (completed_at - job.created_at).num_milliseconds().max(0) as f64;
+        record_proof_request_duration(proof_type, status, duration_ms);
+    } else {
+        tracing::warn!(
+            proof_request_id = %job.id,
+            status = %status,
+            "terminal proof job missing completed_at timestamp"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
@@ -147,5 +169,145 @@ pub const fn api_proof_type_label(proof_type: ApiProofType) -> &'static str {
         ApiProofType::Compressed => "compressed",
         ApiProofType::SnarkGroth16 => "snark_groth16",
         ApiProofType::Tee => "tee",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_prover_service_db::{ApiProofType, ProofJobStatus};
+    use chrono::{Duration, Utc};
+    use metrics_util::{
+        MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn terminal_proof_job_records_outcome_and_duration() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let created_at = Utc::now();
+        let completed_at = created_at + Duration::milliseconds(2500);
+        let job = proof_job(created_at, Some(completed_at));
+
+        metrics::with_local_recorder(&recorder, || {
+            record_terminal_proof_job(PROOF_STATUS_SUCCEEDED, &job);
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert_eq!(
+            snapshot.iter().find_map(|(ck, _, _, value)| {
+                if ck.kind() != MetricKind::Counter || ck.key().name() != PROOF_REQUESTS_COMPLETED {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "status" && label.value() == PROOF_STATUS_SUCCEEDED)
+                {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "proof_type" && label.value() == "tee")
+                {
+                    return None;
+                }
+                match value {
+                    DebugValue::Counter(value) => Some(*value),
+                    _ => None,
+                }
+            }),
+            Some(1),
+        );
+        assert!(
+            snapshot.iter().any(|(ck, _, _, value)| {
+                ck.kind() == MetricKind::Histogram
+                    && ck.key().name() == PROOF_REQUEST_DURATION_MS
+                    && ck.key().labels().any(|label| {
+                        label.key() == "status" && label.value() == PROOF_STATUS_SUCCEEDED
+                    })
+                    && ck
+                        .key()
+                        .labels()
+                        .any(|label| label.key() == "proof_type" && label.value() == "tee")
+                    && matches!(value, DebugValue::Histogram(_))
+            }),
+            "terminal completion should record proof duration",
+        );
+    }
+
+    #[test]
+    fn terminal_proof_job_negative_duration_records_zero_duration() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let created_at = Utc::now();
+        let completed_at = created_at - Duration::milliseconds(1);
+        let job = proof_job(created_at, Some(completed_at));
+
+        metrics::with_local_recorder(&recorder, || {
+            record_terminal_proof_job(PROOF_STATUS_SUCCEEDED, &job);
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert_eq!(
+            snapshot.iter().find_map(|(ck, _, _, value)| {
+                if ck.kind() != MetricKind::Histogram
+                    || ck.key().name() != PROOF_REQUEST_DURATION_MS
+                {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "status" && label.value() == PROOF_STATUS_SUCCEEDED)
+                {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "proof_type" && label.value() == "tee")
+                {
+                    return None;
+                }
+                match value {
+                    DebugValue::Histogram(values) => {
+                        Some(values.iter().map(|value| (*value).into_inner()).collect::<Vec<_>>())
+                    }
+                    _ => None,
+                }
+            }),
+            Some(vec![0.0]),
+        );
+    }
+
+    fn proof_job(
+        created_at: chrono::DateTime<Utc>,
+        completed_at: Option<chrono::DateTime<Utc>>,
+    ) -> ProofJob {
+        ProofJob {
+            id: Uuid::new_v4(),
+            session_id: "session-1".to_owned(),
+            request_payload: serde_json::Value::Null,
+            api_proof_type: ApiProofType::Tee,
+            zk_vm: None,
+            tee_kind: None,
+            job_status: ProofJobStatus::Succeeded,
+            attempt: 1,
+            worker_id: Some("worker-1".to_owned()),
+            lock_id: Some(Uuid::new_v4()),
+            lock_expires_at: None,
+            claimed_at: None,
+            last_heartbeat_at: None,
+            error_message: None,
+            result_payload: None,
+            created_at,
+            updated_at: completed_at.unwrap_or(created_at),
+            completed_at,
+        }
     }
 }

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -17,9 +17,12 @@ use jsonrpsee::{
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::server::{
-    ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
-    not_found, record_rpc_result,
+use crate::{
+    metrics,
+    server::{
+        ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
+        not_found, record_rpc_result,
+    },
 };
 
 #[async_trait]
@@ -199,10 +202,19 @@ impl ProverServiceServer {
 
         match outcome {
             SubmitProofOutcome::Completed(job) => {
+                metrics::record_terminal_proof_job(metrics::PROOF_STATUS_SUCCEEDED, &job);
                 info!(
                     worker_id = %request.worker_id,
                     session_id = %request.session_id,
                     "worker submitted proof result"
+                );
+                Ok(WorkerSubmitProofResponse { job: into_protocol_job(job)? })
+            }
+            SubmitProofOutcome::AlreadyCompleted(job) => {
+                info!(
+                    worker_id = %request.worker_id,
+                    session_id = %request.session_id,
+                    "worker replayed already completed proof result"
                 );
                 Ok(WorkerSubmitProofResponse { job: into_protocol_job(job)? })
             }

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -110,14 +110,14 @@ impl StatusPoller {
                         );
                         metrics::inc_retried_requests(proof_type_label);
                     }
-                    Ok(RetryOutcome::PermanentlyFailed) => {
+                    Ok(RetryOutcome::PermanentlyFailed(job)) => {
                         error!(
                             proof_request_id = %request.id,
                             retry_count = request.retry_count,
                             "Permanently failing stuck request — max retries exceeded"
                         );
                         metrics::inc_stuck_requests(proof_type_label);
-                        metrics::inc_proof_requests_completed("failed", proof_type_label);
+                        metrics::record_terminal_proof_job(metrics::PROOF_STATUS_FAILED, &job);
                     }
                     Ok(RetryOutcome::Skipped) => {
                         warn!(
@@ -167,7 +167,7 @@ impl StatusPoller {
         for job in jobs {
             let proof_type = metrics::api_proof_type_label(job.api_proof_type);
             metrics::inc_worker_jobs_failed(reason, proof_type);
-            metrics::inc_proof_requests_completed("failed", proof_type);
+            metrics::record_terminal_proof_job(metrics::PROOF_STATUS_FAILED, job);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Record terminal prover-service success and duration metrics when worker `submit_proof` newly completes a job.
- Split idempotent `submit_proof` replays into `AlreadyCompleted` so repeated worker submissions return the stored result without double-counting terminal metrics.
- Reuse the same terminal metric helper for expired-claim reaper failures and stuck-request permanent failures so `proof_requests_completed` and `proof_request_duration_ms` stay aligned on normal terminal paths.
- Route fraudulent ZK challenge checkpoint validation through the existing output validator method, now named `validate_claimed_root_at_block`, so Path 2 emits the existing validation latency, error, and invalid-root metrics without adding wrapper indirection.

## Why
The existing metric definitions were present, but some terminal paths did not emit them. Successful worker completions skipped `prover_service.proof_requests_completed` and `prover_service.proof_request_duration_ms`, and the fraudulent-ZK-challenge path computed one checkpoint directly instead of using the shared instrumented validator. That made dashboards undercount successful proof outcomes and hide Path 2 validation work.

The README metric sections added earlier were removed after review so the source constants remain the single source of truth for metric names.

## How to test
- `RUSTFMT_BOOTSTRAP=1 cargo fmt --check` (passes; rustfmt prints the workspace stable-channel warnings for unstable config keys)
- `git diff --check`
- `cargo clippy -p base-challenger --features metrics --all-targets -- -D warnings`
- `cargo test -p base-prover-service terminal_proof_job_records_outcome_and_duration`
- `cargo test -p base-challenger --features metrics validate_claimed_root_at_block_emits_shared_validation_metrics`
- `cargo test -p base-prover-service`
- `cargo test -p base-prover-service-db`
- `cargo test -p base-challenger --features metrics`

Notes: Postgres-backed integration tests in `base-prover-service` and `base-prover-service-db` remain ignored unless `DATABASE_URL` is set, which matches the existing test setup.
