### PR TITLE
chore(devnet): schedule Base Cobalt on the local devnet

### DIFF
--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -188,6 +188,9 @@ L2_BASE_AZUL_BLOCK=20
 # Optional: set to a non-negative block number to schedule Base Beryl in devnet.
 # Leave unset to avoid setting base.beryl during genesis generation.
 L2_BASE_BERYL_BLOCK=21
+# Optional: set to a non-negative block number to schedule Base Cobalt in devnet.
+# Leave unset to avoid setting base.cobalt during genesis generation.
+L2_BASE_COBALT_BLOCK=22
 
 # Metering Resource Limits
 # Whole-block budgets for gas/state-root/DA, plus a per-flashblock execution budget.

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -161,6 +161,7 @@ services:
       - L2_CHAIN_ID=${L2_CHAIN_ID}
       - L2_BASE_AZUL_BLOCK=${L2_BASE_AZUL_BLOCK-}
       - L2_BASE_BERYL_BLOCK=${L2_BASE_BERYL_BLOCK-}
+      - L2_BASE_COBALT_BLOCK=${L2_BASE_COBALT_BLOCK-}
       - OUTPUT_DIR=/devnet/l2/configs
       - L2_DATA_DIR=/data
       - DEPLOYER_ADDR=${DEPLOYER_ADDR}


### PR DESCRIPTION
## Summary

Plumb an optional `L2_BASE_COBALT_BLOCK` through the docker-compose devnet so it can activate **Base Cobalt** (and therefore include EIP-8130 type `0x7B` transactions) at a chosen block. This mirrors the existing Beryl scheduling exactly:

* `devnet-env`: add `L2_BASE_COBALT_BLOCK` (defaults to block 22).
* `docker-compose.yml`: pass `L2_BASE_COBALT_BLOCK` into the L2 setup service.

This is purely the final bit of devnet wiring. The supporting pieces already live on `main`:

* `setup-l2.sh` already validates `L2_BASE_COBALT_BLOCK`, derives the activation timestamp from `genesis_time + block_time * block`, and patches `base.cobalt` into the generated `rollup.json` and `genesis.json` (same pattern as `base.beryl`).
* Node-side Cobalt config parsing (`cobalt_timestamp` / `is_cobalt_active`) is already on `main`.

## Test plan

* `bash -n etc/scripts/devnet/setup-l2.sh` (syntax)
* `just devnet-up` with `L2_BASE_COBALT_BLOCK=22` activates Cobalt at the expected block and accepts a `0x7B` transaction