### PR TITLE
feat: alt-DA derivation resolver (PRIV-1973)

### DIFF
--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -141,6 +141,13 @@ pub struct ConsensusNodeConfigArgs {
     /// Path to the checkpoint database. If not set, a default path under `~/.base` is used.
     #[arg(long = "checkpoint.path", env = "BASE_NODE_CHECKPOINT_PATH")]
     pub checkpoint_path: Option<PathBuf>,
+
+    /// Alt-DA server URL (e.g. `http://base-da-server:2583`).
+    ///
+    /// When set, the node derives from off-chain DA: it resolves `0x01` commitments from this
+    /// server and ignores inline calldata. Leave unset to derive from calldata or blobs.
+    #[arg(long = "altda.da-server", env = "BASE_NODE_ALTDA_DA_SERVER")]
+    pub altda_da_server: Option<Url>,
 }
 
 /// Consensus node configuration arguments for embedded callers.
@@ -177,6 +184,13 @@ pub struct EmbeddedConsensusNodeConfigArgs {
     /// Path to the checkpoint database. If not set, a default path under `~/.base` is used.
     #[arg(long = "checkpoint.path", env = "BASE_NODE_CHECKPOINT_PATH")]
     pub checkpoint_path: Option<PathBuf>,
+
+    /// Alt-DA server URL (e.g. `http://base-da-server:2583`).
+    ///
+    /// When set, the node derives from off-chain DA: it resolves `0x01` commitments from this
+    /// server and ignores inline calldata. Leave unset to derive from calldata or blobs.
+    #[arg(long = "altda.da-server", env = "BASE_NODE_ALTDA_DA_SERVER")]
+    pub altda_da_server: Option<Url>,
 }
 
 impl From<EmbeddedConsensusNodeConfigArgs> for ConsensusNodeConfigArgs {
@@ -192,6 +206,7 @@ impl From<EmbeddedConsensusNodeConfigArgs> for ConsensusNodeConfigArgs {
             sequencer_flags: SequencerArgs::default(),
             safedb_path: args.safedb_path,
             checkpoint_path: args.checkpoint_path,
+            altda_da_server: args.altda_da_server,
         }
     }
 }
@@ -309,6 +324,7 @@ impl ConsensusNodeArgs {
         if let Some(path) = self.config.safedb_path.clone() {
             builder = builder.with_safedb_path(path);
         }
+        builder = builder.with_alt_da_server(self.config.altda_da_server.clone());
 
         builder.build().await.wrap_err("Failed to build rollup node")
     }
@@ -386,6 +402,7 @@ mod tests {
             sequencer_flags: SequencerArgs::default(),
             safedb_path: None,
             checkpoint_path: None,
+            altda_da_server: None,
         }
     }
 

--- a/crates/consensus/derive/src/lib.rs
+++ b/crates/consensus/derive/src/lib.rs
@@ -30,8 +30,9 @@ pub use pipeline::{
 
 mod sources;
 pub use sources::{
-    BLOB_ENCODING_ROUNDS, BLOB_ENCODING_VERSION, BLOB_MAX_DATA_SIZE, BlobData, BlobSource,
-    CalldataSource, EthereumDataSource,
+    AltDaCommitmentResolver, AltDaDataSource, AltDaResolverError, BLOB_ENCODING_ROUNDS,
+    BLOB_ENCODING_VERSION, BLOB_MAX_DATA_SIZE, BlobData, BlobSource, CalldataSource,
+    DynAltDaResolver, EthereumDataSource,
 };
 
 mod stages;

--- a/crates/consensus/derive/src/sources/alt_da.rs
+++ b/crates/consensus/derive/src/sources/alt_da.rs
@@ -63,12 +63,19 @@ pub type DynAltDaResolver = Arc<dyn AltDaCommitmentResolver>;
 pub struct AltDaDataSource<D> {
     inner: D,
     resolver: Option<DynAltDaResolver>,
+    /// A commitment popped from the inner source but not yet resolved.
+    ///
+    /// Resolution happens after the item is consumed from the inner source, so a transient
+    /// resolve failure must not drop the batch. The commitment is buffered here and retried at
+    /// the top of the next `next()` call before any new inner item is pulled, preserving
+    /// at-least-once delivery so the safe head stays in sync with the calldata path.
+    pending: Option<Bytes>,
 }
 
 impl<D> AltDaDataSource<D> {
     /// Wrap `inner`. A `None` resolver is pass-through; `Some` enables alt-DA-only mode.
     pub const fn new(inner: D, resolver: Option<DynAltDaResolver>) -> Self {
-        Self { inner, resolver }
+        Self { inner, resolver, pending: None }
     }
 }
 
@@ -84,25 +91,44 @@ where
         block_ref: &BlockInfo,
         batcher_addr: Address,
     ) -> PipelineResult<Self::Item> {
+        // Clone the resolver handle (a cheap Arc) so the inner source and `pending` can be
+        // borrowed mutably below. No resolver means transparent pass-through.
+        let Some(resolver) = self.resolver.clone() else {
+            return self.inner.next(block_ref, batcher_addr).await;
+        };
+
         loop {
-            let data = self.inner.next(block_ref, batcher_addr).await?;
-            let Some(resolver) = &self.resolver else {
-                return Ok(data);
-            };
-            match data.first() {
-                Some(&DERIVATION_VERSION_1) => {
-                    let bytes = resolver.resolve(&data[1..]).await?;
-                    return Ok(bytes);
+            // Retry a previously-popped commitment before pulling a new inner item, so a
+            // transient resolve failure replays the same commitment instead of dropping the
+            // batch (the inner item was already consumed when it was popped).
+            let commitment = if let Some(commitment) = self.pending.clone() {
+                commitment
+            } else {
+                let data = self.inner.next(block_ref, batcher_addr).await?;
+                match data.first() {
+                    Some(&DERIVATION_VERSION_1) => {
+                        let commitment = Bytes::copy_from_slice(&data[1..]);
+                        self.pending = Some(commitment.clone());
+                        commitment
+                    }
+                    // Alt-DA mode ignores inline calldata/blob frames and any empty item; pull
+                    // the next item. Termination relies on the inner source returning Eof once
+                    // the block's data is exhausted.
+                    other => {
+                        trace!(first_byte = ?other, "alt-da: skipping non-commitment item");
+                        continue;
+                    }
                 }
-                // Alt-DA mode ignores inline calldata/blob frames (Some(_)) and any empty item
-                // (None); pull the next item. Termination relies on the inner source returning
-                // Eof once the block's data is exhausted.
-                Some(_) | None => continue,
-            }
+            };
+
+            let bytes = resolver.resolve(&commitment).await?;
+            self.pending = None;
+            return Ok(bytes);
         }
     }
 
     fn clear(&mut self) {
+        self.pending = None;
         self.inner.clear();
     }
 }
@@ -184,5 +210,44 @@ mod tests {
         let mut src = AltDaDataSource::new(inner, Some(resolver));
         let err = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
         assert!(matches!(err, PipelineErrorKind::Temporary(_)));
+    }
+
+    #[derive(Debug)]
+    struct FlakyResolver {
+        calls: core::sync::atomic::AtomicUsize,
+        bytes: Bytes,
+    }
+
+    #[async_trait]
+    impl AltDaCommitmentResolver for FlakyResolver {
+        async fn resolve(&self, _commitment: &[u8]) -> Result<Bytes, AltDaResolverError> {
+            let n = self.calls.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                Err(AltDaResolverError::Resolve("transient".into()))
+            } else {
+                Ok(self.bytes.clone())
+            }
+        }
+    }
+
+    // A transient resolve failure must retry the same commitment, not drop the batch: the inner
+    // item is already consumed when popped, so without buffering the batch would be skipped.
+    #[tokio::test]
+    async fn retries_same_commitment_after_transient_failure() {
+        let stored = Bytes::from(vec![0x00, 5, 5, 5]);
+        let resolver: DynAltDaResolver = Arc::new(FlakyResolver {
+            calls: core::sync::atomic::AtomicUsize::new(0),
+            bytes: stored.clone(),
+        });
+        // Inner yields a single commitment, then Eof.
+        let inner = MockInner { items: VecDeque::from([l1_commitment(&[0xcc; 34])]) };
+        let mut src = AltDaDataSource::new(inner, Some(resolver));
+
+        let err = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Temporary(_)));
+
+        // The commitment is retried (inner is now empty) and resolves on the second attempt.
+        let out = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap();
+        assert_eq!(out, stored);
     }
 }

--- a/crates/consensus/derive/src/sources/alt_da.rs
+++ b/crates/consensus/derive/src/sources/alt_da.rs
@@ -1,0 +1,183 @@
+//! Alt-DA data source that resolves L1 commitments to off-chain batch bytes.
+
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+};
+use core::fmt::Debug;
+
+use alloy_primitives::{Address, Bytes};
+use async_trait::async_trait;
+use base_protocol::{BlockInfo, DERIVATION_VERSION_1};
+use thiserror::Error;
+
+use crate::{DataAvailabilityProvider, PipelineError, PipelineErrorKind, PipelineResult};
+
+/// Error returned by an [`AltDaCommitmentResolver`].
+#[derive(Debug, Error)]
+pub enum AltDaResolverError {
+    /// No object is stored for the commitment.
+    #[error("alt-da commitment not found")]
+    NotFound,
+    /// The resolver failed to fetch the bytes (transport, server, or decode error).
+    #[error("alt-da resolve failed: {0}")]
+    Resolve(String),
+}
+
+impl From<AltDaResolverError> for PipelineErrorKind {
+    fn from(err: AltDaResolverError) -> Self {
+        // A failed or missing resolve is treated as temporary so the node retries rather than
+        // halting. The DA server may be briefly unavailable or the object not yet visible.
+        PipelineError::Provider(err.to_string()).temp()
+    }
+}
+
+/// Resolves a generic alt-DA commitment to the batch bytes stored off-chain (e.g. S3).
+///
+/// The trait lives in this `no_std` crate; the concrete HTTP client is injected by the node
+/// binary, mirroring how [`BlobProvider`](crate::BlobProvider) is supplied.
+#[async_trait]
+pub trait AltDaCommitmentResolver: Debug + Send + Sync {
+    /// Fetch the batch bytes for `commitment`, the 34-byte generic commitment without the
+    /// leading derivation-version byte.
+    async fn resolve(&self, commitment: &[u8]) -> Result<Bytes, AltDaResolverError>;
+}
+
+/// Shared handle to an [`AltDaCommitmentResolver`].
+pub type DynAltDaResolver = Arc<dyn AltDaCommitmentResolver>;
+
+/// Wraps an inner [`DataAvailabilityProvider`] to resolve alt-DA commitments.
+///
+/// With `resolver` `None` this is a transparent pass-through: the inner source drives
+/// derivation unchanged (calldata or blobs).
+///
+/// With `resolver` `Some` the node derives from off-chain DA only. A `DERIVATION_VERSION_1`
+/// (`0x01`) commitment is resolved to its stored bytes, and any other item (inline `0x00`
+/// calldata or blob frames) is skipped. This is the post-cutover behavior and lets a shadow
+/// follower derive purely from S3 during the dual-write window.
+#[derive(Debug, Clone)]
+pub struct AltDaDataSource<D> {
+    inner: D,
+    resolver: Option<DynAltDaResolver>,
+}
+
+impl<D> AltDaDataSource<D> {
+    /// Wrap `inner`. A `None` resolver is pass-through; `Some` enables alt-DA-only mode.
+    pub const fn new(inner: D, resolver: Option<DynAltDaResolver>) -> Self {
+        Self { inner, resolver }
+    }
+}
+
+#[async_trait]
+impl<D> DataAvailabilityProvider for AltDaDataSource<D>
+where
+    D: DataAvailabilityProvider<Item = Bytes> + Send + Sync + Debug,
+{
+    type Item = Bytes;
+
+    async fn next(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_addr: Address,
+    ) -> PipelineResult<Self::Item> {
+        loop {
+            let data = self.inner.next(block_ref, batcher_addr).await?;
+            let Some(resolver) = &self.resolver else {
+                return Ok(data);
+            };
+            match data.first() {
+                Some(&DERIVATION_VERSION_1) => {
+                    let bytes = resolver.resolve(&data[1..]).await?;
+                    return Ok(bytes);
+                }
+                // Alt-DA mode ignores inline calldata or blob frames; pull the next item.
+                _ => continue,
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{
+        collections::{BTreeMap, VecDeque},
+        vec,
+        vec::Vec,
+    };
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct MockInner {
+        items: VecDeque<Bytes>,
+    }
+
+    #[async_trait]
+    impl DataAvailabilityProvider for MockInner {
+        type Item = Bytes;
+
+        async fn next(&mut self, _: &BlockInfo, _: Address) -> PipelineResult<Bytes> {
+            self.items.pop_front().ok_or(PipelineError::Eof.temp())
+        }
+
+        fn clear(&mut self) {
+            self.items.clear();
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockResolver {
+        map: BTreeMap<Vec<u8>, Bytes>,
+    }
+
+    #[async_trait]
+    impl AltDaCommitmentResolver for MockResolver {
+        async fn resolve(&self, commitment: &[u8]) -> Result<Bytes, AltDaResolverError> {
+            self.map.get(commitment).cloned().ok_or(AltDaResolverError::NotFound)
+        }
+    }
+
+    fn l1_commitment(commitment: &[u8]) -> Bytes {
+        let mut data = vec![DERIVATION_VERSION_1];
+        data.extend_from_slice(commitment);
+        Bytes::from(data)
+    }
+
+    #[tokio::test]
+    async fn passthrough_when_no_resolver() {
+        let inner = MockInner { items: VecDeque::from([Bytes::from(vec![0x00, 1, 2, 3])]) };
+        let mut src = AltDaDataSource::new(inner, None);
+        let out = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap();
+        assert_eq!(out.as_ref(), &[0x00, 1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn resolves_commitment_and_skips_calldata() {
+        let commitment = vec![0xaa; 34];
+        let stored = Bytes::from(vec![0x00, 9, 9, 9]);
+        let mut map = BTreeMap::new();
+        map.insert(commitment.clone(), stored.clone());
+        let resolver: DynAltDaResolver = Arc::new(MockResolver { map });
+
+        let inner = MockInner {
+            items: VecDeque::from([Bytes::from(vec![0x00, 7, 7, 7]), l1_commitment(&commitment)]),
+        };
+        let mut src = AltDaDataSource::new(inner, Some(resolver));
+        let out = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap();
+        assert_eq!(out, stored);
+    }
+
+    #[tokio::test]
+    async fn resolve_not_found_is_temporary() {
+        let resolver: DynAltDaResolver = Arc::new(MockResolver { map: BTreeMap::new() });
+        let inner = MockInner { items: VecDeque::from([l1_commitment(&[0xbb; 34])]) };
+        let mut src = AltDaDataSource::new(inner, Some(resolver));
+        let err = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Temporary(_)));
+    }
+}

--- a/crates/consensus/derive/src/sources/alt_da.rs
+++ b/crates/consensus/derive/src/sources/alt_da.rs
@@ -9,7 +9,7 @@ use core::fmt::Debug;
 
 use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
-use base_protocol::{BlockInfo, DERIVATION_VERSION_1};
+use base_protocol::{BlockInfo, DERIVATION_VERSION_1, GENERIC_COMMITMENT_LEN};
 use thiserror::Error;
 
 use crate::{DataAvailabilityProvider, PipelineError, PipelineErrorKind, PipelineResult};
@@ -27,12 +27,16 @@ pub enum AltDaResolverError {
 
 impl From<AltDaResolverError> for PipelineErrorKind {
     fn from(err: AltDaResolverError) -> Self {
-        // Both NotFound and transport/server errors map to a temporary error so derivation
-        // retries rather than halting. The batcher posts a commitment to L1 only after a
-        // successful S3 PUT, so any committed pointer has a backing object; a NotFound at
-        // derivation time is therefore transient (read-after-write visibility or a brief DA
-        // server outage), not a permanently missing object.
-        PipelineError::Provider(err.to_string()).temp()
+        let msg = err.to_string();
+        match err {
+            // A 404 is permanent in our model: the batcher posts a commitment to L1 only after a
+            // successful S3 PUT, and S3 is read-after-write consistent, so a missing object means
+            // real data loss or corruption. Halt with a diagnostic instead of retrying forever
+            // (the pending-commitment buffer would otherwise spin on the same item indefinitely).
+            AltDaResolverError::NotFound => PipelineError::Provider(msg).crit(),
+            // Transport errors, timeouts, and 5xx responses are transient; retry.
+            AltDaResolverError::Resolve(_) => PipelineError::Provider(msg).temp(),
+        }
     }
 }
 
@@ -107,6 +111,13 @@ where
                 let data = self.inner.next(block_ref, batcher_addr).await?;
                 match data.first() {
                     Some(&DERIVATION_VERSION_1) => {
+                        // A valid commitment tx is the version byte plus the fixed-size generic
+                        // commitment. Skip malformed lengths (e.g. a bare 0x01) so they are not
+                        // buffered and retried against the DA server forever.
+                        if data.len() != 1 + GENERIC_COMMITMENT_LEN {
+                            warn!(len = data.len(), "alt-da: skipping malformed commitment tx");
+                            continue;
+                        }
                         let commitment = Bytes::copy_from_slice(&data[1..]);
                         self.pending = Some(commitment.clone());
                         commitment
@@ -204,12 +215,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_not_found_is_temporary() {
+    async fn resolve_not_found_is_critical() {
         let resolver: DynAltDaResolver = Arc::new(MockResolver { map: BTreeMap::new() });
         let inner = MockInner { items: VecDeque::from([l1_commitment(&[0xbb; 34])]) };
         let mut src = AltDaDataSource::new(inner, Some(resolver));
         let err = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
-        assert!(matches!(err, PipelineErrorKind::Temporary(_)));
+        assert!(matches!(err, PipelineErrorKind::Critical(_)));
+    }
+
+    #[tokio::test]
+    async fn skips_malformed_commitment_tx() {
+        // A bare 0x01 with no commitment payload must be skipped, not buffered and retried.
+        let commitment = vec![0xaa; 34];
+        let stored = Bytes::from(vec![0x00, 1, 2, 3]);
+        let mut map = BTreeMap::new();
+        map.insert(commitment.clone(), stored.clone());
+        let resolver: DynAltDaResolver = Arc::new(MockResolver { map });
+        let inner = MockInner {
+            items: VecDeque::from([
+                Bytes::from(vec![DERIVATION_VERSION_1]),
+                l1_commitment(&commitment),
+            ]),
+        };
+        let mut src = AltDaDataSource::new(inner, Some(resolver));
+        let out = src.next(&BlockInfo::default(), Address::ZERO).await.unwrap();
+        assert_eq!(out, stored);
     }
 
     #[derive(Debug)]

--- a/crates/consensus/derive/src/sources/alt_da.rs
+++ b/crates/consensus/derive/src/sources/alt_da.rs
@@ -27,8 +27,11 @@ pub enum AltDaResolverError {
 
 impl From<AltDaResolverError> for PipelineErrorKind {
     fn from(err: AltDaResolverError) -> Self {
-        // A failed or missing resolve is treated as temporary so the node retries rather than
-        // halting. The DA server may be briefly unavailable or the object not yet visible.
+        // Both NotFound and transport/server errors map to a temporary error so derivation
+        // retries rather than halting. The batcher posts a commitment to L1 only after a
+        // successful S3 PUT, so any committed pointer has a backing object; a NotFound at
+        // derivation time is therefore transient (read-after-write visibility or a brief DA
+        // server outage), not a permanently missing object.
         PipelineError::Provider(err.to_string()).temp()
     }
 }

--- a/crates/consensus/derive/src/sources/alt_da.rs
+++ b/crates/consensus/derive/src/sources/alt_da.rs
@@ -91,8 +91,10 @@ where
                     let bytes = resolver.resolve(&data[1..]).await?;
                     return Ok(bytes);
                 }
-                // Alt-DA mode ignores inline calldata or blob frames; pull the next item.
-                _ => continue,
+                // Alt-DA mode ignores inline calldata/blob frames (Some(_)) and any empty item
+                // (None); pull the next item. Termination relies on the inner source returning
+                // Eof once the block's data is exhausted.
+                Some(_) | None => continue,
             }
         }
     }

--- a/crates/consensus/derive/src/sources/mod.rs
+++ b/crates/consensus/derive/src/sources/mod.rs
@@ -18,3 +18,6 @@ pub use blobs::BlobSource;
 
 mod calldata;
 pub use calldata::CalldataSource;
+
+mod alt_da;
+pub use alt_da::{AltDaCommitmentResolver, AltDaDataSource, AltDaResolverError, DynAltDaResolver};

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -54,6 +54,16 @@ pub const BLOB_DERIVATION_PREFIX_SIZE: usize = 1;
 /// derivation-version prefix.
 pub const MAX_BLOB_FRAME_SIZE: usize = BLOB_MAX_DATA_SIZE - BLOB_DERIVATION_PREFIX_SIZE;
 
+/// Encoded length of an alt-DA generic commitment: a `0x01` type byte, a `0xff` sentinel, then
+/// a 32-byte payload. A [`DERIVATION_VERSION_1`] batcher transaction carries
+/// `1 + GENERIC_COMMITMENT_LEN` bytes (the version byte followed by the commitment).
+pub const GENERIC_COMMITMENT_LEN: usize = 34;
+
+/// Maximum alt-DA object size accepted on PUT/GET, sized for eight max-size blob frames per
+/// channel submission. Shared so the DA server, batcher, and derivation resolver agree on the
+/// cap without each crate redefining the formula.
+pub const MAX_DA_OBJECT_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
+
 /// A frame decoding error.
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FrameDecodingError {

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -35,7 +35,8 @@ pub use block::{BlockInfo, FromBlockError, L2BlockInfo};
 mod frame;
 pub use frame::{
     BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, DERIVATION_VERSION_0, DERIVATION_VERSION_1,
-    Frame, FrameDecodingError, FrameParseError, MAX_BLOB_FRAME_SIZE,
+    Frame, FrameDecodingError, FrameParseError, GENERIC_COMMITMENT_LEN, MAX_BLOB_FRAME_SIZE,
+    MAX_DA_OBJECT_BYTES,
 };
 
 mod utils;

--- a/crates/consensus/providers/src/alt_da.rs
+++ b/crates/consensus/providers/src/alt_da.rs
@@ -60,12 +60,29 @@ impl AltDaCommitmentResolver for HttpAltDaResolver {
             )));
         }
 
-        let bytes = resp.bytes().await.map_err(|e| AltDaResolverError::Resolve(e.to_string()))?;
-        if bytes.len() > MAX_RESOLVE_BYTES {
+        // Reject oversized responses up front by Content-Length, then stream chunks with a
+        // running cap so a misconfigured or malicious DA server cannot OOM the node by sending
+        // an arbitrarily large body. Mirrors `base_alt_da::Client::get`.
+        if let Some(len) = resp.content_length()
+            && len as usize > MAX_RESOLVE_BYTES
+        {
             return Err(AltDaResolverError::Resolve(format!(
-                "response too large: {} bytes (max {MAX_RESOLVE_BYTES})",
-                bytes.len()
+                "response too large: content-length {len} (max {MAX_RESOLVE_BYTES})"
             )));
+        }
+
+        let mut bytes = Vec::new();
+        let mut response = resp;
+        while let Some(chunk) =
+            response.chunk().await.map_err(|e| AltDaResolverError::Resolve(e.to_string()))?
+        {
+            if bytes.len() + chunk.len() > MAX_RESOLVE_BYTES {
+                return Err(AltDaResolverError::Resolve(format!(
+                    "response too large: {} bytes (max {MAX_RESOLVE_BYTES})",
+                    bytes.len() + chunk.len()
+                )));
+            }
+            bytes.extend_from_slice(&chunk);
         }
         Ok(Bytes::from(bytes))
     }

--- a/crates/consensus/providers/src/alt_da.rs
+++ b/crates/consensus/providers/src/alt_da.rs
@@ -31,8 +31,10 @@ impl HttpAltDaResolver {
         let mut base = server;
         base.set_query(None);
         base.set_fragment(None);
+        // 60s matches base_alt_da::Client, which calls the same DA server endpoint, so the
+        // two derivation paths do not time out at different points during dual-write.
         let http = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(60))
             .build()
             .map_err(|e| AltDaResolverError::Resolve(e.to_string()))?;
         Ok(Self { base, http })

--- a/crates/consensus/providers/src/alt_da.rs
+++ b/crates/consensus/providers/src/alt_da.rs
@@ -1,0 +1,72 @@
+//! HTTP-backed [`AltDaCommitmentResolver`] used by the online node to resolve alt-DA
+//! commitments to off-chain batch bytes.
+
+use std::time::Duration;
+
+use alloy_primitives::{Bytes, hex};
+use async_trait::async_trait;
+use base_consensus_derive::{AltDaCommitmentResolver, AltDaResolverError};
+use base_protocol::BLOB_MAX_DATA_SIZE;
+use url::Url;
+
+/// Max bytes accepted from a single resolve, matching the DA server's object cap.
+const MAX_RESOLVE_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
+
+/// Resolves commitments by calling the alt-DA server's `GET /get/0x{commitment}` endpoint.
+///
+/// This is the std HTTP counterpart of the `no_std` [`AltDaCommitmentResolver`] trait. It is
+/// constructed in the node layer so the consensus crates avoid an `infra` dependency.
+#[derive(Debug, Clone)]
+pub struct HttpAltDaResolver {
+    base: Url,
+    http: reqwest::Client,
+}
+
+impl HttpAltDaResolver {
+    /// Build a resolver targeting `server` (e.g. `http://base-da-server:2583`).
+    pub fn new(server: Url) -> Result<Self, AltDaResolverError> {
+        let mut base = server;
+        base.set_query(None);
+        base.set_fragment(None);
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| AltDaResolverError::Resolve(e.to_string()))?;
+        Ok(Self { base, http })
+    }
+}
+
+#[async_trait]
+impl AltDaCommitmentResolver for HttpAltDaResolver {
+    async fn resolve(&self, commitment: &[u8]) -> Result<Bytes, AltDaResolverError> {
+        let mut url = self.base.clone();
+        url.set_path(&format!("get/0x{}", hex::encode(commitment)));
+
+        let resp = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| AltDaResolverError::Resolve(e.to_string()))?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(AltDaResolverError::NotFound);
+        }
+        if !status.is_success() {
+            return Err(AltDaResolverError::Resolve(format!(
+                "unexpected status {}",
+                status.as_u16()
+            )));
+        }
+
+        let bytes = resp.bytes().await.map_err(|e| AltDaResolverError::Resolve(e.to_string()))?;
+        if bytes.len() > MAX_RESOLVE_BYTES {
+            return Err(AltDaResolverError::Resolve(format!(
+                "response too large: {} bytes (max {MAX_RESOLVE_BYTES})",
+                bytes.len()
+            )));
+        }
+        Ok(Bytes::from(bytes))
+    }
+}

--- a/crates/consensus/providers/src/alt_da.rs
+++ b/crates/consensus/providers/src/alt_da.rs
@@ -6,14 +6,11 @@ use std::time::Duration;
 use alloy_primitives::{Bytes, hex};
 use async_trait::async_trait;
 use base_consensus_derive::{AltDaCommitmentResolver, AltDaResolverError};
-use base_protocol::BLOB_MAX_DATA_SIZE;
+use base_protocol::MAX_DA_OBJECT_BYTES;
 use url::Url;
 
-/// Max bytes accepted from a single resolve. Must stay in sync with
-/// `base_alt_da::MAX_OBJECT_BYTES` (both are `8 * BLOB_MAX_DATA_SIZE`); the value is duplicated
-/// rather than imported because the consensus layer cannot depend on the infra `base-alt-da`
-/// crate (see `etc/scripts/ci/check-crate-deps.sh`).
-const MAX_RESOLVE_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
+/// Max error-response body bytes preserved for diagnostics on a non-success status.
+const MAX_ERROR_BODY_BYTES: usize = 256;
 
 /// Resolves commitments by calling the alt-DA server's `GET /get/0x{commitment}` endpoint.
 ///
@@ -59,10 +56,14 @@ impl AltDaCommitmentResolver for HttpAltDaResolver {
             return Err(AltDaResolverError::NotFound);
         }
         if !status.is_success() {
-            return Err(AltDaResolverError::Resolve(format!(
-                "unexpected status {}",
-                status.as_u16()
-            )));
+            // Preserve a bounded snippet of the server's error body for diagnostics, matching
+            // `base_alt_da::Client::get`.
+            let code = status.as_u16();
+            let mut detail = read_bounded_error_body(resp).await;
+            if detail.is_empty() {
+                detail = "(no response body)".into();
+            }
+            return Err(AltDaResolverError::Resolve(format!("unexpected status {code}: {detail}")));
         }
 
         // Reject oversized responses up front by Content-Length, then stream chunks with a
@@ -70,22 +71,22 @@ impl AltDaCommitmentResolver for HttpAltDaResolver {
         // an arbitrarily large body. Mirrors `base_alt_da::Client::get`.
         let content_len = resp.content_length();
         if let Some(len) = content_len
-            && len as usize > MAX_RESOLVE_BYTES
+            && len as usize > MAX_DA_OBJECT_BYTES
         {
             return Err(AltDaResolverError::Resolve(format!(
-                "response too large: content-length {len} (max {MAX_RESOLVE_BYTES})"
+                "response too large: content-length {len} (max {MAX_DA_OBJECT_BYTES})"
             )));
         }
 
-        // Pre-size to the Content-Length when known; it is already validated <= MAX_RESOLVE_BYTES.
+        // Pre-size to the Content-Length when known; it is already validated <= MAX_DA_OBJECT_BYTES.
         let mut bytes = Vec::with_capacity(content_len.unwrap_or(0) as usize);
         let mut response = resp;
         while let Some(chunk) =
             response.chunk().await.map_err(|e| AltDaResolverError::Resolve(e.to_string()))?
         {
-            if bytes.len() + chunk.len() > MAX_RESOLVE_BYTES {
+            if bytes.len() + chunk.len() > MAX_DA_OBJECT_BYTES {
                 return Err(AltDaResolverError::Resolve(format!(
-                    "response too large: {} bytes (max {MAX_RESOLVE_BYTES})",
+                    "response too large: {} bytes (max {MAX_DA_OBJECT_BYTES})",
                     bytes.len() + chunk.len()
                 )));
             }
@@ -93,4 +94,18 @@ impl AltDaCommitmentResolver for HttpAltDaResolver {
         }
         Ok(Bytes::from(bytes))
     }
+}
+
+/// Read up to [`MAX_ERROR_BODY_BYTES`] of a non-success response body for diagnostics.
+async fn read_bounded_error_body(mut resp: reqwest::Response) -> String {
+    let mut bytes = Vec::new();
+    while let Ok(Some(chunk)) = resp.chunk().await {
+        let remaining = MAX_ERROR_BODY_BYTES.saturating_sub(bytes.len());
+        if remaining == 0 {
+            break;
+        }
+        let take = chunk.len().min(remaining);
+        bytes.extend_from_slice(&chunk[..take]);
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
 }

--- a/crates/consensus/providers/src/alt_da.rs
+++ b/crates/consensus/providers/src/alt_da.rs
@@ -9,7 +9,10 @@ use base_consensus_derive::{AltDaCommitmentResolver, AltDaResolverError};
 use base_protocol::BLOB_MAX_DATA_SIZE;
 use url::Url;
 
-/// Max bytes accepted from a single resolve, matching the DA server's object cap.
+/// Max bytes accepted from a single resolve. Must stay in sync with
+/// `base_alt_da::MAX_OBJECT_BYTES` (both are `8 * BLOB_MAX_DATA_SIZE`); the value is duplicated
+/// rather than imported because the consensus layer cannot depend on the infra `base-alt-da`
+/// crate (see `etc/scripts/ci/check-crate-deps.sh`).
 const MAX_RESOLVE_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
 
 /// Resolves commitments by calling the alt-DA server's `GET /get/0x{commitment}` endpoint.
@@ -63,7 +66,8 @@ impl AltDaCommitmentResolver for HttpAltDaResolver {
         // Reject oversized responses up front by Content-Length, then stream chunks with a
         // running cap so a misconfigured or malicious DA server cannot OOM the node by sending
         // an arbitrarily large body. Mirrors `base_alt_da::Client::get`.
-        if let Some(len) = resp.content_length()
+        let content_len = resp.content_length();
+        if let Some(len) = content_len
             && len as usize > MAX_RESOLVE_BYTES
         {
             return Err(AltDaResolverError::Resolve(format!(
@@ -71,7 +75,8 @@ impl AltDaCommitmentResolver for HttpAltDaResolver {
             )));
         }
 
-        let mut bytes = Vec::new();
+        // Pre-size to the Content-Length when known; it is already validated <= MAX_RESOLVE_BYTES.
+        let mut bytes = Vec::with_capacity(content_len.unwrap_or(0) as usize);
         let mut response = resp;
         while let Some(chunk) =
             response.chunk().await.map_err(|e| AltDaResolverError::Resolve(e.to_string()))?

--- a/crates/consensus/providers/src/lib.rs
+++ b/crates/consensus/providers/src/lib.rs
@@ -32,5 +32,8 @@ pub use conf_depth::{ConfDepthProvider, L1HeadNumber};
 mod l2_chain_provider;
 pub use l2_chain_provider::{AlloyL2ChainProvider, AlloyL2ChainProviderError};
 
+mod alt_da;
+pub use alt_da::HttpAltDaResolver;
+
 mod pipeline;
 pub use pipeline::OnlinePipeline;

--- a/crates/consensus/providers/src/pipeline.rs
+++ b/crates/consensus/providers/src/pipeline.rs
@@ -7,9 +7,9 @@ use alloy_genesis::ChainConfig;
 use async_trait::async_trait;
 use base_common_genesis::{RollupConfig, SystemConfig};
 use base_consensus_derive::{
-    DerivationPipeline, EthereumDataSource, OriginProvider, Pipeline, PipelineBuilder,
-    PipelineErrorKind, PipelineResult, PolledAttributesQueueStage, ResetSignal, Signal,
-    SignalReceiver, StatefulAttributesBuilder, StepResult,
+    AltDaDataSource, DerivationPipeline, DynAltDaResolver, EthereumDataSource, OriginProvider,
+    Pipeline, PipelineBuilder, PipelineErrorKind, PipelineResult, PolledAttributesQueueStage,
+    ResetSignal, Signal, SignalReceiver, StatefulAttributesBuilder, StepResult,
 };
 use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
@@ -28,8 +28,8 @@ type OnlinePolledDerivationPipeline = DerivationPipeline<
     AlloyL2ChainProvider,
 >;
 
-/// An RPC-backed Ethereum data source.
-type OnlineDataProvider = EthereumDataSource<ConfDepthProvider, L1BlobProvider>;
+/// An RPC-backed Ethereum data source, wrapped to optionally resolve alt-DA commitments.
+type OnlineDataProvider = AltDaDataSource<EthereumDataSource<ConfDepthProvider, L1BlobProvider>>;
 
 /// An RPC-backed payload attributes builder for the `AttributesQueue` stage of the derivation
 /// pipeline.
@@ -54,6 +54,7 @@ impl OnlinePipeline {
         l2_chain_provider: AlloyL2ChainProvider,
         l1_head_number: L1HeadNumber,
         verifier_l1_confs: u64,
+        alt_da_resolver: Option<DynAltDaResolver>,
     ) -> PipelineResult<Self> {
         let mut pipeline = Self::new_polled(
             Arc::clone(&cfg),
@@ -63,6 +64,7 @@ impl OnlinePipeline {
             l2_chain_provider,
             l1_head_number,
             verifier_l1_confs,
+            alt_da_resolver,
         );
 
         // Reset the pipeline to populate the initial L1/L2 cursor and system configuration in L1
@@ -88,6 +90,7 @@ impl OnlinePipeline {
         l2_chain_provider: AlloyL2ChainProvider,
         l1_head_number: L1HeadNumber,
         verifier_l1_confs: u64,
+        alt_da_resolver: Option<DynAltDaResolver>,
     ) -> Self {
         let chain_provider =
             ConfDepthProvider::new(chain_provider, l1_head_number, verifier_l1_confs);
@@ -97,7 +100,9 @@ impl OnlinePipeline {
             l2_chain_provider.clone(),
             chain_provider.clone(),
         );
-        let dap = EthereumDataSource::new_from_parts(chain_provider.clone(), blob_provider, &cfg);
+        let eth_dap =
+            EthereumDataSource::new_from_parts(chain_provider.clone(), blob_provider, &cfg);
+        let dap = AltDaDataSource::new(eth_dap, alt_da_resolver);
 
         let pipeline = PipelineBuilder::new()
             .rollup_config(cfg)

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -235,11 +235,17 @@ impl RollupNodeBuilder {
             )
         });
 
-        let alt_da_resolver: Option<DynAltDaResolver> = self.alt_da_server.map(|server| {
-            let resolver = HttpAltDaResolver::new(server)
-                .expect("failed to build alt-da resolver http client");
-            Arc::new(resolver) as DynAltDaResolver
-        });
+        let alt_da_resolver: Option<DynAltDaResolver> = self
+            .alt_da_server
+            .map(|server| HttpAltDaResolver::new(server).map(|r| Arc::new(r) as DynAltDaResolver))
+            .transpose()
+            .map_err(|e| {
+                alloy_transport::TransportError::from(
+                    alloy_transport::TransportErrorKind::custom_str(&format!(
+                        "failed to build alt-da resolver: {e}"
+                    )),
+                )
+            })?;
 
         Ok(RollupNode {
             config: rollup_config,

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -7,8 +7,9 @@ use alloy_provider::RootProvider;
 use alloy_transport::TransportResult;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
+use base_consensus_derive::DynAltDaResolver;
 use base_consensus_engine::BaseEngineClient;
-use base_consensus_providers::OnlineBeaconClient;
+use base_consensus_providers::{HttpAltDaResolver, OnlineBeaconClient};
 use base_consensus_rpc::RpcBuilder;
 use url::Url;
 
@@ -85,6 +86,11 @@ pub struct RollupNodeBuilder {
     /// When set, enables persistent safe head tracking via redb and serves
     /// `optimism_safeHeadAtL1Block` RPC requests from the database.
     pub safedb_path: Option<PathBuf>,
+    /// Optional alt-DA server URL.
+    ///
+    /// When set, derivation resolves `0x01` alt-DA commitments to off-chain batch bytes from
+    /// this server and derives purely from off-chain DA (skipping inline calldata).
+    pub alt_da_server: Option<Url>,
 }
 
 impl RollupNodeBuilder {
@@ -123,6 +129,7 @@ impl RollupNodeBuilder {
             finalized_poll_interval: None,
             checkpoint_path: None,
             safedb_path: None,
+            alt_da_server: None,
         }
     }
 
@@ -167,6 +174,14 @@ impl RollupNodeBuilder {
     /// Sets the checkpoint database path.
     pub fn with_checkpoint_path(self, path: PathBuf) -> Self {
         Self { checkpoint_path: Some(path), ..self }
+    }
+
+    /// Enables alt-DA derivation by setting the DA server URL.
+    ///
+    /// When set, the node resolves `0x01` commitments from this server and derives purely from
+    /// off-chain DA.
+    pub fn with_alt_da_server(self, server: Option<Url>) -> Self {
+        Self { alt_da_server: server, ..self }
     }
 
     /// Assembles the [`RollupNode`] service.
@@ -220,6 +235,12 @@ impl RollupNodeBuilder {
             )
         });
 
+        let alt_da_resolver: Option<DynAltDaResolver> = self.alt_da_server.map(|server| {
+            let resolver = HttpAltDaResolver::new(server)
+                .expect("failed to build alt-da resolver http client");
+            Arc::new(resolver) as DynAltDaResolver
+        });
+
         Ok(RollupNode {
             config: rollup_config,
             l1_config,
@@ -232,6 +253,7 @@ impl RollupNodeBuilder {
             derivation_delegate_provider,
             checkpoint_path,
             safedb_path: self.safedb_path,
+            alt_da_resolver,
         })
     }
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -12,7 +12,9 @@ use alloy_provider::RootProvider;
 use base_common_chains::ChainConfig;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
-use base_consensus_derive::{Pipeline, SignalReceiver, StatefulAttributesBuilder};
+use base_consensus_derive::{
+    DynAltDaResolver, Pipeline, SignalReceiver, StatefulAttributesBuilder,
+};
 use base_consensus_engine::{Engine, EngineClient, EngineState, ForkchoiceCheckpointReader};
 use base_consensus_providers::{
     AlloyChainProvider, AlloyL2ChainProvider, L1BlobProvider, OnlineBeaconClient,
@@ -125,6 +127,12 @@ pub struct RollupNode {
     /// If the path is set but the database cannot be opened (e.g., bad permissions, disk
     /// error, or corrupted file), the node **fails to start** with an error.
     pub safedb_path: Option<PathBuf>,
+    /// Optional alt-DA commitment resolver.
+    ///
+    /// When set, derivation resolves `0x01` alt-DA commitments to their off-chain batch bytes
+    /// and ignores inline calldata, so the node derives purely from off-chain DA. When `None`
+    /// (the default), the node derives from calldata or blobs as usual.
+    pub alt_da_resolver: Option<DynAltDaResolver>,
 }
 
 /// A RollupNode-level derivation actor wrapper.
@@ -243,6 +251,7 @@ impl RollupNode {
             l2_derivation_provider,
             l1_head_number,
             self.l1_config.verifier_l1_confs,
+            self.alt_da_resolver.clone(),
         )
     }
 

--- a/crates/infra/alt-da/src/client.rs
+++ b/crates/infra/alt-da/src/client.rs
@@ -14,9 +14,11 @@ const MAX_PUT_RESPONSE_BYTES: usize = GENERIC_COMMITMENT_LEN + 1;
 /// Max error response body bytes preserved on non-success PUT responses.
 const MAX_ERROR_RESPONSE_BYTES: usize = 256;
 
-/// Alt-DA HTTP client used by the batcher to upload batch bytes.
+/// Alt-DA HTTP client: the batcher uploads batch bytes (`put`), derivation resolves
+/// commitments back to bytes (`get`).
 #[derive(Debug, Clone)]
 pub struct Client {
+    base: Url,
     put_url: Url,
     http: reqwest::Client,
 }
@@ -24,12 +26,58 @@ pub struct Client {
 impl Client {
     /// Build a client targeting `server` (e.g. `http://base-da-server:2583`).
     pub fn new(server: Url) -> Result<Self, ClientError> {
-        let mut put_url = server;
+        let mut base = server;
+        base.set_query(None);
+        base.set_fragment(None);
+        let mut put_url = base.clone();
         put_url.set_path("put");
-        put_url.set_query(None);
-        put_url.set_fragment(None);
         let http = reqwest::Client::builder().timeout(Duration::from_secs(60)).build()?;
-        Ok(Self { put_url, http })
+        Ok(Self { base, put_url, http })
+    }
+
+    /// Fetch the batch bytes stored under `commitment` (the `GET /get/0x…` endpoint).
+    ///
+    /// Returns [`ClientError::NotFound`] when the DA server has no object for the
+    /// commitment, so derivation can distinguish a missing object from a transport error.
+    pub async fn get(&self, commitment: &[u8]) -> Result<Vec<u8>, ClientError> {
+        let mut url = self.base.clone();
+        url.set_path(&format!("get/0x{}", hex::encode(commitment)));
+
+        let resp = self.http.get(url).send().await?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(ClientError::NotFound);
+        }
+        if !status.is_success() {
+            let mut detail = read_bounded_error_body(resp).await?;
+            if detail.is_empty() {
+                detail = "(no response body)".into();
+            }
+            return Err(ClientError::UnexpectedStatus { status: status.as_u16(), detail });
+        }
+
+        if let Some(len) = resp.content_length()
+            && len as usize > crate::MAX_OBJECT_BYTES
+        {
+            return Err(ClientError::ResponseTooLarge {
+                size: len as usize,
+                max: crate::MAX_OBJECT_BYTES,
+            });
+        }
+
+        let mut bytes = Vec::new();
+        let mut response = resp;
+        while let Some(chunk) = response.chunk().await? {
+            if bytes.len() + chunk.len() > crate::MAX_OBJECT_BYTES {
+                return Err(ClientError::ResponseTooLarge {
+                    size: bytes.len() + chunk.len(),
+                    max: crate::MAX_OBJECT_BYTES,
+                });
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
     }
 
     /// Upload batch bytes; returns the server-generated generic commitment.
@@ -130,6 +178,25 @@ mod tests {
         let client = Client::new(url).unwrap();
         let err = client.put(&[]).await.unwrap_err();
         assert!(matches!(err, crate::ClientError::EmptyBody));
+    }
+
+    #[tokio::test]
+    async fn put_then_get_roundtrip() {
+        let (url, _dir) = spawn_test_server().await;
+        let client = Client::new(url).unwrap();
+        let body = b"hello-batch-bytes";
+        let commitment = client.put(body).await.unwrap();
+        let fetched = client.get(&commitment).await.unwrap();
+        assert_eq!(fetched, body);
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_not_found() {
+        let (url, _dir) = spawn_test_server().await;
+        let client = Client::new(url).unwrap();
+        let missing = [0x01u8, 0xff, 0xaa, 0xbb];
+        let err = client.get(&missing).await.unwrap_err();
+        assert!(matches!(err, crate::ClientError::NotFound));
     }
 
     #[tokio::test]

--- a/crates/infra/alt-da/src/client.rs
+++ b/crates/infra/alt-da/src/client.rs
@@ -57,7 +57,8 @@ impl Client {
             return Err(ClientError::UnexpectedStatus { status: status.as_u16(), detail });
         }
 
-        if let Some(len) = resp.content_length()
+        let content_len = resp.content_length();
+        if let Some(len) = content_len
             && len as usize > crate::MAX_OBJECT_BYTES
         {
             return Err(ClientError::ResponseTooLarge {
@@ -66,7 +67,8 @@ impl Client {
             });
         }
 
-        let mut bytes = Vec::new();
+        // Pre-size to the Content-Length when known; it is already validated <= MAX_OBJECT_BYTES.
+        let mut bytes = Vec::with_capacity(content_len.unwrap_or(0) as usize);
         let mut response = resp;
         while let Some(chunk) = response.chunk().await? {
             if bytes.len() + chunk.len() > crate::MAX_OBJECT_BYTES {

--- a/crates/infra/alt-da/src/commitment.rs
+++ b/crates/infra/alt-da/src/commitment.rs
@@ -10,7 +10,9 @@ pub const GENERIC_COMMITMENT_TYPE: u8 = 0x01;
 /// Generic commitment sentinel byte (`0xff`).
 pub const GENERIC_COMMITMENT_SENTINEL: u8 = 0xff;
 /// Encoded generic commitment length in bytes.
-pub const GENERIC_COMMITMENT_LEN: usize = 34;
+///
+/// Single source of truth: [`base_protocol::GENERIC_COMMITMENT_LEN`].
+pub const GENERIC_COMMITMENT_LEN: usize = base_protocol::GENERIC_COMMITMENT_LEN;
 /// Max decoded commitment bytes (generic format is always 34).
 const MAX_COMMITMENT_LEN: usize = GENERIC_COMMITMENT_LEN;
 

--- a/crates/infra/alt-da/src/error.rs
+++ b/crates/infra/alt-da/src/error.rs
@@ -120,6 +120,17 @@ pub enum ClientError {
     /// PUT response had a malformed generic commitment prefix.
     #[error("alt-da put returned malformed commitment prefix")]
     InvalidCommitment,
+    /// GET found no object for the requested commitment.
+    #[error("alt-da get: commitment not found")]
+    NotFound,
+    /// GET response body exceeds [`crate::MAX_OBJECT_BYTES`].
+    #[error("alt-da get response too large: {size} bytes (max {max})")]
+    ResponseTooLarge {
+        /// Response body size in bytes.
+        size: usize,
+        /// Configured maximum object size in bytes.
+        max: usize,
+    },
 }
 
 impl From<CommitmentError> for ClientError {

--- a/crates/infra/alt-da/src/lib.rs
+++ b/crates/infra/alt-da/src/lib.rs
@@ -7,11 +7,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use base_protocol::BLOB_MAX_DATA_SIZE;
-
 /// Max batch blob bytes accepted on PUT and loaded from the backing store.
-/// Sized for eight max-size blob frames per channel submission.
-pub const MAX_OBJECT_BYTES: usize = 8 * BLOB_MAX_DATA_SIZE;
+///
+/// Single source of truth: [`base_protocol::MAX_DA_OBJECT_BYTES`].
+pub const MAX_OBJECT_BYTES: usize = base_protocol::MAX_DA_OBJECT_BYTES;
 
 mod commitment;
 pub use commitment::{


### PR DESCRIPTION
## Summary

Adds the alt-DA derivation resolver so a node reads S3 commitments back, completing the dual-write loop (PRIV-1973; closes the PRIV-1996 spike). With `--altda.da-server` set, the node resolves `0x01` commitments to off-chain batch bytes and derives purely from S3 (skipping inline calldata); unset, derivation is unchanged. Seam and integration point are documented in `l3-notes/altda-resolver-spike.md`.

Pieces:
- `base-alt-da`: `Client::get` for `GET /get/0x…`.
- `base-consensus-derive` (no_std): `AltDaCommitmentResolver` trait + `AltDaDataSource` wrapper, mirroring `BlobProvider` injection.
- `base-consensus-providers`: `HttpAltDaResolver` (reqwest) + threads an optional resolver through `OnlinePipeline`.
- `base-consensus-node` / `base-consensus-cli`: `--altda.da-server` flag wired through `RollupNodeBuilder`.

## Test plan

- `cargo test -p base-alt-da -p base-consensus-derive` (resolver + get unit tests)
- `cargo +nightly fmt --all --check`, `clippy -D warnings`, and `etc/scripts/ci/check-crate-deps.sh`
- Devnet: run a second follower with `--altda.da-server`, confirm its safe head tracks the calldata node, then disable calldata batches (PRIV-1974).

type=routine
risk=low
impact=sev5