### PR TITLE
feat(registrar): make discovery cache TTL configurable

### DIFF
--- a/bin/prover-registrar/README.md
+++ b/bin/prover-registrar/README.md
@@ -5,3 +5,12 @@ Automated TEE prover signer registration service.
 Discovers new TEE prover instances via AWS ALB target group, generates ZK proofs
 of their Nitro attestation certificates via the Boundless Network, and registers
 their signers on-chain via `TEEProverRegistry`.
+
+## Discovery Cache TTL
+
+When an instance disappears from otherwise successful AWS/ALB discovery output,
+the registrar preserves its last-known active signers for
+`--instance-cache-ttl-cycles` cycles (`BASE_REGISTRAR_INSTANCE_CACHE_TTL_CYCLES`,
+default `5`). Shorter TTLs can speed up cleanup for genuinely removed instances
+but increase exposure to transient discovery flakes; longer TTLs protect against
+flakes but delay real cleanup.

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -6,7 +6,8 @@ use alloy_primitives::{Address, hex::FromHex};
 use base_proof_tee_nitro_attestation_prover::{BoundlessProver, BoundlessProverConfig};
 use base_proof_tee_registrar::{
     DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
-    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, RegistrarConfig, RegistrarError,
+    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, INSTANCE_CACHE_TTL_CYCLES, RegistrarConfig,
+    RegistrarError,
 };
 use base_tx_manager::{SignerConfig, TxManagerConfig};
 use boundless_market::{
@@ -176,6 +177,17 @@ pub(crate) struct Cli {
     )]
     max_concurrency: usize,
 
+    /// Discovery cycles to preserve signers for instances missing from discovery output.
+    ///
+    /// Shorter TTLs speed up real cleanup but are more vulnerable to transient AWS/ALB
+    /// discovery flakes; longer TTLs protect against flakes but delay cleanup.
+    #[arg(
+        long,
+        env = cli_env!("INSTANCE_CACHE_TTL_CYCLES"),
+        default_value_t = INSTANCE_CACHE_TTL_CYCLES
+    )]
+    instance_cache_ttl_cycles: u32,
+
     /// Maximum number of transaction submission retries for transient errors.
     #[arg(long, env = cli_env!("MAX_TX_RETRIES"), default_value_t = DEFAULT_MAX_TX_RETRIES)]
     max_tx_retries: u32,
@@ -262,6 +274,7 @@ impl Cli {
             poll_interval: Duration::from_secs(self.poll_interval),
             prover_timeout: Duration::from_secs(self.prover_timeout),
             max_concurrency: self.max_concurrency,
+            instance_cache_ttl_cycles: self.instance_cache_ttl_cycles,
             max_tx_retries: self.max_tx_retries,
             tx_retry_delay: Duration::from_secs(self.tx_retry_delay),
             unhealthy_registration_window: Duration::from_secs(self.unhealthy_registration_window),
@@ -375,11 +388,23 @@ mod tests {
             "30",
             "--tx-retry-delay-secs",
             "2",
+            "--instance-cache-ttl-cycles",
+            "3",
             "--unhealthy-registration-window-secs",
             "600",
         ]);
 
         assert!(Cli::try_parse_from(args).is_ok());
+    }
+
+    #[test]
+    fn instance_cache_ttl_cycles_configures_registrar() {
+        let mut args = required_args();
+        args.extend(["--instance-cache-ttl-cycles", "2"]);
+
+        let config = Cli::parse_from(args).config().unwrap();
+
+        assert_eq!(config.instance_cache_ttl_cycles, 2);
     }
 
     #[test]

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -9,6 +9,14 @@ to detect new Nitro enclave instances, fetches their attestation documents via
 (RISC Zero / Automata SDK), and submits registration transactions to
 `TEEProverRegistry` on L1.
 
+## Discovery Cache TTL
+
+When an instance disappears from otherwise successful discovery output, the
+registrar preserves its last-known active signers for `instance_cache_ttl_cycles`
+cycles. Shorter TTLs can speed up cleanup for genuinely removed instances but
+increase exposure to transient AWS/ALB discovery flakes; longer TTLs protect
+against flakes but delay real cleanup.
+
 ## Modules
 
 - **`service`** — [`RegistrarConfig`] runtime config and lifecycle runner.

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -44,8 +44,9 @@ pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 /// of 90 minutes.
 pub const DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS: u64 = 5100;
 
-/// Number of consecutive discovery cycles to protect last-known active signers
-/// for an instance that disappears from otherwise successful discovery output.
+/// Default number of consecutive discovery cycles to protect last-known active
+/// signers for an instance that disappears from otherwise successful discovery
+/// output.
 ///
 /// Five cycles is roughly 2.5 minutes with the default 30 second poll interval.
 /// A shorter window is more vulnerable to transient discovery flakes; a longer
@@ -62,6 +63,10 @@ pub struct DriverConfig {
     pub cancel: CancellationToken,
     /// Maximum number of instances resolved concurrently per discovery cycle.
     pub max_concurrency: usize,
+    /// Number of consecutive discovery cycles to protect last-known active
+    /// signers for an instance missing from otherwise successful discovery
+    /// output. Defaults to [`INSTANCE_CACHE_TTL_CYCLES`].
+    pub instance_cache_ttl_cycles: u32,
     /// Duration after launch during which unhealthy instances are still
     /// eligible for registration. New instances may fail ALB health checks
     /// while the application is still initializing. Set to zero to disable.
@@ -140,6 +145,7 @@ where
         info!(
             poll_interval = ?self.config.poll_interval,
             max_concurrency = self.config.max_concurrency,
+            instance_cache_ttl_cycles = self.config.instance_cache_ttl_cycles,
             "starting registration driver"
         );
 
@@ -385,12 +391,12 @@ where
             }
 
             *ttl_cycles = ttl_cycles.saturating_add(1);
-            if *ttl_cycles <= INSTANCE_CACHE_TTL_CYCLES {
+            if *ttl_cycles <= self.config.instance_cache_ttl_cycles {
                 warn!(
                     instance = %instance_id,
                     cached_signers = addresses.len(),
                     ttl_cycles = *ttl_cycles,
-                    max_ttl_cycles = INSTANCE_CACHE_TTL_CYCLES,
+                    max_ttl_cycles = self.config.instance_cache_ttl_cycles,
                     "instance missing from discovery, preserving last-known active signers"
                 );
                 resolution.active_signers.extend(addresses.iter().copied());
@@ -399,7 +405,8 @@ where
             } else {
                 warn!(
                     instance = %instance_id,
-                    max_ttl_cycles = INSTANCE_CACHE_TTL_CYCLES,
+                    ttl_cycles = *ttl_cycles,
+                    max_ttl_cycles = self.config.instance_cache_ttl_cycles,
                     "last-known active signer cache expired for missing instance"
                 );
                 false
@@ -510,6 +517,20 @@ mod tests {
         signer_client: MockEnclaveEndpointClient,
         cancel: CancellationToken,
     ) -> TestDriver {
+        cycle_driver_with_instance_cache_ttl(
+            instances,
+            signer_client,
+            cancel,
+            INSTANCE_CACHE_TTL_CYCLES,
+        )
+    }
+
+    fn cycle_driver_with_instance_cache_ttl(
+        instances: Vec<ProverInstance>,
+        signer_client: MockEnclaveEndpointClient,
+        cancel: CancellationToken,
+        instance_cache_ttl_cycles: u32,
+    ) -> TestDriver {
         let signer_manager = Arc::new(SignerManager::new(
             signer_client.clone(),
             (),
@@ -530,6 +551,7 @@ mod tests {
                 poll_interval: Duration::from_secs(1),
                 cancel,
                 max_concurrency: DEFAULT_MAX_CONCURRENCY,
+                instance_cache_ttl_cycles,
                 unhealthy_registration_window: Duration::from_secs(
                     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
                 ),
@@ -711,18 +733,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_evicts_cached_missing_instance_after_ttl() {
+    async fn discover_and_resolve_evicts_cached_missing_instance_after_configured_ttl() {
+        const TEST_TTL_CYCLES: u32 = 2;
+
         let signer_addr = signer_from_private_key(&HARDHAT_KEY_0);
         let inst = healthy_prover_instance(EP1);
         let signer_client = MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-        let first_cycle =
-            cycle_driver(vec![inst.clone()], signer_client.clone(), CancellationToken::new());
-        let missing_cycle = cycle_driver(vec![], signer_client, CancellationToken::new());
+        let first_cycle = cycle_driver_with_instance_cache_ttl(
+            vec![inst.clone()],
+            signer_client.clone(),
+            CancellationToken::new(),
+            TEST_TTL_CYCLES,
+        );
+        let missing_cycle = cycle_driver_with_instance_cache_ttl(
+            vec![],
+            signer_client,
+            CancellationToken::new(),
+            TEST_TTL_CYCLES,
+        );
         let mut last_known_active = HashMap::new();
 
         first_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
 
-        for expected_ttl in 1..=INSTANCE_CACHE_TTL_CYCLES {
+        for expected_ttl in 1..=TEST_TTL_CYCLES {
             let resolution =
                 missing_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
 

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -53,6 +53,8 @@ pub struct RegistrarConfig {
     pub prover_timeout: Duration,
     /// Maximum number of instances to process concurrently.
     pub max_concurrency: usize,
+    /// Discovery cycles to preserve last-known active signers for missing instances.
+    pub instance_cache_ttl_cycles: u32,
     /// Maximum number of transaction submission retries for transient errors.
     pub max_tx_retries: u32,
     /// Initial delay between transaction submission retries.
@@ -83,6 +85,7 @@ impl fmt::Debug for RegistrarConfig {
             .field("poll_interval", &self.poll_interval)
             .field("prover_timeout", &self.prover_timeout)
             .field("max_concurrency", &self.max_concurrency)
+            .field("instance_cache_ttl_cycles", &self.instance_cache_ttl_cycles)
             .field("max_tx_retries", &self.max_tx_retries)
             .field("tx_retry_delay", &self.tx_retry_delay)
             .field("unhealthy_registration_window", &self.unhealthy_registration_window)
@@ -243,6 +246,7 @@ impl RegistrarConfig {
                 poll_interval: self.poll_interval,
                 cancel: cancel.clone(),
                 max_concurrency: self.max_concurrency,
+                instance_cache_ttl_cycles: self.instance_cache_ttl_cycles,
                 unhealthy_registration_window: self.unhealthy_registration_window,
             },
             cert_manager,
@@ -327,6 +331,7 @@ mod tests {
             poll_interval: Duration::from_secs(1),
             prover_timeout: Duration::from_secs(1),
             max_concurrency: 1,
+            instance_cache_ttl_cycles: crate::INSTANCE_CACHE_TTL_CYCLES,
             max_tx_retries: 1,
             tx_retry_delay: Duration::from_secs(1),
             unhealthy_registration_window: Duration::from_secs(1),


### PR DESCRIPTION
## Summary
- Adds `instance_cache_ttl_cycles` to registrar service and driver config, threaded through `discover_and_resolve`.
- Adds `--instance-cache-ttl-cycles` / `BASE_REGISTRAR_INSTANCE_CACHE_TTL_CYCLES` with the existing default of `5`, preserving current behavior unless configured.
- Documents the operational trade-off: shorter TTLs speed real cleanup but increase exposure to transient AWS/ALB discovery flakes; longer TTLs protect against flakes but delay cleanup.

## Why
The signer protection window is coupled to discovery reliability and poll interval. Making it configurable gives operators an incident-time knob to tune the balance between premature deregistration risk and delayed cleanup without changing code or rebuilding binaries.

## Tests
- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar -p base-proof-tee-registrar-bin`
