### PR TITLE
refactor(proposer): clean proof dispatcher

### DIFF
--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -283,7 +283,7 @@ mod tests {
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
             l1.clone(),
-            l2.clone(),
+            l2,
             rollup.clone(),
             &config,
         );

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -15,7 +15,7 @@ use std::{
 
 use alloy_primitives::{Address, B256};
 use async_trait::async_trait;
-use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
+use base_proof_rpc::{L1Provider, RollupProvider};
 use eyre::Result;
 use tokio::{sync::Mutex as TokioMutex, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -127,22 +127,20 @@ struct Session {
 
 /// Manages the lifecycle of a [`ProvingPipeline`], allowing it to be started
 /// and stopped at runtime (e.g. via the admin RPC).
-pub struct PipelineHandle<L1, L2, R>
+pub struct PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
-    pipeline: Arc<ProvingPipeline<L1, L2, R>>,
+    pipeline: Arc<ProvingPipeline<L1, R>>,
     session: TokioMutex<Session>,
     global_cancel: CancellationToken,
     running: Arc<AtomicBool>,
 }
 
-impl<L1, L2, R> std::fmt::Debug for PipelineHandle<L1, L2, R>
+impl<L1, R> std::fmt::Debug for PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,14 +150,13 @@ where
     }
 }
 
-impl<L1, L2, R> PipelineHandle<L1, L2, R>
+impl<L1, R> PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     /// Creates a new [`PipelineHandle`] wrapping the given proving pipeline.
-    pub fn new(pipeline: ProvingPipeline<L1, L2, R>, global_cancel: CancellationToken) -> Self {
+    pub fn new(pipeline: ProvingPipeline<L1, R>, global_cancel: CancellationToken) -> Self {
         let session = Session { cancel: global_cancel.child_token(), task: None };
         Self {
             pipeline: Arc::new(pipeline),
@@ -171,10 +168,9 @@ where
 }
 
 #[async_trait]
-impl<L1, L2, R> ProposerDriverControl for PipelineHandle<L1, L2, R>
+impl<L1, R> ProposerDriverControl for PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     async fn start_proposer(&self) -> Result<(), String> {
@@ -258,8 +254,8 @@ mod tests {
 
     fn test_pipeline_handle(
         global_cancel: CancellationToken,
-    ) -> PipelineHandle<MockL1, MockL2, MockRollupClient> {
-        let l1 = Arc::new(MockL1::new(1000));
+    ) -> PipelineHandle<MockL1, MockRollupClient> {
+        let l1 = Arc::new(MockL1 { latest_block_number: 1000, ..Default::default() });
         let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
         let rollup = Arc::new(MockRollupClient {
             sync_status: test_sync_status(200, B256::ZERO),
@@ -292,9 +288,9 @@ mod tests {
 
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            Arc::clone(&l1),
-            Arc::clone(&l2),
-            Arc::clone(&rollup),
+            l1.clone(),
+            l2.clone(),
+            rollup.clone(),
             ProofDispatcherConfig {
                 proposer_address: config.proposer_address,
                 allow_non_finalized: config.allow_non_finalized,

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -32,10 +32,6 @@ use crate::pipeline::ProvingPipeline;
 pub struct DriverConfig {
     /// Polling interval for new blocks.
     pub poll_interval: Duration,
-    /// Maximum proof request dispatch retries for a single target block before
-    /// dropping the cached recovery. Collector-side proof/session failures and
-    /// submit errors do not count against this budget.
-    pub max_retries: u32,
     /// Maximum number of concurrent RPC calls during the recovery scan.
     pub recovery_scan_concurrency: usize,
     /// Optional maximum duration for a single inline submit (validation + L1
@@ -70,7 +66,6 @@ impl Default for DriverConfig {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(12),
-            max_retries: 8,
             recovery_scan_concurrency: 8,
             submit_timeout: None,
             tee_prover_registry_address: None,
@@ -278,7 +273,6 @@ mod tests {
         let config = DriverConfig {
             poll_interval: Duration::from_secs(3600),
             submit_timeout: Some(std::time::Duration::from_secs(60)),
-            max_retries: 3,
             recovery_scan_concurrency: 8,
             tee_prover_registry_address: None,
             block_interval: 512,

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -238,8 +238,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ProofCollector, ProofDispatcher, ProofDispatcherConfig, ProofRecovery, ProofRecoveryConfig,
-        ProofSubmitter, ProofSubmitterConfig,
+        ProofCollector, ProofDispatcher, ProofRecovery, ProofRecoveryConfig, ProofSubmitter,
+        ProofSubmitterConfig,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockProofRequester, MockRollupClient, test_anchor_root,
@@ -285,12 +285,7 @@ mod tests {
             l1.clone(),
             l2.clone(),
             rollup.clone(),
-            ProofDispatcherConfig {
-                proposer_address: config.proposer_address,
-                allow_non_finalized: config.allow_non_finalized,
-                intermediate_block_interval: config.intermediate_block_interval,
-                tee_image_hash: config.tee_image_hash,
-            },
+            &config,
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -33,7 +33,7 @@ mod proof_collector;
 pub use proof_collector::ProofCollector;
 
 mod proof_dispatcher;
-pub use proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig, ProofDispatcherState};
+pub use proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig};
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -33,10 +33,7 @@ mod proof_collector;
 pub use proof_collector::ProofCollector;
 
 mod proof_dispatcher;
-pub use proof_dispatcher::{
-    ProofDispatchAttempt, ProofDispatchOutcome, ProofDispatcher, ProofDispatcherConfig,
-    ProofDispatcherState,
-};
+pub use proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig, ProofDispatcherState};
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -33,7 +33,7 @@ mod proof_collector;
 pub use proof_collector::ProofCollector;
 
 mod proof_dispatcher;
-pub use proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig};
+pub use proof_dispatcher::ProofDispatcher;
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -17,9 +17,6 @@ base_metrics::define_metrics! {
     #[no_zero]
     last_collected_block: gauge,
 
-    #[describe("Total pending retries across all target blocks")]
-    pipeline_retries: gauge,
-
     #[describe("Total proof dispatch outcomes from the prover service")]
     #[label(name = "outcome", default = ["accepted", "failed", "build_failed"])]
     proof_dispatch_total: counter,
@@ -31,9 +28,6 @@ base_metrics::define_metrics! {
     #[describe("Total proof statuses received when polling the prover service")]
     #[label(name = "status", default = ["queued", "running", "succeeded", "failed"])]
     proof_status_received_total: counter,
-
-    #[describe("Total number of proof retries scheduled after a failed dispatch or collection")]
-    proof_retries_total: counter,
 
     #[describe("Latest safe (or finalized) L2 block number")]
     #[no_zero]
@@ -93,8 +87,6 @@ impl Metrics {
 
     /// Label value for a dispatch attempt that failed before reaching the
     /// prover service (e.g. while building the request from L1/L2 RPC data).
-    /// Build failures are transient infrastructure errors and do not count
-    /// against the per-target retry budget.
     pub const DISPATCH_OUTCOME_BUILD_FAILED: &str = "build_failed";
 
     /// Label value for a ready (successfully collected) proof.

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -180,14 +180,6 @@ mod tests {
         time::Duration,
     };
 
-    use super::*;
-    use crate::{
-        OutputProposer, ProofRecoveryConfig, ProofSubmitter, ProofSubmitterConfig,
-        test_utils::{
-            MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
-            MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
-        },
-    };
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
     use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
@@ -195,6 +187,15 @@ mod tests {
     use base_prover_service_protocol::{
         DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
         ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    };
+
+    use super::*;
+    use crate::{
+        OutputProposer, ProofRecoveryConfig, ProofSubmitter, ProofSubmitterConfig,
+        test_utils::{
+            MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
+            MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
+        },
     };
 
     #[derive(Debug, Default)]

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -21,8 +21,7 @@ use crate::{
 ///
 /// Runs concurrent dispatcher and collector tasks per [`Self::run`] session.
 /// The collector chains ready proofs internally and restarts both tasks only
-/// when it needs fresh onchain state; dispatcher retry exhaustion clears
-/// dispatcher recovery state without interrupting collection.
+/// when it needs fresh onchain state.
 pub struct ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
@@ -116,25 +115,12 @@ where
                     Metrics::safe_head().set(safe_head as f64);
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
-                    let drop_recovery_cache = self
-                        .proof_dispatcher
-                        .tick(
-                            &mut state,
-                            recovered,
-                            safe_head,
-                            self.config.block_interval,
-                            self.config.max_retries,
-                            cancel,
-                        )
+                    self.proof_dispatcher
+                        .tick(&mut state, recovered, safe_head, self.config.block_interval, cancel)
                         .await;
 
                     if let Some((_, cursor)) = state.cursor {
                         dispatched_through.store(cursor.l2_block_number, Ordering::Relaxed);
-                    }
-
-                    if drop_recovery_cache {
-                        cache = None;
-                        dispatched_through.store(0, Ordering::Relaxed);
                     }
                 }
             }
@@ -256,7 +242,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dispatcher_retry_exhaustion_keeps_dispatcher_loop_running() {
+    async fn dispatcher_failures_keep_dispatcher_loop_running() {
         let requester = Arc::new(RejectingProofRequester::default());
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::<RejectingProofRequester>::clone(&requester);
@@ -278,7 +264,6 @@ mod tests {
         let output_proposer: Arc<dyn OutputProposer> = Arc::new(MockOutputProposer::default());
         let config = DriverConfig {
             poll_interval: Duration::from_millis(10),
-            max_retries: 1,
             block_interval: 100,
             intermediate_block_interval: 100,
             ..Default::default()
@@ -342,7 +327,7 @@ mod tests {
             )
             .await
             .is_err(),
-            "dispatcher retry exhaustion should not end the dispatcher loop"
+            "dispatcher failures should not end the dispatcher loop"
         );
         assert!(
             requester.prove_count.load(Ordering::SeqCst) > 1,

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -5,7 +5,7 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
+use base_proof_rpc::{L1Provider, RollupProvider};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -23,22 +23,20 @@ use crate::{
 /// The collector chains ready proofs internally and restarts both tasks only
 /// when it needs fresh onchain state; dispatcher retry exhaustion clears
 /// dispatcher recovery state without interrupting collection.
-pub struct ProvingPipeline<L1, L2, R>
+pub struct ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     config: DriverConfig,
-    proof_dispatcher: ProofDispatcher<L1, L2, R>,
+    proof_dispatcher: ProofDispatcher,
     proof_recovery: Arc<ProofRecovery<R>>,
     proof_collector: ProofCollector<L1, R>,
 }
 
-impl<L1, L2, R> std::fmt::Debug for ProvingPipeline<L1, L2, R>
+impl<L1, R> std::fmt::Debug for ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -46,16 +44,15 @@ where
     }
 }
 
-impl<L1, L2, R> ProvingPipeline<L1, L2, R>
+impl<L1, R> ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     /// Creates a new proving pipeline.
     pub const fn new(
         config: DriverConfig,
-        proof_dispatcher: ProofDispatcher<L1, L2, R>,
+        proof_dispatcher: ProofDispatcher,
         proof_recovery: Arc<ProofRecovery<R>>,
         proof_collector: ProofCollector<L1, R>,
     ) -> Self {
@@ -107,7 +104,7 @@ where
         dispatched_through: Arc<AtomicU64>,
     ) {
         let mut cache: Option<ProofRecoveryCache> = None;
-        let mut state = ProofDispatcherState::new();
+        let mut state = ProofDispatcherState::default();
 
         loop {
             {
@@ -131,7 +128,7 @@ where
                         )
                         .await;
 
-                    if let Some(cursor) = state.cursor {
+                    if let Some((_, cursor)) = state.cursor {
                         dispatched_through.store(cursor.l2_block_number, Ordering::Relaxed);
                     }
 
@@ -288,9 +285,9 @@ mod tests {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            Arc::clone(&l1),
-            Arc::clone(&l2),
-            Arc::clone(&rollup),
+            l1.clone(),
+            l2.clone(),
+            rollup.clone(),
             ProofDispatcherConfig {
                 proposer_address: config.proposer_address,
                 allow_non_finalized: config.allow_non_finalized,

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -13,7 +13,7 @@ use crate::{
     Metrics,
     driver::{DriverConfig, RecoveredState},
     proof_collector::ProofCollector,
-    proof_dispatcher::{ProofDispatcher, ProofDispatcherState},
+    proof_dispatcher::ProofDispatcher,
     proof_recovery::{ProofRecovery, ProofRecoveryCache},
 };
 
@@ -103,7 +103,7 @@ where
         dispatched_through: Arc<AtomicU64>,
     ) {
         let mut cache: Option<ProofRecoveryCache> = None;
-        let mut state = ProofDispatcherState::default();
+        let mut cursor = None;
 
         loop {
             {
@@ -116,10 +116,10 @@ where
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
                     self.proof_dispatcher
-                        .tick(&mut state, recovered, safe_head, self.config.block_interval, cancel)
+                        .tick(&mut cursor, recovered, safe_head, self.config.block_interval, cancel)
                         .await;
 
-                    if let Some((_, cursor)) = state.cursor {
+                    if let Some((_, cursor)) = cursor {
                         dispatched_through.store(cursor.l2_block_number, Ordering::Relaxed);
                     }
                 }

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -182,8 +182,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
-        ProofSubmitterConfig,
+        OutputProposer, ProofRecoveryConfig, ProofSubmitter, ProofSubmitterConfig,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
@@ -267,12 +266,7 @@ mod tests {
             l1.clone(),
             l2.clone(),
             rollup.clone(),
-            ProofDispatcherConfig {
-                proposer_address: config.proposer_address,
-                allow_non_finalized: config.allow_non_finalized,
-                intermediate_block_interval: config.intermediate_block_interval,
-                tee_image_hash: config.tee_image_hash,
-            },
+            &config,
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -83,7 +83,7 @@ where
             let restart = tokio::select! {
                 biased;
                 () = cancel.cancelled() => false,
-                () = self.dispatcher_loop(&cancel, Arc::clone(&dispatched_through)) => true,
+                () = self.dispatcher_loop(Arc::clone(&dispatched_through)) => true,
                 () = self.collector_loop(&cancel, Arc::clone(&dispatched_through)) => true,
             };
 
@@ -97,11 +97,7 @@ where
         info!("Proving pipeline stopped");
     }
 
-    async fn dispatcher_loop(
-        &self,
-        cancel: &CancellationToken,
-        dispatched_through: Arc<AtomicU64>,
-    ) {
+    async fn dispatcher_loop(&self, dispatched_through: Arc<AtomicU64>) {
         let mut cache: Option<ProofRecoveryCache> = None;
         let mut cursor = None;
 
@@ -116,7 +112,7 @@ where
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
                     self.proof_dispatcher
-                        .tick(&mut cursor, recovered, safe_head, self.config.block_interval, cancel)
+                        .tick(&mut cursor, recovered, safe_head, self.config.block_interval)
                         .await;
 
                     if let Some((_, cursor)) = cursor {
@@ -184,16 +180,6 @@ mod tests {
         time::Duration,
     };
 
-    use alloy_primitives::{Address, B256};
-    use async_trait::async_trait;
-    use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
-    use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
-    use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    };
-    use tokio_util::sync::CancellationToken;
-
     use super::*;
     use crate::{
         OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
@@ -202,6 +188,14 @@ mod tests {
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
         },
+    };
+    use alloy_primitives::{Address, B256};
+    use async_trait::async_trait;
+    use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
+    use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
+    use base_prover_service_protocol::{
+        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
 
     #[derive(Debug, Default)]
@@ -318,12 +312,11 @@ mod tests {
         );
         let pipeline =
             ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector);
-        let cancel = CancellationToken::new();
 
         assert!(
             tokio::time::timeout(
                 Duration::from_millis(100),
-                pipeline.dispatcher_loop(&cancel, Arc::new(AtomicU64::new(0)))
+                pipeline.dispatcher_loop(Arc::new(AtomicU64::new(0)))
             )
             .await
             .is_err(),

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -338,7 +338,7 @@ where
                 // Persistent submit failures intentionally keep the proof request
                 // so transient RPC/L1 issues can retry the same completed proof.
                 // Operators should alert on base_proposer_errors_total if this
-                // repeats; submit failures do not count against max_retries.
+                // repeats.
                 Metrics::errors_total(error.metric_label()).increment(1);
                 warn!(target_block, error = %error, "Submission failed");
             }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256};
-use base_optimism_rpc::{L1BlockRef, L2BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
@@ -207,59 +206,12 @@ mod tests {
         )
     }
 
-    fn headers_for_sync_status(
-        sync_status: &SyncStatus,
-    ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
-        let mut headers = HashMap::new();
-        for l1_head in [sync_status.finalized_l1, sync_status.safe_l1] {
-            headers.insert(l1_head.hash, test_l1_header(l1_head.hash, l1_head.number));
-        }
-        headers
-    }
-
-    fn sync_status_with_distinct_heads(finalized_l2: u64, safe_l2: u64) -> SyncStatus {
-        let mut finalized_l1 = test_l1_block_ref(10);
-        finalized_l1.hash = B256::repeat_byte(0xf1);
-        let mut safe_l1 = test_l1_block_ref(20);
-        safe_l1.hash = B256::repeat_byte(0x5a);
-        let mut finalized_l2 = test_l2_block_ref(finalized_l2, B256::repeat_byte(0xf2));
-        finalized_l2.l1origin.hash = finalized_l1.hash;
-        finalized_l2.l1origin.number = finalized_l1.number;
-        let mut safe_l2 = test_l2_block_ref(safe_l2, B256::repeat_byte(0x52));
-        safe_l2.l1origin.hash = safe_l1.hash;
-        safe_l2.l1origin.number = safe_l1.number;
-
-        SyncStatus {
-            current_l1: safe_l1,
-            current_l1_finalized: Some(finalized_l1),
-            head_l1: safe_l1,
-            safe_l1,
-            finalized_l1,
-            unsafe_l2: safe_l2,
-            safe_l2,
-            finalized_l2,
-            pending_safe_l2: None,
-        }
-    }
-
     fn recovered() -> RecoveredState {
         RecoveredState {
             parent_address: Address::ZERO,
             output_root: B256::repeat_byte(0x03),
             l2_block_number: 100,
         }
-    }
-
-    #[tokio::test]
-    async fn dispatch_sends_root_derived_session() {
-        let (dispatcher, requester) = dispatcher();
-        let claimed_root = B256::repeat_byte(0xaa);
-
-        let outcome = dispatcher.dispatch(200, &recovered(), claimed_root).await;
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
-
-        assert!(outcome);
-        assert!(requester.requests.lock().unwrap().contains_key(&session_id));
     }
 
     #[tokio::test]
@@ -290,7 +242,10 @@ mod tests {
 
         dispatcher.tick(&mut cursor, recovered(), 400, 100).await;
 
-        assert_eq!(requester.requests.lock().unwrap().len(), 3);
+        let requests = requester.requests.lock().unwrap();
+        let session_id = ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(200));
+        assert_eq!(requests.len(), 3);
+        assert!(requests.contains_key(&session_id));
         assert_eq!(cursor.map(|(_, cursor)| cursor.l2_block_number), Some(400));
     }
 

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -30,7 +30,11 @@ pub struct ProofDispatcher {
 
 impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofDispatcher").finish_non_exhaustive()
+        f.debug_struct("ProofDispatcher")
+            .field("proposer_address", &self.proposer_address)
+            .field("intermediate_block_interval", &self.intermediate_block_interval)
+            .field("tee_image_hash", &self.tee_image_hash)
+            .finish_non_exhaustive()
     }
 }
 
@@ -142,14 +146,13 @@ impl ProofDispatcher {
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
         let expected_session_id = request.proof.session_id.clone();
 
-        let session_id = match self.proof_requester.prove_block_range(request).await {
-            Ok(response) if response.session_id == expected_session_id => response.session_id,
+        match self.proof_requester.prove_block_range(request).await {
+            Ok(response) if response.session_id == expected_session_id => {}
             Err(e) if e.is_l1_head_conflict_for_session(&expected_session_id) => {
                 debug!(
                     session_id = %expected_session_id,
                     "prover-service already has this TEE proof session with a different l1_head"
                 );
-                expected_session_id
             }
             result => {
                 let error = match result {
@@ -165,12 +168,12 @@ impl ProofDispatcher {
                 warn!(target_block, error = %error, "Proof dispatch failed, will retry next tick");
                 return false;
             }
-        };
+        }
 
         Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
         info!(
             target_block,
-            session_id = %session_id,
+            session_id = %expected_session_id,
             from_block = recovered.l2_block_number,
             l1_head_number = l1_head.number,
             "Proof request accepted by prover service"

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -76,6 +76,7 @@ impl ProofDispatcher {
             .cursor
             .filter(|(source, _)| *source == recovered)
             .map_or(recovered, |(_, cursor)| cursor);
+
         loop {
             if cancel.is_cancelled() {
                 break;
@@ -86,6 +87,7 @@ impl ProofDispatcher {
             else {
                 break;
             };
+
             if target_block > safe_head {
                 debug!(
                     current_block = current.l2_block_number,
@@ -151,6 +153,7 @@ impl ProofDispatcher {
             l1_head_number: l1_head.number,
             image_hash: self.config.tee_image_hash,
         };
+
         info!(
             from_block = recovered.l2_block_number,
             to_block = target_block,

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -8,7 +8,6 @@ use base_optimism_rpc::{L1BlockRef, L2BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
-use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -63,17 +62,12 @@ impl ProofDispatcher {
         recovered: RecoveredState,
         safe_head: u64,
         block_interval: u64,
-        cancel: &CancellationToken,
     ) {
         let mut current = cursor
             .filter(|(source, _)| *source == recovered)
             .map_or(recovered, |(_, cursor)| cursor);
 
         loop {
-            if cancel.is_cancelled() {
-                break;
-            }
-
             let Some(target_block) =
                 ProofTarget::next_block(current.l2_block_number, block_interval)
             else {
@@ -146,13 +140,6 @@ impl ProofDispatcher {
             image_hash: self.config.tee_image_hash,
         };
 
-        info!(
-            from_block = recovered.l2_block_number,
-            to_block = target_block,
-            l1_head_number = l1_head.number,
-            "Built proof request"
-        );
-
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
         let expected_session_id = request.proof.session_id.clone();
 
@@ -182,12 +169,12 @@ impl ProofDispatcher {
             }
         };
 
-        debug!(session_id = %session_id, "dispatched TEE proof request");
         Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
         info!(
             target_block,
             session_id = %session_id,
             from_block = recovered.l2_block_number,
+            l1_head_number = l1_head.number,
             "Proof request accepted by prover service"
         );
         true
@@ -299,9 +286,8 @@ mod tests {
     async fn tick_dispatches_all_targets_up_to_safe_head() {
         let (dispatcher, requester) = dispatcher();
         let mut cursor = None;
-        let cancel = CancellationToken::new();
 
-        dispatcher.tick(&mut cursor, recovered(), 400, 100, &cancel).await;
+        dispatcher.tick(&mut cursor, recovered(), 400, 100).await;
 
         assert_eq!(requester.requests.lock().unwrap().len(), 3);
         assert_eq!(cursor.map(|(_, cursor)| cursor.l2_block_number), Some(400));
@@ -310,7 +296,6 @@ mod tests {
     #[tokio::test]
     async fn tick_resets_cursor_when_recovery_rewinds() {
         let (dispatcher, requester) = dispatcher();
-        let cancel = CancellationToken::new();
         let mut cursor = Some((
             RecoveredState {
                 parent_address: Address::repeat_byte(0x01),
@@ -324,7 +309,7 @@ mod tests {
             },
         ));
 
-        dispatcher.tick(&mut cursor, recovered(), 200, 100, &cancel).await;
+        dispatcher.tick(&mut cursor, recovered(), 200, 100).await;
 
         assert_eq!(cursor.map(|(source, _)| source), Some(recovered()));
         assert_eq!(cursor.map(|(_, cursor)| cursor.l2_block_number), Some(200));

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -9,7 +9,7 @@ use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     Metrics, driver::RecoveredState, error::ProposerError, proof_adapter::ProposerProofAdapter,
@@ -34,8 +34,6 @@ pub struct ProofDispatcherConfig {
 pub struct ProofDispatcherState {
     /// Recovery source and latest block the dispatcher has sent proof requests through.
     pub cursor: Option<(RecoveredState, RecoveredState)>,
-    /// Active proof/dispatch retry count.
-    pub retry: Option<(u64, u32)>,
 }
 
 /// Builds and dispatches proposer TEE proof requests.
@@ -72,26 +70,21 @@ impl ProofDispatcher {
         recovered: RecoveredState,
         safe_head: u64,
         block_interval: u64,
-        max_retries: u32,
         cancel: &CancellationToken,
-    ) -> bool {
-        if matches!(state.retry, Some((target, _)) if target <= recovered.l2_block_number) {
-            state.retry = None;
-        }
-
+    ) {
         let mut current = state
             .cursor
             .filter(|(source, _)| *source == recovered)
             .map_or(recovered, |(_, cursor)| cursor);
-        let drop_recovery_cache = loop {
+        loop {
             if cancel.is_cancelled() {
-                break false;
+                break;
             }
 
             let Some(target_block) =
                 ProofTarget::next_block(current.l2_block_number, block_interval)
             else {
-                break false;
+                break;
             };
             if target_block > safe_head {
                 debug!(
@@ -100,7 +93,7 @@ impl ProofDispatcher {
                     safe_head,
                     "Safe head below dispatch target, waiting for L2 head to advance"
                 );
-                break false;
+                break;
             }
 
             let Some(claimed_l2_output_root) = ProofTarget::canonical_output_root(
@@ -110,42 +103,26 @@ impl ProofDispatcher {
             )
             .await
             else {
-                break false;
+                break;
             };
 
-            match self
-                .dispatch_with_retry(
-                    target_block,
-                    &current,
-                    claimed_l2_output_root,
-                    state,
-                    max_retries,
-                )
-                .await
-            {
-                Ok(true) => {
-                    current.l2_block_number = target_block;
-                    current.output_root = claimed_l2_output_root;
-                    state.cursor = Some((recovered, current));
-                }
-                Err(()) => break true,
-                Ok(false) => break false,
+            if self.dispatch(target_block, &current, claimed_l2_output_root).await {
+                current.l2_block_number = target_block;
+                current.output_root = claimed_l2_output_root;
+                state.cursor = Some((recovered, current));
+            } else {
+                break;
             }
-        };
-
-        Metrics::pipeline_retries().set(state.retry.map_or(0, |(_, count)| count) as f64);
-        drop_recovery_cache
+        }
     }
 
-    /// Builds and dispatches a fresh root-derived request with retry accounting.
-    pub async fn dispatch_with_retry(
+    /// Builds and dispatches a fresh root-derived request.
+    pub async fn dispatch(
         &self,
         target_block: u64,
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
-        state: &mut ProofDispatcherState,
-        max_retries: u32,
-    ) -> Result<bool, ()> {
+    ) -> bool {
         let (l1_head, agreed_l2_head) = match tokio::try_join!(
             self.l1_client.header_by_number(BlockNumberOrTag::Finalized),
             self.l2_client.header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number)),
@@ -159,7 +136,7 @@ impl ProofDispatcher {
                     error = %error,
                     "Failed to build proof request, will retry next iteration"
                 );
-                return Ok(false);
+                return false;
             }
         };
 
@@ -204,33 +181,9 @@ impl ProofDispatcher {
             Err(error) => {
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
                 Metrics::errors_total(error.metric_label()).increment(1);
-                Metrics::proof_retries_total().increment(1);
 
-                let count = match state.retry {
-                    Some((retry_target, count)) if retry_target == target_block => count + 1,
-                    _ => 1,
-                };
-                state.retry = Some((target_block, count));
-
-                if count >= max_retries {
-                    error!(
-                        target_block,
-                        attempts = count,
-                        error = %error,
-                        "Proof failed after max retries, dropping cached recovery"
-                    );
-                    state.retry = None;
-                    state.cursor = None;
-                    return Err(());
-                }
-
-                warn!(
-                    target_block,
-                    attempt = count,
-                    error = %error,
-                    "Proof failed, re-dispatching"
-                );
-                return Ok(false);
+                warn!(target_block, error = %error, "Proof dispatch failed, will retry next tick");
+                return false;
             }
         };
 
@@ -242,7 +195,7 @@ impl ProofDispatcher {
             from_block = recovered.l2_block_number,
             "Proof request accepted by prover service"
         );
-        Ok(true)
+        true
     }
 }
 
@@ -315,46 +268,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dispatch_with_retry_sends_root_derived_session() {
+    async fn dispatch_sends_root_derived_session() {
         let (dispatcher, requester) = dispatcher();
         let claimed_root = B256::repeat_byte(0xaa);
-        let mut state = ProofDispatcherState::default();
 
-        let outcome =
-            dispatcher.dispatch_with_retry(200, &recovered(), claimed_root, &mut state, 3).await;
+        let outcome = dispatcher.dispatch(200, &recovered(), claimed_root).await;
         let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
 
-        assert_eq!(outcome, Ok(true));
+        assert!(outcome);
         assert!(requester.requests.lock().unwrap().contains_key(&session_id));
-        assert_eq!(state.retry, None);
     }
 
     #[tokio::test]
-    async fn dispatch_with_retry_rejects_mismatched_session_id() {
+    async fn dispatch_rejects_mismatched_session_id() {
         let (dispatcher, requester) = dispatcher();
         *requester.accepted_session_id.lock().unwrap() = Some("wrong-session".to_owned());
-        let mut state = ProofDispatcherState::default();
 
-        let outcome = dispatcher
-            .dispatch_with_retry(200, &recovered(), B256::repeat_byte(0xaa), &mut state, 2)
-            .await;
+        let outcome = dispatcher.dispatch(200, &recovered(), B256::repeat_byte(0xaa)).await;
 
-        assert_eq!(outcome, Ok(false));
-        assert_eq!(state.retry, Some((200, 1)));
+        assert!(!outcome);
     }
 
     #[tokio::test]
-    async fn dispatch_with_retry_accepts_existing_l1_head_conflict() {
+    async fn dispatch_accepts_existing_l1_head_conflict() {
         let (dispatcher, requester) = dispatcher();
         requester.l1_head_conflict.store(true, Ordering::SeqCst);
         let claimed_root = B256::repeat_byte(0xaa);
-        let mut state = ProofDispatcherState::default();
 
-        let outcome =
-            dispatcher.dispatch_with_retry(200, &recovered(), claimed_root, &mut state, 3).await;
+        let outcome = dispatcher.dispatch(200, &recovered(), claimed_root).await;
 
-        assert_eq!(outcome, Ok(true));
-        assert_eq!(state.retry, None);
+        assert!(outcome);
     }
 
     #[tokio::test]
@@ -363,12 +306,10 @@ mod tests {
         let mut state = ProofDispatcherState::default();
         let cancel = CancellationToken::new();
 
-        let result = dispatcher.tick(&mut state, recovered(), 400, 100, 3, &cancel).await;
+        dispatcher.tick(&mut state, recovered(), 400, 100, &cancel).await;
 
-        assert!(!result);
         assert_eq!(requester.requests.lock().unwrap().len(), 3);
         assert_eq!(state.cursor.map(|(_, cursor)| cursor.l2_block_number), Some(400));
-        assert_eq!(state.retry, None);
     }
 
     #[tokio::test]
@@ -388,22 +329,20 @@ mod tests {
                     l2_block_number: 500,
                 },
             )),
-            retry: None,
         };
 
-        let result = dispatcher.tick(&mut state, recovered(), 200, 100, 3, &cancel).await;
+        dispatcher.tick(&mut state, recovered(), 200, 100, &cancel).await;
 
-        assert!(!result);
         assert_eq!(state.cursor.map(|(source, _)| source), Some(recovered()));
         assert_eq!(state.cursor.map(|(_, cursor)| cursor.l2_block_number), Some(200));
         assert_eq!(requester.requests.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
-    async fn dispatch_with_retry_clears_cursor_on_retry_exhaustion() {
+    async fn dispatch_keeps_cursor_on_failure() {
         let (dispatcher, requester) = dispatcher();
         *requester.accepted_session_id.lock().unwrap() = Some("wrong-session".to_owned());
-        let mut state = ProofDispatcherState {
+        let state = ProofDispatcherState {
             cursor: Some((
                 recovered(),
                 RecoveredState {
@@ -412,15 +351,11 @@ mod tests {
                     l2_block_number: 300,
                 },
             )),
-            retry: Some((200, 1)),
         };
 
-        let outcome = dispatcher
-            .dispatch_with_retry(200, &recovered(), B256::repeat_byte(0xaa), &mut state, 2)
-            .await;
+        let outcome = dispatcher.dispatch(200, &recovered(), B256::repeat_byte(0xaa)).await;
 
-        assert_eq!(outcome, Err(()));
-        assert!(state.cursor.is_none());
-        assert_eq!(state.retry, None);
+        assert!(!outcome);
+        assert!(state.cursor.is_some());
     }
 }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -11,22 +11,12 @@ use base_prover_service_client::ProofRequesterProvider;
 use tracing::{debug, info, warn};
 
 use crate::{
-    Metrics, driver::RecoveredState, error::ProposerError, proof_adapter::ProposerProofAdapter,
+    Metrics,
+    driver::{DriverConfig, RecoveredState},
+    error::ProposerError,
+    proof_adapter::ProposerProofAdapter,
     proof_target::ProofTarget,
 };
-
-/// Static parameters needed to build proposer proof requests.
-#[derive(Debug, Clone, Copy)]
-pub struct ProofDispatcherConfig {
-    /// Address of the proposer that will submit the proof onchain.
-    pub proposer_address: Address,
-    /// Whether requests may target safe, non-finalized L2 blocks.
-    pub allow_non_finalized: bool,
-    /// Number of L2 blocks between intermediate output root checkpoints.
-    pub intermediate_block_interval: u64,
-    /// Expected TEE enclave image hash.
-    pub tee_image_hash: B256,
-}
 
 /// Builds and dispatches proposer TEE proof requests.
 pub struct ProofDispatcher {
@@ -34,12 +24,18 @@ pub struct ProofDispatcher {
     l1_client: Arc<dyn L1Provider>,
     l2_client: Arc<dyn L2Provider>,
     rollup_client: Arc<dyn RollupProvider>,
-    config: ProofDispatcherConfig,
+    proposer_address: Address,
+    intermediate_block_interval: u64,
+    tee_image_hash: B256,
 }
 
 impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofDispatcher").field("config", &self.config).finish_non_exhaustive()
+        f.debug_struct("ProofDispatcher")
+            .field("proposer_address", &self.proposer_address)
+            .field("intermediate_block_interval", &self.intermediate_block_interval)
+            .field("tee_image_hash", &self.tee_image_hash)
+            .finish_non_exhaustive()
     }
 }
 
@@ -50,9 +46,17 @@ impl ProofDispatcher {
         l1_client: Arc<dyn L1Provider>,
         l2_client: Arc<dyn L2Provider>,
         rollup_client: Arc<dyn RollupProvider>,
-        config: ProofDispatcherConfig,
+        config: &DriverConfig,
     ) -> Self {
-        Self { proof_requester, l1_client, l2_client, rollup_client, config }
+        Self {
+            proof_requester,
+            l1_client,
+            l2_client,
+            rollup_client,
+            proposer_address: config.proposer_address,
+            intermediate_block_interval: config.intermediate_block_interval,
+            tee_image_hash: config.tee_image_hash,
+        }
     }
 
     /// Dispatches every target from the current dispatcher cursor up to `safe_head`.
@@ -134,10 +138,10 @@ impl ProofDispatcher {
             agreed_l2_output_root: recovered.output_root,
             claimed_l2_output_root,
             claimed_l2_block_number: target_block,
-            proposer: self.config.proposer_address,
-            intermediate_block_interval: self.config.intermediate_block_interval,
+            proposer: self.proposer_address,
+            intermediate_block_interval: self.intermediate_block_interval,
             l1_head_number: l1_head.number,
-            image_hash: self.config.tee_image_hash,
+            image_hash: self.tee_image_hash,
         };
 
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
@@ -190,17 +194,19 @@ mod tests {
 
     fn dispatcher() -> (ProofDispatcher, Arc<MockProofRequester>) {
         let requester = Arc::new(MockProofRequester::default());
+        let config = DriverConfig {
+            proposer_address: Address::repeat_byte(0x04),
+            intermediate_block_interval: 300,
+            tee_image_hash: B256::repeat_byte(0x05),
+            ..Default::default()
+        };
         (
             ProofDispatcher::new(
                 requester.clone(),
                 Arc::new(MockL1 { latest_block_number: 1000, ..Default::default() }),
                 Arc::new(MockL2 { block_not_found: false, canonical_hash: None }),
                 Arc::new(MockRollupClient::default()),
-                ProofDispatcherConfig {
-                    proposer_address: Address::repeat_byte(0x04),
-                    intermediate_block_interval: 300,
-                    tee_image_hash: B256::repeat_byte(0x05),
-                },
+                &config,
             ),
             requester,
         )

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -1,6 +1,6 @@
 //! Proof request construction and dispatch helpers for proposer TEE proofs.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256};
@@ -8,7 +8,6 @@ use base_optimism_rpc::{L1BlockRef, L2BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::ProveBlockRangeRequest;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -33,274 +32,37 @@ pub struct ProofDispatcherConfig {
 /// Mutable dispatcher-side orchestration state.
 #[derive(Debug, Default)]
 pub struct ProofDispatcherState {
-    /// Recovered chain state that the current cursor was derived from.
-    pub recovered: Option<RecoveredState>,
-    /// Latest block the dispatcher has sent proof requests through.
-    pub cursor: Option<RecoveredState>,
-    /// Per-target proof/dispatch retry counts.
-    pub retry_counts: HashMap<u64, u32>,
-}
-
-/// Outcome of a single target dispatch attempt after retry accounting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProofDispatchOutcome {
-    /// The request was accepted by prover-service.
-    Accepted,
-    /// The request failed and exhausted the retry budget.
-    RetryExhausted,
-    /// The request was skipped because it could not be built or dispatched.
-    Skipped,
-}
-
-/// Outcome of attempting to dispatch a proof request.
-#[derive(Debug)]
-pub enum ProofDispatchAttempt {
-    /// The request was accepted by prover-service.
-    Accepted(String),
-    /// The request could not be built from local RPC data.
-    BuildFailed(ProposerError),
-    /// The request reached prover-service but dispatch failed.
-    DispatchFailed(ProposerError),
-}
-
-impl ProofDispatchAttempt {
-    /// Returns the metrics outcome label for this dispatch attempt.
-    pub const fn metric_label(&self) -> &'static str {
-        match self {
-            Self::Accepted(_) => Metrics::DISPATCH_OUTCOME_ACCEPTED,
-            Self::BuildFailed(_) => Metrics::DISPATCH_OUTCOME_BUILD_FAILED,
-            Self::DispatchFailed(_) => Metrics::DISPATCH_OUTCOME_FAILED,
-        }
-    }
+    /// Recovery source and latest block the dispatcher has sent proof requests through.
+    pub cursor: Option<(RecoveredState, RecoveredState)>,
+    /// Active proof/dispatch retry count.
+    pub retry: Option<(u64, u32)>,
 }
 
 /// Builds and dispatches proposer TEE proof requests.
-///
-/// This type intentionally holds only shared clients and static config. Mutable
-/// cursor and retry state belongs in [`ProofDispatcherState`] so cloned
-/// dispatchers do not diverge.
-pub struct ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider,
-    L2: L2Provider,
-    R: RollupProvider,
-{
+pub struct ProofDispatcher {
     proof_requester: Arc<dyn ProofRequesterProvider>,
-    l1_client: Arc<L1>,
-    l2_client: Arc<L2>,
-    rollup_client: Arc<R>,
+    l1_client: Arc<dyn L1Provider>,
+    l2_client: Arc<dyn L2Provider>,
+    rollup_client: Arc<dyn RollupProvider>,
     config: ProofDispatcherConfig,
 }
 
-impl<L1, L2, R> std::fmt::Debug for ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider,
-    L2: L2Provider,
-    R: RollupProvider,
-{
+impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofDispatcher").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
-impl<L1, L2, R> Clone for ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider,
-    L2: L2Provider,
-    R: RollupProvider,
-{
-    fn clone(&self) -> Self {
-        Self {
-            proof_requester: Arc::clone(&self.proof_requester),
-            l1_client: Arc::clone(&self.l1_client),
-            l2_client: Arc::clone(&self.l2_client),
-            rollup_client: Arc::clone(&self.rollup_client),
-            config: self.config,
-        }
-    }
-}
-
-impl<L1, L2, R> ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
-    R: RollupProvider + 'static,
-{
+impl ProofDispatcher {
     /// Creates a proof dispatcher.
     pub fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
-        l1_client: Arc<L1>,
-        l2_client: Arc<L2>,
-        rollup_client: Arc<R>,
+        l1_client: Arc<dyn L1Provider>,
+        l2_client: Arc<dyn L2Provider>,
+        rollup_client: Arc<dyn RollupProvider>,
         config: ProofDispatcherConfig,
     ) -> Self {
         Self { proof_requester, l1_client, l2_client, rollup_client, config }
-    }
-
-    /// Builds a proof request for `target_block` using `recovered` as the agreed parent.
-    pub async fn build_request(
-        &self,
-        target_block: u64,
-        recovered: &RecoveredState,
-        claimed_l2_output_root: B256,
-    ) -> Result<ProofRequest, ProposerError> {
-        let (sync_status, agreed_l2_head) = tokio::try_join!(
-            async { self.rollup_client.sync_status().await.map_err(ProposerError::Rpc) },
-            async {
-                self.l2_client
-                    .header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number))
-                    .await
-                    .map_err(ProposerError::Rpc)
-            },
-        )?;
-        let (l1_head_source, l1_head, l2_coverage) = Self::select_l1_head_for_target(
-            target_block,
-            &sync_status,
-            self.config.allow_non_finalized,
-        )?;
-        let l1_header =
-            self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
-        if l1_header.hash != l1_head.hash || l1_header.number != l1_head.number {
-            return Err(ProposerError::Internal(format!(
-                "selected {l1_head_source} L1 head {}:{} does not match L1 RPC header {}:{}",
-                l1_head.number, l1_head.hash, l1_header.number, l1_header.hash
-            )));
-        }
-
-        let request = ProofRequest {
-            l1_head: l1_header.hash,
-            agreed_l2_head_hash: agreed_l2_head.hash,
-            agreed_l2_output_root: recovered.output_root,
-            claimed_l2_output_root,
-            claimed_l2_block_number: target_block,
-            proposer: self.config.proposer_address,
-            intermediate_block_interval: self.config.intermediate_block_interval,
-            l1_head_number: l1_header.number,
-            image_hash: self.config.tee_image_hash,
-        };
-
-        info!(
-            from_block = recovered.l2_block_number,
-            to_block = target_block,
-            allow_non_finalized = self.config.allow_non_finalized,
-            l1_head_source = l1_head_source,
-            l1_head_number = l1_header.number,
-            l1_head_hash = %l1_header.hash,
-            l2_coverage_block = l2_coverage.number,
-            l2_coverage_hash = %l2_coverage.hash,
-            finalized_l1_number = sync_status.finalized_l1.number,
-            finalized_l1_hash = %sync_status.finalized_l1.hash,
-            finalized_l2_number = sync_status.finalized_l2.number,
-            finalized_l2_hash = %sync_status.finalized_l2.hash,
-            safe_l1_number = sync_status.safe_l1.number,
-            safe_l1_hash = %sync_status.safe_l1.hash,
-            safe_l2_number = sync_status.safe_l2.number,
-            safe_l2_hash = %sync_status.safe_l2.hash,
-            agreed_l2_head_hash = %agreed_l2_head.hash,
-            agreed_l2_output_root = %recovered.output_root,
-            claimed_l2_output_root = %claimed_l2_output_root,
-            "Built proof request"
-        );
-
-        Ok(request)
-    }
-
-    fn select_l1_head_for_target(
-        target_block: u64,
-        sync_status: &SyncStatus,
-        allow_non_finalized: bool,
-    ) -> Result<(&'static str, L1BlockRef, L2BlockRef), ProposerError> {
-        let selected = if target_block <= sync_status.finalized_l2.number {
-            ("finalized", sync_status.finalized_l1, sync_status.finalized_l2)
-        } else if !allow_non_finalized {
-            return Err(ProposerError::Internal(format!(
-                "target block {target_block} is above rollup finalized head {}",
-                sync_status.finalized_l2.number
-            )));
-        } else if target_block <= sync_status.safe_l2.number {
-            ("safe", sync_status.safe_l1, sync_status.safe_l2)
-        } else {
-            return Err(ProposerError::Internal(format!(
-                "target block {target_block} is above rollup safe head {}",
-                sync_status.safe_l2.number
-            )));
-        };
-
-        let (l1_head_source, l1_head, l2_coverage) = selected;
-        if l1_head.number < l2_coverage.l1origin.number {
-            return Err(ProposerError::Internal(format!(
-                "selected {l1_head_source} L1 head {} is below {l1_head_source} L2 origin {}",
-                l1_head.number, l2_coverage.l1origin.number
-            )));
-        }
-
-        Ok(selected)
-    }
-
-    /// Builds and dispatches a root-derived proof request for `target_block`.
-    pub async fn dispatch_for(
-        &self,
-        target_block: u64,
-        recovered: &RecoveredState,
-        claimed_l2_output_root: B256,
-    ) -> ProofDispatchAttempt {
-        let expected_session_id =
-            ProposerProofAdapter::tee_session_id_for_root(claimed_l2_output_root);
-        let request =
-            match self.build_request(target_block, recovered, claimed_l2_output_root).await {
-                Ok(request) => request,
-                Err(error) => return ProofDispatchAttempt::BuildFailed(error),
-            };
-
-        match self.dispatch_tee(request).await {
-            Ok(session_id) if session_id == expected_session_id => {
-                ProofDispatchAttempt::Accepted(session_id)
-            }
-            Ok(session_id) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {expected_session_id}, got {session_id}"
-            ))),
-            Err(error) => ProofDispatchAttempt::DispatchFailed(error),
-        }
-    }
-
-    /// Submits a TEE proof request under an explicit session id.
-    pub async fn dispatch_tee_with_session_id(
-        &self,
-        request: ProofRequest,
-        session_id: String,
-    ) -> Result<String, ProposerError> {
-        let request = ProposerProofAdapter::tee_prove_block_range_request_with_session_id(
-            request, session_id,
-        );
-        self.dispatch_prepared(request).await
-    }
-
-    async fn dispatch_tee(&self, request: ProofRequest) -> Result<String, ProposerError> {
-        let request = ProposerProofAdapter::tee_prove_block_range_request(request);
-        self.dispatch_prepared(request).await
-    }
-
-    async fn dispatch_prepared(
-        &self,
-        request: ProveBlockRangeRequest,
-    ) -> Result<String, ProposerError> {
-        let session_id = request.proof.session_id.clone();
-        let response = match self.proof_requester.prove_block_range(request).await {
-            Ok(response) => response,
-            Err(e) if e.is_l1_head_conflict_for_session(&session_id) => {
-                debug!(
-                    session_id = %session_id,
-                    "prover-service already has this TEE proof session with a different l1_head"
-                );
-                return Ok(session_id);
-            }
-            Err(e) => return Err(ProposerError::Prover(e.to_string())),
-        };
-        debug!(
-            session_id = %response.session_id,
-            "dispatched TEE proof request"
-        );
-        Ok(response.session_id)
     }
 
     /// Dispatches every target from the current dispatcher cursor up to `safe_head`.
@@ -313,25 +75,23 @@ where
         max_retries: u32,
         cancel: &CancellationToken,
     ) -> bool {
-        state.retry_counts.retain(|&target, _| target > recovered.l2_block_number);
-
-        if state.recovered != Some(recovered) || state.cursor.is_none() {
-            state.recovered = Some(recovered);
-            state.cursor = Some(recovered);
+        if matches!(state.retry, Some((target, _)) if target <= recovered.l2_block_number) {
+            state.retry = None;
         }
 
-        let mut current = state.cursor.expect("dispatcher cursor initialized from recovery");
-        let mut drop_recovery_cache = false;
-
-        loop {
+        let mut current = state
+            .cursor
+            .filter(|(source, _)| *source == recovered)
+            .map_or(recovered, |(_, cursor)| cursor);
+        let drop_recovery_cache = loop {
             if cancel.is_cancelled() {
-                break;
+                break false;
             }
 
             let Some(target_block) =
                 ProofTarget::next_block(current.l2_block_number, block_interval)
             else {
-                break;
+                break false;
             };
             if target_block > safe_head {
                 debug!(
@@ -340,7 +100,7 @@ where
                     safe_head,
                     "Safe head below dispatch target, waiting for L2 head to advance"
                 );
-                break;
+                break false;
             }
 
             let Some(claimed_l2_output_root) = ProofTarget::canonical_output_root(
@@ -350,7 +110,7 @@ where
             )
             .await
             else {
-                break;
+                break false;
             };
 
             match self
@@ -360,24 +120,20 @@ where
                     claimed_l2_output_root,
                     state,
                     max_retries,
-                    true,
                 )
                 .await
             {
-                ProofDispatchOutcome::Accepted => {
+                Ok(true) => {
                     current.l2_block_number = target_block;
                     current.output_root = claimed_l2_output_root;
-                    state.cursor = Some(current);
+                    state.cursor = Some((recovered, current));
                 }
-                ProofDispatchOutcome::RetryExhausted => {
-                    drop_recovery_cache = true;
-                    break;
-                }
-                ProofDispatchOutcome::Skipped => break,
+                Err(()) => break true,
+                Ok(false) => break false,
             }
-        }
+        };
 
-        Metrics::pipeline_retries().set(state.retry_counts.values().sum::<u32>() as f64);
+        Metrics::pipeline_retries().set(state.retry.map_or(0, |(_, count)| count) as f64);
         drop_recovery_cache
     }
 
@@ -389,224 +145,129 @@ where
         claimed_l2_output_root: B256,
         state: &mut ProofDispatcherState,
         max_retries: u32,
-        count_dispatch_failure: bool,
-    ) -> ProofDispatchOutcome {
-        let dispatch = self.dispatch_for(target_block, recovered, claimed_l2_output_root).await;
-        Metrics::proof_dispatch_total(dispatch.metric_label()).increment(1);
-
-        match dispatch {
-            ProofDispatchAttempt::Accepted(session_id) => {
-                info!(
-                    target_block,
-                    session_id = %session_id,
-                    from_block = recovered.l2_block_number,
-                    "Proof request accepted by prover service"
-                );
-                ProofDispatchOutcome::Accepted
-            }
-            ProofDispatchAttempt::BuildFailed(error) => {
+    ) -> Result<bool, ()> {
+        let (l1_head, agreed_l2_head) = match tokio::try_join!(
+            self.l1_client.header_by_number(BlockNumberOrTag::Finalized),
+            self.l2_client.header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number)),
+        ) {
+            Ok(headers) => headers,
+            Err(error) => {
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
+                let error = ProposerError::Rpc(error);
                 warn!(
                     target_block,
                     error = %error,
                     "Failed to build proof request, will retry next iteration"
                 );
-                ProofDispatchOutcome::Skipped
+                return Ok(false);
             }
-            ProofDispatchAttempt::DispatchFailed(error) => {
-                if count_dispatch_failure {
-                    if state.handle_proof_failure(target_block, error, max_retries) {
-                        ProofDispatchOutcome::Skipped
-                    } else {
-                        ProofDispatchOutcome::RetryExhausted
-                    }
-                } else {
-                    warn!(
+        };
+
+        let request = ProofRequest {
+            l1_head: l1_head.hash,
+            agreed_l2_head_hash: agreed_l2_head.hash,
+            agreed_l2_output_root: recovered.output_root,
+            claimed_l2_output_root,
+            claimed_l2_block_number: target_block,
+            proposer: self.config.proposer_address,
+            intermediate_block_interval: self.config.intermediate_block_interval,
+            l1_head_number: l1_head.number,
+            image_hash: self.config.tee_image_hash,
+        };
+        info!(
+            from_block = recovered.l2_block_number,
+            to_block = target_block,
+            l1_head_number = l1_head.number,
+            "Built proof request"
+        );
+
+        let request = ProposerProofAdapter::tee_prove_block_range_request(request);
+        let expected_session_id = request.proof.session_id.clone();
+
+        let session_id = match self.proof_requester.prove_block_range(request).await {
+            Ok(response) if response.session_id == expected_session_id => Ok(response.session_id),
+            Err(e) if e.is_l1_head_conflict_for_session(&expected_session_id) => {
+                debug!(
+                    session_id = %expected_session_id,
+                    "prover-service already has this TEE proof session with a different l1_head"
+                );
+                Ok(expected_session_id)
+            }
+            Ok(response) => Err(ProposerError::Prover(format!(
+                "prover service returned mismatched session_id: expected {expected_session_id}, got {}",
+                response.session_id
+            ))),
+            Err(error) => Err(ProposerError::Prover(error.to_string())),
+        };
+        let session_id = match session_id {
+            Ok(session_id) => session_id,
+            Err(error) => {
+                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+                Metrics::errors_total(error.metric_label()).increment(1);
+                Metrics::proof_retries_total().increment(1);
+
+                let count = match state.retry {
+                    Some((retry_target, count)) if retry_target == target_block => count + 1,
+                    _ => 1,
+                };
+                state.retry = Some((target_block, count));
+
+                if count >= max_retries {
+                    error!(
                         target_block,
+                        attempts = count,
                         error = %error,
-                        "Immediate re-dispatch failed after failed proof session"
+                        "Proof failed after max retries, dropping cached recovery"
                     );
-                    ProofDispatchOutcome::Skipped
+                    state.retry = None;
+                    state.cursor = None;
+                    return Err(());
                 }
+
+                warn!(
+                    target_block,
+                    attempt = count,
+                    error = %error,
+                    "Proof failed, re-dispatching"
+                );
+                return Ok(false);
             }
-        }
-    }
-}
+        };
 
-impl ProofDispatcherState {
-    /// Creates empty dispatcher state.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Records a proof/dispatch failure and returns whether retrying is allowed.
-    pub fn handle_proof_failure(
-        &mut self,
-        target: u64,
-        error: ProposerError,
-        max_retries: u32,
-    ) -> bool {
-        Metrics::errors_total(error.metric_label()).increment(1);
-        Metrics::proof_retries_total().increment(1);
-
-        let count = self.retry_counts.entry(target).or_insert(0);
-        *count += 1;
-        if *count >= max_retries {
-            error!(
-                target_block = target,
-                attempts = *count,
-                error = %error,
-                "Proof failed after max retries, dropping cached recovery"
-            );
-            self.retry_counts.remove(&target);
-            self.recovered = None;
-            self.cursor = None;
-            false
-        } else {
-            warn!(
-                target_block = target,
-                attempt = *count,
-                error = %error,
-                "Proof failed, re-dispatching"
-            );
-            true
-        }
+        debug!(session_id = %session_id, "dispatched TEE proof request");
+        Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+        info!(
+            target_block,
+            session_id = %session_id,
+            from_block = recovered.l2_block_number,
+            "Proof request accepted by prover service"
+        );
+        Ok(true)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use async_trait::async_trait;
-    use base_prover_service_client::ProverServiceClientError;
-    use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProofRequestIdCollisionMessage, ProveBlockRangeRequest,
-        ProveBlockRangeResponse,
-    };
-    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
+    use std::sync::atomic::Ordering;
 
     use super::*;
-    use crate::test_utils::{
-        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l1_header,
-        test_l2_block_ref, test_sync_status,
-    };
+    use crate::test_utils::{MockL1, MockL2, MockProofRequester, MockRollupClient};
 
-    #[derive(Debug)]
-    struct MismatchedProofRequester {
-        session_id: String,
-    }
-
-    #[derive(Debug)]
-    struct L1HeadConflictRequester;
-
-    #[async_trait]
-    impl ProofRequesterProvider for MismatchedProofRequester {
-        async fn prove_block_range(
-            &self,
-            _request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            Ok(ProveBlockRangeResponse { session_id: self.session_id.clone() })
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not poll proofs")
-        }
-
-        async fn delete_proof_request(
-            &self,
-            _request: DeleteProofRequest,
-        ) -> Result<(), ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not delete proofs")
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not list proofs")
-        }
-    }
-
-    #[async_trait]
-    impl ProofRequesterProvider for L1HeadConflictRequester {
-        async fn prove_block_range(
-            &self,
-            request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            let session_id = request.proof.session_id;
-            Err(ProverServiceClientError::from(JsonRpcClientError::Call(ErrorObjectOwned::owned(
-                ProverServiceClientError::ERROR_FAILED_PRECONDITION,
-                ProofRequestIdCollisionMessage::for_field(session_id, "l1_head"),
-                None::<()>,
-            ))))
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not poll proofs")
-        }
-
-        async fn delete_proof_request(
-            &self,
-            _request: DeleteProofRequest,
-        ) -> Result<(), ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not delete proofs")
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not list proofs")
-        }
-    }
-
-    fn dispatcher() -> (ProofDispatcher<MockL1, MockL2, MockRollupClient>, Arc<MockProofRequester>)
-    {
+    fn dispatcher() -> (ProofDispatcher, Arc<MockProofRequester>) {
         let requester = Arc::new(MockProofRequester::default());
-        let dispatcher =
-            dispatcher_for_requester(Arc::clone(&requester) as Arc<dyn ProofRequesterProvider>);
-        (dispatcher, requester)
-    }
-
-    fn dispatcher_for_requester(
-        requester: Arc<dyn ProofRequesterProvider>,
-    ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
-        dispatcher_for_requester_and_sync(requester, test_sync_status(10_000, B256::ZERO), false)
-    }
-
-    fn dispatcher_for_requester_and_sync(
-        requester: Arc<dyn ProofRequesterProvider>,
-        sync_status: SyncStatus,
-        allow_non_finalized: bool,
-    ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
-        let l1 = Arc::new(MockL1::with_headers(
-            sync_status.finalized_l1.number,
-            headers_for_sync_status(&sync_status),
-        ));
-        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status,
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        ProofDispatcher::new(
+        (
+            ProofDispatcher::new(
+                requester.clone(),
+                Arc::new(MockL1 { latest_block_number: 1000, ..Default::default() }),
+                Arc::new(MockL2 { block_not_found: false, canonical_hash: None }),
+                Arc::new(MockRollupClient::default()),
+                ProofDispatcherConfig {
+                    proposer_address: Address::repeat_byte(0x04),
+                    intermediate_block_interval: 300,
+                    tee_image_hash: B256::repeat_byte(0x05),
+                },
+            ),
             requester,
-            l1,
-            l2,
-            rollup,
-            ProofDispatcherConfig {
-                proposer_address: Address::repeat_byte(0x04),
-                allow_non_finalized,
-                intermediate_block_interval: 300,
-                tee_image_hash: B256::repeat_byte(0x05),
-            },
         )
     }
 
@@ -654,180 +315,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_request_uses_finalized_l1_head_for_finalized_target() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            true,
-        );
-
-        let request = dispatcher
-            .build_request(200, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect("request should build for finalized target");
-
-        assert_eq!(request.l1_head, B256::repeat_byte(0xf1));
-        assert_eq!(request.l1_head_number, 10);
-    }
-
-    #[tokio::test]
-    async fn build_request_uses_safe_l1_head_for_safe_target() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            true,
-        );
-
-        let request = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect("request should build for safe target");
-
-        assert_eq!(request.l1_head, B256::repeat_byte(0x5a));
-        assert_eq!(request.l1_head_number, 20);
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_l2_coverage_beyond_selected_l1_head() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let mut sync_status = sync_status_with_distinct_heads(300, 600);
-        sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number + 1;
-        let dispatcher = dispatcher_for_requester_and_sync(requester, sync_status, true);
-
-        let err = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("safe L1 must cover selected safe L2 origin");
-
-        assert!(err.to_string().contains("below safe L2 origin"));
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_l1_rpc_header_mismatch() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let sync_status = sync_status_with_distinct_heads(300, 600);
-        let mut headers = headers_for_sync_status(&sync_status);
-        headers.insert(
-            sync_status.safe_l1.hash,
-            test_l1_header(sync_status.safe_l1.hash, sync_status.safe_l1.number + 1),
-        );
-        let l1 = Arc::new(MockL1::with_headers(sync_status.finalized_l1.number, headers));
-        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status,
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        let dispatcher = ProofDispatcher::new(
-            requester,
-            l1,
-            l2,
-            rollup,
-            ProofDispatcherConfig {
-                proposer_address: Address::repeat_byte(0x04),
-                allow_non_finalized: true,
-                intermediate_block_interval: 300,
-                tee_image_hash: B256::repeat_byte(0x05),
-            },
-        );
-
-        let err = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("L1 RPC header must match rollup-selected L1 head");
-
-        assert!(err.to_string().contains("does not match L1 RPC header"));
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_target_above_safe_l2() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            true,
-        );
-
-        let err = dispatcher
-            .build_request(700, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("target above safe L2 should not build");
-
-        assert!(err.to_string().contains("above rollup safe head"));
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_safe_target_when_non_finalized_disallowed() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            false,
-        );
-
-        let err = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("non-finalized target should not build when disabled");
-
-        assert!(err.to_string().contains("above rollup finalized head"));
-    }
-
-    #[tokio::test]
-    async fn dispatch_for_sends_root_derived_session() {
+    async fn dispatch_with_retry_sends_root_derived_session() {
         let (dispatcher, requester) = dispatcher();
         let claimed_root = B256::repeat_byte(0xaa);
+        let mut state = ProofDispatcherState::default();
 
-        let outcome = dispatcher.dispatch_for(200, &recovered(), claimed_root).await;
-        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
-            panic!("expected accepted dispatch")
-        };
+        let outcome =
+            dispatcher.dispatch_with_retry(200, &recovered(), claimed_root, &mut state, 3).await;
+        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
 
-        assert_eq!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
+        assert_eq!(outcome, Ok(true));
         assert!(requester.requests.lock().unwrap().contains_key(&session_id));
+        assert_eq!(state.retry, None);
     }
 
     #[tokio::test]
-    async fn dispatch_for_rejects_mismatched_session_id() {
-        let dispatcher = dispatcher_for_requester(Arc::new(MismatchedProofRequester {
-            session_id: "wrong-session".to_owned(),
-        }));
+    async fn dispatch_with_retry_rejects_mismatched_session_id() {
+        let (dispatcher, requester) = dispatcher();
+        *requester.accepted_session_id.lock().unwrap() = Some("wrong-session".to_owned());
+        let mut state = ProofDispatcherState::default();
 
-        let outcome = dispatcher.dispatch_for(200, &recovered(), B256::repeat_byte(0xaa)).await;
+        let outcome = dispatcher
+            .dispatch_with_retry(200, &recovered(), B256::repeat_byte(0xaa), &mut state, 2)
+            .await;
 
-        let ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(message)) = outcome else {
-            panic!("expected mismatched session id to fail dispatch")
-        };
-        assert!(message.contains("mismatched session_id"));
+        assert_eq!(outcome, Ok(false));
+        assert_eq!(state.retry, Some((200, 1)));
     }
 
     #[tokio::test]
-    async fn dispatch_for_accepts_existing_l1_head_conflict() {
-        let dispatcher = dispatcher_for_requester(Arc::new(L1HeadConflictRequester));
+    async fn dispatch_with_retry_accepts_existing_l1_head_conflict() {
+        let (dispatcher, requester) = dispatcher();
+        requester.l1_head_conflict.store(true, Ordering::SeqCst);
         let claimed_root = B256::repeat_byte(0xaa);
+        let mut state = ProofDispatcherState::default();
 
-        let outcome = dispatcher.dispatch_for(200, &recovered(), claimed_root).await;
+        let outcome =
+            dispatcher.dispatch_with_retry(200, &recovered(), claimed_root, &mut state, 3).await;
 
-        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
-            panic!("expected accepted dispatch")
-        };
-        assert_eq!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
+        assert_eq!(outcome, Ok(true));
+        assert_eq!(state.retry, None);
     }
 
     #[tokio::test]
     async fn tick_dispatches_all_targets_up_to_safe_head() {
         let (dispatcher, requester) = dispatcher();
-        let mut state = ProofDispatcherState::new();
+        let mut state = ProofDispatcherState::default();
         let cancel = CancellationToken::new();
 
         let result = dispatcher.tick(&mut state, recovered(), 400, 100, 3, &cancel).await;
 
         assert!(!result);
         assert_eq!(requester.requests.lock().unwrap().len(), 3);
-        assert_eq!(state.cursor.map(|cursor| cursor.l2_block_number), Some(400));
-        assert!(state.retry_counts.is_empty());
+        assert_eq!(state.cursor.map(|(_, cursor)| cursor.l2_block_number), Some(400));
+        assert_eq!(state.retry, None);
     }
 
     #[tokio::test]
@@ -835,53 +376,51 @@ mod tests {
         let (dispatcher, requester) = dispatcher();
         let cancel = CancellationToken::new();
         let mut state = ProofDispatcherState {
-            recovered: Some(RecoveredState {
-                parent_address: Address::repeat_byte(0x01),
-                output_root: B256::repeat_byte(0x01),
-                l2_block_number: 300,
-            }),
-            cursor: Some(RecoveredState {
-                parent_address: Address::repeat_byte(0x02),
-                output_root: B256::repeat_byte(0x02),
-                l2_block_number: 500,
-            }),
-            retry_counts: HashMap::new(),
+            cursor: Some((
+                RecoveredState {
+                    parent_address: Address::repeat_byte(0x01),
+                    output_root: B256::repeat_byte(0x01),
+                    l2_block_number: 300,
+                },
+                RecoveredState {
+                    parent_address: Address::repeat_byte(0x02),
+                    output_root: B256::repeat_byte(0x02),
+                    l2_block_number: 500,
+                },
+            )),
+            retry: None,
         };
 
         let result = dispatcher.tick(&mut state, recovered(), 200, 100, 3, &cancel).await;
 
         assert!(!result);
-        assert_eq!(state.recovered, Some(recovered()));
-        assert_eq!(state.cursor.map(|cursor| cursor.l2_block_number), Some(200));
+        assert_eq!(state.cursor.map(|(source, _)| source), Some(recovered()));
+        assert_eq!(state.cursor.map(|(_, cursor)| cursor.l2_block_number), Some(200));
         assert_eq!(requester.requests.lock().unwrap().len(), 1);
     }
 
-    #[test]
-    fn handle_proof_failure_clears_cursor_on_retry_exhaustion() {
-        let mut state = ProofDispatcherState::new();
-        state.cursor = Some(RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::repeat_byte(0x09),
-            l2_block_number: 300,
-        });
-        state.retry_counts.insert(200, 1);
-
-        let should_retry = state.handle_proof_failure(200, ProposerError::Prover("boom".into()), 2);
-
-        assert!(!should_retry);
-        assert!(state.recovered.is_none());
-        assert!(state.cursor.is_none());
-        assert!(!state.retry_counts.contains_key(&200));
-    }
-
-    #[test]
-    fn config_is_copyable() {
-        let config = ProofDispatcherConfig {
-            proposer_address: Address::ZERO,
-            allow_non_finalized: false,
-            intermediate_block_interval: 1,
-            tee_image_hash: B256::ZERO,
+    #[tokio::test]
+    async fn dispatch_with_retry_clears_cursor_on_retry_exhaustion() {
+        let (dispatcher, requester) = dispatcher();
+        *requester.accepted_session_id.lock().unwrap() = Some("wrong-session".to_owned());
+        let mut state = ProofDispatcherState {
+            cursor: Some((
+                recovered(),
+                RecoveredState {
+                    parent_address: Address::ZERO,
+                    output_root: B256::repeat_byte(0x09),
+                    l2_block_number: 300,
+                },
+            )),
+            retry: Some((200, 1)),
         };
-        let _copy = config;
+
+        let outcome = dispatcher
+            .dispatch_with_retry(200, &recovered(), B256::repeat_byte(0xaa), &mut state, 2)
+            .await;
+
+        assert_eq!(outcome, Err(()));
+        assert!(state.cursor.is_none());
+        assert_eq!(state.retry, None);
     }
 }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -31,11 +31,7 @@ pub struct ProofDispatcher {
 
 impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofDispatcher")
-            .field("proposer_address", &self.proposer_address)
-            .field("intermediate_block_interval", &self.intermediate_block_interval)
-            .field("tee_image_hash", &self.tee_image_hash)
-            .finish_non_exhaustive()
+        f.debug_struct("ProofDispatcher").finish_non_exhaustive()
     }
 }
 
@@ -148,23 +144,22 @@ impl ProofDispatcher {
         let expected_session_id = request.proof.session_id.clone();
 
         let session_id = match self.proof_requester.prove_block_range(request).await {
-            Ok(response) if response.session_id == expected_session_id => Ok(response.session_id),
+            Ok(response) if response.session_id == expected_session_id => response.session_id,
             Err(e) if e.is_l1_head_conflict_for_session(&expected_session_id) => {
                 debug!(
                     session_id = %expected_session_id,
                     "prover-service already has this TEE proof session with a different l1_head"
                 );
-                Ok(expected_session_id)
+                expected_session_id
             }
-            Ok(response) => Err(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {expected_session_id}, got {}",
-                response.session_id
-            ))),
-            Err(error) => Err(ProposerError::Prover(error.to_string())),
-        };
-        let session_id = match session_id {
-            Ok(session_id) => session_id,
-            Err(error) => {
+            result => {
+                let error = match result {
+                    Ok(response) => ProposerError::Prover(format!(
+                        "prover service returned mismatched session_id: expected {expected_session_id}, got {}",
+                        response.session_id
+                    )),
+                    Err(error) => ProposerError::Prover(error.to_string()),
+                };
                 Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
                 Metrics::errors_total(error.metric_label()).increment(1);
 

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -29,13 +29,6 @@ pub struct ProofDispatcherConfig {
     pub tee_image_hash: B256,
 }
 
-/// Mutable dispatcher-side orchestration state.
-#[derive(Debug, Default)]
-pub struct ProofDispatcherState {
-    /// Recovery source and latest block the dispatcher has sent proof requests through.
-    pub cursor: Option<(RecoveredState, RecoveredState)>,
-}
-
 /// Builds and dispatches proposer TEE proof requests.
 pub struct ProofDispatcher {
     proof_requester: Arc<dyn ProofRequesterProvider>,
@@ -66,14 +59,13 @@ impl ProofDispatcher {
     /// Dispatches every target from the current dispatcher cursor up to `safe_head`.
     pub async fn tick(
         &self,
-        state: &mut ProofDispatcherState,
+        cursor: &mut Option<(RecoveredState, RecoveredState)>,
         recovered: RecoveredState,
         safe_head: u64,
         block_interval: u64,
         cancel: &CancellationToken,
     ) {
-        let mut current = state
-            .cursor
+        let mut current = cursor
             .filter(|(source, _)| *source == recovered)
             .map_or(recovered, |(_, cursor)| cursor);
 
@@ -111,7 +103,7 @@ impl ProofDispatcher {
             if self.dispatch(target_block, &current, claimed_l2_output_root).await {
                 current.l2_block_number = target_block;
                 current.output_root = claimed_l2_output_root;
-                state.cursor = Some((recovered, current));
+                *cursor = Some((recovered, current));
             } else {
                 break;
             }
@@ -306,59 +298,36 @@ mod tests {
     #[tokio::test]
     async fn tick_dispatches_all_targets_up_to_safe_head() {
         let (dispatcher, requester) = dispatcher();
-        let mut state = ProofDispatcherState::default();
+        let mut cursor = None;
         let cancel = CancellationToken::new();
 
-        dispatcher.tick(&mut state, recovered(), 400, 100, &cancel).await;
+        dispatcher.tick(&mut cursor, recovered(), 400, 100, &cancel).await;
 
         assert_eq!(requester.requests.lock().unwrap().len(), 3);
-        assert_eq!(state.cursor.map(|(_, cursor)| cursor.l2_block_number), Some(400));
+        assert_eq!(cursor.map(|(_, cursor)| cursor.l2_block_number), Some(400));
     }
 
     #[tokio::test]
     async fn tick_resets_cursor_when_recovery_rewinds() {
         let (dispatcher, requester) = dispatcher();
         let cancel = CancellationToken::new();
-        let mut state = ProofDispatcherState {
-            cursor: Some((
-                RecoveredState {
-                    parent_address: Address::repeat_byte(0x01),
-                    output_root: B256::repeat_byte(0x01),
-                    l2_block_number: 300,
-                },
-                RecoveredState {
-                    parent_address: Address::repeat_byte(0x02),
-                    output_root: B256::repeat_byte(0x02),
-                    l2_block_number: 500,
-                },
-            )),
-        };
+        let mut cursor = Some((
+            RecoveredState {
+                parent_address: Address::repeat_byte(0x01),
+                output_root: B256::repeat_byte(0x01),
+                l2_block_number: 300,
+            },
+            RecoveredState {
+                parent_address: Address::repeat_byte(0x02),
+                output_root: B256::repeat_byte(0x02),
+                l2_block_number: 500,
+            },
+        ));
 
-        dispatcher.tick(&mut state, recovered(), 200, 100, &cancel).await;
+        dispatcher.tick(&mut cursor, recovered(), 200, 100, &cancel).await;
 
-        assert_eq!(state.cursor.map(|(source, _)| source), Some(recovered()));
-        assert_eq!(state.cursor.map(|(_, cursor)| cursor.l2_block_number), Some(200));
+        assert_eq!(cursor.map(|(source, _)| source), Some(recovered()));
+        assert_eq!(cursor.map(|(_, cursor)| cursor.l2_block_number), Some(200));
         assert_eq!(requester.requests.lock().unwrap().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn dispatch_keeps_cursor_on_failure() {
-        let (dispatcher, requester) = dispatcher();
-        *requester.accepted_session_id.lock().unwrap() = Some("wrong-session".to_owned());
-        let state = ProofDispatcherState {
-            cursor: Some((
-                recovered(),
-                RecoveredState {
-                    parent_address: Address::ZERO,
-                    output_root: B256::repeat_byte(0x09),
-                    l2_block_number: 300,
-                },
-            )),
-        };
-
-        let outcome = dispatcher.dispatch(200, &recovered(), B256::repeat_byte(0xaa)).await;
-
-        assert!(!outcome);
-        assert!(state.cursor.is_some());
     }
 }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256};
+use base_optimism_rpc::{L1BlockRef, L2BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
@@ -24,6 +25,7 @@ pub struct ProofDispatcher {
     l2_client: Arc<dyn L2Provider>,
     rollup_client: Arc<dyn RollupProvider>,
     proposer_address: Address,
+    allow_non_finalized: bool,
     intermediate_block_interval: u64,
     tee_image_hash: B256,
 }
@@ -32,6 +34,7 @@ impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofDispatcher")
             .field("proposer_address", &self.proposer_address)
+            .field("allow_non_finalized", &self.allow_non_finalized)
             .field("intermediate_block_interval", &self.intermediate_block_interval)
             .field("tee_image_hash", &self.tee_image_hash)
             .finish_non_exhaustive()
@@ -53,6 +56,7 @@ impl ProofDispatcher {
             l2_client,
             rollup_client,
             proposer_address: config.proposer_address,
+            allow_non_finalized: config.allow_non_finalized,
             intermediate_block_interval: config.intermediate_block_interval,
             tee_image_hash: config.tee_image_hash,
         }
@@ -107,6 +111,86 @@ impl ProofDispatcher {
         }
     }
 
+    /// Builds a proof request for `target_block`.
+    pub async fn build_request(
+        &self,
+        target_block: u64,
+        recovered: &RecoveredState,
+        claimed_l2_output_root: B256,
+    ) -> Result<ProofRequest, ProposerError> {
+        let (sync_status, agreed_l2_head) = tokio::try_join!(
+            self.rollup_client.sync_status(),
+            self.l2_client.header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number)),
+        )
+        .map_err(ProposerError::Rpc)?;
+        let (l1_head_source, l1_head, l2_coverage) =
+            Self::select_l1_head_for_target(target_block, &sync_status, self.allow_non_finalized)?;
+        let l1_header =
+            self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
+        if l1_header.hash != l1_head.hash || l1_header.number != l1_head.number {
+            return Err(ProposerError::Internal(format!(
+                "selected {l1_head_source} L1 head {}:{} does not match L1 RPC header {}:{}",
+                l1_head.number, l1_head.hash, l1_header.number, l1_header.hash
+            )));
+        }
+
+        info!(
+            target_block,
+            from_block = recovered.l2_block_number,
+            allow_non_finalized = self.allow_non_finalized,
+            l1_head_source = l1_head_source,
+            l1_head_number = l1_header.number,
+            l1_head_hash = %l1_header.hash,
+            l2_coverage_block = l2_coverage.number,
+            l2_coverage_hash = %l2_coverage.hash,
+            "Built proof request"
+        );
+
+        Ok(ProofRequest {
+            l1_head: l1_header.hash,
+            agreed_l2_head_hash: agreed_l2_head.hash,
+            agreed_l2_output_root: recovered.output_root,
+            claimed_l2_output_root,
+            claimed_l2_block_number: target_block,
+            proposer: self.proposer_address,
+            intermediate_block_interval: self.intermediate_block_interval,
+            l1_head_number: l1_header.number,
+            image_hash: self.tee_image_hash,
+        })
+    }
+
+    fn select_l1_head_for_target(
+        target_block: u64,
+        sync_status: &SyncStatus,
+        allow_non_finalized: bool,
+    ) -> Result<(&'static str, L1BlockRef, L2BlockRef), ProposerError> {
+        let selected = if target_block <= sync_status.finalized_l2.number {
+            ("finalized", sync_status.finalized_l1, sync_status.finalized_l2)
+        } else if !allow_non_finalized {
+            return Err(ProposerError::Internal(format!(
+                "target block {target_block} is above rollup finalized head {}",
+                sync_status.finalized_l2.number
+            )));
+        } else if target_block <= sync_status.safe_l2.number {
+            ("safe", sync_status.safe_l1, sync_status.safe_l2)
+        } else {
+            return Err(ProposerError::Internal(format!(
+                "target block {target_block} is above rollup safe head {}",
+                sync_status.safe_l2.number
+            )));
+        };
+
+        let (l1_head_source, l1_head, l2_coverage) = selected;
+        if l1_head.number < l2_coverage.l1origin.number {
+            return Err(ProposerError::Internal(format!(
+                "selected {l1_head_source} L1 head {} is below {l1_head_source} L2 origin {}",
+                l1_head.number, l2_coverage.l1origin.number
+            )));
+        }
+
+        Ok(selected)
+    }
+
     /// Builds and dispatches a fresh root-derived request.
     pub async fn dispatch(
         &self,
@@ -114,34 +198,21 @@ impl ProofDispatcher {
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
     ) -> bool {
-        let (l1_head, agreed_l2_head) = match tokio::try_join!(
-            self.l1_client.header_by_number(BlockNumberOrTag::Finalized),
-            self.l2_client.header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number)),
-        ) {
-            Ok(headers) => headers,
-            Err(error) => {
-                Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED).increment(1);
-                let error = ProposerError::Rpc(error);
-                warn!(
-                    target_block,
-                    error = %error,
-                    "Failed to build proof request, will retry next iteration"
-                );
-                return false;
-            }
-        };
-
-        let request = ProofRequest {
-            l1_head: l1_head.hash,
-            agreed_l2_head_hash: agreed_l2_head.hash,
-            agreed_l2_output_root: recovered.output_root,
-            claimed_l2_output_root,
-            claimed_l2_block_number: target_block,
-            proposer: self.proposer_address,
-            intermediate_block_interval: self.intermediate_block_interval,
-            l1_head_number: l1_head.number,
-            image_hash: self.tee_image_hash,
-        };
+        let request =
+            match self.build_request(target_block, recovered, claimed_l2_output_root).await {
+                Ok(request) => request,
+                Err(error) => {
+                    Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED)
+                        .increment(1);
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Failed to build proof request, will retry next iteration"
+                    );
+                    return false;
+                }
+            };
+        let l1_head_number = request.l1_head_number;
 
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
         let expected_session_id = request.proof.session_id.clone();
@@ -175,7 +246,7 @@ impl ProofDispatcher {
             target_block,
             session_id = %expected_session_id,
             from_block = recovered.l2_block_number,
-            l1_head_number = l1_head.number,
+            l1_head_number,
             "Proof request accepted by prover service"
         );
         true
@@ -184,15 +255,28 @@ impl ProofDispatcher {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
+    use std::{collections::HashMap, sync::atomic::Ordering};
+
+    use base_optimism_rpc::SyncStatus;
 
     use super::*;
-    use crate::test_utils::{MockL1, MockL2, MockProofRequester, MockRollupClient};
+    use crate::test_utils::{
+        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l1_header,
+        test_l2_block_ref,
+    };
 
     fn dispatcher() -> (ProofDispatcher, Arc<MockProofRequester>) {
+        dispatcher_with_sync(sync_status_with_distinct_heads(600, 600), false)
+    }
+
+    fn dispatcher_with_sync(
+        sync_status: SyncStatus,
+        allow_non_finalized: bool,
+    ) -> (ProofDispatcher, Arc<MockProofRequester>) {
         let requester = Arc::new(MockProofRequester::default());
         let config = DriverConfig {
             proposer_address: Address::repeat_byte(0x04),
+            allow_non_finalized,
             intermediate_block_interval: 300,
             tee_image_hash: B256::repeat_byte(0x05),
             ..Default::default()
@@ -200,13 +284,56 @@ mod tests {
         (
             ProofDispatcher::new(
                 requester.clone(),
-                Arc::new(MockL1 { latest_block_number: 1000, ..Default::default() }),
+                Arc::new(MockL1::with_headers(
+                    sync_status.finalized_l1.number,
+                    headers_for_sync_status(&sync_status),
+                )),
                 Arc::new(MockL2 { block_not_found: false, canonical_hash: None }),
-                Arc::new(MockRollupClient::default()),
+                Arc::new(MockRollupClient {
+                    sync_status,
+                    output_roots: HashMap::new(),
+                    max_safe_block: None,
+                }),
                 &config,
             ),
             requester,
         )
+    }
+
+    fn headers_for_sync_status(
+        sync_status: &SyncStatus,
+    ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
+        let mut headers = HashMap::new();
+        for l1_head in [sync_status.finalized_l1, sync_status.safe_l1] {
+            headers.insert(l1_head.hash, test_l1_header(l1_head.hash, l1_head.number));
+        }
+        headers
+    }
+
+    fn sync_status_with_distinct_heads(finalized_l2: u64, safe_l2: u64) -> SyncStatus {
+        let mut finalized_l1 = test_l1_block_ref(10);
+        finalized_l1.hash = B256::repeat_byte(0xf1);
+        let mut safe_l1 = test_l1_block_ref(20);
+        safe_l1.hash = B256::repeat_byte(0x5a);
+
+        let mut finalized_l2 = test_l2_block_ref(finalized_l2, B256::repeat_byte(0xf2));
+        finalized_l2.l1origin.hash = finalized_l1.hash;
+        finalized_l2.l1origin.number = finalized_l1.number;
+        let mut safe_l2 = test_l2_block_ref(safe_l2, B256::repeat_byte(0x52));
+        safe_l2.l1origin.hash = safe_l1.hash;
+        safe_l2.l1origin.number = safe_l1.number;
+
+        SyncStatus {
+            current_l1: safe_l1,
+            current_l1_finalized: Some(finalized_l1),
+            head_l1: safe_l1,
+            safe_l1,
+            finalized_l1,
+            unsafe_l2: safe_l2,
+            safe_l2,
+            finalized_l2,
+            pending_safe_l2: None,
+        }
     }
 
     fn recovered() -> RecoveredState {
@@ -215,6 +342,39 @@ mod tests {
             output_root: B256::repeat_byte(0x03),
             l2_block_number: 100,
         }
+    }
+
+    #[tokio::test]
+    async fn build_request_uses_finalized_l1_head_for_finalized_target() {
+        let (dispatcher, _) = dispatcher_with_sync(sync_status_with_distinct_heads(300, 600), true);
+
+        let request =
+            dispatcher.build_request(200, &recovered(), B256::repeat_byte(0xaa)).await.unwrap();
+
+        assert_eq!(request.l1_head, B256::repeat_byte(0xf1));
+        assert_eq!(request.l1_head_number, 10);
+    }
+
+    #[tokio::test]
+    async fn build_request_uses_safe_l1_head_for_safe_target() {
+        let (dispatcher, _) = dispatcher_with_sync(sync_status_with_distinct_heads(300, 600), true);
+
+        let request =
+            dispatcher.build_request(400, &recovered(), B256::repeat_byte(0xaa)).await.unwrap();
+
+        assert_eq!(request.l1_head, B256::repeat_byte(0x5a));
+        assert_eq!(request.l1_head_number, 20);
+    }
+
+    #[tokio::test]
+    async fn build_request_rejects_safe_target_when_non_finalized_disallowed() {
+        let (dispatcher, _) =
+            dispatcher_with_sync(sync_status_with_distinct_heads(300, 600), false);
+
+        let err =
+            dispatcher.build_request(400, &recovered(), B256::repeat_byte(0xaa)).await.unwrap_err();
+
+        assert!(err.to_string().contains("above rollup finalized head"));
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_target.rs
+++ b/crates/proof/proposer/src/proof_target.rs
@@ -32,7 +32,7 @@ impl ProofTarget {
         caller: &'static str,
     ) -> Option<B256>
     where
-        R: RollupProvider,
+        R: RollupProvider + ?Sized,
     {
         match rollup_client.output_at_block(target_block).await {
             Ok(output) => Some(output.output_root),

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -234,9 +234,9 @@ impl ProposerService {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            Arc::clone(&l1_client),
-            Arc::clone(&l2_client),
-            Arc::clone(&rollup_client),
+            l1_client.clone(),
+            l2_client.clone(),
+            rollup_client.clone(),
             ProofDispatcherConfig {
                 proposer_address: driver_config.proposer_address,
                 allow_non_finalized: driver_config.allow_non_finalized,

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -36,7 +36,7 @@ use crate::{
     output_proposer::{OutputProposer, ProposalSubmitter},
     pipeline::ProvingPipeline,
     proof_collector::ProofCollector,
-    proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
+    proof_dispatcher::ProofDispatcher,
     proof_recovery::{ProofRecovery, ProofRecoveryConfig},
     proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
 };
@@ -236,12 +236,7 @@ impl ProposerService {
             l1_client.clone(),
             l2_client.clone(),
             rollup_client.clone(),
-            ProofDispatcherConfig {
-                proposer_address: driver_config.proposer_address,
-                allow_non_finalized: driver_config.allow_non_finalized,
-                intermediate_block_interval: driver_config.intermediate_block_interval,
-                tee_image_hash: driver_config.tee_image_hash,
-            },
+            &driver_config,
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -220,7 +220,6 @@ impl ProposerService {
 
         let driver_config = DriverConfig {
             poll_interval: config.poll_interval,
-            max_retries: 8,
             recovery_scan_concurrency: config.recovery_scan_concurrency,
             submit_timeout,
             tee_prover_registry_address: config.tee_prover_registry_address,

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -24,9 +24,9 @@ use base_proof_rpc::{BaseBlock, L1Provider, L2Provider, RollupProvider, RpcError
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
     DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
-    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    TeeKind, TeeProofResult,
+    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestIdCollisionMessage,
+    ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
 };
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
@@ -151,6 +151,16 @@ pub struct MockRollupClient {
     pub output_roots: HashMap<u64, B256>,
     /// When set, blocks beyond this number return an error.
     pub max_safe_block: Option<u64>,
+}
+
+impl Default for MockRollupClient {
+    fn default() -> Self {
+        Self {
+            sync_status: test_sync_status(0, B256::ZERO),
+            output_roots: HashMap::new(),
+            max_safe_block: None,
+        }
+    }
 }
 
 #[async_trait]
@@ -467,6 +477,8 @@ pub struct MockProofRequester {
     pub failed_sessions: std::sync::Mutex<HashMap<String, String>>,
     /// Reject every `prove_block_range` call with a timeout.
     pub reject_prove: AtomicBool,
+    /// Return an L1-head collision for every `prove_block_range` call.
+    pub l1_head_conflict: AtomicBool,
     /// Override the accepted session id returned by `prove_block_range`.
     pub accepted_session_id: std::sync::Mutex<Option<String>>,
     /// Number of `prove_block_range` calls accepted.
@@ -486,6 +498,16 @@ impl ProofRequesterProvider for MockProofRequester {
         }
 
         let session_id = request.proof.session_id.clone();
+        if self.l1_head_conflict.load(Ordering::SeqCst) {
+            return Err(ProverServiceClientError::from(JsonRpcClientError::Call(
+                ErrorObjectOwned::owned(
+                    ProverServiceClientError::ERROR_FAILED_PRECONDITION,
+                    ProofRequestIdCollisionMessage::for_field(session_id, "l1_head"),
+                    None::<()>,
+                ),
+            )));
+        }
+
         self.prove_count.fetch_add(1, Ordering::SeqCst);
         self.requests.lock().unwrap().insert(session_id.clone(), request);
         if let Some(session_id) = self.accepted_session_id.lock().unwrap().clone() {


### PR DESCRIPTION
### What changed? Why?

Simplifies proposer proof dispatch by collapsing request building, dispatch, and retry handling into the dispatcher tick path. The dispatcher now tracks the recovered source with the dispatch cursor, uses a single active retry slot, and stores provider clients behind trait objects so downstream pipeline types no longer carry dispatcher-only generics.

### Notes to reviewers

Retry metrics now report the active retry count instead of summing a per-target retry map. Retry state is cleared when recovery moves past the target or retry exhaustion drops the cached recovery.

### How has it been tested?

- `cargo test -p base-proposer`