### PR TITLE
feat(proof): execute zk dry runs locally

### DIFF
--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -61,39 +61,39 @@ struct WorkerArgs {
     #[arg(long, env = "PROOF_TYPE", value_enum, default_value = "compressed")]
     proof_type: ZkProofTypeArg,
 
-    /// Proving backend to run: `mock`, `dry_run`, `cluster`, or `network`.
+    /// Proving backend to run: `mock`, `dry-run`, `cluster`, or `network`.
     #[arg(long, env = "ZK_BACKEND", value_enum)]
     backend: ZkBackendArg,
 
-    /// Base consensus node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    /// Base consensus node RPC URL. Required for `ZK_BACKEND=dry-run`, `cluster`, or `network`.
     #[arg(
         long,
         env = "BASE_CONSENSUS_ADDRESS",
-        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+        required_if_eq_any([("backend", "dry-run"), ("backend", "cluster"), ("backend", "network")])
     )]
     base_consensus_address: Option<Url>,
 
-    /// L1 execution node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    /// L1 execution node RPC URL. Required for `ZK_BACKEND=dry-run`, `cluster`, or `network`.
     #[arg(
         long,
         env = "L1_NODE_ADDRESS",
-        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+        required_if_eq_any([("backend", "dry-run"), ("backend", "cluster"), ("backend", "network")])
     )]
     l1_node_address: Option<Url>,
 
-    /// L1 beacon node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    /// L1 beacon node RPC URL. Required for `ZK_BACKEND=dry-run`, `cluster`, or `network`.
     #[arg(
         long,
         env = "L1_BEACON_ADDRESS",
-        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+        required_if_eq_any([("backend", "dry-run"), ("backend", "cluster"), ("backend", "network")])
     )]
     l1_beacon_address: Option<Url>,
 
-    /// L2 execution node RPC URL. Required for `ZK_BACKEND=cluster` or `network`.
+    /// L2 execution node RPC URL. Required for `ZK_BACKEND=dry-run`, `cluster`, or `network`.
     #[arg(
         long,
         env = "L2_NODE_ADDRESS",
-        required_if_eq_any([("backend", "cluster"), ("backend", "network")])
+        required_if_eq_any([("backend", "dry-run"), ("backend", "cluster"), ("backend", "network")])
     )]
     l2_node_address: Option<Url>,
 
@@ -207,7 +207,7 @@ impl From<ZkProofTypeArg> for ZkProofClaimType {
 enum ZkBackendArg {
     /// Return placeholder proof bytes without an external backend.
     Mock,
-    /// Return empty proof bytes without an external backend.
+    /// Run local SP1 execution and return dry-run stats without proof bytes.
     #[value(alias = "dry_run", alias = "dryrun")]
     DryRun,
     /// Submit proofs to an SP1 cluster.
@@ -236,8 +236,10 @@ impl fmt::Display for ZkBackendArg {
 impl ZkBackendArg {
     const fn supports_proof_type(self, proof_type: ZkProofTypeArg) -> bool {
         match self {
-            Self::Mock | Self::DryRun => true,
-            Self::Cluster | Self::Network => matches!(proof_type, ZkProofTypeArg::Compressed),
+            Self::Mock => true,
+            Self::DryRun | Self::Cluster | Self::Network => {
+                matches!(proof_type, ZkProofTypeArg::Compressed)
+            }
         }
     }
 }
@@ -246,7 +248,10 @@ impl WorkerArgs {
     fn backend_config(&self) -> eyre::Result<SuccinctZkBackendConfig> {
         match self.backend {
             ZkBackendArg::Mock => Ok(SuccinctZkBackendConfig::Mock),
-            ZkBackendArg::DryRun => Ok(SuccinctZkBackendConfig::DryRun),
+            ZkBackendArg::DryRun => Ok(SuccinctZkBackendConfig::DryRun {
+                rpc: self.rpc_config()?,
+                range_cycle_limit: self.range_cycle_limit,
+            }),
             ZkBackendArg::Cluster => {
                 Ok(SuccinctZkBackendConfig::Cluster(SuccinctClusterBackendConfig {
                     rpc: self.rpc_config()?,

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -251,7 +251,11 @@ mod tests {
     #[test]
     fn snark_groth16_dispute_proof_bytes_prefixes_zk_type() {
         let result = ProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: Bytes::from_static(&[0xab, 0xcd]) },
+            proof: ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: Bytes::from_static(&[0xab, 0xcd]),
+                execution_stats: None,
+            },
         });
 
         let proof_bytes =

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -754,7 +754,11 @@ impl ProofRequesterProvider for MockZkProofProvider {
             } else {
                 state.result.or_else(|| {
                     Some(ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                        proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: state.proof.into() },
+                        proof: ZkProofResult {
+                            zk_vm: ZkVm::Sp1,
+                            proof: state.proof.into(),
+                            execution_stats: None,
+                        },
                     }))
                 })
             }

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -160,12 +160,17 @@ mod tests {
                 ProofResult::Compressed(ZkProofResult {
                     zk_vm: ZkVm::Sp1,
                     proof: Bytes::from(vec![]),
+                    execution_stats: None,
                 }),
                 "expected TEE proof result, got Compressed",
             ),
             (
                 ProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                    proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: Bytes::from(vec![]) },
+                    proof: ZkProofResult {
+                        zk_vm: ZkVm::Sp1,
+                        proof: Bytes::from(vec![]),
+                        execution_stats: None,
+                    },
                 }),
                 "expected TEE proof result, got SnarkGroth16",
             ),

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -426,6 +426,7 @@ mod tests {
                 result: Some(ProofResult::Compressed(ZkProofResult {
                     zk_vm: ZkVm::Sp1,
                     proof: vec![0xab, 0xcd].into(),
+                    execution_stats: None,
                 })),
             })
         }

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -694,7 +694,11 @@ mod tests {
     }
 
     fn proof_result() -> ProofResult {
-        ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![1, 2, 3].into() })
+        ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![1, 2, 3].into(),
+            execution_stats: None,
+        })
     }
 
     #[tokio::test]

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -241,11 +241,16 @@ impl ProofRequest {
                 ProtocolProofResult::Compressed(ZkProofResult {
                     zk_vm: ProtocolZkVm::Sp1,
                     proof: proof.into(),
+                    execution_stats: None,
                 })
             }),
             Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16) => self.snark_receipt.map(|proof| {
                 ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                    proof: ZkProofResult { zk_vm: ProtocolZkVm::Sp1, proof: proof.into() },
+                    proof: ZkProofResult {
+                        zk_vm: ProtocolZkVm::Sp1,
+                        proof: proof.into(),
+                        execution_stats: None,
+                    },
                 })
             }),
             None => None,
@@ -420,6 +425,7 @@ mod tests {
         let expected = ProtocolProofResult::Compressed(ZkProofResult {
             zk_vm: ProtocolZkVm::Sp1,
             proof: vec![0xAA, 0xBB].into(),
+            execution_stats: None,
         });
         let mut req = proof_request(Some(ProofType::OpSuccinctSp1ClusterCompressed));
         req.stark_receipt = Some(vec![0xDE, 0xAD]);
@@ -439,6 +445,7 @@ mod tests {
             Some(ProtocolProofResult::Compressed(ZkProofResult {
                 zk_vm: ProtocolZkVm::Sp1,
                 proof: vec![1, 2, 3].into(),
+                execution_stats: None,
             }))
         );
     }
@@ -451,7 +458,11 @@ mod tests {
         assert_eq!(
             req.stored_proof_result().unwrap(),
             Some(ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                proof: ZkProofResult { zk_vm: ProtocolZkVm::Sp1, proof: vec![4, 5, 6].into() },
+                proof: ZkProofResult {
+                    zk_vm: ProtocolZkVm::Sp1,
+                    proof: vec![4, 5, 6].into(),
+                    execution_stats: None
+                },
             }))
         );
     }

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1298,6 +1298,7 @@ mod tests {
         let result = ProtocolProofResult::Compressed(ZkProofResult {
             zk_vm: ZkVm::Sp1,
             proof: vec![0x01].into(),
+            execution_stats: None,
         });
 
         assert_eq!(job.validate_submitted_result(&result), Ok(()));
@@ -1309,6 +1310,7 @@ mod tests {
         let result = ProtocolProofResult::Compressed(ZkProofResult {
             zk_vm: ZkVm::Sp1,
             proof: vec![0x01].into(),
+            execution_stats: None,
         });
 
         assert!(job.validate_submitted_result(&result).is_err());
@@ -1318,7 +1320,11 @@ mod tests {
     fn validate_submitted_result_rejects_snark_for_compressed_job() {
         let job = proof_job_with(ApiProofType::Compressed, Some(ZkVmKind::Sp1), None);
         let result = ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![0x01].into() },
+            proof: ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: vec![0x01].into(),
+                execution_stats: None,
+            },
         });
 
         assert!(job.validate_submitted_result(&result).is_err());
@@ -1330,6 +1336,7 @@ mod tests {
         let result = ProtocolProofResult::Compressed(ZkProofResult {
             zk_vm: ZkVm::Sp1,
             proof: vec![0x01].into(),
+            execution_stats: None,
         });
 
         assert!(job.validate_submitted_result(&result).is_err());

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1869,7 +1869,11 @@ fn proof_result_from_receipt_update(update: &UpdateReceipt) -> Option<ProtocolPr
     // stores SP1 receipts. Protocol-native completions carry their own ZK VM.
     if let Some(snark_receipt) = &update.snark_receipt {
         return Some(ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_receipt.clone().into() },
+            proof: ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: snark_receipt.clone().into(),
+                execution_stats: None,
+            },
         }));
     }
 
@@ -1877,6 +1881,7 @@ fn proof_result_from_receipt_update(update: &UpdateReceipt) -> Option<ProtocolPr
         ProtocolProofResult::Compressed(ZkProofResult {
             zk_vm: ZkVm::Sp1,
             proof: stark_receipt.clone().into(),
+            execution_stats: None,
         })
     })
 }
@@ -2627,7 +2632,8 @@ mod tests {
             result,
             ProtocolProofResult::Compressed(ZkProofResult {
                 zk_vm: ZkVm::Sp1,
-                proof: vec![1, 2, 3].into()
+                proof: vec![1, 2, 3].into(),
+                execution_stats: None,
             })
         );
     }
@@ -2668,7 +2674,11 @@ mod tests {
         assert_eq!(
             result,
             ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![4, 5, 6].into() }
+                proof: ZkProofResult {
+                    zk_vm: ZkVm::Sp1,
+                    proof: vec![4, 5, 6].into(),
+                    execution_stats: None
+                }
             })
         );
     }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1449,7 +1449,11 @@ async fn test_full_snark_pipeline() {
     assert_eq!(
         result,
         ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: snark_receipt.into() }
+            proof: ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: snark_receipt.into(),
+                execution_stats: None
+            }
         })
     );
     assert!(req.completed_at.is_some());
@@ -1530,7 +1534,11 @@ async fn expire_lock(pool: &PgPool, id: Uuid) {
 }
 
 fn compressed_result(bytes: Vec<u8>) -> ProtocolProofResult {
-    ProtocolProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: bytes.into() })
+    ProtocolProofResult::Compressed(ZkProofResult {
+        zk_vm: ZkVm::Sp1,
+        proof: bytes.into(),
+        execution_stats: None,
+    })
 }
 
 fn uppercase_uuid_session_id() -> (Uuid, String) {
@@ -1881,7 +1889,11 @@ async fn test_complete_claimed_proof_job_rejects_mismatched_result() {
             lock_id: Uuid::new_v4(),
             worker_id: "non-owner".to_owned(),
             result: ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![0x01].into() },
+                proof: ZkProofResult {
+                    zk_vm: ZkVm::Sp1,
+                    proof: vec![0x01].into(),
+                    execution_stats: None,
+                },
             }),
         })
         .await
@@ -1895,7 +1907,11 @@ async fn test_complete_claimed_proof_job_rejects_mismatched_result() {
             lock_id,
             worker_id: "mismatch-worker".to_owned(),
             result: ProtocolProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![0x01].into() },
+                proof: ZkProofResult {
+                    zk_vm: ZkVm::Sp1,
+                    proof: vec![0x01].into(),
+                    execution_stats: None,
+                },
             }),
         })
         .await

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -12,7 +12,7 @@ pub use session::ProofSessionId;
 
 mod types;
 pub use types::{
-    BackendSession, BackendSessionState, DeleteProofRequest, GetNextProofRequest,
+    BackendSession, BackendSessionState, DeleteProofRequest, ExecutionStats, GetNextProofRequest,
     GetNextProofResponse, GetProofRequest, GetProofResponse, GetProofSessionRequest,
     GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse, ListProofsRequest,
     ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest,

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC request and response types for the shared prover service protocol.
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_primitives::{ProofRequest as PrimitiveProofRequest, Proposal};
@@ -176,6 +176,24 @@ pub struct ZkProofResult {
     pub zk_vm: ZkVm,
     /// Serialized proof bytes.
     pub proof: Bytes,
+    /// Local execution statistics, present for dry-run ZK results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_stats: Option<ExecutionStats>,
+}
+
+/// Local SP1 execution statistics for a dry-run ZK proof.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionStats {
+    /// Total RISC-V instruction cycles reported by SP1.
+    pub total_instruction_cycles: u64,
+    /// Total SP1 gas reported by SP1.
+    pub total_sp1_gas: u64,
+    /// Per-section cycle tracker values reported by the range program.
+    pub cycle_tracker: HashMap<String, u64>,
+    /// Time spent generating the witness, in milliseconds.
+    pub witness_generation_ms: u64,
+    /// Time spent executing the SP1 range program, in milliseconds.
+    pub execution_ms: u64,
 }
 
 /// Groth16 SNARK proof result.
@@ -441,6 +459,8 @@ pub struct RecordProofSessionResponse {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy_primitives::{Bytes, address};
     use serde_json::json;
 
@@ -498,6 +518,49 @@ mod tests {
         }));
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn zk_result_omits_execution_stats_unless_present() {
+        let result = ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: Bytes::from_static(&[0xab, 0xcd]),
+            execution_stats: None,
+        });
+        let value = serde_json::to_value(result).expect("zk result should serialize");
+        assert!(value["payload"].get("execution_stats").is_none());
+
+        let result = ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: Bytes::new(),
+            execution_stats: Some(ExecutionStats {
+                total_instruction_cycles: 10,
+                total_sp1_gas: 20,
+                cycle_tracker: HashMap::from([("section".to_owned(), 30)]),
+                witness_generation_ms: 40,
+                execution_ms: 50,
+            }),
+        });
+        let value = serde_json::to_value(result).expect("zk result should serialize");
+        assert_eq!(
+            value,
+            json!({
+                "proof_type": "compressed",
+                "payload": {
+                    "zk_vm": "sp1",
+                    "proof": "0x",
+                    "execution_stats": {
+                        "total_instruction_cycles": 10,
+                        "total_sp1_gas": 20,
+                        "cycle_tracker": {
+                            "section": 30
+                        },
+                        "witness_generation_ms": 40,
+                        "execution_ms": 50
+                    }
+                }
+            })
+        );
     }
 
     #[test]
@@ -830,6 +893,7 @@ mod tests {
             result: ProofResult::Compressed(ZkProofResult {
                 zk_vm: ZkVm::Sp1,
                 proof: vec![1, 2, 3].into(),
+                execution_stats: None,
             }),
         };
 

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -3,11 +3,11 @@ use base_prover_service_db::{
     canonical_session_id,
 };
 use base_prover_service_protocol::{
-    GetProofRequest, GetProofResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofResult, ProofStatus,
-    ZkProofResult, ZkVm,
+    ExecutionStats, GetProofRequest, GetProofResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE,
+    ProofResult, ProofStatus, ZkProofResult, ZkVm,
 };
 use jsonrpsee::core::RpcResult;
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -15,12 +15,45 @@ use crate::{
     server::{ProverServiceServer, internal, invalid_argument, not_found, record_rpc_result},
 };
 
-fn is_dry_run_metadata(metadata: &serde_json::Value) -> bool {
+#[cfg(test)]
+fn execution_stats_from_metadata(metadata: &serde_json::Value) -> Option<ExecutionStats> {
+    is_dry_run_result_metadata(metadata).then_some(())?;
+    let stats = metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)?;
+    execution_stats_from_value(stats)
+}
+
+fn execution_stats_from_value(stats: &serde_json::Value) -> Option<ExecutionStats> {
+    Some(ExecutionStats {
+        total_instruction_cycles: stats.get("total_instruction_cycles")?.as_u64()?,
+        total_sp1_gas: stats.get("total_sp1_gas")?.as_u64()?,
+        cycle_tracker: serde_json::from_value(stats.get("cycle_tracker")?.clone()).ok()?,
+        witness_generation_ms: milliseconds_from_metadata(stats.get("witness_generation_ms")?)?,
+        execution_ms: milliseconds_from_metadata(stats.get("execution_ms")?)?,
+    })
+}
+
+fn is_dry_run_result_metadata(metadata: &serde_json::Value) -> bool {
     metadata
         .get(OP_SUCCINCT_DRY_RUN_METADATA_KEY)
         .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
+        .unwrap_or_default()
         && metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY).is_some()
+}
+
+fn milliseconds_from_metadata(value: &serde_json::Value) -> Option<u64> {
+    if let Some(milliseconds) = value.as_u64() {
+        return Some(milliseconds);
+    }
+
+    let milliseconds = value.as_f64()?;
+    if milliseconds.is_sign_negative()
+        || !milliseconds.is_finite()
+        || milliseconds > u64::MAX as f64
+    {
+        return None;
+    }
+
+    Some(milliseconds as u64)
 }
 
 const fn should_use_dry_run_result(proof_req: &ProofRequest) -> bool {
@@ -39,26 +72,54 @@ impl ProverServiceServer {
         result
     }
 
-    async fn request_is_dry_run(&self, proof_request_id: Uuid) -> RpcResult<bool> {
+    async fn dry_run_execution_stats_for_request(
+        &self,
+        proof_request_id: Uuid,
+    ) -> RpcResult<(bool, Option<ExecutionStats>)> {
         let sessions = self
             .repo
             .get_sessions_for_request(proof_request_id)
             .await
             .map_err(|e| internal(format!("Database error: {e}")))?;
 
-        Ok(sessions
+        let mut has_dry_run_result = false;
+        for metadata in sessions
             .iter()
             .filter(|session| session.status == DbSessionStatus::Completed)
             .filter_map(|session| session.metadata.as_ref())
-            .any(is_dry_run_metadata))
+        {
+            if is_dry_run_result_metadata(metadata) {
+                has_dry_run_result = true;
+                if let Some(execution_stats) = metadata
+                    .get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)
+                    .and_then(execution_stats_from_value)
+                {
+                    return Ok((true, Some(execution_stats)));
+                }
+            }
+        }
+
+        Ok((has_dry_run_result, None))
     }
 
     async fn succeeded_result(&self, proof_req: ProofRequest) -> RpcResult<Option<ProofResult>> {
-        if should_use_dry_run_result(&proof_req) && self.request_is_dry_run(proof_req.id).await? {
-            return Ok(Some(ProofResult::Compressed(ZkProofResult {
-                zk_vm: ZkVm::Sp1,
-                proof: Vec::new().into(),
-            })));
+        if should_use_dry_run_result(&proof_req) {
+            let (is_dry_run, execution_stats) =
+                self.dry_run_execution_stats_for_request(proof_req.id).await?;
+            if is_dry_run {
+                if execution_stats.is_none() {
+                    warn!(
+                        proof_request_id = %proof_req.id,
+                        "dry-run proof has no valid execution stats in session metadata"
+                    );
+                }
+
+                return Ok(Some(ProofResult::Compressed(ZkProofResult {
+                    zk_vm: ZkVm::Sp1,
+                    proof: Vec::new().into(),
+                    execution_stats,
+                })));
+            }
         }
 
         let result = proof_req
@@ -154,7 +215,28 @@ mod tests {
     }
 
     #[test]
-    fn dry_run_metadata_requires_marker_and_stats() {
+    fn dry_run_execution_stats_from_metadata_deserializes_integer_stats() {
+        let metadata = metadata_with_execution_stats(serde_json::json!({
+            "total_instruction_cycles": 100,
+            "total_sp1_gas": 200,
+            "cycle_tracker": {
+                "range": 42
+            },
+            "witness_generation_ms": 12,
+            "execution_ms": 34
+        }));
+
+        let stats = execution_stats_from_metadata(&metadata).expect("execution stats");
+
+        assert_eq!(stats.total_instruction_cycles, 100);
+        assert_eq!(stats.total_sp1_gas, 200);
+        assert_eq!(stats.cycle_tracker.get("range"), Some(&42));
+        assert_eq!(stats.witness_generation_ms, 12);
+        assert_eq!(stats.execution_ms, 34);
+    }
+
+    #[test]
+    fn dry_run_execution_stats_from_metadata_truncates_fractional_milliseconds() {
         let metadata = metadata_with_execution_stats(serde_json::json!({
             "total_instruction_cycles": 100,
             "total_sp1_gas": 200,
@@ -162,11 +244,52 @@ mod tests {
                 "range": 42
             },
             "witness_generation_ms": 12.5,
+            "execution_ms": 34.9
+        }));
+
+        let stats = execution_stats_from_metadata(&metadata).expect("execution stats");
+
+        assert_eq!(stats.witness_generation_ms, 12);
+        assert_eq!(stats.execution_ms, 34);
+    }
+
+    #[test]
+    fn dry_run_execution_stats_from_metadata_requires_marker_and_valid_stats() {
+        assert!(execution_stats_from_metadata(&serde_json::json!({ "dry_run": true })).is_none());
+
+        let metadata = metadata_with_execution_stats(serde_json::json!({
+            "total_instruction_cycles": "100",
+            "total_sp1_gas": 200,
+            "cycle_tracker": {},
+            "witness_generation_ms": 12,
+            "execution_ms": 34
+        }));
+
+        assert!(execution_stats_from_metadata(&metadata).is_none());
+
+        let metadata = metadata_with_execution_stats(serde_json::json!({
+            "total_instruction_cycles": 100,
+            "total_sp1_gas": 200,
+            "cycle_tracker": {},
+            "witness_generation_ms": -12.5,
             "execution_ms": 34.5
         }));
 
-        assert!(is_dry_run_metadata(&metadata));
-        assert!(!is_dry_run_metadata(&serde_json::json!({ "dry_run": true })));
+        assert!(execution_stats_from_metadata(&metadata).is_none());
+    }
+
+    #[test]
+    fn dry_run_result_metadata_accepts_malformed_stats_for_empty_result_compatibility() {
+        let metadata = metadata_with_execution_stats(serde_json::json!({
+            "total_instruction_cycles": "100",
+            "total_sp1_gas": 200,
+            "cycle_tracker": {},
+            "witness_generation_ms": 12,
+            "execution_ms": 34
+        }));
+
+        assert!(is_dry_run_result_metadata(&metadata));
+        assert!(execution_stats_from_metadata(&metadata).is_none());
     }
 
     #[test]
@@ -174,6 +297,7 @@ mod tests {
         let stored_result = ProofResult::Compressed(ZkProofResult {
             zk_vm: ZkVm::Sp1,
             proof: vec![0xAA, 0xBB].into(),
+            execution_stats: None,
         });
         let mut req = make_proof_request(ProofType::OpSuccinctSp1ClusterCompressed, None, None);
         req.result_payload =

--- a/crates/proof/prover-service/tests/worker_api_e2e.rs
+++ b/crates/proof/prover-service/tests/worker_api_e2e.rs
@@ -200,6 +200,7 @@ async fn worker_claim_heartbeat_submit_round_trip() {
             result: ProofResult::Compressed(ZkProofResult {
                 zk_vm: ZkVm::Sp1,
                 proof: vec![1, 2, 3].into(),
+                execution_stats: None,
             }),
         })
         .await
@@ -233,6 +234,7 @@ async fn worker_submit_unknown_session_is_not_found() {
             result: ProofResult::Compressed(ZkProofResult {
                 zk_vm: ZkVm::Sp1,
                 proof: vec![9].into(),
+                execution_stats: None,
             }),
         })
         .await

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -428,6 +428,7 @@ mod tests {
             result: ProofResult::Compressed(ZkProofResult {
                 zk_vm: ZkVm::Sp1,
                 proof: vec![1, 2, 3].into(),
+                execution_stats: None,
             }),
         }
     }

--- a/crates/proof/zk/backend/Cargo.toml
+++ b/crates/proof/zk/backend/Cargo.toml
@@ -38,7 +38,7 @@ sp1-sdk = { workspace = true, features = ["network"] }
 backoff.workspace = true
 async-trait.workspace = true
 tokio-util.workspace = true
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 # error handling
 thiserror.workspace = true

--- a/crates/proof/zk/backend/README.md
+++ b/crates/proof/zk/backend/README.md
@@ -9,6 +9,6 @@ interface.
 ## Backends
 
 - `MockZkProver`: instant placeholder proofs for exercising the full worker flow.
-- `DryRunZkProver`: instant completion with an empty proof payload.
+- `DryRunZkProver`: local SP1 execution statistics with an empty proof payload.
 - `ClusterZkProver`: SP1 cluster range-proof backend for compressed proofs.
 - `NetworkZkProver`: SP1 prover-network range-proof backend for compressed proofs.

--- a/crates/proof/zk/backend/src/lib.rs
+++ b/crates/proof/zk/backend/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod succinct;
 pub use succinct::{
-    ClusterSessionId, ClusterZkProver, ClusterZkProverConfig, DRY_RUN_SNARK_PREFIX, DryRunZkProver,
+    ClusterSessionId, ClusterZkProver, ClusterZkProverConfig, DRY_RUN_PREFIX, DryRunZkProver,
     L1HeadSource, MOCK_PROOF_BYTES, MOCK_SNARK_PREFIX, MockZkProver, NetworkZkProver,
     NetworkZkProverConfig, OpSuccinctWitnessProvider, SuccinctClusterBackendConfig,
     SuccinctNetworkBackendConfig, SuccinctRpcConfig, SuccinctZkBackendConfig,

--- a/crates/proof/zk/backend/src/succinct/builder.rs
+++ b/crates/proof/zk/backend/src/succinct/builder.rs
@@ -56,8 +56,13 @@ impl SuccinctZkProverBuildError {
 pub enum SuccinctZkBackendConfig {
     /// Return placeholder proof bytes without an external backend.
     Mock,
-    /// Return empty proof bytes without an external backend.
-    DryRun,
+    /// Generate a witness and run local SP1 execution without producing proof bytes.
+    DryRun {
+        /// Shared RPC settings.
+        rpc: SuccinctRpcConfig,
+        /// Cycle limit for local range program execution.
+        range_cycle_limit: u64,
+    },
     /// Submit proofs to an SP1 cluster.
     Cluster(SuccinctClusterBackendConfig),
     /// Submit proofs to the Succinct SP1 Network.
@@ -102,7 +107,9 @@ impl SuccinctZkProverBuilder {
 
         match self.config {
             SuccinctZkBackendConfig::Mock => Ok(Some(Arc::new(MockZkProver))),
-            SuccinctZkBackendConfig::DryRun => Ok(Some(Arc::new(DryRunZkProver))),
+            SuccinctZkBackendConfig::DryRun { rpc, range_cycle_limit } => {
+                DryRunZkProver::build_until_cancelled(rpc, range_cycle_limit, cancel).await
+            }
             SuccinctZkBackendConfig::Cluster(config) => {
                 ClusterZkProver::build_until_cancelled(config, cancel).await
             }

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -761,7 +761,11 @@ impl ZkProver for ClusterZkProver {
         let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
             .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
 
-        Ok(ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into() }))
+        Ok(ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: proof.into(),
+            execution_stats: None,
+        }))
     }
 }
 

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -1,24 +1,229 @@
-//! Dry-run [`ZkProver`] that completes instantly with an empty proof.
+//! Dry-run [`ZkProver`] for local SP1 execution statistics.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
+use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
+use base_proof_succinct_proof_utils::get_range_elf_embedded;
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, SnarkGroth16ProofResult, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{ExecutionStats, ProofResult, ZkProofResult, ZkVm};
+use sp1_sdk::{
+    Elf, SP1Stdin,
+    blocking::{LightProver, Prover},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
 
-/// Prefix marking a dry-run backend session id for a SNARK proof.
-pub const DRY_RUN_SNARK_PREFIX: &str = "dry-run-snark-";
+use crate::succinct::{
+    L1HeadSource, OpSuccinctWitnessProvider, SuccinctRpcConfig, SuccinctZkProverBuildError,
+    SuccinctZkProverBuilder, WitnessParams,
+};
 
-/// [`ZkProver`] that completes instantly with an empty proof payload.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct DryRunZkProver;
+macro_rules! backend_error {
+    ($($arg:tt)*) => {
+        ZkProverError::Backend(std::io::Error::other(format!($($arg)*)).into())
+    };
+}
 
-impl DryRunZkProver {
-    /// Derive the deterministic backend session id for a request.
-    pub fn backend_session_id(request: &ZkProofRequestKind, request_session_id: &str) -> String {
-        let session_type = if request.is_snark_groth16() { "snark" } else { "stark" };
-        format!("dry-run-{session_type}-{request_session_id}")
+/// Prefix marking a dry-run backend session id.
+pub const DRY_RUN_PREFIX: &str = "dry-run-stark-";
+
+/// [`ZkProver`] that generates a witness and executes the range program locally.
+#[derive(Clone)]
+pub struct DryRunZkProver {
+    provider: OpSuccinctWitnessProvider,
+    base_consensus_url: String,
+    l1_node_url: String,
+    default_sequence_window: u64,
+    range_cycle_limit: u64,
+    completed_results: Arc<Mutex<HashMap<String, ProofResult>>>,
+}
+
+impl std::fmt::Debug for DryRunZkProver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DryRunZkProver")
+            .field("base_consensus_url", &self.base_consensus_url)
+            .field("l1_node_url", &self.l1_node_url)
+            .field("default_sequence_window", &self.default_sequence_window)
+            .field("range_cycle_limit", &self.range_cycle_limit)
+            .finish_non_exhaustive()
     }
 }
 
+impl DryRunZkProver {
+    /// Create a dry-run prover with a witness provider and RPC config.
+    pub fn new(
+        provider: OpSuccinctWitnessProvider,
+        base_consensus_url: String,
+        l1_node_url: String,
+        default_sequence_window: u64,
+        range_cycle_limit: u64,
+    ) -> Self {
+        Self {
+            provider,
+            base_consensus_url,
+            l1_node_url,
+            default_sequence_window,
+            range_cycle_limit,
+            completed_results: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Builds a dry-run backend.
+    pub async fn build_until_cancelled(
+        rpc: SuccinctRpcConfig,
+        range_cycle_limit: u64,
+        cancel: &CancellationToken,
+    ) -> Result<Option<Arc<dyn ZkProver>>, SuccinctZkProverBuildError> {
+        let base_consensus_url = rpc.base_consensus_rpc.as_str().to_owned();
+        let l1_node_url = rpc.l1_rpc.as_str().to_owned();
+        let default_sequence_window = rpc.default_sequence_window;
+
+        info!(backend = "dry_run", "using local SP1 dry-run backend");
+        let Some(provider) = SuccinctZkProverBuilder::build_witness_provider(rpc, cancel).await?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Arc::new(Self::new(
+            provider,
+            base_consensus_url,
+            l1_node_url,
+            default_sequence_window,
+            range_cycle_limit,
+        ))))
+    }
+
+    /// Execute the range program with SP1's light prover and return execution statistics.
+    ///
+    /// Cancellation note: SP1's blocking execution is not interruptible once dispatched. Dropping
+    /// this future does not stop an already-running local execution task.
+    pub async fn execute_range_program(
+        stdin: SP1Stdin,
+        range_cycle_limit: u64,
+    ) -> Result<ExecutionStats, ZkProverError> {
+        let (execution_result, execution_ms) = tokio::task::spawn_blocking(move || {
+            info!(range_cycle_limit = range_cycle_limit, "starting local SP1 zkVM execution");
+
+            let execution_start = std::time::Instant::now();
+            let prover = LightProver::new();
+            let result = prover
+                .execute(Elf::Static(get_range_elf_embedded()), stdin)
+                .cycle_limit(range_cycle_limit)
+                .calculate_gas(true)
+                .deferred_proof_verification(false)
+                .run();
+            let execution_ms =
+                u64::try_from(execution_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+            (result, execution_ms)
+        })
+        .await
+        .map_err(|e| backend_error!("SP1 execution task failed to join: {e}"))?;
+        let (_, report) =
+            execution_result.map_err(|e| backend_error!("SP1 execution failed: {e}"))?;
+
+        Ok(ExecutionStats {
+            total_instruction_cycles: report.total_instruction_count(),
+            total_sp1_gas: report.gas().unwrap_or_else(|| {
+                warn!("gas calculation returned None despite calculate_gas(true)");
+                0
+            }),
+            cycle_tracker: report.cycle_tracker.into_iter().collect(),
+            witness_generation_ms: 0,
+            execution_ms,
+        })
+    }
+
+    /// Generate the witness, execute it locally, and return an empty-proof dry-run result.
+    pub async fn prove_range(
+        &self,
+        request: &base_prover_service_protocol::ZkProofRequest,
+        request_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError> {
+        if request.number_of_blocks_to_prove == 0 {
+            return Err(backend_error!("number_of_blocks_to_prove must be greater than zero"));
+        }
+
+        let start_block = request.start_block_number;
+        let end_block = start_block
+            .checked_add(request.number_of_blocks_to_prove)
+            .ok_or_else(|| backend_error!("proof range end block overflowed u64"))?;
+        let sequence_window = request.sequence_window.unwrap_or(self.default_sequence_window);
+        let intermediate_root_interval =
+            request.intermediate_root_interval.unwrap_or(DEFAULT_INTERMEDIATE_ROOT_INTERVAL);
+
+        info!(
+            request_session_id = %request_session_id,
+            start_block = start_block,
+            end_block = end_block,
+            number_of_blocks = request.number_of_blocks_to_prove,
+            sequence_window = sequence_window,
+            intermediate_root_interval = intermediate_root_interval,
+            range_cycle_limit = self.range_cycle_limit,
+            l1_head = ?request.l1_head,
+            "starting dry-run SP1 execution"
+        );
+
+        let witness_start = std::time::Instant::now();
+        let stdin = self
+            .provider
+            .generate_witness(WitnessParams {
+                start_block,
+                end_block,
+                l1_head: request.l1_head.map_or(
+                    L1HeadSource::SequenceWindow {
+                        sequence_window,
+                        l1_node_url: &self.l1_node_url,
+                        base_consensus_url: &self.base_consensus_url,
+                    },
+                    L1HeadSource::Pinned,
+                ),
+                intermediate_root_interval,
+            })
+            .await
+            .map_err(|e| {
+                error!(
+                    start_block = start_block,
+                    end_block = end_block,
+                    error = %e,
+                    "dry-run witness generation failed"
+                );
+                backend_error!("witness generation failed: {e}")
+            })?;
+        let witness_generation_ms =
+            u64::try_from(witness_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+        let mut execution_stats =
+            Self::execute_range_program(stdin, self.range_cycle_limit).await?;
+        execution_stats.witness_generation_ms = witness_generation_ms;
+
+        info!(
+            request_session_id = %request_session_id,
+            total_instruction_cycles = execution_stats.total_instruction_cycles,
+            total_sp1_gas = execution_stats.total_sp1_gas,
+            witness_generation_ms = witness_generation_ms,
+            execution_ms = execution_stats.execution_ms,
+            tracked_sections = execution_stats.cycle_tracker.len(),
+            "dry-run SP1 execution completed"
+        );
+
+        Ok(ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: Vec::new().into(),
+            execution_stats: Some(execution_stats),
+        }))
+    }
+}
+
+/// Dry-run submission is synchronous: `submit` generates the witness and runs local SP1 execution
+/// before returning a completed backend session id. The backend stores one result per session, so
+/// `poll` only reports `Completed` before the single `download` call consumes that result.
+/// Results are process-local and non-durable; if the process exits before `download`, the dry-run
+/// must be submitted again.
 #[async_trait]
 impl ZkProver for DryRunZkProver {
     async fn submit(
@@ -26,77 +231,38 @@ impl ZkProver for DryRunZkProver {
         request: &ZkProofRequestKind,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
-        Ok(Self::backend_session_id(request, request_session_id))
+        let ZkProofRequestKind::Compressed(request) = request else {
+            return Err(backend_error!(
+                "dry-run backend only supports compressed proof types; SNARK_GROTH16 requires a proof-producing backend"
+            ));
+        };
+
+        let backend_session_id = format!("{DRY_RUN_PREFIX}{request_session_id}");
+        let result = self.prove_range(request, request_session_id).await?;
+        self.completed_results
+            .lock()
+            .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?
+            .insert(backend_session_id.clone(), result);
+
+        Ok(backend_session_id)
     }
 
-    async fn poll(&self, _backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
-        Ok(ZkSessionState::Completed)
+    async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+        let contains_result = self
+            .completed_results
+            .lock()
+            .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?
+            .contains_key(backend_session_id);
+        if contains_result { Ok(ZkSessionState::Completed) } else { Ok(ZkSessionState::NotFound) }
     }
 
     async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
-        let zk_proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: Vec::new().into() };
-
-        if backend_session_id.starts_with(DRY_RUN_SNARK_PREFIX) {
-            Ok(ProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof: zk_proof }))
-        } else {
-            Ok(ProofResult::Compressed(zk_proof))
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
-
-    use super::*;
-
-    fn zk_request() -> ZkProofRequest {
-        ZkProofRequest {
-            start_block_number: 1,
-            number_of_blocks_to_prove: 1,
-            sequence_window: None,
-            l1_head: None,
-            intermediate_root_interval: None,
-            zk_vm: ZkVm::Sp1,
-        }
-    }
-
-    fn compressed() -> ZkProofRequestKind {
-        ZkProofRequestKind::Compressed(zk_request())
-    }
-
-    fn snark_groth16() -> ZkProofRequestKind {
-        ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-            proof: zk_request(),
-            prover_address: Default::default(),
-        })
-    }
-
-    #[tokio::test]
-    async fn dry_run_completes_with_empty_proof() {
-        let prover = DryRunZkProver;
-        let id = prover.submit(&compressed(), "session-1").await.unwrap();
-
-        assert_eq!(id, "dry-run-stark-session-1");
-        assert_eq!(prover.poll(&id).await.unwrap(), ZkSessionState::Completed);
-
-        match prover.download(&id).await.unwrap() {
-            ProofResult::Compressed(proof) => assert!(proof.proof.is_empty()),
-            other => panic!("expected compressed proof, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn dry_run_completes_with_empty_snark_groth16_proof() {
-        let prover = DryRunZkProver;
-        let id = prover.submit(&snark_groth16(), "session-1").await.unwrap();
-
-        assert_eq!(id, "dry-run-snark-session-1");
-        assert_eq!(prover.poll(&id).await.unwrap(), ZkSessionState::Completed);
-
-        match prover.download(&id).await.unwrap() {
-            ProofResult::SnarkGroth16(proof) => assert!(proof.proof.proof.is_empty()),
-            other => panic!("expected SNARK Groth16 proof, got {other:?}"),
-        }
+        self.completed_results
+            .lock()
+            .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?
+            .remove(backend_session_id)
+            .ok_or_else(|| ZkProverError::BackendSessionNotFound {
+                backend_session_id: backend_session_id.to_owned(),
+            })
     }
 }

--- a/crates/proof/zk/backend/src/succinct/mock.rs
+++ b/crates/proof/zk/backend/src/succinct/mock.rs
@@ -37,7 +37,11 @@ impl ZkProver for MockZkProver {
     }
 
     async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
-        let zk_proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: MOCK_PROOF_BYTES.to_vec().into() };
+        let zk_proof = ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: MOCK_PROOF_BYTES.to_vec().into(),
+            execution_stats: None,
+        };
 
         if backend_session_id.starts_with(MOCK_SNARK_PREFIX) {
             Ok(ProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof: zk_proof }))

--- a/crates/proof/zk/backend/src/succinct/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/mod.rs
@@ -20,7 +20,7 @@ mod network;
 pub use network::{NetworkZkProver, NetworkZkProverConfig, SuccinctNetworkBackendConfig};
 
 mod dry_run;
-pub use dry_run::{DRY_RUN_SNARK_PREFIX, DryRunZkProver};
+pub use dry_run::{DRY_RUN_PREFIX, DryRunZkProver};
 
 mod mock;
 pub use mock::{MOCK_PROOF_BYTES, MOCK_SNARK_PREFIX, MockZkProver};

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -412,6 +412,10 @@ impl ZkProver for NetworkZkProver {
         let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
             .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
 
-        Ok(ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into() }))
+        Ok(ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: proof.into(),
+            execution_stats: None,
+        }))
     }
 }

--- a/crates/proof/zk/host/src/proof_submitter.rs
+++ b/crates/proof/zk/host/src/proof_submitter.rs
@@ -39,7 +39,11 @@ mod tests {
     use super::*;
 
     fn zk_result() -> ProofResult {
-        ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![1, 2, 3].into() })
+        ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![1, 2, 3].into(),
+            execution_stats: None,
+        })
     }
 
     #[test]

--- a/crates/proof/zk/requester/src/requester.rs
+++ b/crates/proof/zk/requester/src/requester.rs
@@ -240,12 +240,20 @@ mod tests {
 
     fn snark_result() -> ProofResult {
         ProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: Bytes::from(vec![2]) },
+            proof: ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: Bytes::from(vec![2]),
+                execution_stats: None,
+            },
         })
     }
 
     fn compressed_result() -> ProofResult {
-        ProofResult::Compressed(ZkProofResult { zk_vm: ZkVm::Sp1, proof: Bytes::from(vec![1]) })
+        ProofResult::Compressed(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: Bytes::from(vec![1]),
+            execution_stats: None,
+        })
     }
 
     fn succeeded(result: ProofResult) -> GetProofResponse {


### PR DESCRIPTION
## Summary
Make the dry-run ZK backend generate a witness and execute the SP1 range program with LightProver. Return local execution stats in ZK proof results and keep dry-run compressed-only.