### PR TITLE
fix(eip8130): keep enshrined system accounts non-empty under EIP-161 via Cobalt code stub

### DIFF
--- a/crates/common/evm/src/cobalt.rs
+++ b/crates/common/evm/src/cobalt.rs
@@ -1,0 +1,145 @@
+use alloy_evm::Database;
+use alloy_primitives::{Address, Bytes};
+use base_common_chains::Upgrades;
+use base_common_precompiles::NonceManagerStorage;
+use revm::{DatabaseCommit, primitives::HashMap, state::Bytecode};
+
+/// Single-byte code stub planted on otherwise code-less EIP-8130 system accounts.
+///
+/// `0xEF` is the EIP-3541 reserved prefix: it can never be produced by a normal
+/// `CREATE`/`CREATE2` deployment, so it is an unambiguous "this is a protocol
+/// system account" sentinel. Its only job is to give the account a non-empty
+/// code hash; the address is still serviced by the native precompile, not by
+/// executing this byte.
+const SYSTEM_ACCOUNT_STUB: [u8; 1] = [0xEF];
+
+/// Code-less EIP-8130 system accounts that hold persistent storage but carry no
+/// code on any chain, and therefore must be made non-empty so EIP-161
+/// end-of-block state clearing does not reap them together with their storage.
+///
+/// Only the [`NonceManager`](NonceManagerStorage) qualifies: it persists the 2D
+/// nonce channels in the state trie while never being a deployed contract. The
+/// transaction-context precompile (`0x8130…aa02`) uses transient storage only
+/// (cleared every transaction, never trie-resident) so it needs no stub, and
+/// `AccountConfiguration` is a genuinely deployed contract (it carries code) on
+/// every chain where EIP-8130 is enabled.
+const CODELESS_SYSTEM_ACCOUNTS: [Address; 1] = [NonceManagerStorage::ADDRESS];
+
+/// The Cobalt upgrade enables EIP-8130. The enshrined execution path writes
+/// persistent state (e.g. 2D nonce channels) to system accounts that hold
+/// storage but carry no code, leaving them EIP-161-"empty" and liable to be
+/// reaped — discarding that storage — by end-of-block state clearing.
+///
+/// This issues an irregular state transition at the Cobalt activation that
+/// force-deploys a one-byte code stub onto those accounts, mirroring the Canyon
+/// create2-deployer transition in [`ensure_create2_deployer`]. Once an account
+/// has code it is no longer EIP-161-empty and survives clearing.
+///
+/// The stub is only planted on an account that has no code yet, so it never
+/// overwrites a real deployment, and it is idempotent: it fires on the first
+/// Cobalt block and is a no-op thereafter.
+///
+/// [`ensure_create2_deployer`]: crate::ensure_create2_deployer
+pub fn ensure_eip8130_system_accounts<DB>(
+    chain_spec: impl Upgrades,
+    timestamp: u64,
+    db: &mut DB,
+) -> Result<(), DB::Error>
+where
+    DB: Database + DatabaseCommit,
+{
+    if !chain_spec.is_cobalt_active_at_timestamp(timestamp) {
+        return Ok(());
+    }
+
+    let stub = Bytecode::new_legacy(Bytes::from_static(&SYSTEM_ACCOUNT_STUB));
+    let stub_hash = stub.hash_slow();
+
+    let mut updates = HashMap::default();
+    for address in CODELESS_SYSTEM_ACCOUNTS {
+        let mut acc_info = db.basic(address)?.unwrap_or_default();
+
+        // Skip if the account already carries code (real deployment, or the stub
+        // planted on a previous block); only an empty-code account needs it.
+        if !acc_info.is_empty_code_hash() {
+            continue;
+        }
+
+        acc_info.code_hash = stub_hash;
+        acc_info.code = Some(stub.clone());
+
+        let mut revm_acc: revm::state::Account = acc_info.into();
+        revm_acc.mark_touch();
+        updates.insert(address, revm_acc);
+    }
+
+    if !updates.is_empty() {
+        db.commit(updates);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_hardforks::ForkCondition;
+    use base_common_chains::{BaseUpgradeExt, ChainUpgrades};
+    use base_common_genesis::BaseUpgrade;
+    use revm::{Database as _, database::InMemoryDB, state::AccountInfo};
+
+    use super::*;
+
+    const ADDR: Address = NonceManagerStorage::ADDRESS;
+
+    /// Cobalt active: the code-less nonce manager is given the `0xEF` stub so it
+    /// is no longer EIP-161-empty.
+    #[test]
+    fn cobalt_active_plants_stub_on_codeless_system_account() {
+        let mut db = InMemoryDB::default();
+
+        ensure_eip8130_system_accounts(cobalt(ForkCondition::Timestamp(0)), 100, &mut db).unwrap();
+
+        let acc = db.basic(ADDR).unwrap().expect("system account must exist");
+        assert!(!acc.is_empty_code_hash(), "the stub must give the account a non-empty code hash");
+        assert_eq!(
+            acc.code.as_ref().map(Bytecode::original_bytes),
+            Some(Bytes::from_static(&SYSTEM_ACCOUNT_STUB)),
+        );
+    }
+
+    /// Cobalt inactive: nothing is planted.
+    #[test]
+    fn cobalt_inactive_is_a_noop() {
+        let mut db = InMemoryDB::default();
+
+        ensure_eip8130_system_accounts(cobalt(ForkCondition::Never), 100, &mut db).unwrap();
+
+        assert!(db.basic(ADDR).unwrap().is_none(), "no system account should be materialized");
+    }
+
+    /// An account that already has code (a real deployment) is left untouched.
+    #[test]
+    fn existing_code_is_not_overwritten() {
+        let mut db = InMemoryDB::default();
+        let real = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]));
+        db.insert_account_info(
+            ADDR,
+            AccountInfo {
+                code_hash: real.hash_slow(),
+                code: Some(real.clone()),
+                ..Default::default()
+            },
+        );
+
+        ensure_eip8130_system_accounts(cobalt(ForkCondition::Timestamp(0)), 100, &mut db).unwrap();
+
+        let acc = db.basic(ADDR).unwrap().unwrap();
+        assert_eq!(acc.code_hash, real.hash_slow(), "a real deployment must not be overwritten");
+    }
+
+    fn cobalt(condition: ForkCondition) -> ChainUpgrades {
+        ChainUpgrades::new(BaseUpgrade::devnet().into_iter().map(move |(fork, cond)| {
+            if fork == BaseUpgrade::Cobalt { (fork, condition) } else { (fork, cond) }
+        }))
+    }
+}

--- a/crates/common/evm/src/executor/block_executor.rs
+++ b/crates/common/evm/src/executor/block_executor.rs
@@ -144,6 +144,17 @@ where
         )
         .map_err(BlockExecutionError::other)?;
 
+        // At the Cobalt (EIP-8130) transition, plant a code stub on the code-less
+        // enshrined system accounts (the 2D nonce manager) so the persistent state
+        // the enshrined path writes to them is not reaped by EIP-161 end-of-block
+        // state clearing.
+        crate::cobalt::ensure_eip8130_system_accounts(
+            &self.spec,
+            self.evm.block().timestamp().saturating_to(),
+            self.evm.db_mut(),
+        )
+        .map_err(BlockExecutionError::other)?;
+
         Ok(())
     }
 

--- a/crates/common/evm/src/lib.rs
+++ b/crates/common/evm/src/lib.rs
@@ -58,6 +58,9 @@ pub use receipt_builder::{AlloyReceiptBuilder, BaseReceiptBuilder};
 mod canyon;
 pub use canyon::ensure_create2_deployer;
 
+mod cobalt;
+pub use cobalt::ensure_eip8130_system_accounts;
+
 mod executor;
 pub use executor::{
     BaseBlockExecutionCtx, BaseBlockExecutor, BaseBlockExecutorFactory, BaseTxResult,

--- a/crates/common/precompile-storage/src/journal.rs
+++ b/crates/common/precompile-storage/src/journal.rs
@@ -126,39 +126,15 @@ impl PrecompileStorageProvider for JournalStorageProvider<'_> {
     }
 
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
+        // Writing only mutates the storage trie; it deliberately does not touch
+        // nonce/balance/code. Code-less enshrined system accounts that hold
+        // persistent storage (e.g. the 2D `NonceManager`) are instead made
+        // EIP-161-non-empty out of band by a one-byte code stub planted at the
+        // Cobalt transition (see `ensure_eip8130_system_accounts`), so their
+        // storage survives end-of-block state clearing without a per-write guard.
         self.internals
             .sstore(address, key, value)
             .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-
-        // EIP-161 guard for enshrined system storage. `sstore` writes only the
-        // storage trie; it never sets nonce/balance/code, so the target account
-        // can remain EIP-161-"empty" (no code, zero nonce, zero balance) even
-        // after it holds storage. End-of-block state clearing reaps a
-        // touched-and-empty account together with its storage, which would
-        // silently discard the persistent state the enshrined EIP-8130 path
-        // writes — the 2D-nonce channels in the native `NonceManager` precompile
-        // (which carries no code on any chain), and the account configuration in
-        // the `AccountConfiguration` system account on a chain where it is
-        // enshrined rather than deployed. Bump the nonce to 1 the first time a
-        // non-zero value materializes storage on an otherwise-empty account so it
-        // survives clearing; once non-empty (including any chain where the target
-        // is a deployed contract with code) this is a no-op. The bump is
-        // journaled, so an enclosing checkpoint revert (e.g. a rejected EIP-8130
-        // transaction) rolls it back together with the write.
-        if !value.is_zero() {
-            let is_empty = {
-                let state_load = self
-                    .internals
-                    .load_account(address)
-                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-                state_load.data.info.is_empty()
-            };
-            if is_empty {
-                self.internals
-                    .bump_nonce(address)
-                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-            }
-        }
 
         Ok(())
     }
@@ -298,79 +274,5 @@ mod tests {
         assert_eq!(provider.state_gas_used(), 0);
         assert_eq!(provider.gas_refunded(), 0);
         assert!(!provider.is_static());
-    }
-
-    fn nonce_of(provider: &mut JournalStorageProvider<'_>, address: Address) -> u64 {
-        let mut nonce = 0;
-        provider.with_account_info(address, &mut |info| nonce = info.nonce).unwrap();
-        nonce
-    }
-
-    /// A non-zero store onto an EIP-161-empty account bumps its nonce to 1, so the
-    /// account is no longer "empty" and end-of-block state clearing will not reap
-    /// it (and discard the enshrined storage written to it).
-    #[test]
-    fn sstore_materializes_empty_account_to_survive_state_clearing() {
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        let mut provider =
-            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
-
-        assert_eq!(nonce_of(&mut provider, ADDR), 0, "account starts empty");
-        provider.sstore(ADDR, U256::from(1u64), U256::from(42u64)).unwrap();
-        assert_eq!(
-            nonce_of(&mut provider, ADDR),
-            1,
-            "a non-zero store must materialize the account (nonce bumped to 1)"
-        );
-    }
-
-    /// The materialization fires once: subsequent stores see a non-empty account
-    /// and must not keep incrementing the nonce.
-    #[test]
-    fn repeated_sstore_bumps_nonce_only_once() {
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        let mut provider =
-            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
-
-        provider.sstore(ADDR, U256::from(1u64), U256::from(42u64)).unwrap();
-        provider.sstore(ADDR, U256::from(2u64), U256::from(43u64)).unwrap();
-        assert_eq!(
-            nonce_of(&mut provider, ADDR),
-            1,
-            "the account is materialized once; later stores must not keep incrementing"
-        );
-    }
-
-    /// A zero-value store does not materialize an otherwise-empty account: there is
-    /// no persistent data to protect, so the account stays clearable.
-    #[test]
-    fn sstore_zero_value_does_not_materialize_empty_account() {
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        let mut provider =
-            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
-
-        provider.sstore(ADDR, U256::from(1u64), U256::ZERO).unwrap();
-        assert_eq!(
-            nonce_of(&mut provider, ADDR),
-            0,
-            "a zero store writes no persistent data, so the account is left empty"
-        );
-    }
-
-    /// An account that already carries code (e.g. a deployed system contract) is
-    /// not EIP-161-empty, so the guard leaves its nonce untouched.
-    #[test]
-    fn sstore_does_not_bump_nonce_of_account_with_code() {
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
-        let mut provider =
-            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
-
-        provider.set_code(ADDR, Bytecode::new_raw([0x60u8, 0x00].as_ref().into())).unwrap();
-        provider.sstore(ADDR, U256::from(1u64), U256::from(42u64)).unwrap();
-        assert_eq!(
-            nonce_of(&mut provider, ADDR),
-            0,
-            "an account with code is already non-empty; the guard must not bump its nonce"
-        );
     }
 }

--- a/crates/common/precompile-storage/src/journal.rs
+++ b/crates/common/precompile-storage/src/journal.rs
@@ -54,6 +54,11 @@ impl<'a> JournalStorageProvider<'a> {
     /// `caller`. Block metadata (number, timestamp, chain id, beneficiary,
     /// origin) is snapshotted from the journal's block/transaction environment.
     pub fn new(internals: EvmInternals<'a>, caller: Address) -> Self {
+        // Truncating to `u64` is safe: EVM block numbers are bounded far below
+        // `u64::MAX` and `block_env().number()` is only `U256` for ABI uniformity.
+        // (Unlike the block *timestamp*, which the EIP-8130 executor converts with
+        // a checked `try_into` because it feeds consensus-critical expiry checks,
+        // the block number here only backs the `block_number()` getter.)
         let block_number = internals.block_env().number().to::<u64>();
         let timestamp = internals.block_env().timestamp();
         let chain_id = internals.chain_id();
@@ -96,14 +101,15 @@ impl PrecompileStorageProvider for JournalStorageProvider<'_> {
         address: Address,
         f: &mut dyn FnMut(&AccountInfo),
     ) -> Result<()> {
-        let info = {
-            let state_load = self
-                .internals
-                .load_account(address)
-                .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
-            state_load.data.info.clone()
-        };
-        f(&info);
+        // Pass the journal's borrowed `AccountInfo` straight to the callback. The
+        // callback cannot re-enter the provider (it has no `self` access), so the
+        // outstanding borrow is safe and we avoid cloning the full `AccountInfo`
+        // (including a potentially large `code` `Bytecode`) on every read.
+        let state_load = self
+            .internals
+            .load_account(address)
+            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+        f(&state_load.data.info);
         Ok(())
     }
 
@@ -122,8 +128,39 @@ impl PrecompileStorageProvider for JournalStorageProvider<'_> {
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
         self.internals
             .sstore(address, key, value)
-            .map(|_| ())
-            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))
+            .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+
+        // EIP-161 guard for enshrined system storage. `sstore` writes only the
+        // storage trie; it never sets nonce/balance/code, so the target account
+        // can remain EIP-161-"empty" (no code, zero nonce, zero balance) even
+        // after it holds storage. End-of-block state clearing reaps a
+        // touched-and-empty account together with its storage, which would
+        // silently discard the persistent state the enshrined EIP-8130 path
+        // writes — the 2D-nonce channels in the native `NonceManager` precompile
+        // (which carries no code on any chain), and the account configuration in
+        // the `AccountConfiguration` system account on a chain where it is
+        // enshrined rather than deployed. Bump the nonce to 1 the first time a
+        // non-zero value materializes storage on an otherwise-empty account so it
+        // survives clearing; once non-empty (including any chain where the target
+        // is a deployed contract with code) this is a no-op. The bump is
+        // journaled, so an enclosing checkpoint revert (e.g. a rejected EIP-8130
+        // transaction) rolls it back together with the write.
+        if !value.is_zero() {
+            let is_empty = {
+                let state_load = self
+                    .internals
+                    .load_account(address)
+                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+                state_load.data.info.is_empty()
+            };
+            if is_empty {
+                self.internals
+                    .bump_nonce(address)
+                    .map_err(|e| BasePrecompileError::Fatal(e.to_string()))?;
+            }
+        }
+
+        Ok(())
     }
 
     fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
@@ -261,5 +298,79 @@ mod tests {
         assert_eq!(provider.state_gas_used(), 0);
         assert_eq!(provider.gas_refunded(), 0);
         assert!(!provider.is_static());
+    }
+
+    fn nonce_of(provider: &mut JournalStorageProvider<'_>, address: Address) -> u64 {
+        let mut nonce = 0;
+        provider.with_account_info(address, &mut |info| nonce = info.nonce).unwrap();
+        nonce
+    }
+
+    /// A non-zero store onto an EIP-161-empty account bumps its nonce to 1, so the
+    /// account is no longer "empty" and end-of-block state clearing will not reap
+    /// it (and discard the enshrined storage written to it).
+    #[test]
+    fn sstore_materializes_empty_account_to_survive_state_clearing() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        assert_eq!(nonce_of(&mut provider, ADDR), 0, "account starts empty");
+        provider.sstore(ADDR, U256::from(1u64), U256::from(42u64)).unwrap();
+        assert_eq!(
+            nonce_of(&mut provider, ADDR),
+            1,
+            "a non-zero store must materialize the account (nonce bumped to 1)"
+        );
+    }
+
+    /// The materialization fires once: subsequent stores see a non-empty account
+    /// and must not keep incrementing the nonce.
+    #[test]
+    fn repeated_sstore_bumps_nonce_only_once() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        provider.sstore(ADDR, U256::from(1u64), U256::from(42u64)).unwrap();
+        provider.sstore(ADDR, U256::from(2u64), U256::from(43u64)).unwrap();
+        assert_eq!(
+            nonce_of(&mut provider, ADDR),
+            1,
+            "the account is materialized once; later stores must not keep incrementing"
+        );
+    }
+
+    /// A zero-value store does not materialize an otherwise-empty account: there is
+    /// no persistent data to protect, so the account stays clearable.
+    #[test]
+    fn sstore_zero_value_does_not_materialize_empty_account() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        provider.sstore(ADDR, U256::from(1u64), U256::ZERO).unwrap();
+        assert_eq!(
+            nonce_of(&mut provider, ADDR),
+            0,
+            "a zero store writes no persistent data, so the account is left empty"
+        );
+    }
+
+    /// An account that already carries code (e.g. a deployed system contract) is
+    /// not EIP-161-empty, so the guard leaves its nonce untouched.
+    #[test]
+    fn sstore_does_not_bump_nonce_of_account_with_code() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), SpecId::AMSTERDAM);
+        let mut provider =
+            JournalStorageProvider::new(EvmInternals::from_context(&mut ctx), Address::ZERO);
+
+        provider.set_code(ADDR, Bytecode::new_raw([0x60u8, 0x00].as_ref().into())).unwrap();
+        provider.sstore(ADDR, U256::from(1u64), U256::from(42u64)).unwrap();
+        assert_eq!(
+            nonce_of(&mut provider, ADDR),
+            0,
+            "an account with code is already non-empty; the guard must not bump its nonce"
+        );
     }
 }

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -14,7 +14,9 @@ use alloy_rpc_types::TransactionTrait;
 use alloy_rpc_types_eth::state::StateOverride;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BasePrimitives, BaseReceipt, BaseTxEnvelope, Predeploys};
-use base_common_evm::{BaseHaltReason, L1BlockInfo, ensure_create2_deployer, ensure_eip8130_system_accounts};
+use base_common_evm::{
+    BaseHaltReason, L1BlockInfo, ensure_create2_deployer, ensure_eip8130_system_accounts,
+};
 use base_common_flz::tx_estimated_size_fjord as estimate_tx_compressed_size;
 use base_common_rpc_types::{BaseTransactionReceipt, Transaction};
 use base_execution_rpc::BaseReceiptBuilder as BaseRpcReceiptBuilder;

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types::TransactionTrait;
 use alloy_rpc_types_eth::state::StateOverride;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BasePrimitives, BaseReceipt, BaseTxEnvelope, Predeploys};
-use base_common_evm::{BaseHaltReason, L1BlockInfo, ensure_create2_deployer};
+use base_common_evm::{BaseHaltReason, L1BlockInfo, ensure_create2_deployer, ensure_eip8130_system_accounts};
 use base_common_flz::tx_estimated_size_fjord as estimate_tx_compressed_size;
 use base_common_rpc_types::{BaseTransactionReceipt, Transaction};
 use base_execution_rpc::BaseReceiptBuilder as BaseRpcReceiptBuilder;
@@ -190,6 +190,13 @@ where
             .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
 
         ensure_create2_deployer(spec, self.pending_block.timestamp, self.evm.db_mut())
+            .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
+
+        // At the Cobalt (EIP-8130) transition, plant a code stub on the code-less
+        // enshrined system accounts (the 2D nonce manager) so the persistent state
+        // the enshrined path writes to them is not reaped by EIP-161 end-of-block
+        // state clearing.
+        ensure_eip8130_system_accounts(spec, self.pending_block.timestamp, self.evm.db_mut())
             .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
 
         Ok(())


### PR DESCRIPTION
## Summary

The enshrined EIP-8130 execution path writes persistent state (the 2D-nonce channels in the native `NonceManager`, account configuration, etc.) through the journal's `sstore`, which only mutates the **storage trie** — it never sets nonce/balance/code. A code-less system account therefore stays EIP-161-"empty" (`code == ∅ && nonce == 0 && balance == 0`) and is **reaped together with its storage** by end-of-block state clearing, silently discarding the enshrined state.

The native `NonceManager` (`0x8130…aa01`) is the account that hits this: it holds persistent storage but carries **no code on any chain**, so it is empty-with-storage even on mainnet.

## Fix

Make the code-less enshrined system accounts EIP-161-**non-empty by giving them code**, via an irregular state transition at the Cobalt (EIP-8130) activation — mirroring the existing Canyon create2-deployer force-deploy. `ensure_eip8130_system_accounts` plants a one-byte `0xEF` stub on the `NonceManager` account on the first Cobalt block:

- **`0xEF`** is the EIP-3541-reserved prefix: it can never come from a real `CREATE`/`CREATE2`, so it is an unambiguous protocol-system-account sentinel. The address is still serviced by the native precompile, not by executing the byte.
- **Idempotent & non-destructive** — gated on `is_cobalt_active` + empty code hash, so it fires once and never overwrites a real deployment.
- **Protects every write path** — once the account has code, both the gas-free journal provider and `EvmPrecompileStorageProvider` are safe, with no per-`sstore` guard.

This supersedes the earlier per-`sstore` nonce-bump guard, which is removed (along with its four tests). The unrelated `journal.rs` `with_account_info` clone-removal nit is retained.

### Why nothing else needs a stub
- The transaction-context precompile (`0x8130…aa02`) uses **transient** storage only — cleared every transaction, never trie-resident.
- `AccountConfiguration` is a genuinely **deployed** contract (it carries code) on every chain where EIP-8130 is enabled; it is expected to be deployed before Cobalt is ready, so it needs no special handling.

### Note
Once Cobalt is live this makes `EXTCODESIZE(0x8130…aa01) == 1` and `EXTCODEHASH == keccak(0xEF)`, where the `NonceManager` previously reported as code-less. That is the intended trade-off of the code-stub approach.

## Test plan

* `cargo test -p base-common-evm cobalt` — 3 tests: stub planted when Cobalt active; no-op when inactive; existing deployed code never overwritten.
* `cargo test -p base-precompile-storage --lib` — journal/storage suite green after guard removal.
* `cargo test -p base-common-evm --lib executor` — `eip8130_transaction_is_included_with_typed_receipt` still passes with the new pre-execution hook.
* `cargo clippy -p base-common-evm -p base-precompile-storage --all-targets`