### PR TITLE
Remove deprecated ingress raw transaction forwarding

### DIFF
--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -8,12 +8,10 @@ use base_bundles::MeterBundleResponse;
 use base_cli_utils::LogConfig;
 use base_common_network::Base;
 use clap::Parser;
-use ingress_rpc_lib::{
-    BuilderConnector, Config, HealthServer, IngressApiServer, IngressService, Providers,
-};
+use ingress_rpc_lib::{BuilderConnector, Config, HealthServer, IngressApiServer, IngressService};
 use jsonrpsee::server::Server;
 use tokio::sync::{broadcast, mpsc};
-use tracing::info;
+use tracing::{info, warn};
 
 base_cli_utils::define_log_args!("TIPS_INGRESS");
 base_cli_utils::define_metrics_args!("TIPS_INGRESS", 9002);
@@ -52,18 +50,26 @@ async fn main() -> anyhow::Result<()> {
         message = "Starting ingress service",
         address = %config.address,
         port = config.port,
-        mempool_url = %config.mempool_url,
         simulation_rpc = %config.simulation_rpc,
         metrics_addr = %metrics_addr,
         metrics_port = metrics_port,
         health_check_address = %config.health_check_addr,
     );
 
-    let providers = Providers {
-        mempool: RootProvider::<Base>::new_http(config.mempool_url),
-        simulation: RootProvider::<Base>::new_http(config.simulation_rpc),
-        raw_tx_forward: config.raw_tx_forward_rpc.clone().map(RootProvider::<Base>::new_http),
-    };
+    if config.deprecated_mempool_url.is_some() {
+        warn!(
+            env = "TIPS_INGRESS_RPC_MEMPOOL",
+            "Deprecated ingress mempool forwarding config is set and will be ignored"
+        );
+    }
+    if config.deprecated_raw_tx_forward_rpc.is_some() {
+        warn!(
+            env = "TIPS_INGRESS_RAW_TX_FORWARD_RPC",
+            "Deprecated ingress raw transaction forwarder config is set and will be ignored"
+        );
+    }
+
+    let simulation_provider = RootProvider::<Base>::new_http(config.simulation_rpc.clone());
 
     let audit_publisher = RpcBundleEventPublisher::new(
         config.audit_rpc_url.as_str(),
@@ -97,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let bind_addr = format!("{}:{}", config.address, config.port);
-    let service = IngressService::new(providers, audit_tx, builder_tx, cli.config);
+    let service = IngressService::new(simulation_provider, audit_tx, builder_tx, cli.config);
 
     let server = Server::builder().build(&bind_addr).await?;
     let addr = server.local_addr()?;

--- a/crates/infra/ingress-rpc/README.md
+++ b/crates/infra/ingress-rpc/README.md
@@ -6,8 +6,8 @@ Ingress RPC library.
 
 Handles incoming transaction and bundle submission for the Base block builder pipeline.
 `IngressService` exposes a JSON-RPC endpoint that validates bundles (`validate_bundle`),
-meters them via `BuilderConnector`, and routes accepted transactions to the mempool. Also
-provides `HealthServer` for liveness checks and `Metrics` for request tracking.
+meters them via `BuilderConnector`, and emits audit events. Also provides `HealthServer`
+for liveness checks and `Metrics` for request tracking.
 
 ## Usage
 

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -10,7 +10,7 @@ pub use metrics::Metrics;
 
 /// Core RPC service implementation.
 mod service;
-pub use service::{IngressApiServer, IngressService, Providers};
+pub use service::{IngressApiServer, IngressService};
 
 /// Transaction validation implementation.
 mod validation;
@@ -43,9 +43,9 @@ pub struct Config {
     #[arg(long, env = "TIPS_INGRESS_PORT", default_value = "8080")]
     pub port: u16,
 
-    /// URL of the mempool service to proxy transactions to
-    #[arg(long, env = "TIPS_INGRESS_RPC_MEMPOOL")]
-    pub mempool_url: Url,
+    /// Deprecated. Ingress no longer proxies transactions to the mempool.
+    #[arg(long = "mempool-url", env = "TIPS_INGRESS_RPC_MEMPOOL", hide = true)]
+    pub deprecated_mempool_url: Option<Url>,
 
     /// URL of the audit-archiver RPC endpoint that receives bundle events via
     /// `base_persistBatchedBundleEvent`.
@@ -100,9 +100,9 @@ pub struct Config {
     #[arg(long, env = "TIPS_INGRESS_CHAIN_ID", default_value = "11")]
     pub chain_id: u64,
 
-    /// URL of third-party RPC endpoint to forward raw transactions to (enables forwarding if set)
-    #[arg(long, env = "TIPS_INGRESS_RAW_TX_FORWARD_RPC")]
-    pub raw_tx_forward_rpc: Option<Url>,
+    /// Deprecated. Ingress no longer forwards raw transactions to another RPC endpoint.
+    #[arg(long = "raw-tx-forward-rpc", env = "TIPS_INGRESS_RAW_TX_FORWARD_RPC", hide = true)]
+    pub deprecated_raw_tx_forward_rpc: Option<Url>,
 
     /// TTL for bundle cache in seconds
     #[arg(long, env = "TIPS_INGRESS_BUNDLE_CACHE_TTL", default_value = "20")]

--- a/crates/infra/ingress-rpc/src/metrics.rs
+++ b/crates/infra/ingress-rpc/src/metrics.rs
@@ -10,8 +10,6 @@ base_metrics::define_metrics! {
     successful_simulations: counter,
     #[describe("Number of bundles that failed simulation")]
     failed_simulations: counter,
-    #[describe("Number of transactions sent to mempool")]
-    sent_to_mempool: counter,
     #[describe("Duration of validate_tx")]
     validate_tx_duration: histogram,
     #[describe("Duration of validate_bundle")]
@@ -20,8 +18,6 @@ base_metrics::define_metrics! {
     meter_bundle_duration: histogram,
     #[describe("Duration of send_raw_transaction")]
     send_raw_transaction_duration: histogram,
-    #[describe("Total raw transactions forwarded to additional endpoint")]
-    raw_tx_forwards_total: counter,
     #[describe("Number of bundles that exceeded the metering time")]
     bundles_exceeded_metering_time: counter,
     #[describe("Size of buffered meter bundle responses")]

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -28,17 +28,6 @@ use tracing::{debug, info, warn};
 
 use crate::{Config, metrics::Metrics};
 
-/// RPC providers for different endpoints.
-#[derive(Debug)]
-pub struct Providers {
-    /// Provider for sending transactions to the mempool.
-    pub mempool: RootProvider<Base>,
-    /// Provider for simulating bundles.
-    pub simulation: RootProvider<Base>,
-    /// Optional provider for forwarding raw transactions.
-    pub raw_tx_forward: Option<RootProvider<Base>>,
-}
-
 #[rpc(server, namespace = "eth")]
 pub trait IngressApi {
     /// Handler for: `eth_sendRawTransaction`
@@ -48,9 +37,7 @@ pub trait IngressApi {
 
 /// Core ingress RPC service that handles transaction submission.
 pub struct IngressService {
-    mempool_provider: Arc<RootProvider<Base>>,
     simulation_provider: Arc<RootProvider<Base>>,
-    raw_tx_forward_provider: Option<Arc<RootProvider<Base>>>,
     audit_channel: mpsc::Sender<BundleEvent>,
     send_transaction_default_lifetime_seconds: u64,
     block_time_milliseconds: u64,
@@ -70,24 +57,20 @@ impl std::fmt::Debug for IngressService {
 impl IngressService {
     /// Creates a new ingress service with the given providers and configuration.
     pub fn new(
-        providers: Providers,
+        simulation_provider: RootProvider<Base>,
         audit_channel: mpsc::Sender<BundleEvent>,
         builder_tx: broadcast::Sender<MeterBundleResponse>,
         config: Config,
     ) -> Self {
-        let mempool_provider = Arc::new(providers.mempool);
-        let simulation_provider = Arc::new(providers.simulation);
-        let raw_tx_forward_provider = providers.raw_tx_forward.map(Arc::new);
         let cobalt_timestamp = ChainConfig::by_chain_id(config.chain_id)
             .and_then(|chain_config| chain_config.cobalt_timestamp);
+        let simulation_provider = Arc::new(simulation_provider);
 
         // A TTL cache to deduplicate bundles with the same Bundle ID
         let bundle_cache =
             Cache::builder().time_to_live(Duration::from_secs(config.bundle_cache_ttl)).build();
         Self {
-            mempool_provider,
             simulation_provider,
-            raw_tx_forward_provider,
             audit_channel,
             send_transaction_default_lifetime_seconds: config
                 .send_transaction_default_lifetime_seconds,
@@ -108,23 +91,6 @@ impl IngressApiServer for IngressService {
         let transaction = self.get_tx(&data).await?;
 
         Metrics::transactions_received().increment(1);
-
-        // Forward before metering
-        if let Some(forward_provider) = self.raw_tx_forward_provider.clone() {
-            Metrics::raw_tx_forwards_total().increment(1);
-            let tx_data = data.clone();
-            let tx_hash = transaction.tx_hash();
-            tokio::spawn(async move {
-                match forward_provider.send_raw_transaction(tx_data.iter().as_slice()).await {
-                    Ok(_) => {
-                        debug!(message = "Forwarded raw tx", hash = %tx_hash);
-                    }
-                    Err(e) => {
-                        warn!(message = "Failed to forward raw tx", hash = %tx_hash, error = %e);
-                    }
-                }
-            });
-        }
 
         let expiry_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
             + self.send_transaction_default_lifetime_seconds;
@@ -196,17 +162,6 @@ impl IngressApiServer for IngressService {
             let accepted_bundle =
                 AcceptedBundle::new(parsed_bundle, meter_bundle_response.unwrap_or_default());
 
-            let response = self.mempool_provider.send_raw_transaction(data.iter().as_slice()).await;
-            match response {
-                Ok(_) => {
-                    Metrics::sent_to_mempool().increment(1);
-                    debug!(message = "sent transaction to the mempool", hash=%transaction.tx_hash());
-                }
-                Err(e) => {
-                    warn!(message = "Failed to send raw transaction to mempool", error = %e);
-                }
-            }
-
             info!(
                 message = "processed transaction",
                 bundle_hash = %bundle_hash,
@@ -250,7 +205,7 @@ impl IngressService {
         }
 
         let block = self
-            .mempool_provider
+            .simulation_provider
             .get_block(BlockId::Number(BlockNumberOrTag::Latest))
             .await
             .map_err(|error| {
@@ -361,7 +316,7 @@ mod tests {
         Config {
             address: IpAddr::from([127, 0, 0, 1]),
             port: 8080,
-            mempool_url: Url::parse("http://localhost:3000").unwrap(),
+            deprecated_mempool_url: None,
             send_transaction_default_lifetime_seconds: 300,
             simulation_rpc: mock_server.uri().parse().unwrap(),
             block_time_milliseconds: 1000,
@@ -369,8 +324,8 @@ mod tests {
             builder_rpcs: vec![],
             max_buffered_meter_bundle_responses: 100,
             health_check_addr: SocketAddr::from(([127, 0, 0, 1], 8081)),
-            raw_tx_forward_rpc: None,
             chain_id: 11,
+            deprecated_raw_tx_forward_rpc: None,
             bundle_cache_ttl: 20,
             audit_channel_capacity: 512,
             send_to_builder: false,
@@ -446,19 +401,13 @@ mod tests {
 
         let config = create_test_config(&mock_server);
 
-        let provider: RootProvider<Base> =
+        let simulation_provider: RootProvider<Base> =
             RootProvider::new_http(mock_server.uri().parse().unwrap());
-
-        let providers = Providers {
-            mempool: provider.clone(),
-            simulation: provider.clone(),
-            raw_tx_forward: None,
-        };
 
         let (audit_tx, _audit_rx) = mpsc::channel(512);
         let (builder_tx, _builder_rx) = broadcast::channel(1);
 
-        let service = IngressService::new(providers, audit_tx, builder_tx, config);
+        let service = IngressService::new(simulation_provider, audit_tx, builder_tx, config);
 
         let bundle = Bundle::default();
         let bundle_hash = B256::default();
@@ -472,46 +421,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_raw_tx_forward() {
+    async fn test_send_raw_transaction_meters_broadcasts_and_audits() {
         let simulation_server = MockServer::start().await;
-        let forward_server = MockServer::start().await;
 
-        // Mock error response from base_meterBundle
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "error": {
-                    "code": -32000,
-                    "message": "Simulation failed"
-                }
-            })))
-            .mount(&simulation_server)
-            .await;
+        let meter_response = create_test_meter_bundle_response();
 
-        // Mock forward endpoint - expect exactly 1 call
         Mock::given(method("POST"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
-                "result": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                "result": meter_response,
             })))
             .expect(1)
-            .mount(&forward_server)
+            .mount(&simulation_server)
             .await;
 
-        let config = create_test_config(&simulation_server);
+        let mut config = create_test_config(&simulation_server);
+        config.send_to_builder = true;
 
-        let providers = Providers {
-            mempool: RootProvider::new_http(simulation_server.uri().parse().unwrap()),
-            simulation: RootProvider::new_http(simulation_server.uri().parse().unwrap()),
-            raw_tx_forward: Some(RootProvider::new_http(forward_server.uri().parse().unwrap())),
-        };
+        let simulation_provider = RootProvider::new_http(simulation_server.uri().parse().unwrap());
+        let (audit_tx, mut audit_rx) = mpsc::channel(512);
+        let (builder_tx, mut builder_rx) = broadcast::channel(1);
 
-        let (audit_tx, _audit_rx) = mpsc::channel(512);
-        let (builder_tx, _builder_rx) = broadcast::channel(1);
-
-        let service = IngressService::new(providers, audit_tx, builder_tx, config);
+        let service = IngressService::new(simulation_provider, audit_tx, builder_tx, config);
 
         // Valid signed transaction bytes
         let tx_bytes = Bytes::from_str("0x02f86c0d010183072335825208940000000000000000000000000000000000000000872386f26fc1000080c001a0cdb9e4f2f1ba53f9429077e7055e078cf599786e29059cd80c5e0e923bb2c114a01c90e29201e031baf1da66296c3a5c15c200bcb5e6c34da2f05f7d1778f8be07").unwrap();
@@ -519,9 +451,10 @@ mod tests {
         let result = service.send_raw_transaction(tx_bytes).await;
         assert!(result.is_ok());
 
-        // Wait for spawned forward task to complete
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let metering = timeout(Duration::from_secs(1), builder_rx.recv()).await.unwrap().unwrap();
+        assert_eq!(metering, create_test_meter_bundle_response());
 
-        // wiremock automatically verifies expect(1) when forward_server is dropped
+        let audit_event = timeout(Duration::from_secs(1), audit_rx.recv()).await.unwrap().unwrap();
+        assert!(matches!(audit_event, BundleEvent::Received { .. }));
     }
 }

--- a/etc/docker/docker-compose.ingress.yml
+++ b/etc/docker/docker-compose.ingress.yml
@@ -55,7 +55,6 @@ services:
       - TIPS_INGRESS_HEALTH_CHECK_ADDR=0.0.0.0:${L2_INGRESS_HEALTH_PORT}
       - TIPS_INGRESS_METRICS_ADDR=0.0.0.0
       - TIPS_INGRESS_METRICS_PORT=${L2_INGRESS_METRICS_PORT}
-      - TIPS_INGRESS_RPC_MEMPOOL=http://base-builder:${L2_BUILDER_HTTP_PORT}
       - TIPS_INGRESS_RPC_SIMULATION=http://base-client:${L2_CLIENT_HTTP_PORT}
       # Fan out metering data to both builder and client; both expose
       # `base_setMeteringInformation` for trusted ingestion.

--- a/etc/docker/proxyd/proxyd.toml
+++ b/etc/docker/proxyd/proxyd.toml
@@ -1,6 +1,6 @@
 # Optimistic async forwarding of eth_sendRawTransaction to ingress-rpc
 # (matches production topology where proxyd sends to mempool nodes and
-# optimistically copies to ingress)
+# optimistically copies to ingress for metering and audit)
 ingress_rpc = "http://ingress-rpc:8080"
 
 [server]
@@ -26,8 +26,9 @@ backends = ["builder"]
 backends = ["client"]
 
 [rpc_method_mappings]
-# Transaction submission routed to builder; proxyd optimistically forwards
-# eth_sendRawTransaction to ingress-rpc via the ingress_rpc config above.
+# Transaction submission routed to builder; proxyd optimistically copies
+# eth_sendRawTransaction to ingress-rpc for metering and audit via the
+# ingress_rpc config above.
 eth_sendRawTransaction = "builder"
 
 # All other methods routed to client


### PR DESCRIPTION
## Summary
- deprecate `TIPS_INGRESS_RPC_MEMPOOL` and `TIPS_INGRESS_RAW_TX_FORWARD_RPC` while continuing to accept the old env/CLI knobs as hidden no-op config
- stop `ingress-rpc` from submitting raw transactions to mempool or an extra raw tx forward RPC
- keep ingress metering, builder metering broadcast, and audit behavior intact
- update local ingress docker/proxyd comments and README to match the new role

## Context
This is one step toward deprecating ingress entirely. For the 200ms blocks work, the desired direction is to move metering from ingress RPC hops into the mempool node as local work running in parallel, rather than keeping ingress as another transaction submission path.

The duplicate raw transaction submission behavior was introduced by base/base#2716, which removed `TxSubmissionMethod` / `TIPS_INGRESS_TX_SUBMISSION_METHOD` from `ingress-rpc` and made the mempool send unconditional for non-duplicate ingress transactions. protocols/tips#109 then deployed that behavior by bumping the ingress image and removing `TIPS_INGRESS_TX_SUBMISSION_METHOD: "none"` from mainnet chart config. That PR merged on `2026-05-21T14:56:29Z`; Datadog `base.tips_ingress_rpc_sent_to_mempool.count` became sustained around `2026-05-21T17:00:00Z`.

The deprecated config values are intentionally still parsed so existing `protocols/tips` chart env vars do not break rollout. If set, ingress logs a warning and ignores them.

## Testing
- cargo +nightly fmt
- cargo test -p ingress-rpc-lib
- cargo check -p ingress-rpc

type=routine
risk=low
impact=sev5
