### PR TITLE
feat(ci): Add AI Blocking Review

### DIFF
--- a/.github/scripts/enforce-ai-blocking-review.sh
+++ b/.github/scripts/enforce-ai-blocking-review.sh
@@ -6,18 +6,35 @@ if [[ -z "${HEAD_SHA:-}" ]]; then
   exit 1
 fi
 
-if [[ -z "${REVIEW_JSON:-}" ]]; then
-  echo "REVIEW_JSON is required" >&2
-  exit 1
-fi
-
 summary_file="${GITHUB_STEP_SUMMARY:-}"
+bypass_label="${BYPASS_LABEL:-ai-review-override}"
+pr_labels_json="${PR_LABELS_JSON:-[]}"
 
 write_summary() {
   if [[ -n "$summary_file" ]]; then
     printf '%s\n' "$@" >> "$summary_file"
   fi
 }
+
+has_bypass_label() {
+  jq -e --arg label "$bypass_label" '
+    type == "array" and any(.[]; . == $label)
+  ' >/dev/null 2>&1 <<< "$pr_labels_json"
+}
+
+if has_bypass_label; then
+  write_summary \
+    "## AI Blocking Review" \
+    "" \
+    "AI blocking review enforcement was bypassed for \`$HEAD_SHA\` because the \`$bypass_label\` label is present."
+  exit 0
+fi
+
+if [[ -z "${REVIEW_JSON:-}" ]]; then
+  write_summary "## AI Blocking Review" "" "The blocking review did not return structured output."
+  echo "REVIEW_JSON is required" >&2
+  exit 1
+fi
 
 if ! jq -e . >/dev/null <<< "$REVIEW_JSON"; then
   write_summary "## AI Blocking Review" "" "The blocking review did not return valid JSON."

--- a/.github/scripts/enforce-ai-blocking-review.sh
+++ b/.github/scripts/enforce-ai-blocking-review.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${HEAD_SHA:-}" ]]; then
+  echo "HEAD_SHA is required" >&2
+  exit 1
+fi
+
+if [[ -z "${REVIEW_JSON:-}" ]]; then
+  echo "REVIEW_JSON is required" >&2
+  exit 1
+fi
+
+summary_file="${GITHUB_STEP_SUMMARY:-}"
+
+write_summary() {
+  if [[ -n "$summary_file" ]]; then
+    printf '%s\n' "$@" >> "$summary_file"
+  fi
+}
+
+if ! jq -e . >/dev/null <<< "$REVIEW_JSON"; then
+  write_summary "## AI Blocking Review" "" "The blocking review did not return valid JSON."
+  echo "REVIEW_JSON is not valid JSON" >&2
+  exit 1
+fi
+
+if ! jq -e --arg head_sha "$HEAD_SHA" '
+  (.head_sha == $head_sha) and
+  (.has_blocking_findings | type == "boolean") and
+  (.findings | type == "array") and
+  (.max_severity == "NONE" or .max_severity == "HIGH" or .max_severity == "CRITICAL")
+' >/dev/null <<< "$REVIEW_JSON"; then
+  write_summary \
+    "## AI Blocking Review" \
+    "" \
+    "The blocking review result is malformed or does not match the current PR head SHA." \
+    "" \
+    "- Expected head SHA: \`$HEAD_SHA\`" \
+    "- Reported head SHA: \`$(jq -r '.head_sha // "missing"' <<< "$REVIEW_JSON")\`"
+  echo "Blocking review result is malformed or stale" >&2
+  exit 1
+fi
+
+has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
+max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
+blocking_count="$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' <<< "$REVIEW_JSON")"
+
+if [[ "$has_blocking_findings" == "false" && "$max_severity" == "NONE" && "$blocking_count" == "0" ]]; then
+  write_summary \
+    "## AI Blocking Review" \
+    "" \
+    "No critical or high issues were reported for \`$HEAD_SHA\`."
+  exit 0
+fi
+
+write_summary \
+  "## AI Blocking Review" \
+  "" \
+  "Critical or high issues were reported for \`$HEAD_SHA\`. The PR is blocked until the findings are fixed or the review is rerun with no blocking findings." \
+  ""
+
+jq -r '
+  .findings[]
+  | select(.severity == "HIGH" or .severity == "CRITICAL")
+  | "- **\(.severity)** \(.path // "unknown")\(if (.line // null) then ":\(.line)" else "" end): \(.title)"
+' <<< "$REVIEW_JSON" | while IFS= read -r finding; do
+  write_summary "$finding"
+done
+
+echo "AI blocking review found critical or high issues" >&2
+exit 1

--- a/.github/scripts/update-ai-blocking-review-comment.sh
+++ b/.github/scripts/update-ai-blocking-review-comment.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 marker="<!-- CLAUDE_BLOCKING_REVIEW:v1"
 
-required_vars=(GITHUB_REPOSITORY PR_NUMBER HEAD_SHA REVIEW_JSON)
+required_vars=(GITHUB_REPOSITORY PR_NUMBER HEAD_SHA)
 for var in "${required_vars[@]}"; do
   if [[ -z "${!var:-}" ]]; then
     echo "$var is required" >&2
@@ -11,23 +11,52 @@ for var in "${required_vars[@]}"; do
   fi
 done
 
-if ! jq -e . >/dev/null <<< "$REVIEW_JSON"; then
-  echo "REVIEW_JSON is not valid JSON" >&2
-  exit 1
-fi
-
-if ! jq -e --arg head_sha "$HEAD_SHA" '
-  (.head_sha == $head_sha) and
-  (.has_blocking_findings | type == "boolean") and
-  (.findings | type == "array") and
-  (.max_severity == "NONE" or .max_severity == "HIGH" or .max_severity == "CRITICAL")
-' >/dev/null <<< "$REVIEW_JSON"; then
-  echo "Blocking review result is malformed or stale" >&2
-  exit 1
-fi
+bypass_label="${BYPASS_LABEL:-ai-review-override}"
+pr_labels_json="${PR_LABELS_JSON:-[]}"
 
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
+
+has_bypass_label() {
+  jq -e --arg label "$bypass_label" '
+    type == "array" and any(.[]; . == $label)
+  ' >/dev/null 2>&1 <<< "$pr_labels_json"
+}
+
+if has_bypass_label; then
+  marker_payload="$(jq -cn \
+    --arg head_sha "$HEAD_SHA" \
+    --arg bypass_label "$bypass_label" \
+    '{head_sha: $head_sha, bypassed: true, bypass_label: $bypass_label}')"
+
+  {
+    printf '%s\n' "$marker"
+    printf '%s\n' "$marker_payload"
+    printf '%s\n\n' "-->"
+    printf '## AI Blocking Review\n\n'
+    printf 'AI blocking review enforcement was bypassed for `%s` because the `%s` label is present.\n\n' "$HEAD_SHA" "$bypass_label"
+    printf 'Remove the `%s` label to rerun the required AI blocking review gate.\n' "$bypass_label"
+  } > "$body_file"
+else
+  if [[ -z "${REVIEW_JSON:-}" ]]; then
+    echo "REVIEW_JSON is required when the bypass label is absent" >&2
+    exit 1
+  fi
+
+  if ! jq -e . >/dev/null <<< "$REVIEW_JSON"; then
+    echo "REVIEW_JSON is not valid JSON" >&2
+    exit 1
+  fi
+
+  if ! jq -e --arg head_sha "$HEAD_SHA" '
+    (.head_sha == $head_sha) and
+    (.has_blocking_findings | type == "boolean") and
+    (.findings | type == "array") and
+    (.max_severity == "NONE" or .max_severity == "HIGH" or .max_severity == "CRITICAL")
+  ' >/dev/null <<< "$REVIEW_JSON"; then
+    echo "Blocking review result is malformed or stale" >&2
+    exit 1
+  fi
 
 has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
 max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
@@ -43,7 +72,7 @@ marker_payload="$(jq -cn \
   --arg head_sha "$HEAD_SHA" \
   --arg max_severity "$max_severity" \
   --argjson has_blocking_findings "$effective_has_blocking_findings" \
-  '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity}')"
+  '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity, bypassed: false}')"
 
 {
   printf '%s\n' "$marker"
@@ -79,6 +108,7 @@ marker_payload="$(jq -cn \
     fi
   fi
 } > "$body_file"
+fi
 
 existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
   --paginate \

--- a/.github/scripts/update-ai-blocking-review-comment.sh
+++ b/.github/scripts/update-ai-blocking-review-comment.sh
@@ -23,6 +23,28 @@ has_bypass_label() {
   ' >/dev/null 2>&1 <<< "$pr_labels_json"
 }
 
+write_fail_closed_body() {
+  local reason="$1"
+  shift
+
+  marker_payload="$(jq -cn \
+    --arg head_sha "$HEAD_SHA" \
+    --arg reason "$reason" \
+    '{head_sha: $head_sha, bypassed: false, error: true, error_reason: $reason}')"
+
+  {
+    printf '%s\n' "$marker"
+    printf '%s\n' "$marker_payload"
+    printf '%s\n\n' "-->"
+    printf '## AI Blocking Review\n\n'
+    printf 'The AI blocking review gate failed closed for `%s`.\n\n' "$HEAD_SHA"
+    for line in "$@"; do
+      printf '%s\n' "$line"
+    done
+    printf '\nCheck the workflow logs and rerun the review after fixing the structured output issue.\n'
+  } > "$body_file"
+}
+
 if has_bypass_label; then
   marker_payload="$(jq -cn \
     --arg head_sha "$HEAD_SHA" \
@@ -39,54 +61,57 @@ if has_bypass_label; then
   } > "$body_file"
 else
   if [[ -z "${REVIEW_JSON:-}" ]]; then
-    echo "REVIEW_JSON is required when the bypass label is absent" >&2
-    exit 1
-  fi
-
-  if ! jq -e . >/dev/null <<< "$REVIEW_JSON"; then
-    echo "REVIEW_JSON is not valid JSON" >&2
-    exit 1
-  fi
-
-  if ! jq -e --arg head_sha "$HEAD_SHA" '
+    write_fail_closed_body \
+      "missing-structured-output" \
+      "The blocking review did not return structured output."
+  elif ! jq -e . >/dev/null 2>&1 <<< "$REVIEW_JSON"; then
+    write_fail_closed_body \
+      "invalid-json" \
+      "The blocking review produced output that was not valid JSON."
+  elif ! jq -e --arg head_sha "$HEAD_SHA" '
     (.head_sha == $head_sha) and
     (.has_blocking_findings | type == "boolean") and
     (.findings | type == "array") and
     (.max_severity == "NONE" or .max_severity == "HIGH" or .max_severity == "CRITICAL")
   ' >/dev/null <<< "$REVIEW_JSON"; then
-    echo "Blocking review result is malformed or stale" >&2
-    exit 1
-  fi
+    reported_head="$(jq -r '.head_sha // "missing"' <<< "$REVIEW_JSON" 2>/dev/null || printf 'unreadable')"
+    write_fail_closed_body \
+      "malformed-or-stale" \
+      "The blocking review result was malformed or did not match the current PR head SHA." \
+      "" \
+      "- Expected head SHA: \`$HEAD_SHA\`" \
+      "- Reported head SHA: \`$reported_head\`"
+  else
 
-  has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
-  max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
-  blocking_count="$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' <<< "$REVIEW_JSON")"
-  summary="$(jq -r '.summary // ""' <<< "$REVIEW_JSON")"
+    has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
+    max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
+    blocking_count="$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' <<< "$REVIEW_JSON")"
+    summary="$(jq -r '.summary // ""' <<< "$REVIEW_JSON")"
 
-  effective_has_blocking_findings="false"
-  if [[ "$has_blocking_findings" == "true" || "$max_severity" != "NONE" || "$blocking_count" != "0" ]]; then
-    effective_has_blocking_findings="true"
-  fi
+    effective_has_blocking_findings="false"
+    if [[ "$has_blocking_findings" == "true" || "$max_severity" != "NONE" || "$blocking_count" != "0" ]]; then
+      effective_has_blocking_findings="true"
+    fi
 
-  marker_payload="$(jq -cn \
-    --arg head_sha "$HEAD_SHA" \
-    --arg max_severity "$max_severity" \
-    --argjson has_blocking_findings "$effective_has_blocking_findings" \
-    '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity, bypassed: false}')"
+    marker_payload="$(jq -cn \
+      --arg head_sha "$HEAD_SHA" \
+      --arg max_severity "$max_severity" \
+      --argjson has_blocking_findings "$effective_has_blocking_findings" \
+      '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity, bypassed: false}')"
 
-  {
-    printf '%s\n' "$marker"
-    printf '%s\n' "$marker_payload"
-    printf '%s\n\n' "-->"
-    printf '## AI Blocking Review\n\n'
+    {
+      printf '%s\n' "$marker"
+      printf '%s\n' "$marker_payload"
+      printf '%s\n\n' "-->"
+      printf '## AI Blocking Review\n\n'
 
-    if [[ "$effective_has_blocking_findings" == "true" ]]; then
-      printf 'Blocking findings were reported for `%s`.\n\n' "$HEAD_SHA"
-      if [[ -n "$summary" ]]; then
-        printf '%s\n\n' "$summary"
-      fi
+      if [[ "$effective_has_blocking_findings" == "true" ]]; then
+        printf 'Blocking findings were reported for `%s`.\n\n' "$HEAD_SHA"
+        if [[ -n "$summary" ]]; then
+          printf '%s\n\n' "$summary"
+        fi
 
-      rendered_findings="$(jq -r '
+        rendered_findings="$(jq -r '
         .findings[]
         | select(.severity == "HIGH" or .severity == "CRITICAL")
         | "### \(.severity): \(.title)\n\n" +
@@ -96,18 +121,19 @@ else
           "**Required fix**\n\n\(.required_fix // "Not provided")\n"
       ' <<< "$REVIEW_JSON")"
 
-      if [[ -n "$rendered_findings" ]]; then
-        printf '%s\n' "$rendered_findings"
+        if [[ -n "$rendered_findings" ]]; then
+          printf '%s\n' "$rendered_findings"
+        else
+          printf 'The structured review marked this PR as blocking, but did not include a renderable HIGH or CRITICAL finding. Treat this as fail-closed and rerun the review after checking the workflow logs.\n'
+        fi
       else
-        printf 'The structured review marked this PR as blocking, but did not include a renderable HIGH or CRITICAL finding. Treat this as fail-closed and rerun the review after checking the workflow logs.\n'
+        printf 'No critical or high issues were reported for `%s`.\n\n' "$HEAD_SHA"
+        if [[ -n "$summary" ]]; then
+          printf '%s\n' "$summary"
+        fi
       fi
-    else
-      printf 'No critical or high issues were reported for `%s`.\n\n' "$HEAD_SHA"
-      if [[ -n "$summary" ]]; then
-        printf '%s\n' "$summary"
-      fi
-    fi
-  } > "$body_file"
+    } > "$body_file"
+  fi
 fi
 
 existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \

--- a/.github/scripts/update-ai-blocking-review-comment.sh
+++ b/.github/scripts/update-ai-blocking-review-comment.sh
@@ -58,56 +58,56 @@ else
     exit 1
   fi
 
-has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
-max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
-blocking_count="$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' <<< "$REVIEW_JSON")"
-summary="$(jq -r '.summary // ""' <<< "$REVIEW_JSON")"
+  has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
+  max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
+  blocking_count="$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' <<< "$REVIEW_JSON")"
+  summary="$(jq -r '.summary // ""' <<< "$REVIEW_JSON")"
 
-effective_has_blocking_findings="false"
-if [[ "$has_blocking_findings" == "true" || "$max_severity" != "NONE" || "$blocking_count" != "0" ]]; then
-  effective_has_blocking_findings="true"
-fi
-
-marker_payload="$(jq -cn \
-  --arg head_sha "$HEAD_SHA" \
-  --arg max_severity "$max_severity" \
-  --argjson has_blocking_findings "$effective_has_blocking_findings" \
-  '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity, bypassed: false}')"
-
-{
-  printf '%s\n' "$marker"
-  printf '%s\n' "$marker_payload"
-  printf '%s\n\n' "-->"
-  printf '## AI Blocking Review\n\n'
-
-  if [[ "$effective_has_blocking_findings" == "true" ]]; then
-    printf 'Blocking findings were reported for `%s`.\n\n' "$HEAD_SHA"
-    if [[ -n "$summary" ]]; then
-      printf '%s\n\n' "$summary"
-    fi
-
-    rendered_findings="$(jq -r '
-      .findings[]
-      | select(.severity == "HIGH" or .severity == "CRITICAL")
-      | "### \(.severity): \(.title)\n\n" +
-        "- Location: `\(.path // "unknown")\(if (.line // null) then ":\(.line)" else "" end)`\n" +
-        "- Confidence: `\(.confidence // "unspecified")`\n\n" +
-        "**Evidence**\n\n\(.evidence // "Not provided")\n\n" +
-        "**Required fix**\n\n\(.required_fix // "Not provided")\n"
-    ' <<< "$REVIEW_JSON")"
-
-    if [[ -n "$rendered_findings" ]]; then
-      printf '%s\n' "$rendered_findings"
-    else
-      printf 'The structured review marked this PR as blocking, but did not include a renderable HIGH or CRITICAL finding. Treat this as fail-closed and rerun the review after checking the workflow logs.\n'
-    fi
-  else
-    printf 'No critical or high issues were reported for `%s`.\n\n' "$HEAD_SHA"
-    if [[ -n "$summary" ]]; then
-      printf '%s\n' "$summary"
-    fi
+  effective_has_blocking_findings="false"
+  if [[ "$has_blocking_findings" == "true" || "$max_severity" != "NONE" || "$blocking_count" != "0" ]]; then
+    effective_has_blocking_findings="true"
   fi
-} > "$body_file"
+
+  marker_payload="$(jq -cn \
+    --arg head_sha "$HEAD_SHA" \
+    --arg max_severity "$max_severity" \
+    --argjson has_blocking_findings "$effective_has_blocking_findings" \
+    '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity, bypassed: false}')"
+
+  {
+    printf '%s\n' "$marker"
+    printf '%s\n' "$marker_payload"
+    printf '%s\n\n' "-->"
+    printf '## AI Blocking Review\n\n'
+
+    if [[ "$effective_has_blocking_findings" == "true" ]]; then
+      printf 'Blocking findings were reported for `%s`.\n\n' "$HEAD_SHA"
+      if [[ -n "$summary" ]]; then
+        printf '%s\n\n' "$summary"
+      fi
+
+      rendered_findings="$(jq -r '
+        .findings[]
+        | select(.severity == "HIGH" or .severity == "CRITICAL")
+        | "### \(.severity): \(.title)\n\n" +
+          "- Location: `\(.path // "unknown")\(if (.line // null) then ":\(.line)" else "" end)`\n" +
+          "- Confidence: `\(.confidence // "unspecified")`\n\n" +
+          "**Evidence**\n\n\(.evidence // "Not provided")\n\n" +
+          "**Required fix**\n\n\(.required_fix // "Not provided")\n"
+      ' <<< "$REVIEW_JSON")"
+
+      if [[ -n "$rendered_findings" ]]; then
+        printf '%s\n' "$rendered_findings"
+      else
+        printf 'The structured review marked this PR as blocking, but did not include a renderable HIGH or CRITICAL finding. Treat this as fail-closed and rerun the review after checking the workflow logs.\n'
+      fi
+    else
+      printf 'No critical or high issues were reported for `%s`.\n\n' "$HEAD_SHA"
+      if [[ -n "$summary" ]]; then
+        printf '%s\n' "$summary"
+      fi
+    fi
+  } > "$body_file"
 fi
 
 existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \

--- a/.github/scripts/update-ai-blocking-review-comment.sh
+++ b/.github/scripts/update-ai-blocking-review-comment.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+marker="<!-- CLAUDE_BLOCKING_REVIEW:v1"
+
+required_vars=(GITHUB_REPOSITORY PR_NUMBER HEAD_SHA REVIEW_JSON)
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "$var is required" >&2
+    exit 1
+  fi
+done
+
+if ! jq -e . >/dev/null <<< "$REVIEW_JSON"; then
+  echo "REVIEW_JSON is not valid JSON" >&2
+  exit 1
+fi
+
+if ! jq -e --arg head_sha "$HEAD_SHA" '
+  (.head_sha == $head_sha) and
+  (.has_blocking_findings | type == "boolean") and
+  (.findings | type == "array") and
+  (.max_severity == "NONE" or .max_severity == "HIGH" or .max_severity == "CRITICAL")
+' >/dev/null <<< "$REVIEW_JSON"; then
+  echo "Blocking review result is malformed or stale" >&2
+  exit 1
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+has_blocking_findings="$(jq -r '.has_blocking_findings' <<< "$REVIEW_JSON")"
+max_severity="$(jq -r '.max_severity' <<< "$REVIEW_JSON")"
+blocking_count="$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' <<< "$REVIEW_JSON")"
+summary="$(jq -r '.summary // ""' <<< "$REVIEW_JSON")"
+
+effective_has_blocking_findings="false"
+if [[ "$has_blocking_findings" == "true" || "$max_severity" != "NONE" || "$blocking_count" != "0" ]]; then
+  effective_has_blocking_findings="true"
+fi
+
+marker_payload="$(jq -cn \
+  --arg head_sha "$HEAD_SHA" \
+  --arg max_severity "$max_severity" \
+  --argjson has_blocking_findings "$effective_has_blocking_findings" \
+  '{head_sha: $head_sha, has_blocking_findings: $has_blocking_findings, max_severity: $max_severity}')"
+
+{
+  printf '%s\n' "$marker"
+  printf '%s\n' "$marker_payload"
+  printf '%s\n\n' "-->"
+  printf '## AI Blocking Review\n\n'
+
+  if [[ "$effective_has_blocking_findings" == "true" ]]; then
+    printf 'Blocking findings were reported for `%s`.\n\n' "$HEAD_SHA"
+    if [[ -n "$summary" ]]; then
+      printf '%s\n\n' "$summary"
+    fi
+
+    rendered_findings="$(jq -r '
+      .findings[]
+      | select(.severity == "HIGH" or .severity == "CRITICAL")
+      | "### \(.severity): \(.title)\n\n" +
+        "- Location: `\(.path // "unknown")\(if (.line // null) then ":\(.line)" else "" end)`\n" +
+        "- Confidence: `\(.confidence // "unspecified")`\n\n" +
+        "**Evidence**\n\n\(.evidence // "Not provided")\n\n" +
+        "**Required fix**\n\n\(.required_fix // "Not provided")\n"
+    ' <<< "$REVIEW_JSON")"
+
+    if [[ -n "$rendered_findings" ]]; then
+      printf '%s\n' "$rendered_findings"
+    else
+      printf 'The structured review marked this PR as blocking, but did not include a renderable HIGH or CRITICAL finding. Treat this as fail-closed and rerun the review after checking the workflow logs.\n'
+    fi
+  else
+    printf 'No critical or high issues were reported for `%s`.\n\n' "$HEAD_SHA"
+    if [[ -n "$summary" ]]; then
+      printf '%s\n' "$summary"
+    fi
+  fi
+} > "$body_file"
+
+existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+  --paginate \
+  --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | startswith(\"${marker}\")) | .id" \
+  | sed '/^$/d' \
+  | sed -n '1p')"
+
+body="$(cat "$body_file")"
+
+if [[ -n "$existing_id" ]]; then
+  gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+    -X PATCH \
+    --raw-field body="$body" > /dev/null
+else
+  gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+    --raw-field body="$body" > /dev/null
+fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -111,7 +111,10 @@ jobs:
     # Note: This job runs on the BaseRunnerGroup to be able to access LLM Gateway
     # It will not work on other runners
     # Skip for external contributor PRs (forks) — secrets and runner group are unavailable
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'ai-review-override')
     runs-on:
       group: BaseRunnerGroup
     steps:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   # This allows posting comments and reviews
   # It does not allow pushing any commits or modifying any files in the repo
+  issues: write
   pull-requests: write
 
 jobs:
@@ -92,12 +93,90 @@ jobs:
             - Rust idioms: &String instead of &str, &Vec<T> instead of &[T], manual implementations of standard traits, needless lifetime annotations
 
             COMMENT MANAGEMENT:
-            Before posting your review summary, clean up previous summary comments from earlier runs:
-            1. Delete your previous summary comments by running: gh pr comment ${{ github.event.pull_request.number }} --delete-last --yes
-            2. Repeat step 1 until it returns an error (no more comments to delete)
-            3. Then post your new summary using: gh pr comment ${{ github.event.pull_request.number }} --body "<!-- CLAUDE_REVIEW_SUMMARY -->\n\n<your summary>"
-            Note: --delete-last only deletes your own top-level comments, not inline review comments or other users' comments.
+            When posting your review summary, do not delete previous comments with `gh pr comment --delete-last`.
+            Instead, upsert one top-level summary comment from github-actions[bot] whose body starts with:
+            <!-- CLAUDE_REVIEW_SUMMARY:v1 -->
+            Use `gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments` to find the existing comment by marker.
+            If it exists, update it with `gh api repos/${{ github.repository }}/issues/comments/<comment-id> -X PATCH --raw-field body="<body>"`.
+            If it does not exist, create it with `gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --raw-field body="<body>"`.
 
           claude_args: |
             --model claude-opus-4-6-default
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment ${{ github.event.pull_request.number }} --body:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --edit-last --body:*),Bash(gh pr comment ${{ github.event.pull_request.number }} --delete-last:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/issues/comments/*:*)"
+
+  ai-blocking-review:
+    name: AI Blocking Review
+    # Note: This job runs on the BaseRunnerGroup to be able to access LLM Gateway
+    # It will not work on other runners
+    # Skip for external contributor PRs (forks) — secrets and runner group are unavailable
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      group: BaseRunnerGroup
+    steps:
+      - name: Harden the runner (Block unauthorized outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            bun.sh:443
+            github.com:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            ${{ vars.LLM_GATEWAY_HOSTNAME }}:443
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Run blocking AI review
+        id: blocking-review
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
+        env:
+          ANTHROPIC_BASE_URL: https://${{ vars.LLM_GATEWAY_HOSTNAME }}
+        with:
+          anthropic_api_key: ${{ secrets.LLM_GATEWAY_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: false
+          prompt: |
+            You are reviewing a Pull Request for Base Reth Node — a Rust Ethereum L2 node built on Reth.
+
+            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }} for CRITICAL and HIGH severity issues only.
+            Current PR head SHA: ${{ github.event.pull_request.head.sha }}
+
+            Severity definitions:
+            - CRITICAL: consensus failure, chain divergence, funds at risk, authorization bypass, signer/key compromise, or deterministic production data corruption.
+            - HIGH: likely production outage, major safety invariant violation, externally triggerable unbounded resource denial-of-service, silent corruption, or severe API/compatibility break.
+            - NONE: no CRITICAL or HIGH issues found.
+
+            Rules:
+            - Ignore style, formatting, medium/low severity issues, missing tests alone, speculative concerns, and non-blocking maintainability feedback.
+            - Every finding must be directly supported by the PR diff and repository context.
+            - Do not post GitHub comments or inline review comments. Return structured output only.
+            - Set `head_sha` exactly to `${{ github.event.pull_request.head.sha }}`.
+            - Set `has_blocking_findings` to true if and only if there is at least one CRITICAL or HIGH finding.
+            - Set `max_severity` to CRITICAL, HIGH, or NONE.
+            - If there are no blocking findings, return an empty `findings` array.
+            - For each finding, include the concrete file path, line when available, evidence, required fix, and a confidence value from 0 to 1.
+
+          claude_args: |
+            --model claude-opus-4-6-default
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"head_sha":{"type":"string"},"has_blocking_findings":{"type":"boolean"},"max_severity":{"type":"string","enum":["NONE","HIGH","CRITICAL"]},"summary":{"type":"string"},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"severity":{"type":"string","enum":["HIGH","CRITICAL"]},"title":{"type":"string"},"path":{"type":"string"},"line":{"type":"integer"},"evidence":{"type":"string"},"required_fix":{"type":"string"},"confidence":{"type":"number","minimum":0,"maximum":1}},"required":["severity","title","path","evidence","required_fix","confidence"]}}},"required":["head_sha","has_blocking_findings","max_severity","summary","findings"]}'
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      - name: Update blocking review comment
+        if: always() && steps.blocking-review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_JSON: ${{ steps.blocking-review.outputs.structured_output }}
+        run: .github/scripts/update-ai-blocking-review-comment.sh
+
+      - name: Enforce blocking review
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_JSON: ${{ steps.blocking-review.outputs.structured_output }}
+        run: .github/scripts/enforce-ai-blocking-review.sh

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Update blocking review comment
         if: always() && steps.blocking-review.outputs.structured_output != ''
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -176,6 +177,7 @@ jobs:
         run: .github/scripts/update-ai-blocking-review-comment.sh
 
       - name: Enforce blocking review
+        if: always()
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_JSON: ${{ steps.blocking-review.outputs.structured_output }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened, labeled, unlabeled]
 
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   # This allows posting comments and reviews
@@ -18,6 +14,9 @@ permissions:
 jobs:
   review:
     name: Review PR
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}-review
+      cancel-in-progress: true
     # Note: This job runs on the BaseRunnerGroup to be able to access LLM Gateway
     # It will not work on other runners
     # Skip for external contributor PRs (forks) — secrets and runner group are unavailable
@@ -106,6 +105,9 @@ jobs:
 
   ai-blocking-review:
     name: AI Blocking Review
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}-ai-blocking-review
+      cancel-in-progress: true
     # Note: This job runs on the BaseRunnerGroup to be able to access LLM Gateway
     # It will not work on other runners
     # Skip for external contributor PRs (forks) — secrets and runner group are unavailable

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, labeled, unlabeled]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -21,7 +21,7 @@ jobs:
     # Note: This job runs on the BaseRunnerGroup to be able to access LLM Gateway
     # It will not work on other runners
     # Skip for external contributor PRs (forks) — secrets and runner group are unavailable
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled' && github.event.action != 'unlabeled'
     runs-on:
       group: BaseRunnerGroup
     steps:
@@ -132,6 +132,7 @@ jobs:
 
       - name: Run blocking AI review
         id: blocking-review
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ai-review-override') }}
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         env:
           ANTHROPIC_BASE_URL: https://${{ vars.LLM_GATEWAY_HOSTNAME }}
@@ -166,7 +167,7 @@ jobs:
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       - name: Update blocking review comment
-        if: always() && steps.blocking-review.outputs.structured_output != ''
+        if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -174,6 +175,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_JSON: ${{ steps.blocking-review.outputs.structured_output }}
+          BYPASS_LABEL: ai-review-override
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: .github/scripts/update-ai-blocking-review-comment.sh
 
       - name: Enforce blocking review
@@ -181,4 +184,6 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_JSON: ${{ steps.blocking-review.outputs.structured_output }}
+          BYPASS_LABEL: ai-review-override
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: .github/scripts/enforce-ai-blocking-review.sh


### PR DESCRIPTION
## Summary

This adds a blocking AI review job to the Claude review workflow that classifies only critical and high severity PR issues through the Coinbase LLM Gateway. The job records a structured marker comment tied to the PR head SHA and fails closed when blocking findings, malformed output, or stale output are present. It also updates the existing review prompt to use marker-based summary comments so the bot does not delete the new blocking review comment. Maintainers can apply the `ai-review-override` label to bypass the blocking AI gate, and adding or removing that label reruns the required check so the override state stays visible in CI and the marker comment.