### PR TITLE
feat(consensus): add Base millisecond timestamp primitives

### DIFF
--- a/crates/common/consensus/src/header.rs
+++ b/crates/common/consensus/src/header.rs
@@ -1,10 +1,13 @@
 //! Header type for Base chains.
 
 use alloc::vec::Vec;
+use core::mem;
 
-use alloy_consensus::Header;
-use alloy_primitives::{B256, Sealable, Sealed, U256, keccak256};
-use alloy_rlp::{BufMut, Encodable, length_of_length};
+use alloy_consensus::{BlockHeader as AlloyBlockHeader, Header, InMemorySize};
+use alloy_primitives::{
+    Address, B64, B256, BlockNumber, Bloom, Bytes, Sealable, Sealed, U256, keccak256,
+};
+use alloy_rlp::{BufMut, Decodable, Encodable, length_of_length};
 
 /// Number of milliseconds in one Unix timestamp second.
 pub const TIMESTAMP_MILLIS_PER_SECOND: u16 = 1_000;
@@ -56,11 +59,21 @@ pub enum TimestampMillisPartError {
 }
 
 /// Base header wrapper with an optional post-Beryl millisecond timestamp component.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+///
+/// `BaseHeader` is the canonical Base block header: it wraps the upstream Ethereum
+/// [`Header`] fields and adds an optional post-Beryl `timestamp_millis_part`
+/// committed by the header hash. When `timestamp_millis_part` is `None`, the RLP
+/// encoding, hash, and reth `Compact` bytes are byte-identical to the upstream
+/// [`Header`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BaseHeader {
     /// Standard Ethereum execution header fields.
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: Header,
     /// Post-Beryl millisecond subsecond component committed by the header hash.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub timestamp_millis_part: Option<u16>,
 }
 
@@ -167,7 +180,10 @@ impl BaseHeader {
         let mut length = base_header_payload_length(&self.inner);
 
         if let Some(timestamp_millis_part) = self.timestamp_millis_part {
-            length += timestamp_millis_part.length();
+            // The millisecond trailer is encoded as a single-element RLP list so the decoder
+            // can disambiguate it from a missing intermediate post-Bedrock optional field.
+            let inner_len = timestamp_millis_part.length();
+            length += inner_len + length_of_length(inner_len);
         }
 
         length
@@ -180,15 +196,128 @@ impl From<Header> for BaseHeader {
     }
 }
 
+impl From<BaseHeader> for Header {
+    fn from(header: BaseHeader) -> Self {
+        header.inner
+    }
+}
+
 impl AsRef<Header> for BaseHeader {
     fn as_ref(&self) -> &Header {
         &self.inner
     }
 }
 
+impl AsRef<Self> for BaseHeader {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl Sealable for BaseHeader {
     fn hash_slow(&self) -> B256 {
         Self::hash_slow(self)
+    }
+}
+
+impl InMemorySize for BaseHeader {
+    #[inline]
+    fn size(&self) -> usize {
+        self.inner.size() + mem::size_of::<Option<u16>>()
+    }
+}
+
+impl AlloyBlockHeader for BaseHeader {
+    fn parent_hash(&self) -> B256 {
+        self.inner.parent_hash()
+    }
+
+    fn ommers_hash(&self) -> B256 {
+        self.inner.ommers_hash()
+    }
+
+    fn beneficiary(&self) -> Address {
+        self.inner.beneficiary()
+    }
+
+    fn state_root(&self) -> B256 {
+        self.inner.state_root()
+    }
+
+    fn transactions_root(&self) -> B256 {
+        self.inner.transactions_root()
+    }
+
+    fn receipts_root(&self) -> B256 {
+        self.inner.receipts_root()
+    }
+
+    fn withdrawals_root(&self) -> Option<B256> {
+        self.inner.withdrawals_root()
+    }
+
+    fn logs_bloom(&self) -> Bloom {
+        self.inner.logs_bloom()
+    }
+
+    fn difficulty(&self) -> U256 {
+        self.inner.difficulty()
+    }
+
+    fn number(&self) -> BlockNumber {
+        self.inner.number()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.inner.gas_limit()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.inner.gas_used()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp()
+    }
+
+    fn mix_hash(&self) -> Option<B256> {
+        self.inner.mix_hash()
+    }
+
+    fn nonce(&self) -> Option<B64> {
+        self.inner.nonce()
+    }
+
+    fn base_fee_per_gas(&self) -> Option<u64> {
+        self.inner.base_fee_per_gas()
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        self.inner.blob_gas_used()
+    }
+
+    fn excess_blob_gas(&self) -> Option<u64> {
+        self.inner.excess_blob_gas()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.inner.parent_beacon_block_root()
+    }
+
+    fn requests_hash(&self) -> Option<B256> {
+        self.inner.requests_hash()
+    }
+
+    fn block_access_list_hash(&self) -> Option<B256> {
+        self.inner.block_access_list_hash()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number()
+    }
+
+    fn extra_data(&self) -> &Bytes {
+        self.inner.extra_data()
     }
 }
 
@@ -200,6 +329,11 @@ impl Encodable for BaseHeader {
         encode_inner_header(&self.inner, out);
 
         if let Some(timestamp_millis_part) = self.timestamp_millis_part {
+            // Wrap in a single-element list (`[u16]`) so the trailer cannot be confused with a
+            // missing intermediate post-Bedrock optional field (which are all strings).
+            let trailer_header =
+                alloy_rlp::Header { list: true, payload_length: timestamp_millis_part.length() };
+            trailer_header.encode(out);
             timestamp_millis_part.encode(out);
         }
     }
@@ -207,6 +341,103 @@ impl Encodable for BaseHeader {
     fn length(&self) -> usize {
         let length = self.header_payload_length();
         length + length_of_length(length)
+    }
+}
+
+impl Decodable for BaseHeader {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let rlp_head = alloy_rlp::Header::decode(buf)?;
+        if !rlp_head.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started_len = buf.len();
+        let mut inner = Header {
+            parent_hash: Decodable::decode(buf)?,
+            ommers_hash: Decodable::decode(buf)?,
+            beneficiary: Decodable::decode(buf)?,
+            state_root: Decodable::decode(buf)?,
+            transactions_root: Decodable::decode(buf)?,
+            receipts_root: Decodable::decode(buf)?,
+            logs_bloom: Decodable::decode(buf)?,
+            difficulty: Decodable::decode(buf)?,
+            number: u64::decode(buf)?,
+            gas_limit: u64::decode(buf)?,
+            gas_used: u64::decode(buf)?,
+            timestamp: Decodable::decode(buf)?,
+            extra_data: Decodable::decode(buf)?,
+            mix_hash: Decodable::decode(buf)?,
+            nonce: B64::decode(buf)?,
+            base_fee_per_gas: None,
+            withdrawals_root: None,
+            blob_gas_used: None,
+            excess_blob_gas: None,
+            parent_beacon_block_root: None,
+            requests_hash: None,
+            block_access_list_hash: None,
+            slot_number: None,
+        };
+
+        // After the mandatory fields, the upstream Ethereum [`Header`] writes a contiguous
+        // suffix of fork-specific optional fields. The Base millisecond trailer is encoded as
+        // a single-element RLP list and is always written last, so we can disambiguate it
+        // from a missing intermediate optional field by peeking for an RLP list header.
+        let has_more = |buf: &&[u8]| started_len - buf.len() < rlp_head.payload_length;
+        let is_trailer = |buf: &&[u8]| -> bool { buf.first().is_some_and(|b| *b >= 0xC0) };
+
+        if has_more(buf) && !is_trailer(buf) {
+            inner.base_fee_per_gas = Some(u64::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.withdrawals_root = Some(Decodable::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.blob_gas_used = Some(u64::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.excess_blob_gas = Some(u64::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.parent_beacon_block_root = Some(B256::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.requests_hash = Some(B256::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.block_access_list_hash = Some(B256::decode(buf)?);
+        }
+        if has_more(buf) && !is_trailer(buf) {
+            inner.slot_number = Some(u64::decode(buf)?);
+        }
+
+        let timestamp_millis_part = if has_more(buf) {
+            let trailer_head = alloy_rlp::Header::decode(buf)?;
+            if !trailer_head.list {
+                return Err(alloy_rlp::Error::UnexpectedString);
+            }
+            let trailer_started = buf.len();
+            let part = u16::decode(buf)?;
+            if trailer_started - buf.len() != trailer_head.payload_length {
+                return Err(alloy_rlp::Error::ListLengthMismatch {
+                    expected: trailer_head.payload_length,
+                    got: trailer_started - buf.len(),
+                });
+            }
+            Self::validate_timestamp_millis_part(part).map_err(|_| {
+                alloy_rlp::Error::Custom("invalid base header timestamp_millis_part")
+            })?;
+            Some(part)
+        } else {
+            None
+        };
+
+        let consumed = started_len - buf.len();
+        if consumed != rlp_head.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: rlp_head.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(Self { inner, timestamp_millis_part })
     }
 }
 
@@ -316,7 +547,7 @@ fn encode_inner_header(header: &Header, out: &mut dyn BufMut) {
 #[cfg(test)]
 mod tests {
     use alloy_consensus::Header;
-    use alloy_rlp::Encodable;
+    use alloy_rlp::{Decodable, Encodable};
 
     use super::*;
 
@@ -452,5 +683,93 @@ mod tests {
 
         assert_ne!(zero_millis_header.hash_slow(), no_millis_header.hash_slow());
         assert_ne!(two_hundred_millis_header.hash_slow(), zero_millis_header.hash_slow());
+    }
+
+    fn sample_post_subsecond_header() -> Header {
+        Header {
+            timestamp: 1_780_334_562,
+            number: 42_000,
+            gas_limit: 30_000_000,
+            gas_used: 1_234,
+            base_fee_per_gas: Some(1_000_000_000),
+            withdrawals_root: Some(B256::repeat_byte(0x11)),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            parent_beacon_block_root: Some(B256::repeat_byte(0x22)),
+            requests_hash: Some(B256::repeat_byte(0x33)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rlp_round_trip_with_none_millis_part() {
+        let header = sample_post_subsecond_header();
+        let base_header = BaseHeader::new(header, None).unwrap();
+        let mut encoded = Vec::new();
+        base_header.encode(&mut encoded);
+
+        let mut slice = encoded.as_slice();
+        let decoded = BaseHeader::decode(&mut slice).unwrap();
+        assert!(slice.is_empty(), "decoder must consume the entire RLP list");
+        assert_eq!(decoded, base_header);
+    }
+
+    #[test]
+    fn rlp_round_trip_with_some_millis_part() {
+        for part in VALID_TIMESTAMP_MILLIS_PARTS {
+            let header = sample_post_subsecond_header();
+            let base_header = BaseHeader::new(header, Some(part)).unwrap();
+            let mut encoded = Vec::new();
+            base_header.encode(&mut encoded);
+
+            let mut slice = encoded.as_slice();
+            let decoded = BaseHeader::decode(&mut slice).unwrap();
+            assert!(slice.is_empty(), "decoder must consume the entire RLP list for part={part}");
+            assert_eq!(decoded, base_header);
+        }
+    }
+
+    #[test]
+    fn rlp_decode_of_plain_header_yields_none_millis_part() {
+        let header = sample_post_subsecond_header();
+        let mut encoded = Vec::new();
+        header.encode(&mut encoded);
+
+        let mut slice = encoded.as_slice();
+        let decoded = BaseHeader::decode(&mut slice).unwrap();
+        assert!(slice.is_empty());
+        assert_eq!(decoded.inner, header);
+        assert_eq!(decoded.timestamp_millis_part, None);
+    }
+
+    #[test]
+    fn rlp_decode_rejects_invalid_millis_part() {
+        let header = sample_post_subsecond_header();
+        // Manually craft a header with a trailing u16 outside the 200ms cadence.
+        let base_header = BaseHeader::new_unchecked(header, Some(123));
+        let mut encoded = Vec::new();
+        base_header.encode(&mut encoded);
+
+        let mut slice = encoded.as_slice();
+        let err = BaseHeader::decode(&mut slice).expect_err("invalid millis part must be rejected");
+        assert!(matches!(err, alloy_rlp::Error::Custom(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn block_header_trait_forwards_to_inner() {
+        let inner = sample_post_subsecond_header();
+        let base_header = BaseHeader::new(inner.clone(), Some(400)).unwrap();
+        assert_eq!(AlloyBlockHeader::number(&base_header), inner.number);
+        assert_eq!(AlloyBlockHeader::timestamp(&base_header), inner.timestamp);
+        assert_eq!(AlloyBlockHeader::gas_limit(&base_header), inner.gas_limit);
+        assert_eq!(AlloyBlockHeader::base_fee_per_gas(&base_header), inner.base_fee_per_gas);
+        assert_eq!(AlloyBlockHeader::requests_hash(&base_header), inner.requests_hash);
+    }
+
+    #[test]
+    fn in_memory_size_includes_millis_part_slot() {
+        let inner = sample_post_subsecond_header();
+        let base_header = BaseHeader::new(inner.clone(), Some(200)).unwrap();
+        assert_eq!(base_header.size(), inner.size() + mem::size_of::<Option<u16>>());
     }
 }

--- a/crates/common/consensus/src/header.rs
+++ b/crates/common/consensus/src/header.rs
@@ -1,0 +1,456 @@
+//! Header type for Base chains.
+
+use alloc::vec::Vec;
+
+use alloy_consensus::Header;
+use alloy_primitives::{B256, Sealable, Sealed, U256, keccak256};
+use alloy_rlp::{BufMut, Encodable, length_of_length};
+
+/// Number of milliseconds in one Unix timestamp second.
+pub const TIMESTAMP_MILLIS_PER_SECOND: u16 = 1_000;
+
+/// Base block cadence in milliseconds after Beryl.
+pub const BASE_BLOCK_TIME_MILLIS: u16 = 200;
+
+/// Valid millisecond subsecond components for 200ms Base headers.
+pub const VALID_TIMESTAMP_MILLIS_PARTS: [u16; 5] = [0, 200, 400, 600, 800];
+
+/// Error returned when a header millisecond timestamp component is invalid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum TimestampMillisPartError {
+    /// Post-Beryl validation requires a millisecond component.
+    #[error("timestamp millisecond part is required after Beryl")]
+    MissingPart,
+
+    /// Millisecond component is not aligned to the 200ms cadence.
+    #[error("timestamp millisecond part must be one of 0, 200, 400, 600, or 800, got {0}")]
+    InvalidPart(u16),
+
+    /// Header seconds timestamp cannot be represented as milliseconds.
+    #[error("timestamp seconds overflowed when converted to milliseconds")]
+    TimestampOverflow,
+
+    /// Child timestamp seconds cannot be lower than parent timestamp seconds.
+    #[error("child timestamp seconds {child} is lower than parent timestamp seconds {parent}")]
+    ParentSecondsAfterChild {
+        /// Child header seconds timestamp.
+        child: u64,
+        /// Parent header seconds timestamp.
+        parent: u64,
+    },
+
+    /// Child millisecond timestamp must be greater than parent millisecond timestamp.
+    #[error(
+        "child timestamp milliseconds {child} must be greater than parent timestamp milliseconds {parent}"
+    )]
+    NonIncreasingTimestamp {
+        /// Child header millisecond timestamp.
+        child: u64,
+        /// Parent header millisecond timestamp.
+        parent: u64,
+    },
+
+    /// Child millisecond timestamp must advance by an integer number of 200ms slots.
+    #[error("timestamp millisecond delta {0} is not aligned to the 200ms block cadence")]
+    NonSlotAlignedDelta(u64),
+}
+
+/// Base header wrapper with an optional post-Beryl millisecond timestamp component.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BaseHeader {
+    /// Standard Ethereum execution header fields.
+    pub inner: Header,
+    /// Post-Beryl millisecond subsecond component committed by the header hash.
+    pub timestamp_millis_part: Option<u16>,
+}
+
+impl BaseHeader {
+    /// Creates a Base header and validates the optional millisecond timestamp component.
+    pub fn new(
+        inner: Header,
+        timestamp_millis_part: Option<u16>,
+    ) -> Result<Self, TimestampMillisPartError> {
+        if let Some(part) = timestamp_millis_part
+            && !Self::is_valid_timestamp_millis_part(part)
+        {
+            return Err(TimestampMillisPartError::InvalidPart(part));
+        }
+
+        Ok(Self { inner, timestamp_millis_part })
+    }
+
+    /// Creates a Base header without validating its millisecond timestamp component.
+    pub const fn new_unchecked(inner: Header, timestamp_millis_part: Option<u16>) -> Self {
+        Self { inner, timestamp_millis_part }
+    }
+
+    /// Returns true when the millisecond component is valid for a 200ms cadence.
+    pub const fn is_valid_timestamp_millis_part(part: u16) -> bool {
+        part < TIMESTAMP_MILLIS_PER_SECOND && part.is_multiple_of(BASE_BLOCK_TIME_MILLIS)
+    }
+
+    /// Validates a millisecond timestamp component.
+    pub const fn validate_timestamp_millis_part(part: u16) -> Result<(), TimestampMillisPartError> {
+        if Self::is_valid_timestamp_millis_part(part) {
+            Ok(())
+        } else {
+            Err(TimestampMillisPartError::InvalidPart(part))
+        }
+    }
+
+    /// Returns the canonical post-Beryl timestamp in milliseconds when present.
+    pub fn timestamp_millis(&self) -> Result<Option<u64>, TimestampMillisPartError> {
+        let Some(part) = self.timestamp_millis_part else {
+            return Ok(None);
+        };
+
+        let timestamp_seconds = self
+            .inner
+            .timestamp
+            .checked_mul(u64::from(TIMESTAMP_MILLIS_PER_SECOND))
+            .ok_or(TimestampMillisPartError::TimestampOverflow)?;
+
+        Ok(Some(timestamp_seconds + u64::from(part)))
+    }
+
+    /// Returns the canonical post-Beryl timestamp in milliseconds.
+    pub fn required_timestamp_millis(&self) -> Result<u64, TimestampMillisPartError> {
+        self.timestamp_millis()?.ok_or(TimestampMillisPartError::MissingPart)
+    }
+
+    /// Validates a child Base header timestamp against its parent for post-Beryl blocks.
+    pub fn validate_timestamp_millis_after(
+        &self,
+        parent: &Self,
+    ) -> Result<(), TimestampMillisPartError> {
+        if self.inner.timestamp < parent.inner.timestamp {
+            return Err(TimestampMillisPartError::ParentSecondsAfterChild {
+                child: self.inner.timestamp,
+                parent: parent.inner.timestamp,
+            });
+        }
+
+        let child_timestamp = self.required_timestamp_millis()?;
+        let parent_timestamp = parent.required_timestamp_millis()?;
+
+        if child_timestamp <= parent_timestamp {
+            return Err(TimestampMillisPartError::NonIncreasingTimestamp {
+                child: child_timestamp,
+                parent: parent_timestamp,
+            });
+        }
+
+        let delta = child_timestamp - parent_timestamp;
+        if delta % u64::from(BASE_BLOCK_TIME_MILLIS) != 0 {
+            return Err(TimestampMillisPartError::NonSlotAlignedDelta(delta));
+        }
+
+        Ok(())
+    }
+
+    /// Heavy function that calculates the Base header hash from its RLP encoding.
+    pub fn hash_slow(&self) -> B256 {
+        let mut out = Vec::<u8>::new();
+        self.encode(&mut out);
+        keccak256(&out)
+    }
+
+    /// Seal the Base header with a known hash.
+    ///
+    /// WARNING: This method does not validate whether the hash is correct.
+    #[inline]
+    pub const fn seal(self, hash: B256) -> Sealed<Self> {
+        Sealed::new_unchecked(self, hash)
+    }
+
+    fn header_payload_length(&self) -> usize {
+        let mut length = base_header_payload_length(&self.inner);
+
+        if let Some(timestamp_millis_part) = self.timestamp_millis_part {
+            length += timestamp_millis_part.length();
+        }
+
+        length
+    }
+}
+
+impl From<Header> for BaseHeader {
+    fn from(inner: Header) -> Self {
+        Self { inner, timestamp_millis_part: None }
+    }
+}
+
+impl AsRef<Header> for BaseHeader {
+    fn as_ref(&self) -> &Header {
+        &self.inner
+    }
+}
+
+impl Sealable for BaseHeader {
+    fn hash_slow(&self) -> B256 {
+        Self::hash_slow(self)
+    }
+}
+
+impl Encodable for BaseHeader {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let list_header =
+            alloy_rlp::Header { list: true, payload_length: self.header_payload_length() };
+        list_header.encode(out);
+        encode_inner_header(&self.inner, out);
+
+        if let Some(timestamp_millis_part) = self.timestamp_millis_part {
+            timestamp_millis_part.encode(out);
+        }
+    }
+
+    fn length(&self) -> usize {
+        let length = self.header_payload_length();
+        length + length_of_length(length)
+    }
+}
+
+fn base_header_payload_length(header: &Header) -> usize {
+    let mut length = 0;
+    length += header.parent_hash.length();
+    length += header.ommers_hash.length();
+    length += header.beneficiary.length();
+    length += header.state_root.length();
+    length += header.transactions_root.length();
+    length += header.receipts_root.length();
+    length += header.logs_bloom.length();
+    length += header.difficulty.length();
+    length += U256::from(header.number).length();
+    length += U256::from(header.gas_limit).length();
+    length += U256::from(header.gas_used).length();
+    length += header.timestamp.length();
+    length += header.extra_data.length();
+    length += header.mix_hash.length();
+    length += header.nonce.length();
+
+    if let Some(base_fee) = header.base_fee_per_gas {
+        length += U256::from(base_fee).length();
+    }
+
+    if let Some(root) = header.withdrawals_root {
+        length += root.length();
+    }
+
+    if let Some(blob_gas_used) = header.blob_gas_used {
+        length += U256::from(blob_gas_used).length();
+    }
+
+    if let Some(excess_blob_gas) = header.excess_blob_gas {
+        length += U256::from(excess_blob_gas).length();
+    }
+
+    if let Some(parent_beacon_block_root) = header.parent_beacon_block_root {
+        length += parent_beacon_block_root.length();
+    }
+
+    if let Some(requests_hash) = header.requests_hash {
+        length += requests_hash.length();
+    }
+
+    if let Some(block_access_list_hash) = header.block_access_list_hash {
+        length += block_access_list_hash.length();
+    }
+
+    if let Some(slot_number) = header.slot_number {
+        length += U256::from(slot_number).length();
+    }
+
+    length
+}
+
+fn encode_inner_header(header: &Header, out: &mut dyn BufMut) {
+    header.parent_hash.encode(out);
+    header.ommers_hash.encode(out);
+    header.beneficiary.encode(out);
+    header.state_root.encode(out);
+    header.transactions_root.encode(out);
+    header.receipts_root.encode(out);
+    header.logs_bloom.encode(out);
+    header.difficulty.encode(out);
+    U256::from(header.number).encode(out);
+    U256::from(header.gas_limit).encode(out);
+    U256::from(header.gas_used).encode(out);
+    header.timestamp.encode(out);
+    header.extra_data.encode(out);
+    header.mix_hash.encode(out);
+    header.nonce.encode(out);
+
+    if let Some(base_fee) = header.base_fee_per_gas {
+        U256::from(base_fee).encode(out);
+    }
+
+    if let Some(root) = header.withdrawals_root {
+        root.encode(out);
+    }
+
+    if let Some(blob_gas_used) = header.blob_gas_used {
+        U256::from(blob_gas_used).encode(out);
+    }
+
+    if let Some(excess_blob_gas) = header.excess_blob_gas {
+        U256::from(excess_blob_gas).encode(out);
+    }
+
+    if let Some(parent_beacon_block_root) = header.parent_beacon_block_root {
+        parent_beacon_block_root.encode(out);
+    }
+
+    if let Some(requests_hash) = header.requests_hash {
+        requests_hash.encode(out);
+    }
+
+    if let Some(block_access_list_hash) = header.block_access_list_hash {
+        block_access_list_hash.encode(out);
+    }
+
+    if let Some(slot_number) = header.slot_number {
+        U256::from(slot_number).encode(out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Header;
+    use alloy_rlp::Encodable;
+
+    use super::*;
+
+    #[test]
+    fn timestamp_millis_part_validation_accepts_200ms_cadence() {
+        for valid_part in VALID_TIMESTAMP_MILLIS_PARTS {
+            assert!(BaseHeader::is_valid_timestamp_millis_part(valid_part));
+            assert_eq!(BaseHeader::validate_timestamp_millis_part(valid_part), Ok(()));
+        }
+    }
+
+    #[test]
+    fn timestamp_millis_part_validation_rejects_out_of_cadence_parts() {
+        for invalid_part in [1, 100, 199, 201, 999, 1_000] {
+            assert!(!BaseHeader::is_valid_timestamp_millis_part(invalid_part));
+            assert_eq!(
+                BaseHeader::validate_timestamp_millis_part(invalid_part),
+                Err(TimestampMillisPartError::InvalidPart(invalid_part))
+            );
+        }
+    }
+
+    #[test]
+    fn timestamp_millis_combines_header_seconds_and_part() {
+        let header = Header { timestamp: 1_234, ..Default::default() };
+        let base_header = BaseHeader::new(header, Some(600)).unwrap();
+
+        assert_eq!(base_header.timestamp_millis(), Ok(Some(1_234_600)));
+    }
+
+    #[test]
+    fn timestamp_millis_is_absent_before_beryl() {
+        let header = Header { timestamp: 1_234, ..Default::default() };
+        let base_header = BaseHeader::new(header, None).unwrap();
+
+        assert_eq!(base_header.timestamp_millis(), Ok(None));
+    }
+
+    #[test]
+    fn timestamp_millis_validation_accepts_same_second_sequence() {
+        let parent =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(0)).unwrap();
+        let child =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(200)).unwrap();
+
+        assert_eq!(child.validate_timestamp_millis_after(&parent), Ok(()));
+    }
+
+    #[test]
+    fn timestamp_millis_validation_accepts_second_rollover() {
+        let parent =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(800)).unwrap();
+        let child =
+            BaseHeader::new(Header { timestamp: 11, ..Default::default() }, Some(0)).unwrap();
+
+        assert_eq!(child.validate_timestamp_millis_after(&parent), Ok(()));
+    }
+
+    #[test]
+    fn timestamp_millis_validation_rejects_duplicate_millis() {
+        let parent =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(200)).unwrap();
+        let child =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(200)).unwrap();
+
+        assert_eq!(
+            child.validate_timestamp_millis_after(&parent),
+            Err(TimestampMillisPartError::NonIncreasingTimestamp { child: 10_200, parent: 10_200 })
+        );
+    }
+
+    #[test]
+    fn timestamp_millis_validation_rejects_backward_millis() {
+        let parent =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(400)).unwrap();
+        let child =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(200)).unwrap();
+
+        assert_eq!(
+            child.validate_timestamp_millis_after(&parent),
+            Err(TimestampMillisPartError::NonIncreasingTimestamp { child: 10_200, parent: 10_400 })
+        );
+    }
+
+    #[test]
+    fn timestamp_millis_validation_rejects_non_slot_aligned_delta() {
+        let parent =
+            BaseHeader::new_unchecked(Header { timestamp: 10, ..Default::default() }, Some(0));
+        let child =
+            BaseHeader::new_unchecked(Header { timestamp: 10, ..Default::default() }, Some(100));
+
+        assert_eq!(
+            child.validate_timestamp_millis_after(&parent),
+            Err(TimestampMillisPartError::NonSlotAlignedDelta(100))
+        );
+    }
+
+    #[test]
+    fn timestamp_millis_validation_rejects_parent_seconds_after_child() {
+        let parent =
+            BaseHeader::new(Header { timestamp: 11, ..Default::default() }, Some(0)).unwrap();
+        let child =
+            BaseHeader::new(Header { timestamp: 10, ..Default::default() }, Some(800)).unwrap();
+
+        assert_eq!(
+            child.validate_timestamp_millis_after(&parent),
+            Err(TimestampMillisPartError::ParentSecondsAfterChild { child: 10, parent: 11 })
+        );
+    }
+
+    #[test]
+    fn base_header_without_millis_part_matches_alloy_header_encoding_and_hash() {
+        let header =
+            Header { timestamp: 42, number: 7, gas_limit: 30_000_000, ..Default::default() };
+        let base_header = BaseHeader::new(header.clone(), None).unwrap();
+        let mut alloy_encoding = Vec::new();
+        let mut base_encoding = Vec::new();
+
+        header.encode(&mut alloy_encoding);
+        base_header.encode(&mut base_encoding);
+
+        assert_eq!(base_encoding, alloy_encoding);
+        assert_eq!(base_header.hash_slow(), header.hash_slow());
+    }
+
+    #[test]
+    fn base_header_hash_commits_millis_part() {
+        let header =
+            Header { timestamp: 42, number: 7, gas_limit: 30_000_000, ..Default::default() };
+        let no_millis_header = BaseHeader::new(header.clone(), None).unwrap();
+        let zero_millis_header = BaseHeader::new(header.clone(), Some(0)).unwrap();
+        let two_hundred_millis_header = BaseHeader::new(header, Some(200)).unwrap();
+
+        assert_ne!(zero_millis_header.hash_slow(), no_millis_header.hash_slow());
+        assert_ne!(two_hundred_millis_header.hash_slow(), zero_millis_header.hash_slow());
+    }
+}

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -16,7 +16,10 @@ use revm as _;
 #[cfg(feature = "reth")]
 mod reth_compat;
 #[cfg(feature = "reth")]
-pub use reth_compat::{BaseBlockBody, BasePrimitives, CompactTxDeposit, DepositReceiptExt};
+pub use reth_compat::{
+    BaseBlockBody, BaseHeaderCompact, BaseHeaderExt, BasePrimitives, CompactTxDeposit,
+    DepositReceiptExt,
+};
 
 mod receipts;
 pub use receipts::{

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -49,6 +49,12 @@ pub use predeploys::{Deployers, Predeploys, SystemAddresses};
 mod block;
 pub use block::BaseBlock;
 
+mod header;
+pub use header::{
+    BASE_BLOCK_TIME_MILLIS, BaseHeader, TIMESTAMP_MILLIS_PER_SECOND, TimestampMillisPartError,
+    VALID_TIMESTAMP_MILLIS_PARTS,
+};
+
 /// Signed transaction type alias for [`BaseTxEnvelope`].
 pub type BaseTransactionSigned = BaseTxEnvelope;
 

--- a/crates/common/consensus/src/reth_compat.rs
+++ b/crates/common/consensus/src/reth_compat.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{
     Header, Receipt, Sealed, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy, TxReceipt,
     constants::EIP7702_TX_TYPE_ID,
 };
-use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
+use alloy_primitives::{Address, B256, BlockNumber, Bloom, Bytes, Signature, TxKind, U256};
 use bytes::{Buf, BufMut};
 use reth_codecs::{
     Compact, CompactZstd, DecompressError,
@@ -21,7 +21,7 @@ use reth_codecs::{
 };
 
 use crate::{
-    BaseBlock, BaseReceipt, BaseTxEnvelope, BaseTypedTransaction, DEPOSIT_TX_TYPE_ID,
+    BaseBlock, BaseHeader, BaseReceipt, BaseTxEnvelope, BaseTypedTransaction, DEPOSIT_TX_TYPE_ID,
     DepositReceipt, EIP8130_TX_TYPE_ID, OpTxType, TxDeposit, TxEip8130,
 };
 
@@ -455,6 +455,177 @@ impl DepositReceiptExt for BaseReceipt {
 }
 
 // ---------------------------------------------------------------------------
+// Compact – BaseHeader
+// ---------------------------------------------------------------------------
+
+/// Helper struct used to derive [`Compact`] for [`BaseHeader`].
+///
+/// Notice: field layout is byte-compatible with the upstream reth helper used for
+/// [`alloy_consensus::Header`]. The only Base-specific addition lives in [`BaseHeaderExt`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Compact)]
+#[reth_codecs(crate = "reth_codecs")]
+pub struct BaseHeaderCompact {
+    /// Parent block hash.
+    pub parent_hash: B256,
+    /// Ommers list hash.
+    pub ommers_hash: B256,
+    /// Block proposer / fee recipient.
+    pub beneficiary: Address,
+    /// State root after applying the block's transactions.
+    pub state_root: B256,
+    /// Transactions Merkle Patricia trie root.
+    pub transactions_root: B256,
+    /// Receipts trie root.
+    pub receipts_root: B256,
+    /// Withdrawals root (Shanghai).
+    pub withdrawals_root: Option<B256>,
+    /// Bloom filter for the block's logs.
+    pub logs_bloom: Bloom,
+    /// Block difficulty (Pre-PoS only).
+    pub difficulty: U256,
+    /// Block number.
+    pub number: BlockNumber,
+    /// Block gas limit.
+    pub gas_limit: u64,
+    /// Block gas used.
+    pub gas_used: u64,
+    /// Unix seconds timestamp.
+    pub timestamp: u64,
+    /// Post-PoS mixHash field.
+    pub mix_hash: B256,
+    /// Block nonce.
+    pub nonce: u64,
+    /// EIP-1559 base fee per gas.
+    pub base_fee_per_gas: Option<u64>,
+    /// EIP-4844 blob gas used.
+    pub blob_gas_used: Option<u64>,
+    /// EIP-4844 excess blob gas.
+    pub excess_blob_gas: Option<u64>,
+    /// EIP-4788 parent beacon block root.
+    pub parent_beacon_block_root: Option<B256>,
+    /// Optional newly-added header fields, including the Base millisecond trailer.
+    pub extra_fields: Option<BaseHeaderExt>,
+    /// Free-form extra data.
+    pub extra_data: Bytes,
+}
+
+/// Optional extension fields appended to [`BaseHeaderCompact`].
+///
+/// New fields must always be `Option<T>` and appended at the end of this struct so older
+/// compact-encoded headers continue to decode.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Compact)]
+#[reth_codecs(crate = "reth_codecs")]
+pub struct BaseHeaderExt {
+    /// EIP-7685 execution requests hash.
+    pub requests_hash: Option<B256>,
+    /// EIP-7928 block access list hash.
+    pub block_access_list_hash: Option<B256>,
+    /// EIP-7843 slot number.
+    pub slot_number: Option<u64>,
+    /// Post-Beryl millisecond subsecond component (Base-specific).
+    ///
+    /// Stored as `u64` because reth-codecs only implements [`Compact`] for `u8`/`u64`/`u128`;
+    /// the value is always in the range `0..1000` and is converted to/from `u16` at the
+    /// [`BaseHeader`] boundary.
+    pub timestamp_millis_part: Option<u64>,
+}
+
+impl BaseHeaderExt {
+    /// Returns `Some(self)` if any field is populated, `None` otherwise.
+    ///
+    /// Used to keep the `extra_fields` bucket absent (and therefore byte-compatible with
+    /// pre-extension stored headers) when no extension data is present.
+    pub const fn into_option(self) -> Option<Self> {
+        if self.requests_hash.is_some()
+            || self.block_access_list_hash.is_some()
+            || self.slot_number.is_some()
+            || self.timestamp_millis_part.is_some()
+        {
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl Compact for BaseHeader {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: BufMut + AsMut<[u8]>,
+    {
+        let extra_fields = BaseHeaderExt {
+            requests_hash: self.inner.requests_hash,
+            block_access_list_hash: self.inner.block_access_list_hash,
+            slot_number: self.inner.slot_number,
+            timestamp_millis_part: self.timestamp_millis_part.map(u64::from),
+        };
+
+        let helper = BaseHeaderCompact {
+            parent_hash: self.inner.parent_hash,
+            ommers_hash: self.inner.ommers_hash,
+            beneficiary: self.inner.beneficiary,
+            state_root: self.inner.state_root,
+            transactions_root: self.inner.transactions_root,
+            receipts_root: self.inner.receipts_root,
+            withdrawals_root: self.inner.withdrawals_root,
+            logs_bloom: self.inner.logs_bloom,
+            difficulty: self.inner.difficulty,
+            number: self.inner.number,
+            gas_limit: self.inner.gas_limit,
+            gas_used: self.inner.gas_used,
+            timestamp: self.inner.timestamp,
+            mix_hash: self.inner.mix_hash,
+            nonce: self.inner.nonce.into(),
+            base_fee_per_gas: self.inner.base_fee_per_gas,
+            blob_gas_used: self.inner.blob_gas_used,
+            excess_blob_gas: self.inner.excess_blob_gas,
+            parent_beacon_block_root: self.inner.parent_beacon_block_root,
+            extra_fields: extra_fields.into_option(),
+            extra_data: self.inner.extra_data.clone(),
+        };
+        helper.to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (helper, buf) = BaseHeaderCompact::from_compact(buf, len);
+        let timestamp_millis_part = helper
+            .extra_fields
+            .as_ref()
+            .and_then(|h| h.timestamp_millis_part)
+            .map(|v| u16::try_from(v).unwrap_or(0));
+        let inner = Header {
+            parent_hash: helper.parent_hash,
+            ommers_hash: helper.ommers_hash,
+            beneficiary: helper.beneficiary,
+            state_root: helper.state_root,
+            transactions_root: helper.transactions_root,
+            receipts_root: helper.receipts_root,
+            withdrawals_root: helper.withdrawals_root,
+            logs_bloom: helper.logs_bloom,
+            difficulty: helper.difficulty,
+            number: helper.number,
+            gas_limit: helper.gas_limit,
+            gas_used: helper.gas_used,
+            timestamp: helper.timestamp,
+            mix_hash: helper.mix_hash,
+            nonce: helper.nonce.into(),
+            base_fee_per_gas: helper.base_fee_per_gas,
+            blob_gas_used: helper.blob_gas_used,
+            excess_blob_gas: helper.excess_blob_gas,
+            parent_beacon_block_root: helper.parent_beacon_block_root,
+            requests_hash: helper.extra_fields.as_ref().and_then(|h| h.requests_hash),
+            block_access_list_hash: helper
+                .extra_fields
+                .as_ref()
+                .and_then(|h| h.block_access_list_hash),
+            slot_number: helper.extra_fields.as_ref().and_then(|h| h.slot_number),
+            extra_data: helper.extra_data,
+        };
+        (Self { inner, timestamp_millis_part }, buf)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // BaseBlockBody / BasePrimitives
 // ---------------------------------------------------------------------------
 
@@ -472,4 +643,87 @@ impl reth_primitives_traits::NodePrimitives for BasePrimitives {
     type BlockBody = BaseBlockBody;
     type SignedTx = BaseTxEnvelope;
     type Receipt = BaseReceipt;
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Header;
+    use alloy_primitives::B256;
+
+    use super::*;
+    use crate::VALID_TIMESTAMP_MILLIS_PARTS;
+
+    fn sample_inner_header() -> Header {
+        Header {
+            timestamp: 1_780_334_562,
+            number: 42_000,
+            gas_limit: 30_000_000,
+            gas_used: 1_234,
+            base_fee_per_gas: Some(1_000_000_000),
+            withdrawals_root: Some(B256::repeat_byte(0x11)),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            parent_beacon_block_root: Some(B256::repeat_byte(0x22)),
+            requests_hash: Some(B256::repeat_byte(0x33)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn base_header_compact_round_trip_with_none_millis_part() {
+        let base_header = BaseHeader::from(sample_inner_header());
+        let mut encoded = Vec::new();
+        let len = base_header.to_compact(&mut encoded);
+        assert_eq!(len, encoded.len());
+
+        let (decoded, rest) = BaseHeader::from_compact(&encoded, len);
+        assert!(rest.is_empty());
+        assert_eq!(decoded, base_header);
+    }
+
+    #[test]
+    fn base_header_compact_round_trip_with_some_millis_part() {
+        for part in VALID_TIMESTAMP_MILLIS_PARTS {
+            let base_header = BaseHeader::new(sample_inner_header(), Some(part)).unwrap();
+            let mut encoded = Vec::new();
+            let len = base_header.to_compact(&mut encoded);
+            assert_eq!(len, encoded.len());
+
+            let (decoded, rest) = BaseHeader::from_compact(&encoded, len);
+            assert!(rest.is_empty(), "decoder must consume all bytes for part={part}");
+            assert_eq!(decoded, base_header);
+        }
+    }
+
+    #[test]
+    fn base_header_compact_with_none_matches_alloy_header_bytes() {
+        // For headers without the Base millisecond trailer, the compact encoding must be
+        // byte-identical to the upstream `alloy_consensus::Header` compact encoding so
+        // pre-Subsecond stored bytes continue to decode (and re-encode) unchanged.
+        let inner = sample_inner_header();
+        let base_header = BaseHeader::from(inner.clone());
+
+        let mut base_encoding = Vec::new();
+        let base_len = base_header.to_compact(&mut base_encoding);
+
+        let mut alloy_encoding = Vec::new();
+        let alloy_len = inner.to_compact(&mut alloy_encoding);
+
+        assert_eq!(base_len, alloy_len);
+        assert_eq!(base_encoding, alloy_encoding);
+    }
+
+    #[test]
+    fn base_header_compact_decodes_alloy_header_bytes_as_none_millis_part() {
+        // Old compact bytes (produced before the Base millisecond trailer existed) must
+        // decode cleanly as `timestamp_millis_part = None`.
+        let inner = sample_inner_header();
+        let mut alloy_encoding = Vec::new();
+        let alloy_len = inner.to_compact(&mut alloy_encoding);
+
+        let (decoded, rest) = BaseHeader::from_compact(&alloy_encoding, alloy_len);
+        assert!(rest.is_empty());
+        assert_eq!(decoded.timestamp_millis_part, None);
+        assert_eq!(decoded.inner, inner);
+    }
 }

--- a/crates/common/rpc-types/src/block.rs
+++ b/crates/common/rpc-types/src/block.rs
@@ -1,0 +1,227 @@
+//! Block and header RPC response types.
+
+use alloy_consensus::{BlockHeader, Header as ConsensusHeader};
+use alloy_network_primitives::HeaderResponse;
+use alloy_primitives::{Address, B64, B256, BlockHash, Bloom, Bytes, U256};
+use alloy_rpc_types_eth::{Block, Header};
+use base_common_consensus::{BaseHeader, TIMESTAMP_MILLIS_PER_SECOND, TimestampMillisPartError};
+
+use crate::Transaction;
+
+/// Base block RPC response type.
+pub type BaseBlockResponse<T = Transaction> = Block<T, BaseHeaderResponse>;
+
+/// Base header RPC response type.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseHeaderResponse<H = Header> {
+    /// Standard Ethereum header response fields.
+    #[serde(flatten)]
+    pub inner: H,
+    /// Full Unix timestamp in milliseconds for post-Beryl Base blocks.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub timestamp_ms: Option<u64>,
+    /// Sub-second millisecond component of the block timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub timestamp_millis_part: Option<u16>,
+}
+
+impl<H> BaseHeaderResponse<H> {
+    /// Creates a header response without Base millisecond timestamp extensions.
+    pub const fn new(inner: H) -> Self {
+        Self { inner, timestamp_ms: None, timestamp_millis_part: None }
+    }
+
+    /// Creates a header response with a computed Base millisecond timestamp extension.
+    pub fn with_timestamp_millis_part(
+        inner: H,
+        timestamp_millis_part: u16,
+    ) -> Result<Self, TimestampMillisPartError>
+    where
+        H: BlockHeader,
+    {
+        BaseHeader::validate_timestamp_millis_part(timestamp_millis_part)?;
+
+        let timestamp_ms = inner
+            .timestamp()
+            .checked_mul(u64::from(TIMESTAMP_MILLIS_PER_SECOND))
+            .and_then(|timestamp| timestamp.checked_add(u64::from(timestamp_millis_part)))
+            .ok_or(TimestampMillisPartError::TimestampOverflow)?;
+
+        Ok(Self {
+            inner,
+            timestamp_ms: Some(timestamp_ms),
+            timestamp_millis_part: Some(timestamp_millis_part),
+        })
+    }
+
+    /// Consumes the response and returns the wrapped Ethereum header response.
+    pub fn into_inner(self) -> H {
+        self.inner
+    }
+}
+
+impl<H> From<H> for BaseHeaderResponse<H> {
+    fn from(inner: H) -> Self {
+        Self::new(inner)
+    }
+}
+
+impl<H> AsRef<H> for BaseHeaderResponse<H> {
+    fn as_ref(&self) -> &H {
+        &self.inner
+    }
+}
+
+impl AsRef<ConsensusHeader> for BaseHeaderResponse<Header<ConsensusHeader>> {
+    fn as_ref(&self) -> &ConsensusHeader {
+        self.inner.as_ref()
+    }
+}
+
+impl<H: BlockHeader> BlockHeader for BaseHeaderResponse<H> {
+    fn parent_hash(&self) -> B256 {
+        self.inner.parent_hash()
+    }
+
+    fn ommers_hash(&self) -> B256 {
+        self.inner.ommers_hash()
+    }
+
+    fn beneficiary(&self) -> Address {
+        self.inner.beneficiary()
+    }
+
+    fn state_root(&self) -> B256 {
+        self.inner.state_root()
+    }
+
+    fn transactions_root(&self) -> B256 {
+        self.inner.transactions_root()
+    }
+
+    fn receipts_root(&self) -> B256 {
+        self.inner.receipts_root()
+    }
+
+    fn withdrawals_root(&self) -> Option<B256> {
+        self.inner.withdrawals_root()
+    }
+
+    fn logs_bloom(&self) -> Bloom {
+        self.inner.logs_bloom()
+    }
+
+    fn difficulty(&self) -> U256 {
+        self.inner.difficulty()
+    }
+
+    fn number(&self) -> u64 {
+        self.inner.number()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.inner.gas_limit()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.inner.gas_used()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp()
+    }
+
+    fn mix_hash(&self) -> Option<B256> {
+        self.inner.mix_hash()
+    }
+
+    fn nonce(&self) -> Option<B64> {
+        self.inner.nonce()
+    }
+
+    fn base_fee_per_gas(&self) -> Option<u64> {
+        self.inner.base_fee_per_gas()
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        self.inner.blob_gas_used()
+    }
+
+    fn excess_blob_gas(&self) -> Option<u64> {
+        self.inner.excess_blob_gas()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.inner.parent_beacon_block_root()
+    }
+
+    fn requests_hash(&self) -> Option<B256> {
+        self.inner.requests_hash()
+    }
+
+    fn block_access_list_hash(&self) -> Option<B256> {
+        self.inner.block_access_list_hash()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number()
+    }
+
+    fn extra_data(&self) -> &Bytes {
+        self.inner.extra_data()
+    }
+}
+
+impl<H: HeaderResponse> HeaderResponse for BaseHeaderResponse<H> {
+    fn hash(&self) -> BlockHash {
+        self.inner.hash()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{BlockHeader, Header as ConsensusHeader};
+    use alloy_primitives::U256;
+    use alloy_rpc_types_eth::Header;
+    use serde_json::json;
+
+    use super::BaseHeaderResponse;
+
+    #[test]
+    fn base_header_response_serializes_timestamp_millis_fields() {
+        let inner = Header::new(ConsensusHeader { timestamp: 42, ..Default::default() });
+        let response = BaseHeaderResponse::with_timestamp_millis_part(inner, 200).unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["timestamp"], json!("0x2a"));
+        assert_eq!(value["timestampMs"], json!("0xa4d8"));
+        assert_eq!(value["timestampMillisPart"], json!("0xc8"));
+    }
+
+    #[test]
+    fn base_header_response_omits_timestamp_millis_fields_when_absent() {
+        let inner = Header::new(ConsensusHeader { timestamp: 42, ..Default::default() });
+        let value = serde_json::to_value(BaseHeaderResponse::new(inner)).unwrap();
+
+        assert!(value.get("timestampMs").is_none());
+        assert!(value.get("timestampMillisPart").is_none());
+    }
+
+    #[test]
+    fn base_header_response_rejects_invalid_timestamp_millis_part() {
+        let inner = Header::new(ConsensusHeader { timestamp: 42, ..Default::default() });
+        let error = BaseHeaderResponse::with_timestamp_millis_part(inner, 100).unwrap_err();
+
+        assert_eq!(error, base_common_consensus::TimestampMillisPartError::InvalidPart(100));
+    }
+
+    #[test]
+    fn base_header_response_keeps_standard_timestamp_seconds() {
+        let inner = Header::new(ConsensusHeader { timestamp: 42, ..Default::default() });
+        let response = BaseHeaderResponse::with_timestamp_millis_part(inner, 200).unwrap();
+
+        assert_eq!(response.timestamp(), 42);
+        assert_ne!(U256::from(response.timestamp()), U256::from(42_200_u64));
+    }
+}

--- a/crates/common/rpc-types/src/lib.rs
+++ b/crates/common/rpc-types/src/lib.rs
@@ -10,6 +10,9 @@
 
 extern crate alloc;
 
+mod block;
+pub use block::{BaseBlockResponse, BaseHeaderResponse};
+
 mod genesis;
 pub use genesis::{ChainInfo, FeeInfo, GenesisInfo, UpgradeInfo};
 


### PR DESCRIPTION
## Summary
- add the `BaseHeader` primitive with optional `timestamp_millis_part`
- preserve RLP and reth compact compatibility when the millis part is absent
- add Base RPC block/header response wrappers that expose millisecond timestamp fields

## Testing
- `cargo test -p base-common-consensus`
- `cargo check -p base-common-rpc-types`

## Notes
- `cargo test -p base-common-rpc-types` still fails on a pre-existing baseline test that calls `BaseTxEnvelope::try_into_recovered()` in `crates/common/rpc-types/src/transaction.rs`