### PR TITLE
fix: seed AnchorStateRegistry with real L2 genesis output root (PRIV-2006)

### DIFF
--- a/etc/scripts/devnet/register-aggregate-verifier.sh
+++ b/etc/scripts/devnet/register-aggregate-verifier.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # real hash and points the DisputeGameFactory's game type at it.
 
 L1_RPC_URL="${L1_RPC_URL:-http://l1-el:4545}"
-L2_RPC_URL="${L2_RPC_URL:-http://base-rpc:8545}"
+L2_RPC_URL="${L2_RPC_URL:-http://base-rpc:8645}"
 L1_CHAIN_ID="${L1_CHAIN_ID:-1337}"
 OUTPUT_DIR="${OUTPUT_DIR:-/devnet/l2/configs}"
 TEMPLATE_DIR="${TEMPLATE_DIR:-/templates}"

--- a/etc/scripts/devnet/register-aggregate-verifier.sh
+++ b/etc/scripts/devnet/register-aggregate-verifier.sh
@@ -13,12 +13,15 @@ set -euo pipefail
 # real hash and points the DisputeGameFactory's game type at it.
 
 L1_RPC_URL="${L1_RPC_URL:-http://l1-el:4545}"
+L2_RPC_URL="${L2_RPC_URL:-http://base-rpc:8545}"
 L1_CHAIN_ID="${L1_CHAIN_ID:-1337}"
 OUTPUT_DIR="${OUTPUT_DIR:-/devnet/l2/configs}"
 TEMPLATE_DIR="${TEMPLATE_DIR:-/templates}"
 WORKDIR=/contracts
 HASH_FILE="${HASH_FILE:-$OUTPUT_DIR/multiproof-config-hash}"
 DEPLOY_OUTFILE="$OUTPUT_DIR/${L1_CHAIN_ID}-deploy.json"
+# L2ToL1MessagePasser predeploy; its storage root is part of the OP output-root preimage.
+L2_TO_L1_MESSAGE_PASSER=0x4200000000000000000000000000000000000016
 # foundry.toml only grants fs_permissions write access to paths under /contracts
 # (./deployments/). DEPLOYMENT_OUTFILE must therefore live there, not on the shared volume;
 # we stage the shared copy in and copy the result back out (mirrors setup-l2.sh).
@@ -51,15 +54,55 @@ if [ ! -f "$DEPLOY_OUTFILE" ]; then
   exit 1
 fi
 
+# Compute the real L2 genesis output root now that L2 genesis exists. The main deploy seeded the
+# AnchorStateRegistry with a placeholder (the real root is unknowable pre-genesis), so SystemDeploy
+# deferred ASR initialization to registerAggregateVerifier, which reads this value from cfg. Derive
+# it from the L2 EL (op-node is being deprecated) using the standard OP output-root formula:
+#   keccak256(version=0x0 ++ stateRoot ++ messagePasserStorageRoot ++ blockHash) at block 0.
+echo ""
+echo "--- Computing L2 genesis output root ---"
+echo "L2 RPC URL: $L2_RPC_URL"
+MAX_RETRIES=100
+RETRY_COUNT=0
+until cast block 0 --json --rpc-url "$L2_RPC_URL" >/dev/null 2>&1; do
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+    echo "ERROR: L2 RPC not ready after $MAX_RETRIES retries: $L2_RPC_URL"
+    exit 1
+  fi
+  sleep 0.5
+done
+
+L2_GENESIS_BLOCK="$(cast block 0 --json --rpc-url "$L2_RPC_URL")"
+L2_STATE_ROOT="$(echo "$L2_GENESIS_BLOCK" | jq -r '.stateRoot')"
+L2_BLOCK_HASH="$(echo "$L2_GENESIS_BLOCK" | jq -r '.hash')"
+L2_MESSAGE_PASSER_ROOT="$(cast proof "$L2_TO_L1_MESSAGE_PASSER" --block 0 --rpc-url "$L2_RPC_URL" | jq -r '.storageHash')"
+for field in "$L2_STATE_ROOT" "$L2_BLOCK_HASH" "$L2_MESSAGE_PASSER_ROOT"; do
+  if ! [[ "$field" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+    echo "ERROR: malformed L2 genesis field while computing output root: '$field'"
+    exit 1
+  fi
+done
+OUTPUT_ROOT_VERSION="0x0000000000000000000000000000000000000000000000000000000000000000"
+OUTPUT_ROOT_PREIMAGE="0x${OUTPUT_ROOT_VERSION#0x}${L2_STATE_ROOT#0x}${L2_MESSAGE_PASSER_ROOT#0x}${L2_BLOCK_HASH#0x}"
+MULTIPROOF_GENESIS_OUTPUT_ROOT="$(cast keccak "$OUTPUT_ROOT_PREIMAGE")"
+echo "L2 genesis state root:           $L2_STATE_ROOT"
+echo "L2 message passer storage root:  $L2_MESSAGE_PASSER_ROOT"
+echo "L2 genesis block hash:           $L2_BLOCK_HASH"
+echo "Computed L2 genesis output root: $MULTIPROOF_GENESIS_OUTPUT_ROOT"
+
 # Regenerate the deploy config from the template exactly as setup-l2.sh step 1 did, so the
 # verifier's non-hash inputs (teeImageHash, intervals, game type, …) match the original deploy.
 # Override MULTIPROOF_CONFIG_HASH with the computed hash (the env carries only the deploy-time
 # placeholder) so the regenerated devnet.json is self-consistent with the value we register —
 # the forge arg below is authoritative, but this avoids a stale hash on disk being read silently.
+# Also inject the real MULTIPROOF_GENESIS_OUTPUT_ROOT so registerAggregateVerifier initializes the
+# AnchorStateRegistry with the true anchor (the env carries only the deploy-time placeholder).
 echo ""
 echo "--- Regenerating deploy-config.json ---"
 mkdir -p "$WORKDIR/deploy-config"
 MULTIPROOF_CONFIG_HASH="$MULTIPROOF_CONFIG_HASH_COMPUTED" \
+MULTIPROOF_GENESIS_OUTPUT_ROOT="$MULTIPROOF_GENESIS_OUTPUT_ROOT" \
   envsubst <"$TEMPLATE_DIR/deploy-config.json.template" >"$WORKDIR/deploy-config/devnet.json"
 
 echo ""

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -27,6 +27,11 @@ TEE_IMAGE_HASH="${TEE_IMAGE_HASH:-0x00000000000000000000000000000000000000000000
 # When true, SystemDeploy skips the AggregateVerifier; the register-aggregate-verifier one-shot
 # deploys + registers it after L2 genesis with the real config hash (see devnet-l3-env).
 MULTIPROOF_DEFER_REGISTRATION="${MULTIPROOF_DEFER_REGISTRATION:-false}"
+# Anchor (L2 genesis output root) seeded into the AnchorStateRegistry. The real value is only
+# known after L2 genesis, so the main deploy uses a non-zero placeholder (required to pass
+# SystemDeploy's startingAnchorRoot validation) and the register-aggregate-verifier one-shot
+# recomputes the real root and initializes the registry. Exported for envsubst (Step 1).
+export MULTIPROOF_GENESIS_OUTPUT_ROOT="${MULTIPROOF_GENESIS_OUTPUT_ROOT:-0x0000000000000000000000000000000000000000000000000000000000000001}"
 
 if [ -n "$L2_BASE_AZUL_BLOCK" ] && ! [[ "$L2_BASE_AZUL_BLOCK" =~ ^[0-9]+$ ]]; then
   echo "ERROR: L2_BASE_AZUL_BLOCK must be a non-negative integer when set, got: $L2_BASE_AZUL_BLOCK"

--- a/etc/scripts/devnet/templates/deploy-config.json.template
+++ b/etc/scripts/devnet/templates/deploy-config.json.template
@@ -28,7 +28,7 @@
   "multiproofConfigHash": "${MULTIPROOF_CONFIG_HASH}",
   "multiproofGameType": 621,
   "multiproofGenesisBlockNumber": 0,
-  "multiproofGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  "multiproofGenesisOutputRoot": "${MULTIPROOF_GENESIS_OUTPUT_ROOT}",
   "multiproofIntermediateBlockInterval": 10,
   "slowFinalizationDelay": 0,
   "fastFinalizationDelay": 0,


### PR DESCRIPTION
## Summary

The dev-multiproof L3 settles to an **anchor** — the L2 genesis output root — that is only known *after* L2 genesis. The main deploy runs before genesis, so it seeded the `AnchorStateRegistry` with a placeholder root (`0x00..01`). The TEE prover then rejects every proof built from that anchor (`Output root does not match L2 head`), the proposer creates **zero dispute games**, and L3→L1 withdrawals never finalize.

This is the devnet-scripts half of the fix; the contract-side deferral is in base/contracts#349.

Linear: [PRIV-2006](https://linear.app/coinbase/issue/PRIV-2006)

## Changes

- **`templates/deploy-config.json.template`**: make `multiproofGenesisOutputRoot` substitutable (`${MULTIPROOF_GENESIS_OUTPUT_ROOT}`) instead of a hard-coded `0x..01`.
- **`setup-l2.sh`**: export a non-zero placeholder default for `MULTIPROOF_GENESIS_OUTPUT_ROOT`. The main deploy still needs a non-zero `startingAnchorRoot` to pass `SystemDeploy`'s validation, and the real root is unknowable pre-genesis.
- **`register-aggregate-verifier.sh`** (post-genesis one-shot): compute the **real** L2 genesis output root from the L2 EL and inject it into the regenerated deploy-config, so `SystemDeploy.registerAggregateVerifier(bytes32)` initializes the `AnchorStateRegistry` with the true anchor before deploying the verifier.

## Output-root derivation

op-node is being deprecated, so the root is computed directly from the L2 EL using the standard OP formula at block 0:

```
keccak256(version(0x0) ++ stateRoot ++ L2ToL1MessagePasser.storageHash ++ blockHash)
```

via `cast block 0`, `cast proof 0x42..16 --block 0`, and `cast keccak`. The script waits for the L2 RPC, validates each field is `0x` + 64 hex, and fails loudly otherwise.

## Companion PRs

- base/contracts#349 — defers ASR `initialize()` in `SystemDeploy` to `registerAggregateVerifier`.
- privacy-enclave — vendored `setup-l2.sh` mirror + `services.yml` (pass `L2_RPC_URL` to the one-shot and depend on `base-rpc`).

Made with [Cursor](https://cursor.com)