### PR TITLE
perf: reuse recovered tx in ingress sendRawTransaction

### DIFF
--- a/crates/common/bundles/src/parsed.rs
+++ b/crates/common/bundles/src/parsed.rs
@@ -33,25 +33,22 @@ pub struct ParsedBundle {
     pub dropping_tx_hashes: Vec<TxHash>,
 }
 
-impl TryFrom<Bundle> for ParsedBundle {
-    type Error = String;
-
-    fn try_from(bundle: Bundle) -> Result<Self, Self::Error> {
-        let txs: Vec<Recovered<BaseTxEnvelope>> = bundle
-            .txs
-            .into_iter()
-            .map(|tx| {
-                BaseTxEnvelope::decode_2718_exact(tx.iter().as_slice())
-                    .map_err(|e| format!("Failed to decode transaction: {e:?}"))
-                    .and_then(|tx| {
-                        tx.try_into_recovered().map_err(|e| {
-                            format!("Failed to convert transaction to recovered: {e:?}")
-                        })
-                    })
-            })
-            .collect::<Result<Vec<Recovered<BaseTxEnvelope>>, String>>()?;
-
-        let uuid = bundle
+impl ParsedBundle {
+    /// Builds a [`ParsedBundle`] from transactions that have already been decoded and
+    /// signer-recovered, reusing them instead of decoding the raw bytes again.
+    ///
+    /// Callers that already hold the recovered transaction (such as the ingress RPC, which
+    /// recovers it before wrapping it in a bundle) should use this to avoid a redundant
+    /// decode and signature recovery.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bundle.replacement_uuid` is set but is not a valid UUID.
+    pub fn from_recovered_txs(
+        txs: Vec<Recovered<BaseTxEnvelope>>,
+        bundle: Bundle,
+    ) -> Result<Self, String> {
+        let replacement_uuid = bundle
             .replacement_uuid
             .map(|x| Uuid::parse_str(x.as_ref()))
             .transpose()
@@ -65,15 +62,37 @@ impl TryFrom<Bundle> for ParsedBundle {
             min_timestamp: bundle.min_timestamp,
             max_timestamp: bundle.max_timestamp,
             reverting_tx_hashes: bundle.reverting_tx_hashes,
-            replacement_uuid: uuid,
+            replacement_uuid,
             dropping_tx_hashes: bundle.dropping_tx_hashes,
         })
     }
 }
 
+impl TryFrom<Bundle> for ParsedBundle {
+    type Error = String;
+
+    fn try_from(bundle: Bundle) -> Result<Self, Self::Error> {
+        let txs: Vec<Recovered<BaseTxEnvelope>> = bundle
+            .txs
+            .iter()
+            .map(|tx| {
+                BaseTxEnvelope::decode_2718_exact(tx.iter().as_slice())
+                    .map_err(|e| format!("Failed to decode transaction: {e:?}"))
+                    .and_then(|tx| {
+                        tx.try_into_recovered().map_err(|e| {
+                            format!("Failed to convert transaction to recovered: {e:?}")
+                        })
+                    })
+            })
+            .collect::<Result<Vec<Recovered<BaseTxEnvelope>>, String>>()?;
+
+        Self::from_recovered_txs(txs, bundle)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::U256;
+    use alloy_primitives::{Bytes, U256};
     use alloy_provider::network::eip2718::Encodable2718;
     use alloy_signer_local::PrivateKeySigner;
 
@@ -108,6 +127,34 @@ mod tests {
         assert_eq!(parsed.min_timestamp, Some(1000));
         assert_eq!(parsed.max_timestamp, Some(2000));
         assert!(parsed.replacement_uuid.is_none());
+    }
+
+    #[test]
+    fn from_recovered_txs_matches_try_from() {
+        let alice = PrivateKeySigner::random();
+        let bob = PrivateKeySigner::random();
+
+        let tx = create_transaction(alice, 7, bob.address(), U256::from(10_000));
+        let tx_bytes: Bytes = tx.encoded_2718().into();
+
+        let bundle = Bundle {
+            txs: vec![tx_bytes.clone()],
+            block_number: 100,
+            max_timestamp: Some(2000),
+            ..Default::default()
+        };
+
+        // Decode and recover once, then build the parsed bundle from the recovered tx.
+        let recovered = BaseTxEnvelope::decode_2718_exact(tx_bytes.as_ref())
+            .unwrap()
+            .try_into_recovered()
+            .unwrap();
+        let reused = ParsedBundle::from_recovered_txs(vec![recovered], bundle.clone()).unwrap();
+
+        // Decoding the raw bytes must produce an identical bundle (same fields, same hash).
+        let from_bytes: ParsedBundle = bundle.try_into().unwrap();
+
+        assert_eq!(reused, from_bytes);
     }
 
     #[test]

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -100,6 +100,7 @@ impl IngressApiServer for IngressService {
     async fn send_raw_transaction(&self, data: Bytes) -> RpcResult<B256> {
         let start = Instant::now();
         let transaction = self.get_tx(&data).await?;
+        let tx_hash = transaction.tx_hash();
 
         Metrics::transactions_received().increment(1);
 
@@ -107,7 +108,6 @@ impl IngressApiServer for IngressService {
         if let Some(forward_provider) = self.raw_tx_forward_provider.clone() {
             Metrics::raw_tx_forwards_total().increment(1);
             let tx_data = data.clone();
-            let tx_hash = transaction.tx_hash();
             tokio::spawn(async move {
                 match forward_provider.send_raw_transaction(tx_data.iter().as_slice()).await {
                     Ok(_) => {
@@ -126,14 +126,14 @@ impl IngressApiServer for IngressService {
         let bundle = Bundle {
             txs: vec![data.clone()],
             max_timestamp: Some(expiry_timestamp),
-            reverting_tx_hashes: vec![transaction.tx_hash()],
+            reverting_tx_hashes: vec![tx_hash],
             ..Default::default()
         };
 
-        let parsed_bundle: ParsedBundle = bundle
-            .clone()
-            .try_into()
-            .map_err(|e: String| EthApiError::InvalidParams(e).into_rpc_err())?;
+        // Reuse the transaction already decoded and signer-recovered in `get_tx` instead of
+        // decoding and recovering the same bytes again inside `ParsedBundle::try_from`.
+        let parsed_bundle = ParsedBundle::from_recovered_txs(vec![transaction], bundle.clone())
+            .map_err(|e| EthApiError::InvalidParams(e).into_rpc_err())?;
 
         let bundle_hash = &parsed_bundle.bundle_hash();
 
@@ -141,7 +141,7 @@ impl IngressApiServer for IngressService {
             debug!(
                 message = "Duplicate bundle detected, skipping",
                 bundle_hash = %bundle_hash,
-                transaction_hash = %transaction.tx_hash(),
+                transaction_hash = %tx_hash,
             );
         } else {
             self.bundle_cache.insert(*bundle_hash, ()).await;
@@ -194,7 +194,7 @@ impl IngressApiServer for IngressService {
             match response {
                 Ok(_) => {
                     Metrics::sent_to_mempool().increment(1);
-                    debug!(message = "sent transaction to the mempool", hash=%transaction.tx_hash());
+                    debug!(message = "sent transaction to the mempool", hash=%tx_hash);
                 }
                 Err(e) => {
                     warn!(message = "Failed to send raw transaction to mempool", error = %e);
@@ -204,7 +204,7 @@ impl IngressApiServer for IngressService {
             info!(
                 message = "processed transaction",
                 bundle_hash = %bundle_hash,
-                transaction_hash = %transaction.tx_hash(),
+                transaction_hash = %tx_hash,
             );
 
             self.send_audit_event(&accepted_bundle, accepted_bundle.bundle_hash());
@@ -212,7 +212,7 @@ impl IngressApiServer for IngressService {
 
         Metrics::send_raw_transaction_duration().record(start.elapsed().as_secs_f64());
 
-        Ok(transaction.tx_hash())
+        Ok(tx_hash)
     }
 }
 


### PR DESCRIPTION
## Summary

`eth_sendRawTransaction` on the ingress RPC decoded and ECDSA-recovered each raw transaction twice: once in `get_tx`, then again when `ParsedBundle::try_from` re-decoded the same bytes. This adds `ParsedBundle::from_recovered_txs` and uses it on the single-tx path, so the bundle is built from the transaction we already recovered. The redundant decode and signature recovery on the public hot path are gone.

## Test plan

- `cargo test -p base-bundles` (adds `from_recovered_txs_matches_try_from`, asserting the reused path produces a bundle identical to the decode path)
- `cargo clippy -p base-bundles -p ingress-rpc-lib --all-targets`

type=routine
risk=low
impact=sev5