### PR TITLE
feat(prover-service): delete completed proof requests

### DIFF
--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -25,9 +25,9 @@ use base_proof_contracts::{
 use base_proof_rpc::{L2Provider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
-    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    SnarkGroth16ProofResult, ZkProofResult, ZkVm,
+    DeleteProofRequest, GetProofRequest, GetProofResponse, ProofResult as ApiProofResult,
+    ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse, SnarkGroth16ProofResult,
+    ZkProofResult, ZkVm,
 };
 use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager};
 
@@ -771,11 +771,10 @@ impl ProofRequesterProvider for MockZkProofProvider {
     async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
-    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+    ) -> Result<(), ProverServiceClientError> {
         let mut state = self.state.lock().unwrap();
-        let count_before = state.prove_block_range_log.len();
         state.prove_block_range_log.retain(|entry| entry.proof.session_id != request.session_id);
-        Ok(DeleteProofResponse { deleted: state.prove_block_range_log.len() != count_before })
+        Ok(())
     }
 
     async fn list_proofs(

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -25,8 +25,9 @@ use base_proof_contracts::{
 use base_proof_rpc::{L2Provider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ProofResult as ApiProofResult, ProofStatus,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, SnarkGroth16ProofResult, ZkProofResult, ZkVm,
+    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
+    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    SnarkGroth16ProofResult, ZkProofResult, ZkVm,
 };
 use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager};
 
@@ -766,6 +767,17 @@ impl ProofRequesterProvider for MockZkProofProvider {
             result,
         })
     }
+
+    async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        let mut state = self.state.lock().unwrap();
+        let count_before = state.prove_block_range_log.len();
+        state.prove_block_range_log.retain(|entry| entry.proof.session_id != request.session_id);
+        Ok(DeleteProofResponse { deleted: state.prove_block_range_log.len() != count_before })
+    }
+
     async fn list_proofs(
         &self,
         _request: base_prover_service_protocol::ListProofsRequest,

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -167,8 +167,8 @@ mod tests {
     use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
     use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
     use base_prover_service_protocol::{
-        DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
-        ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -207,7 +207,7 @@ mod tests {
         async fn delete_proof_request(
             &self,
             _request: DeleteProofRequest,
-        ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        ) -> Result<(), ProverServiceClientError> {
             unimplemented!("pipeline tests do not delete proofs")
         }
 

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -167,8 +167,8 @@ mod tests {
     use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
     use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
     use base_prover_service_protocol::{
-        GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-        ProveBlockRangeRequest, ProveBlockRangeResponse,
+        DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -202,6 +202,13 @@ mod tests {
             _request: GetProofRequest,
         ) -> Result<GetProofResponse, ProverServiceClientError> {
             Err(ProverServiceClientError::Timeout("simulated poll failure".into()))
+        }
+
+        async fn delete_proof_request(
+            &self,
+            _request: DeleteProofRequest,
+        ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+            unimplemented!("pipeline tests do not delete proofs")
         }
 
         async fn list_proofs(

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1115,8 +1115,7 @@ mod tests {
         async fn delete_proof_request(
             &self,
             _request: base_prover_service_protocol::DeleteProofRequest,
-        ) -> Result<base_prover_service_protocol::DeleteProofResponse, ProverServiceClientError>
-        {
+        ) -> Result<(), ProverServiceClientError> {
             unimplemented!("tests do not delete proofs")
         }
 
@@ -1152,8 +1151,7 @@ mod tests {
         async fn delete_proof_request(
             &self,
             _request: base_prover_service_protocol::DeleteProofRequest,
-        ) -> Result<base_prover_service_protocol::DeleteProofResponse, ProverServiceClientError>
-        {
+        ) -> Result<(), ProverServiceClientError> {
             unimplemented!("tests do not delete proofs")
         }
 

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1112,6 +1112,14 @@ mod tests {
             unimplemented!("tests do not poll proofs")
         }
 
+        async fn delete_proof_request(
+            &self,
+            _request: base_prover_service_protocol::DeleteProofRequest,
+        ) -> Result<base_prover_service_protocol::DeleteProofResponse, ProverServiceClientError>
+        {
+            unimplemented!("tests do not delete proofs")
+        }
+
         async fn list_proofs(
             &self,
             _request: base_prover_service_protocol::ListProofsRequest,
@@ -1139,6 +1147,14 @@ mod tests {
         ) -> Result<base_prover_service_protocol::GetProofResponse, ProverServiceClientError>
         {
             unimplemented!("tests do not poll proofs")
+        }
+
+        async fn delete_proof_request(
+            &self,
+            _request: base_prover_service_protocol::DeleteProofRequest,
+        ) -> Result<base_prover_service_protocol::DeleteProofResponse, ProverServiceClientError>
+        {
+            unimplemented!("tests do not delete proofs")
         }
 
         async fn list_proofs(

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -462,9 +462,9 @@ mod tests {
     use async_trait::async_trait;
     use base_prover_service_client::ProverServiceClientError;
     use base_prover_service_protocol::{
-        DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
-        ListProofsRequest, ListProofsResponse, ProofRequestIdCollisionMessage,
-        ProveBlockRangeRequest, ProveBlockRangeResponse,
+        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+        ListProofsResponse, ProofRequestIdCollisionMessage, ProveBlockRangeRequest,
+        ProveBlockRangeResponse,
     };
     use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
@@ -500,7 +500,7 @@ mod tests {
         async fn delete_proof_request(
             &self,
             _request: DeleteProofRequest,
-        ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        ) -> Result<(), ProverServiceClientError> {
             unimplemented!("dispatcher tests do not delete proofs")
         }
 
@@ -536,7 +536,7 @@ mod tests {
         async fn delete_proof_request(
             &self,
             _request: DeleteProofRequest,
-        ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        ) -> Result<(), ProverServiceClientError> {
             unimplemented!("dispatcher tests do not delete proofs")
         }
 

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -462,8 +462,9 @@ mod tests {
     use async_trait::async_trait;
     use base_prover_service_client::ProverServiceClientError;
     use base_prover_service_protocol::{
-        GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-        ProofRequestIdCollisionMessage, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProofRequestIdCollisionMessage,
+        ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
     use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
@@ -496,6 +497,13 @@ mod tests {
             unimplemented!("dispatcher tests do not poll proofs")
         }
 
+        async fn delete_proof_request(
+            &self,
+            _request: DeleteProofRequest,
+        ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+            unimplemented!("dispatcher tests do not delete proofs")
+        }
+
         async fn list_proofs(
             &self,
             _request: ListProofsRequest,
@@ -523,6 +531,13 @@ mod tests {
             _request: GetProofRequest,
         ) -> Result<GetProofResponse, ProverServiceClientError> {
             unimplemented!("dispatcher tests do not poll proofs")
+        }
+
+        async fn delete_proof_request(
+            &self,
+            _request: DeleteProofRequest,
+        ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+            unimplemented!("dispatcher tests do not delete proofs")
         }
 
         async fn list_proofs(

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -23,8 +23,8 @@ use base_proof_primitives::Proposal;
 use base_proof_rpc::{BaseBlock, L1Provider, L2Provider, RollupProvider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
+    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse, ListProofsRequest,
+    ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
     ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
     TeeKind, TeeProofResult,
 };
@@ -497,6 +497,16 @@ impl ProofRequesterProvider for MockProofRequester {
                 tee_kind: TeeKind::AwsNitro,
             })),
         })
+    }
+
+    async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        let deleted_request = self.requests.lock().unwrap().remove(&request.session_id).is_some();
+        let deleted_failure =
+            self.failed_sessions.lock().unwrap().remove(&request.session_id).is_some();
+        Ok(DeleteProofResponse { deleted: deleted_request || deleted_failure })
     }
 
     async fn list_proofs(

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -23,8 +23,8 @@ use base_proof_primitives::Proposal;
 use base_proof_rpc::{BaseBlock, L1Provider, L2Provider, RollupProvider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse, ListProofsRequest,
-    ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
+    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
+    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
     ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
     TeeKind, TeeProofResult,
 };
@@ -502,11 +502,10 @@ impl ProofRequesterProvider for MockProofRequester {
     async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
-    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
-        let deleted_request = self.requests.lock().unwrap().remove(&request.session_id).is_some();
-        let deleted_failure =
-            self.failed_sessions.lock().unwrap().remove(&request.session_id).is_some();
-        Ok(DeleteProofResponse { deleted: deleted_request || deleted_failure })
+    ) -> Result<(), ProverServiceClientError> {
+        self.requests.lock().unwrap().remove(&request.session_id);
+        self.failed_sessions.lock().unwrap().remove(&request.session_id);
+        Ok(())
     }
 
     async fn list_proofs(

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use backon::Retryable;
 use base_prover_service_protocol::{
-    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse, ListProofsRequest,
-    ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
+    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
 };
 use base_retry::RetryConfig;
 use jsonrpsee::http_client::HttpClient;
@@ -36,7 +36,7 @@ pub trait ProofRequesterProvider: Send + Sync {
     async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
-    ) -> Result<DeleteProofResponse, ProverServiceClientError>;
+    ) -> Result<(), ProverServiceClientError>;
 
     /// List submitted proof requests.
     async fn list_proofs(
@@ -148,7 +148,7 @@ impl ProofRequesterClient {
     pub async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
-    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+    ) -> Result<(), ProverServiceClientError> {
         debug!(session_id = %request.session_id, "deleting proof");
         (|| {
             let request = request.clone();
@@ -215,7 +215,7 @@ impl ProofRequesterProvider for ProofRequesterClient {
     async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
-    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+    ) -> Result<(), ProverServiceClientError> {
         Self::delete_proof_request(self, request).await
     }
 
@@ -241,10 +241,10 @@ mod tests {
 
     use async_trait::async_trait;
     use base_prover_service_protocol::{
-        DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
-        ListProofsRequest, ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult,
-        ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
-        ProverRequesterApiServer, ZkProofRequest, ZkProofResult, ZkVm,
+        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+        ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
+        ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
+        ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -430,10 +430,7 @@ mod tests {
             })
         }
 
-        async fn delete_proof_request(
-            &self,
-            request: DeleteProofRequest,
-        ) -> RpcResult<DeleteProofResponse> {
+        async fn delete_proof_request(&self, request: DeleteProofRequest) -> RpcResult<()> {
             self.delete_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").delete_request =
                 Some(request);
@@ -446,7 +443,7 @@ mod tests {
                 Some(ScriptedOutcome::Fatal) => {
                     Err(invalid_params_error("scripted delete_proof_request fatal failure"))
                 }
-                None | Some(ScriptedOutcome::Success) => Ok(DeleteProofResponse { deleted: true }),
+                None | Some(ScriptedOutcome::Success) => Ok(()),
             }
         }
 
@@ -511,11 +508,10 @@ mod tests {
         }
 
         let delete_request = DeleteProofRequest { session_id: "session-get".to_owned() };
-        let delete_response = provider
+        provider
             .delete_proof_request(delete_request.clone())
             .await
             .expect("delete_proof_request should succeed");
-        assert!(delete_response.deleted);
 
         let list_request =
             ListProofsRequest { offset: 7, limit: 25, status_filter: Some(ProofStatus::Succeeded) };
@@ -635,13 +631,12 @@ mod tests {
         let api_clone = api.clone();
         let server = RunningRequesterServer::spawn_with_retry(api, fast_retry_config()).await;
 
-        let response = server
+        server
             .client
             .delete_proof_request(DeleteProofRequest { session_id: "session-delete".to_owned() })
             .await
             .expect("delete_proof_request should succeed after retry");
 
-        assert!(response.deleted);
         assert_eq!(api_clone.delete_calls(), 2);
 
         server.shutdown().await;

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -260,10 +260,11 @@ mod tests {
 
     /// Outcome script for a single requester call when the test wants to drive
     /// retry behavior. The server returns the head of the queue per call.
-    #[derive(Debug)]
+    #[derive(Clone, Copy, Debug)]
     enum ScriptedOutcome {
         Retryable,
         Fatal,
+        AlreadyDeleted,
         Success,
     }
 
@@ -273,8 +274,10 @@ mod tests {
         reject_get_proof: bool,
         prove_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
         get_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
+        delete_script: Arc<Mutex<VecDeque<ScriptedOutcome>>>,
         prove_calls: Arc<AtomicU32>,
         get_calls: Arc<AtomicU32>,
+        delete_calls: Arc<AtomicU32>,
     }
 
     #[derive(Debug, Default)]
@@ -298,8 +301,10 @@ mod tests {
                 reject_get_proof: false,
                 prove_script: Arc::new(Mutex::new(VecDeque::new())),
                 get_script: Arc::new(Mutex::new(VecDeque::new())),
+                delete_script: Arc::new(Mutex::new(VecDeque::new())),
                 prove_calls: Arc::new(AtomicU32::new(0)),
                 get_calls: Arc::new(AtomicU32::new(0)),
+                delete_calls: Arc::new(AtomicU32::new(0)),
             }
         }
 
@@ -317,12 +322,20 @@ mod tests {
             self.get_script.lock().expect("script lock").extend(outcomes);
         }
 
+        fn queue_delete_outcomes<I: IntoIterator<Item = ScriptedOutcome>>(&self, outcomes: I) {
+            self.delete_script.lock().expect("script lock").extend(outcomes);
+        }
+
         fn prove_calls(&self) -> u32 {
             self.prove_calls.load(Ordering::SeqCst)
         }
 
         fn get_calls(&self) -> u32 {
             self.get_calls.load(Ordering::SeqCst)
+        }
+
+        fn delete_calls(&self) -> u32 {
+            self.delete_calls.load(Ordering::SeqCst)
         }
     }
 
@@ -382,6 +395,9 @@ mod tests {
                 Some(ScriptedOutcome::Fatal) => {
                     Err(invalid_params_error("scripted prove_block_range fatal failure"))
                 }
+                Some(ScriptedOutcome::AlreadyDeleted) => {
+                    panic!("AlreadyDeleted is only valid for delete_proof_request")
+                }
                 None | Some(ScriptedOutcome::Success) => {
                     Ok(ProveBlockRangeResponse { session_id: request.proof.session_id })
                 }
@@ -399,6 +415,9 @@ mod tests {
                     "session_id {} is invalid",
                     request.session_id
                 )));
+            }
+            if let Some(ScriptedOutcome::AlreadyDeleted) = scripted {
+                panic!("AlreadyDeleted is only valid for delete_proof_request");
             }
 
             if self.reject_get_proof || matches!(scripted, Some(ScriptedOutcome::Retryable)) {
@@ -422,9 +441,21 @@ mod tests {
             &self,
             request: DeleteProofRequest,
         ) -> RpcResult<DeleteProofResponse> {
+            self.delete_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").delete_request =
                 Some(request);
-            Ok(DeleteProofResponse { deleted: true })
+
+            let scripted = self.delete_script.lock().expect("script lock").pop_front();
+            match scripted {
+                Some(ScriptedOutcome::Retryable) => {
+                    Err(unavailable_error("scripted delete_proof_request retryable failure"))
+                }
+                Some(ScriptedOutcome::Fatal) => {
+                    Err(invalid_params_error("scripted delete_proof_request fatal failure"))
+                }
+                Some(ScriptedOutcome::AlreadyDeleted) => Ok(DeleteProofResponse { deleted: false }),
+                None | Some(ScriptedOutcome::Success) => Ok(DeleteProofResponse { deleted: true }),
+            }
         }
 
         async fn list_proofs(&self, request: ListProofsRequest) -> RpcResult<ListProofsResponse> {
@@ -601,6 +632,25 @@ mod tests {
 
         assert!(!err.is_retryable());
         assert_eq!(api_clone.get_calls(), 1);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requester_retries_retryable_delete_until_success() {
+        let api = MockRequesterApi::new();
+        api.queue_delete_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::AlreadyDeleted]);
+        let api_clone = api.clone();
+        let server = RunningRequesterServer::spawn_with_retry(api, fast_retry_config()).await;
+
+        let response = server
+            .client
+            .delete_proof_request(DeleteProofRequest { session_id: "session-delete".to_owned() })
+            .await
+            .expect("delete_proof_request should succeed after retry");
+
+        assert!(!response.deleted);
+        assert_eq!(api_clone.delete_calls(), 2);
 
         server.shutdown().await;
     }

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use backon::Retryable;
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
+    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse, ListProofsRequest,
+    ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
 };
 use base_retry::RetryConfig;
 use jsonrpsee::http_client::HttpClient;
@@ -31,6 +31,12 @@ pub trait ProofRequesterProvider: Send + Sync {
         &self,
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError>;
+
+    /// Delete a completed proof request so the same session id can be retried.
+    async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> Result<DeleteProofResponse, ProverServiceClientError>;
 
     /// List submitted proof requests.
     async fn list_proofs(
@@ -138,6 +144,30 @@ impl ProofRequesterClient {
         .await
     }
 
+    /// Delete a completed proof request so the same session id can be retried.
+    pub async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        debug!(session_id = %request.session_id, "deleting proof");
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.delete_proof_request(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "delete proof failed; retrying"
+            );
+        })
+        .await
+    }
+
     /// List submitted proof requests.
     pub async fn list_proofs(
         &self,
@@ -182,6 +212,13 @@ impl ProofRequesterProvider for ProofRequesterClient {
         Self::get_proof(self, request).await
     }
 
+    async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> Result<DeleteProofResponse, ProverServiceClientError> {
+        Self::delete_proof_request(self, request).await
+    }
+
     async fn list_proofs(
         &self,
         request: ListProofsRequest,
@@ -204,10 +241,10 @@ mod tests {
 
     use async_trait::async_trait;
     use base_prover_service_protocol::{
-        GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse, ProofRequest,
-        ProofRequestKind, ProofResult, ProofStatus, ProofSummary, ProofType,
-        ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer, ZkProofRequest,
-        ZkProofResult, ZkVm,
+        DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult,
+        ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        ProverRequesterApiServer, ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -244,6 +281,7 @@ mod tests {
     struct MockRequesterState {
         prove_request: Option<ProveBlockRangeRequest>,
         get_request: Option<GetProofRequest>,
+        delete_request: Option<DeleteProofRequest>,
         list_request: Option<ListProofsRequest>,
     }
 
@@ -380,6 +418,15 @@ mod tests {
             })
         }
 
+        async fn delete_proof_request(
+            &self,
+            request: DeleteProofRequest,
+        ) -> RpcResult<DeleteProofResponse> {
+            self.state.lock().expect("state lock should not be poisoned").delete_request =
+                Some(request);
+            Ok(DeleteProofResponse { deleted: true })
+        }
+
         async fn list_proofs(&self, request: ListProofsRequest) -> RpcResult<ListProofsResponse> {
             self.state.lock().expect("state lock should not be poisoned").list_request =
                 Some(request);
@@ -440,6 +487,13 @@ mod tests {
             other => panic!("unexpected proof result variant: {other:?}"),
         }
 
+        let delete_request = DeleteProofRequest { session_id: "session-get".to_owned() };
+        let delete_response = provider
+            .delete_proof_request(delete_request.clone())
+            .await
+            .expect("delete_proof_request should succeed");
+        assert!(delete_response.deleted);
+
         let list_request =
             ListProofsRequest { offset: 7, limit: 25, status_filter: Some(ProofStatus::Succeeded) };
         let list_response =
@@ -452,6 +506,7 @@ mod tests {
             let state = api.state.lock().expect("state lock should not be poisoned");
             assert_eq!(state.prove_request.as_ref(), Some(&prove_request));
             assert_eq!(state.get_request.as_ref(), Some(&get_request));
+            assert_eq!(state.delete_request.as_ref(), Some(&delete_request));
             assert_eq!(state.list_request, Some(list_request));
         }
 

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -264,7 +264,6 @@ mod tests {
     enum ScriptedOutcome {
         Retryable,
         Fatal,
-        AlreadyDeleted,
         Success,
     }
 
@@ -395,9 +394,6 @@ mod tests {
                 Some(ScriptedOutcome::Fatal) => {
                     Err(invalid_params_error("scripted prove_block_range fatal failure"))
                 }
-                Some(ScriptedOutcome::AlreadyDeleted) => {
-                    panic!("AlreadyDeleted is only valid for delete_proof_request")
-                }
                 None | Some(ScriptedOutcome::Success) => {
                     Ok(ProveBlockRangeResponse { session_id: request.proof.session_id })
                 }
@@ -415,9 +411,6 @@ mod tests {
                     "session_id {} is invalid",
                     request.session_id
                 )));
-            }
-            if let Some(ScriptedOutcome::AlreadyDeleted) = scripted {
-                panic!("AlreadyDeleted is only valid for delete_proof_request");
             }
 
             if self.reject_get_proof || matches!(scripted, Some(ScriptedOutcome::Retryable)) {
@@ -453,7 +446,6 @@ mod tests {
                 Some(ScriptedOutcome::Fatal) => {
                     Err(invalid_params_error("scripted delete_proof_request fatal failure"))
                 }
-                Some(ScriptedOutcome::AlreadyDeleted) => Ok(DeleteProofResponse { deleted: false }),
                 None | Some(ScriptedOutcome::Success) => Ok(DeleteProofResponse { deleted: true }),
             }
         }
@@ -639,7 +631,7 @@ mod tests {
     #[tokio::test]
     async fn requester_retries_retryable_delete_until_success() {
         let api = MockRequesterApi::new();
-        api.queue_delete_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::AlreadyDeleted]);
+        api.queue_delete_outcomes([ScriptedOutcome::Retryable, ScriptedOutcome::Success]);
         let api_clone = api.clone();
         let server = RunningRequesterServer::spawn_with_retry(api, fast_retry_config()).await;
 
@@ -649,7 +641,7 @@ mod tests {
             .await
             .expect("delete_proof_request should succeed after retry");
 
-        assert!(!response.deleted);
+        assert!(response.deleted);
         assert_eq!(api_clone.delete_calls(), 2);
 
         server.shutdown().await;

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -10,12 +10,12 @@ mod models;
 pub use models::{
     ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult,
     CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
-    CreateProofRequestValidationError, CreateProofSession, DerivedProofRequestFields,
-    FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob,
-    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
-    ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType,
-    SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
-    canonical_session_id,
+    CreateProofRequestValidationError, CreateProofSession, DeleteProofRequestOutcome,
+    DerivedProofRequestFields, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob,
+    JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage,
+    ProofSession, ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome, SessionStatus,
+    SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
+    WorkerSessionUpsert, ZkVmKind, canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -212,13 +212,12 @@ pub enum RetryOutcome {
 pub enum CreateProofRequestOutcome {
     /// A new proof request row was inserted.
     Created(Uuid),
-    /// An existing terminal `FAILED` row was reset to `CREATED` and a fresh
-    /// worker job was made claimable again.
+    /// An existing failed row was reset to `CREATED` and a fresh worker job
+    /// was made claimable again.
     Requeued(Uuid),
-    /// An existing non-terminal or `SUCCEEDED` row was returned unchanged for
-    /// idempotent replay.
+    /// An existing non-failed row was returned unchanged for idempotent replay.
     Replayed(Uuid),
-    /// An existing terminal `FAILED` row is at the retry cap; no requeue.
+    /// An existing failed row is at the retry cap; no requeue.
     RetryExhausted(Uuid),
 }
 
@@ -232,6 +231,17 @@ impl CreateProofRequestOutcome {
             | Self::RetryExhausted(id) => *id,
         }
     }
+}
+
+/// Outcome of deleting a completed proof request by session id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteProofRequestOutcome {
+    /// A terminal proof request was deleted.
+    Deleted,
+    /// No proof request exists for the session id.
+    NotFound,
+    /// The proof request exists but is not terminal.
+    NotCompleted(ProofStatus),
 }
 
 /// Errors returned while creating proof requests.

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -8,11 +8,12 @@ use uuid::Uuid;
 use crate::{
     ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult,
     CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
-    CreateProofRequestValidationError, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome,
-    SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
-    WorkerSessionUpsert, ZkVmKind, canonical_session_id,
+    CreateProofRequestValidationError, CreateProofSession, DeleteProofRequestOutcome,
+    FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob,
+    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
+    ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType,
+    SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
+    canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -151,10 +152,10 @@ impl ProofRequestRepo {
 
         let mismatch = match status {
             ProofStatus::Failed => params.first_mismatch_allowing_l1_head_replacement(&row),
-            ProofStatus::Created
-            | ProofStatus::Pending
-            | ProofStatus::Running
-            | ProofStatus::Succeeded => params.first_mismatch(&row),
+            ProofStatus::Created | ProofStatus::Pending | ProofStatus::Running => {
+                params.first_mismatch(&row)
+            }
+            ProofStatus::Succeeded => params.first_mismatch(&row),
         };
         if let Some(field) = mismatch {
             tx.rollback().await?;
@@ -228,6 +229,53 @@ impl ProofRequestRepo {
                 Ok(CreateProofRequestOutcome::Requeued(existing_id))
             }
         }
+    }
+
+    /// Delete a terminal proof request by public session id.
+    pub async fn delete_proof_request_by_session_id(
+        &self,
+        session_id: &str,
+    ) -> Result<DeleteProofRequestOutcome> {
+        let session_id = canonical_session_id(session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+        let mut tx = self.pool.begin().await?;
+
+        let row = sqlx::query(
+            r#"
+            SELECT id, status
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(&session_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = row else {
+            tx.rollback().await?;
+            return Ok(DeleteProofRequestOutcome::NotFound);
+        };
+
+        let status_str: &str = row.get("status");
+        let status = ProofStatus::try_from(status_str).map_err(|e| {
+            sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}"))
+        })?;
+        if !matches!(status, ProofStatus::Succeeded | ProofStatus::Failed) {
+            tx.rollback().await?;
+            return Ok(DeleteProofRequestOutcome::NotCompleted(status));
+        }
+
+        let id: Uuid = row.get("id");
+        // Outbox rows do not cascade; proof_sessions rows cascade from proof_requests.
+        sqlx::query("DELETE FROM proof_request_outbox WHERE proof_request_id = $1")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM proof_requests WHERE id = $1").bind(id).execute(&mut *tx).await?;
+
+        tx.commit().await?;
+        Ok(DeleteProofRequestOutcome::Deleted)
     }
 
     /// Get a proof request by ID

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -155,6 +155,7 @@ impl ProofRequestRepo {
             ProofStatus::Created | ProofStatus::Pending | ProofStatus::Running => {
                 params.first_mismatch(&row)
             }
+            // Succeeded requests are replay-only; l1_head replacement is only for failed retries.
             ProofStatus::Succeeded => params.first_mismatch(&row),
         };
         if let Some(field) = mismatch {

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -152,11 +152,11 @@ impl ProofRequestRepo {
 
         let mismatch = match status {
             ProofStatus::Failed => params.first_mismatch_allowing_l1_head_replacement(&row),
-            ProofStatus::Created | ProofStatus::Pending | ProofStatus::Running => {
-                params.first_mismatch(&row)
-            }
-            // Succeeded requests are replay-only; l1_head replacement is only for failed retries.
-            ProofStatus::Succeeded => params.first_mismatch(&row),
+            // Non-failed existing requests are replay-only; l1_head replacement is only for failed retries.
+            ProofStatus::Created
+            | ProofStatus::Pending
+            | ProofStatus::Running
+            | ProofStatus::Succeeded => params.first_mismatch(&row),
         };
         if let Some(field) = mismatch {
             tx.rollback().await?;

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -17,8 +17,9 @@ use std::time::Duration;
 
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
-    CreateProofRequestOutcome, CreateProofSession, FailExpiredProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType,
+    CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
+    DeleteProofRequestOutcome, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob,
+    ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType,
     RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
     UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
 };
@@ -62,6 +63,21 @@ fn compressed_request_at(start_block_number: u64) -> CreateProofRequest {
             number_of_blocks_to_prove: 5,
             sequence_window: Some(50),
             l1_head: None,
+            intermediate_root_interval: None,
+            zk_vm: ZkVm::Sp1,
+        }),
+    })
+    .expect("compressed request should validate")
+}
+
+fn compressed_request_with_l1_head(l1_head: &str) -> CreateProofRequest {
+    CreateProofRequest::new(ProtocolProofRequest {
+        session_id: Uuid::new_v4().to_string(),
+        request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
+            start_block_number: 100,
+            number_of_blocks_to_prove: 5,
+            sequence_window: Some(50),
+            l1_head: Some(l1_head.parse().expect("valid hash")),
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
         }),
@@ -1121,6 +1137,160 @@ async fn test_create_for_worker_queue_requeues_failed_row() {
     assert_eq!(job_status, "PENDING");
     assert_eq!(attempt, 0);
     assert!(worker_id.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_for_worker_queue_replays_succeeded_row() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    let first = repo.create_for_worker_queue(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+
+    sqlx::query(
+        "UPDATE proof_requests SET status = 'SUCCEEDED', job_status = 'SUCCEEDED', \
+         result_payload = '{}'::jsonb, completed_at = NOW(), attempt = 4 WHERE id = $1",
+    )
+    .bind(explicit_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let second = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(second, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+
+    let after = repo.get(explicit_id).await.unwrap().unwrap();
+    assert_eq!(after.status, ProofStatus::Succeeded);
+    assert_eq!(after.retry_count, 0);
+    assert!(after.result_payload.is_some());
+    assert!(after.completed_at.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_for_worker_queue_rejects_succeeded_row_with_new_l1_head() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request_with_l1_head(
+        "0x0101010101010101010101010101010101010101010101010101010101010101",
+    );
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+
+    sqlx::query(
+        "UPDATE proof_requests SET status = 'SUCCEEDED', job_status = 'SUCCEEDED', \
+         result_payload = '{}'::jsonb, completed_at = NOW() WHERE id = $1",
+    )
+    .bind(explicit_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let mut req = compressed_request_with_l1_head(
+        "0x0202020202020202020202020202020202020202020202020202020202020202",
+    );
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    let err = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap_err();
+    assert!(matches!(
+        err,
+        CreateProofRequestError::IdCollision { id, field: "l1_head" } if id == explicit_id
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_delete_proof_request_by_session_id_deletes_succeeded_row() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+
+    sqlx::query(
+        "INSERT INTO proof_request_outbox (proof_request_id, request_params) VALUES ($1, '{}'::jsonb)",
+    )
+    .bind(explicit_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE proof_requests SET status = 'SUCCEEDED', job_status = 'SUCCEEDED', \
+         result_payload = '{}'::jsonb, completed_at = NOW() WHERE id = $1",
+    )
+    .bind(explicit_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let outcome = repo.delete_proof_request_by_session_id(&explicit_id.to_string()).await.unwrap();
+    assert_eq!(outcome, DeleteProofRequestOutcome::Deleted);
+    assert!(repo.get(explicit_id).await.unwrap().is_none());
+
+    let outbox_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM proof_request_outbox WHERE proof_request_id = $1")
+            .bind(explicit_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(outbox_count, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_delete_proof_request_by_session_id_deletes_failed_row() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+
+    sqlx::query(
+        "UPDATE proof_requests SET status = 'FAILED', job_status = 'FAILED', \
+         error_message = 'simulated failure', completed_at = NOW() WHERE id = $1",
+    )
+    .bind(explicit_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let outcome = repo.delete_proof_request_by_session_id(&explicit_id.to_string()).await.unwrap();
+    assert_eq!(outcome, DeleteProofRequestOutcome::Deleted);
+    assert!(repo.get(explicit_id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_delete_proof_request_by_session_id_rejects_non_terminal_row() {
+    let repo = test_repo(test_pool().await);
+
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+
+    let outcome = repo.delete_proof_request_by_session_id(&explicit_id.to_string()).await.unwrap();
+    assert_eq!(outcome, DeleteProofRequestOutcome::NotCompleted(ProofStatus::Created));
+    assert!(repo.get(explicit_id).await.unwrap().is_some());
 }
 
 // ============================================================

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1209,71 +1209,51 @@ async fn test_create_for_worker_queue_rejects_succeeded_row_with_new_l1_head() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
-async fn test_delete_proof_request_by_session_id_deletes_succeeded_row() {
+async fn test_delete_proof_request_by_session_id_deletes_terminal_rows() {
     let pool = test_pool().await;
     let repo = test_repo(pool.clone());
 
-    let explicit_id = Uuid::new_v4();
-    let mut req = compressed_request();
-    set_request_session_id(&mut req, explicit_id.to_string());
+    for status in ["SUCCEEDED", "FAILED"] {
+        let explicit_id = Uuid::new_v4();
+        let mut req = compressed_request();
+        set_request_session_id(&mut req, explicit_id.to_string());
 
-    let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
-    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
+        let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
+        assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
 
-    sqlx::query(
-        "INSERT INTO proof_request_outbox (proof_request_id, request_params) VALUES ($1, '{}'::jsonb)",
-    )
-    .bind(explicit_id)
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query(
-        "UPDATE proof_requests SET status = 'SUCCEEDED', job_status = 'SUCCEEDED', \
-         result_payload = '{}'::jsonb, completed_at = NOW() WHERE id = $1",
-    )
-    .bind(explicit_id)
-    .execute(&pool)
-    .await
-    .unwrap();
+        sqlx::query(
+            "INSERT INTO proof_request_outbox (proof_request_id, request_params) VALUES ($1, '{}'::jsonb)",
+        )
+        .bind(explicit_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE proof_requests SET status = $1, job_status = $1, \
+             result_payload = CASE WHEN $1 = 'SUCCEEDED' THEN '{}'::jsonb ELSE NULL END, \
+             error_message = CASE WHEN $1 = 'FAILED' THEN 'simulated failure' ELSE NULL END, \
+             completed_at = NOW() WHERE id = $2",
+        )
+        .bind(status)
+        .bind(explicit_id)
+        .execute(&pool)
+        .await
+        .unwrap();
 
-    let outcome = repo.delete_proof_request_by_session_id(&explicit_id.to_string()).await.unwrap();
-    assert_eq!(outcome, DeleteProofRequestOutcome::Deleted);
-    assert!(repo.get(explicit_id).await.unwrap().is_none());
+        let outcome =
+            repo.delete_proof_request_by_session_id(&explicit_id.to_string()).await.unwrap();
+        assert_eq!(outcome, DeleteProofRequestOutcome::Deleted);
+        assert!(repo.get(explicit_id).await.unwrap().is_none());
 
-    let outbox_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM proof_request_outbox WHERE proof_request_id = $1")
-            .bind(explicit_id)
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(outbox_count, 0);
-}
-
-#[tokio::test]
-#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
-async fn test_delete_proof_request_by_session_id_deletes_failed_row() {
-    let pool = test_pool().await;
-    let repo = test_repo(pool.clone());
-
-    let explicit_id = Uuid::new_v4();
-    let mut req = compressed_request();
-    set_request_session_id(&mut req, explicit_id.to_string());
-
-    let first = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
-    assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
-
-    sqlx::query(
-        "UPDATE proof_requests SET status = 'FAILED', job_status = 'FAILED', \
-         error_message = 'simulated failure', completed_at = NOW() WHERE id = $1",
-    )
-    .bind(explicit_id)
-    .execute(&pool)
-    .await
-    .unwrap();
-
-    let outcome = repo.delete_proof_request_by_session_id(&explicit_id.to_string()).await.unwrap();
-    assert_eq!(outcome, DeleteProofRequestOutcome::Deleted);
-    assert!(repo.get(explicit_id).await.unwrap().is_none());
+        let outbox_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM proof_request_outbox WHERE proof_request_id = $1",
+        )
+        .bind(explicit_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(outbox_count, 0);
+    }
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/protocol/src/api.rs
+++ b/crates/proof/prover-service/protocol/src/api.rs
@@ -3,11 +3,11 @@
 use jsonrpsee::proc_macros::rpc;
 
 use crate::{
-    DeleteProofRequest, DeleteProofResponse, GetNextProofRequest, GetNextProofResponse,
-    GetProofRequest, GetProofResponse, GetProofSessionRequest, GetProofSessionResponse,
-    HeartbeatRequest, HeartbeatResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
-    RecordProofSessionResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
+    DeleteProofRequest, GetNextProofRequest, GetNextProofResponse, GetProofRequest,
+    GetProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
+    HeartbeatResponse, ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest,
+    ProveBlockRangeResponse, RecordProofSessionRequest, RecordProofSessionResponse,
+    WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 
 #[cfg_attr(
@@ -43,7 +43,7 @@ pub trait ProverRequesterApi {
     async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
-    ) -> jsonrpsee::core::RpcResult<DeleteProofResponse>;
+    ) -> jsonrpsee::core::RpcResult<()>;
 
     /// List submitted proof requests.
     #[method(name = "listProofs")]

--- a/crates/proof/prover-service/protocol/src/api.rs
+++ b/crates/proof/prover-service/protocol/src/api.rs
@@ -3,11 +3,11 @@
 use jsonrpsee::proc_macros::rpc;
 
 use crate::{
-    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse,
-    GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse,
-    ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse,
+    DeleteProofRequest, DeleteProofResponse, GetNextProofRequest, GetNextProofResponse,
+    GetProofRequest, GetProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ListProofsRequest, ListProofsResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
+    RecordProofSessionResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 
 #[cfg_attr(
@@ -37,6 +37,13 @@ pub trait ProverRequesterApi {
         &self,
         request: GetProofRequest,
     ) -> jsonrpsee::core::RpcResult<GetProofResponse>;
+
+    /// Delete a completed proof request so it can be retried with the same session id.
+    #[method(name = "deleteProofRequest")]
+    async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> jsonrpsee::core::RpcResult<DeleteProofResponse>;
 
     /// List submitted proof requests.
     #[method(name = "listProofs")]

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -12,13 +12,13 @@ pub use session::ProofSessionId;
 
 mod types;
 pub use types::{
-    BackendSession, BackendSessionState, DeleteProofRequest, DeleteProofResponse,
-    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse,
-    GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse,
-    ListProofsRequest, ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob,
-    ProofJobStatus, ProofRequest, ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult,
-    ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    RecordProofSessionRequest, RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest,
-    SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
+    BackendSession, BackendSessionState, DeleteProofRequest, GetNextProofRequest,
+    GetNextProofResponse, GetProofRequest, GetProofResponse, GetProofSessionRequest,
+    GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse, ListProofsRequest,
+    ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest,
+    ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
+    ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
+    RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
+    TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
+    ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -12,13 +12,13 @@ pub use session::ProofSessionId;
 
 mod types;
 pub use types::{
-    BackendSession, BackendSessionState, GetNextProofRequest, GetNextProofResponse,
-    GetProofRequest, GetProofResponse, GetProofSessionRequest, GetProofSessionResponse,
-    HeartbeatRequest, HeartbeatResponse, ListProofsRequest, ListProofsResponse,
-    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest,
-    ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
-    ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
-    RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
-    TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
-    ZkProofRequest, ZkProofResult, ZkVm,
+    BackendSession, BackendSessionState, DeleteProofRequest, DeleteProofResponse,
+    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse,
+    GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse,
+    ListProofsRequest, ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob,
+    ProofJobStatus, ProofRequest, ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult,
+    ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    RecordProofSessionRequest, RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest,
+    SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest,
+    WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -98,13 +98,6 @@ pub struct DeleteProofRequest {
     pub session_id: String,
 }
 
-/// Response returned after deleting a completed proof request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DeleteProofResponse {
-    /// Whether a completed proof request was found and deleted.
-    pub deleted: bool,
-}
-
 /// Submitted proof request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProofRequest {

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -91,6 +91,20 @@ pub struct ProveBlockRangeResponse {
     pub session_id: String,
 }
 
+/// Request to delete a completed proof request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteProofRequest {
+    /// Proof session identifier.
+    pub session_id: String,
+}
+
+/// Response returned after deleting a completed proof request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteProofResponse {
+    /// Whether a completed proof request was deleted.
+    pub deleted: bool,
+}
+
 /// Submitted proof request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProofRequest {

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -101,7 +101,7 @@ pub struct DeleteProofRequest {
 /// Response returned after deleting a completed proof request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeleteProofResponse {
-    /// Whether a completed proof request was deleted.
+    /// Whether a completed proof request was found and deleted.
     pub deleted: bool,
 }
 

--- a/crates/proof/prover-service/src/server/delete_proof_request.rs
+++ b/crates/proof/prover-service/src/server/delete_proof_request.rs
@@ -1,0 +1,47 @@
+use base_prover_service_db::{DeleteProofRequestOutcome, canonical_session_id};
+use base_prover_service_protocol::{DeleteProofRequest, DeleteProofResponse};
+use jsonrpsee::core::RpcResult;
+use tracing::info;
+
+use crate::server::{
+    ProverServiceServer, failed_precondition, internal, invalid_argument, not_found,
+    record_rpc_result,
+};
+
+impl ProverServiceServer {
+    /// Deletes a completed proof request so the same session id can be retried.
+    pub async fn delete_proof_request_impl(
+        &self,
+        request: DeleteProofRequest,
+    ) -> RpcResult<DeleteProofResponse> {
+        let start = std::time::Instant::now();
+        let result = self.delete_proof_request_inner(request).await;
+        record_rpc_result("DeleteProofRequest", start, &result);
+
+        result
+    }
+
+    async fn delete_proof_request_inner(
+        &self,
+        request: DeleteProofRequest,
+    ) -> RpcResult<DeleteProofResponse> {
+        let session_id = canonical_session_id(&request.session_id)
+            .map_err(|e| invalid_argument(format!("{e}")))?;
+        match self.repo.delete_proof_request_by_session_id(&session_id).await {
+            Ok(DeleteProofRequestOutcome::Deleted) => {
+                info!(session_id = %session_id, "Deleted terminal proof request");
+                Ok(DeleteProofResponse { deleted: true })
+            }
+            Ok(DeleteProofRequestOutcome::NotFound) => {
+                Err(not_found(format!("session_id {session_id}: proof request not found")))
+            }
+            Ok(DeleteProofRequestOutcome::NotCompleted(status)) => {
+                Err(failed_precondition(format!(
+                    "session_id {session_id}: proof request status is {}, expected SUCCEEDED or FAILED",
+                    status.as_str()
+                )))
+            }
+            Err(e) => Err(internal(format!("Database error: {e}"))),
+        }
+    }
+}

--- a/crates/proof/prover-service/src/server/delete_proof_request.rs
+++ b/crates/proof/prover-service/src/server/delete_proof_request.rs
@@ -4,8 +4,7 @@ use jsonrpsee::core::RpcResult;
 use tracing::info;
 
 use crate::server::{
-    ProverServiceServer, failed_precondition, internal, invalid_argument, not_found,
-    record_rpc_result,
+    ProverServiceServer, failed_precondition, internal, invalid_argument, record_rpc_result,
 };
 
 impl ProverServiceServer {
@@ -32,9 +31,7 @@ impl ProverServiceServer {
                 info!(session_id = %session_id, "Deleted terminal proof request");
                 Ok(DeleteProofResponse { deleted: true })
             }
-            Ok(DeleteProofRequestOutcome::NotFound) => {
-                Err(not_found(format!("session_id {session_id}: proof request not found")))
-            }
+            Ok(DeleteProofRequestOutcome::NotFound) => Ok(DeleteProofResponse { deleted: false }),
             Ok(DeleteProofRequestOutcome::NotCompleted(status)) => {
                 Err(failed_precondition(format!(
                     "session_id {session_id}: proof request status is {}, expected SUCCEEDED or FAILED",

--- a/crates/proof/prover-service/src/server/delete_proof_request.rs
+++ b/crates/proof/prover-service/src/server/delete_proof_request.rs
@@ -1,5 +1,5 @@
 use base_prover_service_db::{DeleteProofRequestOutcome, canonical_session_id};
-use base_prover_service_protocol::{DeleteProofRequest, DeleteProofResponse};
+use base_prover_service_protocol::DeleteProofRequest;
 use jsonrpsee::core::RpcResult;
 use tracing::info;
 
@@ -9,10 +9,7 @@ use crate::server::{
 
 impl ProverServiceServer {
     /// Deletes a completed proof request so the same session id can be retried.
-    pub async fn delete_proof_request_impl(
-        &self,
-        request: DeleteProofRequest,
-    ) -> RpcResult<DeleteProofResponse> {
+    pub async fn delete_proof_request_impl(&self, request: DeleteProofRequest) -> RpcResult<()> {
         let start = std::time::Instant::now();
         let result = self.delete_proof_request_inner(request).await;
         record_rpc_result("DeleteProofRequest", start, &result);
@@ -20,18 +17,15 @@ impl ProverServiceServer {
         result
     }
 
-    async fn delete_proof_request_inner(
-        &self,
-        request: DeleteProofRequest,
-    ) -> RpcResult<DeleteProofResponse> {
+    async fn delete_proof_request_inner(&self, request: DeleteProofRequest) -> RpcResult<()> {
         let session_id = canonical_session_id(&request.session_id)
             .map_err(|e| invalid_argument(format!("{e}")))?;
         match self.repo.delete_proof_request_by_session_id(&session_id).await {
             Ok(DeleteProofRequestOutcome::Deleted) => {
                 info!(session_id = %session_id, "Deleted terminal proof request");
-                Ok(DeleteProofResponse { deleted: true })
+                Ok(())
             }
-            Ok(DeleteProofRequestOutcome::NotFound) => Ok(DeleteProofResponse { deleted: false }),
+            Ok(DeleteProofRequestOutcome::NotFound) => Ok(()),
             Ok(DeleteProofRequestOutcome::NotCompleted(status)) => {
                 Err(failed_precondition(format!(
                     "session_id {session_id}: proof request status is {}, expected SUCCEEDED or FAILED",

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use base_prover_service_db::ProofRequestRepo;
 use base_prover_service_protocol::{
-    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse, ListProofsRequest,
-    ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
+    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -102,10 +102,7 @@ impl ProverRequesterApiServer for ProverServiceServer {
         self.get_proof_impl(request).await
     }
 
-    async fn delete_proof_request(
-        &self,
-        request: DeleteProofRequest,
-    ) -> RpcResult<DeleteProofResponse> {
+    async fn delete_proof_request(&self, request: DeleteProofRequest) -> RpcResult<()> {
         self.delete_proof_request_impl(request).await
     }
 

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use base_prover_service_db::ProofRequestRepo;
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
+    DeleteProofRequest, DeleteProofResponse, GetProofRequest, GetProofResponse, ListProofsRequest,
+    ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -14,6 +14,7 @@ use jsonrpsee::{
 
 use crate::WorkerQueueConfig;
 
+mod delete_proof_request;
 mod get_proof;
 mod list_proofs;
 mod prove_block_range;
@@ -99,6 +100,13 @@ impl ProverRequesterApiServer for ProverServiceServer {
 
     async fn get_proof(&self, request: GetProofRequest) -> RpcResult<GetProofResponse> {
         self.get_proof_impl(request).await
+    }
+
+    async fn delete_proof_request(
+        &self,
+        request: DeleteProofRequest,
+    ) -> RpcResult<DeleteProofResponse> {
+        self.delete_proof_request_impl(request).await
     }
 
     async fn list_proofs(&self, request: ListProofsRequest) -> RpcResult<ListProofsResponse> {

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -87,7 +87,7 @@ impl ProverServiceServer {
                     "rejected ProveBlockRange: proof request retry budget exhausted for this session_id",
                 );
                 return Err(resource_exhausted(format!(
-                    "session_id {session_id}: proof request retry budget exhausted; use get_proof for the stored terminal failure",
+                    "session_id {session_id}: proof request retry budget exhausted; use get_proof for the stored terminal result",
                 )));
             }
             CreateProofRequestOutcome::Created(id) => {
@@ -99,13 +99,13 @@ impl ProverServiceServer {
             CreateProofRequestOutcome::Requeued(id) => {
                 info!(
                     proof_request_id = %id,
-                    "Requeued previously failed proof request"
+                    "Requeued terminal proof request"
                 );
             }
             CreateProofRequestOutcome::Replayed(id) => {
                 info!(
                     proof_request_id = %id,
-                    "Idempotent replay of in-flight or succeeded proof request"
+                    "Idempotent replay of in-flight proof request"
                 );
             }
         }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -99,7 +99,7 @@ impl ProverServiceServer {
             CreateProofRequestOutcome::Requeued(id) => {
                 info!(
                     proof_request_id = %id,
-                    "Requeued terminal proof request"
+                    "Requeued previously failed proof request"
                 );
             }
             CreateProofRequestOutcome::Replayed(id) => {

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -105,7 +105,7 @@ impl ProverServiceServer {
             CreateProofRequestOutcome::Replayed(id) => {
                 info!(
                     proof_request_id = %id,
-                    "Idempotent replay of in-flight proof request"
+                    "Idempotent replay of non-failed proof request"
                 );
             }
         }


### PR DESCRIPTION
### What changed? Why?

Adds requester, protocol, server, and DB support for deleting completed prover-service proof requests by session id. This lets callers remove a terminal `SUCCEEDED` or `FAILED` request before retrying the same session id.

Also keeps succeeded request replay idempotent and rejects succeeded-row replays when the request payload no longer matches.

### Notes to reviewers

Only terminal proof requests can be deleted. Non-terminal requests return a failed precondition error, and missing session ids return not found.

The DB delete removes matching outbox rows before deleting the proof request; proof sessions still cascade from `proof_requests`.

### How has it been tested?

`cargo fmt --check`

`cargo test -p base-prover-service-protocol -p base-prover-service-client -p base-prover-service -p base-prover-service-db --lib --tests`

Postgres integration tests compile in the test command above, but the ignored DB cases still require a running Postgres with `DATABASE_URL`.