### PR TITLE
refactor(load-test): simplify & harden metric reporting

### DIFF
--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -263,92 +263,22 @@ async fn run_load_test(args: LoadArgs) -> Result<()> {
 
     if summary.error.is_none() || summary.throughput.total_submitted > 0 {
         println!();
-        println!("=== Results: Observed Window ===");
+        println!("=== Results ===");
         if let Some(ref err) = summary.error {
             println!("Error: {err}");
         }
-        let fh = &summary.observed_window;
-        let fhbr = &fh.block_range;
-        match fhbr.first_block {
-            Some(first) => println!(
-                "Window: blocks {first}..={} ({} blocks, ~{:.1}s)",
-                first.saturating_add(fh.expected_block_count.saturating_sub(1)),
-                fh.expected_block_count,
-                fh.duration.as_secs_f64()
-            ),
-            _ => println!(
-                "Window: {} blocks ({:.1}s) — no test txs landed",
-                fh.expected_block_count,
-                fh.duration.as_secs_f64()
-            ),
-        }
-        println!("Confirmed: {} | TPS: {:.2} | GPS: {:.0}", fh.confirmed_count, fh.tps, fh.gps);
-        let fhbl = &fh.block_latency;
+        let tp = &summary.throughput;
+        println!("TPS: {:.2} | GPS: {:.0}", tp.tps, tp.gps);
+        let bl = &summary.block_latency;
         println!(
-            "Block Latency:       min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-            fhbl.min, fhbl.p50, fhbl.mean, fhbl.p99, fhbl.max
+            "Block Latency:       min={:.1?}  p50={:.1?}  mean={:.1?}  p95={:.1?}  p99={:.1?}  max={:.1?}",
+            bl.min, bl.p50, bl.mean, bl.p95, bl.p99, bl.max
         );
-        let fhbrd = &fh.block_receipt_delay;
+        let fb = &summary.flashblocks_latency;
         println!(
-            "Block Receipt Delay: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-            fhbrd.min, fhbrd.p50, fhbrd.mean, fhbrd.p99, fhbrd.max
+            "FB Latency:          min={:.1?}  p50={:.1?}  mean={:.1?}  p95={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
+            fb.min, fb.p50, fb.mean, fb.p95, fb.p99, fb.max, fb.count
         );
-        let fhfb = &fh.flashblocks_latency;
-        println!(
-            "FB Latency:          min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
-            fhfb.min, fhfb.p50, fhfb.mean, fhfb.p99, fhfb.max, fhfb.count
-        );
-
-        println!();
-        println!("=== Results: Tail Inclusion (txs past the observed window) ===");
-        match &summary.tail {
-            None => println!("N/A: continuous run (no configured duration)"),
-            Some(tail) => {
-                if let Some(boundary) = tail.observed_window_end_block {
-                    println!("Boundary: tail = blocks > {boundary} (end of observed window)");
-                } else {
-                    println!("Boundary: no confirmed data");
-                }
-                if tail.count == 0 {
-                    println!(
-                        "Tail: 0 of {} confirmed — no txs landed past the observed window",
-                        summary.throughput.total_confirmed
-                    );
-                } else {
-                    println!(
-                        "Tail: {} of {} confirmed ({:.2}%)",
-                        tail.count, summary.throughput.total_confirmed, tail.confirmed_pct
-                    );
-                    let tbr = &tail.block_range;
-                    if let (Some(first), Some(last)) = (tbr.first_block, tbr.last_block) {
-                        println!(
-                            "Blocks: first={first}  last={last}  span={} block(s)",
-                            tbr.block_count
-                        );
-                    }
-                    let tp = &tail.time_past_observed_window;
-                    println!(
-                        "Time past observed window: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-                        tp.min, tp.p50, tp.mean, tp.p99, tp.max
-                    );
-                    let tbl = &tail.block_latency;
-                    println!(
-                        "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-                        tbl.min, tbl.p50, tbl.mean, tbl.p99, tbl.max
-                    );
-                    let tbrd = &tail.block_receipt_delay;
-                    println!(
-                        "Block Receipt Delay:              min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-                        tbrd.min, tbrd.p50, tbrd.mean, tbrd.p99, tbrd.max
-                    );
-                    let tfb = &tail.flashblocks_latency;
-                    println!(
-                        "FB Latency:                       min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}  (n={})",
-                        tfb.min, tfb.p50, tfb.mean, tfb.p99, tfb.max, tfb.count
-                    );
-                }
-            }
-        }
 
         println!();
         println!(

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -70,9 +70,12 @@ duration: "30s"
 distributed across the configured HTTP endpoints.
 `txpool_nodes` is optional and defaults to an empty list; when present, the load tester calls
 `admin_dropSenderTransactions` for every sender address on every configured node before funding.
-Canonical confirmation and gas metrics are collected by polling `query_rpc` for new blocks and
-fetching `eth_getBlockReceipts` for each observed block, so `query_rpc` must support
-`eth_getBlockReceipts`.
+Transaction landing is detected by polling `query_rpc` with `eth_getBlockByNumber` every 2s and
+matching submitted transaction hashes against each block's transaction list; the recorded block
+latency therefore includes the block poll and scan cost. Gas usage and revert status are backfilled
+in a single `eth_getBlockReceipts` batch pass at the very end of the run, scoped only to the blocks
+that contained our transactions, so `query_rpc` must support `eth_getBlockReceipts`. Receipt-fetch
+delay is measured for logging but is no longer included in the JSON output.
 
 ### Available Configs
 

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -70,7 +70,7 @@ duration: "30s"
 distributed across the configured HTTP endpoints.
 `txpool_nodes` is optional and defaults to an empty list; when present, the load tester calls
 `admin_dropSenderTransactions` for every sender address on every configured node before funding.
-Transaction landing is detected by polling `query_rpc` with `eth_getBlockByNumber` every 2s and
+Transaction landing is detected by polling `query_rpc` with `eth_getBlockByNumber` every 500ms and
 matching submitted transaction hashes against each block's transaction list; the recorded block
 latency therefore includes the block poll and scan cost. Gas usage and revert status are backfilled
 in a single `eth_getBlockReceipts` batch pass at the very end of the run, scoped only to the blocks

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -20,9 +20,8 @@ pub use rpc::{
 mod metrics;
 pub use metrics::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    MetricsAggregator, MetricsCollector, MetricsSummary, ObservedWindowMetrics, RollingWindow,
-    SubmissionStats, TailMetrics, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
-    TransactionMetrics,
+    MetricsAggregator, MetricsCollector, MetricsSummary, RollingWindow, SubmissionStats,
+    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -4,8 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    ObservedWindowMetrics, SubmissionStats, TailMetrics, ThroughputMetrics, ThroughputPercentiles,
-    ThroughputSample, TransactionMetrics, types::BLOCK_INTERVAL,
+    SubmissionStats, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -25,16 +24,9 @@ impl<'a> MetricsAggregator<'a> {
     /// `wall_clock_duration` is used as a fallback for TPS when block timestamps
     /// are unavailable. When block timestamps are present, TPS is derived from
     /// the first-to-last block time span instead.
-    ///
-    /// `configured_duration` is the user-configured test duration (e.g. `60s`
-    /// from `--duration 60s`). When provided, it anchors the observed-window
-    /// boundary and the "tail" (post-observed-window) classification. When
-    /// `None` (continuous run), `wall_clock_duration` is used for the observed
-    /// window and `tail` is reported as `None`.
     pub fn summarize(
         &self,
         wall_clock_duration: Duration,
-        configured_duration: Option<Duration>,
         submission: SubmissionStats<'_>,
         throughput_samples: &[ThroughputSample],
         config: Option<ConfigSummary>,
@@ -49,28 +41,11 @@ impl<'a> MetricsAggregator<'a> {
 
         let block_range = Self::compute_block_range(self.transactions);
         let throughput_duration = block_range.block_time_duration().unwrap_or(wall_clock_duration);
-        let reference_duration = configured_duration.unwrap_or(wall_clock_duration);
-
-        let observed_window = Self::compute_observed_window(
-            self.transactions,
-            reference_duration,
-            block_range.first_block,
-        );
-        let tail = configured_duration.map(|_| {
-            Self::compute_tail(
-                self.transactions,
-                observed_window.expected_block_count,
-                block_range.first_block,
-            )
-        });
 
         MetricsSummary {
             config,
             error: None,
-            observed_window,
-            tail,
             block_latency: Self::compute_block_latency(self.transactions),
-            block_receipt_delay: Self::compute_block_receipt_delay(self.transactions),
             flashblocks_latency: Self::compute_flashblocks_latency(self.transactions),
             throughput: Self::compute_throughput(
                 self.transactions,
@@ -83,106 +58,6 @@ impl<'a> MetricsAggregator<'a> {
             gas: Self::compute_gas(self.transactions),
             block_range,
             top_failure_reasons,
-        }
-    }
-
-    /// Computes the observed reporting window:
-    /// `expected_block_count = reference_duration.as_secs() / BLOCK_INTERVAL.as_secs()`,
-    /// starting at `first_block`. TPS / GPS denominator = `expected_block_count *
-    /// BLOCK_INTERVAL` (real L2 wall-time spanned by those expected blocks).
-    ///
-    /// `first_block` is taken from the caller's pre-computed full block range
-    /// to avoid re-scanning `transactions`.
-    fn compute_observed_window(
-        transactions: &[TransactionMetrics],
-        reference_duration: Duration,
-        first_block: Option<u64>,
-    ) -> ObservedWindowMetrics {
-        let expected_block_count = reference_duration.as_secs() / BLOCK_INTERVAL.as_secs();
-        let duration =
-            Duration::from_secs(expected_block_count.saturating_mul(BLOCK_INTERVAL.as_secs()));
-        let Some(first_block) = first_block else {
-            return ObservedWindowMetrics {
-                expected_block_count,
-                duration,
-                ..ObservedWindowMetrics::default()
-            };
-        };
-
-        let end_block = first_block.saturating_add(expected_block_count.saturating_sub(1));
-        let in_window = |t: &&TransactionMetrics| t.block_number.is_some_and(|b| b <= end_block);
-
-        let (confirmed_count, total_gas) = transactions
-            .iter()
-            .filter(in_window)
-            .fold((0u64, 0u64), |(n, gas), t| (n + 1, gas + t.gas_used));
-        let duration_secs = duration.as_secs_f64();
-        let (tps, gps) = if duration_secs > 0.0 {
-            (confirmed_count as f64 / duration_secs, total_gas as f64 / duration_secs)
-        } else {
-            (0.0, 0.0)
-        };
-
-        ObservedWindowMetrics {
-            expected_block_count,
-            block_range: Self::compute_block_range(transactions.iter().filter(in_window)),
-            duration,
-            confirmed_count,
-            tps,
-            gps,
-            block_latency: Self::compute_block_latency(transactions.iter().filter(in_window)),
-            block_receipt_delay: Self::compute_block_receipt_delay(
-                transactions.iter().filter(in_window),
-            ),
-            flashblocks_latency: Self::compute_flashblocks_latency(
-                transactions.iter().filter(in_window),
-            ),
-        }
-    }
-
-    /// Computes the inclusion-delay tail: transactions whose block number is
-    /// strictly greater than the observed-window end block
-    /// (`first_block + observed_window_expected_block_count - 1`). Captures
-    /// straggler receipts that landed past the clean reporting window.
-    fn compute_tail(
-        transactions: &[TransactionMetrics],
-        observed_window_expected_block_count: u64,
-        first_block: Option<u64>,
-    ) -> TailMetrics {
-        let Some(first_block) = first_block else {
-            return TailMetrics::default();
-        };
-        let total_confirmed = transactions.len() as u64;
-
-        let observed_window_end_block =
-            first_block.saturating_add(observed_window_expected_block_count.saturating_sub(1));
-        let is_tail =
-            |t: &&TransactionMetrics| t.block_number.is_some_and(|b| b > observed_window_end_block);
-
-        let count = transactions.iter().filter(is_tail).count() as u64;
-        let confirmed_pct =
-            if total_confirmed > 0 { (count as f64 / total_confirmed as f64) * 100.0 } else { 0.0 };
-
-        let mut time_past: Vec<Duration> = transactions
-            .iter()
-            .filter(is_tail)
-            .filter_map(|t| t.block_number)
-            .map(|b| BLOCK_INTERVAL * (b - observed_window_end_block) as u32)
-            .collect();
-
-        TailMetrics {
-            observed_window_end_block: Some(observed_window_end_block),
-            count,
-            confirmed_pct,
-            block_range: Self::compute_block_range(transactions.iter().filter(is_tail)),
-            time_past_observed_window: Self::compute_duration_metrics(&mut time_past),
-            block_latency: Self::compute_block_latency(transactions.iter().filter(is_tail)),
-            block_receipt_delay: Self::compute_block_receipt_delay(
-                transactions.iter().filter(is_tail),
-            ),
-            flashblocks_latency: Self::compute_flashblocks_latency(
-                transactions.iter().filter(is_tail),
-            ),
         }
     }
 
@@ -202,15 +77,6 @@ impl<'a> MetricsAggregator<'a> {
     ) -> LatencyMetrics {
         let mut latencies: Vec<Duration> =
             transactions.into_iter().filter_map(|t| t.block_latency).collect();
-
-        Self::compute_duration_metrics(&mut latencies)
-    }
-
-    fn compute_block_receipt_delay<'t>(
-        transactions: impl IntoIterator<Item = &'t TransactionMetrics>,
-    ) -> LatencyMetrics {
-        let mut latencies: Vec<Duration> =
-            transactions.into_iter().filter_map(|t| t.block_receipt_delay).collect();
 
         Self::compute_duration_metrics(&mut latencies)
     }
@@ -348,18 +214,7 @@ impl<'a> MetricsAggregator<'a> {
     }
 }
 
-/// Summary of all collected metrics.
-///
-/// Reporting is split into two diagnostic scopes:
-/// * `observed_window` covers the clean reporting window of the configured
-///   run and is used for headline TPS / latency comparisons.
-/// * `tail` quantifies the inclusion delay: transactions that landed in
-///   blocks past the configured submission window. `None` for continuous runs.
-///
-/// Top-level fields (`throughput`, `block_latency`, `gas`, `block_range`,
-/// `top_failure_reasons`, etc.) are baseline full-run accounting, not headline
-/// metrics — full-run TPS/latency is misleading because it averages the clean
-/// window with the tail.
+/// Summary of all collected metrics over the full run.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MetricsSummary {
     /// Test configuration (excludes URLs and secrets).
@@ -368,19 +223,11 @@ pub struct MetricsSummary {
     /// Fatal error that stopped the test (e.g., funding failure).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    /// First-half reporting window (clean TPS / block / FB latency).
-    pub observed_window: ObservedWindowMetrics,
-    /// Inclusion-delay tail (txs landing after the configured submission
-    /// window). `None` when the run had no configured duration.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tail: Option<TailMetrics>,
-    /// Block production latency (full run, baseline accounting).
+    /// Block landing latency (full run).
     pub block_latency: LatencyMetrics,
-    /// Delay between block production time and receipt observation (full run).
-    pub block_receipt_delay: LatencyMetrics,
-    /// Flashblocks sequencer latency (full run, baseline accounting).
+    /// Flashblocks sequencer latency (full run).
     pub flashblocks_latency: FlashblocksLatencyMetrics,
-    /// Throughput statistics (full run, baseline accounting).
+    /// Throughput statistics (full run).
     pub throughput: ThroughputMetrics,
     /// Rolling-window throughput percentiles (TPS and GPS).
     pub throughput_percentiles: ThroughputPercentiles,

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    SubmissionStats, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    SubmissionStats, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -10,6 +10,7 @@ use super::{
     ConfigSummary, MetricsAggregator, MetricsSummary, RollingWindow, SubmissionStats,
     ThroughputSample, TransactionMetrics,
 };
+use crate::runner::BlockReceipt;
 
 /// Collects transaction metrics during test execution.
 #[derive(Debug)]
@@ -20,7 +21,6 @@ pub struct MetricsCollector {
     reverted_count: u64,
     failure_reasons: HashMap<String, u64>,
     rolling: RollingWindow,
-    block_receipt_delay_rolling: RollingWindow,
     flashblocks_rolling: RollingWindow,
     throughput_samples: Vec<ThroughputSample>,
 }
@@ -35,7 +35,6 @@ impl MetricsCollector {
             reverted_count: 0,
             failure_reasons: HashMap::new(),
             rolling: RollingWindow::new(),
-            block_receipt_delay_rolling: RollingWindow::new(),
             flashblocks_rolling: RollingWindow::new(),
             throughput_samples: Vec::new(),
         }
@@ -46,17 +45,16 @@ impl MetricsCollector {
         self.submitted_count += 1;
     }
 
-    /// Records a confirmed transaction with metrics.
+    /// Records a transaction that landed in a polled block.
+    ///
+    /// Gas and revert status are unknown at landing time and stay at their defaults
+    /// until [`Self::apply_receipts`] backfills them from the end-of-run receipt pass.
     pub fn record_confirmed(&mut self, metrics: TransactionMetrics) {
         debug!(
             tx_hash = %metrics.tx_hash,
             block_latency_ms = ?metrics.block_latency.map(|d| d.as_millis()),
-            reverted = metrics.reverted,
-            "tx confirmed"
+            "tx landed"
         );
-        if metrics.reverted {
-            self.reverted_count += 1;
-        }
         let at = metrics.confirmed_at.unwrap_or_else(Instant::now);
         if let Some(latency) = metrics.block_latency {
             self.rolling.push(metrics.gas_used, latency, at);
@@ -66,10 +64,31 @@ impl MetricsCollector {
         if let Some(flashblocks_latency) = metrics.flashblocks_latency {
             self.flashblocks_rolling.push_latency(flashblocks_latency, at);
         }
-        if let Some(block_receipt_delay) = metrics.block_receipt_delay {
-            self.block_receipt_delay_rolling.push_latency(block_receipt_delay, at);
-        }
         self.transactions.push(metrics);
+    }
+
+    /// Backfills gas, effective gas price, and revert status onto landed transactions
+    /// from the end-of-run canonical receipt pass.
+    ///
+    /// Receipts are keyed by transaction hash. Landed transactions without a matching
+    /// receipt keep their default gas (0) and `reverted = false`.
+    pub fn apply_receipts(&mut self, receipts: &HashMap<TxHash, BlockReceipt>) {
+        let mut reverted = 0;
+        let mut matched = 0;
+        for tx in &mut self.transactions {
+            let Some(receipt) = receipts.get(&tx.tx_hash) else {
+                continue;
+            };
+            tx.gas_used = receipt.gas_used;
+            tx.gas_price = receipt.effective_gas_price;
+            tx.reverted = !receipt.success;
+            if tx.reverted {
+                reverted += 1;
+            }
+            matched += 1;
+        }
+        self.reverted_count = reverted;
+        debug!(matched, total = self.transactions.len(), reverted, "applied end-of-run receipts");
     }
 
     /// Records a failed transaction with a categorized reason.
@@ -108,20 +127,14 @@ impl MetricsCollector {
     ///
     /// `wall_clock_duration` is used as a fallback when block timestamps are
     /// unavailable. TPS is normally derived from block time span.
-    ///
-    /// `configured_duration` is the user-configured test duration; when present
-    /// it anchors the observed window and enables tail (post-observed-window)
-    /// metrics. Pass `None` for continuous runs.
     pub fn summarize(
         &self,
         wall_clock_duration: Duration,
-        configured_duration: Option<Duration>,
         config: Option<ConfigSummary>,
     ) -> MetricsSummary {
         let aggregator = MetricsAggregator::new(&self.transactions);
         aggregator.summarize(
             wall_clock_duration,
-            configured_duration,
             SubmissionStats {
                 submitted: self.submitted_count,
                 failed: self.failed_count,
@@ -140,7 +153,6 @@ impl MetricsCollector {
         self.reverted_count = 0;
         self.failure_reasons.clear();
         self.rolling = RollingWindow::new();
-        self.block_receipt_delay_rolling = RollingWindow::new();
         self.flashblocks_rolling = RollingWindow::new();
         self.throughput_samples.clear();
     }
@@ -178,13 +190,6 @@ impl MetricsCollector {
         self.flashblocks_rolling.p50_p99()
     }
 
-    /// Rolling 30s block receipt delay (p50, p99).
-    pub fn rolling_block_receipt_delay_p50_p99(
-        &mut self,
-    ) -> (std::time::Duration, std::time::Duration) {
-        self.block_receipt_delay_rolling.p50_p99()
-    }
-
     /// Returns the average gas used per confirmed transaction.
     pub fn avg_gas_used(&self) -> Option<u64> {
         if self.transactions.is_empty() {
@@ -198,5 +203,70 @@ impl MetricsCollector {
 impl Default for MetricsCollector {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn landed(tx_hash: TxHash, block_number: u64) -> TransactionMetrics {
+        TransactionMetrics::new(
+            tx_hash,
+            Some(Duration::from_millis(100)),
+            None,
+            0,
+            0,
+            Some(block_number),
+        )
+    }
+
+    fn receipt(tx_hash: TxHash, gas_used: u64, success: bool) -> BlockReceipt {
+        BlockReceipt {
+            tx_hash,
+            block_number: 1,
+            gas_used,
+            effective_gas_price: 1_000_000_000,
+            success,
+        }
+    }
+
+    #[test]
+    fn apply_receipts_backfills_gas_and_revert() {
+        let ok_hash = TxHash::repeat_byte(1);
+        let bad_hash = TxHash::repeat_byte(2);
+        let mut collector = MetricsCollector::new();
+        collector.record_confirmed(landed(ok_hash, 5));
+        collector.record_confirmed(landed(bad_hash, 5));
+
+        let receipts = HashMap::from([
+            (ok_hash, receipt(ok_hash, 21_000, true)),
+            (bad_hash, receipt(bad_hash, 45_000, false)),
+        ]);
+        collector.apply_receipts(&receipts);
+
+        let summary = collector.summarize(Duration::from_secs(1), None);
+        assert_eq!(summary.gas.total_gas, 66_000, "gas backfilled from receipts");
+        assert_eq!(summary.throughput.total_reverted, 1, "exactly one tx reverted");
+        assert_eq!(collector.reverted_count(), 1, "reverted_count set by apply_receipts");
+    }
+
+    #[test]
+    fn apply_receipts_leaves_unmatched_tx_at_defaults() {
+        let landed_hash = TxHash::repeat_byte(3);
+        let unmatched_hash = TxHash::repeat_byte(4);
+        let mut collector = MetricsCollector::new();
+        collector.record_confirmed(landed(landed_hash, 7));
+        collector.record_confirmed(landed(unmatched_hash, 7));
+
+        let receipts = HashMap::from([(landed_hash, receipt(landed_hash, 30_000, true))]);
+        collector.apply_receipts(&receipts);
+
+        let summary = collector.summarize(Duration::from_secs(1), None);
+        assert_eq!(summary.gas.total_gas, 30_000, "only matched tx contributes gas");
+        assert_eq!(summary.throughput.total_reverted, 0, "no reverts");
+        assert_eq!(collector.reverted_count(), 0, "unmatched tx stays non-reverted");
     }
 }

--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -23,6 +23,10 @@ pub struct MetricsCollector {
     rolling: RollingWindow,
     flashblocks_rolling: RollingWindow,
     throughput_samples: Vec<ThroughputSample>,
+    /// Fallback per-tx gas used for live throughput while the real receipt gas is
+    /// still pending. Canonical gas arrives only in the end-of-run receipt pass, so
+    /// without this the rolling GPS would read 0 for the whole run.
+    estimated_gas: u64,
 }
 
 impl MetricsCollector {
@@ -37,7 +41,13 @@ impl MetricsCollector {
             rolling: RollingWindow::new(),
             flashblocks_rolling: RollingWindow::new(),
             throughput_samples: Vec::new(),
+            estimated_gas: 0,
         }
+    }
+
+    /// Sets the estimated per-tx gas used for live throughput before receipts arrive.
+    pub const fn set_estimated_gas(&mut self, estimated_gas: u64) {
+        self.estimated_gas = estimated_gas;
     }
 
     /// Records a submitted transaction.
@@ -56,10 +66,14 @@ impl MetricsCollector {
             "tx landed"
         );
         let at = metrics.confirmed_at.unwrap_or_else(Instant::now);
+        // Canonical gas is backfilled later by the receipt pass, so a freshly landed
+        // tx reports gas_used == 0. Use the estimate for the live rolling window
+        // (GPS, rate-limiter feedback); the final summary still uses real gas.
+        let live_gas = if metrics.gas_used == 0 { self.estimated_gas } else { metrics.gas_used };
         if let Some(latency) = metrics.block_latency {
-            self.rolling.push(metrics.gas_used, latency, at);
+            self.rolling.push(live_gas, latency, at);
         } else {
-            self.rolling.push_gas(metrics.gas_used, at);
+            self.rolling.push_gas(live_gas, at);
         }
         if let Some(flashblocks_latency) = metrics.flashblocks_latency {
             self.flashblocks_rolling.push_latency(flashblocks_latency, at);
@@ -155,6 +169,7 @@ impl MetricsCollector {
         self.rolling = RollingWindow::new();
         self.flashblocks_rolling = RollingWindow::new();
         self.throughput_samples.clear();
+        self.estimated_gas = 0;
     }
 
     /// Snapshots the current rolling TPS and GPS with elapsed time for timeseries output.
@@ -191,12 +206,17 @@ impl MetricsCollector {
     }
 
     /// Returns the average gas used per confirmed transaction.
+    ///
+    /// Before the end-of-run receipt pass backfills canonical gas, landed txs report
+    /// `gas_used == 0`; in that window this falls back to the configured estimate so
+    /// the rate limiter keeps a non-zero feedback signal.
     pub fn avg_gas_used(&self) -> Option<u64> {
         if self.transactions.is_empty() {
             return None;
         }
         let total: u64 = self.transactions.iter().map(|t| t.gas_used).sum();
-        Some(total / self.transactions.len() as u64)
+        let avg = total / self.transactions.len() as u64;
+        if avg == 0 { (self.estimated_gas > 0).then_some(self.estimated_gas) } else { Some(avg) }
     }
 }
 
@@ -268,5 +288,32 @@ mod tests {
         assert_eq!(summary.gas.total_gas, 30_000, "only matched tx contributes gas");
         assert_eq!(summary.throughput.total_reverted, 0, "no reverts");
         assert_eq!(collector.reverted_count(), 0, "unmatched tx stays non-reverted");
+    }
+
+    #[test]
+    fn estimated_gas_drives_live_throughput_before_receipts() {
+        let mut collector = MetricsCollector::new();
+        collector.set_estimated_gas(21_000);
+
+        // Landed txs report gas_used == 0 until the receipt pass runs.
+        for i in 0..5u8 {
+            collector.record_confirmed(landed(TxHash::repeat_byte(i), 100 + u64::from(i)));
+        }
+
+        assert!(collector.rolling_gps() > 0.0, "live GPS must use the estimate, not 0");
+        assert_eq!(
+            collector.avg_gas_used(),
+            Some(21_000),
+            "avg gas falls back to the estimate before receipts backfill real gas"
+        );
+    }
+
+    #[test]
+    fn live_throughput_is_zero_without_estimate() {
+        let mut collector = MetricsCollector::new();
+        collector.record_confirmed(landed(TxHash::repeat_byte(1), 100));
+
+        assert_eq!(collector.rolling_gps(), 0.0, "no estimate set → GPS stays 0");
+        assert_eq!(collector.avg_gas_used(), None, "no estimate and no real gas → None");
     }
 }

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -3,8 +3,7 @@
 mod types;
 pub use types::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    ObservedWindowMetrics, SubmissionStats, TailMetrics, ThroughputMetrics, ThroughputPercentiles,
-    ThroughputSample, TransactionMetrics,
+    SubmissionStats, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -3,7 +3,8 @@
 mod types;
 pub use types::{
     BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics, LatencyMetrics,
-    SubmissionStats, ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    SubmissionStats, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -24,9 +24,12 @@ pub struct SubmissionStats<'a> {
 pub struct TransactionMetrics {
     /// Transaction hash.
     pub tx_hash: TxHash,
-    /// Time from submission to block production.
+    /// Time from submission to first observation in a polled block (includes the
+    /// block poll + scan cost).
     pub block_latency: Option<Duration>,
-    /// Time from block production to receipt observation by the block watcher.
+    /// Time from block production to receipt observation by the end-of-run receipt
+    /// pass. Internal-only: measured for logging, never serialized.
+    #[serde(skip)]
     pub block_receipt_delay: Option<Duration>,
     /// Time from submission to sequencer acceptance.
     pub flashblocks_latency: Option<Duration>,
@@ -189,76 +192,6 @@ impl BlockRange {
         }
         Some(BLOCK_INTERVAL * (self.block_count - 1) as u32)
     }
-}
-
-/// Throughput + latency over the clean reporting window (the expected first
-/// portion of the test, before any inclusion tail).
-///
-/// The observed window is defined as transactions confirmed in blocks
-/// `[first_block, first_block + expected_block_count - 1]`, where
-/// `expected_block_count = reference_duration.as_secs() / BLOCK_INTERVAL` and
-/// `reference_duration` is the configured test duration when known and
-/// falls back to the observed wall-clock duration otherwise.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ObservedWindowMetrics {
-    /// Expected observed-window block count = `reference_duration.as_secs() / BLOCK_INTERVAL`.
-    /// For a 30s test this is 15.
-    pub expected_block_count: u64,
-    /// Block range of confirmed transactions that fell inside the observed
-    /// window. May be smaller than `expected_block_count` blocks if inclusion
-    /// gaps left some expected blocks empty of test txs.
-    pub block_range: BlockRange,
-    /// Expected observed-window wall-time = `expected_block_count * BLOCK_INTERVAL`.
-    /// For a 30s test (15 expected blocks at 2s/block), this is 30s of L2 time.
-    /// Used as the denominator for `tps` and `gps`.
-    pub duration: Duration,
-    /// Confirmed transactions inside the observed window.
-    pub confirmed_count: u64,
-    /// Transactions per second = `confirmed_count / duration.as_secs_f64()`
-    /// (denominator is the expected observed-window in L2 wall-time).
-    pub tps: f64,
-    /// Gas per second over the observed window (same denominator as `tps`).
-    pub gps: f64,
-    /// Block production latency (submit→inclusion) for observed-window transactions.
-    pub block_latency: LatencyMetrics,
-    /// Delay between block production and receipt observation by the block
-    /// watcher, for observed-window transactions.
-    pub block_receipt_delay: LatencyMetrics,
-    /// Flashblocks sequencer latency for observed-window transactions.
-    pub flashblocks_latency: FlashblocksLatencyMetrics,
-}
-
-/// Inclusion-delay metrics for transactions that landed past the observed
-/// window — i.e. straggler receipts that the chain produced well after the
-/// clean reporting window.
-///
-/// A transaction is "tail" iff its block number is strictly greater than
-/// `observed_window_end_block` (the upper bound of the observed window).
-/// Only populated when `configured_duration` is provided to
-/// `MetricsAggregator::summarize`; continuous runs produce `None`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TailMetrics {
-    /// Upper bound of the observed window =
-    /// `first_block + observed_window_expected_block_count - 1`. Transactions
-    /// with `block_number > observed_window_end_block` are classified as tail.
-    /// `None` when the dataset is empty.
-    pub observed_window_end_block: Option<u64>,
-    /// Number of confirmed transactions in the tail.
-    pub count: u64,
-    /// Tail count as a percentage of total confirmed transactions.
-    pub confirmed_pct: f64,
-    /// Block range covered by the tail.
-    pub block_range: BlockRange,
-    /// Per-tx wall-time the block landed past `observed_window_end_block`,
-    /// derived from `(block_number - observed_window_end_block) * BLOCK_INTERVAL`.
-    pub time_past_observed_window: LatencyMetrics,
-    /// Submit→inclusion latency for tail transactions only.
-    pub block_latency: LatencyMetrics,
-    /// Delay between block production and receipt observation by the block
-    /// watcher, for tail transactions only.
-    pub block_receipt_delay: LatencyMetrics,
-    /// Flashblocks sequencer latency for tail transactions only.
-    pub flashblocks_latency: FlashblocksLatencyMetrics,
 }
 
 /// Aggregated flashblocks latency percentiles.

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -27,10 +27,6 @@ pub struct TransactionMetrics {
     /// Time from submission to first observation in a polled block (includes the
     /// block poll + scan cost).
     pub block_latency: Option<Duration>,
-    /// Time from block production to receipt observation by the end-of-run receipt
-    /// pass. Internal-only: measured for logging, never serialized.
-    #[serde(skip)]
-    pub block_receipt_delay: Option<Duration>,
     /// Time from submission to sequencer acceptance.
     pub flashblocks_latency: Option<Duration>,
     /// Gas used by the transaction.
@@ -59,7 +55,6 @@ impl TransactionMetrics {
         Self {
             tx_hash,
             block_latency,
-            block_receipt_delay: None,
             flashblocks_latency,
             gas_used,
             gas_price,

--- a/crates/infra/load-tests/src/runner/block_watcher.rs
+++ b/crates/infra/load-tests/src/runner/block_watcher.rs
@@ -3,27 +3,33 @@
 //! The watcher polls for new canonical blocks and reports the transaction hashes
 //! contained in each block to the [`ResultsTracker`], which records landing latency.
 //! Canonical receipts (gas, revert status) are fetched separately in a single batch
-//! pass at the end of the run via [`fetch_block_receipts`], not during polling.
+//! pass at the end of the run via [`BlockWatcher::fetch_receipts`], not during polling.
 
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use alloy_network::ReceiptResponse;
 use alloy_primitives::TxHash;
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use base_common_network::Base;
+use futures::{StreamExt, stream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
 use super::{BlockObservation, BlockReceipt, ResultsTracker};
 
 /// How frequently to poll for a new canonical block.
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(1000);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Maximum time to wait for a block watcher RPC request.
 const BLOCK_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+/// Maximum time to wait for a block receipt RPC request.
+const RECEIPT_RPC_TIMEOUT: Duration = Duration::from_secs(50);
 /// Small startup lookback so early landings are not missed if the watcher task is
 /// scheduled after the first submissions.
 const INITIAL_BLOCK_LOOKBACK: u64 = 8;
+/// Maximum concurrent `eth_getBlockReceipts` requests during the end-of-run pass.
+/// Blocks are independent, so they are fetched in parallel up to this bound.
+const RECEIPT_FETCH_CONCURRENCY: usize = 3;
 
 /// Polls canonical blocks and reports their transaction hashes for landing detection.
 #[derive(Debug)]
@@ -77,22 +83,26 @@ impl BlockWatcher {
                     backoff = (backoff * 2).min(max_backoff);
                     continue;
                 }
-                Ok(Some((latest_block, latest_hashes))) => {
+                Ok(Some(latest)) => {
                     backoff = Duration::from_millis(100);
-                    let latest_block_number = latest_block.number;
+                    let latest_block_number = latest.0.number;
                     let first_block = last_seen_block.map_or_else(
                         || latest_block_number.saturating_sub(INITIAL_BLOCK_LOOKBACK),
                         |block| block.saturating_add(1),
                     );
 
                     if first_block <= latest_block_number {
+                        // The latest block was already fetched above; move it out (no
+                        // clone of its tx-hash Vec) on the final iteration that reaches
+                        // it, and fetch only the intermediate gap blocks.
+                        let mut latest = Some(latest);
                         for block_number in first_block..=latest_block_number {
                             if self.cancel_token.is_cancelled() {
                                 return;
                             }
                             trace!(block = block_number, "received new block");
                             let observed = if block_number == latest_block_number {
-                                Some((latest_block, latest_hashes.clone()))
+                                latest.take()
                             } else {
                                 self.fetch_block(block_number)
                                     .await
@@ -149,11 +159,7 @@ impl BlockWatcher {
             return Ok(None);
         };
 
-        let observation = BlockObservation {
-            number: block.header.number,
-            block_time: timestamp_to_instant(block.header.timestamp, observed_at),
-            observed_at,
-        };
+        let observation = BlockObservation { number: block.header.number, observed_at };
         let tx_hashes = block.transactions.hashes().collect();
 
         Ok(Some((observation, tx_hashes)))
@@ -169,45 +175,50 @@ impl BlockWatcher {
         provider: &RootProvider<Base>,
         block_numbers: &[u64],
     ) -> Vec<BlockReceipt> {
-        let mut out = Vec::new();
-        for &block_number in block_numbers {
-            let block_id = BlockId::Number(BlockNumberOrTag::Number(block_number));
-            match tokio::time::timeout(BLOCK_RPC_TIMEOUT, provider.get_block_receipts(block_id))
-                .await
-            {
-                Ok(Ok(Some(receipts))) => {
-                    out.extend(receipts.into_iter().map(|receipt| BlockReceipt {
-                        tx_hash: receipt.transaction_hash(),
-                        block_number: receipt.block_number().unwrap_or(block_number),
-                        gas_used: receipt.gas_used(),
-                        effective_gas_price: receipt.effective_gas_price(),
-                        success: receipt.status(),
-                    }));
-                }
-                Ok(Ok(None)) => {
-                    warn!(block = block_number, "eth_getBlockReceipts returned no receipts")
-                }
-                Ok(Err(e)) => {
-                    warn!(block = block_number, error = %e, "eth_getBlockReceipts failed")
-                }
-                Err(_) => warn!(
+        stream::iter(block_numbers.iter().copied())
+            .map(|block_number| Self::fetch_block_receipts(provider, block_number))
+            .buffer_unordered(RECEIPT_FETCH_CONCURRENCY)
+            .flat_map(stream::iter)
+            .collect()
+            .await
+    }
+
+    /// Fetches the canonical receipts for a single block, mapping each into a
+    /// [`BlockReceipt`]. Returns an empty vector on timeout, RPC error, or missing
+    /// receipts (logged as a warning) so a single bad block cannot fail the pass.
+    async fn fetch_block_receipts(
+        provider: &RootProvider<Base>,
+        block_number: u64,
+    ) -> Vec<BlockReceipt> {
+        let block_id = BlockId::Number(BlockNumberOrTag::Number(block_number));
+        match tokio::time::timeout(RECEIPT_RPC_TIMEOUT, provider.get_block_receipts(block_id)).await
+        {
+            Ok(Ok(Some(receipts))) => receipts
+                .into_iter()
+                .map(|receipt| BlockReceipt {
+                    tx_hash: receipt.transaction_hash(),
+                    block_number: receipt.block_number().unwrap_or(block_number),
+                    gas_used: receipt.gas_used(),
+                    effective_gas_price: receipt.effective_gas_price(),
+                    success: receipt.status(),
+                })
+                .collect(),
+            Ok(Ok(None)) => {
+                warn!(block = block_number, "eth_getBlockReceipts returned no receipts");
+                Vec::new()
+            }
+            Ok(Err(e)) => {
+                warn!(block = block_number, error = %e, "eth_getBlockReceipts failed");
+                Vec::new()
+            }
+            Err(_) => {
+                warn!(
                     block = block_number,
-                    timeout_secs = BLOCK_RPC_TIMEOUT.as_secs(),
+                    timeout_secs = RECEIPT_RPC_TIMEOUT.as_secs(),
                     "eth_getBlockReceipts timed out"
-                ),
+                );
+                Vec::new()
             }
         }
-        out
     }
-}
-
-fn timestamp_to_instant(timestamp: u64, now_instant: Instant) -> Option<Instant> {
-    let now_system = SystemTime::now();
-    let block_system = UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))?;
-
-    if let Ok(delta) = now_system.duration_since(block_system) {
-        return now_instant.checked_sub(delta);
-    }
-
-    block_system.duration_since(now_system).ok().and_then(|delta| now_instant.checked_add(delta))
 }

--- a/crates/infra/load-tests/src/runner/block_watcher.rs
+++ b/crates/infra/load-tests/src/runner/block_watcher.rs
@@ -1,8 +1,14 @@
-//! Block watching, receipt ingestion, and first-seen timestamp tracking.
+//! Block watching and transaction landing detection via `eth_getBlockByNumber`.
+//!
+//! The watcher polls for new canonical blocks and reports the transaction hashes
+//! contained in each block to the [`ResultsTracker`], which records landing latency.
+//! Canonical receipts (gas, revert status) are fetched separately in a single batch
+//! pass at the end of the run via [`fetch_block_receipts`], not during polling.
 
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use alloy_network::ReceiptResponse;
+use alloy_primitives::TxHash;
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use base_common_network::Base;
@@ -12,14 +18,14 @@ use tracing::{debug, error, info, trace, warn};
 use super::{BlockObservation, BlockReceipt, ResultsTracker};
 
 /// How frequently to poll for a new canonical block.
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(1000);
 /// Maximum time to wait for a block watcher RPC request.
 const BLOCK_RPC_TIMEOUT: Duration = Duration::from_secs(10);
-/// Small startup lookback so early confirmations are not missed if the watcher task is scheduled
-/// after the first submissions.
+/// Small startup lookback so early landings are not missed if the watcher task is
+/// scheduled after the first submissions.
 const INITIAL_BLOCK_LOOKBACK: u64 = 8;
 
-/// Tracks canonical blocks and their receipts.
+/// Polls canonical blocks and reports their transaction hashes for landing detection.
 #[derive(Debug)]
 pub struct BlockWatcher {
     provider: RootProvider<Base>,
@@ -52,7 +58,7 @@ impl BlockWatcher {
         let mut last_seen_block: Option<u64> = None;
 
         while !self.cancel_token.is_cancelled() {
-            match self.fetch_latest_block_observation().await {
+            match self.fetch_latest_block().await {
                 Err(e) => {
                     if self.cancel_token.is_cancelled() {
                         return;
@@ -71,7 +77,7 @@ impl BlockWatcher {
                     backoff = (backoff * 2).min(max_backoff);
                     continue;
                 }
-                Ok(Some(latest_block)) => {
+                Ok(Some((latest_block, latest_hashes))) => {
                     backoff = Duration::from_millis(100);
                     let latest_block_number = latest_block.number;
                     let first_block = last_seen_block.map_or_else(
@@ -85,32 +91,25 @@ impl BlockWatcher {
                                 return;
                             }
                             trace!(block = block_number, "received new block");
-                            let block = if block_number == latest_block_number {
-                                Some(latest_block)
+                            let observed = if block_number == latest_block_number {
+                                Some((latest_block, latest_hashes.clone()))
                             } else {
-                                self.fetch_block_observation(block_number)
+                                self.fetch_block(block_number)
                                     .await
                                     .inspect_err(|e| {
                                         warn!(
                                             block = block_number,
                                             error = %e,
-                                            "failed to fetch block header"
+                                            "failed to fetch block hashes"
                                         );
                                     })
                                     .ok()
                                     .flatten()
                             };
-                            let Some(block) = block else {
+                            let Some((block, tx_hashes)) = observed else {
                                 break;
                             };
-                            if let Err(e) = self.fetch_and_record_receipts(block).await {
-                                warn!(
-                                    block = block_number,
-                                    error = %e,
-                                    "failed to fetch block receipts"
-                                );
-                                break;
-                            }
+                            self.results_tracker.on_new_block_hashes(block, tx_hashes);
                             last_seen_block = Some(block_number);
                         }
                     }
@@ -128,16 +127,16 @@ impl BlockWatcher {
         debug!("block watcher stopped");
     }
 
-    async fn fetch_latest_block_observation(
+    async fn fetch_latest_block(
         &self,
-    ) -> std::result::Result<Option<BlockObservation>, String> {
-        self.fetch_block_observation(BlockNumberOrTag::Latest).await
+    ) -> std::result::Result<Option<(BlockObservation, Vec<TxHash>)>, String> {
+        self.fetch_block(BlockNumberOrTag::Latest).await
     }
 
-    async fn fetch_block_observation(
+    async fn fetch_block(
         &self,
         block: impl Into<BlockNumberOrTag>,
-    ) -> std::result::Result<Option<BlockObservation>, String> {
+    ) -> std::result::Result<Option<(BlockObservation, Vec<TxHash>)>, String> {
         let observed_at = Instant::now();
         let block = tokio::time::timeout(BLOCK_RPC_TIMEOUT, async {
             self.provider.get_block_by_number(block.into()).hashes().await
@@ -150,60 +149,65 @@ impl BlockWatcher {
             return Ok(None);
         };
 
-        Ok(Some(BlockObservation {
+        let observation = BlockObservation {
             number: block.header.number,
-            block_time: Self::timestamp_to_instant(block.header.timestamp, observed_at),
+            block_time: timestamp_to_instant(block.header.timestamp, observed_at),
             observed_at,
-        }))
+        };
+        let tx_hashes = block.transactions.hashes().collect();
+
+        Ok(Some((observation, tx_hashes)))
     }
 
-    async fn fetch_and_record_receipts(
-        &self,
-        block: BlockObservation,
-    ) -> std::result::Result<(), String> {
-        let receipts = self.fetch_receipts(block.number).await?;
-        let observed_at = Instant::now();
-        self.results_tracker.on_new_block(BlockObservation { observed_at, ..block }, receipts);
-
-        Ok(())
-    }
-
-    async fn fetch_receipts(
-        &self,
-        block_number: u64,
-    ) -> std::result::Result<Vec<BlockReceipt>, String> {
-        let block_id = BlockId::Number(BlockNumberOrTag::Number(block_number));
-        let receipts = tokio::time::timeout(BLOCK_RPC_TIMEOUT, async {
-            self.provider.get_block_receipts(block_id).await
-        })
-        .await
-        .map_err(|_| format!("eth_getBlockReceipts timed out after {BLOCK_RPC_TIMEOUT:?}"))?
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| "eth_getBlockReceipts returned no receipts".to_string())?;
-
-        Ok(receipts
-            .into_iter()
-            .map(|receipt| BlockReceipt {
-                tx_hash: receipt.transaction_hash(),
-                block_number: receipt.block_number().unwrap_or(block_number),
-                gas_used: receipt.gas_used(),
-                effective_gas_price: receipt.effective_gas_price(),
-                success: receipt.status(),
-            })
-            .collect())
-    }
-
-    fn timestamp_to_instant(timestamp: u64, now_instant: Instant) -> Option<Instant> {
-        let now_system = SystemTime::now();
-        let block_system = UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))?;
-
-        if let Ok(delta) = now_system.duration_since(block_system) {
-            return now_instant.checked_sub(delta);
+    /// Fetches canonical receipts for the given block numbers in a single batch pass.
+    ///
+    /// Returns one [`BlockReceipt`] per transaction across all requested blocks.
+    /// Intended for the end-of-run enrichment pass, where the caller already knows
+    /// exactly which blocks contain its transactions, so receipts are fetched only
+    /// for those blocks.
+    pub async fn fetch_receipts(
+        provider: &RootProvider<Base>,
+        block_numbers: &[u64],
+    ) -> Vec<BlockReceipt> {
+        let mut out = Vec::new();
+        for &block_number in block_numbers {
+            let block_id = BlockId::Number(BlockNumberOrTag::Number(block_number));
+            match tokio::time::timeout(BLOCK_RPC_TIMEOUT, provider.get_block_receipts(block_id))
+                .await
+            {
+                Ok(Ok(Some(receipts))) => {
+                    out.extend(receipts.into_iter().map(|receipt| BlockReceipt {
+                        tx_hash: receipt.transaction_hash(),
+                        block_number: receipt.block_number().unwrap_or(block_number),
+                        gas_used: receipt.gas_used(),
+                        effective_gas_price: receipt.effective_gas_price(),
+                        success: receipt.status(),
+                    }));
+                }
+                Ok(Ok(None)) => {
+                    warn!(block = block_number, "eth_getBlockReceipts returned no receipts")
+                }
+                Ok(Err(e)) => {
+                    warn!(block = block_number, error = %e, "eth_getBlockReceipts failed")
+                }
+                Err(_) => warn!(
+                    block = block_number,
+                    timeout_secs = BLOCK_RPC_TIMEOUT.as_secs(),
+                    "eth_getBlockReceipts timed out"
+                ),
+            }
         }
-
-        block_system
-            .duration_since(now_system)
-            .ok()
-            .and_then(|delta| now_instant.checked_add(delta))
+        out
     }
+}
+
+fn timestamp_to_instant(timestamp: u64, now_instant: Instant) -> Option<Instant> {
+    let now_system = SystemTime::now();
+    let block_system = UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))?;
+
+    if let Ok(delta) = now_system.duration_since(block_system) {
+        return now_instant.checked_sub(delta);
+    }
+
+    block_system.duration_since(now_system).ok().and_then(|delta| now_instant.checked_add(delta))
 }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1031,9 +1031,10 @@ impl LoadRunner {
         );
 
         info!(url = %self.config.query_rpc, "starting block watcher");
+        let receipt_provider = RootProvider::<Base>::new_http(self.config.query_rpc.clone());
         let block_watcher_task = Some(
             BlockWatcher::new(
-                RootProvider::<Base>::new_http(self.config.query_rpc.clone()),
+                receipt_provider.clone(),
                 results_tracker.clone(),
                 self.cancel_token.clone(),
             )
@@ -1176,8 +1177,6 @@ impl LoadRunner {
                 let senders_blocked = results_tracker.senders_at_limit(max_in_flight_per_sender);
                 let total_queued: u64 = queued_per_sender.values().sum();
                 let (p50, p99) = self.collector.rolling_p50_p99();
-                let (block_receipt_delay_p50, block_receipt_delay_p99) =
-                    self.collector.rolling_block_receipt_delay_p50_p99();
                 let (flashblocks_p50, flashblocks_p99) =
                     self.collector.rolling_flashblocks_p50_p99();
                 info!(
@@ -1193,8 +1192,6 @@ impl LoadRunner {
                     base_fee = self.base_fee,
                     p50_ms = p50.as_millis() as u64,
                     p99_ms = p99.as_millis() as u64,
-                    block_receipt_delay_p50_ms = block_receipt_delay_p50.as_millis() as u64,
-                    block_receipt_delay_p99_ms = block_receipt_delay_p99.as_millis() as u64,
                     flashblocks_p50_ms = flashblocks_p50.as_millis() as u64,
                     flashblocks_p99_ms = flashblocks_p99.as_millis() as u64,
                     "progress"
@@ -1424,11 +1421,29 @@ impl LoadRunner {
         let confirmed = self.collector.confirmed_count();
         info!(confirmed, submitted, "confirmation collection complete");
 
-        Ok(self.collector.summarize(
-            last_confirmed_at,
-            self.config.duration,
-            self.config_summary.clone(),
-        ))
+        // Fetch canonical receipts in a single batch pass, scoped to only the blocks
+        // our transactions landed in, to backfill gas and revert status. This can be
+        // slow on large runs, so notify the user before starting.
+        let landed_blocks = results_tracker.landed_block_numbers();
+        if !landed_blocks.is_empty() {
+            println!(
+                "Fetching receipts for {} block(s) to compute gas and reverts (this may take a while)...",
+                landed_blocks.len()
+            );
+            let receipt_fetch_start = Instant::now();
+            let receipts = BlockWatcher::fetch_receipts(&receipt_provider, &landed_blocks).await;
+            let receipts_by_hash: HashMap<TxHash, _> =
+                receipts.into_iter().map(|receipt| (receipt.tx_hash, receipt)).collect();
+            self.collector.apply_receipts(&receipts_by_hash);
+            info!(
+                blocks = landed_blocks.len(),
+                receipts = receipts_by_hash.len(),
+                elapsed_secs = receipt_fetch_start.elapsed().as_secs_f64(),
+                "end-of-run receipt pass complete"
+            );
+        }
+
+        Ok(self.collector.summarize(last_confirmed_at, self.config_summary.clone()))
     }
 
     fn build_snapshot(
@@ -1439,8 +1454,6 @@ impl LoadRunner {
         account_count: usize,
     ) -> DisplaySnapshot {
         let (p50, p99) = self.collector.rolling_p50_p99();
-        let (block_receipt_delay_p50, block_receipt_delay_p99) =
-            self.collector.rolling_block_receipt_delay_p50_p99();
         let (flashblocks_p50, flashblocks_p99) = self.collector.rolling_flashblocks_p50_p99();
         DisplaySnapshot {
             elapsed: start.elapsed(),
@@ -1456,8 +1469,6 @@ impl LoadRunner {
             rolling_gps: self.collector.rolling_gps(),
             p50_latency: p50,
             p99_latency: p99,
-            block_receipt_delay_p50,
-            block_receipt_delay_p99,
             flashblocks_p50_latency: flashblocks_p50,
             flashblocks_p99_latency: flashblocks_p99,
             gas_price_gwei: self.base_fee as f64 / 1e9,

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1044,6 +1044,9 @@ impl LoadRunner {
         let max_in_flight_per_sender = self.config.max_in_flight_per_sender;
 
         let initial_avg_gas = self.estimate_avg_gas();
+        // Seed the collector so live throughput (rolling GPS) and rate-limiter
+        // feedback have a non-zero gas figure before canonical receipt gas lands.
+        self.collector.set_estimated_gas(initial_avg_gas);
         let mut rate_limiter = RateLimiter::new(self.config.target_gps, initial_avg_gas);
         let start = Instant::now();
         let mut current_account_idx = 0usize;
@@ -1171,7 +1174,6 @@ impl LoadRunner {
                 let submitted = self.collector.submitted_count();
                 let confirmed = self.collector.confirmed_count();
                 let failed = self.collector.failed_count();
-                let reverted = self.collector.reverted_count();
                 let in_flight = results_tracker.total_in_flight();
                 let pending = results_tracker.pending_count();
                 let senders_blocked = results_tracker.senders_at_limit(max_in_flight_per_sender);
@@ -1184,7 +1186,6 @@ impl LoadRunner {
                     submitted,
                     confirmed,
                     failed,
-                    reverted,
                     in_flight,
                     pending,
                     total_queued,
@@ -1461,7 +1462,6 @@ impl LoadRunner {
             submitted: self.collector.submitted_count(),
             confirmed: self.collector.confirmed_count(),
             failed: self.collector.failed_count(),
-            reverted: self.collector.reverted_count(),
             in_flight: results_tracker.total_in_flight(),
             senders_blocked: results_tracker.senders_at_limit(max_in_flight_per_sender),
             total_senders: account_count,

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -28,15 +28,14 @@ pub struct SentTransaction {
 pub struct BlockObservation {
     /// Canonical block number.
     pub number: u64,
-    /// Local instant corresponding to the block timestamp, when available.
-    pub block_time: Option<Instant>,
-    /// Local time when the load-test process observed the block.
+    /// Local time when the load-test process observed the block. Used as the
+    /// landing time for transactions first seen in this block.
     pub observed_at: Instant,
 }
 
 /// Canonical receipt data for a transaction, fetched in a single batch pass at the
 /// end of the load test (not during the run). Used to backfill gas, effective gas
-/// price, and revert status, and to measure receipt-fetch delay internally.
+/// price, and revert status.
 #[derive(Debug, Clone, Copy)]
 pub struct BlockReceipt {
     /// Transaction hash.
@@ -296,7 +295,7 @@ mod tests {
     use super::*;
 
     fn block_at(number: u64, observed_at: Instant) -> BlockObservation {
-        BlockObservation { number, block_time: Some(observed_at), observed_at }
+        BlockObservation { number, observed_at }
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -1,7 +1,7 @@
 //! Result tracking for submitted transactions and inclusion observations.
 
 use std::{
-    collections::{HashMap, VecDeque, hash_map::Entry},
+    collections::{BTreeSet, HashMap, VecDeque, hash_map::Entry},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -11,8 +11,6 @@ use parking_lot::RwLock;
 
 use crate::metrics::TransactionMetrics;
 
-/// Maximum canonical receipt entries retained from recent blocks.
-const MAX_RECEIPT_CACHE_SIZE: usize = 100_000;
 /// Maximum flashblock entries retained from recent stream events.
 const MAX_FLASHBLOCK_CACHE_SIZE: usize = 50_000;
 
@@ -36,7 +34,9 @@ pub struct BlockObservation {
     pub observed_at: Instant,
 }
 
-/// Canonical receipt data observed for a transaction in a block.
+/// Canonical receipt data for a transaction, fetched in a single batch pass at the
+/// end of the load test (not during the run). Used to backfill gas, effective gas
+/// price, and revert status, and to measure receipt-fetch delay internally.
 #[derive(Debug, Clone, Copy)]
 pub struct BlockReceipt {
     /// Transaction hash.
@@ -69,13 +69,14 @@ pub struct ResultsTracker {
 #[derive(Debug)]
 struct ResultsTrackerInner {
     pending: HashMap<TxHash, PendingTransaction>,
-    block_receipts: HashMap<TxHash, BlockReceiptInclusion>,
     flashblocks: HashMap<TxHash, Instant>,
-    receipt_eviction_queue: VecDeque<TxHash>,
     flashblock_eviction_queue: VecDeque<TxHash>,
     unreported_confirmations: VecDeque<TransactionMetrics>,
     in_flight_per_sender: HashMap<Address, u64>,
     total_in_flight: u64,
+    /// Block numbers in which at least one of our transactions landed, used to scope
+    /// the end-of-run `eth_getBlockReceipts` pass to only relevant blocks.
+    landed_blocks: BTreeSet<u64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -86,16 +87,6 @@ struct PendingTransaction {
     in_flight_released: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct BlockReceiptInclusion {
-    observed_at: Instant,
-    block_time: Option<Instant>,
-    block_number: u64,
-    gas_used: u64,
-    effective_gas_price: u128,
-    success: bool,
-}
-
 impl ResultsTracker {
     /// Creates a new tracker for the given sender addresses.
     pub fn new(sender_addresses: &[Address]) -> Self {
@@ -104,13 +95,12 @@ impl ResultsTracker {
         Self {
             inner: Arc::new(RwLock::new(ResultsTrackerInner {
                 pending: HashMap::new(),
-                block_receipts: HashMap::new(),
                 flashblocks: HashMap::new(),
-                receipt_eviction_queue: VecDeque::new(),
                 flashblock_eviction_queue: VecDeque::new(),
                 unreported_confirmations: VecDeque::new(),
                 in_flight_per_sender,
                 total_in_flight: 0,
+                landed_blocks: BTreeSet::new(),
             })),
         }
     }
@@ -139,7 +129,6 @@ impl ResultsTracker {
                 .and_modify(|count| *count = count.saturating_add(1))
                 .or_insert(1);
             inner.total_in_flight = inner.total_in_flight.saturating_add(1);
-            inner.confirm_if_ready(transaction.tx_hash);
         }
     }
 
@@ -169,28 +158,20 @@ impl ResultsTracker {
         inner.evict_flashblocks();
     }
 
-    /// Records a newly observed canonical block and its receipts.
-    pub fn on_new_block(&self, block: BlockObservation, receipts: Vec<BlockReceipt>) {
+    /// Records the transaction hashes observed in a newly polled canonical block.
+    ///
+    /// This is the in-run landing detector: the first time one of our pending
+    /// transactions is seen in a block's transaction list, its landing latency
+    /// (submit -> first-seen, which includes the block poll + scan cost) is recorded,
+    /// its block number is captured, and a [`TransactionMetrics`] entry is emitted.
+    /// Gas, effective gas price, and revert status are left at defaults here and
+    /// backfilled later by the end-of-run receipt pass.
+    pub fn on_new_block_hashes(&self, block: BlockObservation, tx_hashes: Vec<TxHash>) {
         let mut inner = self.inner.write();
 
-        for receipt in receipts {
-            let inclusion = BlockReceiptInclusion {
-                observed_at: block.observed_at,
-                block_time: block.block_time,
-                block_number: receipt.block_number,
-                gas_used: receipt.gas_used,
-                effective_gas_price: receipt.effective_gas_price,
-                success: receipt.success,
-            };
-
-            if let Entry::Vacant(e) = inner.block_receipts.entry(receipt.tx_hash) {
-                e.insert(inclusion);
-                inner.receipt_eviction_queue.push_back(receipt.tx_hash);
-            }
-            inner.confirm_if_ready(receipt.tx_hash);
+        for tx_hash in tx_hashes {
+            inner.land_if_pending(tx_hash, &block);
         }
-
-        inner.evict_block_receipts();
     }
 
     /// Expires submitted transactions that were not observed in a canonical block.
@@ -247,23 +228,26 @@ impl ResultsTracker {
     pub fn senders_at_limit(&self, limit: u64) -> usize {
         self.inner.read().in_flight_per_sender.values().filter(|&&count| count >= limit).count()
     }
+
+    /// Returns the sorted set of block numbers in which our transactions landed.
+    ///
+    /// Used to scope the end-of-run `eth_getBlockReceipts` pass to only the blocks
+    /// that actually contained our transactions.
+    pub fn landed_block_numbers(&self) -> Vec<u64> {
+        self.inner.read().landed_blocks.iter().copied().collect()
+    }
 }
 
 impl ResultsTrackerInner {
-    fn confirm_if_ready(&mut self, tx_hash: TxHash) {
-        let Some(receipt) = self.block_receipts.get(&tx_hash).copied() else {
-            return;
-        };
+    /// Records the first observation of `tx_hash` in a polled block, emitting its
+    /// landing metrics. Idempotent: a tx is removed from `pending` on first landing,
+    /// so later blocks containing the same hash are ignored.
+    fn land_if_pending(&mut self, tx_hash: TxHash, block: &BlockObservation) {
         let Some(pending) = self.pending.remove(&tx_hash) else {
             return;
         };
 
-        let block_latency = receipt
-            .block_time
-            .map(|block_time| block_time.saturating_duration_since(pending.submit_time));
-        let block_receipt_delay = receipt
-            .block_time
-            .map(|block_time| receipt.observed_at.saturating_duration_since(block_time));
+        let block_latency = block.observed_at.checked_duration_since(pending.submit_time);
         let flashblocks_latency = self
             .flashblocks
             .remove(&tx_hash)
@@ -273,15 +257,13 @@ impl ResultsTrackerInner {
             tx_hash,
             block_latency,
             flashblocks_latency,
-            receipt.gas_used,
-            receipt.effective_gas_price,
-            Some(receipt.block_number),
+            0,
+            0,
+            Some(block.number),
         );
-        metrics.block_receipt_delay = block_receipt_delay;
-        metrics.confirmed_at = Some(receipt.observed_at);
-        metrics.reverted = !receipt.success;
+        metrics.confirmed_at = Some(block.observed_at);
 
-        self.block_receipts.remove(&tx_hash);
+        self.landed_blocks.insert(block.number);
         if !pending.in_flight_released {
             self.decrement_in_flight(&pending.from);
         }
@@ -293,17 +275,6 @@ impl ResultsTrackerInner {
             *count = count.saturating_sub(1);
         }
         self.total_in_flight = self.total_in_flight.saturating_sub(1);
-    }
-
-    fn evict_block_receipts(&mut self) {
-        while self.block_receipts.len() > MAX_RECEIPT_CACHE_SIZE {
-            match self.receipt_eviction_queue.pop_front() {
-                Some(old) => {
-                    self.block_receipts.remove(&old);
-                }
-                None => break,
-            }
-        }
     }
 
     fn evict_flashblocks(&mut self) {
@@ -324,68 +295,46 @@ mod tests {
 
     use super::*;
 
+    fn block_at(number: u64, observed_at: Instant) -> BlockObservation {
+        BlockObservation { number, block_time: Some(observed_at), observed_at }
+    }
+
     #[test]
-    fn confirms_pending_transaction_from_block_receipt() {
+    fn confirms_pending_transaction_from_block_hashes() {
         let from = address!("0000000000000000000000000000000000000001");
         let tx_hash = TxHash::repeat_byte(1);
         let tracker = ResultsTracker::new(&[from]);
 
         tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
-        let block_time = Instant::now() + Duration::from_millis(50);
-        tracker.on_new_block(
-            BlockObservation {
-                number: 7,
-                block_time: Some(block_time),
-                observed_at: block_time + Duration::from_millis(250),
-            },
-            vec![BlockReceipt {
-                tx_hash,
-                block_number: 7,
-                gas_used: 21_000,
-                effective_gas_price: 1_000_000_000,
-                success: true,
-            }],
-        );
+        let observed_at = Instant::now() + Duration::from_millis(250);
+        tracker.on_new_block_hashes(block_at(7, observed_at), vec![tx_hash]);
 
         let metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics.len(), 1, "landed tx should produce exactly one metric");
         assert_eq!(metrics[0].tx_hash, tx_hash);
-        assert_eq!(metrics[0].block_number, Some(7));
-        assert_eq!(metrics[0].gas_used, 21_000);
-        assert!(!metrics[0].reverted);
-        assert_eq!(metrics[0].block_receipt_delay, Some(Duration::from_millis(250)));
-        assert_eq!(tracker.total_in_flight(), 0);
+        assert_eq!(metrics[0].block_number, Some(7), "block number from polled block");
+        assert!(metrics[0].block_latency.is_some(), "landing latency must be recorded");
+        assert_eq!(metrics[0].gas_used, 0, "gas backfilled later by receipt pass");
+        assert!(!metrics[0].reverted, "revert backfilled later by receipt pass");
+        assert_eq!(tracker.landed_block_numbers(), vec![7], "block 7 tracked for receipt pass");
+        assert_eq!(tracker.total_in_flight(), 0, "landing releases in-flight slot");
     }
 
     #[test]
-    fn marks_reverted_transaction() {
+    fn second_block_with_same_hash_is_ignored() {
         let from = address!("0000000000000000000000000000000000000001");
-        let tx_hash = TxHash::repeat_byte(3);
+        let tx_hash = TxHash::repeat_byte(7);
         let tracker = ResultsTracker::new(&[from]);
 
         tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
-        let block_time = Instant::now() + Duration::from_millis(50);
-        tracker.on_new_block(
-            BlockObservation {
-                number: 9,
-                block_time: Some(block_time),
-                observed_at: block_time + Duration::from_millis(100),
-            },
-            vec![BlockReceipt {
-                tx_hash,
-                block_number: 9,
-                gas_used: 45_000,
-                effective_gas_price: 1_000_000_000,
-                success: false,
-            }],
-        );
+        let now = Instant::now();
+        tracker.on_new_block_hashes(block_at(11, now + Duration::from_millis(100)), vec![tx_hash]);
+        tracker.on_new_block_hashes(block_at(12, now + Duration::from_millis(300)), vec![tx_hash]);
 
         let metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(metrics.len(), 1, "reverted tx should still produce metrics");
-        assert_eq!(metrics[0].tx_hash, tx_hash);
-        assert!(metrics[0].reverted, "reverted flag should be set");
-        assert_eq!(metrics[0].gas_used, 45_000);
-        assert_eq!(tracker.total_in_flight(), 0);
+        assert_eq!(metrics.len(), 1, "tx should land exactly once despite reappearing");
+        assert_eq!(metrics[0].block_number, Some(11), "first-seen block wins");
+        assert_eq!(tracker.landed_block_numbers(), vec![11], "only first block tracked");
     }
 
     #[test]
@@ -395,30 +344,20 @@ mod tests {
         let tracker = ResultsTracker::new(&[from]);
 
         tracker.sent_transactions(vec![SentTransaction { tx_hash, from }]);
-        tracker
-            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
-        tracker.on_new_block(
-            BlockObservation {
-                number: 8,
-                block_time: Some(Instant::now()),
-                observed_at: Instant::now(),
-            },
-            vec![BlockReceipt {
-                tx_hash,
-                block_number: 8,
-                gas_used: 21_000,
-                effective_gas_price: 1_000_000_000,
-                success: true,
-            }],
-        );
+        let now = Instant::now();
+        tracker.on_new_flashblock(vec![FlashblockInclusion {
+            tx_hash,
+            included_at: now + Duration::from_millis(50),
+        }]);
+        tracker.on_new_block_hashes(block_at(8, now + Duration::from_millis(200)), vec![tx_hash]);
 
         let metrics = tracker.drain_confirmed_metrics();
         assert_eq!(metrics.len(), 1);
-        assert!(metrics[0].flashblocks_latency.is_some());
+        assert!(metrics[0].flashblocks_latency.is_some(), "FB latency joined at landing");
     }
 
     #[test]
-    fn flashblock_releases_in_flight_before_block_receipt() {
+    fn flashblock_releases_in_flight_before_block_landing() {
         let from = address!("0000000000000000000000000000000000000001");
         let tx_hash = TxHash::repeat_byte(4);
         let tracker = ResultsTracker::new(&[from]);
@@ -432,26 +371,12 @@ mod tests {
         assert_eq!(tracker.total_in_flight(), 0, "flashblock should release in-flight slot");
         assert_eq!(tracker.in_flight_for(&from), 0);
 
-        // Block receipt arrives later — should not double-decrement.
-        let block_time = Instant::now() + Duration::from_millis(500);
-        tracker.on_new_block(
-            BlockObservation {
-                number: 10,
-                block_time: Some(block_time),
-                observed_at: block_time + Duration::from_millis(100),
-            },
-            vec![BlockReceipt {
-                tx_hash,
-                block_number: 10,
-                gas_used: 112_000,
-                effective_gas_price: 1_000_000_000,
-                success: true,
-            }],
-        );
+        let observed_at = Instant::now() + Duration::from_millis(500);
+        tracker.on_new_block_hashes(block_at(10, observed_at), vec![tx_hash]);
 
-        assert_eq!(tracker.total_in_flight(), 0, "block receipt should not double-decrement");
+        assert_eq!(tracker.total_in_flight(), 0, "block landing should not double-decrement");
         let metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(metrics.len(), 1, "metrics should still be produced from block receipt");
+        assert_eq!(metrics.len(), 1, "metrics should still be produced from block landing");
         assert!(metrics[0].flashblocks_latency.is_some());
     }
 

--- a/crates/infra/load-tests/src/runner/status.rs
+++ b/crates/infra/load-tests/src/runner/status.rs
@@ -30,14 +30,10 @@ pub struct DisplaySnapshot {
     pub rolling_tps: f64,
     /// Rolling 30s GPS.
     pub rolling_gps: f64,
-    /// Rolling 30s p50 latency.
+    /// Rolling 30s p50 block landing latency.
     pub p50_latency: Duration,
-    /// Rolling 30s p99 latency.
+    /// Rolling 30s p99 block landing latency.
     pub p99_latency: Duration,
-    /// Rolling 30s block receipt delay p50.
-    pub block_receipt_delay_p50: Duration,
-    /// Rolling 30s block receipt delay p99.
-    pub block_receipt_delay_p99: Duration,
     /// Rolling 30s flashblocks p50 latency.
     pub flashblocks_p50_latency: Duration,
     /// Rolling 30s flashblocks p99 latency.
@@ -220,12 +216,10 @@ impl LoadTestDisplay {
         });
 
         self.gas_lat.set_message(format!(
-            "gas     {:.2} gwei   block latency p50 {}   p99 {}   receipt delay p50 {}   p99 {}",
+            "gas     {:.2} gwei   block latency p50 {}   p99 {}",
             snap.gas_price_gwei,
             fmt_latency(snap.p50_latency),
             fmt_latency(snap.p99_latency),
-            fmt_latency(snap.block_receipt_delay_p50),
-            fmt_latency(snap.block_receipt_delay_p99),
         ));
 
         if snap.flashblocks_p50_latency > Duration::ZERO

--- a/crates/infra/load-tests/src/runner/status.rs
+++ b/crates/infra/load-tests/src/runner/status.rs
@@ -18,8 +18,6 @@ pub struct DisplaySnapshot {
     pub confirmed: usize,
     /// Total transactions failed.
     pub failed: u64,
-    /// Total confirmed transactions that reverted.
-    pub reverted: u64,
     /// Total in-flight (unconfirmed) transactions.
     pub in_flight: u64,
     /// Number of senders at the in-flight limit.
@@ -159,22 +157,12 @@ impl LoadTestDisplay {
             self.header.set_message(format!("Base Load Test  elapsed {elapsed_str}   continuous"));
         }
 
-        self.txs.set_message(if snap.reverted > 0 {
-            format!(
-                "txs     sub {}   conf {}   failed {}   reverted {}",
-                fmt_num(snap.submitted),
-                fmt_num(snap.confirmed as u64),
-                fmt_num(snap.failed),
-                fmt_num(snap.reverted),
-            )
-        } else {
-            format!(
-                "txs     sub {}   conf {}   failed {}",
-                fmt_num(snap.submitted),
-                fmt_num(snap.confirmed as u64),
-                fmt_num(snap.failed),
-            )
-        });
+        self.txs.set_message(format!(
+            "txs     sub {}   conf {}   failed {}",
+            fmt_num(snap.submitted),
+            fmt_num(snap.confirmed as u64),
+            fmt_num(snap.failed),
+        ));
 
         let success_rate = if snap.submitted > 0 {
             snap.confirmed as f64 / snap.submitted as f64 * 100.0

--- a/crates/infra/load-tests/tests/smoke.rs
+++ b/crates/infra/load-tests/tests/smoke.rs
@@ -122,7 +122,7 @@ fn metrics_summary_latency() {
         ));
     }
 
-    let summary = collector.summarize(Duration::from_secs(10), None, None);
+    let summary = collector.summarize(Duration::from_secs(10), None);
 
     assert_eq!(summary.throughput.total_confirmed, 5);
 
@@ -133,30 +133,13 @@ fn metrics_summary_latency() {
 
     let fb_latency = &summary.flashblocks_latency;
     assert_eq!(fb_latency.p50, Duration::from_millis(150));
-
-    let mut metrics = TransactionMetrics::new(
-        TxHash::repeat_byte(99),
-        Some(Duration::from_millis(600)),
-        None,
-        21000,
-        1_000_000_000,
-        Some(99),
-    );
-    metrics.block_receipt_delay = Some(Duration::from_millis(75));
-    collector.record_confirmed(metrics);
-    let summary = collector.summarize(Duration::from_secs(10), None, None);
-    assert_eq!(summary.block_receipt_delay.p50, Duration::from_millis(75));
 }
 
 #[test]
-fn metrics_summary_observed_window_split() {
+fn metrics_summary_full_run_throughput_and_block_range() {
     let mut collector = MetricsCollector::new();
 
-    // 30 txs across blocks 100..=129.
-    // configured_duration = 30s
-    // → expected_block_count = 30 / 2 = 15
-    // → end_block = 100 + 15 - 1 = 114
-    // → first half includes blocks 100..=114 (15 txs).
+    // 30 txs across blocks 100..=129, each with block + FB latency.
     for i in 0..30u64 {
         collector.record_confirmed(TransactionMetrics::new(
             TxHash::repeat_byte(i as u8),
@@ -168,213 +151,25 @@ fn metrics_summary_observed_window_split() {
         ));
     }
 
-    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
+    let summary = collector.summarize(Duration::from_secs(60), None);
 
-    let fh = &summary.observed_window;
-    assert_eq!(fh.expected_block_count, 15, "30s / 2 = 15 expected blocks");
-    assert_eq!(fh.confirmed_count, 15, "blocks 100..=114");
-    assert_eq!(fh.block_range.first_block, Some(100));
-    assert_eq!(fh.block_range.last_block, Some(114));
-    assert_eq!(fh.block_range.block_count, 15);
-    // duration = expected_block_count * BLOCK_INTERVAL = 15 blocks × 2s/block = 30s.
-    assert_eq!(fh.duration, Duration::from_secs(30), "15 blocks × 2s/block = 30s of L2 time");
-    // TPS = 15 txs / 30s = 0.5.
-    assert!((fh.tps - 0.5).abs() < 1e-6, "tps={}, expected 0.5", fh.tps);
-    // First-half block latencies for txs 0..=14 → 100..=240ms.
-    assert_eq!(fh.block_latency.min, Duration::from_millis(100));
-    assert_eq!(fh.block_latency.max, Duration::from_millis(240));
-    assert_eq!(fh.flashblocks_latency.count, 15);
-
-    // Full-range still spans all 30 blocks.
     assert_eq!(summary.throughput.total_confirmed, 30);
+    assert_eq!(summary.block_range.first_block, Some(100));
+    assert_eq!(summary.block_range.last_block, Some(129));
     assert_eq!(summary.block_range.block_count, 30);
+    assert_eq!(summary.block_latency.min, Duration::from_millis(100), "tx 0 block latency");
+    assert_eq!(summary.block_latency.max, Duration::from_millis(390), "tx 29 block latency");
+    assert_eq!(summary.flashblocks_latency.count, 30);
 }
 
 #[test]
-fn metrics_summary_observed_window_inclusion_gap() {
-    let mut collector = MetricsCollector::new();
-
-    // 6 txs across blocks 100..=105 with configured_duration=30s.
-    // → expected_block_count = 15
-    // → end_block = 114
-    // → all 6 txs are in the first-half window
-    // → inclusion gap = 15 - 6 = 9 blocks (60% gap) — reproduces the user-reported scenario.
-    for i in 0..6u64 {
-        collector.record_confirmed(TransactionMetrics::new(
-            TxHash::repeat_byte(i as u8),
-            Some(Duration::from_millis(100)),
-            None,
-            21_000,
-            1_000_000_000,
-            Some(100 + i),
-        ));
-    }
-
-    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
-
-    let fh = &summary.observed_window;
-    assert_eq!(fh.expected_block_count, 15, "30s / 2 = 15 expected blocks");
-    assert_eq!(fh.confirmed_count, 6);
-    assert_eq!(fh.block_range.block_count, 6, "only 6 of 15 expected blocks had txs");
-}
-
-#[test]
-fn metrics_summary_block_receipt_delay_per_window() {
-    let mut collector = MetricsCollector::new();
-
-    // 20 txs across blocks 100..=119 with configured_duration = 30s.
-    // → expected_block_count = 15, observed_window_end_block = 114.
-    // First half = txs in blocks 100..=114 (15 txs), receipt delays 100..=240ms.
-    // Tail = txs in blocks 115..=119 (5 txs), receipt delays 250..=290ms.
-    for i in 0..20u64 {
-        let mut metrics = TransactionMetrics::new(
-            TxHash::repeat_byte(i as u8),
-            Some(Duration::from_millis(50)),
-            None,
-            21_000,
-            1_000_000_000,
-            Some(100 + i),
-        );
-        metrics.block_receipt_delay = Some(Duration::from_millis(100 + i * 10));
-        collector.record_confirmed(metrics);
-    }
-
-    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
-
-    let fh_brd = &summary.observed_window.block_receipt_delay;
-    assert_eq!(fh_brd.min, Duration::from_millis(100), "first half receipt delay min");
-    assert_eq!(fh_brd.max, Duration::from_millis(240), "first half receipt delay max");
-
-    let tail_brd = &summary.tail.as_ref().expect("tail Some").block_receipt_delay;
-    assert_eq!(tail_brd.min, Duration::from_millis(250), "tail receipt delay min");
-    assert_eq!(tail_brd.max, Duration::from_millis(290), "tail receipt delay max");
-}
-
-#[test]
-fn metrics_summary_observed_window_empty_when_no_confirms() {
+fn metrics_summary_empty_when_no_confirms() {
     let collector = MetricsCollector::new();
-    let summary = collector.summarize(Duration::from_secs(60), None, None);
+    let summary = collector.summarize(Duration::from_secs(60), None);
 
-    assert_eq!(summary.observed_window.confirmed_count, 0);
-    assert_eq!(summary.observed_window.block_range.block_count, 0);
-    assert_eq!(summary.observed_window.tps, 0.0);
-    assert!(summary.tail.is_none(), "tail should be None when no configured_duration");
-}
-
-#[test]
-fn metrics_summary_tail_classification() {
-    let mut collector = MetricsCollector::new();
-
-    // 30 txs across blocks 100..=129.
-    // configured_duration = 30s
-    // → observed_window_expected_block_count = 30 / 2 = 15
-    // → observed_window_end_block = 100 + 15 - 1 = 114
-    // → tail = blocks > 114 → blocks 115..=129 (15 txs).
-    for i in 0..30u64 {
-        collector.record_confirmed(TransactionMetrics::new(
-            TxHash::repeat_byte(i as u8),
-            Some(Duration::from_millis(100 + i * 10)),
-            Some(Duration::from_millis(50 + i * 5)),
-            21_000,
-            1_000_000_000,
-            Some(100 + i),
-        ));
-    }
-
-    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
-
-    let tail = summary.tail.as_ref().expect("tail should be Some when configured_duration is set");
-    assert_eq!(tail.observed_window_end_block, Some(114));
-    assert_eq!(tail.count, 15, "blocks 115..=129 should be classified as tail");
-    assert_eq!(tail.block_range.first_block, Some(115));
-    assert_eq!(tail.block_range.last_block, Some(129));
-    assert_eq!(tail.block_range.block_count, 15);
-    assert!((tail.confirmed_pct - 50.0).abs() < 1e-6, "15 of 30 = 50%, got {}", tail.confirmed_pct);
-
-    // time_past for tail blocks 115..=129 vs observed_window_end_block=114, at 2s/block:
-    // → [2s, 4s, ..., 30s]. min=2s, max=30s, p50 (rank 8 of 15) = 16s.
-    let tp = &tail.time_past_observed_window;
-    assert_eq!(tp.min, Duration::from_secs(2));
-    assert_eq!(tp.max, Duration::from_secs(30));
-    assert_eq!(tp.p50, Duration::from_secs(16));
-
-    // Tail block latencies for txs 15..=29 → 250..=390ms.
-    assert_eq!(tail.block_latency.min, Duration::from_millis(250));
-    assert_eq!(tail.block_latency.max, Duration::from_millis(390));
-    assert_eq!(tail.flashblocks_latency.count, 15);
-}
-
-#[test]
-fn metrics_summary_tail_straggler_after_gap() {
-    let mut collector = MetricsCollector::new();
-
-    // Reproduces the user-reported scenario: tight cluster at the start,
-    // then a "big block of txs 10 blocks later".
-    // configured_duration = 30s → observed_window_expected_block_count = 15
-    // → observed_window_end_block = 100 + 14 = 114
-    //
-    // 6 txs in blocks 100..=105 (clean cluster).
-    for i in 0..6u64 {
-        collector.record_confirmed(TransactionMetrics::new(
-            TxHash::repeat_byte(i as u8),
-            Some(Duration::from_millis(100)),
-            None,
-            21_000,
-            1_000_000_000,
-            Some(100 + i),
-        ));
-    }
-    // Then 20 txs all in block 125 (10 blocks past observed_window_end_block=114).
-    for i in 0..20u64 {
-        collector.record_confirmed(TransactionMetrics::new(
-            TxHash::repeat_byte(50 + i as u8),
-            Some(Duration::from_millis(8000)),
-            None,
-            21_000,
-            1_000_000_000,
-            Some(125),
-        ));
-    }
-
-    let summary = collector.summarize(Duration::from_secs(60), Some(Duration::from_secs(30)), None);
-
-    let tail = summary.tail.as_ref().expect("tail should be Some");
-    assert_eq!(tail.observed_window_end_block, Some(114));
-    assert_eq!(tail.count, 20, "the 20 stragglers in block 125 are tail");
-    // 20 of 26 ≈ 76.9%.
-    let expected_pct = 20.0 / 26.0 * 100.0;
-    assert!((tail.confirmed_pct - expected_pct).abs() < 1e-6);
-    // All 20 stragglers in block 125 → time_past = (125-114)*2s = 22s for every tx.
-    assert_eq!(tail.time_past_observed_window.min, Duration::from_secs(22));
-    assert_eq!(tail.time_past_observed_window.max, Duration::from_secs(22));
-    assert_eq!(tail.time_past_observed_window.p50, Duration::from_secs(22));
-}
-
-#[test]
-fn metrics_summary_tail_empty_when_all_inside_observed_window() {
-    let mut collector = MetricsCollector::new();
-
-    // 5 txs in blocks 100..=104 with configured_duration = 30s
-    // → observed_window_end_block = 100 + 14 = 114
-    // → no tail (max block 104 < 114).
-    for i in 0..5u64 {
-        collector.record_confirmed(TransactionMetrics::new(
-            TxHash::repeat_byte(i as u8),
-            Some(Duration::from_millis(100)),
-            None,
-            21_000,
-            1_000_000_000,
-            Some(100 + i),
-        ));
-    }
-
-    let summary = collector.summarize(Duration::from_secs(20), Some(Duration::from_secs(30)), None);
-
-    let tail = summary.tail.as_ref().expect("tail should be Some when configured_duration is set");
-    assert_eq!(tail.observed_window_end_block, Some(114));
-    assert_eq!(tail.count, 0, "no txs landed past the first half");
-    assert_eq!(tail.confirmed_pct, 0.0);
-    assert_eq!(tail.block_range.block_count, 0);
+    assert_eq!(summary.throughput.total_confirmed, 0);
+    assert_eq!(summary.block_range.block_count, 0);
+    assert_eq!(summary.throughput.tps, 0.0);
 }
 
 #[test]
@@ -399,7 +194,7 @@ fn metrics_summary_gas() {
         Some(2),
     ));
 
-    let summary = collector.summarize(Duration::from_secs(10), None, None);
+    let summary = collector.summarize(Duration::from_secs(10), None);
 
     assert_eq!(summary.gas.total_gas, 63000);
     assert_eq!(summary.gas.avg_gas, 31500);
@@ -418,11 +213,14 @@ fn metrics_summary_json_serialization() {
         Some(1),
     ));
 
-    let summary = collector.summarize(Duration::from_secs(10), None, None);
+    let summary = collector.summarize(Duration::from_secs(10), None);
     let json = summary.to_json().unwrap();
 
     assert!(json.contains("block_latency"));
-    assert!(json.contains("block_receipt_delay"));
+    assert!(
+        !json.contains("block_receipt_delay"),
+        "receipt delay is internal-only and must not be serialized to JSON"
+    );
     assert!(json.contains("throughput"));
     assert!(json.contains("gas"));
 }


### PR DESCRIPTION
The purpose of the load testing metric summary is to report the client-to-client e2e latency. That is, from the moment the user submits a transaction via eth_sendRawTransaction to when the client receives AND processes the transaction (i.e., calling eth_getBlockByNumber and seeing their own txHash in that block)

Restructures the metrics to report on this behaviour

Simplifies the metric summary by removing observed + tail summary to 1 generalized view (no longer needed since fixing https://github.com/base/base/pull/3646 )

Example summary: 
```
=== Results ===
TPS: 2847.50 | GPS: 321181119
Block Latency:       min=537.9ms  p50=3.5s  mean=3.5s  p95=4.8s  p99=5.7s  max=8.0s
FB Latency:          min=12.4µs  p50=534.9ms  mean=632.1ms  p95=1.5s  p99=2.3s  max=5.5s  (n=96104)

Totals: Submitted=113900 | Confirmed=113900 | Failed=0 | Reverted=0 | Success=100.0%
Gas: total=12847244763  avg/tx=112794
Blocks: first=43192733  last=43192753  span=21 block(s)
```