### PR TITLE
feat(upgrade-signal): wire execution upgrade signal observer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "base-cli-utils",
  "base-common-chains",
  "base-common-consensus",
+ "base-common-genesis",
  "base-execution-chainspec",
  "base-execution-consensus",
  "base-execution-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,6 +4398,7 @@ name = "base-execution-cli"
 version = "0.0.0"
 dependencies = [
  "alloy-eips 2.0.5",
+ "alloy-primitives",
  "alloy-provider 2.0.5",
  "axum 0.8.9",
  "backon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,6 +4398,7 @@ name = "base-execution-cli"
 version = "0.0.0"
 dependencies = [
  "alloy-eips 2.0.5",
+ "alloy-provider 2.0.5",
  "axum 0.8.9",
  "backon",
  "base-bundle-extension",
@@ -4417,10 +4418,12 @@ dependencies = [
  "base-tx-forwarding",
  "base-txpool-rpc",
  "base-txpool-tracing",
+ "base-upgrade-signal",
  "clap",
  "eyre",
  "futures",
  "humantime",
+ "jsonrpsee",
  "proptest",
  "reqwest 0.13.4",
  "reth-chainspec",
@@ -5069,6 +5072,7 @@ dependencies = [
  "base-execution-trie",
  "base-execution-txpool",
  "base-node-core",
+ "base-upgrade-signal",
  "clap",
  "eyre",
  "futures",

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -9,7 +9,9 @@ use base_consensus_cli::{
     CliMetrics, ConsensusNodeArgs, ConsensusNodeOverrides, EmbeddedSequencerConsensusNodeConfigArgs,
 };
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_cli::{ExecutionNodeConfigArgs, chainspec::chain_value_parser};
+use base_execution_cli::{
+    ExecutionNodeConfigArgs, StandardBaseRethNode, chainspec::chain_value_parser,
+};
 use base_node_runner::BaseNodeRunner;
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use clap::Args;
@@ -72,13 +74,24 @@ impl SequencerCommand {
                 .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
             let task_executor = ctx.task_executor.clone();
             let builder = execution.into_default_node_builder(ctx)?;
-            let mut runner = BaseNodeRunner::new(rollup_args)
+            // Execution upgrade-signal polling remains independently configured from consensus,
+            // so this path still relies on an explicit `--upgrade-signal.l1-rpc` when enabled.
+            let builder = StandardBaseRethNode::apply_initial_upgrade_signal_from_rollup_args(
+                builder,
+                &rollup_args,
+            )
+            .await?;
+            let mut runner = BaseNodeRunner::new(rollup_args.clone())
                 .with_da_config(da_config)
                 .with_gas_limit_config(gas_limit_config)
                 .with_service_builder(FlashblocksServiceBuilder(builder_config));
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
             runner.install_ext::<BuilderApiExtension>(());
+            StandardBaseRethNode::install_upgrade_signal_metrics_extension(
+                &mut runner,
+                &rollup_args,
+            )?;
 
             let launched = runner.launch(builder).await?;
             let handle = launched.handle;

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use base_builder_cli::Args;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
-use base_execution_cli::Cli;
+use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 
@@ -25,6 +25,11 @@ fn main() {
 
     cli.run(|builder, builder_args| async move {
         let rollup_args = builder_args.rollup_args.clone();
+        let builder = StandardBaseRethNode::apply_initial_upgrade_signal_from_rollup_args(
+            builder,
+            &rollup_args,
+        )
+        .await?;
 
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder_args.build_metering_store());
@@ -35,13 +40,14 @@ fn main() {
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
 
-        let mut runner = BaseNodeRunner::new(rollup_args)
+        let mut runner = BaseNodeRunner::new(rollup_args.clone())
             .with_da_config(da_config)
             .with_gas_limit_config(gas_limit_config)
             .with_service_builder(FlashblocksServiceBuilder(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
         runner.install_ext::<BuilderApiExtension>(());
+        StandardBaseRethNode::install_upgrade_signal_metrics_extension(&mut runner, &rollup_args)?;
         runner.add_started_callback(|| {
             base_cli_utils::register_version_metrics!();
             Ok(())

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -40,6 +40,7 @@ base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
 base-node-runner.workspace = true
 base-common-chains.workspace = true
+base-common-genesis.workspace = true
 base-execution-evm.workspace = true
 base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -49,6 +49,7 @@ base-bundle-extension.workspace = true
 base-proofs-extension.workspace = true
 base-execution-chainspec.workspace = true
 base-execution-consensus.workspace = true
+base-upgrade-signal = { workspace = true, features = ["metrics"] }
 
 # misc
 tar.workspace = true
@@ -56,16 +57,18 @@ zstd.workspace = true
 eyre.workspace = true
 humantime.workspace = true
 url.workspace = true
-tokio.workspace = true
 backon.workspace = true
 futures.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
+jsonrpsee = { workspace = true, features = ["server"] }
 reqwest = { workspace = true, features = ["json", "stream"] }
 alloy-eips.workspace = true
+alloy-provider.workspace = true
 secp256k1.workspace = true
 tokio-stream.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 
 # reth test-vectors
 proptest = { workspace = true, optional = true }

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -76,6 +76,7 @@ proptest = { workspace = true, optional = true }
 base-common-consensus = { workspace = true, features = ["reth"] }
 
 [dev-dependencies]
+alloy-primitives.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
 axum = { workspace = true, features = ["tokio", "http1"] }

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -43,6 +43,11 @@ use reth_node_core::{
 use reth_node_metrics as _;
 use reth_rpc_server_types::{LenientRpcModuleValidator, RpcModuleValidator};
 pub use standard_node::{RpcStandardNodeArgs, StandardBaseRethNode, StandardNodeArgs};
+mod upgrade_signal;
+pub use upgrade_signal::{
+    ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalMetricsExtension,
+    ExecutionUpgradeSignalRuntimeRefresher,
+};
 
 /// The main base-reth cli interface.
 ///

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -4,6 +4,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeBuilder, LaunchedBaseNode};
+use base_upgrade_signal::UpgradeSignalStartupMode;
 use clap::{Args, value_parser};
 use reth_cli_runner::CliContext;
 use reth_db::init_db;
@@ -147,7 +148,11 @@ impl ExecutionNodeConfigArgs {
             node_config.network.max_outbound_peers = Some(DEFAULT_BASE_MAX_OUTBOUND_EL_PEERS);
         }
 
-        ExecutionNodeRuntimeConfig { node_config, with_unused_ports }
+        ExecutionNodeRuntimeConfig {
+            node_config,
+            with_unused_ports,
+            upgrade_signal_startup: UpgradeSignalStartupMode::ReadAndApply,
+        }
     }
 }
 
@@ -171,6 +176,7 @@ impl ExecutionNodeArgs {
             node_config: runtime.node_config,
             standard: self.standard.into(),
             with_unused_ports: runtime.with_unused_ports,
+            upgrade_signal_startup: runtime.upgrade_signal_startup,
         }
     }
 }
@@ -182,6 +188,8 @@ pub struct ExecutionNodeRuntimeConfig {
     pub node_config: NodeConfig<BaseChainSpec>,
     /// Whether all ports should be assigned by the OS.
     pub with_unused_ports: bool,
+    /// Whether this launch should perform its own upgrade-signal startup read.
+    pub upgrade_signal_startup: UpgradeSignalStartupMode,
 }
 
 impl ExecutionNodeRuntimeConfig {
@@ -198,6 +206,12 @@ impl ExecutionNodeRuntimeConfig {
     /// Enables authenticated Engine API over IPC.
     pub const fn with_auth_ipc(mut self) -> Self {
         Self::enable_auth_ipc(&mut self.node_config);
+        self
+    }
+
+    /// Marks the upgrade-signal startup schedule as already applied by the caller.
+    pub const fn with_upgrade_signal_startup_already_applied(mut self) -> Self {
+        self.upgrade_signal_startup = UpgradeSignalStartupMode::AlreadyApplied;
         self
     }
 
@@ -256,18 +270,38 @@ pub struct ExecutionNodeLaunchConfig {
     pub standard: StandardNodeArgs,
     /// Whether all ports should be assigned by the OS.
     pub with_unused_ports: bool,
+    /// Whether this launch should perform its own upgrade-signal startup read.
+    pub upgrade_signal_startup: UpgradeSignalStartupMode,
 }
 
 impl ExecutionNodeLaunchConfig {
     /// Converts this standard launch config into the shared runtime config plus standard args.
     pub fn into_runtime_config(self) -> (ExecutionNodeRuntimeConfig, StandardNodeArgs) {
-        let Self { node_config, standard, with_unused_ports } = self;
-        (ExecutionNodeRuntimeConfig { node_config, with_unused_ports }, standard)
+        let Self {
+            node_config,
+            standard,
+            with_unused_ports,
+            upgrade_signal_startup,
+        } = self;
+        (
+            ExecutionNodeRuntimeConfig {
+                node_config,
+                with_unused_ports,
+                upgrade_signal_startup,
+            },
+            standard,
+        )
     }
 
     /// Enables authenticated Engine API over IPC.
     pub const fn with_auth_ipc(mut self) -> Self {
         ExecutionNodeRuntimeConfig::enable_auth_ipc(&mut self.node_config);
+        self
+    }
+
+    /// Marks the upgrade-signal startup schedule as already applied by the caller.
+    pub const fn with_upgrade_signal_startup_already_applied(mut self) -> Self {
+        self.upgrade_signal_startup = UpgradeSignalStartupMode::AlreadyApplied;
         self
     }
 
@@ -282,8 +316,14 @@ impl ExecutionNodeLaunchConfig {
         Rpc: RpcModuleValidator,
     {
         let (execution, standard) = self.into_runtime_config();
+        let upgrade_signal_startup = execution.upgrade_signal_startup;
         let builder = execution.into_node_builder::<Rpc>(ctx)?;
-        crate::StandardBaseRethNode::launch(builder, standard).await
+        crate::StandardBaseRethNode::launch_with_upgrade_signal_startup(
+            builder,
+            standard,
+            upgrade_signal_startup,
+        )
+        .await
     }
 
     /// Launches the execution node with the default RPC module validator.

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -277,18 +277,9 @@ pub struct ExecutionNodeLaunchConfig {
 impl ExecutionNodeLaunchConfig {
     /// Converts this standard launch config into the shared runtime config plus standard args.
     pub fn into_runtime_config(self) -> (ExecutionNodeRuntimeConfig, StandardNodeArgs) {
-        let Self {
-            node_config,
-            standard,
-            with_unused_ports,
-            upgrade_signal_startup,
-        } = self;
+        let Self { node_config, standard, with_unused_ports, upgrade_signal_startup } = self;
         (
-            ExecutionNodeRuntimeConfig {
-                node_config,
-                with_unused_ports,
-                upgrade_signal_startup,
-            },
+            ExecutionNodeRuntimeConfig { node_config, with_unused_ports, upgrade_signal_startup },
             standard,
         )
     }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -1,13 +1,13 @@
 //! Standard Base execution-node arguments and runner wiring.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use base_bundle_extension::BundleExtension;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringResourceLimits};
 use base_node_core::args::RollupArgs;
-use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode};
+use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode, PayloadServiceBuilder};
 use base_proofs_extension::ProofsHistoryExtension;
 use base_tx_forwarding::{
     DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
@@ -15,7 +15,12 @@ use base_tx_forwarding::{
 };
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
+use base_upgrade_signal::UpgradeSignalStartupMode;
 use url::Url;
+
+use crate::upgrade_signal::{
+    ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalMetricsExtension,
+};
 
 /// CLI arguments for a standard Base execution node.
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -221,14 +226,84 @@ impl From<&StandardNodeArgs> for TxForwardingConfig {
 pub struct StandardBaseRethNode;
 
 impl StandardBaseRethNode {
+    /// Applies a configured L1 upgrade signal to the execution chain spec before startup.
+    pub async fn apply_initial_upgrade_signal(
+        builder: BaseNodeBuilder,
+        args: &StandardNodeArgs,
+    ) -> eyre::Result<BaseNodeBuilder> {
+        Self::apply_initial_upgrade_signal_from_rollup_args(builder, &args.rpc.rollup_args).await
+    }
+
+    /// Applies a configured L1 upgrade signal from rollup args before startup.
+    pub async fn apply_initial_upgrade_signal_from_rollup_args(
+        builder: BaseNodeBuilder,
+        rollup_args: &RollupArgs,
+    ) -> eyre::Result<BaseNodeBuilder> {
+        Self::apply_initial_upgrade_signal_from_rollup_args_with_startup_mode(
+            builder,
+            rollup_args,
+            UpgradeSignalStartupMode::ReadAndApply,
+        )
+        .await
+    }
+
+    /// Applies a configured L1 upgrade signal from rollup args with explicit startup behavior.
+    pub async fn apply_initial_upgrade_signal_from_rollup_args_with_startup_mode(
+        mut builder: BaseNodeBuilder,
+        rollup_args: &RollupArgs,
+        startup_mode: UpgradeSignalStartupMode,
+    ) -> eyre::Result<BaseNodeBuilder> {
+        let Some(config) = Self::upgrade_signal_config(rollup_args)? else {
+            return Ok(builder);
+        };
+        if !startup_mode.reads_and_applies() || !config.signal_config.mode.applies_at_startup() {
+            return Ok(builder);
+        }
+
+        let chain_spec = Arc::make_mut(&mut builder.config_mut().chain);
+        ExecutionUpgradeSignal::apply_initial_signal_to_chain_spec(&config, chain_spec).await?;
+
+        Ok(builder)
+    }
+
+    /// Installs the upgrade signal metrics observer extension when configured.
+    pub fn install_upgrade_signal_metrics_extension<SB: PayloadServiceBuilder>(
+        runner: &mut BaseNodeRunner<SB>,
+        rollup_args: &RollupArgs,
+    ) -> eyre::Result<()> {
+        let Some(config) = Self::upgrade_signal_config(rollup_args)? else {
+            return Ok(());
+        };
+
+        runner.install_ext::<ExecutionUpgradeSignalMetricsExtension>(config);
+
+        Ok(())
+    }
+
+    fn upgrade_signal_config(
+        rollup_args: &RollupArgs,
+    ) -> eyre::Result<Option<ExecutionUpgradeSignalConfig>> {
+        let Some(signal_config) = rollup_args.upgrade_signal.config()? else {
+            return Ok(None);
+        };
+        let Some(l1_rpc) = rollup_args.upgrade_signal_l1_rpc.upgrade_signal_l1_rpc.clone() else {
+            eyre::bail!(
+                "--upgrade-signal.contract requires --upgrade-signal.l1-rpc for base-reth-node"
+            );
+        };
+
+        Ok(Some(ExecutionUpgradeSignalConfig { signal_config, l1_rpc }))
+    }
+
     /// Builds a runner with the standard Base execution-node extensions installed.
     pub fn runner(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner> {
-        let mut runner = BaseNodeRunner::new(args.rpc.rollup_args.clone());
+        let rollup_args = args.rpc.rollup_args.clone();
+        let mut runner = BaseNodeRunner::new(rollup_args.clone());
 
         // Create flashblocks config first so we can share its state with metering.
         let flashblocks_config: Option<FlashblocksConfig> = (&args).into();
 
-        // Feature extensions (FlashblocksExtension must be last - uses replace_configured).
+        // Feature extensions.
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig {
             sequencer_rpc: args.rpc.rollup_args.sequencer.clone(),
         });
@@ -268,7 +343,8 @@ impl StandardBaseRethNode {
         runner.install_ext::<BundleExtension>(());
         runner.install_ext::<TxForwardingExtension>((&args).into());
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
-        runner.install_ext::<ProofsHistoryExtension>(args.rpc.rollup_args);
+        runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
+        Self::install_upgrade_signal_metrics_extension(&mut runner, &rollup_args)?;
 
         Ok(runner)
     }
@@ -285,6 +361,8 @@ impl StandardBaseRethNode {
 
     /// Launches the node and waits for it to exit.
     pub async fn run(builder: BaseNodeBuilder, args: StandardNodeArgs) -> eyre::Result<()> {
+        let builder = Self::apply_initial_upgrade_signal(builder, &args).await?;
+
         Self::runner_with_version_metrics(args)?.run(builder).await
     }
 
@@ -293,6 +371,27 @@ impl StandardBaseRethNode {
         builder: BaseNodeBuilder,
         args: StandardNodeArgs,
     ) -> eyre::Result<LaunchedBaseNode> {
+        Self::launch_with_upgrade_signal_startup(
+            builder,
+            args,
+            UpgradeSignalStartupMode::ReadAndApply,
+        )
+        .await
+    }
+
+    /// Launches the node with explicit upgrade-signal startup behavior.
+    pub async fn launch_with_upgrade_signal_startup(
+        builder: BaseNodeBuilder,
+        args: StandardNodeArgs,
+        startup_mode: UpgradeSignalStartupMode,
+    ) -> eyre::Result<LaunchedBaseNode> {
+        let builder = Self::apply_initial_upgrade_signal_from_rollup_args_with_startup_mode(
+            builder,
+            &args.rpc.rollup_args,
+            startup_mode,
+        )
+        .await?;
+
         Self::runner_with_version_metrics(args)?.launch(builder).await
     }
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -326,7 +326,7 @@ impl StandardBaseRethNode {
         // Create flashblocks config first so we can share its state with metering.
         let flashblocks_config: Option<FlashblocksConfig> = (&args).into();
 
-        // Feature extensions.
+        // Feature extensions (FlashblocksExtension must be last - uses replace_configured).
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig {
             sequencer_rpc: args.rpc.rollup_args.sequencer.clone(),
         });
@@ -365,9 +365,9 @@ impl StandardBaseRethNode {
         runner.install_ext::<MeteringExtension>(metering_config);
         runner.install_ext::<BundleExtension>(());
         runner.install_ext::<TxForwardingExtension>((&args).into());
-        runner.install_ext::<FlashblocksExtension>(flashblocks_config);
         runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
         Self::install_upgrade_signal_metrics_extension(&mut runner, &rollup_args)?;
+        runner.install_ext::<FlashblocksExtension>(flashblocks_config);
 
         Ok(runner)
     }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -280,19 +280,20 @@ impl StandardBaseRethNode {
         Ok(())
     }
 
-    /// Validates standalone execution-node upgrade signal arguments before node setup.
+    /// Validates execution upgrade signal arguments before node setup.
     ///
-    /// A standalone `base-reth-node` has no derived L1 RPC (unlike `base rpc` and the consensus
-    /// node), so a configured contract requires an explicit `--upgrade-signal.l1-rpc`. This holds
-    /// for every mode, including the default metrics-only mode, which still polls the contract.
+    /// Execution upgrade-signal polling is configured independently from consensus polling, so a
+    /// configured contract always requires an explicit `--upgrade-signal.l1-rpc`. This holds for
+    /// every mode, including the default metrics-only mode, which still polls the contract.
     pub fn validate_upgrade_signal_args(rollup_args: &RollupArgs) -> eyre::Result<()> {
         if rollup_args.upgrade_signal.contract_address.is_some()
             && rollup_args.upgrade_signal_l1_rpc.upgrade_signal_l1_rpc.is_none()
         {
             eyre::bail!(
                 "--upgrade-signal.contract (env BASE_NODE_UPGRADE_SIGNAL_CONTRACT) requires \
-                 --upgrade-signal.l1-rpc (env BASE_NODE_UPGRADE_SIGNAL_L1_RPC) for base-reth-node; \
-                 every mode, including the default metrics-only mode, reads the contract over L1"
+                 --upgrade-signal.l1-rpc (env BASE_NODE_UPGRADE_SIGNAL_L1_RPC) for execution \
+                 upgrade-signal polling; every mode, including the default metrics-only mode, \
+                 reads the contract over L1"
             );
         }
 
@@ -422,6 +423,7 @@ impl StandardBaseRethNode {
 mod tests {
     use std::time::Duration;
 
+    use alloy_primitives::address;
     use clap::{Args, Parser};
 
     use super::*;
@@ -538,5 +540,19 @@ mod tests {
         assert_eq!(standard_args.rpc.rollup_args.sequencer, None);
         assert!(!config.enabled);
         assert!(config.builder_urls.is_empty());
+    }
+
+    #[test]
+    fn test_upgrade_signal_contract_requires_execution_l1_rpc() {
+        let error = StandardBaseRethNode::validate_upgrade_signal_args(&RollupArgs {
+            upgrade_signal: base_upgrade_signal::UpgradeSignalArgs {
+                contract_address: Some(address!("0000000000000000000000000000000000000001")),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .expect_err("upgrade signal contract should require an explicit execution L1 RPC");
+
+        assert!(error.to_string().contains("--upgrade-signal.l1-rpc"));
     }
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -280,17 +280,37 @@ impl StandardBaseRethNode {
         Ok(())
     }
 
+    /// Validates standalone execution-node upgrade signal arguments before node setup.
+    ///
+    /// A standalone `base-reth-node` has no derived L1 RPC (unlike `base rpc` and the consensus
+    /// node), so a configured contract requires an explicit `--upgrade-signal.l1-rpc`. This holds
+    /// for every mode, including the default metrics-only mode, which still polls the contract.
+    pub fn validate_upgrade_signal_args(rollup_args: &RollupArgs) -> eyre::Result<()> {
+        if rollup_args.upgrade_signal.contract_address.is_some()
+            && rollup_args.upgrade_signal_l1_rpc.upgrade_signal_l1_rpc.is_none()
+        {
+            eyre::bail!(
+                "--upgrade-signal.contract (env BASE_NODE_UPGRADE_SIGNAL_CONTRACT) requires \
+                 --upgrade-signal.l1-rpc (env BASE_NODE_UPGRADE_SIGNAL_L1_RPC) for base-reth-node; \
+                 every mode, including the default metrics-only mode, reads the contract over L1"
+            );
+        }
+
+        Ok(())
+    }
+
     fn upgrade_signal_config(
         rollup_args: &RollupArgs,
     ) -> eyre::Result<Option<ExecutionUpgradeSignalConfig>> {
         let Some(signal_config) = rollup_args.upgrade_signal.config()? else {
             return Ok(None);
         };
-        let Some(l1_rpc) = rollup_args.upgrade_signal_l1_rpc.upgrade_signal_l1_rpc.clone() else {
-            eyre::bail!(
-                "--upgrade-signal.contract requires --upgrade-signal.l1-rpc for base-reth-node"
-            );
-        };
+        Self::validate_upgrade_signal_args(rollup_args)?;
+        let l1_rpc = rollup_args
+            .upgrade_signal_l1_rpc
+            .upgrade_signal_l1_rpc
+            .clone()
+            .expect("validated by validate_upgrade_signal_args");
 
         Ok(Some(ExecutionUpgradeSignalConfig { signal_config, l1_rpc }))
     }
@@ -298,6 +318,8 @@ impl StandardBaseRethNode {
     /// Builds a runner with the standard Base execution-node extensions installed.
     pub fn runner(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner> {
         let rollup_args = args.rpc.rollup_args.clone();
+        // Fail fast on an incomplete upgrade-signal configuration before installing extensions.
+        Self::validate_upgrade_signal_args(&rollup_args)?;
         let mut runner = BaseNodeRunner::new(rollup_args.clone());
 
         // Create flashblocks config first so we can share its state with metering.

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -1,0 +1,433 @@
+//! Execution-node upgrade signal schedule application.
+
+use alloy_provider::RootProvider;
+use base_execution_chainspec::BaseChainSpec;
+use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
+use base_upgrade_signal::{
+    AlloyUpgradeSignalReader, DEFAULT_UPGRADE_SIGNAL_POLL_INTERVAL, UpgradeSignalApplySummary,
+    UpgradeSignalConfig, UpgradeSignalMetrics, UpgradeSignalMonitor, UpgradeSignalRefresher,
+    UpgradeSignalRuntimeApplier, UpgradeSignalRuntimeValidation, UpgradeSignalSchedule,
+    UpgradeSignalStateUpdate,
+};
+use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
+use reth_chainspec::EthChainSpec;
+use reth_rpc_server_types::RethRpcModule;
+use tracing::{debug, info, warn};
+use url::Url;
+
+/// Configuration for execution-node upgrade signal schedule reads.
+#[derive(Debug, Clone)]
+pub struct ExecutionUpgradeSignalConfig {
+    /// Shared upgrade signal schedule read configuration.
+    pub signal_config: UpgradeSignalConfig,
+    /// L1 RPC URL used to read the upgrade signal contract.
+    pub l1_rpc: Url,
+}
+
+/// Applies contract-backed upgrade signal schedules to execution node configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct ExecutionUpgradeSignal;
+
+impl ExecutionUpgradeSignal {
+    /// Applies the configured L1 upgrade signal to the chain spec before startup.
+    pub async fn apply_initial_signal_to_chain_spec(
+        config: &ExecutionUpgradeSignalConfig,
+        chain_spec: &mut BaseChainSpec,
+    ) -> eyre::Result<()> {
+        if !config.signal_config.mode.applies_at_startup() {
+            info!(
+                target: "upgrade_signal",
+                mode = ?config.signal_config.mode,
+                "observing execution upgrade signal without startup schedule application"
+            );
+            return Ok(());
+        }
+
+        let reader = AlloyUpgradeSignalReader::new(
+            RootProvider::new_http(config.l1_rpc.clone()),
+            config.signal_config.contract_address,
+        );
+        let schedule = match reader.read_schedule(&config.signal_config.hardfork_ids).await {
+            Ok(schedule) => schedule,
+            Err(error) => return Err(error.into()),
+        };
+        UpgradeSignalMetrics::record_schedule(&schedule);
+        for signal in &schedule.signals {
+            info!(
+                target: "upgrade_signal",
+                hardfork_id = %signal.hardfork_id,
+                activation_timestamp = signal.activation_timestamp,
+                minimum_protocol_version = %signal.protocol_version,
+                node_protocol_version = %config.signal_config.node_protocol_version,
+                l1_block_number = signal.l1_block_number,
+                "read dynamic upgrade signal for execution startup"
+            );
+        }
+        let application_schedule = config.signal_config.application_schedule(&schedule);
+        config.signal_config.validate_schedule_protocol_versions(&application_schedule)?;
+
+        Self::apply_schedule_to_chain_spec(chain_spec, &application_schedule)?;
+
+        Ok(())
+    }
+
+    /// Applies a contract-backed hardfork activation schedule to an execution chain spec.
+    pub fn apply_schedule_to_chain_spec(
+        chain_spec: &mut BaseChainSpec,
+        schedule: &UpgradeSignalSchedule,
+    ) -> eyre::Result<usize> {
+        let mut applied = 0;
+        let mut cleared = 0;
+        for signal in &schedule.signals {
+            let Some(timestamp) = signal.positive_activation_timestamp() else {
+                if !chain_spec.try_clear_hardfork_activation_timestamp(&signal.hardfork_id)? {
+                    debug!(
+                        target: "upgrade_signal",
+                        hardfork_id = %signal.hardfork_id,
+                        activation_timestamp = signal.activation_timestamp,
+                        "ignored unsupported execution hardfork signal"
+                    );
+                    continue;
+                }
+                cleared += 1;
+                info!(
+                    target: "upgrade_signal",
+                    hardfork_id = %signal.hardfork_id,
+                    "cleared upgrade signal from execution chain spec"
+                );
+                continue;
+            };
+            if !chain_spec.try_set_hardfork_activation_timestamp(&signal.hardfork_id, timestamp)? {
+                debug!(
+                    target: "upgrade_signal",
+                    hardfork_id = %signal.hardfork_id,
+                    activation_timestamp = timestamp,
+                    "ignored unsupported execution hardfork signal"
+                );
+                continue;
+            }
+            applied += 1;
+            info!(
+                target: "upgrade_signal",
+                hardfork_id = %signal.hardfork_id,
+                activation_timestamp = timestamp,
+                "applied upgrade signal to execution chain spec"
+            );
+        }
+        chain_spec.refresh_genesis_header();
+        info!(
+            target: "upgrade_signal",
+            applied_hardforks = applied,
+            cleared_hardforks = cleared,
+            configured_hardforks = schedule.signals.len(),
+            "applied upgrade signal schedule to execution chain spec"
+        );
+
+        Ok(applied)
+    }
+
+    /// Validates that a runtime schedule can be applied to this execution chain spec.
+    pub fn validate_runtime_schedule_for_chain_spec(
+        chain_spec: &BaseChainSpec,
+        schedule: &UpgradeSignalSchedule,
+    ) -> eyre::Result<()> {
+        UpgradeSignalRuntimeValidation::with_activation_admin_address(
+            chain_spec.activation_admin_address,
+        )
+        .validate_schedule(chain_spec.chain().id(), schedule)?;
+
+        Ok(())
+    }
+
+    /// Refreshes the runtime upgrade signal schedule for a running execution node.
+    pub async fn refresh_runtime_upgrade_signal(
+        refresher: &ExecutionUpgradeSignalRuntimeRefresher,
+    ) -> RpcResult<UpgradeSignalApplySummary> {
+        match refresher.refresher.read_validated_schedule().await {
+            Ok(schedule) => {
+                if let Err(error) =
+                    Self::validate_runtime_schedule_for_chain_spec(&refresher.chain_spec, &schedule)
+                {
+                    warn!(
+                        target: "upgrade_signal",
+                        error = %error,
+                        "failed to validate execution runtime upgrade signal"
+                    );
+                    return Err(ErrorObject::owned(
+                        -32003,
+                        "failed to refresh upgrade signal",
+                        Some(error.to_string()),
+                    ));
+                }
+                let summary = UpgradeSignalRuntimeApplier::apply_schedule(
+                    refresher.refresher.chain_id,
+                    &schedule,
+                );
+                info!(
+                    target: "upgrade_signal",
+                    chain_id = summary.chain_id,
+                    l1_block_number = ?summary.l1_block_number,
+                    applied_hardforks = summary.applied_hardforks,
+                    cleared_hardforks = summary.cleared_hardforks,
+                    ignored_hardforks = summary.ignored_hardforks,
+                    configured_hardforks = summary.configured_hardforks,
+                    "refreshed execution runtime upgrade signal"
+                );
+                Ok(summary)
+            }
+            Err(error) => {
+                warn!(
+                    target: "upgrade_signal",
+                    error = %error,
+                    "failed to refresh execution runtime upgrade signal"
+                );
+                Err(ErrorObject::owned(
+                    -32003,
+                    "failed to refresh upgrade signal",
+                    Some(error.to_string()),
+                ))
+            }
+        }
+    }
+
+    /// Registers the execution admin RPC method for runtime upgrade signal refreshes.
+    pub fn register_runtime_refresh_rpc(
+        ctx: &mut BaseRpcContext<'_>,
+        config: ExecutionUpgradeSignalConfig,
+    ) -> eyre::Result<()> {
+        if !config.signal_config.mode.allows_runtime_admin() {
+            return Ok(());
+        }
+
+        let chain_id = ctx.config().chain.chain().id();
+        let refresher = ExecutionUpgradeSignalRuntimeRefresher::new(
+            UpgradeSignalRefresher::new(
+                config.signal_config,
+                RootProvider::new_http(config.l1_rpc),
+                chain_id,
+            ),
+            ctx.config().chain.as_ref().clone(),
+        );
+        let mut module = RpcModule::new(refresher);
+        module
+            .register_async_method("admin_refreshUpgradeSignal", |_, refresher, _| async move {
+                Self::refresh_runtime_upgrade_signal(&refresher).await
+            })
+            .map_err(|error| eyre::eyre!(error))?;
+        ctx.modules.merge_if_module_configured(RethRpcModule::Admin, module)?;
+
+        Ok(())
+    }
+}
+
+/// Execution runtime upgrade signal refresher with execution-specific validation context.
+#[derive(Debug, Clone)]
+pub struct ExecutionUpgradeSignalRuntimeRefresher {
+    /// Shared runtime refresher.
+    pub refresher: UpgradeSignalRefresher,
+    /// Execution chain spec used for runtime schedule validation.
+    pub chain_spec: BaseChainSpec,
+}
+
+impl ExecutionUpgradeSignalRuntimeRefresher {
+    /// Creates an execution runtime upgrade signal refresher.
+    pub const fn new(refresher: UpgradeSignalRefresher, chain_spec: BaseChainSpec) -> Self {
+        Self { refresher, chain_spec }
+    }
+}
+
+/// Execution-node extension that records live L1 upgrade signal metrics only.
+#[derive(Debug)]
+pub struct ExecutionUpgradeSignalMetricsExtension {
+    /// Extension configuration.
+    pub config: ExecutionUpgradeSignalConfig,
+}
+
+impl ExecutionUpgradeSignalMetricsExtension {
+    /// Creates a new execution upgrade signal metrics extension.
+    pub const fn new(config: ExecutionUpgradeSignalConfig) -> Self {
+        Self { config }
+    }
+
+    /// Polls L1 upgrade signal state and records metrics without mutating local config.
+    pub async fn poll_l1_signal(
+        monitor: &mut UpgradeSignalMonitor,
+        reader: &AlloyUpgradeSignalReader,
+        hardfork_ids: &[String],
+    ) {
+        match reader.read_schedule(hardfork_ids).await {
+            Ok(schedule) => {
+                let updates = monitor.update_schedule(schedule);
+                let updated_hardforks = updates
+                    .iter()
+                    .filter(|update| matches!(update, UpgradeSignalStateUpdate::Changed))
+                    .count();
+                if updated_hardforks > 0 {
+                    info!(
+                        target: "upgrade_signal",
+                        updated_hardforks,
+                        "observed live L1 upgrade signal update"
+                    );
+                }
+            }
+            Err(error) => {
+                warn!(
+                    target: "upgrade_signal",
+                    error = %error,
+                    hardfork_ids = ?hardfork_ids,
+                    "failed to read live L1 upgrade signal metrics"
+                );
+            }
+        }
+    }
+}
+
+impl BaseNodeExtension for ExecutionUpgradeSignalMetricsExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        let config = self.config;
+
+        let hooks = if config.signal_config.mode.allows_runtime_admin() {
+            let rpc_config = config.clone();
+            hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
+                ExecutionUpgradeSignal::register_runtime_refresh_rpc(ctx, rpc_config)
+            })
+        } else {
+            hooks
+        };
+
+        hooks.add_node_started_hook(move |ctx| {
+            let reader = AlloyUpgradeSignalReader::new(
+                RootProvider::new_http(config.l1_rpc.clone()),
+                config.signal_config.contract_address,
+            );
+            let hardfork_ids = config.signal_config.hardfork_ids;
+            let mut monitor = UpgradeSignalMonitor::new(&hardfork_ids);
+            let executor = ctx.task_executor;
+
+            executor.spawn_with_graceful_shutdown_signal(|signal| {
+                Box::pin(async move {
+                    let mut interval = tokio::time::interval(DEFAULT_UPGRADE_SIGNAL_POLL_INTERVAL);
+                    let mut signal = Box::pin(signal);
+
+                    loop {
+                        tokio::select! {
+                            _ = &mut signal => break,
+                            _ = interval.tick() => {
+                                Self::poll_l1_signal(&mut monitor, &reader, &hardfork_ids).await;
+                            }
+                        }
+                    }
+                })
+            });
+
+            info!(target: "upgrade_signal", "execution upgrade signal metrics observer spawned");
+            Ok(())
+        })
+    }
+}
+
+impl FromExtensionConfig for ExecutionUpgradeSignalMetricsExtension {
+    type Config = ExecutionUpgradeSignalConfig;
+
+    fn from_config(config: Self::Config) -> Self {
+        Self::new(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_chains::BaseUpgrade;
+    use reth_chainspec::{ChainSpec, EthereumHardfork, ForkCondition};
+
+    use super::*;
+
+    fn schedule(signals: &[(&str, u64)]) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(
+            signals
+                .iter()
+                .map(|(hardfork_id, activation_timestamp)| base_upgrade_signal::UpgradeSignal {
+                    hardfork_id: hardfork_id.to_string(),
+                    activation_timestamp: *activation_timestamp,
+                    protocol_version: Default::default(),
+                    l1_block_number: 1,
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn applies_positive_schedule_to_chain_spec() {
+        let mut chain_spec = BaseChainSpec::devnet();
+
+        chain_spec.set_fork(EthereumHardfork::Shanghai, ForkCondition::Never);
+        chain_spec.set_fork(BaseUpgrade::Canyon, ForkCondition::Never);
+        chain_spec.set_fork(EthereumHardfork::Osaka, ForkCondition::Never);
+        chain_spec.set_fork(BaseUpgrade::Azul, ForkCondition::Never);
+
+        let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
+            &mut chain_spec,
+            &schedule(&[("canyon", 40), ("azul", 42)]),
+        )
+        .unwrap();
+
+        assert_eq!(applied, 2);
+        assert_eq!(chain_spec.fork(EthereumHardfork::Shanghai), ForkCondition::Timestamp(40));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(40));
+        assert_eq!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Timestamp(42));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Azul), ForkCondition::Timestamp(42));
+    }
+
+    #[test]
+    fn zero_signal_clears_existing_chain_spec_forks() {
+        let mut chain_spec = BaseChainSpec::devnet();
+
+        chain_spec.set_fork(EthereumHardfork::Shanghai, ForkCondition::Timestamp(40));
+        chain_spec.set_fork(BaseUpgrade::Canyon, ForkCondition::Timestamp(40));
+        chain_spec.set_fork(EthereumHardfork::Osaka, ForkCondition::Timestamp(42));
+        chain_spec.set_fork(BaseUpgrade::Azul, ForkCondition::Timestamp(42));
+
+        let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
+            &mut chain_spec,
+            &schedule(&[("azul", 0)]),
+        )
+        .unwrap();
+
+        assert_eq!(applied, 0);
+        assert_eq!(chain_spec.fork(EthereumHardfork::Shanghai), ForkCondition::Timestamp(40));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(40));
+        assert_eq!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Never);
+        assert_eq!(chain_spec.fork(BaseUpgrade::Azul), ForkCondition::Never);
+    }
+
+    #[test]
+    fn ignores_unsupported_signal_for_chain_spec() {
+        let mut chain_spec = BaseChainSpec::devnet();
+
+        chain_spec.set_fork(EthereumHardfork::Osaka, ForkCondition::Never);
+        chain_spec.set_fork(BaseUpgrade::Azul, ForkCondition::Never);
+
+        let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
+            &mut chain_spec,
+            &schedule(&[("delta", 42)]),
+        )
+        .unwrap();
+
+        assert_eq!(applied, 0);
+        assert_eq!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Never);
+        assert_eq!(chain_spec.fork(BaseUpgrade::Azul), ForkCondition::Never);
+    }
+
+    #[test]
+    fn rejects_beryl_schedule_without_activation_admin() {
+        let mut chain_spec = BaseChainSpec::from(ChainSpec::default());
+
+        let error = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
+            &mut chain_spec,
+            &schedule(&[("beryl", 42)]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("missing activation admin address"));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Beryl), ForkCondition::Never);
+    }
+}

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -1,18 +1,18 @@
 //! Execution-node upgrade signal schedule application.
 
 use alloy_provider::RootProvider;
+use base_common_genesis::BaseUpgrade;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_upgrade_signal::{
-    AlloyUpgradeSignalReader, DEFAULT_UPGRADE_SIGNAL_POLL_INTERVAL, UpgradeSignalApplySummary,
-    UpgradeSignalConfig, UpgradeSignalMetrics, UpgradeSignalMonitor, UpgradeSignalRefresher,
+    AlloyUpgradeSignalReader, UpgradeSignalApplySummary, UpgradeSignalConfig,
+    UpgradeSignalDefaults, UpgradeSignalMonitor, UpgradeSignalRefresher,
     UpgradeSignalRuntimeApplier, UpgradeSignalRuntimeValidation, UpgradeSignalSchedule,
-    UpgradeSignalStateUpdate,
 };
 use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
 use reth_chainspec::EthChainSpec;
 use reth_rpc_server_types::RethRpcModule;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 use url::Url;
 
 /// Configuration for execution-node upgrade signal schedule reads.
@@ -46,84 +46,29 @@ impl ExecutionUpgradeSignal {
         let reader = AlloyUpgradeSignalReader::new(
             RootProvider::new_http(config.l1_rpc.clone()),
             config.signal_config.contract_address,
-        );
-        let schedule = match reader.read_schedule(&config.signal_config.hardfork_ids).await {
-            Ok(schedule) => schedule,
-            Err(error) => return Err(error.into()),
-        };
-        UpgradeSignalMetrics::record_schedule(&schedule);
-        for signal in &schedule.signals {
-            info!(
-                target: "upgrade_signal",
-                hardfork_id = %signal.hardfork_id,
-                activation_timestamp = signal.activation_timestamp,
-                minimum_protocol_version = %signal.protocol_version,
-                node_protocol_version = %config.signal_config.node_protocol_version,
-                l1_block_number = signal.l1_block_number,
-                "read dynamic upgrade signal for execution startup"
-            );
-        }
-        let application_schedule = config.signal_config.application_schedule(&schedule);
-        config.signal_config.validate_schedule_protocol_versions(&application_schedule)?;
+        )
+        .with_block_tag(config.signal_config.l1_block_tag);
+        let application_schedule = config
+            .signal_config
+            .read_validated_application_schedule(&reader, "execution startup")
+            .await?;
 
         Self::apply_schedule_to_chain_spec(chain_spec, &application_schedule)?;
 
         Ok(())
     }
 
-    /// Applies a contract-backed hardfork activation schedule to an execution chain spec.
+    /// Applies a contract-backed upgrade activation schedule to an execution chain spec.
     pub fn apply_schedule_to_chain_spec(
         chain_spec: &mut BaseChainSpec,
         schedule: &UpgradeSignalSchedule,
     ) -> eyre::Result<usize> {
-        let mut applied = 0;
-        let mut cleared = 0;
-        for signal in &schedule.signals {
-            let Some(timestamp) = signal.positive_activation_timestamp() else {
-                if !chain_spec.try_clear_hardfork_activation_timestamp(&signal.hardfork_id)? {
-                    debug!(
-                        target: "upgrade_signal",
-                        hardfork_id = %signal.hardfork_id,
-                        activation_timestamp = signal.activation_timestamp,
-                        "ignored unsupported execution hardfork signal"
-                    );
-                    continue;
-                }
-                cleared += 1;
-                info!(
-                    target: "upgrade_signal",
-                    hardfork_id = %signal.hardfork_id,
-                    "cleared upgrade signal from execution chain spec"
-                );
-                continue;
-            };
-            if !chain_spec.try_set_hardfork_activation_timestamp(&signal.hardfork_id, timestamp)? {
-                debug!(
-                    target: "upgrade_signal",
-                    hardfork_id = %signal.hardfork_id,
-                    activation_timestamp = timestamp,
-                    "ignored unsupported execution hardfork signal"
-                );
-                continue;
-            }
-            applied += 1;
-            info!(
-                target: "upgrade_signal",
-                hardfork_id = %signal.hardfork_id,
-                activation_timestamp = timestamp,
-                "applied upgrade signal to execution chain spec"
-            );
-        }
-        chain_spec.refresh_genesis_header();
-        info!(
-            target: "upgrade_signal",
-            applied_hardforks = applied,
-            cleared_hardforks = cleared,
-            configured_hardforks = schedule.signals.len(),
-            "applied upgrade signal schedule to execution chain spec"
-        );
+        let chain_id = chain_spec.chain().id();
+        let summary =
+            UpgradeSignalRuntimeApplier::apply_schedule_to_sink(chain_id, schedule, chain_spec)?;
+        summary.log("execution chain spec");
 
-        Ok(applied)
+        Ok(summary.applied_hardforks)
     }
 
     /// Validates that a runtime schedule can be applied to this execution chain spec.
@@ -200,11 +145,14 @@ impl ExecutionUpgradeSignal {
         }
 
         let chain_id = ctx.config().chain.chain().id();
+        // Execution validates each refresh against the live chain spec in
+        // `refresh_runtime_upgrade_signal`, so the shared refresher itself stays unvalidated.
         let refresher = ExecutionUpgradeSignalRuntimeRefresher::new(
             UpgradeSignalRefresher::new(
                 config.signal_config,
                 RootProvider::new_http(config.l1_rpc),
                 chain_id,
+                UpgradeSignalRuntimeValidation::disabled(),
             ),
             ctx.config().chain.as_ref().clone(),
         );
@@ -253,31 +201,15 @@ impl ExecutionUpgradeSignalMetricsExtension {
     pub async fn poll_l1_signal(
         monitor: &mut UpgradeSignalMonitor,
         reader: &AlloyUpgradeSignalReader,
-        hardfork_ids: &[String],
+        hardfork_ids: &[BaseUpgrade],
     ) {
-        match reader.read_schedule(hardfork_ids).await {
-            Ok(schedule) => {
-                let updates = monitor.update_schedule(schedule);
-                let updated_hardforks = updates
-                    .iter()
-                    .filter(|update| matches!(update, UpgradeSignalStateUpdate::Changed))
-                    .count();
-                if updated_hardforks > 0 {
-                    info!(
-                        target: "upgrade_signal",
-                        updated_hardforks,
-                        "observed live L1 upgrade signal update"
-                    );
-                }
-            }
-            Err(error) => {
-                warn!(
-                    target: "upgrade_signal",
-                    error = %error,
-                    hardfork_ids = ?hardfork_ids,
-                    "failed to read live L1 upgrade signal metrics"
-                );
-            }
+        let updated_hardforks = monitor.poll(reader, hardfork_ids).await;
+        if updated_hardforks > 0 {
+            info!(
+                target: "upgrade_signal",
+                updated_hardforks,
+                "observed live L1 upgrade signal update"
+            );
         }
     }
 }
@@ -299,14 +231,15 @@ impl BaseNodeExtension for ExecutionUpgradeSignalMetricsExtension {
             let reader = AlloyUpgradeSignalReader::new(
                 RootProvider::new_http(config.l1_rpc.clone()),
                 config.signal_config.contract_address,
-            );
+            )
+            .with_block_tag(config.signal_config.l1_block_tag);
             let hardfork_ids = config.signal_config.hardfork_ids;
             let mut monitor = UpgradeSignalMonitor::new(&hardfork_ids);
             let executor = ctx.task_executor;
 
             executor.spawn_with_graceful_shutdown_signal(|signal| {
                 Box::pin(async move {
-                    let mut interval = tokio::time::interval(DEFAULT_UPGRADE_SIGNAL_POLL_INTERVAL);
+                    let mut interval = tokio::time::interval(UpgradeSignalDefaults::POLL_INTERVAL);
                     let mut signal = Box::pin(signal);
 
                     loop {
@@ -341,12 +274,12 @@ mod tests {
 
     use super::*;
 
-    fn schedule(signals: &[(&str, u64)]) -> UpgradeSignalSchedule {
+    fn schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
             signals
                 .iter()
                 .map(|(hardfork_id, activation_timestamp)| base_upgrade_signal::UpgradeSignal {
-                    hardfork_id: hardfork_id.to_string(),
+                    hardfork_id: *hardfork_id,
                     activation_timestamp: *activation_timestamp,
                     protocol_version: Default::default(),
                     l1_block_number: 1,
@@ -366,7 +299,7 @@ mod tests {
 
         let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
             &mut chain_spec,
-            &schedule(&[("canyon", 40), ("azul", 42)]),
+            &schedule(&[(BaseUpgrade::Canyon, 40), (BaseUpgrade::Azul, 42)]),
         )
         .unwrap();
 
@@ -388,7 +321,7 @@ mod tests {
 
         let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
             &mut chain_spec,
-            &schedule(&[("azul", 0)]),
+            &schedule(&[(BaseUpgrade::Azul, 0)]),
         )
         .unwrap();
 
@@ -408,7 +341,7 @@ mod tests {
 
         let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
             &mut chain_spec,
-            &schedule(&[("delta", 42)]),
+            &schedule(&[(BaseUpgrade::Delta, 42)]),
         )
         .unwrap();
 
@@ -423,7 +356,7 @@ mod tests {
 
         let error = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
             &mut chain_spec,
-            &schedule(&[("beryl", 42)]),
+            &schedule(&[(BaseUpgrade::Beryl, 42)]),
         )
         .unwrap_err();
 

--- a/crates/execution/node/Cargo.toml
+++ b/crates/execution/node/Cargo.toml
@@ -61,6 +61,7 @@ revm = { workspace = true, features = [
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 base-common-chains.workspace = true
+base-upgrade-signal.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine.workspace = true
 base-common-consensus = { workspace = true, features = ["reth"] }

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -4,6 +4,7 @@
 
 use std::{path::PathBuf, time::Duration};
 
+use base_upgrade_signal::{UpgradeSignalArgs, UpgradeSignalL1RpcArgs};
 use clap::{ValueEnum, builder::ArgPredicate};
 
 /// Transaction ordering strategy for the mempool.
@@ -133,6 +134,21 @@ pub struct RollupArgs {
         default_value_t = 0
     )]
     pub proofs_history_verification_interval: u64,
+
+    /// Enable the Base discv5 protocol identity.
+    ///
+    /// When enabled, the node advertises itself with the `basev0` protocol ID in discv5,
+    /// allowing it to find and connect to other Base nodes more efficiently.
+    #[arg(long = "rollup.discovery.v5.base", default_value_t = true, action = clap::ArgAction::Set)]
+    pub base_protocol: bool,
+
+    /// L1 upgrade signal observer arguments.
+    #[command(flatten)]
+    pub upgrade_signal: UpgradeSignalArgs,
+
+    /// Standalone execution-node L1 RPC argument for the upgrade signal observer.
+    #[command(flatten)]
+    pub upgrade_signal_l1_rpc: UpgradeSignalL1RpcArgs,
 }
 
 impl Default for RollupArgs {
@@ -151,12 +167,16 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
+            base_protocol: true,
+            upgrade_signal: UpgradeSignalArgs::default(),
+            upgrade_signal_l1_rpc: UpgradeSignalL1RpcArgs::default(),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::address;
     use clap::{Args, Parser};
 
     use super::*;
@@ -270,5 +290,44 @@ mod tests {
         ])
         .args;
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
+    }
+
+    #[test]
+    fn test_parse_base_protocol_default_true() {
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert!(args.base_protocol);
+    }
+
+    #[test]
+    fn test_parse_base_protocol_disabled() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.discovery.v5.base",
+            "false",
+        ])
+        .args;
+        assert!(!args.base_protocol);
+    }
+
+    #[test]
+    fn test_parse_upgrade_signal_args() {
+        let contract = address!("0000000000000000000000000000000000000001");
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--upgrade-signal.contract",
+            "0x0000000000000000000000000000000000000001",
+            "--upgrade-signal.hardfork-id",
+            "azul",
+            "--upgrade-signal.l1-rpc",
+            "http://localhost:8545",
+        ])
+        .args;
+
+        assert_eq!(args.upgrade_signal.contract_address, Some(contract));
+        assert_eq!(args.upgrade_signal.hardfork_ids, ["azul"]);
+        assert_eq!(
+            args.upgrade_signal_l1_rpc.upgrade_signal_l1_rpc.as_ref().map(|url| url.as_str()),
+            Some("http://localhost:8545/")
+        );
     }
 }

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -135,18 +135,11 @@ pub struct RollupArgs {
     )]
     pub proofs_history_verification_interval: u64,
 
-    /// Enable the Base discv5 protocol identity.
-    ///
-    /// When enabled, the node advertises itself with the `basev0` protocol ID in discv5,
-    /// allowing it to find and connect to other Base nodes more efficiently.
-    #[arg(long = "rollup.discovery.v5.base", default_value_t = true, action = clap::ArgAction::Set)]
-    pub base_protocol: bool,
-
     /// L1 upgrade signal observer arguments.
     #[command(flatten)]
     pub upgrade_signal: UpgradeSignalArgs,
 
-    /// Standalone execution-node L1 RPC argument for the upgrade signal observer.
+    /// Execution-side L1 RPC argument for the upgrade signal observer.
     #[command(flatten)]
     pub upgrade_signal_l1_rpc: UpgradeSignalL1RpcArgs,
 }
@@ -167,7 +160,6 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
-            base_protocol: true,
             upgrade_signal: UpgradeSignalArgs::default(),
             upgrade_signal_l1_rpc: UpgradeSignalL1RpcArgs::default(),
         }
@@ -290,23 +282,6 @@ mod tests {
         ])
         .args;
         assert_eq!(args.txpool_ordering, TxpoolOrdering::Timestamp);
-    }
-
-    #[test]
-    fn test_parse_base_protocol_default_true() {
-        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
-        assert!(args.base_protocol);
-    }
-
-    #[test]
-    fn test_parse_base_protocol_disabled() {
-        let args = CommandParser::<RollupArgs>::parse_from([
-            "reth",
-            "--rollup.discovery.v5.base",
-            "false",
-        ])
-        .args;
-        assert!(!args.base_protocol);
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/args.rs
+++ b/crates/utilities/upgrade-signal/src/config/args.rs
@@ -131,11 +131,10 @@ impl UpgradeSignalArgs {
     }
 }
 
-/// TODO: Default this to the execution CLI's L1 RPC URL so users do not need to pass the same
-/// endpoint twice. This likely requires refactoring how the upgrade signal args are wired into
-/// the standalone execution CLI.
+/// TODO: If an execution service gains its own explicit L1 execution RPC setting, default this
+/// to that URL so users do not need to pass the same endpoint twice.
 ///
-/// CLI argument for the L1 RPC endpoint used by standalone execution nodes.
+/// CLI argument for the L1 RPC endpoint used by execution upgrade-signal polling.
 #[derive(Debug, Clone, Default, PartialEq, Eq, clap::Args)]
 pub struct UpgradeSignalL1RpcArgs {
     /// L1 execution RPC URL used to read the upgrade signal contract.

--- a/crates/utilities/upgrade-signal/src/error.rs
+++ b/crates/utilities/upgrade-signal/src/error.rs
@@ -41,6 +41,12 @@ pub enum UpgradeSignalError {
         /// Node protocol version supported by this binary.
         node_protocol_version: String,
     },
+    /// A runtime Beryl schedule was requested without a known activation admin address.
+    #[error("missing activation admin address for Beryl-enabled chain ID: {chain_id}")]
+    MissingActivationAdminAddress {
+        /// L2 chain ID whose runtime schedule was validated.
+        chain_id: u64,
+    },
 }
 
 impl UpgradeSignalError {
@@ -75,5 +81,10 @@ impl UpgradeSignalError {
             minimum_protocol_version: minimum_protocol_version.to_string(),
             node_protocol_version: node_protocol_version.to_string(),
         }
+    }
+
+    /// Creates a missing activation admin address error.
+    pub const fn missing_activation_admin_address(chain_id: u64) -> Self {
+        Self::MissingActivationAdminAddress { chain_id }
     }
 }

--- a/crates/utilities/upgrade-signal/src/lib.rs
+++ b/crates/utilities/upgrade-signal/src/lib.rs
@@ -26,6 +26,7 @@ mod runtime;
 pub use runtime::{
     RuntimeRegistrySink, UpgradeSignalApplyAction, UpgradeSignalApplyChange,
     UpgradeSignalApplySummary, UpgradeSignalRefresher, UpgradeSignalRuntimeApplier,
+    UpgradeSignalRuntimeValidation,
 };
 
 mod state;

--- a/crates/utilities/upgrade-signal/src/runtime/mod.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/mod.rs
@@ -8,3 +8,6 @@ pub use sink::{RuntimeRegistrySink, UpgradeSignalRuntimeApplier};
 
 mod summary;
 pub use summary::{UpgradeSignalApplyAction, UpgradeSignalApplyChange, UpgradeSignalApplySummary};
+
+mod validation;
+pub use validation::UpgradeSignalRuntimeValidation;

--- a/crates/utilities/upgrade-signal/src/runtime/refresher.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/refresher.rs
@@ -1,7 +1,9 @@
 use alloy_provider::RootProvider;
 use tracing::info;
 
-use super::{UpgradeSignalApplySummary, UpgradeSignalRuntimeApplier};
+use super::{
+    UpgradeSignalApplySummary, UpgradeSignalRuntimeApplier, UpgradeSignalRuntimeValidation,
+};
 use crate::{
     AlloyUpgradeSignalReader, UpgradeSignalConfig, UpgradeSignalError, UpgradeSignalSchedule,
 };
@@ -15,6 +17,8 @@ pub struct UpgradeSignalRefresher {
     pub reader: AlloyUpgradeSignalReader,
     /// L2 chain ID whose runtime fork view is updated.
     pub chain_id: u64,
+    /// Runtime schedule validation context.
+    pub runtime_validation: UpgradeSignalRuntimeValidation,
 }
 
 impl UpgradeSignalRefresher {
@@ -23,17 +27,24 @@ impl UpgradeSignalRefresher {
         config: UpgradeSignalConfig,
         l1_provider: RootProvider,
         chain_id: u64,
+        runtime_validation: UpgradeSignalRuntimeValidation,
     ) -> Self {
         let reader = AlloyUpgradeSignalReader::new(l1_provider, config.contract_address)
             .with_block_tag(config.l1_block_tag);
-        Self { config, reader, chain_id }
+        Self { config, reader, chain_id, runtime_validation }
     }
 
     /// Reads, metrics-records, logs, and validates the current L1 schedule.
     pub async fn read_validated_schedule(
         &self,
     ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
-        self.config.read_validated_application_schedule(&self.reader, "runtime refresh").await
+        let application_schedule = self
+            .config
+            .read_validated_application_schedule(&self.reader, "runtime refresh")
+            .await?;
+        self.runtime_validation.validate_schedule(self.chain_id, &application_schedule)?;
+
+        Ok(application_schedule)
     }
 
     /// Reads, validates, metrics-records, logs, and applies the current L1 schedule.

--- a/crates/utilities/upgrade-signal/src/runtime/validation.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/validation.rs
@@ -1,0 +1,114 @@
+//! Runtime upgrade signal validation.
+
+use alloy_primitives::Address;
+use base_common_genesis::BaseUpgrade;
+
+use crate::{UpgradeSignalError, UpgradeSignalSchedule};
+
+/// Runtime schedule validation context shared by execution and consensus refresh paths.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct UpgradeSignalRuntimeValidation {
+    /// Whether positive Beryl signals require an execution activation admin address.
+    pub require_activation_admin_for_beryl: bool,
+    /// Execution activation admin address for the L2 chain, when known.
+    pub activation_admin_address: Option<Address>,
+}
+
+impl UpgradeSignalRuntimeValidation {
+    /// Creates a validation context with execution-specific checks disabled.
+    pub const fn disabled() -> Self {
+        Self { require_activation_admin_for_beryl: false, activation_admin_address: None }
+    }
+
+    /// Creates a validation context that enforces execution activation admin invariants.
+    pub const fn with_activation_admin_address(activation_admin_address: Option<Address>) -> Self {
+        Self { require_activation_admin_for_beryl: true, activation_admin_address }
+    }
+
+    /// Creates the fail-closed validation context used when no activation admin source is known.
+    ///
+    /// This requires an activation admin address for positive Beryl signals but has none, so a
+    /// positive Beryl signal is rejected rather than applied unguarded.
+    pub const fn fail_closed() -> Self {
+        Self::with_activation_admin_address(None)
+    }
+
+    /// Validates a schedule before it mutates the process-local runtime registry.
+    pub fn validate_schedule(
+        &self,
+        chain_id: u64,
+        schedule: &UpgradeSignalSchedule,
+    ) -> Result<(), UpgradeSignalError> {
+        if self.require_activation_admin_for_beryl
+            && !matches!(self.activation_admin_address, Some(address) if address != Address::ZERO)
+            && schedule.signals.iter().any(|signal| {
+                signal.positive_activation_timestamp().is_some()
+                    && signal.hardfork_id == BaseUpgrade::Beryl
+            })
+        {
+            return Err(UpgradeSignalError::missing_activation_admin_address(chain_id));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for UpgradeSignalRuntimeValidation {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{U256, address};
+
+    use super::*;
+    use crate::{UpgradeSignal, UpgradeSignalSchedule};
+
+    fn beryl_schedule(timestamp: u64) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(vec![UpgradeSignal {
+            hardfork_id: BaseUpgrade::Beryl,
+            activation_timestamp: timestamp,
+            protocol_version: U256::from(7),
+            l1_block_number: 1,
+        }])
+    }
+
+    #[test]
+    fn rejects_positive_beryl_schedule_without_activation_admin() {
+        let validation = UpgradeSignalRuntimeValidation::with_activation_admin_address(None);
+
+        assert!(matches!(
+            validation.validate_schedule(1, &beryl_schedule(42)),
+            Err(UpgradeSignalError::MissingActivationAdminAddress { chain_id: 1 })
+        ));
+    }
+
+    #[test]
+    fn rejects_positive_beryl_schedule_with_zero_activation_admin() {
+        let validation =
+            UpgradeSignalRuntimeValidation::with_activation_admin_address(Some(Address::ZERO));
+
+        assert!(matches!(
+            validation.validate_schedule(1, &beryl_schedule(42)),
+            Err(UpgradeSignalError::MissingActivationAdminAddress { chain_id: 1 })
+        ));
+    }
+
+    #[test]
+    fn accepts_positive_beryl_schedule_with_nonzero_activation_admin() {
+        let validation = UpgradeSignalRuntimeValidation::with_activation_admin_address(Some(
+            address!("0000000000000000000000000000000000000001"),
+        ));
+
+        assert!(validation.validate_schedule(1, &beryl_schedule(42)).is_ok());
+    }
+
+    #[test]
+    fn accepts_zero_beryl_schedule_without_activation_admin() {
+        let validation = UpgradeSignalRuntimeValidation::with_activation_admin_address(None);
+
+        assert!(validation.validate_schedule(1, &beryl_schedule(0)).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Wires the L1 upgrade signal foundation from #3476 into execution
services. Adds CLI args, a startup schedule apply path, and a live
metrics-polling extension. All paths are no-ops when
`--upgrade-signal.contract` is not set — existing deployments are
unaffected.

## Changes

- add `--upgrade-signal.*` CLI args to `RollupArgs` (contract address,
  mode, L1 RPC, block tag)
- add `ExecutionUpgradeSignal` module with startup apply and metrics
  observer logic
- install the extension in `StandardBaseRethNode` (`base-reth-node` and
  embedded `base rpc`)
- install the extension in `bin/builder` and `base sequencer`; in
  the sequencer, default the upgrade signal L1 RPC to the CL's
  `--l1-eth-rpc` when not explicitly set
- extract `UpgradeSignalRuntimeValidation` into `base-upgrade-signal`
  so the Beryl activation-admin guard is shared between execution and
  consensus refresh paths

## Testing

- cargo fmt --check --all
- cargo test -p base-upgrade-signal -p base-execution-chainspec -p base-execution-cli

## Manual Validation

- just devnet up
- start node without `--upgrade-signal.contract` and confirm behaviour
  is unchanged
- start with contract + `metrics-only`, confirm metrics appear and fork
  schedule is untouched
- start with contract + `startup-apply`, confirm chain spec reflects L1
  schedule before first block

## Follow-ups

- wire the upgrade signal into consensus startup and runtime flows