### PR TITLE
refactor(load-test): every sender can mint b20

### DIFF
--- a/bin/load-tester/src/cli.rs
+++ b/bin/load-tester/src/cli.rs
@@ -382,7 +382,7 @@ async fn run_test_phases(
 
     if runner.needs_b20_setup() {
         println!("Setting up B-20 tokens...");
-        runner.setup_b20_tokens(funding_key.clone(), amounts.b20_mint).await?;
+        runner.setup_b20_tokens(amounts.b20_mint).await?;
         println!("B-20 tokens ready.");
     }
     println!();

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -176,22 +176,18 @@ The `PrecompileLooper` contract enables batch testing by calling a precompile mu
 #### B-20 Token Testing
 
 B-20 precompile tokens can be load-tested to benchmark the precompile's `transfer` performance.
-The load tester handles the full lifecycle: token creation via the B-20 factory, role grants
-(`MINT_ROLE` / `BURN_ROLE` to every sender), minting during setup, and burning during teardown.
+Each sender creates and owns its own B-20 token: during setup every sender sends one `createB20`
+factory tx (in parallel) whose privileged init calls grant the sender `BURN_ROLE` and mint its
+supply, during the load phase each sender transfers its own token, and during teardown each sender
+burns its remaining balance. A fresh per-run salt keeps each run's token addresses distinct.
 
 Requires Beryl activation (B-20 factory and token features must be active on the target chain).
 
 ```yaml
-# Auto-create a new B-20 token per run (devnet/zeronet)
+# Each sender creates and transfers its own B-20 token per run
 transactions:
   - weight: 100
     type: b20
-
-# Use a pre-deployed B-20 token
-transactions:
-  - weight: 100
-    type: b20
-    contract: "0x..."
 ```
 
 #### Swap Testing
@@ -218,3 +214,7 @@ real_token_setup:
 ```
 
 `reverse_min_amount` and `reverse_max_amount` on `uniswap_v3` and `aerodrome_cl` set the amount range for `token_out → token_in` swaps. Use these when the two tokens have different decimal scales; when omitted, the reverse range matches the forward range.
+
+#### Running multiple load tests
+
+- You may need to tune `target_gps` and sender count appropriately. 

--- a/crates/infra/load-tests/src/config/real_token.rs
+++ b/crates/infra/load-tests/src/config/real_token.rs
@@ -154,7 +154,7 @@ fn validate_real_token_pair_matches_swaps(
             TxTypeConfig::Transfer
             | TxTypeConfig::Calldata { .. }
             | TxTypeConfig::Erc20 { .. }
-            | TxTypeConfig::B20 { .. }
+            | TxTypeConfig::B20
             | TxTypeConfig::Precompile { .. }
             | TxTypeConfig::Osaka { .. } => continue,
         };

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -239,13 +239,9 @@ pub enum TxTypeConfig {
         #[serde(default)]
         reverse_max_amount: Option<String>,
     },
-    /// B-20 precompile token transfer.
-    B20 {
-        /// B-20 token precompile address. When omitted, a new token is created via the factory
-        /// during setup.
-        #[serde(default)]
-        contract: Option<String>,
-    },
+    /// B-20 precompile token transfer. Each sender creates and transfers its own token, created
+    /// per run during setup.
+    B20,
 
     /// Aerodrome Slipstream (concentrated liquidity) swap.
     AerodromeCl {
@@ -596,19 +592,7 @@ impl TestConfig {
                     looper_contract,
                 }
             }
-            TxTypeConfig::B20 { contract } => {
-                let contract = contract
-                    .as_ref()
-                    .map(|c| {
-                        c.parse::<Address>().map_err(|e| {
-                            BaselineError::Config(format!(
-                                "invalid b20 contract address '{c}': {e}"
-                            ))
-                        })
-                    })
-                    .transpose()?;
-                TxType::B20 { contract }
-            }
+            TxTypeConfig::B20 => TxType::B20,
             TxTypeConfig::Osaka { target } => TxType::Osaka { target: target.clone() },
             TxTypeConfig::UniswapV3 {
                 router,

--- a/crates/infra/load-tests/src/runner/b20.rs
+++ b/crates/infra/load-tests/src/runner/b20.rs
@@ -20,7 +20,7 @@ use super::{LoadRunner, SubmissionPipeline, TxType, load_runner::FUNDING_CONCURR
 use crate::{
     BaselineError, Result,
     rpc::{BaseFeeExt, RpcResultExt, WalletProvider, create_wallet_provider},
-    workload::b20_token_for,
+    workload::{b20_salt_for, b20_token_for},
 };
 
 /// Gas limit for a `createB20` tx (token creation plus the self-grant and self-mint init calls).
@@ -35,7 +35,7 @@ const REPLACEMENT_FEE_MULTIPLIER: u128 = 3;
 impl LoadRunner {
     /// Returns `true` if any configured transaction type is [`TxType::B20`].
     pub fn needs_b20_setup(&self) -> bool {
-        self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20 { .. }))
+        self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20))
     }
 
     /// Creates a per-sender B-20 ASSET token, with each sender minting its own supply.
@@ -86,7 +86,7 @@ impl LoadRunner {
                 // Build the create tx for this sender's own token. The init calls run with factory
                 // privilege, so the grant and mint bypass the normal role checks: the sender ends
                 // up holding BURN_ROLE and `amount_per_sender` of its own supply.
-                let salt = crate::workload::b20_salt_for(sender, run_salt);
+                let salt = b20_salt_for(sender, run_salt);
                 let create_params = IB20Factory::B20AssetCreateParams {
                     version: params_version,
                     name: "Load Test B20".to_string(),
@@ -182,7 +182,7 @@ impl LoadRunner {
             return Err(BaselineError::Transaction(format!(
                 "{failed}/{total} per-sender B-20 token setups failed (first: {detail}). \
                  Likely cause: B-20 ASSET feature not activated on this chain, \
-                 or a factory validation error."
+                 a factory validation error, or clear the txpool and try again."
             )));
         }
 

--- a/crates/infra/load-tests/src/runner/b20.rs
+++ b/crates/infra/load-tests/src/runner/b20.rs
@@ -7,9 +7,9 @@
 
 use std::time::Duration;
 
-use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes, U256};
-use alloy_provider::Provider;
+use alloy_provider::{PendingTransactionBuilder, Provider};
 use alloy_rpc_types::TransactionRequest;
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_precompiles::{B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory};
@@ -19,7 +19,7 @@ use tracing::{debug, info, warn};
 use super::{LoadRunner, SubmissionPipeline, TxType, load_runner::FUNDING_CONCURRENCY};
 use crate::{
     BaselineError, Result,
-    rpc::{BaseFeeExt, RpcResultExt, create_wallet_provider},
+    rpc::{BaseFeeExt, RpcResultExt, WalletProvider, create_wallet_provider},
     workload::b20_token_for,
 };
 
@@ -57,8 +57,7 @@ impl LoadRunner {
         let max_fee =
             SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
         let replacement_max_fee = max_fee.saturating_mul(REPLACEMENT_FEE_MULTIPLIER);
-        let replacement_priority_fee =
-            max_priority_fee.saturating_mul(REPLACEMENT_FEE_MULTIPLIER);
+        let replacement_priority_fee = max_priority_fee.saturating_mul(REPLACEMENT_FEE_MULTIPLIER);
 
         // A fresh random salt per run keeps each run's token addresses distinct, so re-running the
         // same sender set never collides with the previous run's tokens.
@@ -72,11 +71,14 @@ impl LoadRunner {
         let params_version = B20Variant::Asset.supported_version();
 
         info!(senders = total, amount = %amount_per_sender, "creating per-sender B-20 tokens");
-        let pb = self.progress_bar(total as u64, "Creating per-sender B-20 tokens");
 
-        let create_futs = account_data.into_iter().map(|(sender, signer)| {
+        // Phase 1: submit every sender's create tx in parallel. Submission is fast (one RPC per
+        // sender) and does not block on confirmation, so all creates land in the mempool quickly
+        // instead of the stream stalling behind a slow receipt at the buffer head.
+        let pb_submit = self.progress_bar(total as u64, "Submitting per-sender B-20 creates");
+        let submit_futs = account_data.into_iter().map(|(sender, signer)| {
             let rpc_url = rpc_url.clone();
-            let pb = pb.clone();
+            let pb_submit = pb_submit.clone();
             async move {
                 let wallet = EthereumWallet::from(signer);
                 let provider = create_wallet_provider(rpc_url, wallet);
@@ -106,8 +108,8 @@ impl LoadRunner {
                 };
                 let input = Bytes::from(create_call.abi_encode());
 
-                let outcome = Self::submit_b20_create(
-                    &provider,
+                let result = Self::submit_b20_create(
+                    provider,
                     sender,
                     input,
                     chain_id,
@@ -118,27 +120,62 @@ impl LoadRunner {
                     replacement_priority_fee,
                 )
                 .await;
-                pb.inc(1);
-                (sender, outcome)
+                pb_submit.inc(1);
+                (sender, result)
             }
         });
 
-        let mut create_stream = stream::iter(create_futs).buffer_unordered(FUNDING_CONCURRENCY);
+        let submit_results: Vec<_> =
+            stream::iter(submit_futs).buffer_unordered(FUNDING_CONCURRENCY).collect().await;
+        pb_submit.finish_and_clear();
+
+        // Phase 2: collect all create receipts in parallel. Confirmation latency now overlaps
+        // across senders instead of serializing at the submit stream's head.
+        let pb_confirm = self.progress_bar(total as u64, "Confirming per-sender B-20 creates");
         let mut failed = 0usize;
         let mut first_error: Option<String> = None;
-        while let Some((sender, outcome)) = create_stream.next().await {
-            match outcome {
-                Ok(()) => debug!(sender = %sender, "B-20 token created"),
+        let mut receipt_futs = Vec::with_capacity(submit_results.len());
+        for (sender, result) in submit_results {
+            match result {
+                Ok(pending) => receipt_futs.push(async move {
+                    (sender, pending.with_timeout(Some(B20_RECEIPT_TIMEOUT)).get_receipt().await)
+                }),
                 Err(e) => {
-                    warn!(sender = %sender, error = %e, "B-20 token creation failed");
+                    warn!(sender = %sender, error = %e, "B-20 create submission failed");
                     failed += 1;
                     if first_error.is_none() {
                         first_error = Some(e.to_string());
                     }
+                    pb_confirm.inc(1);
                 }
             }
         }
-        pb.finish_and_clear();
+
+        let mut receipt_stream = stream::iter(receipt_futs).buffer_unordered(FUNDING_CONCURRENCY);
+        while let Some((sender, result)) = receipt_stream.next().await {
+            match result {
+                Ok(receipt) if receipt.status() => {
+                    debug!(sender = %sender, tx_hash = %receipt.transaction_hash, "B-20 token created");
+                }
+                Ok(receipt) => {
+                    warn!(sender = %sender, tx_hash = %receipt.transaction_hash, "B-20 create reverted");
+                    failed += 1;
+                    if first_error.is_none() {
+                        first_error =
+                            Some(format!("createB20 reverted (tx {})", receipt.transaction_hash));
+                    }
+                }
+                Err(e) => {
+                    warn!(sender = %sender, error = %e, "B-20 create receipt failed");
+                    failed += 1;
+                    if first_error.is_none() {
+                        first_error = Some(format!("receipt failed: {e}"));
+                    }
+                }
+            }
+            pb_confirm.inc(1);
+        }
+        pb_confirm.finish_and_clear();
 
         if failed > 0 {
             let detail = first_error.unwrap_or_else(|| "unknown error".to_string());
@@ -151,22 +188,23 @@ impl LoadRunner {
 
         // Rebuild the generator now that the per-run salt is known, so the B-20 payload derives the
         // correct per-sender token addresses.
-        self.generator = Self::create_generator(self.workload_config(), &self.config, Some(run_salt))?;
+        self.generator =
+            Self::create_generator(self.workload_config(), &self.config, Some(run_salt))?;
 
         info!(senders = total, amount = %amount_per_sender, "B-20 token setup complete");
         Ok(())
     }
 
-    /// Sends one `createB20` tx for a sender, replacing a stuck pending tx if necessary.
+    /// Submits one `createB20` tx for a sender, replacing a stuck pending tx if necessary.
     ///
-    /// Mirrors the funding path's replacement handling: a `replacement transaction underpriced` or
-    /// `already known` rejection (a leftover pending tx from a prior run at the same nonce) is
-    /// retried at the same nonce with bumped fees, and a `nonce too low` rejection refetches the
-    /// pending nonce. The original send's pending tx is awaited first; only a send rejection
-    /// triggers the fee-bumped replacement.
+    /// Returns the pending tx so the caller can await its receipt in a separate phase, keeping
+    /// submission decoupled from confirmation. Mirrors the funding path's replacement handling: a
+    /// `replacement transaction underpriced` or `already known` rejection (a leftover pending tx
+    /// from a prior run at the same nonce) is retried at the same nonce with bumped fees, and a
+    /// `nonce too low` rejection refetches the pending nonce.
     #[allow(clippy::too_many_arguments)]
     async fn submit_b20_create(
-        provider: &impl Provider,
+        provider: WalletProvider,
         sender: Address,
         input: Bytes,
         chain_id: u64,
@@ -175,7 +213,7 @@ impl LoadRunner {
         max_priority_fee: u128,
         replacement_max_fee: u128,
         replacement_priority_fee: u128,
-    ) -> Result<()> {
+    ) -> Result<PendingTransactionBuilder<Ethereum>> {
         let nonce = provider
             .get_transaction_count(sender)
             .pending()
@@ -193,9 +231,8 @@ impl LoadRunner {
                 .with_max_priority_fee_per_gas(priority_fee)
         };
 
-        let pending = match provider.send_transaction(build(nonce, max_fee, max_priority_fee)).await
-        {
-            Ok(pending) => pending,
+        match provider.send_transaction(build(nonce, max_fee, max_priority_fee)).await {
+            Ok(pending) => Ok(pending),
             Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("replacement transaction underpriced")
@@ -211,7 +248,7 @@ impl LoadRunner {
                         .await
                         .map_err(|e| {
                             BaselineError::Transaction(format!("replacement send failed: {e}"))
-                        })?
+                        })
                 } else if msg.contains("nonce too low") {
                     // The pending nonce was stale; refetch and resend.
                     let fresh = provider
@@ -224,26 +261,12 @@ impl LoadRunner {
                         .await
                         .map_err(|e| {
                             BaselineError::Transaction(format!("nonce-refreshed send failed: {e}"))
-                        })?
+                        })
                 } else {
-                    return Err(BaselineError::Transaction(format!("send failed: {e}")));
+                    Err(BaselineError::Transaction(format!("send failed: {e}")))
                 }
             }
-        };
-
-        let receipt = pending
-            .with_timeout(Some(B20_RECEIPT_TIMEOUT))
-            .get_receipt()
-            .await
-            .map_err(|e| BaselineError::Transaction(format!("receipt failed: {e}")))?;
-
-        if !receipt.status() {
-            return Err(BaselineError::Transaction(format!(
-                "createB20 reverted (tx {})",
-                receipt.transaction_hash
-            )));
         }
-        Ok(())
     }
 
     /// Burns each sender's remaining balance of its own B-20 token.

--- a/crates/infra/load-tests/src/runner/b20.rs
+++ b/crates/infra/load-tests/src/runner/b20.rs
@@ -1,24 +1,36 @@
-//! B-20 precompile token lifecycle for load tests: creation, role grants,
-//! minting during setup, and burning during teardown.
+//! B-20 precompile token lifecycle for load tests: per-sender token creation with self-mint
+//! during setup, and per-sender burning during teardown.
+//!
+//! Each sender creates and owns its own B-20 ASSET token (mirroring the parallel uniswap/aerodrome
+//! setup), so setup is fully parallel with each sender on its own nonce stream — there is no funder
+//! bottleneck and no admin-gated role grants routed through a single account.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use alloy_network::{EthereumWallet, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::TransactionRequest;
-use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_precompiles::{B20FactoryStorage, B20TokenRole, B20Variant, IB20, IB20Factory};
 use futures::{StreamExt, stream};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, warn};
 
 use super::{LoadRunner, SubmissionPipeline, TxType, load_runner::FUNDING_CONCURRENCY};
 use crate::{
     BaselineError, Result,
-    config::WorkloadConfig,
     rpc::{BaseFeeExt, RpcResultExt, create_wallet_provider},
+    workload::b20_token_for,
 };
+
+/// Gas limit for a `createB20` tx (token creation plus the self-grant and self-mint init calls).
+const B20_CREATE_GAS_LIMIT: u64 = 10_000_000;
+/// Gas limit for a single `burn` tx during teardown.
+const B20_BURN_GAS_LIMIT: u64 = 200_000;
+/// Timeout for awaiting a setup/teardown tx receipt before treating it as failed.
+const B20_RECEIPT_TIMEOUT: Duration = Duration::from_secs(120);
+/// Fee multiplier applied when replacing a stuck pending tx (matches the funding-path bump).
+const REPLACEMENT_FEE_MULTIPLIER: u128 = 3;
 
 impl LoadRunner {
     /// Returns `true` if any configured transaction type is [`TxType::B20`].
@@ -26,385 +38,221 @@ impl LoadRunner {
         self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20 { .. }))
     }
 
-    /// Builds the fatal error returned when a funder nonce gap could not be cleared on-chain.
+    /// Creates a per-sender B-20 ASSET token, with each sender minting its own supply.
     ///
-    /// The funder is reused across runs, so a leftover gap bricks future runs until the missing
-    /// nonce is mined. The message tells the operator to regenerate the funding seed.
-    fn nonce_gap_error(funder: Address) -> BaselineError {
-        BaselineError::Transaction(format!(
-            "funder {funder} has an uncleared nonce gap from a failed B-20 setup submission; \
-             this account is reused across runs and future runs will stall until the gap is \
-             filled — regenerate the funding seed for a clean run"
-        ))
-    }
-
-    /// Creates a B-20 token via the factory, grants `MINT_ROLE` and `BURN_ROLE` to all senders,
-    /// then mints tokens to every sender account.
+    /// Every sender sends ONE `createB20` tx from its own account, in parallel. The token's
+    /// `initialAdmin` is the sender itself, and the create's privileged `initCalls` grant the
+    /// sender `BURN_ROLE` (so teardown can burn) and mint `amount_per_sender` to the sender.
+    /// Because each sender uses its own nonce stream, a stuck pending tx from a prior run at the
+    /// same nonce is replaced by a fee-bumped resend (see [`Self::submit_b20_create`]).
     ///
-    /// If all B-20 transaction configs already have a resolved `contract` address, this is a
-    /// no-op for creation but still handles role grants and minting.
-    #[instrument(skip(self, funding_key), fields(accounts = self.accounts.len()))]
-    pub async fn setup_b20_tokens(
-        &mut self,
-        funding_key: PrivateKeySigner,
-        amount_per_sender: U256,
-    ) -> Result<()> {
-        let funder_address = funding_key.address();
-        let wallet = EthereumWallet::from(funding_key);
-        let funder_provider =
-            Arc::new(create_wallet_provider(self.config.primary_submission_rpc().clone(), wallet));
+    /// A fresh per-run salt is generated and stored on the runner so the derived token addresses
+    /// differ from previous runs (avoiding `TokenAlreadyExists`) and so the load payload and
+    /// teardown can recompute the same addresses.
+    pub async fn setup_b20_tokens(&mut self, amount_per_sender: U256) -> Result<()> {
         let chain_id = self.config.chain_id;
         let max_gas_price = self.config.max_gas_price;
         let base_fee = self.client.get_base_fee().await?;
         let max_priority_fee = (base_fee / 10).max(1);
         let max_fee =
             SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
-        let b20_gas_limit = 10_000_000u64;
+        let replacement_max_fee = max_fee.saturating_mul(REPLACEMENT_FEE_MULTIPLIER);
+        let replacement_priority_fee =
+            max_priority_fee.saturating_mul(REPLACEMENT_FEE_MULTIPLIER);
 
-        let mut nonce = funder_provider
-            .get_transaction_count(funder_address)
+        // A fresh random salt per run keeps each run's token addresses distinct, so re-running the
+        // same sender set never collides with the previous run's tokens.
+        let run_salt = B256::from(rand::random::<[u8; 32]>());
+        self.b20_run_salt = Some(run_salt);
+
+        let account_data: Vec<(Address, _)> =
+            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
+        let total = account_data.len();
+        let rpc_url = self.config.primary_submission_rpc().clone();
+        let params_version = B20Variant::Asset.supported_version();
+
+        info!(senders = total, amount = %amount_per_sender, "creating per-sender B-20 tokens");
+        let pb = self.progress_bar(total as u64, "Creating per-sender B-20 tokens");
+
+        let create_futs = account_data.into_iter().map(|(sender, signer)| {
+            let rpc_url = rpc_url.clone();
+            let pb = pb.clone();
+            async move {
+                let wallet = EthereumWallet::from(signer);
+                let provider = create_wallet_provider(rpc_url, wallet);
+
+                // Build the create tx for this sender's own token. The init calls run with factory
+                // privilege, so the grant and mint bypass the normal role checks: the sender ends
+                // up holding BURN_ROLE and `amount_per_sender` of its own supply.
+                let salt = crate::workload::b20_salt_for(sender, run_salt);
+                let create_params = IB20Factory::B20AssetCreateParams {
+                    version: params_version,
+                    name: "Load Test B20".to_string(),
+                    symbol: "LTB20".to_string(),
+                    initialAdmin: sender,
+                    decimals: 6,
+                };
+                let grant_burn =
+                    IB20::grantRoleCall { role: B20TokenRole::Burn.id(), account: sender };
+                let mint = IB20::mintCall { to: sender, amount: amount_per_sender };
+                let create_call = IB20Factory::createB20Call {
+                    variant: IB20Factory::B20Variant::ASSET,
+                    salt,
+                    params: create_params.abi_encode().into(),
+                    initCalls: vec![
+                        Bytes::from(grant_burn.abi_encode()),
+                        Bytes::from(mint.abi_encode()),
+                    ],
+                };
+                let input = Bytes::from(create_call.abi_encode());
+
+                let outcome = Self::submit_b20_create(
+                    &provider,
+                    sender,
+                    input,
+                    chain_id,
+                    B20_CREATE_GAS_LIMIT,
+                    max_fee,
+                    max_priority_fee,
+                    replacement_max_fee,
+                    replacement_priority_fee,
+                )
+                .await;
+                pb.inc(1);
+                (sender, outcome)
+            }
+        });
+
+        let mut create_stream = stream::iter(create_futs).buffer_unordered(FUNDING_CONCURRENCY);
+        let mut failed = 0usize;
+        let mut first_error: Option<String> = None;
+        while let Some((sender, outcome)) = create_stream.next().await {
+            match outcome {
+                Ok(()) => debug!(sender = %sender, "B-20 token created"),
+                Err(e) => {
+                    warn!(sender = %sender, error = %e, "B-20 token creation failed");
+                    failed += 1;
+                    if first_error.is_none() {
+                        first_error = Some(e.to_string());
+                    }
+                }
+            }
+        }
+        pb.finish_and_clear();
+
+        if failed > 0 {
+            let detail = first_error.unwrap_or_else(|| "unknown error".to_string());
+            return Err(BaselineError::Transaction(format!(
+                "{failed}/{total} per-sender B-20 token setups failed (first: {detail}). \
+                 Likely cause: B-20 ASSET feature not activated on this chain, \
+                 or a factory validation error."
+            )));
+        }
+
+        // Rebuild the generator now that the per-run salt is known, so the B-20 payload derives the
+        // correct per-sender token addresses.
+        self.generator = Self::create_generator(self.workload_config(), &self.config, Some(run_salt))?;
+
+        info!(senders = total, amount = %amount_per_sender, "B-20 token setup complete");
+        Ok(())
+    }
+
+    /// Sends one `createB20` tx for a sender, replacing a stuck pending tx if necessary.
+    ///
+    /// Mirrors the funding path's replacement handling: a `replacement transaction underpriced` or
+    /// `already known` rejection (a leftover pending tx from a prior run at the same nonce) is
+    /// retried at the same nonce with bumped fees, and a `nonce too low` rejection refetches the
+    /// pending nonce. The original send's pending tx is awaited first; only a send rejection
+    /// triggers the fee-bumped replacement.
+    #[allow(clippy::too_many_arguments)]
+    async fn submit_b20_create(
+        provider: &impl Provider,
+        sender: Address,
+        input: Bytes,
+        chain_id: u64,
+        gas_limit: u64,
+        max_fee: u128,
+        max_priority_fee: u128,
+        replacement_max_fee: u128,
+        replacement_priority_fee: u128,
+    ) -> Result<()> {
+        let nonce = provider
+            .get_transaction_count(sender)
             .pending()
             .await
             .rpc("get pending transaction count")?;
 
-        // Phase 1: Create B-20 token if no contract address is configured.
-        let mut token_address: Option<Address> = None;
-        for tx_config in &self.config.transactions {
-            if let TxType::B20 { contract: Some(addr) } = &tx_config.tx_type {
-                token_address = Some(*addr);
-                break;
-            }
-        }
-
-        if token_address.is_none() {
-            // B-20 activation is a one-time chain-lifecycle operation performed by the activation
-            // admin (see `ActivationRegistry`), not by the load tester. The funder only creates a
-            // token; if the feature is not active, the factory's `ensure_activated` check will
-            // revert the create tx with `FeatureNotActivated`.
-            info!("creating new B-20 token via factory");
-
-            let salt = B256::from(rand::random::<[u8; 32]>());
-            let predicted = B20Variant::Asset.compute_address(funder_address, salt).0;
-
-            let params = IB20Factory::B20AssetCreateParams {
-                version: B20Variant::Asset.supported_version(),
-                name: "Load Test B20".to_string(),
-                symbol: "LTB20".to_string(),
-                initialAdmin: funder_address,
-                decimals: 6,
-            };
-
-            // Factory sets the cap to `DEFAULT_SUPPLY_CAP` (== `B20_MAX_SUPPLY_CAP`) at
-            // creation, so no init call is needed; an `updateSupplyCap(U256::MAX)` would
-            // revert on builds that clamp the cap to `B20_MAX_SUPPLY_CAP`.
-            let create_call = IB20Factory::createB20Call {
-                variant: IB20Factory::B20Variant::ASSET,
-                salt,
-                params: params.abi_encode().into(),
-                initCalls: Vec::new(),
-            };
-
-            let tx = TransactionRequest::default()
-                .with_to(B20FactoryStorage::ADDRESS)
-                .with_input(Bytes::from(create_call.abi_encode()))
-                .with_nonce(nonce)
-                .with_chain_id(chain_id)
-                .with_gas_limit(b20_gas_limit)
-                .with_max_fee_per_gas(max_fee)
-                .with_max_priority_fee_per_gas(max_priority_fee);
-            nonce += 1;
-
-            let pending = funder_provider.send_transaction(tx).await.map_err(|e| {
-                BaselineError::Transaction(format!("failed to create B-20 token: {e}"))
-            })?;
-
-            let receipt = pending.get_receipt().await.map_err(|e| {
-                BaselineError::Transaction(format!("B-20 creation receipt failed: {e}"))
-            })?;
-
-            if !receipt.status() {
-                return Err(BaselineError::Transaction(format!(
-                    "B-20 token creation reverted (tx {}). \
-                     Likely causes: B-20 feature not yet activated on this chain \
-                     (activation is done once by the activation admin, not the load tester), \
-                     or a factory validation error (decimals/version/initCall). \
-                     Inspect the tx trace for the precise revert reason.",
-                    receipt.transaction_hash
-                )));
-            }
-
-            info!(token = %predicted, "B-20 token created");
-            token_address = Some(predicted);
-        }
-
-        let token = token_address.ok_or_else(|| {
-            BaselineError::Config("b20 token address was not resolved during setup".into())
-        })?;
-
-        for tx_config in &mut self.config.transactions {
-            if let TxType::B20 { contract } = &mut tx_config.tx_type {
-                *contract = Some(token);
-            }
-        }
-
-        // Phase 2: Grant MINT_ROLE to funder + MINT_ROLE and BURN_ROLE to all senders.
-        let sender_addresses: Vec<Address> =
-            self.accounts.accounts().iter().map(|a| a.address).collect();
-        let roles = [B20TokenRole::Mint.id(), B20TokenRole::Burn.id()];
-
-        let total_grants = 1 + sender_addresses.len() * roles.len();
-        let pb = self.progress_bar(total_grants as u64, "Granting B-20 roles");
-
-        let mut grant_txs: Vec<(TransactionRequest, u64)> = Vec::with_capacity(total_grants);
-
-        // Funder needs MINT_ROLE to execute Phase 3 mints.
-        let funder_mint_grant =
-            IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: funder_address };
-        grant_txs.push((
+        let build = |nonce: u64, max_fee: u128, priority_fee: u128| {
             TransactionRequest::default()
-                .with_to(token)
-                .with_input(Bytes::from(funder_mint_grant.abi_encode()))
+                .with_to(B20FactoryStorage::ADDRESS)
+                .with_input(input.clone())
                 .with_nonce(nonce)
                 .with_chain_id(chain_id)
-                .with_gas_limit(b20_gas_limit)
+                .with_gas_limit(gas_limit)
                 .with_max_fee_per_gas(max_fee)
-                .with_max_priority_fee_per_gas(max_priority_fee),
-            nonce,
-        ));
-        nonce += 1;
+                .with_max_priority_fee_per_gas(priority_fee)
+        };
 
-        for &sender in &sender_addresses {
-            for &role in &roles {
-                let call = IB20::grantRoleCall { role, account: sender };
-                grant_txs.push((
-                    TransactionRequest::default()
-                        .with_to(token)
-                        .with_input(Bytes::from(call.abi_encode()))
-                        .with_nonce(nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(b20_gas_limit)
-                        .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee),
-                    nonce,
-                ));
-                nonce += 1;
-            }
-        }
-
-        // Pipeline: submit all grant txs first, then collect receipts.
-        // Decoupling submission from confirmation gives ~6x speedup.
-        // Submission is sequential, so a send failure at nonce N means N+1.. are not yet
-        // submitted; we backfill N with a noop so the txs we keep submitting are still accepted.
-        // If the noop send also fails the gap is unfillable, so we stop to avoid stranding higher
-        // nonces. The funder is reused across runs, so the noop must actually be mined to clear
-        // the gap; if it doesn't, we abort before the main receipt collection (whose higher-nonce
-        // txs could never confirm and would hang, since alloy has no default receipt timeout).
-        let mut grant_failed = 0usize;
-        let mut gap_cleared = true;
-        let mut pending_txs = Vec::with_capacity(total_grants);
-        let mut noop_pending = Vec::new();
-        for (tx, tx_nonce) in grant_txs {
-            match funder_provider.send_transaction(tx).await {
-                Ok(pending) => pending_txs.push(pending),
-                Err(e) => {
-                    warn!(error = %e, nonce = tx_nonce, "B-20 role grant submission failed");
-                    grant_failed += 1;
-                    pb.inc(1);
-                    let noop = TransactionRequest::default()
-                        .with_to(funder_address)
-                        .with_value(U256::ZERO)
-                        .with_nonce(tx_nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(21_000)
-                        .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee);
-                    match funder_provider.send_transaction(noop).await {
-                        Ok(pending) => noop_pending.push((tx_nonce, pending)),
-                        Err(noop_err) => {
-                            error!(error = %noop_err, nonce = tx_nonce, "noop backfill failed, aborting grant submission");
-                            gap_cleared = false;
-                            break;
-                        }
-                    }
+        let pending = match provider.send_transaction(build(nonce, max_fee, max_priority_fee)).await
+        {
+            Ok(pending) => pending,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("replacement transaction underpriced")
+                    || msg.contains("already known")
+                {
+                    // A prior run left a pending tx at this nonce; replace it at a higher fee.
+                    provider
+                        .send_transaction(build(
+                            nonce,
+                            replacement_max_fee,
+                            replacement_priority_fee,
+                        ))
+                        .await
+                        .map_err(|e| {
+                            BaselineError::Transaction(format!("replacement send failed: {e}"))
+                        })?
+                } else if msg.contains("nonce too low") {
+                    // The pending nonce was stale; refetch and resend.
+                    let fresh = provider
+                        .get_transaction_count(sender)
+                        .pending()
+                        .await
+                        .rpc("refetch pending transaction count")?;
+                    provider
+                        .send_transaction(build(fresh, max_fee, max_priority_fee))
+                        .await
+                        .map_err(|e| {
+                            BaselineError::Transaction(format!("nonce-refreshed send failed: {e}"))
+                        })?
+                } else {
+                    return Err(BaselineError::Transaction(format!("send failed: {e}")));
                 }
             }
-        }
+        };
 
-        for (tx_nonce, pending) in noop_pending {
-            match tokio::time::timeout(Duration::from_secs(60), pending.get_receipt()).await {
-                Ok(Ok(_)) => {}
-                Ok(Err(e)) => {
-                    warn!(error = %e, nonce = tx_nonce, "noop backfill receipt failed");
-                    gap_cleared = false;
-                }
-                Err(_) => {
-                    warn!(nonce = tx_nonce, "noop backfill receipt timed out after 60s");
-                    gap_cleared = false;
-                }
-            }
-        }
+        let receipt = pending
+            .with_timeout(Some(B20_RECEIPT_TIMEOUT))
+            .get_receipt()
+            .await
+            .map_err(|e| BaselineError::Transaction(format!("receipt failed: {e}")))?;
 
-        if !gap_cleared {
-            pb.finish_and_clear();
-            return Err(Self::nonce_gap_error(funder_address));
-        }
-
-        let receipt_futs = pending_txs.into_iter().map(|pending| async move {
-            pending.with_timeout(Some(Duration::from_secs(120))).get_receipt().await
-        });
-        let mut receipt_stream = stream::iter(receipt_futs).buffer_unordered(FUNDING_CONCURRENCY);
-        while let Some(result) = receipt_stream.next().await {
-            match result {
-                Ok(receipt) if receipt.status() => pb.inc(1),
-                Ok(receipt) => {
-                    warn!(tx_hash = %receipt.transaction_hash, "B-20 role grant reverted");
-                    grant_failed += 1;
-                    pb.inc(1);
-                }
-                Err(e) => {
-                    warn!(error = %e, "B-20 role grant receipt failed");
-                    grant_failed += 1;
-                    pb.inc(1);
-                }
-            }
-        }
-
-        pb.finish_and_clear();
-        if grant_failed > 0 {
+        if !receipt.status() {
             return Err(BaselineError::Transaction(format!(
-                "{grant_failed}/{total_grants} B-20 role grants failed"
+                "createB20 reverted (tx {})",
+                receipt.transaction_hash
             )));
         }
-
-        info!(roles = total_grants, "B-20 roles granted");
-
-        // Phase 3: Mint tokens to all senders.
-        let total_mints = sender_addresses.len();
-        let pb_mint = self.progress_bar(total_mints as u64, "Minting B-20 tokens");
-
-        let mint_txs: Vec<(TransactionRequest, Address, u64)> = sender_addresses
-            .iter()
-            .map(|&sender| {
-                let call = IB20::mintCall { to: sender, amount: amount_per_sender };
-                let tx = TransactionRequest::default()
-                    .with_to(token)
-                    .with_input(Bytes::from(call.abi_encode()))
-                    .with_nonce(nonce)
-                    .with_chain_id(chain_id)
-                    .with_gas_limit(b20_gas_limit)
-                    .with_max_fee_per_gas(max_fee)
-                    .with_max_priority_fee_per_gas(max_priority_fee);
-                let tx_nonce = nonce;
-                nonce += 1;
-                (tx, sender, tx_nonce)
-            })
-            .collect();
-
-        let mut mint_failed = 0usize;
-        let mut gap_cleared = true;
-        let mut pending_mints = Vec::with_capacity(total_mints);
-        let mut noop_pending = Vec::new();
-        for (tx, sender, tx_nonce) in mint_txs {
-            match funder_provider.send_transaction(tx).await {
-                Ok(pending) => pending_mints.push((pending, sender)),
-                Err(e) => {
-                    warn!(to = %sender, error = %e, nonce = tx_nonce, "B-20 mint submission failed");
-                    mint_failed += 1;
-                    pb_mint.inc(1);
-                    let noop = TransactionRequest::default()
-                        .with_to(funder_address)
-                        .with_value(U256::ZERO)
-                        .with_nonce(tx_nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(21_000)
-                        .with_max_fee_per_gas(max_fee)
-                        .with_max_priority_fee_per_gas(max_priority_fee);
-                    match funder_provider.send_transaction(noop).await {
-                        Ok(pending) => noop_pending.push((tx_nonce, pending)),
-                        Err(noop_err) => {
-                            error!(error = %noop_err, nonce = tx_nonce, "noop backfill failed, aborting mint submission");
-                            gap_cleared = false;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        for (tx_nonce, pending) in noop_pending {
-            match tokio::time::timeout(Duration::from_secs(60), pending.get_receipt()).await {
-                Ok(Ok(_)) => {}
-                Ok(Err(e)) => {
-                    warn!(error = %e, nonce = tx_nonce, "noop backfill receipt failed");
-                    gap_cleared = false;
-                }
-                Err(_) => {
-                    warn!(nonce = tx_nonce, "noop backfill receipt timed out after 60s");
-                    gap_cleared = false;
-                }
-            }
-        }
-
-        if !gap_cleared {
-            pb_mint.finish_and_clear();
-            return Err(Self::nonce_gap_error(funder_address));
-        }
-
-        let receipt_futs = pending_mints.into_iter().map(|(pending, sender)| async move {
-            (pending.with_timeout(Some(Duration::from_secs(120))).get_receipt().await, sender)
-        });
-        let mut receipt_stream = stream::iter(receipt_futs).buffer_unordered(FUNDING_CONCURRENCY);
-        while let Some((result, sender)) = receipt_stream.next().await {
-            match result {
-                Ok(receipt) if receipt.status() => {
-                    debug!(to = %sender, tx_hash = %receipt.transaction_hash, "B-20 mint confirmed");
-                    pb_mint.inc(1);
-                }
-                Ok(receipt) => {
-                    warn!(to = %sender, tx_hash = %receipt.transaction_hash, "B-20 mint reverted");
-                    mint_failed += 1;
-                    pb_mint.inc(1);
-                }
-                Err(e) => {
-                    warn!(to = %sender, error = %e, "B-20 mint receipt failed");
-                    mint_failed += 1;
-                    pb_mint.inc(1);
-                }
-            }
-        }
-
-        pb_mint.finish_and_clear();
-        if mint_failed > 0 {
-            return Err(BaselineError::Transaction(format!(
-                "{mint_failed}/{total_mints} B-20 mints failed"
-            )));
-        }
-
-        // Rebuild the workload generator now that the B-20 contract address is resolved.
-        let workload_config = WorkloadConfig::new("load-test").with_seed(self.config.seed);
-        self.generator = Self::create_generator(workload_config, &self.config)?;
-
-        info!(
-            token = %token,
-            senders = total_mints,
-            amount = %amount_per_sender,
-            "B-20 token setup complete"
-        );
         Ok(())
     }
 
-    /// Burns remaining B-20 token balances from all sender accounts.
+    /// Burns each sender's remaining balance of its own B-20 token.
     ///
-    /// Each sender calls `burn(uint256)` with their full balance. Requires senders to hold
-    /// `BURN_ROLE`, which is granted during [`Self::setup_b20_tokens`].
-    #[instrument(skip(self), fields(accounts = self.accounts.len()))]
+    /// No-op when no per-run salt is recorded (setup never ran). Each sender holds `BURN_ROLE` on
+    /// its own token (granted at creation), so the burn passes the role check. Each sender signs
+    /// its own single tx, so nonce streams are independent and a failed send strands nothing.
     pub async fn teardown_b20_tokens(&self) -> Result<()> {
-        let token = self.config.transactions.iter().find_map(|t| match &t.tx_type {
-            TxType::B20 { contract: Some(addr) } => Some(*addr),
-            _ => None,
-        });
-
-        let Some(token) = token else {
+        let Some(run_salt) = self.b20_run_salt else {
             return Ok(());
         };
 
@@ -414,20 +262,19 @@ impl LoadRunner {
         let max_priority_fee = (base_fee / 10).max(1);
         let max_fee =
             SubmissionPipeline::submission_max_fee(base_fee, max_priority_fee, max_gas_price);
-        let burn_gas_limit = 200_000u64;
 
         let sender_addresses: Vec<Address> =
             self.accounts.accounts().iter().map(|a| a.address).collect();
-
         let signers = Self::build_signers(&self.accounts);
         let client = &self.client;
         let rpc_url = self.config.primary_submission_rpc().clone();
 
-        // Phase 1: Query all balances in parallel.
+        // Phase 1: Query each sender's balance of its own token in parallel.
         let balance_futs: Vec<_> = sender_addresses
             .iter()
             .map(|&sender| {
                 let client = client.clone();
+                let token = b20_token_for(sender, run_salt);
                 let call_data = Self::encode_erc20_balance_of(sender);
                 async move {
                     let balance = client
@@ -441,7 +288,7 @@ impl LoadRunner {
                         .rpc("eth_call")
                         .map(|bytes| U256::from_be_slice(bytes.as_ref()))
                         .unwrap_or(U256::ZERO);
-                    (sender, balance)
+                    (sender, token, balance)
                 }
             })
             .collect();
@@ -450,23 +297,21 @@ impl LoadRunner {
             stream::iter(balance_futs).buffer_unordered(FUNDING_CONCURRENCY).collect().await;
 
         let senders_with_balance: Vec<_> =
-            balances.into_iter().filter(|(_, balance)| !balance.is_zero()).collect();
+            balances.into_iter().filter(|(_, _, balance)| !balance.is_zero()).collect();
 
         if senders_with_balance.is_empty() {
             info!("all B-20 balances are zero, skipping teardown");
             return Ok(());
         }
 
-        // Phase 2: Burn each sender's balance. Each sender signs its own single tx, so the
-        // nonce streams are independent — pipelining submission and receipt collection is safe
-        // and a failed send strands nothing downstream.
+        // Phase 2: Burn each sender's balance of its own token.
         let pb = self.progress_bar(senders_with_balance.len() as u64, "Burning B-20 tokens");
         let mut burn_failed = 0usize;
         let mut burn_count = 0usize;
 
         let submit_futs: Vec<_> = senders_with_balance
             .into_iter()
-            .filter_map(|(sender, balance)| {
+            .filter_map(|(sender, token, balance)| {
                 let signer = signers.get(&sender)?.clone();
                 let wallet = EthereumWallet::from(signer);
                 let provider = create_wallet_provider(rpc_url.clone(), wallet);
@@ -485,7 +330,7 @@ impl LoadRunner {
                         .with_input(Bytes::from(burn_call.abi_encode()))
                         .with_nonce(sender_nonce)
                         .with_chain_id(chain_id)
-                        .with_gas_limit(burn_gas_limit)
+                        .with_gas_limit(B20_BURN_GAS_LIMIT)
                         .with_max_fee_per_gas(max_fee)
                         .with_max_priority_fee_per_gas(max_priority_fee);
 
@@ -508,10 +353,7 @@ impl LoadRunner {
                         (
                             sender,
                             balance,
-                            pending
-                                .with_timeout(Some(Duration::from_secs(120)))
-                                .get_receipt()
-                                .await,
+                            pending.with_timeout(Some(B20_RECEIPT_TIMEOUT)).get_receipt().await,
                         )
                     });
                 }

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -48,11 +48,9 @@ pub enum TxType {
         /// Looper contract address (required when iterations > 1).
         looper_contract: Option<Address>,
     },
-    /// B-20 precompile token transfer.
-    B20 {
-        /// Pre-deployed token address, or `None` to create a new token during setup.
-        contract: Option<Address>,
-    },
+    /// B-20 precompile token transfer. Each sender creates and transfers its own token, created
+    /// per run during setup.
+    B20,
     /// Osaka (Base Azul) opcode or precompile transaction.
     Osaka {
         /// Target Osaka feature.

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, TxHash, U256, utils::format_ether};
+use alloy_primitives::{Address, B256, Bytes, TxHash, U256, utils::format_ether};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
@@ -77,6 +77,8 @@ pub struct LoadRunner {
     last_funds_low: bool,
     funder_address: Option<String>,
     sender_addresses: Vec<String>,
+    /// Per-run salt for deriving each sender's own B-20 token, set during B-20 setup.
+    pub(super) b20_run_salt: Option<B256>,
 }
 
 impl LoadRunner {
@@ -124,7 +126,7 @@ impl LoadRunner {
         let sender_addresses = accounts.accounts().iter().map(|a| a.address.to_string()).collect();
 
         let workload_config = WorkloadConfig::new("load-test").with_seed(config.seed);
-        let generator = Self::create_generator(workload_config, &config)?;
+        let generator = Self::create_generator(workload_config, &config, None)?;
 
         info!(
             account_count = config.account_count,
@@ -153,7 +155,13 @@ impl LoadRunner {
             last_funds_low: false,
             funder_address: None,
             sender_addresses,
+            b20_run_salt: None,
         })
+    }
+
+    /// Builds the workload config used to (re)construct the transaction generator.
+    pub(super) fn workload_config(&self) -> WorkloadConfig {
+        WorkloadConfig::new("load-test").with_seed(self.config.seed)
     }
 
     /// Sets the funder wallet address for inclusion in live snapshots.
@@ -178,6 +186,7 @@ impl LoadRunner {
     pub(super) fn create_generator(
         workload_config: WorkloadConfig,
         config: &LoadConfig,
+        b20_run_salt: Option<B256>,
     ) -> Result<WorkloadGenerator> {
         let mut generator = WorkloadGenerator::new(workload_config);
 
@@ -212,10 +221,13 @@ impl LoadRunner {
                     );
                     generator = generator.with_payload(payload, weight_pct);
                 }
-                TxType::B20 { contract } => {
-                    if let Some(token) = contract {
+                TxType::B20 { contract: _ } => {
+                    // Each sender transfers its own per-run token; the payload derives the token
+                    // from the run salt, which is only known after B-20 setup runs. Before setup
+                    // (salt None) the payload is intentionally not installed.
+                    if let Some(run_salt) = b20_run_salt {
                         generator = generator.with_payload(
-                            B20TransferPayload::new(*token, U256::from(1000), U256::from(10000)),
+                            B20TransferPayload::new(run_salt, U256::from(1000), U256::from(10000)),
                             weight_pct,
                         );
                     }
@@ -977,12 +989,12 @@ impl LoadRunner {
     /// Runs the load test and returns metrics summary.
     #[instrument(skip(self), fields(target_gps = self.config.target_gps, continuous = self.config.duration.is_none(), duration = ?self.config.duration))]
     pub async fn run(&mut self) -> Result<MetricsSummary> {
-        for tx_config in &self.config.transactions {
-            if let TxType::B20 { contract: None } = &tx_config.tx_type {
-                return Err(BaselineError::Config(
-                    "b20 contract address not resolved; call setup_b20_tokens first".into(),
-                ));
-            }
+        if self.b20_run_salt.is_none()
+            && self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20 { .. }))
+        {
+            return Err(BaselineError::Config(
+                "b20 run salt not set; call setup_b20_tokens before run".into(),
+            ));
         }
 
         self.collector.reset();

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -221,7 +221,7 @@ impl LoadRunner {
                     );
                     generator = generator.with_payload(payload, weight_pct);
                 }
-                TxType::B20 { contract: _ } => {
+                TxType::B20 => {
                     // Each sender transfers its own per-run token; the payload derives the token
                     // from the run salt, which is only known after B-20 setup runs. Before setup
                     // (salt None) the payload is intentionally not installed.
@@ -304,7 +304,7 @@ impl LoadRunner {
                 TxType::Transfer => 21_000,
                 TxType::Calldata { max_size, .. } => 21_000 + (*max_size as u64 * 16),
                 TxType::Erc20 { .. } => 65_000,
-                TxType::B20 { .. } => 100_000,
+                TxType::B20 => 100_000,
                 TxType::Precompile { target, iterations, blake2f_rounds, .. } => {
                     let per_call = match target {
                         PrecompileId::Identity | PrecompileId::Bn254Add => 22_000,
@@ -677,7 +677,7 @@ impl LoadRunner {
                 TxType::Transfer
                 | TxType::Calldata { .. }
                 | TxType::Erc20 { .. }
-                | TxType::B20 { .. }
+                | TxType::B20
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
             }
@@ -696,7 +696,7 @@ impl LoadRunner {
                 TxType::Transfer
                 | TxType::Calldata { .. }
                 | TxType::Erc20 { .. }
-                | TxType::B20 { .. }
+                | TxType::B20
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
             }
@@ -990,7 +990,7 @@ impl LoadRunner {
     #[instrument(skip(self), fields(target_gps = self.config.target_gps, continuous = self.config.duration.is_none(), duration = ?self.config.duration))]
     pub async fn run(&mut self) -> Result<MetricsSummary> {
         if self.b20_run_salt.is_none()
-            && self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20 { .. }))
+            && self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20))
         {
             return Err(BaselineError::Config(
                 "b20 run salt not set; call setup_b20_tokens before run".into(),

--- a/crates/infra/load-tests/src/workload/mod.rs
+++ b/crates/infra/load-tests/src/workload/mod.rs
@@ -12,6 +12,7 @@ pub use payloads::{
     PrecompileLooper, PrecompilePayload, StoragePayload, TransferPayload, UniswapV3Payload,
     parse_precompile_id,
 };
+pub(crate) use payloads::{b20_salt_for, b20_token_for};
 
 mod generator;
 pub use generator::WorkloadGenerator;

--- a/crates/infra/load-tests/src/workload/payloads/b20.rs
+++ b/crates/infra/load-tests/src/workload/payloads/b20.rs
@@ -1,24 +1,51 @@
 //! B-20 precompile token transfer payload for load testing.
 
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_rpc_types::TransactionRequest;
 use alloy_sol_types::SolCall;
-use base_common_precompiles::IB20;
+use base_common_precompiles::{B20Variant, IB20};
 
 use super::Payload;
 use crate::workload::SeededRng;
 
+/// Derives the deterministic B-20 token salt for a sender within a single run.
+///
+/// The preimage is `sender (20 bytes) ‖ run_salt (32 bytes)`, so the salt is unique per
+/// (sender, run). The fresh per-run `run_salt` ensures a re-run with the same sender set
+/// creates brand-new tokens instead of colliding with the previous run's tokens (which would
+/// revert `createB20` with `TokenAlreadyExists`).
+///
+/// Setup, the transfer payload, and teardown all derive the token address through this helper so
+/// they cannot drift.
+pub(crate) fn b20_salt_for(sender: Address, run_salt: B256) -> B256 {
+    let mut preimage = [0u8; 52];
+    preimage[..20].copy_from_slice(sender.as_slice());
+    preimage[20..].copy_from_slice(run_salt.as_slice());
+    keccak256(preimage)
+}
+
+/// Derives the deterministic B-20 ASSET token address a sender owns for this run.
+///
+/// Equivalent to the factory's address derivation: each sender is the creator of its own token,
+/// so the address is `B20Variant::Asset.compute_address(sender, b20_salt_for(sender, run_salt))`.
+pub(crate) fn b20_token_for(sender: Address, run_salt: B256) -> Address {
+    B20Variant::Asset.compute_address(sender, b20_salt_for(sender, run_salt)).0
+}
+
 /// Generates B-20 precompile token transfer transactions.
 ///
 /// During the load phase, each generated transaction calls `transfer(address,uint256)` on the
-/// configured B-20 token precompile. The B-20 `transfer` selector is ERC-20 compatible, so this
+/// sender's own B-20 token precompile. The B-20 `transfer` selector is ERC-20 compatible, so this
 /// exercises the precompile's state-mutation code path (balance updates, event emission) under
 /// sustained load.
+///
+/// The token is derived per sender from the run's salt rather than stored, so a single payload
+/// instance serves every sender's own token without a sender→token map.
 #[derive(Debug, Clone)]
 pub struct B20TransferPayload {
-    /// B-20 token precompile address.
-    pub token_address: Address,
+    /// Per-run salt seed used to derive each sender's own token address.
+    pub run_salt: B256,
     /// Minimum transfer amount.
     pub min_amount: U256,
     /// Maximum transfer amount.
@@ -26,9 +53,9 @@ pub struct B20TransferPayload {
 }
 
 impl B20TransferPayload {
-    /// Creates a new B-20 transfer payload.
-    pub const fn new(token_address: Address, min_amount: U256, max_amount: U256) -> Self {
-        Self { token_address, min_amount, max_amount }
+    /// Creates a new B-20 transfer payload bound to a run's token salt.
+    pub const fn new(run_salt: B256, min_amount: U256, max_amount: U256) -> Self {
+        Self { run_salt, min_amount, max_amount }
     }
 }
 
@@ -37,7 +64,7 @@ impl Payload for B20TransferPayload {
         "b20"
     }
 
-    fn generate(&self, rng: &mut SeededRng, _from: Address, to: Address) -> TransactionRequest {
+    fn generate(&self, rng: &mut SeededRng, from: Address, to: Address) -> TransactionRequest {
         let amount = if self.min_amount == self.max_amount {
             self.min_amount
         } else {
@@ -46,11 +73,81 @@ impl Payload for B20TransferPayload {
             U256::from(rng.gen_range(min..=max))
         };
 
+        // Each sender transfers its OWN token; derive the token from the sender, not a fixed
+        // address, so any sender produces a valid transfer against the token it minted at setup.
+        let token = b20_token_for(from, self.run_salt);
         let call = IB20::transferCall { to, amount };
 
         TransactionRequest::default()
-            .with_to(self.token_address)
+            .with_to(token)
             .with_input(Bytes::from(call.abi_encode()))
             .with_gas_limit(100_000)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    #[test]
+    fn token_is_deterministic_per_sender_and_run() {
+        let sender = address!("00000000000000000000000000000000000000a1");
+        let run_salt = B256::repeat_byte(0x11);
+
+        // Same (sender, run_salt) always yields the same salt and token.
+        assert_eq!(b20_salt_for(sender, run_salt), b20_salt_for(sender, run_salt));
+        assert_eq!(b20_token_for(sender, run_salt), b20_token_for(sender, run_salt));
+    }
+
+    #[test]
+    fn different_senders_get_different_tokens() {
+        let run_salt = B256::repeat_byte(0x22);
+        let sender_a = address!("00000000000000000000000000000000000000a1");
+        let sender_b = address!("00000000000000000000000000000000000000b2");
+
+        assert_ne!(
+            b20_token_for(sender_a, run_salt),
+            b20_token_for(sender_b, run_salt),
+            "distinct senders must own distinct tokens"
+        );
+    }
+
+    #[test]
+    fn different_run_salts_get_different_tokens() {
+        let sender = address!("00000000000000000000000000000000000000a1");
+        let run_salt_1 = B256::repeat_byte(0x33);
+        let run_salt_2 = B256::repeat_byte(0x44);
+
+        assert_ne!(
+            b20_token_for(sender, run_salt_1),
+            b20_token_for(sender, run_salt_2),
+            "a fresh run salt must produce a fresh token for the same sender"
+        );
+    }
+
+    #[test]
+    fn generate_targets_senders_own_token() {
+        let run_salt = B256::repeat_byte(0x55);
+        let sender = address!("00000000000000000000000000000000000000a1");
+        let recipient = address!("00000000000000000000000000000000000000b2");
+        let payload = B20TransferPayload::new(run_salt, U256::from(1000), U256::from(1000));
+        let mut rng = SeededRng::new(7);
+
+        let tx = payload.generate(&mut rng, sender, recipient);
+
+        assert_eq!(
+            tx.to,
+            Some(alloy_primitives::TxKind::Call(b20_token_for(sender, run_salt))),
+            "transfer must target the sender's own token"
+        );
+
+        let expected = IB20::transferCall { to: recipient, amount: U256::from(1000) };
+        assert_eq!(
+            tx.input.input().expect("input set").as_ref(),
+            expected.abi_encode().as_slice(),
+            "calldata must be a transfer of the chosen amount to the recipient"
+        );
     }
 }

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -31,6 +31,7 @@ pub use aerodrome::AerodromeClPayload;
 
 mod b20;
 pub use b20::B20TransferPayload;
+pub(crate) use b20::{b20_salt_for, b20_token_for};
 
 mod osaka;
 pub use osaka::OsakaPayload;


### PR DESCRIPTION
- Parallelize b20 creates by enabling every sender to be the admin of its own token creation (instead of relying on the funder key being the sole admin)
- Aligned with Rayyan that the load test sending B20 transfers to itself is still sufficient
- We manually witnessed last time that running 2 load test at the same time made the load test very very slow (>5mins)
   - Now: I tested locally and was able to run 2 load test at the same time and complete in a few minutes