### PR TITLE
fix(precompile-storage): clear stale tail chunks in store_bytes_like on shrink

### DIFF
--- a/crates/common/precompile-storage/src/types/bytes_like.rs
+++ b/crates/common/precompile-storage/src/types/bytes_like.rs
@@ -211,19 +211,40 @@ where
 
 #[inline]
 fn store_bytes_like<S: StorageOps>(bytes: &[u8], storage: &mut S, base_slot: U256) -> Result<()> {
-    let length = bytes.len();
-    if length <= 31 {
+    let new_length = bytes.len();
+
+    // If the previous value was a long string, zero any tail chunks that the new
+    // (shorter) value will not overwrite. Without this, shrinking writes leave
+    // stale data in raw storage even though typed reads are length-bounded.
+    let old_base = storage.load(base_slot)?;
+    if is_long_string(old_base) {
+        let old_chunks = calc_chunks(calc_string_length(old_base, true)?);
+        let new_chunks = if new_length > 31 { calc_chunks(new_length) } else { 0 };
+        if new_chunks < old_chunks {
+            let slot_start = calc_data_slot(base_slot);
+            for i in new_chunks..old_chunks {
+                storage.store(
+                    slot_start
+                        .checked_add(U256::from(i))
+                        .ok_or(BasePrecompileError::SlotOverflow)?,
+                    U256::ZERO,
+                )?;
+            }
+        }
+    }
+
+    if new_length <= 31 {
         storage.store(base_slot, encode_short_string(bytes))
     } else {
-        storage.store(base_slot, encode_long_string_length(length))?;
+        storage.store(base_slot, encode_long_string_length(new_length))?;
         let slot_start = calc_data_slot(base_slot);
-        let chunks = calc_chunks(length);
+        let chunks = calc_chunks(new_length);
 
         for i in 0..chunks {
             let slot =
                 slot_start.checked_add(U256::from(i)).ok_or(BasePrecompileError::SlotOverflow)?;
             let chunk_start = i * 32;
-            let chunk_end = (chunk_start + 32).min(length);
+            let chunk_end = (chunk_start + 32).min(new_length);
             let chunk = &bytes[chunk_start..chunk_end];
             let mut chunk_bytes = [0u8; 32];
             chunk_bytes[..chunk.len()].copy_from_slice(chunk);
@@ -457,5 +478,194 @@ mod tests {
                 Ok(())
             }).unwrap();
         }
+    }
+
+    fn raw_load(
+        storage: &mut crate::hashmap::HashMapStorageProvider,
+        address: Address,
+        slot: U256,
+    ) -> U256 {
+        let mut out = U256::ZERO;
+        StorageCtx::enter(storage, |ctx| -> crate::error::Result<()> {
+            out = Slot::<U256>::new(slot, address, ctx).read().unwrap();
+            Ok(())
+        })
+        .unwrap();
+        out
+    }
+
+    #[test]
+    fn test_long_to_short_clears_stale_chunks() {
+        let (mut storage, address) = setup_storage();
+        let base_slot = U256::from(1u64);
+
+        // Write a 64-byte string (2 chunks).
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            h.write("A".repeat(64)).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        let data_start = calc_data_slot(base_slot);
+        let chunk0_before = raw_load(&mut storage, address, data_start);
+        let chunk1_before = raw_load(&mut storage, address, data_start + U256::ONE);
+        assert_ne!(chunk0_before, U256::ZERO, "chunk 0 should be populated");
+        assert_ne!(chunk1_before, U256::ZERO, "chunk 1 should be populated before shrink");
+
+        // Overwrite with a short (≤31 byte) string.
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            h.write("short".to_string()).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        // Typed read must return the new value.
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            assert_eq!(h.read().unwrap(), "short");
+            Ok(())
+        })
+        .unwrap();
+
+        // Both old data chunks must be zeroed.
+        assert_eq!(
+            raw_load(&mut storage, address, data_start),
+            U256::ZERO,
+            "chunk 0 must be cleared"
+        );
+        assert_eq!(
+            raw_load(&mut storage, address, data_start + U256::ONE),
+            U256::ZERO,
+            "chunk 1 must be cleared"
+        );
+    }
+
+    #[test]
+    fn test_long_to_shorter_long_clears_tail_chunk() {
+        let (mut storage, address) = setup_storage();
+        let base_slot = U256::from(2u64);
+
+        // Write a 96-byte string (3 chunks).
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            h.write("B".repeat(96)).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        let data_start = calc_data_slot(base_slot);
+        let chunk2_before = raw_load(&mut storage, address, data_start + U256::from(2u64));
+        assert_ne!(chunk2_before, U256::ZERO, "chunk 2 must be populated before shrink");
+
+        // Overwrite with a 33-byte string (1 chunk).
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            h.write("C".repeat(32)).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        // Typed read must return the new value.
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            assert_eq!(h.read().unwrap(), "C".repeat(32));
+            Ok(())
+        })
+        .unwrap();
+
+        // Chunk 0 (kept) must be non-zero; chunks 1 and 2 (stale) must be zeroed.
+        assert_ne!(raw_load(&mut storage, address, data_start), U256::ZERO, "chunk 0 must be kept");
+        assert_eq!(
+            raw_load(&mut storage, address, data_start + U256::ONE),
+            U256::ZERO,
+            "chunk 1 must be cleared"
+        );
+        assert_eq!(
+            raw_load(&mut storage, address, data_start + U256::from(2u64)),
+            U256::ZERO,
+            "chunk 2 must be cleared"
+        );
+    }
+
+    #[test]
+    fn test_long_to_empty_clears_all_chunks() {
+        let (mut storage, address) = setup_storage();
+        let base_slot = U256::from(3u64);
+
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            h.write("D".repeat(64)).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            h.write(String::new()).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let h = BytesLikeHandler::<String>::new(base_slot, address, ctx);
+            assert_eq!(h.read().unwrap(), "");
+            Ok(())
+        })
+        .unwrap();
+
+        let data_start = calc_data_slot(base_slot);
+        assert_eq!(
+            raw_load(&mut storage, address, data_start),
+            U256::ZERO,
+            "chunk 0 must be cleared"
+        );
+        assert_eq!(
+            raw_load(&mut storage, address, data_start + U256::ONE),
+            U256::ZERO,
+            "chunk 1 must be cleared"
+        );
+    }
+
+    #[test]
+    fn test_bytes_long_to_short_clears_stale_chunks() {
+        let (mut storage, address) = setup_storage();
+        let base_slot = U256::from(4u64);
+
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<Bytes>::new(base_slot, address, ctx);
+            h.write(Bytes::from(vec![0xFFu8; 64])).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        let data_start = calc_data_slot(base_slot);
+        assert_ne!(raw_load(&mut storage, address, data_start + U256::ONE), U256::ZERO);
+
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let mut h = BytesLikeHandler::<Bytes>::new(base_slot, address, ctx);
+            h.write(Bytes::from(vec![0xAAu8; 4])).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        StorageCtx::enter(&mut storage, |ctx| -> crate::error::Result<()> {
+            let h = BytesLikeHandler::<Bytes>::new(base_slot, address, ctx);
+            assert_eq!(h.read().unwrap(), Bytes::from(vec![0xAAu8; 4]));
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            raw_load(&mut storage, address, data_start),
+            U256::ZERO,
+            "chunk 0 must be cleared"
+        );
+        assert_eq!(
+            raw_load(&mut storage, address, data_start + U256::ONE),
+            U256::ZERO,
+            "chunk 1 must be cleared"
+        );
     }
 }


### PR DESCRIPTION
[BOP-339](https://linear.app/coinbase/issue/BOP-339)

## Motivation

`store_bytes_like` (used by `String::store` and `Bytes::store`) did not clear data slots belonging to a previous longer value when overwriting with a shorter one. The `delete_bytes_like` function already handles this correctly: it loads the prior encoded length, then zeros every chunk slot before clearing the base slot. `store_bytes_like` skipped that read entirely, so any shrinking write left ghost bytes in raw storage.

The affected fields with a reachable post-initialization mutation path are `name`, `symbol`, and `contract_uri` on `B20CoreStorage`, all updatable via the `Configurable` trait by accounts with the `Metadata` role. Typed reads (`name()`, `symbol()`, `contract_uri()`) are always length-bounded and return correct values; the stale bytes are only visible via raw slot inspection (`eth_getStorageAt`). The practical impact is missed EIP-2200 gas refunds and ghost data in raw storage explorers.

This was partially addressed in https://github.com/base/base/pull/3384 for `Vec<T>` (via explicit `VecHandler::truncate` / `VecHandler::clear` helpers), but `bytes_like.rs` was not updated at the same time.

## What changed

- `store_bytes_like`: before writing the new value, load the existing base slot. If it encodes a long string, compute `old_chunks` vs `new_chunks` and zero the range `new_chunks..old_chunks`. This mirrors `delete_bytes_like` and adds one extra `SLOAD` only when the previous value was a long string.

## What was considered

Reusing `delete_bytes_like` to fully clear the slot before every store was rejected: it always zeros the base slot and every chunk, so a same-or-growing write would pay redundant `SSTORE`s. Bounding the clear to the retired tail range (`new_chunks..old_chunks`) keeps the common non-shrinking path at zero extra writes.

## Tests

Four regression tests added to `bytes_like.rs`, each verifying the raw slot contents after a shrinking write:

- `test_long_to_short_clears_stale_chunks`: 64-byte `String` overwritten with a short (<=31 byte) value; both old data chunks must be zero.
- `test_long_to_shorter_long_clears_tail_chunk`: 96-byte `String` overwritten with a 32-byte value (1 chunk); tail chunks 1 and 2 must be zero, chunk 0 preserved.
- `test_long_to_empty_clears_all_chunks`: 64-byte `String` overwritten with `""`.
- `test_bytes_long_to_short_clears_stale_chunks`: same scenario for `Bytes`.