### PR TITLE
test(batcher): fix flaky virtual-time races in l1_hybrid tests

### DIFF
--- a/crates/batcher/source/src/l1_hybrid.rs
+++ b/crates/batcher/source/src/l1_hybrid.rs
@@ -141,6 +141,15 @@ mod tests {
         }
     }
 
+    struct ProviderErrorPoller;
+
+    #[async_trait]
+    impl L1HeadPolling for ProviderErrorPoller {
+        async fn latest_head(&self) -> Result<u64, SourceError> {
+            Err(SourceError::Provider("poll down".to_string()))
+        }
+    }
+
     #[test]
     fn test_hybrid_l1_new_head() {
         Runner::start(Config::seeded(0), |ctx| async move {
@@ -185,7 +194,10 @@ mod tests {
             let mut source = HybridL1HeadSource::new(
                 ctx,
                 StreamSub(stream.boxed()),
-                FixedPoller(3),
+                // The virtual-time interval ticks immediately, and `select!` may poll the
+                // interval branch before the stream delivers Ok(10). Keep the fallback poller
+                // from producing a new head so the test only covers stale-drop logic.
+                ProviderErrorPoller,
                 Duration::from_secs(100),
             );
 
@@ -206,7 +218,10 @@ mod tests {
             let mut source = HybridL1HeadSource::new(
                 ctx,
                 StreamSub(stream.boxed()),
-                FixedPoller(1),
+                // The virtual-time interval ticks immediately, and `select!` may poll this
+                // branch before the stream error. Keep the fallback poller from producing a
+                // head so the test only covers subscription error propagation.
+                ProviderErrorPoller,
                 Duration::from_secs(100),
             );
 


### PR DESCRIPTION
## Summary

Two unit tests in `base-batcher-source` became non-deterministic after the migration to the `base_runtime` virtual-time executor:

- `test_hybrid_l1_stream_error`
- `test_hybrid_l1_stale_dropped`

Both were failing in the merge queue (run `28048305483`, job `83032026879`) but passing on the PR head CI run. No production logic changed.

---

## Root cause: unbiased `tokio::select!` + immediately-ready virtual interval

`HybridL1HeadSource::next()` races two branches:

```rust
tokio::select! {
    head = self.sub.next() => { /* subscription stream */ }
    _ = self.interval.next() => { /* poll fallback */ }
}
```

`tokio::select!` is **unbiased** — when multiple branches are ready at the same time, one is chosen at random. The `base_runtime` deterministic clock fires its **first interval tick immediately** (matching `tokio::time::interval`'s behavior), which means both the subscription stream branch *and* the interval branch can be ready on the very first poll.

### What breaks

| Test | Old poller | If interval wins first | Result |
|---|---|---|---|
| `test_hybrid_l1_stream_error` | `FixedPoller(1)` | returns `Ok(1)` → `NewHead(1)` | `unwrap_err()` panics |
| `test_hybrid_l1_stale_dropped` | `FixedPoller(3)` | returns `Ok(3)` → `NewHead(3)` | `assert_eq!(event, NewHead(10))` fails |

The race is 50/50 per-run under the virtual executor, explaining why CI flakes intermittently.

---

## Fix (test-only)

Added a test-only `ProviderErrorPoller` that always returns `Err(SourceError::Provider(_))`. The interval-polling branch treats provider errors as transient and loops without returning a value, so an immediate interval tick **cannot** race past the stream branch. Both tests are now deterministic.

Production `HybridL1HeadSource` logic is completely unchanged.

---

## Verification

```
cargo nextest run --locked -p base-batcher-source \
  l1_hybrid::tests::test_hybrid_l1_stream_error \
  l1_hybrid::tests::test_hybrid_l1_stale_dropped
```

```
Starting 2 tests across 1 binary (30 tests skipped)
    PASS [0.002s] (1/2) base-batcher-source l1_hybrid::tests::test_hybrid_l1_stream_error
    PASS [0.002s] (2/2) base-batcher-source l1_hybrid::tests::test_hybrid_l1_stale_dropped
Summary [0.003s] 2 tests run: 2 passed, 30 skipped
```