### PR TITLE
fix(proposer): select proof L1 head from sync status

### DIFF
--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -260,7 +260,7 @@ mod tests {
     fn test_pipeline_handle(
         global_cancel: CancellationToken,
     ) -> PipelineHandle<MockL1, MockL2, MockRollupClient> {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
         let rollup = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -299,6 +299,7 @@ mod tests {
             Arc::clone(&rollup),
             ProofDispatcherConfig {
                 proposer_address: config.proposer_address,
+                allow_non_finalized: config.allow_non_finalized,
                 intermediate_block_interval: config.intermediate_block_interval,
                 tee_image_hash: config.tee_image_hash,
             },

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -254,6 +254,7 @@ mod tests {
             Arc::clone(&rollup),
             ProofDispatcherConfig {
                 proposer_address: config.proposer_address,
+                allow_non_finalized: config.allow_non_finalized,
                 intermediate_block_interval: config.intermediate_block_interval,
                 tee_image_hash: config.tee_image_hash,
             },

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -224,7 +224,7 @@ mod tests {
         let requester = Arc::new(RejectingProofRequester::default());
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::<RejectingProofRequester>::clone(&requester);
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1181,7 +1181,7 @@ mod tests {
             &self,
             _: B256,
         ) -> base_proof_rpc::RpcResult<alloy_rpc_types_eth::Header> {
-            unimplemented!("tests do not fetch L1 headers by hash")
+            Err(base_proof_rpc::RpcError::Transport("simulated L1 outage".into()))
         }
 
         async fn block_receipts(
@@ -1306,6 +1306,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 300,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1375,6 +1376,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1457,6 +1459,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1519,6 +1522,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1594,6 +1598,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1653,6 +1658,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1717,6 +1723,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1800,6 +1807,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
@@ -1865,6 +1873,7 @@ mod tests {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: false,
                 intermediate_block_interval: 100,
                 tee_image_hash: B256::repeat_byte(0x05),
             },

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -1279,7 +1279,7 @@ mod tests {
     fn make_orchestrator(
         block_interval: u64,
     ) -> ProofCollectorOrchestrator<MockL1, MockL2, MockRollupClient> {
-        make_orchestrator_with_l1(Arc::new(MockL1 { latest_block_number: 1000 }), block_interval)
+        make_orchestrator_with_l1(Arc::new(MockL1::new(1000)), block_interval)
     }
 
     fn make_orchestrator_with_l1<L1>(
@@ -1360,7 +1360,7 @@ mod tests {
     async fn submit_inline_restarts_when_post_submit_recovery_fails() {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::new(MockProofRequester::default());
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),
@@ -1443,7 +1443,7 @@ mod tests {
 
     #[tokio::test]
     async fn discard_retry_dispatch_failure_does_not_store_unaccepted_session() {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),
@@ -1506,7 +1506,7 @@ mod tests {
 
     #[tokio::test]
     async fn discard_retry_session_mismatch_does_not_store_unaccepted_session() {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),
@@ -1642,7 +1642,7 @@ mod tests {
 
     #[tokio::test]
     async fn discard_retry_dispatch_failure_returns_false_on_retry_exhaustion() {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),
@@ -1707,7 +1707,7 @@ mod tests {
 
     #[tokio::test]
     async fn root_retry_dispatch_failure_returns_false_after_failed_session_was_counted() {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),
@@ -1772,7 +1772,7 @@ mod tests {
     #[tokio::test]
     async fn tick_returns_restart_when_discard_retry_budget_exhausts() {
         let proof_requester = Arc::new(MockProofRequester::default());
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
@@ -1847,7 +1847,7 @@ mod tests {
     #[tokio::test]
     async fn tick_returns_restart_when_failed_session_exhausts_retries() {
         let proof_requester = Arc::new(MockProofRequester::default());
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -146,17 +146,24 @@ where
             &sync_status,
             self.config.allow_non_finalized,
         )?;
-        self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
+        let l1_header =
+            self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
+        if l1_header.hash != l1_head.hash || l1_header.number != l1_head.number {
+            return Err(ProposerError::Internal(format!(
+                "selected {l1_head_source} L1 head {}:{} does not match L1 RPC header {}:{}",
+                l1_head.number, l1_head.hash, l1_header.number, l1_header.hash
+            )));
+        }
 
         let request = ProofRequest {
-            l1_head: l1_head.hash,
+            l1_head: l1_header.hash,
             agreed_l2_head_hash: agreed_l2_head.hash,
             agreed_l2_output_root: recovered.output_root,
             claimed_l2_output_root,
             claimed_l2_block_number: target_block,
             proposer: self.config.proposer_address,
             intermediate_block_interval: self.config.intermediate_block_interval,
-            l1_head_number: l1_head.number,
+            l1_head_number: l1_header.number,
             image_hash: self.config.tee_image_hash,
         };
 
@@ -165,8 +172,8 @@ where
             to_block = target_block,
             allow_non_finalized = self.config.allow_non_finalized,
             l1_head_source = l1_head_source,
-            l1_head_number = l1_head.number,
-            l1_head_hash = %l1_head.hash,
+            l1_head_number = l1_header.number,
+            l1_head_hash = %l1_header.hash,
             l2_coverage_block = l2_coverage.number,
             l2_coverage_hash = %l2_coverage.hash,
             finalized_l1_number = sync_status.finalized_l1.number,
@@ -191,25 +198,31 @@ where
         sync_status: &SyncStatus,
         allow_non_finalized: bool,
     ) -> Result<(&'static str, L1BlockRef, L2BlockRef), ProposerError> {
-        if target_block <= sync_status.finalized_l2.number {
-            return Ok(("finalized", sync_status.finalized_l1, sync_status.finalized_l2));
-        }
-
-        if !allow_non_finalized {
+        let selected = if target_block <= sync_status.finalized_l2.number {
+            ("finalized", sync_status.finalized_l1, sync_status.finalized_l2)
+        } else if !allow_non_finalized {
             return Err(ProposerError::Internal(format!(
                 "target block {target_block} is above rollup finalized head {}",
                 sync_status.finalized_l2.number
             )));
+        } else if target_block <= sync_status.safe_l2.number {
+            ("safe", sync_status.safe_l1, sync_status.safe_l2)
+        } else {
+            return Err(ProposerError::Internal(format!(
+                "target block {target_block} is above rollup safe head {}",
+                sync_status.safe_l2.number
+            )));
+        };
+
+        let (l1_head_source, l1_head, l2_coverage) = selected;
+        if l1_head.number < l2_coverage.l1origin.number {
+            return Err(ProposerError::Internal(format!(
+                "selected {l1_head_source} L1 head {} is below {l1_head_source} L2 origin {}",
+                l1_head.number, l2_coverage.l1origin.number
+            )));
         }
 
-        if target_block <= sync_status.safe_l2.number {
-            return Ok(("safe", sync_status.safe_l1, sync_status.safe_l2));
-        }
-
-        Err(ProposerError::Internal(format!(
-            "target block {target_block} is above rollup safe head {}",
-            sync_status.safe_l2.number
-        )))
+        Ok(selected)
     }
 
     /// Builds and dispatches a root-derived proof request for `target_block`.
@@ -516,8 +529,8 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l2_block_ref,
-        test_sync_status,
+        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l1_header,
+        test_l2_block_ref, test_sync_status,
     };
 
     #[derive(Debug)]
@@ -614,7 +627,10 @@ mod tests {
         sync_status: SyncStatus,
         allow_non_finalized: bool,
     ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
-        let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
+        let l1 = Arc::new(MockL1::with_headers(
+            sync_status.finalized_l1.number,
+            headers_for_sync_status(&sync_status),
+        ));
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup = Arc::new(MockRollupClient {
             sync_status,
@@ -635,13 +651,27 @@ mod tests {
         )
     }
 
+    fn headers_for_sync_status(
+        sync_status: &SyncStatus,
+    ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
+        let mut headers = HashMap::new();
+        for l1_head in [sync_status.finalized_l1, sync_status.safe_l1] {
+            headers.insert(l1_head.hash, test_l1_header(l1_head.hash, l1_head.number));
+        }
+        headers
+    }
+
     fn sync_status_with_distinct_heads(finalized_l2: u64, safe_l2: u64) -> SyncStatus {
         let mut finalized_l1 = test_l1_block_ref(10);
         finalized_l1.hash = B256::repeat_byte(0xf1);
         let mut safe_l1 = test_l1_block_ref(20);
         safe_l1.hash = B256::repeat_byte(0x5a);
-        let finalized_l2 = test_l2_block_ref(finalized_l2, B256::repeat_byte(0xf2));
-        let safe_l2 = test_l2_block_ref(safe_l2, B256::repeat_byte(0x52));
+        let mut finalized_l2 = test_l2_block_ref(finalized_l2, B256::repeat_byte(0xf2));
+        finalized_l2.l1origin.hash = finalized_l1.hash;
+        finalized_l2.l1origin.number = finalized_l1.number;
+        let mut safe_l2 = test_l2_block_ref(safe_l2, B256::repeat_byte(0x52));
+        safe_l2.l1origin.hash = safe_l1.hash;
+        safe_l2.l1origin.number = safe_l1.number;
 
         SyncStatus {
             current_l1: safe_l1,
@@ -698,6 +728,58 @@ mod tests {
 
         assert_eq!(request.l1_head, B256::repeat_byte(0x5a));
         assert_eq!(request.l1_head_number, 20);
+    }
+
+    #[tokio::test]
+    async fn build_request_rejects_l2_coverage_beyond_selected_l1_head() {
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+        let mut sync_status = sync_status_with_distinct_heads(300, 600);
+        sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number + 1;
+        let dispatcher = dispatcher_for_requester_and_sync(requester, sync_status, true);
+
+        let err = dispatcher
+            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
+            .await
+            .expect_err("safe L1 must cover selected safe L2 origin");
+
+        assert!(err.to_string().contains("below safe L2 origin"));
+    }
+
+    #[tokio::test]
+    async fn build_request_rejects_l1_rpc_header_mismatch() {
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+        let sync_status = sync_status_with_distinct_heads(300, 600);
+        let mut headers = headers_for_sync_status(&sync_status);
+        headers.insert(
+            sync_status.safe_l1.hash,
+            test_l1_header(sync_status.safe_l1.hash, sync_status.safe_l1.number + 1),
+        );
+        let l1 = Arc::new(MockL1::with_headers(sync_status.finalized_l1.number, headers));
+        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status,
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        });
+        let dispatcher = ProofDispatcher::new(
+            requester,
+            l1,
+            l2,
+            rollup,
+            ProofDispatcherConfig {
+                proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized: true,
+                intermediate_block_interval: 300,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+
+        let err = dispatcher
+            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
+            .await
+            .expect_err("L1 RPC header must match rollup-selected L1 head");
+
+        assert!(err.to_string().contains("does not match L1 RPC header"));
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256};
+use base_optimism_rpc::{L1BlockRef, L2BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
@@ -20,6 +21,8 @@ use crate::{
 pub struct ProofDispatcherConfig {
     /// Address of the proposer that will submit the proof onchain.
     pub proposer_address: Address,
+    /// Whether requests may target safe, non-finalized L2 blocks.
+    pub allow_non_finalized: bool,
     /// Number of L2 blocks between intermediate output root checkpoints.
     pub intermediate_block_interval: u64,
     /// Expected TEE enclave image hash.
@@ -129,13 +132,8 @@ where
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
     ) -> Result<ProofRequest, ProposerError> {
-        let (l1_head, agreed_l2_head) = tokio::try_join!(
-            async {
-                self.l1_client
-                    .header_by_number(BlockNumberOrTag::Finalized)
-                    .await
-                    .map_err(ProposerError::Rpc)
-            },
+        let (sync_status, agreed_l2_head) = tokio::try_join!(
+            async { self.rollup_client.sync_status().await.map_err(ProposerError::Rpc) },
             async {
                 self.l2_client
                     .header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number))
@@ -143,6 +141,12 @@ where
                     .map_err(ProposerError::Rpc)
             },
         )?;
+        let (l1_head_source, l1_head, l2_coverage) = Self::select_l1_head_for_target(
+            target_block,
+            &sync_status,
+            self.config.allow_non_finalized,
+        )?;
+        self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
 
         let request = ProofRequest {
             l1_head: l1_head.hash,
@@ -159,11 +163,53 @@ where
         info!(
             from_block = recovered.l2_block_number,
             to_block = target_block,
+            allow_non_finalized = self.config.allow_non_finalized,
+            l1_head_source = l1_head_source,
             l1_head_number = l1_head.number,
+            l1_head_hash = %l1_head.hash,
+            l2_coverage_block = l2_coverage.number,
+            l2_coverage_hash = %l2_coverage.hash,
+            finalized_l1_number = sync_status.finalized_l1.number,
+            finalized_l1_hash = %sync_status.finalized_l1.hash,
+            finalized_l2_number = sync_status.finalized_l2.number,
+            finalized_l2_hash = %sync_status.finalized_l2.hash,
+            safe_l1_number = sync_status.safe_l1.number,
+            safe_l1_hash = %sync_status.safe_l1.hash,
+            safe_l2_number = sync_status.safe_l2.number,
+            safe_l2_hash = %sync_status.safe_l2.hash,
+            agreed_l2_head_hash = %agreed_l2_head.hash,
+            agreed_l2_output_root = %recovered.output_root,
+            claimed_l2_output_root = %claimed_l2_output_root,
             "Built proof request"
         );
 
         Ok(request)
+    }
+
+    fn select_l1_head_for_target(
+        target_block: u64,
+        sync_status: &SyncStatus,
+        allow_non_finalized: bool,
+    ) -> Result<(&'static str, L1BlockRef, L2BlockRef), ProposerError> {
+        if target_block <= sync_status.finalized_l2.number {
+            return Ok(("finalized", sync_status.finalized_l1, sync_status.finalized_l2));
+        }
+
+        if !allow_non_finalized {
+            return Err(ProposerError::Internal(format!(
+                "target block {target_block} is above rollup finalized head {}",
+                sync_status.finalized_l2.number
+            )));
+        }
+
+        if target_block <= sync_status.safe_l2.number {
+            return Ok(("safe", sync_status.safe_l1, sync_status.safe_l2));
+        }
+
+        Err(ProposerError::Internal(format!(
+            "target block {target_block} is above rollup safe head {}",
+            sync_status.safe_l2.number
+        )))
     }
 
     /// Builds and dispatches a root-derived proof request for `target_block`.
@@ -470,7 +516,8 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockL1, MockL2, MockProofRequester, MockRollupClient, test_sync_status,
+        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l2_block_ref,
+        test_sync_status,
     };
 
     #[derive(Debug)]
@@ -559,10 +606,18 @@ mod tests {
     fn dispatcher_for_requester(
         requester: Arc<dyn ProofRequesterProvider>,
     ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
+        dispatcher_for_requester_and_sync(requester, test_sync_status(10_000, B256::ZERO), false)
+    }
+
+    fn dispatcher_for_requester_and_sync(
+        requester: Arc<dyn ProofRequesterProvider>,
+        sync_status: SyncStatus,
+        allow_non_finalized: bool,
+    ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
         let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
         let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
         let rollup = Arc::new(MockRollupClient {
-            sync_status: test_sync_status(0, B256::ZERO),
+            sync_status,
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
@@ -573,10 +628,32 @@ mod tests {
             rollup,
             ProofDispatcherConfig {
                 proposer_address: Address::repeat_byte(0x04),
+                allow_non_finalized,
                 intermediate_block_interval: 300,
                 tee_image_hash: B256::repeat_byte(0x05),
             },
         )
+    }
+
+    fn sync_status_with_distinct_heads(finalized_l2: u64, safe_l2: u64) -> SyncStatus {
+        let mut finalized_l1 = test_l1_block_ref(10);
+        finalized_l1.hash = B256::repeat_byte(0xf1);
+        let mut safe_l1 = test_l1_block_ref(20);
+        safe_l1.hash = B256::repeat_byte(0x5a);
+        let finalized_l2 = test_l2_block_ref(finalized_l2, B256::repeat_byte(0xf2));
+        let safe_l2 = test_l2_block_ref(safe_l2, B256::repeat_byte(0x52));
+
+        SyncStatus {
+            current_l1: safe_l1,
+            current_l1_finalized: Some(finalized_l1),
+            head_l1: safe_l1,
+            safe_l1,
+            finalized_l1,
+            unsafe_l2: safe_l2,
+            safe_l2,
+            finalized_l2,
+            pending_safe_l2: None,
+        }
     }
 
     fn recovered() -> RecoveredState {
@@ -585,6 +662,76 @@ mod tests {
             output_root: B256::repeat_byte(0x03),
             l2_block_number: 100,
         }
+    }
+
+    #[tokio::test]
+    async fn build_request_uses_finalized_l1_head_for_finalized_target() {
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+        let dispatcher = dispatcher_for_requester_and_sync(
+            requester,
+            sync_status_with_distinct_heads(300, 600),
+            true,
+        );
+
+        let request = dispatcher
+            .build_request(200, &recovered(), B256::repeat_byte(0xaa))
+            .await
+            .expect("request should build for finalized target");
+
+        assert_eq!(request.l1_head, B256::repeat_byte(0xf1));
+        assert_eq!(request.l1_head_number, 10);
+    }
+
+    #[tokio::test]
+    async fn build_request_uses_safe_l1_head_for_safe_target() {
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+        let dispatcher = dispatcher_for_requester_and_sync(
+            requester,
+            sync_status_with_distinct_heads(300, 600),
+            true,
+        );
+
+        let request = dispatcher
+            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
+            .await
+            .expect("request should build for safe target");
+
+        assert_eq!(request.l1_head, B256::repeat_byte(0x5a));
+        assert_eq!(request.l1_head_number, 20);
+    }
+
+    #[tokio::test]
+    async fn build_request_rejects_target_above_safe_l2() {
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+        let dispatcher = dispatcher_for_requester_and_sync(
+            requester,
+            sync_status_with_distinct_heads(300, 600),
+            true,
+        );
+
+        let err = dispatcher
+            .build_request(700, &recovered(), B256::repeat_byte(0xaa))
+            .await
+            .expect_err("target above safe L2 should not build");
+
+        assert!(err.to_string().contains("above rollup safe head"));
+    }
+
+    #[tokio::test]
+    async fn build_request_rejects_safe_target_when_non_finalized_disallowed() {
+        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+        let dispatcher = dispatcher_for_requester_and_sync(
+            requester,
+            sync_status_with_distinct_heads(300, 600),
+            false,
+        );
+
+        let err = dispatcher
+            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
+            .await
+            .expect_err("non-finalized target should not build when disabled");
+
+        assert!(err.to_string().contains("above rollup finalized head"));
     }
 
     #[tokio::test]
@@ -711,6 +858,7 @@ mod tests {
     fn config_is_copyable() {
         let config = ProofDispatcherConfig {
             proposer_address: Address::ZERO,
+            allow_non_finalized: false,
             intermediate_block_interval: 1,
             tee_image_hash: B256::ZERO,
         };

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -658,7 +658,7 @@ mod tests {
                 output_roots,
                 max_safe_block: None,
             }),
-            Arc::new(MockL1 { latest_block_number: 1000 }),
+            Arc::new(MockL1::new(1000)),
             factory,
             Arc::new(verifier),
             ProofSubmitterConfig {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -241,6 +241,7 @@ impl ProposerService {
             Arc::clone(&rollup_client),
             ProofDispatcherConfig {
                 proposer_address: driver_config.proposer_address,
+                allow_non_finalized: driver_config.allow_non_finalized,
                 intermediate_block_interval: driver_config.intermediate_block_interval,
                 tee_image_hash: driver_config.tee_image_hash,
             },

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -10,7 +10,7 @@ use std::{
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bytes, U256};
-use alloy_rpc_types_eth::EIP1186AccountProofResponse;
+use alloy_rpc_types_eth::{EIP1186AccountProofResponse, Header};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_optimism_rpc::{L1BlockId, L1BlockRef, L2BlockRef, OutputAtBlock, SyncStatus};
@@ -43,6 +43,20 @@ const TEST_SIGNATURE: [u8; 65] = {
 pub struct MockL1 {
     /// The block number returned by `block_number()`.
     pub latest_block_number: u64,
+    /// Headers returned by `header_by_hash()`.
+    pub headers_by_hash: HashMap<B256, Header>,
+}
+
+impl MockL1 {
+    /// Creates a mock L1 provider with no hash-specific headers.
+    pub fn new(latest_block_number: u64) -> Self {
+        Self { latest_block_number, headers_by_hash: HashMap::new() }
+    }
+
+    /// Creates a mock L1 provider with hash-specific headers.
+    pub fn with_headers(latest_block_number: u64, headers_by_hash: HashMap<B256, Header>) -> Self {
+        Self { latest_block_number, headers_by_hash }
+    }
 }
 
 #[async_trait]
@@ -54,10 +68,14 @@ impl L1Provider for MockL1 {
         &self,
         _: BlockNumberOrTag,
     ) -> RpcResult<alloy_rpc_types_eth::Header> {
-        Ok(alloy_rpc_types_eth::Header { hash: B256::repeat_byte(0x11), ..Default::default() })
+        Ok(test_l1_header(B256::repeat_byte(0x11), self.latest_block_number))
     }
     async fn header_by_hash(&self, hash: B256) -> RpcResult<alloy_rpc_types_eth::Header> {
-        Ok(alloy_rpc_types_eth::Header { hash, ..Default::default() })
+        Ok(self
+            .headers_by_hash
+            .get(&hash)
+            .cloned()
+            .unwrap_or_else(|| test_l1_header(hash, self.latest_block_number)))
     }
     async fn block_receipts(
         &self,
@@ -370,6 +388,15 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 }
 
+/// Creates a test L1 RPC header with the given block hash and number.
+pub fn test_l1_header(hash: B256, number: u64) -> Header {
+    Header {
+        hash,
+        inner: alloy_consensus::Header { number, ..Default::default() },
+        ..Default::default()
+    }
+}
+
 /// Creates a test [`L1BlockRef`] with the given block number.
 pub fn test_l1_block_ref(number: u64) -> L1BlockRef {
     L1BlockRef { hash: B256::ZERO, number, parent_hash: B256::ZERO, timestamp: 1_000_000 + number }
@@ -389,8 +416,10 @@ pub fn test_l2_block_ref(number: u64, hash: B256) -> L2BlockRef {
 
 /// Creates a test [`SyncStatus`] with the given safe block number and hash.
 pub fn test_sync_status(safe_number: u64, safe_hash: B256) -> SyncStatus {
-    let l1 = test_l1_block_ref(100);
-    let l2 = test_l2_block_ref(safe_number, safe_hash);
+    let l1 = test_l1_block_ref(1000);
+    let mut l2 = test_l2_block_ref(safe_number, safe_hash);
+    l2.l1origin.hash = l1.hash;
+    l2.l1origin.number = l1.number;
     SyncStatus {
         current_l1: l1,
         current_l1_finalized: None,

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -56,8 +56,8 @@ impl L1Provider for MockL1 {
     ) -> RpcResult<alloy_rpc_types_eth::Header> {
         Ok(alloy_rpc_types_eth::Header { hash: B256::repeat_byte(0x11), ..Default::default() })
     }
-    async fn header_by_hash(&self, _: B256) -> RpcResult<alloy_rpc_types_eth::Header> {
-        unimplemented!()
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<alloy_rpc_types_eth::Header> {
+        Ok(alloy_rpc_types_eth::Header { hash, ..Default::default() })
     }
     async fn block_receipts(
         &self,

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -48,9 +48,12 @@ pub struct MockL1 {
 }
 
 impl MockL1 {
-    /// Creates a mock L1 provider with no hash-specific headers.
+    /// Creates a mock L1 provider with the default test L1 head registered.
     pub fn new(latest_block_number: u64) -> Self {
-        Self { latest_block_number, headers_by_hash: HashMap::new() }
+        Self::with_headers(
+            latest_block_number,
+            HashMap::from([(B256::ZERO, test_l1_header(B256::ZERO, latest_block_number))]),
+        )
     }
 
     /// Creates a mock L1 provider with hash-specific headers.
@@ -71,11 +74,10 @@ impl L1Provider for MockL1 {
         Ok(test_l1_header(B256::repeat_byte(0x11), self.latest_block_number))
     }
     async fn header_by_hash(&self, hash: B256) -> RpcResult<alloy_rpc_types_eth::Header> {
-        Ok(self
-            .headers_by_hash
+        self.headers_by_hash
             .get(&hash)
             .cloned()
-            .unwrap_or_else(|| test_l1_header(hash, self.latest_block_number)))
+            .ok_or_else(|| RpcError::HeaderNotFound(format!("mock: no header for hash {hash}")))
     }
     async fn block_receipts(
         &self,


### PR DESCRIPTION
## Summary
- Select proposer proof request L1 heads from rollup sync status instead of always using finalized L1.
- Use finalized L1 for finalized L2 targets and safe L1 for safe, non-finalized targets when enabled.
- Reject targets beyond the selected rollup safety boundary and add request-build logging/tests for the chosen L1/L2 coverage.
- Keep the existing proposer proof session namespace unchanged.
- Validate selected rollup L1 heads against L1 RPC headers and ensure they cover the selected L2 safety boundary.

## Tests
- cargo test -p base-proposer