### PR TITLE
test(system): reproduce missing requestsHash follow root bug

### DIFF
--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -69,7 +69,7 @@ tokio-util.workspace = true
 tokio = { workspace = true, features = ["full", "rt-multi-thread", "macros"] }
 
 # rpc
-jsonrpsee = { workspace = true, features = ["http-client"] }
+jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 
 # p2p
 k256.workspace = true

--- a/etc/systems/src/faults/mod.rs
+++ b/etc/systems/src/faults/mod.rs
@@ -1,0 +1,4 @@
+//! Fault injection helpers for system test stacks.
+
+mod rpc;
+pub use rpc::{FaultedRpcProxy, RpcFault};

--- a/etc/systems/src/faults/rpc.rs
+++ b/etc/systems/src/faults/rpc.rs
@@ -1,0 +1,188 @@
+//! JSON-RPC fault injection helpers for system tests.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use base_builder_core::test_utils::get_available_port;
+use eyre::{Result, WrapErr};
+use jsonrpsee::{
+    RpcModule,
+    server::{Server, ServerHandle},
+    types::{ErrorObjectOwned, error::ErrorCode},
+};
+use serde_json::{Value, json};
+use tracing::info;
+use url::Url;
+
+/// JSON-RPC response fault to apply through a [`FaultedRpcProxy`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RpcFault {
+    /// Remove `requestsHash` from `eth_getBlockByNumber` block responses.
+    MissingRequestsHash,
+}
+
+/// Running JSON-RPC proxy that forwards selected methods and applies configured faults.
+///
+/// This proxy currently registers the source RPC methods used by
+/// `base_consensus_node::RemoteL2Client`: `eth_blockNumber` and
+/// `eth_getBlockByNumber`. If follow-mode source RPC usage expands, add explicit
+/// forwarding for each new method here so tests fail at the missing method boundary
+/// instead of silently bypassing fault injection.
+pub struct FaultedRpcProxy {
+    rpc_addr: SocketAddr,
+    handle: ServerHandle,
+}
+
+impl std::fmt::Debug for FaultedRpcProxy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FaultedRpcProxy").field("rpc_addr", &self.rpc_addr).finish()
+    }
+}
+
+impl FaultedRpcProxy {
+    /// Starts a faulted JSON-RPC proxy against the given upstream endpoint.
+    pub async fn start(upstream_rpc_url: Url, faults: Vec<RpcFault>) -> Result<Self> {
+        let rpc_port = get_available_port();
+        let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .wrap_err("failed to build faulted RPC proxy client")?;
+
+        let mut module = RpcModule::new(());
+        let request_id_counter = Arc::new(AtomicU64::new(1));
+
+        let block_number_client = client.clone();
+        let block_number_upstream = upstream_rpc_url.clone();
+        let block_number_request_id_counter = Arc::clone(&request_id_counter);
+        module
+            .register_async_method("eth_blockNumber", move |_, _, _| {
+                let client = block_number_client.clone();
+                let upstream = block_number_upstream.clone();
+                let request_id = Self::next_request_id(&block_number_request_id_counter);
+                async move {
+                    Self::forward_rpc(&client, &upstream, request_id, "eth_blockNumber", json!([]))
+                        .await
+                }
+            })
+            .wrap_err("failed to register eth_blockNumber proxy method")?;
+
+        let block_by_number_client = client;
+        let block_by_number_upstream = upstream_rpc_url;
+        let block_by_number_faults = faults;
+        let block_by_number_request_id_counter = request_id_counter;
+        module
+            .register_async_method("eth_getBlockByNumber", move |params, _, _| {
+                let client = block_by_number_client.clone();
+                let upstream = block_by_number_upstream.clone();
+                let faults = block_by_number_faults.clone();
+                let request_id = Self::next_request_id(&block_by_number_request_id_counter);
+                async move {
+                    let params = params
+                        .parse::<Vec<Value>>()
+                        .map_err(|e| Self::invalid_params_error(format!("invalid params: {e}")))?;
+                    let mut result = Self::forward_rpc(
+                        &client,
+                        &upstream,
+                        request_id,
+                        "eth_getBlockByNumber",
+                        json!(params),
+                    )
+                    .await?;
+                    Self::apply_block_response_faults(&mut result, &faults);
+                    Ok::<_, ErrorObjectOwned>(result)
+                }
+            })
+            .wrap_err("failed to register eth_getBlockByNumber proxy method")?;
+
+        let server =
+            Server::builder().build(rpc_addr).await.wrap_err("failed to bind faulted RPC proxy")?;
+        let rpc_addr = server.local_addr().wrap_err("failed to read faulted RPC proxy addr")?;
+        let handle = server.start(module);
+
+        info!(rpc_port = rpc_addr.port(), "faulted RPC proxy started");
+        Ok(Self { rpc_addr, handle })
+    }
+
+    /// Returns the next upstream request ID for this proxy.
+    pub fn next_request_id(counter: &AtomicU64) -> Value {
+        Value::from(counter.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Returns the RPC URL for this proxy.
+    pub fn rpc_url(&self) -> Url {
+        Url::parse(&format!("http://{}:{}", self.rpc_addr.ip(), self.rpc_addr.port()))
+            .expect("valid RPC URL")
+    }
+
+    /// Forwards a JSON-RPC request to the upstream endpoint.
+    pub async fn forward_rpc(
+        client: &reqwest::Client,
+        upstream: &Url,
+        request_id: Value,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, ErrorObjectOwned> {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        });
+        let response = client
+            .post(upstream.clone())
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| Self::internal_error(format!("upstream request failed: {e}")))?
+            .json::<Value>()
+            .await
+            .map_err(|e| Self::internal_error(format!("upstream response decode failed: {e}")))?;
+
+        if let Some(error) = response.get("error") {
+            return Err(Self::internal_error(format!("upstream RPC error for {method}: {error}")));
+        }
+
+        response.get("result").cloned().ok_or_else(|| {
+            Self::internal_error(format!("upstream response for {method} omitted result"))
+        })
+    }
+
+    /// Applies configured faults to an `eth_getBlockByNumber` response value.
+    pub fn apply_block_response_faults(value: &mut Value, faults: &[RpcFault]) {
+        for fault in faults {
+            match fault {
+                RpcFault::MissingRequestsHash => Self::remove_requests_hash(value),
+            }
+        }
+    }
+
+    /// Removes `requestsHash` from a block response value.
+    pub fn remove_requests_hash(value: &mut Value) {
+        if let Some(block) = value.as_object_mut() {
+            block.remove("requestsHash");
+        }
+    }
+
+    /// Builds a JSON-RPC internal error object.
+    pub fn internal_error(message: String) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(ErrorCode::InternalError.code(), message, None::<()>)
+    }
+
+    /// Builds a JSON-RPC invalid params error object.
+    pub fn invalid_params_error(message: String) -> ErrorObjectOwned {
+        ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), message, None::<()>)
+    }
+}
+
+impl Drop for FaultedRpcProxy {
+    fn drop(&mut self) {
+        let _ = self.handle.stop();
+    }
+}

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -22,16 +22,19 @@ use super::{
     InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
     InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ContainerConfig,
 };
-use crate::config::SEQUENCER;
+use crate::{FaultedRpcProxy, RpcFault, config::SEQUENCER};
 
 /// Consensus mode used by the L2 client node.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum L2ClientConsensusMode {
     /// Run the client consensus node as a normal validator.
     #[default]
     Validator,
     /// Run the client consensus node in follow mode against the builder RPC.
-    Follow,
+    Follow {
+        /// Faults to apply to the follow-mode source RPC.
+        source_rpc_faults: Vec<RpcFault>,
+    },
 }
 
 /// Configuration for the L2 stack.
@@ -106,6 +109,7 @@ pub struct L2Stack {
     batcher: InProcessBatcher,
     client: InProcessClient,
     client_consensus: L2ClientConsensus,
+    follow_source_rpc_proxy: Option<FaultedRpcProxy>,
 }
 
 impl std::fmt::Debug for L2Stack {
@@ -116,6 +120,7 @@ impl std::fmt::Debug for L2Stack {
             .field("batcher", &self.batcher)
             .field("client", &self.client)
             .field("client_consensus", &self.client_consensus)
+            .field("follow_source_rpc_proxy", &self.follow_source_rpc_proxy)
             .finish()
     }
 }
@@ -218,7 +223,7 @@ impl L2Stack {
             .wrap_err("Failed to start in-process client")?;
 
         // 5. Start client consensus.
-        let client_consensus = match config.client_consensus_mode {
+        let (client_consensus, follow_source_rpc_proxy) = match config.client_consensus_mode {
             L2ClientConsensusMode::Validator => {
                 let client_consensus_config = InProcessConsensusConfig {
                     rollup_config,
@@ -248,17 +253,27 @@ impl L2Stack {
                     .connect_peer(&builder_p2p_addr)
                     .await
                     .wrap_err("Failed to connect client consensus to builder consensus")?;
-                L2ClientConsensus::Validator(client_consensus)
+                (L2ClientConsensus::Validator(client_consensus), None)
             }
-            L2ClientConsensusMode::Follow => {
-                // Follow-mode consensus polls the builder RPC directly, so it does not need a P2P
-                // peer connection before the sequencer starts producing blocks.
+            L2ClientConsensusMode::Follow { source_rpc_faults } => {
+                let follow_source_rpc_proxy = if source_rpc_faults.is_empty() {
+                    None
+                } else {
+                    Some(
+                        FaultedRpcProxy::start(builder.rpc_url()?, source_rpc_faults)
+                            .await
+                            .wrap_err("Failed to start source RPC proxy")?,
+                    )
+                };
+                let source_l2_rpc_url = follow_source_rpc_proxy
+                    .as_ref()
+                    .map_or_else(|| builder.rpc_url(), |proxy| Ok(proxy.rpc_url()))?;
                 let client_consensus_config = InProcessFollowConsensusConfig {
                     rollup_config,
                     jwt_secret: config.jwt_secret,
                     l1_rpc_url,
                     local_l2_rpc_url: client.rpc_url()?,
-                    source_l2_rpc_url: builder.rpc_url()?,
+                    source_l2_rpc_url,
                     l2_engine_url: client.engine_url()?,
                     rpc_port: container_config.and_then(|c| c.client_consensus_rpc_port),
                     insert_delay: Duration::ZERO,
@@ -266,7 +281,7 @@ impl L2Stack {
                 let client_consensus = InProcessFollowConsensus::start(client_consensus_config)
                     .await
                     .wrap_err("Failed to start follow client consensus")?;
-                L2ClientConsensus::Follow(client_consensus)
+                (L2ClientConsensus::Follow(client_consensus), follow_source_rpc_proxy)
             }
         };
 
@@ -276,7 +291,14 @@ impl L2Stack {
             .await
             .wrap_err("Failed to start sequencer after peer connection")?;
 
-        Ok(Self { builder, builder_consensus, batcher, client, client_consensus })
+        Ok(Self {
+            builder,
+            builder_consensus,
+            batcher,
+            client,
+            client_consensus,
+            follow_source_rpc_proxy,
+        })
     }
 
     /// Returns a reference to the in-process builder.

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -33,6 +33,9 @@ pub use docker::{
     stop_system_test_containers,
 };
 
+mod faults;
+pub use faults::{FaultedRpcProxy, RpcFault};
+
 mod host;
 pub use host::{host_address, with_host_port_if_needed};
 

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -207,8 +207,28 @@ impl SystemTestStackBuilder {
     }
 
     /// Runs the L2 client consensus node in follow mode against the builder RPC.
-    pub const fn with_follow_mode_client_consensus(mut self) -> Self {
-        self.client_consensus_mode = L2ClientConsensusMode::Follow;
+    pub fn with_follow_mode_client_consensus(mut self) -> Self {
+        if matches!(self.client_consensus_mode, L2ClientConsensusMode::Validator) {
+            self.client_consensus_mode =
+                L2ClientConsensusMode::Follow { source_rpc_faults: vec![] };
+        }
+        self
+    }
+
+    /// Emulates a follow-mode source RPC that omits `requestsHash` from block responses.
+    pub fn with_follow_source_missing_requests_hash(mut self) -> Self {
+        match self.client_consensus_mode {
+            L2ClientConsensusMode::Validator => {
+                self.client_consensus_mode = L2ClientConsensusMode::Follow {
+                    source_rpc_faults: vec![crate::RpcFault::MissingRequestsHash],
+                };
+            }
+            L2ClientConsensusMode::Follow { ref mut source_rpc_faults } => {
+                if !source_rpc_faults.contains(&crate::RpcFault::MissingRequestsHash) {
+                    source_rpc_faults.push(crate::RpcFault::MissingRequestsHash);
+                }
+            }
+        }
         self
     }
 

--- a/etc/systems/tests/follow_mode.rs
+++ b/etc/systems/tests/follow_mode.rs
@@ -1,0 +1,122 @@
+//! System tests for follow-mode consensus.
+
+use std::time::Duration;
+
+use alloy_consensus::proofs;
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use alloy_provider::{Provider, RootProvider};
+use base_common_network::Base;
+use base_system_tests::SystemTestStackBuilder;
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const ISTHMUS_ACTIVATION_BLOCK: u64 = 0;
+const FOLLOW_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
+const ISTHMUS_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const MIN_POST_ISTHMUS_BLOCK: u64 = 1;
+
+#[tokio::test]
+async fn follow_mode_missing_requests_hash_reproduces_withdrawals_root_bug() -> Result<()> {
+    base_node_runner::test_utils::init_silenced_tracing();
+
+    let system = SystemTestStackBuilder::new()
+        .with_isthmus_activation_block(ISTHMUS_ACTIVATION_BLOCK)
+        .with_follow_source_missing_requests_hash()
+        .build()
+        .await?;
+
+    let builder_provider = system.l2_builder_provider()?;
+    let client_provider = system.l2_client_provider()?;
+
+    let (target_block, builder_hash, builder_withdrawals_root) =
+        wait_for_builder_isthmus_block(&builder_provider).await?;
+
+    let result = async {
+        let (client_hash, client_withdrawals_root) =
+            wait_for_client_block(&client_provider, target_block).await?;
+
+        eyre::ensure!(
+            client_hash == builder_hash,
+            "follow-mode client imported a different block at {target_block}"
+        );
+        eyre::ensure!(
+            client_withdrawals_root == builder_withdrawals_root,
+            "follow-mode client did not preserve the source Isthmus withdrawals root at block {target_block}"
+        );
+
+        Ok::<_, eyre::Error>(())
+    }
+    .await;
+
+    // This is a pre-fix regression reproduction. When follow mode preserves the source
+    // withdrawals root without `requestsHash`, invert this assertion to `result.is_ok()`.
+    assert!(
+        result.is_err(),
+        "expected stripped requestsHash to reproduce the pre-fix withdrawals_root bug"
+    );
+
+    Ok(())
+}
+
+async fn wait_for_builder_isthmus_block(
+    provider: &RootProvider<Base>,
+) -> Result<(u64, B256, B256)> {
+    let empty_withdrawals_root = proofs::calculate_withdrawals_root(&[]);
+
+    timeout(ISTHMUS_BLOCK_TIMEOUT, async {
+        let mut next_block = MIN_POST_ISTHMUS_BLOCK;
+        loop {
+            let head = provider.get_block_number().await?;
+            while next_block <= head {
+                let block = provider
+                    .get_block_by_number(BlockNumberOrTag::Number(next_block))
+                    .await
+                    .wrap_err_with(|| format!("failed to fetch builder block {next_block}"))?
+                    .ok_or_else(|| eyre::eyre!("builder block {next_block} was unavailable"))?;
+
+                let withdrawals_root = block.header.withdrawals_root.ok_or_else(|| {
+                    eyre::eyre!("builder block {next_block} did not include withdrawals_root")
+                })?;
+                if withdrawals_root != empty_withdrawals_root {
+                    return Ok::<_, eyre::Error>((
+                        block.header.number,
+                        block.header.hash,
+                        withdrawals_root,
+                    ));
+                }
+
+                next_block += 1;
+            }
+
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("builder did not produce a post-Isthmus block with a non-empty withdrawals root")?
+}
+
+async fn wait_for_client_block(
+    provider: &RootProvider<Base>,
+    target_block: u64,
+) -> Result<(B256, B256)> {
+    timeout(FOLLOW_SYNC_TIMEOUT, async {
+        loop {
+            if let Some(block) =
+                provider.get_block_by_number(BlockNumberOrTag::Number(target_block)).await?
+            {
+                let withdrawals_root = block.header.withdrawals_root.ok_or_else(|| {
+                    eyre::eyre!("client block {target_block} did not include withdrawals_root")
+                })?;
+                return Ok::<_, eyre::Error>((block.header.hash, withdrawals_root));
+            }
+
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err_with(|| {
+        format!("follow-mode client did not import post-Isthmus block {target_block}")
+    })?
+}


### PR DESCRIPTION
## Summary
- add a follow-mode system regression that starts Isthmus at genesis and emulates a source RPC omitting requestsHash
- introduce a reusable system-test `FaultedRpcProxy` / `RpcFault` module for throwaway RPC response mutations
- encode source RPC faults inside `L2ClientConsensusMode::Follow` so they cannot be silently ignored in validator mode

## Why
The normal in-process builder RPC includes `requestsHash`, so the regression does not reproduce without changing the source RPC response shape. This test captures the upstream-compatible shape where `eth_getBlockByNumber` omits `requestsHash` and verifies the follow client fails to preserve the source Isthmus `withdrawals_root`.

## Review Notes
- the regression assertion is intentionally pre-fix and now documents that it should invert once the fix lands
- the faulted RPC proxy now uses unique upstream JSON-RPC request IDs instead of a hardcoded ID

## Testing
- `forge build` in `crates/utilities/test-utils/contracts`
- `cargo check -p base-system-tests --tests`