### PR TITLE
feat(challenger): Route challenger ZK proofs through requester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,6 +3614,7 @@ dependencies = [
  "base-proof-contracts",
  "base-proof-primitives",
  "base-proof-rpc",
+ "base-proof-zk-requester",
  "base-protocol",
  "base-prover-service-client",
  "base-prover-service-protocol",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -31,6 +31,7 @@ base-balance-monitor.workspace = true
 # Proof
 base-proof-rpc.workspace = true
 base-proof-contracts.workspace = true
+base-proof-zk-requester.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -24,8 +24,9 @@ use alloy_primitives::{Address, B256};
 use base_proof_contracts::{AggregateVerifierClient, GameStatus};
 use base_proof_primitives::ProofRequest as TeeProofRequest;
 use base_proof_rpc::L2Provider;
+use base_proof_zk_requester::{Groth16ProofState, Groth16RangeProofRequest, ZkProofRequester};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{SnarkGroth16ProofRequest, TeeKind, ZkProofRequest, ZkVm};
+use base_prover_service_protocol::{TeeKind, ZkProofRequest, ZkVm};
 use base_runtime::{Clock, TokioRuntime};
 use base_tx_manager::TxManager;
 use tokio::select;
@@ -610,16 +611,20 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         })
     }
 
-    /// Builds a [`SnarkGroth16ProofRequest`] for the given candidate and invalid index.
+    /// Builds a [`Groth16RangeProofRequest`] for the given candidate and invalid index.
     fn build_zk_request(
         &self,
         candidate: &CandidateGame,
         invalid_index: u64,
-    ) -> eyre::Result<SnarkGroth16ProofRequest> {
+    ) -> eyre::Result<Groth16RangeProofRequest> {
         let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
 
-        Ok(SnarkGroth16ProofRequest {
-            proof: ZkProofRequest {
+        Ok(Groth16RangeProofRequest::new(
+            crate::ChallengerProofAdapter::snark_groth16_session_id(
+                candidate.factory.proxy,
+                invalid_index,
+            ),
+            ZkProofRequest {
                 start_block_number,
                 number_of_blocks_to_prove: candidate.intermediate_block_interval,
                 sequence_window: None,
@@ -627,8 +632,8 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                 intermediate_root_interval: Some(candidate.intermediate_block_interval),
                 zk_vm: ZkVm::Sp1,
             },
-            prover_address: self.submitter.sender_address(),
-        })
+            self.submitter.sender_address(),
+        ))
     }
 
     /// Requests a ZK proof, stores the session, and polls for the result.
@@ -646,25 +651,23 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         // needs to cover the single interval that contains the invalid
         // checkpoint: [prior_checkpoint .. invalid_checkpoint].
         let proof_request = self.build_zk_request(&candidate, invalid_index)?;
-        let request = crate::ChallengerProofAdapter::snark_groth16_prove_block_range_request(
-            game_address,
-            invalid_index,
-            proof_request.clone(),
-        );
 
-        let prove_response = self.proof_requester.prove_block_range(request).await?;
+        let prove_response = ZkProofRequester::new(&*self.proof_requester)
+            .request_groth16_proof(&proof_request)
+            .await?;
 
         info!(
             game = %game_address,
-            session_id = %prove_response.session_id,
+            range_session_id = %prove_response.range.session_id,
             "proof job initiated"
         );
 
-        let pending = PendingProof::awaiting(
-            prove_response.session_id,
+        let pending = PendingProof::awaiting_zk(
+            proof_request.parent_session_id.clone(),
             invalid_index,
             expected_root,
             proof_request,
+            prove_response.state,
             intent,
         );
         self.pending_proofs.insert(game_address, pending);
@@ -840,8 +843,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         };
 
         let retry_count = pending.retry_count;
-        let invalid_index = pending.invalid_index;
-
         if retry_count > Self::MAX_PROOF_RETRIES {
             warn!(
                 game = %game_address,
@@ -875,37 +876,37 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
                 // Transition eagerly so retries use the ZK path.
                 if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.kind = ProofKind::Zk { prove_request: fallback_request.clone() };
+                    p.kind = ProofKind::Zk {
+                        prove_request: fallback_request.clone(),
+                        proof_state: Groth16ProofState::AwaitingRange,
+                    };
                     p.intent = fallback_intent;
                     p.retry_count = 0;
                 }
 
                 fallback_request
             }
-            ProofKind::Zk { prove_request } => prove_request.clone(),
+            ProofKind::Zk { prove_request, .. } => prove_request.clone(),
         };
 
         ChallengerMetrics::proof_retries_total().increment(1);
 
-        let prove_request = crate::ChallengerProofAdapter::snark_groth16_prove_block_range_request(
-            game_address,
-            invalid_index,
-            request,
-        );
-
-        match self.proof_requester.prove_block_range(prove_request).await {
+        match ZkProofRequester::new(&*self.proof_requester).request_groth16_proof(&request).await {
             Ok(response) => {
                 info!(
                     game = %game_address,
-                    session_id = %response.session_id,
+                    range_session_id = %response.range.session_id,
                     retry_count = retry_count,
                     "proof job re-initiated"
                 );
                 if let Some(p) = self.pending_proofs.get_mut(&game_address) {
                     p.phase = ProofPhase::AwaitingProof {
-                        session_id: response.session_id,
+                        session_id: request.parent_session_id.clone(),
                         started_at: Instant::now(),
                     };
+                    if let ProofKind::Zk { proof_state, .. } = &mut p.kind {
+                        *proof_state = response.state;
+                    }
                 }
             }
             Err(e) => {

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -13,9 +13,12 @@ use std::{
 };
 
 use alloy_primitives::{Address, B256, Bytes};
+use base_proof_zk_requester::{
+    Groth16ProofState, Groth16RangeProofRequest, ZkProofRequester, ZkProofRequesterError,
+};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{GetProofRequest, ProofStatus, SnarkGroth16ProofRequest};
-use tracing::warn;
+use base_prover_service_protocol::{GetProofRequest, ProofResult, ProofStatus};
+use tracing::{debug, warn};
 
 use crate::{ChallengerMetrics, ChallengerProofAdapter};
 
@@ -32,7 +35,7 @@ pub enum ProofKind {
     Tee {
         /// Pre-built ZK request for fallback if TEE submission fails.
         /// `None` when the fallback request could not be constructed.
-        zk_fallback_request: Option<SnarkGroth16ProofRequest>,
+        zk_fallback_request: Option<Groth16RangeProofRequest>,
         /// The dispute intent to use for the ZK fallback path.
         /// `None` when the fallback request could not be constructed.
         zk_fallback_intent: Option<DisputeIntent>,
@@ -43,7 +46,9 @@ pub enum ProofKind {
     /// `proveBlockRange` on failure.
     Zk {
         /// Original request parameters for retry.
-        prove_request: SnarkGroth16ProofRequest,
+        prove_request: Groth16RangeProofRequest,
+        /// Current stage in the Groth16 requester flow.
+        proof_state: Groth16ProofState,
     },
 }
 
@@ -74,7 +79,7 @@ pub enum DisputeIntent {
 pub enum ProofPhase {
     /// Waiting for the ZK proof service to complete.
     AwaitingProof {
-        /// Session ID returned by the ZK proof service.
+        /// TEE session ID or ZK parent session ID.
         session_id: String,
         /// Wall-clock time at which the proof request was initiated.
         started_at: Instant,
@@ -109,15 +114,37 @@ pub struct PendingProof {
 impl PendingProof {
     /// Creates a new `PendingProof` in the `AwaitingProof` phase.
     pub fn awaiting(
-        session_id: String,
+        parent_session_id: String,
         invalid_index: u64,
         expected_root: B256,
-        prove_request: SnarkGroth16ProofRequest,
+        prove_request: Groth16RangeProofRequest,
+        intent: DisputeIntent,
+    ) -> Self {
+        Self::awaiting_zk(
+            parent_session_id,
+            invalid_index,
+            expected_root,
+            prove_request,
+            Groth16ProofState::AwaitingRange,
+            intent,
+        )
+    }
+
+    /// Creates a new ZK `PendingProof` with the given requester state.
+    pub fn awaiting_zk(
+        parent_session_id: String,
+        invalid_index: u64,
+        expected_root: B256,
+        prove_request: Groth16RangeProofRequest,
+        proof_state: Groth16ProofState,
         intent: DisputeIntent,
     ) -> Self {
         Self {
-            phase: ProofPhase::AwaitingProof { session_id, started_at: Instant::now() },
-            kind: ProofKind::Zk { prove_request },
+            phase: ProofPhase::AwaitingProof {
+                session_id: parent_session_id,
+                started_at: Instant::now(),
+            },
+            kind: ProofKind::Zk { prove_request, proof_state },
             invalid_index,
             expected_root,
             retry_count: 0,
@@ -130,7 +157,7 @@ impl PendingProof {
         session_id: String,
         invalid_index: u64,
         expected_root: B256,
-        zk_fallback_request: Option<SnarkGroth16ProofRequest>,
+        zk_fallback_request: Option<Groth16RangeProofRequest>,
         zk_fallback_intent: Option<DisputeIntent>,
     ) -> Self {
         Self {
@@ -148,12 +175,12 @@ impl PendingProof {
         proof_bytes: Bytes,
         invalid_index: u64,
         expected_root: B256,
-        prove_request: SnarkGroth16ProofRequest,
+        prove_request: Groth16RangeProofRequest,
         intent: DisputeIntent,
     ) -> Self {
         Self {
             phase: ProofPhase::ReadyToSubmit { proof_bytes },
-            kind: ProofKind::Zk { prove_request },
+            kind: ProofKind::Zk { prove_request, proof_state: Groth16ProofState::AwaitingRange },
             invalid_index,
             expected_root,
             retry_count: 0,
@@ -237,10 +264,8 @@ impl PendingProofs {
             None => return Ok(None),
         };
 
-        let (session_id, started_at) = match &pending.phase {
-            ProofPhase::AwaitingProof { session_id, started_at } => {
-                (session_id.clone(), *started_at)
-            }
+        let started_at = match &pending.phase {
+            ProofPhase::AwaitingProof { started_at, .. } => *started_at,
             ProofPhase::ReadyToSubmit { proof_bytes } => {
                 return Ok(Some(ProofUpdate::Ready(proof_bytes.clone())));
             }
@@ -269,6 +294,92 @@ impl PendingProofs {
             return Ok(Some(ProofUpdate::NeedsRetry));
         }
 
+        let zk_prove_request = match &pending.kind {
+            ProofKind::Zk { prove_request, proof_state } => {
+                Some((prove_request.clone(), *proof_state))
+            }
+            ProofKind::Tee { .. } => None,
+        };
+
+        if let Some((prove_request, mut proof_state)) = zk_prove_request {
+            let result = ZkProofRequester::new(proof_requester)
+                .groth16_result(&prove_request, &mut proof_state)
+                .await;
+
+            let pending = match self.0.get_mut(&game) {
+                Some(p) => p,
+                None => return Ok(None),
+            };
+            if let ProofKind::Zk { proof_state: pending_state, .. } = &mut pending.kind {
+                *pending_state = proof_state;
+            }
+
+            let update = match result {
+                Ok(Some(result)) => {
+                    let proof_bytes = ChallengerProofAdapter::snark_groth16_dispute_proof_bytes(
+                        ProofResult::SnarkGroth16(result),
+                    )?;
+                    pending.phase = ProofPhase::ReadyToSubmit { proof_bytes: proof_bytes.clone() };
+                    ProofUpdate::Ready(proof_bytes)
+                }
+                Ok(None) => ProofUpdate::Pending,
+                Err(ZkProofRequesterError::ProofFailed { session_id, message }) => {
+                    warn!(
+                        game = %game,
+                        session_id = %session_id,
+                        error_message = %message,
+                        "proof job failed"
+                    );
+                    ChallengerMetrics::proof_session_failures_total(
+                        ChallengerMetrics::PROOF_FAILURE_FAILED,
+                    )
+                    .increment(1);
+                    pending.retry_count += 1;
+                    pending.phase = ProofPhase::NeedsRetry;
+                    ProofUpdate::NeedsRetry
+                }
+                Err(
+                    ZkProofRequesterError::MissingResult { session_id }
+                    | ZkProofRequesterError::UnexpectedResult { session_id, .. },
+                ) => {
+                    warn!(
+                        game = %game,
+                        session_id = %session_id,
+                        "proof response malformed, treating as retryable failure"
+                    );
+                    ChallengerMetrics::proof_session_failures_total(
+                        ChallengerMetrics::PROOF_FAILURE_MALFORMED,
+                    )
+                    .increment(1);
+                    pending.retry_count += 1;
+                    pending.phase = ProofPhase::NeedsRetry;
+                    ProofUpdate::NeedsRetry
+                }
+                Err(ZkProofRequesterError::AggregationRequestFailed {
+                    range_session_id,
+                    source,
+                }) => {
+                    debug!(
+                        game = %game,
+                        range_session_id = %range_session_id,
+                        error = %source,
+                        "aggregation request failed, will retry next tick"
+                    );
+                    // Retry aggregation submission until the proof timeout.
+                    ProofUpdate::Pending
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            return Ok(Some(update));
+        }
+
+        let session_id = match &pending.phase {
+            ProofPhase::AwaitingProof { session_id, .. } => session_id.clone(),
+            ProofPhase::ReadyToSubmit { .. } | ProofPhase::NeedsRetry => {
+                unreachable!("ready and retry phases returned above")
+            }
+        };
         let request = GetProofRequest { session_id };
 
         let response = proof_requester.get_proof(request).await?;
@@ -291,31 +402,24 @@ impl PendingProofs {
                     pending.phase = ProofPhase::NeedsRetry;
                     return Ok(Some(ProofUpdate::NeedsRetry));
                 };
-                let proof_bytes = match &pending.kind {
-                    ProofKind::Zk { .. } => {
-                        ChallengerProofAdapter::snark_groth16_dispute_proof_bytes(result)?
-                    }
-                    ProofKind::Tee { .. } => {
-                        match ChallengerProofAdapter::tee_dispute_proof_bytes(
-                            result,
-                            pending.expected_root,
-                        ) {
-                            Ok(proof_bytes) => proof_bytes,
-                            Err(e) => {
-                                warn!(
-                                    game = %game,
-                                    error = %e,
-                                    "TEE proof validation failed, falling back to ZK"
-                                );
-                                ChallengerMetrics::proof_session_failures_total(
-                                    ChallengerMetrics::PROOF_FAILURE_TEE_VALIDATION,
-                                )
-                                .increment(1);
-                                pending.retry_count += 1;
-                                pending.phase = ProofPhase::NeedsRetry;
-                                return Ok(Some(ProofUpdate::NeedsRetry));
-                            }
-                        }
+                let proof_bytes = match ChallengerProofAdapter::tee_dispute_proof_bytes(
+                    result,
+                    pending.expected_root,
+                ) {
+                    Ok(proof_bytes) => proof_bytes,
+                    Err(e) => {
+                        warn!(
+                            game = %game,
+                            error = %e,
+                            "TEE proof validation failed, falling back to ZK"
+                        );
+                        ChallengerMetrics::proof_session_failures_total(
+                            ChallengerMetrics::PROOF_FAILURE_TEE_VALIDATION,
+                        )
+                        .increment(1);
+                        pending.retry_count += 1;
+                        pending.phase = ProofPhase::NeedsRetry;
+                        return Ok(Some(ProofUpdate::NeedsRetry));
                     }
                 };
                 let update = ProofUpdate::Ready(proof_bytes.clone());

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -3,8 +3,8 @@
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_primitives::{ProofEncoder, ProofRequest as PrimitiveProofRequest};
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest,
-    SnarkGroth16ProofRequest, TeeKind, TeeProofRequest,
+    ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest, TeeKind,
+    TeeProofRequest,
 };
 use eyre::{Result, WrapErr, bail};
 
@@ -46,18 +46,6 @@ impl ChallengerProofAdapter {
             Self::tee_session_label(tee_kind),
             &[game_address.as_slice(), &invalid_index],
         )
-    }
-
-    /// Builds a prover-service request for a challenger SNARK proof.
-    pub fn snark_groth16_prove_block_range_request(
-        game_address: Address,
-        invalid_index: u64,
-        request: SnarkGroth16ProofRequest,
-    ) -> ProveBlockRangeRequest {
-        let session_id = Self::snark_groth16_session_id(game_address, invalid_index);
-        ProveBlockRangeRequest {
-            proof: ProofRequest { session_id, request: ProofRequestKind::SnarkGroth16(request) },
-        }
     }
 
     /// Builds a prover-service request for a challenger TEE proof.
@@ -120,8 +108,8 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use base_proof_primitives::{PROOF_TYPE_TEE, Proposal};
     use base_prover_service_protocol::{
-        ProofRequestKind, ProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind,
-        TeeProofResult, ZkProofRequest, ZkProofResult, ZkVm,
+        ProofRequestKind, ProofResult, SnarkGroth16ProofResult, TeeKind, TeeProofResult,
+        ZkProofResult, ZkVm,
     };
 
     use super::ChallengerProofAdapter;
@@ -181,45 +169,6 @@ mod tests {
             ChallengerProofAdapter::snark_groth16_session_id(game_address, 1),
             ChallengerProofAdapter::snark_groth16_session_id(Address::repeat_byte(0xbb), 1)
         );
-    }
-
-    #[test]
-    fn snark_groth16_prove_block_range_request_converts_zk_request() {
-        let game_address = Address::repeat_byte(0xaa);
-        let invalid_index = 1;
-        let session_id =
-            ChallengerProofAdapter::snark_groth16_session_id(game_address, invalid_index);
-        let prover_address = Address::repeat_byte(0x11);
-        let l1_head = B256::repeat_byte(0x22);
-        let proof = ZkProofRequest {
-            start_block_number: 100,
-            number_of_blocks_to_prove: 300,
-            sequence_window: Some(10),
-            l1_head: Some(l1_head),
-            intermediate_root_interval: Some(150),
-            zk_vm: ZkVm::Sp1,
-        };
-        let request = SnarkGroth16ProofRequest { proof, prover_address };
-
-        let wrapped = ChallengerProofAdapter::snark_groth16_prove_block_range_request(
-            game_address,
-            invalid_index,
-            request,
-        );
-
-        assert_eq!(wrapped.proof.session_id, session_id);
-        match wrapped.proof.request {
-            ProofRequestKind::SnarkGroth16(snark) => {
-                assert_eq!(snark.prover_address, prover_address);
-                assert_eq!(snark.proof.start_block_number, 100);
-                assert_eq!(snark.proof.number_of_blocks_to_prove, 300);
-                assert_eq!(snark.proof.sequence_window, Some(10));
-                assert_eq!(snark.proof.l1_head, Some(l1_head));
-                assert_eq!(snark.proof.intermediate_root_interval, Some(150));
-                assert_eq!(snark.proof.zk_vm, ZkVm::Sp1);
-            }
-            other => panic!("unexpected proof request kind: {other:?}"),
-        }
     }
 
     #[test]

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -726,6 +726,22 @@ impl Default for MockZkProofState {
     }
 }
 
+impl MockZkProofState {
+    /// Returns a default ZK result for the requested session.
+    pub fn default_zk_result(&self, session_id: &str) -> ApiProofResult {
+        if session_id.ends_with(":range") {
+            return ApiProofResult::Compressed(ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: self.proof.clone().into(),
+            });
+        }
+
+        ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: self.proof.clone().into() },
+        })
+    }
+}
+
 impl Default for MockZkProofProvider {
     fn default() -> Self {
         Self { session_id: String::new(), state: Mutex::new(MockZkProofState::default()) }
@@ -745,18 +761,15 @@ impl ProofRequesterProvider for MockZkProofProvider {
 
     async fn get_proof(
         &self,
-        _request: GetProofRequest,
+        request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
         let state = self.state.lock().unwrap().clone();
         let result = if state.proof_status == ProofStatus::Succeeded {
             if state.omit_result_on_success {
                 None
             } else {
-                state.result.or_else(|| {
-                    Some(ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                        proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: state.proof.into() },
-                    }))
-                })
+                let default_result = state.default_zk_result(&request.session_id);
+                state.result.or(Some(default_result))
             }
         } else {
             None

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -21,10 +21,10 @@ use base_challenger::{
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex, GameStatus};
 use base_proof_primitives::Proposal;
+use base_proof_zk_requester::Groth16RangeProofRequest;
 use base_protocol::OutputRoot;
 use base_prover_service_protocol::{
-    ProofResult as ApiProofResult, ProofStatus, SnarkGroth16ProofRequest, TeeKind, TeeProofResult,
-    ZkProofRequest, ZkVm,
+    ProofResult as ApiProofResult, ProofStatus, TeeKind, TeeProofResult, ZkProofRequest, ZkVm,
 };
 use base_runtime::TokioRuntime;
 use base_tx_manager::TxManagerError;
@@ -137,8 +137,9 @@ const fn tee_api_result(aggregate_proposal: Proposal) -> ApiProofResult {
 }
 
 fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
-    let request = SnarkGroth16ProofRequest {
-        proof: ZkProofRequest {
+    let request = Groth16RangeProofRequest::new(
+        "ready-proof",
+        ZkProofRequest {
             start_block_number: 15,
             number_of_blocks_to_prove: 5,
             sequence_window: None,
@@ -146,8 +147,8 @@ fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
         },
-        prover_address: addr(0),
-    };
+        addr(0),
+    );
 
     PendingProof::ready(
         Bytes::from_static(&[0x01, 0xDE, 0xAD]),
@@ -599,12 +600,12 @@ async fn test_step_proof_retry_succeeds() {
 }
 
 // Regression test for CHAIN-4297 / Immunefi #75829: after a FAILED proof, the
-// driver must re-invoke `proveBlockRange` with the same deterministic
-// `session_id` so the service-side fix in `create_with_outbox` can requeue
-// the row. Independent of the DB layer; fails on a challenger-side regression
-// such as dropping the retry call or losing proof-session determinism.
+// driver must re-invoke `proveBlockRange` with the same deterministic child
+// `session_id`s so the service-side fix in `create_with_outbox` can requeue
+// the rows. Independent of the DB layer; fails on a challenger-side regression
+// such as dropping the retry calls or losing proof-session determinism.
 #[tokio::test]
-async fn test_step_proof_retry_reuses_deterministic_session_id() {
+async fn test_step_proof_retry_reuses_deterministic_groth16_session_ids() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
@@ -620,41 +621,42 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
     let expected_session_id = ChallengerProofAdapter::snark_groth16_session_id(addr(0), 1);
+    let expected_range_session_id = format!("{expected_session_id}:range");
 
-    // Step 1: initial proveBlockRange call from initiate_zk_proof.
+    // Step 1: initial range proveBlockRange call from initiate_zk_proof.
     driver.step().await.unwrap();
     {
         let log = &zk.state.lock().unwrap().prove_block_range_log;
-        assert_eq!(log.len(), 1, "exactly one prove_block_range call on initiation");
+        assert_eq!(log.len(), 1, "range prove_block_range call on initiation");
         assert_eq!(
             log[0].proof.session_id.as_str(),
-            expected_session_id.as_str(),
-            "challenger must use game-address/invalid-index session_id on initiation",
+            expected_range_session_id.as_str(),
+            "challenger must use deterministic range session_id on initiation",
         );
     }
 
     // Step 2: poll observes Failed → NeedsRetry → handle_proof_retry must
-    // invoke proveBlockRange again, reusing the same deterministic session_id.
+    // invoke proveBlockRange again, reusing the same deterministic range session ID.
     driver.step().await.unwrap();
     {
         let log = &zk.state.lock().unwrap().prove_block_range_log;
-        assert_eq!(log.len(), 2, "retry must invoke prove_block_range a second time");
+        assert_eq!(log.len(), 2, "retry must invoke range prove_block_range");
         assert_eq!(
             log[1].proof.session_id.as_str(),
-            expected_session_id.as_str(),
-            "retry must reuse the deterministic session_id so the service can requeue",
+            expected_range_session_id.as_str(),
+            "retry must reuse the deterministic range session_id so the service can requeue",
         );
         assert_eq!(
             log[0].proof.session_id.as_str(),
             log[1].proof.session_id.as_str(),
-            "the deterministic session_id must be stable across retries",
+            "the deterministic range session_id must be stable across retries",
         );
     }
 
     let entry = driver.pending_proofs.get(&addr(0)).expect("entry should be retained after retry");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { ref session_id, .. } if session_id == &expected_session_id),
-        "post-retry phase must be AwaitingProof with the deterministic session_id",
+        "post-retry phase must be AwaitingProof with the deterministic parent session_id",
     );
     assert_eq!(entry.retry_count, 1);
 
@@ -1697,9 +1699,10 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
     );
 }
 
-const fn minimal_prove_request() -> SnarkGroth16ProofRequest {
-    SnarkGroth16ProofRequest {
-        proof: ZkProofRequest {
+fn minimal_prove_request() -> Groth16RangeProofRequest {
+    Groth16RangeProofRequest::new(
+        "minimal-proof",
+        ZkProofRequest {
             start_block_number: 0,
             number_of_blocks_to_prove: 1,
             sequence_window: None,
@@ -1707,8 +1710,8 @@ const fn minimal_prove_request() -> SnarkGroth16ProofRequest {
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
         },
-        prover_address: Address::ZERO,
-    }
+        Address::ZERO,
+    )
 }
 
 #[tokio::test]

--- a/crates/proof/zk/requester/src/error.rs
+++ b/crates/proof/zk/requester/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for ZK proof requester flows.
 
 use base_prover_service_client::ProverServiceClientError;
-use base_prover_service_protocol::{ProofType, ProveBlockRangeResponse};
+use base_prover_service_protocol::ProofType;
 use thiserror::Error;
 
 /// Errors returned while requesting ZK proofs from the prover service.
@@ -10,13 +10,9 @@ pub enum ZkProofRequesterError {
     /// Prover-service requester RPC failed.
     #[error("prover-service requester call failed: {0}")]
     Client(#[from] ProverServiceClientError),
-    /// Aggregation request failed after range request acceptance.
-    #[error(
-        "aggregation request failed after range request {range_session_id} was accepted: {source}"
-    )]
+    /// Aggregation request failed after the range proof completed.
+    #[error("aggregation request failed after range proof {range_session_id} completed: {source}")]
     AggregationRequestFailed {
-        /// Accepted range proof session.
-        range: ProveBlockRangeResponse,
         /// Accepted range proof session identifier.
         range_session_id: String,
         /// Aggregation request failure.

--- a/crates/proof/zk/requester/src/lib.rs
+++ b/crates/proof/zk/requester/src/lib.rs
@@ -7,4 +7,4 @@ mod request;
 pub use request::Groth16RangeProofRequest;
 
 mod requester;
-pub use requester::{Groth16ProofRequestResponse, ZkProofRequester};
+pub use requester::{Groth16ProofRequestResponse, Groth16ProofState, ZkProofRequester};

--- a/crates/proof/zk/requester/src/request.rs
+++ b/crates/proof/zk/requester/src/request.rs
@@ -14,7 +14,7 @@ const AGGREGATION_SESSION_LABEL: &str = "aggregation";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Groth16RangeProofRequest {
     /// Stable parent session identifier for the logical Groth16 proof flow.
-    pub session_id: String,
+    pub parent_session_id: String,
     /// ZK range proof parameters.
     pub proof: ZkProofRequest,
     /// On-chain prover address to embed in the Groth16 aggregation proof.
@@ -24,21 +24,21 @@ pub struct Groth16RangeProofRequest {
 impl Groth16RangeProofRequest {
     /// Create a logical Groth16 range proof request.
     pub fn new(
-        session_id: impl Into<String>,
+        parent_session_id: impl Into<String>,
         proof: ZkProofRequest,
         prover_address: Address,
     ) -> Self {
-        Self { session_id: session_id.into(), proof, prover_address }
+        Self { parent_session_id: parent_session_id.into(), proof, prover_address }
     }
 
     /// Return the child session id used for the range proof stage.
     pub fn range_session_id(&self) -> String {
-        format!("{}:{RANGE_SESSION_LABEL}", self.session_id)
+        format!("{}:{RANGE_SESSION_LABEL}", self.parent_session_id)
     }
 
     /// Return the child session id used for the Groth16 aggregation proof stage.
     pub fn aggregation_session_id(&self) -> String {
-        format!("{}:{AGGREGATION_SESSION_LABEL}", self.session_id)
+        format!("{}:{AGGREGATION_SESSION_LABEL}", self.parent_session_id)
     }
 
     /// Build the prover-service request for the compressed range proof stage.

--- a/crates/proof/zk/requester/src/requester.rs
+++ b/crates/proof/zk/requester/src/requester.rs
@@ -8,79 +8,89 @@ use base_prover_service_protocol::{
 
 use crate::{Groth16RangeProofRequest, ZkProofRequesterError};
 
-/// Accepted prover-service sessions for a requested Groth16 proof flow.
+/// Accepted prover-service range session for a requested Groth16 proof flow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Groth16ProofRequestResponse {
     /// Accepted compressed range proof session.
     pub range: ProveBlockRangeResponse,
-    /// Accepted Groth16 aggregation proof session.
-    pub aggregation: ProveBlockRangeResponse,
+    /// Initial state to use when polling the proof flow.
+    pub state: Groth16ProofState,
+}
+
+/// Stateful progress marker for a requested Groth16 proof flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Groth16ProofState {
+    /// The range proof has been requested and the aggregation proof has not.
+    AwaitingRange,
+    /// The aggregation proof has been requested and should only be polled.
+    AwaitingAggregation,
 }
 
 /// Higher-level requester for ZK proof flows backed by prover-service requests.
 #[derive(Debug, Clone)]
-pub struct ZkProofRequester<Client> {
-    client: Client,
+pub struct ZkProofRequester<'a, Client: ?Sized> {
+    client: &'a Client,
 }
 
-impl<Client> ZkProofRequester<Client> {
+impl<'a, Client: ?Sized> ZkProofRequester<'a, Client> {
     /// Create a requester around a raw prover-service requester client.
-    pub const fn new(client: Client) -> Self {
+    pub const fn new(client: &'a Client) -> Self {
         Self { client }
     }
 
     /// Return the underlying prover-service requester client.
-    pub const fn client(&self) -> &Client {
-        &self.client
+    pub const fn client(&self) -> &'a Client {
+        self.client
     }
 }
 
-impl<Client> ZkProofRequester<Client>
+impl<Client> ZkProofRequester<'_, Client>
 where
-    Client: ProofRequesterProvider,
+    Client: ProofRequesterProvider + ?Sized,
 {
-    /// Request range proof and Groth16 aggregation stages.
+    /// Request the range proof stage.
     ///
-    /// If aggregation submission fails after range acceptance, the error includes
-    /// the accepted range response.
-    ///
-    /// This method is not cancellation-safe between the range and aggregation
-    /// submissions.
+    /// The aggregation stage is submitted by [`Self::groth16_result`] after the
+    /// range proof succeeds.
     pub async fn request_groth16_proof(
         &self,
         request: &Groth16RangeProofRequest,
     ) -> Result<Groth16ProofRequestResponse, ZkProofRequesterError> {
         let range = self.client.prove_block_range(request.range_prove_block_request()).await?;
-        let aggregation =
-            match self.client.prove_block_range(request.aggregation_prove_block_request()).await {
-                Ok(response) => response,
-                Err(source) => {
-                    return Err(ZkProofRequesterError::AggregationRequestFailed {
-                        range_session_id: range.session_id.clone(),
-                        range,
-                        source,
-                    });
-                }
-            };
-        Ok(Groth16ProofRequestResponse { range, aggregation })
+        Ok(Groth16ProofRequestResponse { range, state: Groth16ProofState::AwaitingRange })
     }
 
-    /// Return the completed Groth16 proof if the aggregation stage has finished.
+    /// Advance the requested Groth16 proof flow and return the completed proof.
+    ///
+    /// Once the range stage succeeds, this submits the aggregation stage and
+    /// then polls the aggregation session.
     pub async fn groth16_result(
         &self,
         request: &Groth16RangeProofRequest,
+        state: &mut Groth16ProofState,
     ) -> Result<Option<SnarkGroth16ProofResult>, ZkProofRequesterError> {
-        let range_session_id = request.range_session_id();
-        match self.proof_result(&range_session_id).await? {
-            Some(ProofResult::Compressed(_)) => {}
-            Some(result) => {
-                return Err(Self::unexpected_result(
+        if *state == Groth16ProofState::AwaitingRange {
+            let range_session_id = request.range_session_id();
+            match self.proof_result(&range_session_id).await? {
+                Some(ProofResult::Compressed(_)) => {}
+                Some(result) => {
+                    return Err(Self::unexpected_result(
+                        range_session_id,
+                        &result,
+                        ProofType::Compressed,
+                    ));
+                }
+                None => return Ok(None),
+            };
+
+            self.client
+                .prove_block_range(request.aggregation_prove_block_request())
+                .await
+                .map_err(|source| ZkProofRequesterError::AggregationRequestFailed {
                     range_session_id,
-                    &result,
-                    ProofType::Compressed,
-                ));
-            }
-            None => return Ok(None),
+                    source,
+                })?;
+            *state = Groth16ProofState::AwaitingAggregation;
         }
 
         let session_id = request.aggregation_session_id();
@@ -89,7 +99,7 @@ where
             Some(result) => {
                 Err(Self::unexpected_result(session_id, &result, ProofType::SnarkGroth16))
             }
-            None => Ok(None),
+            None => return Ok(None),
         }
     }
 
@@ -157,7 +167,7 @@ mod tests {
 
     #[derive(Debug, Default)]
     struct MockProofRequester {
-        submitted: Mutex<Vec<String>>,
+        submitted: Mutex<Vec<ProveBlockRangeRequest>>,
         responses: Mutex<VecDeque<GetProofResponse>>,
         prove_outcomes: Mutex<VecDeque<ProveOutcome>>,
     }
@@ -177,16 +187,13 @@ mod tests {
             }
         }
 
-        fn with_prove_outcomes(outcomes: impl Into<VecDeque<ProveOutcome>>) -> Self {
-            Self {
-                submitted: Mutex::new(Vec::new()),
-                responses: Mutex::new(VecDeque::new()),
-                prove_outcomes: Mutex::new(outcomes.into()),
-            }
-        }
-
-        fn submitted(&self) -> Vec<String> {
-            self.submitted.lock().unwrap().clone()
+        fn submitted_session_ids(&self) -> Vec<String> {
+            self.submitted
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|request| request.proof.session_id.clone())
+                .collect()
         }
     }
 
@@ -196,12 +203,11 @@ mod tests {
             &self,
             request: ProveBlockRangeRequest,
         ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            self.submitted.lock().unwrap().push(request.proof.session_id.clone());
+            let session_id = request.proof.session_id.clone();
+            self.submitted.lock().unwrap().push(request);
             match self.prove_outcomes.lock().unwrap().pop_front() {
                 Some(ProveOutcome::Error(error)) => Err(error),
-                None | Some(ProveOutcome::Success) => {
-                    Ok(ProveBlockRangeResponse { session_id: request.proof.session_id })
-                }
+                None | Some(ProveOutcome::Success) => Ok(ProveBlockRangeResponse { session_id }),
             }
         }
 
@@ -257,51 +263,70 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_groth16_proof_requests_range_then_aggregation() {
+    async fn request_groth16_proof_submits_aggregation_once_after_range_succeeds() {
         let requester = MockProofRequester::with_responses(VecDeque::from([
             GetProofResponse { status: ProofStatus::Running, error_message: None, result: None },
             succeeded(compressed_result()),
+            GetProofResponse { status: ProofStatus::Running, error_message: None, result: None },
             succeeded(snark_result()),
         ]));
-        let requester = ZkProofRequester::new(requester);
+        let requester = ZkProofRequester::new(&requester);
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
 
-        let proof = requester.request_groth16_proof(&request).await.unwrap();
+        let mut proof = requester.request_groth16_proof(&request).await.unwrap();
         assert_eq!(proof.range.session_id, "parent:range");
-        assert_eq!(proof.aggregation.session_id, "parent:aggregation");
-        assert!(requester.groth16_result(&request).await.unwrap().is_none());
+        assert_eq!(proof.state, Groth16ProofState::AwaitingRange);
+        assert!(requester.groth16_result(&request, &mut proof.state).await.unwrap().is_none());
+        assert!(requester.groth16_result(&request, &mut proof.state).await.unwrap().is_none());
+        assert_eq!(proof.state, Groth16ProofState::AwaitingAggregation);
         assert_eq!(
-            requester.groth16_result(&request).await.unwrap().unwrap().proof.proof,
+            requester
+                .groth16_result(&request, &mut proof.state)
+                .await
+                .unwrap()
+                .unwrap()
+                .proof
+                .proof,
             Bytes::from(vec![2])
         );
 
-        assert_eq!(requester.client().submitted(), vec!["parent:range", "parent:aggregation"]);
+        assert_eq!(
+            requester.client().submitted_session_ids(),
+            vec!["parent:range", "parent:aggregation"]
+        );
     }
 
     #[tokio::test]
-    async fn request_groth16_proof_reports_accepted_range_on_aggregation_submit_failure() {
-        let requester = MockProofRequester::with_prove_outcomes(VecDeque::from([
-            ProveOutcome::Success,
-            ProveOutcome::Error(ProverServiceClientError::Timeout(
-                "aggregation timed out".to_owned(),
-            )),
-        ]));
-        let requester = ZkProofRequester::new(requester);
+    async fn groth16_result_reports_aggregation_submit_failure_after_range_succeeds() {
+        let requester = MockProofRequester {
+            submitted: Mutex::new(Vec::new()),
+            responses: Mutex::new(VecDeque::from([succeeded(compressed_result())])),
+            prove_outcomes: Mutex::new(VecDeque::from([
+                ProveOutcome::Success,
+                ProveOutcome::Error(ProverServiceClientError::Timeout(
+                    "aggregation timed out".to_owned(),
+                )),
+            ])),
+        };
+        let requester = ZkProofRequester::new(&requester);
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
 
-        let error = requester.request_groth16_proof(&request).await.unwrap_err();
+        let mut proof = requester.request_groth16_proof(&request).await.unwrap();
+        let error = requester.groth16_result(&request, &mut proof.state).await.unwrap_err();
 
-        let ZkProofRequesterError::AggregationRequestFailed { range, range_session_id, source } =
-            error
+        let ZkProofRequesterError::AggregationRequestFailed { range_session_id, source } = error
         else {
             panic!("expected aggregation request failure");
         };
-        assert_eq!(range.session_id, "parent:range");
         assert_eq!(range_session_id, "parent:range");
+        assert_eq!(proof.state, Groth16ProofState::AwaitingRange);
         assert!(matches!(source, ProverServiceClientError::Timeout(_)));
-        assert_eq!(requester.client().submitted(), vec!["parent:range", "parent:aggregation"]);
+        assert_eq!(
+            requester.client().submitted_session_ids(),
+            vec!["parent:range", "parent:aggregation"]
+        );
     }
 
     #[tokio::test]
@@ -311,11 +336,12 @@ mod tests {
             error_message: Some("range failed".to_owned()),
             result: None,
         }]));
-        let requester = ZkProofRequester::new(requester);
+        let requester = ZkProofRequester::new(&requester);
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
+        let mut state = Groth16ProofState::AwaitingRange;
 
-        let error = requester.groth16_result(&request).await.unwrap_err();
+        let error = requester.groth16_result(&request, &mut state).await.unwrap_err();
 
         assert!(matches!(error, ZkProofRequesterError::ProofFailed { .. }));
     }
@@ -330,11 +356,12 @@ mod tests {
                 result: None,
             },
         ]));
-        let requester = ZkProofRequester::new(requester);
+        let requester = ZkProofRequester::new(&requester);
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
+        let mut state = Groth16ProofState::AwaitingRange;
 
-        let error = requester.groth16_result(&request).await.unwrap_err();
+        let error = requester.groth16_result(&request, &mut state).await.unwrap_err();
 
         assert!(matches!(
             error,


### PR DESCRIPTION
Wire the challenger through base-proof-zk-requester so Groth16 proof submission and polling use the requester shim instead of building raw prover-service SNARK requests. The challenger still owns dispute state, retries, and submission intent, while the requester crate owns the range-plus-aggregation proof flow.