### PR TITLE
fix(PRIV-2006): bump devnet CONTRACTS_COMMIT to #350 (broadcast-order fix)

### DIFF
--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -28,13 +28,14 @@ RUN go build -o /go/bin/eth2-val-tools .
 # The foundry image is Ubuntu-based and multi-arch (amd64/arm64)
 FROM ghcr.io/foundry-rs/foundry:v1.7.1 AS contracts-builder
 
-# base/contracts l3-changes commit (PRIV-2006, #349) that defers AnchorStateRegistry
+# base/contracts l3-changes commit (PRIV-2006, #350) that defers AnchorStateRegistry
 # initialization out of genesis and seeds it with the real L3 genesis output root during
-# registerAggregateVerifier. Builds on the deferred AggregateVerifier registration (#345)
-# and the dev-multiproof Base Sepolia support (#348). Required by the post-genesis
-# register-aggregate-verifier.sh flow; without it the anchor stays the 0x..01 placeholder
-# and the TEE prover rejects proofs ("Output root does not match L2 head").
-ARG CONTRACTS_COMMIT=cd6c8a2d8b84a08fa7b4650b1c3a7d348dbd4922
+# registerAggregateVerifier. Builds on deferred AggregateVerifier registration (#345), the
+# dev-multiproof Base Sepolia support (#348), the deferred-anchor seed (#349), and the
+# vm.broadcast cheatcode-ordering fix in registerAggregateVerifier (#350). Required by the
+# post-genesis register-aggregate-verifier.sh flow; without it the anchor stays the 0x..01
+# placeholder and the TEE prover rejects proofs ("Output root does not match L2 head").
+ARG CONTRACTS_COMMIT=25ac730ee6132cbe14fc46d8c04f5003d8484027
 
 # git is pre-installed in the foundry image (Ubuntu 22.04)
 RUN git config --global user.email "docker@build" && \


### PR DESCRIPTION
## Summary
Bumps the contracts pin baked into the devnet image (`etc/docker/Dockerfile.devnet`, `ARG CONTRACTS_COMMIT`) from `cd6c8a2d` (#349) to **`25ac730e`** (#350).

#350 fixes a Foundry cheatcode-ordering bug in `registerAggregateVerifier`: `vm.broadcast(msg.sender)` was armed before the `artifacts.mustGetAddress(...)` / `cfg.*` cheatcode staticcalls used as `ASR.initialize(...)` arguments, so the post-genesis one-shot reverted (`staticcalls are not allowed after broadcast`) and the AnchorStateRegistry was never seeded.

## Why this is needed now
With #349 (the prior pin), the deployed `web3-shared-dev` image correctly computed the real genesis output root (`multiproofGenesisOutputRoot() → 0xa53d466c…`) but `initialize` reverted on the ordering, so the anchor stayed uninitialized and the proposer/prover could not generate proofs (0 games).

## Verification (so this is the final cycle)
- `forge build` passes on #350.
- Live `eth_call` of `ASR.initialize(...)` from the deployer key against the current uninitialized registry **succeeds** (control from a non-owner reverts Unauthorized).
- Auth confirmed: `ProxyAdmin.owner() == 0x609a88` (the one-shot broadcast key).
- Game-type consistency confirmed: `GameTypes.AGGREGATE_VERIFIER == multiproofGameType == 621`.
- The one-shot performs the full post-genesis registration (initialize → AggregateVerifier deploy → setImplementation).

## Rollout after merge
1. base `l3` CI rebuilds `ghcr.io/base/node-reth-dev:*-sha-<l3>`.
2. In `privacy-enclave`, run `scripts/bump-docker-mirror-digests.sh`, merge, redeploy `web3-shared-dev`.

## Type
Bug fix (release plumbing / version pin).

## Risk
Low. Single `ARG` change; `25ac730e` is the merged tip of contracts `l3-changes`, a direct descendant of the prior pin `cd6c8a2d`.

## Impact
Unblocks instant-finality L3 withdrawals on `web3-shared-dev` (proposer can finally generate proofs from a correctly-seeded anchor).

Made with [Cursor](https://cursor.com)