### PR TITLE
fix: use parent timestamps for activation boundaries

### DIFF
--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -167,7 +167,7 @@ impl RecentTxScanner {
                 Batch::Single(sb) => sb.timestamp,
                 Batch::Span(sb) => sb.final_timestamp(),
             };
-            let relative = rollup_config.block_number_from_timestamp(last_timestamp);
+            let relative = rollup_config.block_number_lower_bound_from_timestamp(last_timestamp);
             let l2_block = rollup_config.genesis.l2.number + relative;
             *highest_l2 = Some(highest_l2.map_or(l2_block, |h| h.max(l2_block)));
         }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -166,6 +166,42 @@ impl EthereumHardforks for RollupConfig {
     }
 }
 
+#[derive(Clone, Copy)]
+enum UpgradeActivationLog {
+    Ecotone,
+    Fjord,
+    Granite,
+    Holocene,
+    Isthmus,
+    Jovian,
+    Azul,
+    Beryl,
+    Cobalt,
+}
+
+impl UpgradeActivationLog {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Ecotone => "ecotone",
+            Self::Fjord => "fjord",
+            Self::Granite => "granite",
+            Self::Holocene => "holocene",
+            Self::Isthmus => "isthmus",
+            Self::Jovian => "jovian",
+            Self::Azul => "azul",
+            Self::Beryl => "beryl",
+            Self::Cobalt => "cobalt",
+        }
+    }
+
+    const fn banner(self) -> Option<&'static str> {
+        match self {
+            Self::Azul => Some(RollupConfig::AZUL_ACTIVATION_BANNER),
+            _ => None,
+        }
+    }
+}
+
 macro_rules! rollup_fork_methods {
     ($(
         $active:ident,
@@ -427,45 +463,81 @@ impl RollupConfig {
     /// The activation banner for the Base Azul hardfork, printed when the first block of the fork is built or processed.
     const AZUL_ACTIVATION_BANNER: &str = include_str!("../static/azul_activation_banner.txt");
 
-    /// Logs upgrade activation when building or processing the first block of a fork.
-    pub fn log_upgrade_activation(
-        &self,
-        block_number: u64,
-        timestamp: u64,
-        parent_timestamp: Option<u64>,
-    ) {
-        let is_first = |with_parent: fn(&Self, u64, u64) -> bool,
-                        estimated: fn(&Self, u64) -> bool| {
-            parent_timestamp
-                .map(|parent| with_parent(self, timestamp, parent))
-                .unwrap_or_else(|| estimated(self, timestamp))
-        };
-
-        if is_first(Self::is_first_ecotone_block_with_parent, Self::is_first_ecotone_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating ecotone upgrade");
-        } else if is_first(Self::is_first_fjord_block_with_parent, Self::is_first_fjord_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating fjord upgrade");
-        } else if is_first(Self::is_first_granite_block_with_parent, Self::is_first_granite_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating granite upgrade");
-        } else if is_first(Self::is_first_holocene_block_with_parent, Self::is_first_holocene_block)
-        {
-            tracing::info!(target: "upgrades", block_number, "Activating holocene upgrade");
-        } else if is_first(Self::is_first_isthmus_block_with_parent, Self::is_first_isthmus_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating isthmus upgrade");
-        } else if is_first(Self::is_first_jovian_block_with_parent, Self::is_first_jovian_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating jovian upgrade");
-        } else if is_first(
-            Self::is_first_base_azul_block_with_parent,
-            Self::is_first_base_azul_block,
-        ) {
-            for line in Self::AZUL_ACTIVATION_BANNER.lines() {
+    fn emit_upgrade_activation(&self, block_number: u64, activation: UpgradeActivationLog) {
+        if let Some(banner) = activation.banner() {
+            for line in banner.lines() {
                 tracing::info!(target: "upgrades", "{line}");
             }
-            tracing::info!(target: "upgrades", block_number, "Activating azul upgrade");
-        } else if is_first(Self::is_first_beryl_block_with_parent, Self::is_first_beryl_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating beryl upgrade");
-        } else if is_first(Self::is_first_cobalt_block_with_parent, Self::is_first_cobalt_block) {
-            tracing::info!(target: "upgrades", block_number, "Activating cobalt upgrade");
+        }
+
+        tracing::info!(target: "upgrades", block_number, upgrade = activation.name(), "Activated upgrade");
+    }
+
+    fn first_upgrade_activation_estimated(&self, timestamp: u64) -> Option<UpgradeActivationLog> {
+        if self.is_first_ecotone_block(timestamp) {
+            Some(UpgradeActivationLog::Ecotone)
+        } else if self.is_first_fjord_block(timestamp) {
+            Some(UpgradeActivationLog::Fjord)
+        } else if self.is_first_granite_block(timestamp) {
+            Some(UpgradeActivationLog::Granite)
+        } else if self.is_first_holocene_block(timestamp) {
+            Some(UpgradeActivationLog::Holocene)
+        } else if self.is_first_isthmus_block(timestamp) {
+            Some(UpgradeActivationLog::Isthmus)
+        } else if self.is_first_jovian_block(timestamp) {
+            Some(UpgradeActivationLog::Jovian)
+        } else if self.is_first_base_azul_block(timestamp) {
+            Some(UpgradeActivationLog::Azul)
+        } else if self.is_first_beryl_block(timestamp) {
+            Some(UpgradeActivationLog::Beryl)
+        } else if self.is_first_cobalt_block(timestamp) {
+            Some(UpgradeActivationLog::Cobalt)
+        } else {
+            None
+        }
+    }
+
+    fn first_upgrade_activation_with_parent(
+        &self,
+        timestamp: u64,
+        parent_timestamp: u64,
+    ) -> Option<UpgradeActivationLog> {
+        if self.is_first_ecotone_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Ecotone)
+        } else if self.is_first_fjord_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Fjord)
+        } else if self.is_first_granite_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Granite)
+        } else if self.is_first_holocene_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Holocene)
+        } else if self.is_first_isthmus_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Isthmus)
+        } else if self.is_first_jovian_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Jovian)
+        } else if self.is_first_base_azul_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Azul)
+        } else if self.is_first_beryl_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Beryl)
+        } else if self.is_first_cobalt_block_with_parent(timestamp, parent_timestamp) {
+            Some(UpgradeActivationLog::Cobalt)
+        } else {
+            None
+        }
+    }
+
+    /// Logs upgrade activation when the caller knows the actual parent timestamp.
+    pub fn log_upgrade_activation(&self, block_number: u64, timestamp: u64, parent_timestamp: u64) {
+        if let Some(activation) =
+            self.first_upgrade_activation_with_parent(timestamp, parent_timestamp)
+        {
+            self.emit_upgrade_activation(block_number, activation);
+        }
+    }
+
+    /// Logs upgrade activation using block-time estimation when the parent timestamp is unknown.
+    pub fn log_upgrade_activation_estimated(&self, block_number: u64, timestamp: u64) {
+        if let Some(activation) = self.first_upgrade_activation_estimated(timestamp) {
+            self.emit_upgrade_activation(block_number, activation);
         }
     }
 }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -166,42 +166,6 @@ impl EthereumHardforks for RollupConfig {
     }
 }
 
-#[derive(Clone, Copy)]
-enum UpgradeActivationLog {
-    Ecotone,
-    Fjord,
-    Granite,
-    Holocene,
-    Isthmus,
-    Jovian,
-    Azul,
-    Beryl,
-    Cobalt,
-}
-
-impl UpgradeActivationLog {
-    const fn name(self) -> &'static str {
-        match self {
-            Self::Ecotone => "ecotone",
-            Self::Fjord => "fjord",
-            Self::Granite => "granite",
-            Self::Holocene => "holocene",
-            Self::Isthmus => "isthmus",
-            Self::Jovian => "jovian",
-            Self::Azul => "azul",
-            Self::Beryl => "beryl",
-            Self::Cobalt => "cobalt",
-        }
-    }
-
-    const fn banner(self) -> Option<&'static str> {
-        match self {
-            Self::Azul => Some(RollupConfig::AZUL_ACTIVATION_BANNER),
-            _ => None,
-        }
-    }
-}
-
 macro_rules! rollup_fork_methods {
     ($(
         $active:ident,
@@ -443,39 +407,40 @@ impl RollupConfig {
     /// The activation banner for the Base Azul hardfork, printed when the first block of the fork is built or processed.
     const AZUL_ACTIVATION_BANNER: &str = include_str!("../static/azul_activation_banner.txt");
 
-    fn emit_upgrade_activation(&self, block_number: u64, activation: UpgradeActivationLog) {
-        if let Some(banner) = activation.banner() {
+    fn emit_upgrade_activation(&self, block_number: u64, upgrade: BaseUpgrade) {
+        if let BaseUpgrade::Azul = upgrade {
+            let banner = Self::AZUL_ACTIVATION_BANNER;
             for line in banner.lines() {
                 tracing::info!(target: "upgrades", "{line}");
             }
         }
 
-        tracing::info!(target: "upgrades", block_number, upgrade = activation.name(), "Activated upgrade");
+        tracing::info!(target: "upgrades", block_number, upgrade = upgrade.contract_id(), "Activated upgrade");
     }
 
-    fn first_upgrade_activation(
+    fn first_logged_upgrade_activation(
         &self,
         timestamp: u64,
         parent_timestamp: u64,
-    ) -> Option<UpgradeActivationLog> {
+    ) -> Option<BaseUpgrade> {
         if self.is_first_ecotone_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Ecotone)
+            Some(BaseUpgrade::Ecotone)
         } else if self.is_first_fjord_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Fjord)
+            Some(BaseUpgrade::Fjord)
         } else if self.is_first_granite_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Granite)
+            Some(BaseUpgrade::Granite)
         } else if self.is_first_holocene_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Holocene)
+            Some(BaseUpgrade::Holocene)
         } else if self.is_first_isthmus_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Isthmus)
+            Some(BaseUpgrade::Isthmus)
         } else if self.is_first_jovian_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Jovian)
+            Some(BaseUpgrade::Jovian)
         } else if self.is_first_base_azul_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Azul)
+            Some(BaseUpgrade::Azul)
         } else if self.is_first_beryl_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Beryl)
+            Some(BaseUpgrade::Beryl)
         } else if self.is_first_cobalt_block(timestamp, parent_timestamp) {
-            Some(UpgradeActivationLog::Cobalt)
+            Some(BaseUpgrade::Cobalt)
         } else {
             None
         }
@@ -483,19 +448,18 @@ impl RollupConfig {
 
     /// Logs upgrade activation when the caller knows the actual parent timestamp.
     pub fn log_upgrade_activation(&self, block_number: u64, timestamp: u64, parent_timestamp: u64) {
-        if let Some(activation) = self.first_upgrade_activation(timestamp, parent_timestamp) {
-            self.emit_upgrade_activation(block_number, activation);
+        if let Some(upgrade) = self.first_logged_upgrade_activation(timestamp, parent_timestamp) {
+            self.emit_upgrade_activation(block_number, upgrade);
         }
     }
 
     /// Logs upgrade activation using block-time estimation when the parent timestamp is unknown.
     pub fn log_upgrade_activation_estimated(&self, block_number: u64, timestamp: u64) {
-        let estimated_parent_timestamp = timestamp.saturating_sub(self.block_time);
-        if let Some(activation) =
-            self.first_upgrade_activation(timestamp, estimated_parent_timestamp)
-        {
-            self.emit_upgrade_activation(block_number, activation);
-        }
+        self.log_upgrade_activation(
+            block_number,
+            timestamp,
+            timestamp.saturating_sub(self.block_time),
+        );
     }
 }
 

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -407,23 +407,9 @@ impl RollupConfig {
     /// The activation banner for the Base Azul hardfork, printed when the first block of the fork is built or processed.
     const AZUL_ACTIVATION_BANNER: &str = include_str!("../static/azul_activation_banner.txt");
 
-    fn emit_upgrade_activation(&self, block_number: u64, upgrade: BaseUpgrade) {
-        if let BaseUpgrade::Azul = upgrade {
-            let banner = Self::AZUL_ACTIVATION_BANNER;
-            for line in banner.lines() {
-                tracing::info!(target: "upgrades", "{line}");
-            }
-        }
-
-        tracing::info!(target: "upgrades", block_number, upgrade = upgrade.contract_id(), "Activated upgrade");
-    }
-
-    fn first_logged_upgrade_activation(
-        &self,
-        timestamp: u64,
-        parent_timestamp: u64,
-    ) -> Option<BaseUpgrade> {
-        if self.is_first_ecotone_block(timestamp, parent_timestamp) {
+    /// Logs upgrade activation when the caller knows the actual parent timestamp.
+    pub fn log_upgrade_activation(&self, block_number: u64, timestamp: u64, parent_timestamp: u64) {
+        let upgrade = if self.is_first_ecotone_block(timestamp, parent_timestamp) {
             Some(BaseUpgrade::Ecotone)
         } else if self.is_first_fjord_block(timestamp, parent_timestamp) {
             Some(BaseUpgrade::Fjord)
@@ -443,23 +429,19 @@ impl RollupConfig {
             Some(BaseUpgrade::Cobalt)
         } else {
             None
-        }
-    }
+        };
 
-    /// Logs upgrade activation when the caller knows the actual parent timestamp.
-    pub fn log_upgrade_activation(&self, block_number: u64, timestamp: u64, parent_timestamp: u64) {
-        if let Some(upgrade) = self.first_logged_upgrade_activation(timestamp, parent_timestamp) {
-            self.emit_upgrade_activation(block_number, upgrade);
-        }
-    }
+        let Some(upgrade) = upgrade else {
+            return;
+        };
 
-    /// Logs upgrade activation using block-time estimation when the parent timestamp is unknown.
-    pub fn log_upgrade_activation_estimated(&self, block_number: u64, timestamp: u64) {
-        self.log_upgrade_activation(
-            block_number,
-            timestamp,
-            timestamp.saturating_sub(self.block_time),
-        );
+        if let BaseUpgrade::Azul = upgrade {
+            for line in Self::AZUL_ACTIVATION_BANNER.lines() {
+                tracing::info!(target: "upgrades", "{line}");
+            }
+        }
+
+        tracing::info!(target: "upgrades", block_number, upgrade = upgrade.contract_id(), "Activated upgrade");
     }
 }
 

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -170,6 +170,7 @@ macro_rules! rollup_fork_methods {
     ($(
         $active:ident,
         $first:ident,
+        $first_with_parent:ident,
         [$($timestamp:tt)+],
         $name:literal
         $(, implies $next:ident)?;
@@ -184,6 +185,15 @@ macro_rules! rollup_fork_methods {
             pub fn $first(&self, timestamp: u64) -> bool {
                 self.$active(timestamp)
                     && !self.$active(timestamp.saturating_sub(self.block_time))
+            }
+
+            #[doc = concat!(
+                "Returns true if the block at `timestamp` is the first ",
+                $name,
+                " block when compared against the actual parent timestamp.",
+            )]
+            pub fn $first_with_parent(&self, timestamp: u64, parent_timestamp: u64) -> bool {
+                self.$active(timestamp) && !self.$active(parent_timestamp)
             }
         )*
     };
@@ -251,74 +261,87 @@ impl RollupConfig {
     rollup_fork_methods! {
         is_regolith_active,
         is_first_regolith_block,
+        is_first_regolith_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Regolith)],
         "Regolith",
         implies is_canyon_active;
 
         is_canyon_active,
         is_first_canyon_block,
+        is_first_canyon_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Canyon)],
         "Canyon",
         implies is_delta_active;
 
         is_delta_active,
         is_first_delta_block,
+        is_first_delta_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Delta)],
         "Delta",
         implies is_ecotone_active;
 
         is_ecotone_active,
         is_first_ecotone_block,
+        is_first_ecotone_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Ecotone)],
         "Ecotone",
         implies is_fjord_active;
 
         is_fjord_active,
         is_first_fjord_block,
+        is_first_fjord_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Fjord)],
         "Fjord",
         implies is_granite_active;
 
         is_granite_active,
         is_first_granite_block,
+        is_first_granite_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Granite)],
         "Granite",
         implies is_holocene_active;
 
         is_holocene_active,
         is_first_holocene_block,
+        is_first_holocene_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Holocene)],
         "Holocene",
         implies is_isthmus_active;
 
         is_pectra_blob_schedule_active,
         is_first_pectra_blob_schedule_block,
+        is_first_pectra_blob_schedule_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::PectraBlobSchedule)],
         "pectra blob schedule";
 
         is_isthmus_active,
         is_first_isthmus_block,
+        is_first_isthmus_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus)],
         "Isthmus",
         implies is_jovian_active;
 
         is_jovian_active,
         is_first_jovian_block,
+        is_first_jovian_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Jovian)],
         "Jovian";
 
         is_base_azul_active,
         is_first_base_azul_block,
+        is_first_base_azul_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Azul)],
         "Base Azul";
 
         is_beryl_active,
         is_first_beryl_block,
+        is_first_beryl_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Beryl)],
         "Beryl";
 
         is_cobalt_active,
         is_first_cobalt_block,
+        is_first_cobalt_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)],
         "Cobalt";
     }
@@ -349,12 +372,12 @@ impl RollupConfig {
             self.channel_timeout
         }
     }
-    /// Computes a block number from a timestamp, relative to the L2 genesis time and the block
-    /// time.
+    /// Computes the lower-bound block number for a timestamp, relative to the L2 genesis time and
+    /// the block time.
     ///
-    /// This function assumes that the timestamp is aligned with the block time, and uses floor
-    /// division in its computation.
-    pub const fn block_number_from_timestamp(&self, timestamp: u64) -> u64 {
+    /// This uses floor division, so multiple blocks can share the same seconds-denominated
+    /// timestamp while still mapping to the same lower bound.
+    pub const fn block_number_lower_bound_from_timestamp(&self, timestamp: u64) -> u64 {
         timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time)
     }
 
@@ -426,6 +449,37 @@ impl RollupConfig {
         } else if self.is_first_beryl_block(timestamp) {
             tracing::info!(target: "upgrades", block_number, "Activating beryl upgrade");
         } else if self.is_first_cobalt_block(timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating cobalt upgrade");
+        }
+    }
+
+    /// Logs upgrade activation when the caller knows the actual parent timestamp.
+    pub fn log_upgrade_activation_with_parent_timestamp(
+        &self,
+        block_number: u64,
+        timestamp: u64,
+        parent_timestamp: u64,
+    ) {
+        if self.is_first_ecotone_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating ecotone upgrade");
+        } else if self.is_first_fjord_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating fjord upgrade");
+        } else if self.is_first_granite_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating granite upgrade");
+        } else if self.is_first_holocene_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating holocene upgrade");
+        } else if self.is_first_isthmus_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating isthmus upgrade");
+        } else if self.is_first_jovian_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating jovian upgrade");
+        } else if self.is_first_base_azul_block_with_parent(timestamp, parent_timestamp) {
+            for line in Self::AZUL_ACTIVATION_BANNER.lines() {
+                tracing::info!(target: "upgrades", "{line}");
+            }
+            tracing::info!(target: "upgrades", block_number, "Activating azul upgrade");
+        } else if self.is_first_beryl_block_with_parent(timestamp, parent_timestamp) {
+            tracing::info!(target: "upgrades", block_number, "Activating beryl upgrade");
+        } else if self.is_first_cobalt_block_with_parent(timestamp, parent_timestamp) {
             tracing::info!(target: "upgrades", block_number, "Activating cobalt upgrade");
         }
     }
@@ -569,6 +623,56 @@ mod tests {
         assert!(!cfg.is_first_cobalt_block(128));
         assert!(cfg.is_first_cobalt_block(130));
         assert!(!cfg.is_first_cobalt_block(132));
+    }
+
+    #[test]
+    fn test_is_first_fork_block_with_parent_timestamp() {
+        let cfg = RollupConfig {
+            upgrades: UpgradeConfig {
+                regolith_time: Some(10),
+                canyon_time: Some(20),
+                delta_time: Some(30),
+                ecotone_time: Some(40),
+                fjord_time: Some(50),
+                granite_time: Some(60),
+                holocene_time: Some(70),
+                pectra_blob_schedule_time: Some(80),
+                isthmus_time: Some(90),
+                jovian_time: Some(100),
+                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: Some(130) },
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        assert!(cfg.is_first_regolith_block_with_parent(10, 8));
+        assert!(cfg.is_first_canyon_block_with_parent(20, 18));
+        assert!(cfg.is_first_delta_block_with_parent(30, 28));
+        assert!(cfg.is_first_ecotone_block_with_parent(40, 38));
+        assert!(cfg.is_first_fjord_block_with_parent(50, 48));
+        assert!(cfg.is_first_granite_block_with_parent(60, 58));
+        assert!(cfg.is_first_holocene_block_with_parent(70, 68));
+        assert!(cfg.is_first_pectra_blob_schedule_block_with_parent(80, 78));
+        assert!(cfg.is_first_isthmus_block_with_parent(90, 88));
+        assert!(cfg.is_first_jovian_block_with_parent(100, 98));
+        assert!(cfg.is_first_base_azul_block_with_parent(110, 108));
+        assert!(cfg.is_first_beryl_block_with_parent(120, 118));
+        assert!(cfg.is_first_cobalt_block_with_parent(130, 128));
+    }
+
+    #[test]
+    fn test_first_beryl_block_with_parent_timestamp_handles_same_second_boundary() {
+        let cfg = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: None },
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        assert!(cfg.is_first_beryl_block_with_parent(120, 118));
+        assert!(!cfg.is_first_beryl_block_with_parent(120, 120));
     }
 
     #[test]
@@ -910,14 +1014,14 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_block_number_from_time() {
+    fn test_compute_block_number_lower_bound_from_time() {
         let cfg = RollupConfig {
             genesis: ChainGenesis { l2_time: 10, ..Default::default() },
             block_time: 2,
             ..Default::default()
         };
 
-        assert_eq!(cfg.block_number_from_timestamp(20), 5);
-        assert_eq!(cfg.block_number_from_timestamp(30), 10);
+        assert_eq!(cfg.block_number_lower_bound_from_timestamp(20), 5);
+        assert_eq!(cfg.block_number_lower_bound_from_timestamp(30), 10);
     }
 }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -206,7 +206,6 @@ macro_rules! rollup_fork_methods {
     ($(
         $active:ident,
         $first:ident,
-        $first_with_parent:ident,
         [$($timestamp:tt)+],
         $name:literal
         $(, implies $next:ident)?;
@@ -217,18 +216,12 @@ macro_rules! rollup_fork_methods {
                 self.$($timestamp)+.is_some_and(|t| timestamp >= t) $(|| self.$next(timestamp))?
             }
 
-            #[doc = concat!("Returns true if the timestamp marks the first ", $name, " block.")]
-            pub fn $first(&self, timestamp: u64) -> bool {
-                self.$active(timestamp)
-                    && !self.$active(timestamp.saturating_sub(self.block_time))
-            }
-
             #[doc = concat!(
                 "Returns true if the block at `timestamp` is the first ",
                 $name,
-                " block when compared against the actual parent timestamp.",
+                " block when compared against the parent timestamp.",
             )]
-            pub fn $first_with_parent(&self, timestamp: u64, parent_timestamp: u64) -> bool {
+            pub fn $first(&self, timestamp: u64, parent_timestamp: u64) -> bool {
                 self.$active(timestamp) && !self.$active(parent_timestamp)
             }
         )*
@@ -297,87 +290,74 @@ impl RollupConfig {
     rollup_fork_methods! {
         is_regolith_active,
         is_first_regolith_block,
-        is_first_regolith_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Regolith)],
         "Regolith",
         implies is_canyon_active;
 
         is_canyon_active,
         is_first_canyon_block,
-        is_first_canyon_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Canyon)],
         "Canyon",
         implies is_delta_active;
 
         is_delta_active,
         is_first_delta_block,
-        is_first_delta_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Delta)],
         "Delta",
         implies is_ecotone_active;
 
         is_ecotone_active,
         is_first_ecotone_block,
-        is_first_ecotone_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Ecotone)],
         "Ecotone",
         implies is_fjord_active;
 
         is_fjord_active,
         is_first_fjord_block,
-        is_first_fjord_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Fjord)],
         "Fjord",
         implies is_granite_active;
 
         is_granite_active,
         is_first_granite_block,
-        is_first_granite_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Granite)],
         "Granite",
         implies is_holocene_active;
 
         is_holocene_active,
         is_first_holocene_block,
-        is_first_holocene_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Holocene)],
         "Holocene",
         implies is_isthmus_active;
 
         is_pectra_blob_schedule_active,
         is_first_pectra_blob_schedule_block,
-        is_first_pectra_blob_schedule_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::PectraBlobSchedule)],
         "pectra blob schedule";
 
         is_isthmus_active,
         is_first_isthmus_block,
-        is_first_isthmus_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Isthmus)],
         "Isthmus",
         implies is_jovian_active;
 
         is_jovian_active,
         is_first_jovian_block,
-        is_first_jovian_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Jovian)],
         "Jovian";
 
         is_base_azul_active,
         is_first_base_azul_block,
-        is_first_base_azul_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Azul)],
         "Base Azul";
 
         is_beryl_active,
         is_first_beryl_block,
-        is_first_beryl_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Beryl)],
         "Beryl";
 
         is_cobalt_active,
         is_first_cobalt_block,
-        is_first_cobalt_block_with_parent,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)],
         "Cobalt";
     }
@@ -473,52 +453,28 @@ impl RollupConfig {
         tracing::info!(target: "upgrades", block_number, upgrade = activation.name(), "Activated upgrade");
     }
 
-    fn first_upgrade_activation_estimated(&self, timestamp: u64) -> Option<UpgradeActivationLog> {
-        if self.is_first_ecotone_block(timestamp) {
-            Some(UpgradeActivationLog::Ecotone)
-        } else if self.is_first_fjord_block(timestamp) {
-            Some(UpgradeActivationLog::Fjord)
-        } else if self.is_first_granite_block(timestamp) {
-            Some(UpgradeActivationLog::Granite)
-        } else if self.is_first_holocene_block(timestamp) {
-            Some(UpgradeActivationLog::Holocene)
-        } else if self.is_first_isthmus_block(timestamp) {
-            Some(UpgradeActivationLog::Isthmus)
-        } else if self.is_first_jovian_block(timestamp) {
-            Some(UpgradeActivationLog::Jovian)
-        } else if self.is_first_base_azul_block(timestamp) {
-            Some(UpgradeActivationLog::Azul)
-        } else if self.is_first_beryl_block(timestamp) {
-            Some(UpgradeActivationLog::Beryl)
-        } else if self.is_first_cobalt_block(timestamp) {
-            Some(UpgradeActivationLog::Cobalt)
-        } else {
-            None
-        }
-    }
-
-    fn first_upgrade_activation_with_parent(
+    fn first_upgrade_activation(
         &self,
         timestamp: u64,
         parent_timestamp: u64,
     ) -> Option<UpgradeActivationLog> {
-        if self.is_first_ecotone_block_with_parent(timestamp, parent_timestamp) {
+        if self.is_first_ecotone_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Ecotone)
-        } else if self.is_first_fjord_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_fjord_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Fjord)
-        } else if self.is_first_granite_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_granite_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Granite)
-        } else if self.is_first_holocene_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_holocene_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Holocene)
-        } else if self.is_first_isthmus_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_isthmus_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Isthmus)
-        } else if self.is_first_jovian_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_jovian_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Jovian)
-        } else if self.is_first_base_azul_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_base_azul_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Azul)
-        } else if self.is_first_beryl_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_beryl_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Beryl)
-        } else if self.is_first_cobalt_block_with_parent(timestamp, parent_timestamp) {
+        } else if self.is_first_cobalt_block(timestamp, parent_timestamp) {
             Some(UpgradeActivationLog::Cobalt)
         } else {
             None
@@ -527,16 +483,17 @@ impl RollupConfig {
 
     /// Logs upgrade activation when the caller knows the actual parent timestamp.
     pub fn log_upgrade_activation(&self, block_number: u64, timestamp: u64, parent_timestamp: u64) {
-        if let Some(activation) =
-            self.first_upgrade_activation_with_parent(timestamp, parent_timestamp)
-        {
+        if let Some(activation) = self.first_upgrade_activation(timestamp, parent_timestamp) {
             self.emit_upgrade_activation(block_number, activation);
         }
     }
 
     /// Logs upgrade activation using block-time estimation when the parent timestamp is unknown.
     pub fn log_upgrade_activation_estimated(&self, block_number: u64, timestamp: u64) {
-        if let Some(activation) = self.first_upgrade_activation_estimated(timestamp) {
+        let estimated_parent_timestamp = timestamp.saturating_sub(self.block_time);
+        if let Some(activation) =
+            self.first_upgrade_activation(timestamp, estimated_parent_timestamp)
+        {
             self.emit_upgrade_activation(block_number, activation);
         }
     }
@@ -617,108 +574,73 @@ mod tests {
         };
 
         // Regolith
-        assert!(!cfg.is_first_regolith_block(8));
-        assert!(cfg.is_first_regolith_block(10));
-        assert!(!cfg.is_first_regolith_block(12));
+        assert!(!cfg.is_first_regolith_block(8, 6));
+        assert!(cfg.is_first_regolith_block(10, 8));
+        assert!(!cfg.is_first_regolith_block(12, 10));
 
         // Canyon
-        assert!(!cfg.is_first_canyon_block(18));
-        assert!(cfg.is_first_canyon_block(20));
-        assert!(!cfg.is_first_canyon_block(22));
+        assert!(!cfg.is_first_canyon_block(18, 16));
+        assert!(cfg.is_first_canyon_block(20, 18));
+        assert!(!cfg.is_first_canyon_block(22, 20));
 
         // Delta
-        assert!(!cfg.is_first_delta_block(28));
-        assert!(cfg.is_first_delta_block(30));
-        assert!(!cfg.is_first_delta_block(32));
+        assert!(!cfg.is_first_delta_block(28, 26));
+        assert!(cfg.is_first_delta_block(30, 28));
+        assert!(!cfg.is_first_delta_block(32, 30));
 
         // Ecotone
-        assert!(!cfg.is_first_ecotone_block(38));
-        assert!(cfg.is_first_ecotone_block(40));
-        assert!(!cfg.is_first_ecotone_block(42));
+        assert!(!cfg.is_first_ecotone_block(38, 36));
+        assert!(cfg.is_first_ecotone_block(40, 38));
+        assert!(!cfg.is_first_ecotone_block(42, 40));
 
         // Fjord
-        assert!(!cfg.is_first_fjord_block(48));
-        assert!(cfg.is_first_fjord_block(50));
-        assert!(!cfg.is_first_fjord_block(52));
+        assert!(!cfg.is_first_fjord_block(48, 46));
+        assert!(cfg.is_first_fjord_block(50, 48));
+        assert!(!cfg.is_first_fjord_block(52, 50));
 
         // Granite
-        assert!(!cfg.is_first_granite_block(58));
-        assert!(cfg.is_first_granite_block(60));
-        assert!(!cfg.is_first_granite_block(62));
+        assert!(!cfg.is_first_granite_block(58, 56));
+        assert!(cfg.is_first_granite_block(60, 58));
+        assert!(!cfg.is_first_granite_block(62, 60));
 
         // Holocene
-        assert!(!cfg.is_first_holocene_block(68));
-        assert!(cfg.is_first_holocene_block(70));
-        assert!(!cfg.is_first_holocene_block(72));
+        assert!(!cfg.is_first_holocene_block(68, 66));
+        assert!(cfg.is_first_holocene_block(70, 68));
+        assert!(!cfg.is_first_holocene_block(72, 70));
 
         // Pectra blob schedule
-        assert!(!cfg.is_first_pectra_blob_schedule_block(78));
-        assert!(cfg.is_first_pectra_blob_schedule_block(80));
-        assert!(!cfg.is_first_pectra_blob_schedule_block(82));
+        assert!(!cfg.is_first_pectra_blob_schedule_block(78, 76));
+        assert!(cfg.is_first_pectra_blob_schedule_block(80, 78));
+        assert!(!cfg.is_first_pectra_blob_schedule_block(82, 80));
 
         // Isthmus
-        assert!(!cfg.is_first_isthmus_block(88));
-        assert!(cfg.is_first_isthmus_block(90));
-        assert!(!cfg.is_first_isthmus_block(92));
+        assert!(!cfg.is_first_isthmus_block(88, 86));
+        assert!(cfg.is_first_isthmus_block(90, 88));
+        assert!(!cfg.is_first_isthmus_block(92, 90));
 
         // Jovian
-        assert!(!cfg.is_first_jovian_block(98));
-        assert!(cfg.is_first_jovian_block(100));
-        assert!(!cfg.is_first_jovian_block(102));
+        assert!(!cfg.is_first_jovian_block(98, 96));
+        assert!(cfg.is_first_jovian_block(100, 98));
+        assert!(!cfg.is_first_jovian_block(102, 100));
 
         // Base Azul
-        assert!(!cfg.is_first_base_azul_block(108));
-        assert!(cfg.is_first_base_azul_block(110));
-        assert!(!cfg.is_first_base_azul_block(112));
+        assert!(!cfg.is_first_base_azul_block(108, 106));
+        assert!(cfg.is_first_base_azul_block(110, 108));
+        assert!(!cfg.is_first_base_azul_block(112, 110));
 
         // Beryl
-        assert!(!cfg.is_first_beryl_block(118));
-        assert!(cfg.is_first_beryl_block(120));
-        assert!(!cfg.is_first_beryl_block(122));
+        assert!(!cfg.is_first_beryl_block(118, 116));
+        assert!(cfg.is_first_beryl_block(120, 118));
+        assert!(!cfg.is_first_beryl_block(122, 120));
 
         // Cobalt
-        assert!(!cfg.is_first_cobalt_block(128));
-        assert!(cfg.is_first_cobalt_block(130));
-        assert!(!cfg.is_first_cobalt_block(132));
+        assert!(!cfg.is_first_cobalt_block(128, 126));
+        assert!(cfg.is_first_cobalt_block(130, 128));
+        assert!(!cfg.is_first_cobalt_block(132, 130));
     }
 
     #[test]
-    fn test_is_first_fork_block_with_parent_timestamp() {
-        let cfg = RollupConfig {
-            upgrades: UpgradeConfig {
-                regolith_time: Some(10),
-                canyon_time: Some(20),
-                delta_time: Some(30),
-                ecotone_time: Some(40),
-                fjord_time: Some(50),
-                granite_time: Some(60),
-                holocene_time: Some(70),
-                pectra_blob_schedule_time: Some(80),
-                isthmus_time: Some(90),
-                jovian_time: Some(100),
-                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: Some(130) },
-            },
-            block_time: 2,
-            ..Default::default()
-        };
-
-        assert!(cfg.is_first_regolith_block_with_parent(10, 8));
-        assert!(cfg.is_first_canyon_block_with_parent(20, 18));
-        assert!(cfg.is_first_delta_block_with_parent(30, 28));
-        assert!(cfg.is_first_ecotone_block_with_parent(40, 38));
-        assert!(cfg.is_first_fjord_block_with_parent(50, 48));
-        assert!(cfg.is_first_granite_block_with_parent(60, 58));
-        assert!(cfg.is_first_holocene_block_with_parent(70, 68));
-        assert!(cfg.is_first_pectra_blob_schedule_block_with_parent(80, 78));
-        assert!(cfg.is_first_isthmus_block_with_parent(90, 88));
-        assert!(cfg.is_first_jovian_block_with_parent(100, 98));
-        assert!(cfg.is_first_base_azul_block_with_parent(110, 108));
-        assert!(cfg.is_first_beryl_block_with_parent(120, 118));
-        assert!(cfg.is_first_cobalt_block_with_parent(130, 128));
-    }
-
-    #[test]
-    fn test_first_beryl_block_with_parent_timestamp_handles_same_second_boundary() {
+    fn test_first_beryl_block_handles_same_second_boundary() {
         let cfg = RollupConfig {
             upgrades: UpgradeConfig {
                 base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: None },
@@ -728,8 +650,8 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(cfg.is_first_beryl_block_with_parent(120, 118));
-        assert!(!cfg.is_first_beryl_block_with_parent(120, 120));
+        assert!(cfg.is_first_beryl_block(120, 118));
+        assert!(!cfg.is_first_beryl_block(120, 120));
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -428,58 +428,43 @@ impl RollupConfig {
     const AZUL_ACTIVATION_BANNER: &str = include_str!("../static/azul_activation_banner.txt");
 
     /// Logs upgrade activation when building or processing the first block of a fork.
-    pub fn log_upgrade_activation(&self, block_number: u64, timestamp: u64) {
-        if self.is_first_ecotone_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating ecotone upgrade");
-        } else if self.is_first_fjord_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating fjord upgrade");
-        } else if self.is_first_granite_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating granite upgrade");
-        } else if self.is_first_holocene_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating holocene upgrade");
-        } else if self.is_first_isthmus_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating isthmus upgrade");
-        } else if self.is_first_jovian_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating jovian upgrade");
-        } else if self.is_first_base_azul_block(timestamp) {
-            for line in Self::AZUL_ACTIVATION_BANNER.lines() {
-                tracing::info!(target: "upgrades", "{line}");
-            }
-            tracing::info!(target: "upgrades", block_number, "Activating azul upgrade");
-        } else if self.is_first_beryl_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating beryl upgrade");
-        } else if self.is_first_cobalt_block(timestamp) {
-            tracing::info!(target: "upgrades", block_number, "Activating cobalt upgrade");
-        }
-    }
-
-    /// Logs upgrade activation when the caller knows the actual parent timestamp.
-    pub fn log_upgrade_activation_with_parent_timestamp(
+    pub fn log_upgrade_activation(
         &self,
         block_number: u64,
         timestamp: u64,
-        parent_timestamp: u64,
+        parent_timestamp: Option<u64>,
     ) {
-        if self.is_first_ecotone_block_with_parent(timestamp, parent_timestamp) {
+        let is_first = |with_parent: fn(&Self, u64, u64) -> bool,
+                        estimated: fn(&Self, u64) -> bool| {
+            parent_timestamp
+                .map(|parent| with_parent(self, timestamp, parent))
+                .unwrap_or_else(|| estimated(self, timestamp))
+        };
+
+        if is_first(Self::is_first_ecotone_block_with_parent, Self::is_first_ecotone_block) {
             tracing::info!(target: "upgrades", block_number, "Activating ecotone upgrade");
-        } else if self.is_first_fjord_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_fjord_block_with_parent, Self::is_first_fjord_block) {
             tracing::info!(target: "upgrades", block_number, "Activating fjord upgrade");
-        } else if self.is_first_granite_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_granite_block_with_parent, Self::is_first_granite_block) {
             tracing::info!(target: "upgrades", block_number, "Activating granite upgrade");
-        } else if self.is_first_holocene_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_holocene_block_with_parent, Self::is_first_holocene_block)
+        {
             tracing::info!(target: "upgrades", block_number, "Activating holocene upgrade");
-        } else if self.is_first_isthmus_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_isthmus_block_with_parent, Self::is_first_isthmus_block) {
             tracing::info!(target: "upgrades", block_number, "Activating isthmus upgrade");
-        } else if self.is_first_jovian_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_jovian_block_with_parent, Self::is_first_jovian_block) {
             tracing::info!(target: "upgrades", block_number, "Activating jovian upgrade");
-        } else if self.is_first_base_azul_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(
+            Self::is_first_base_azul_block_with_parent,
+            Self::is_first_base_azul_block,
+        ) {
             for line in Self::AZUL_ACTIVATION_BANNER.lines() {
                 tracing::info!(target: "upgrades", "{line}");
             }
             tracing::info!(target: "upgrades", block_number, "Activating azul upgrade");
-        } else if self.is_first_beryl_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_beryl_block_with_parent, Self::is_first_beryl_block) {
             tracing::info!(target: "upgrades", block_number, "Activating beryl upgrade");
-        } else if self.is_first_cobalt_block_with_parent(timestamp, parent_timestamp) {
+        } else if is_first(Self::is_first_cobalt_block_with_parent, Self::is_first_cobalt_block) {
             tracing::info!(target: "upgrades", block_number, "Activating cobalt upgrade");
         }
     }

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -171,6 +171,7 @@ where
             &sys_config,
             sequence_number,
             &l1_header,
+            l2_parent.block_info.timestamp,
             next_l2_time,
         )
         .map_err(|e| {

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -157,7 +157,9 @@ impl SingleBatch {
 
         // If this is the first block in the jovian upgrade, and the batch contains any
         // transactions, it must be dropped.
-        if cfg.is_first_jovian_block(self.timestamp) && !self.transactions.is_empty() {
+        if cfg.is_first_jovian_block_with_parent(self.timestamp, l2_safe_head.block_info.timestamp)
+            && !self.transactions.is_empty()
+        {
             warn!(
                 target: "single_batch",
                 "Sequencer included user transactions in jovian transition block. Dropping batch."

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -157,7 +157,7 @@ impl SingleBatch {
 
         // If this is the first block in the jovian upgrade, and the batch contains any
         // transactions, it must be dropped.
-        if cfg.is_first_jovian_block(self.timestamp, self.timestamp.saturating_sub(cfg.block_time))
+        if cfg.is_first_jovian_block(self.timestamp, l2_safe_head.block_info.timestamp)
             && !self.transactions.is_empty()
         {
             warn!(

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -157,9 +157,7 @@ impl SingleBatch {
 
         // If this is the first block in the jovian upgrade, and the batch contains any
         // transactions, it must be dropped.
-        if cfg.is_first_jovian_block_with_parent(self.timestamp, l2_safe_head.block_info.timestamp)
-            && !self.transactions.is_empty()
-        {
+        if cfg.is_first_jovian_block(self.timestamp) && !self.transactions.is_empty() {
             warn!(
                 target: "single_batch",
                 "Sequencer included user transactions in jovian transition block. Dropping batch."

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -157,7 +157,9 @@ impl SingleBatch {
 
         // If this is the first block in the jovian upgrade, and the batch contains any
         // transactions, it must be dropped.
-        if cfg.is_first_jovian_block(self.timestamp) && !self.transactions.is_empty() {
+        if cfg.is_first_jovian_block(self.timestamp, self.timestamp.saturating_sub(cfg.block_time))
+            && !self.transactions.is_empty()
+        {
             warn!(
                 target: "single_batch",
                 "Sequencer included user transactions in jovian transition block. Dropping batch."

--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -55,7 +55,7 @@ impl L1BlockInfoTx {
         // upgrade transactions being placed after the L1 info transaction. Because of this,
         // for the first block of Ecotone, we send a Bedrock style L1 block info transaction
         if !rollup_config.is_ecotone_active(l2_block_time)
-            || rollup_config.is_first_ecotone_block_with_parent(l2_block_time, l2_parent_block_time)
+            || rollup_config.is_first_ecotone_block(l2_block_time, l2_parent_block_time)
         {
             return Ok(Self::Bedrock(L1BlockInfoBedrock::new(
                 l1_header.number,
@@ -118,7 +118,7 @@ impl L1BlockInfoTx {
         let base_fee = l1_header.base_fee_per_gas.unwrap_or(0);
 
         if rollup_config.is_jovian_active(l2_block_time)
-            && !rollup_config.is_first_jovian_block_with_parent(l2_block_time, l2_parent_block_time)
+            && !rollup_config.is_first_jovian_block(l2_block_time, l2_parent_block_time)
         {
             let operator_fee_scalar = system_config.operator_fee_scalar.unwrap_or_default();
             let operator_fee_constant = system_config.operator_fee_constant.unwrap_or_default();
@@ -147,8 +147,7 @@ impl L1BlockInfoTx {
         }
 
         if rollup_config.is_isthmus_active(l2_block_time)
-            && !rollup_config
-                .is_first_isthmus_block_with_parent(l2_block_time, l2_parent_block_time)
+            && !rollup_config.is_first_isthmus_block(l2_block_time, l2_parent_block_time)
         {
             let operator_fee_scalar = system_config.operator_fee_scalar.unwrap_or_default();
             let operator_fee_constant = system_config.operator_fee_constant.unwrap_or_default();

--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -48,13 +48,14 @@ impl L1BlockInfoTx {
         system_config: &SystemConfig,
         sequence_number: u64,
         l1_header: &Header,
+        l2_parent_block_time: u64,
         l2_block_time: u64,
     ) -> Result<Self, BlockInfoError> {
         // In the first block of Ecotone, the L1Block contract has not been upgraded yet due to the
         // upgrade transactions being placed after the L1 info transaction. Because of this,
         // for the first block of Ecotone, we send a Bedrock style L1 block info transaction
         if !rollup_config.is_ecotone_active(l2_block_time)
-            || rollup_config.is_first_ecotone_block(l2_block_time)
+            || rollup_config.is_first_ecotone_block_with_parent(l2_block_time, l2_parent_block_time)
         {
             return Ok(Self::Bedrock(L1BlockInfoBedrock::new(
                 l1_header.number,
@@ -117,7 +118,7 @@ impl L1BlockInfoTx {
         let base_fee = l1_header.base_fee_per_gas.unwrap_or(0);
 
         if rollup_config.is_jovian_active(l2_block_time)
-            && !rollup_config.is_first_jovian_block(l2_block_time)
+            && !rollup_config.is_first_jovian_block_with_parent(l2_block_time, l2_parent_block_time)
         {
             let operator_fee_scalar = system_config.operator_fee_scalar.unwrap_or_default();
             let operator_fee_constant = system_config.operator_fee_constant.unwrap_or_default();
@@ -146,7 +147,8 @@ impl L1BlockInfoTx {
         }
 
         if rollup_config.is_isthmus_active(l2_block_time)
-            && !rollup_config.is_first_isthmus_block(l2_block_time)
+            && !rollup_config
+                .is_first_isthmus_block_with_parent(l2_block_time, l2_parent_block_time)
         {
             let operator_fee_scalar = system_config.operator_fee_scalar.unwrap_or_default();
             let operator_fee_constant = system_config.operator_fee_constant.unwrap_or_default();
@@ -188,6 +190,7 @@ impl L1BlockInfoTx {
         system_config: &SystemConfig,
         sequence_number: u64,
         l1_header: &Header,
+        l2_parent_block_time: u64,
         l2_block_time: u64,
     ) -> Result<(Self, Sealed<TxDeposit>), BlockInfoError> {
         let l1_info = Self::try_new(
@@ -196,6 +199,7 @@ impl L1BlockInfoTx {
             system_config,
             sequence_number,
             l1_header,
+            l2_parent_block_time,
             l2_block_time,
         )?;
 
@@ -720,7 +724,7 @@ mod tests {
         let system_config = SystemConfig::default();
         let sequence_number = 0;
         let l1_header = Header::default();
-        let l2_block_time = 0;
+        let l2_block_time = 0u64;
 
         let l1_info = L1BlockInfoTx::try_new(
             &rollup_config,
@@ -728,6 +732,7 @@ mod tests {
             &system_config,
             sequence_number,
             &l1_header,
+            l2_block_time.saturating_sub(2),
             l2_block_time,
         )
         .unwrap();
@@ -756,7 +761,7 @@ mod tests {
         let system_config = SystemConfig::default();
         let sequence_number = 0;
         let l1_header = Header::default();
-        let l2_block_time = 0xFF;
+        let l2_block_time = 0xFFu64;
 
         let l1_info = L1BlockInfoTx::try_new(
             &rollup_config,
@@ -764,6 +769,7 @@ mod tests {
             &system_config,
             sequence_number,
             &l1_header,
+            l2_block_time.saturating_sub(2),
             l2_block_time,
         )
         .unwrap();
@@ -794,6 +800,32 @@ mod tests {
             u32::from_be_bytes(scalar[28..32].try_into().expect("Failed to parse base fee scalar"));
         assert_eq!(l1_info.blob_base_fee_scalar(), blob_base_fee_scalar);
         assert_eq!(l1_info.base_fee_scalar(), base_fee_scalar);
+    }
+
+    #[test]
+    fn test_try_new_ecotone_same_second_boundary_uses_parent_timestamp() {
+        let l2_block_time = 0xFFu64;
+        let rollup_config = RollupConfig {
+            upgrades: UpgradeConfig { ecotone_time: Some(l2_block_time), ..Default::default() },
+            ..Default::default()
+        };
+        let l1_config = Sepolia::l1_config();
+        let system_config = SystemConfig::default();
+        let sequence_number = 0;
+        let l1_header = Header::default();
+
+        let l1_info = L1BlockInfoTx::try_new(
+            &rollup_config,
+            &l1_config,
+            &system_config,
+            sequence_number,
+            &l1_header,
+            l2_block_time,
+            l2_block_time,
+        )
+        .unwrap();
+
+        assert!(matches!(l1_info, L1BlockInfoTx::Ecotone(_)));
     }
 
     #[rstest]
@@ -827,7 +859,7 @@ mod tests {
             requests_hash: Some(B256::ZERO),
             ..Default::default()
         };
-        let l2_block_time = 0xFF;
+        let l2_block_time = 0xFFu64;
 
         let l1_info = L1BlockInfoTx::try_new(
             &rollup_config,
@@ -835,6 +867,7 @@ mod tests {
             &system_config,
             sequence_number,
             &l1_header,
+            l2_block_time.saturating_sub(2),
             l2_block_time,
         )
         .unwrap();
@@ -902,7 +935,7 @@ mod tests {
             requests_hash: Some(B256::ZERO),
             ..Default::default()
         };
-        let l2_block_time = 0xFF;
+        let l2_block_time = 0xFFu64;
 
         let l1_info = L1BlockInfoTx::try_new(
             &rollup_config,
@@ -910,6 +943,7 @@ mod tests {
             &system_config,
             sequence_number,
             &l1_header,
+            l2_block_time.saturating_sub(2),
             l2_block_time,
         )
         .unwrap();
@@ -969,7 +1003,7 @@ mod tests {
             base_fee_per_gas: Some(10445852825),
             ..Default::default()
         };
-        let l2_block_time = 0xFF;
+        let l2_block_time = 0xFFu64;
 
         let l1_info = L1BlockInfoTx::try_new(
             &rollup_config,
@@ -977,6 +1011,7 @@ mod tests {
             &system_config,
             sequence_number,
             &l1_header,
+            l2_block_time.saturating_sub(2),
             l2_block_time,
         )
         .unwrap();
@@ -1034,7 +1069,7 @@ mod tests {
             base_fee_per_gas: Some(10445852825),
             ..Default::default()
         };
-        let l2_block_time = 0xFF;
+        let l2_block_time = 0xFFu64;
 
         let (l1_info, deposit_tx) = L1BlockInfoTx::try_new_with_deposit_tx(
             &rollup_config,
@@ -1042,6 +1077,7 @@ mod tests {
             &system_config,
             sequence_number,
             &l1_header,
+            l2_block_time.saturating_sub(2),
             l2_block_time,
         )
         .unwrap();

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -459,9 +459,10 @@ where
             return;
         }
 
-        self.rollup.log_upgrade_activation_estimated(
+        self.rollup.log_upgrade_activation(
             envelope.execution_payload.block_number(),
             envelope.execution_payload.timestamp(),
+            envelope.execution_payload.timestamp().saturating_sub(self.rollup.block_time),
         );
     }
 

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -459,10 +459,9 @@ where
             return;
         }
 
-        self.rollup.log_upgrade_activation(
+        self.rollup.log_upgrade_activation_estimated(
             envelope.execution_payload.block_number(),
             envelope.execution_payload.timestamp(),
-            None,
         );
     }
 

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -462,6 +462,7 @@ where
         self.rollup.log_upgrade_activation(
             envelope.execution_payload.block_number(),
             envelope.execution_payload.timestamp(),
+            None,
         );
     }
 

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -199,13 +199,18 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             }
         };
 
-        self.rollup_config.log_upgrade_activation(
+        self.rollup_config.log_upgrade_activation_with_parent_timestamp(
             unsafe_head.block_info.number.saturating_add(1),
             attributes.payload_attributes.timestamp,
+            unsafe_head.block_info.timestamp,
         );
         let activator = PoolActivation::new(Arc::clone(&self.rollup_config));
-        attributes.no_tx_pool =
-            Some(!activator.is_enabled(self.recovery_mode.get(), l1_origin, &attributes));
+        attributes.no_tx_pool = Some(!activator.is_enabled(
+            self.recovery_mode.get(),
+            l1_origin,
+            unsafe_head.block_info.timestamp,
+            &attributes,
+        ));
 
         let attrs_with_parent = AttributesWithParent::new(attributes, unsafe_head, None, false);
         Ok(Some(attrs_with_parent))

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -199,10 +199,10 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             }
         };
 
-        self.rollup_config.log_upgrade_activation_with_parent_timestamp(
+        self.rollup_config.log_upgrade_activation(
             unsafe_head.block_info.number.saturating_add(1),
             attributes.payload_attributes.timestamp,
-            unsafe_head.block_info.timestamp,
+            Some(unsafe_head.block_info.timestamp),
         );
         let activator = PoolActivation::new(Arc::clone(&self.rollup_config));
         attributes.no_tx_pool = Some(!activator.is_enabled(

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -202,7 +202,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         self.rollup_config.log_upgrade_activation(
             unsafe_head.block_info.number.saturating_add(1),
             attributes.payload_attributes.timestamp,
-            Some(unsafe_head.block_info.timestamp),
+            unsafe_head.block_info.timestamp,
         );
         let activator = PoolActivation::new(Arc::clone(&self.rollup_config));
         attributes.no_tx_pool = Some(!activator.is_enabled(

--- a/crates/consensus/service/src/actors/sequencer/pool.rs
+++ b/crates/consensus/service/src/actors/sequencer/pool.rs
@@ -27,6 +27,7 @@ impl PoolActivation {
         &self,
         recovery_mode: bool,
         l1_origin: BlockInfo,
+        parent_timestamp: u64,
         attributes: &BasePayloadAttributes,
     ) -> bool {
         if recovery_mode {
@@ -51,33 +52,51 @@ impl PoolActivation {
         }
 
         // Do not include transactions in the first Ecotone block.
-        if self.rollup_config.is_first_ecotone_block(attributes.payload_attributes.timestamp) {
+        if self.rollup_config.is_first_ecotone_block_with_parent(
+            attributes.payload_attributes.timestamp,
+            parent_timestamp,
+        ) {
             return false;
         }
 
         // Do not include transactions in the first Fjord block.
-        if self.rollup_config.is_first_fjord_block(attributes.payload_attributes.timestamp) {
+        if self.rollup_config.is_first_fjord_block_with_parent(
+            attributes.payload_attributes.timestamp,
+            parent_timestamp,
+        ) {
             return false;
         }
 
         // Do not include transactions in the first Granite block.
-        if self.rollup_config.is_first_granite_block(attributes.payload_attributes.timestamp) {
+        if self.rollup_config.is_first_granite_block_with_parent(
+            attributes.payload_attributes.timestamp,
+            parent_timestamp,
+        ) {
             return false;
         }
 
         // Do not include transactions in the first Holocene block.
-        if self.rollup_config.is_first_holocene_block(attributes.payload_attributes.timestamp) {
+        if self.rollup_config.is_first_holocene_block_with_parent(
+            attributes.payload_attributes.timestamp,
+            parent_timestamp,
+        ) {
             return false;
         }
 
         // Do not include transactions in the first Isthmus block.
-        if self.rollup_config.is_first_isthmus_block(attributes.payload_attributes.timestamp) {
+        if self.rollup_config.is_first_isthmus_block_with_parent(
+            attributes.payload_attributes.timestamp,
+            parent_timestamp,
+        ) {
             return false;
         }
 
         // Do not include transactions in the first Jovian block.
         // See: `<https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/derivation.md#activation-block-rules>`
-        if self.rollup_config.is_first_jovian_block(attributes.payload_attributes.timestamp) {
+        if self.rollup_config.is_first_jovian_block_with_parent(
+            attributes.payload_attributes.timestamp,
+            parent_timestamp,
+        ) {
             return false;
         }
 

--- a/crates/consensus/service/src/actors/sequencer/pool.rs
+++ b/crates/consensus/service/src/actors/sequencer/pool.rs
@@ -52,51 +52,51 @@ impl PoolActivation {
         }
 
         // Do not include transactions in the first Ecotone block.
-        if self.rollup_config.is_first_ecotone_block_with_parent(
-            attributes.payload_attributes.timestamp,
-            parent_timestamp,
-        ) {
+        if self
+            .rollup_config
+            .is_first_ecotone_block(attributes.payload_attributes.timestamp, parent_timestamp)
+        {
             return false;
         }
 
         // Do not include transactions in the first Fjord block.
-        if self.rollup_config.is_first_fjord_block_with_parent(
-            attributes.payload_attributes.timestamp,
-            parent_timestamp,
-        ) {
+        if self
+            .rollup_config
+            .is_first_fjord_block(attributes.payload_attributes.timestamp, parent_timestamp)
+        {
             return false;
         }
 
         // Do not include transactions in the first Granite block.
-        if self.rollup_config.is_first_granite_block_with_parent(
-            attributes.payload_attributes.timestamp,
-            parent_timestamp,
-        ) {
+        if self
+            .rollup_config
+            .is_first_granite_block(attributes.payload_attributes.timestamp, parent_timestamp)
+        {
             return false;
         }
 
         // Do not include transactions in the first Holocene block.
-        if self.rollup_config.is_first_holocene_block_with_parent(
-            attributes.payload_attributes.timestamp,
-            parent_timestamp,
-        ) {
+        if self
+            .rollup_config
+            .is_first_holocene_block(attributes.payload_attributes.timestamp, parent_timestamp)
+        {
             return false;
         }
 
         // Do not include transactions in the first Isthmus block.
-        if self.rollup_config.is_first_isthmus_block_with_parent(
-            attributes.payload_attributes.timestamp,
-            parent_timestamp,
-        ) {
+        if self
+            .rollup_config
+            .is_first_isthmus_block(attributes.payload_attributes.timestamp, parent_timestamp)
+        {
             return false;
         }
 
         // Do not include transactions in the first Jovian block.
         // See: `<https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/derivation.md#activation-block-rules>`
-        if self.rollup_config.is_first_jovian_block_with_parent(
-            attributes.payload_attributes.timestamp,
-            parent_timestamp,
-        ) {
+        if self
+            .rollup_config
+            .is_first_jovian_block(attributes.payload_attributes.timestamp, parent_timestamp)
+        {
             return false;
         }
 


### PR DESCRIPTION
Uses actual parent timestamps for first-block upgrade checks in the sequencing and protocol paths so activation boundaries no longer rely on reconstructing a parent with child_timestamp - block_time. It also renames the timestamp-to-block helper to make its lower-bound semantics explicit when multiple blocks can share the same second.
