### PR TITLE
fix(registrar): clarify revokeCert auth failures

### DIFF
--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -40,6 +40,7 @@ pub use tee_prover_registry::{
 mod nitro_enclave_verifier;
 pub use nitro_enclave_verifier::{
     INitroEnclaveVerifier, NitroEnclaveVerifierClient, NitroEnclaveVerifierContractClient,
+    caller_not_owner_or_revoker_selector,
 };
 
 mod error;

--- a/crates/proof/contracts/src/nitro_enclave_verifier.rs
+++ b/crates/proof/contracts/src/nitro_enclave_verifier.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::{Address, FixedBytes};
 use alloy_provider::RootProvider;
-use alloy_sol_types::sol;
+use alloy_sol_types::{SolError, sol};
 use async_trait::async_trait;
 
 use crate::ContractError;
@@ -18,6 +18,9 @@ sol! {
     /// `NitroEnclaveVerifier` contract interface (revocation subset).
     #[sol(rpc)]
     interface INitroEnclaveVerifier {
+        /// Thrown when the caller is neither the owner nor configured revoker.
+        error CallerNotOwnerOrRevoker();
+
         /// Revokes a cached intermediate certificate by its accumulated path digest.
         function revokeCert(bytes32 certHash) external;
 
@@ -25,6 +28,11 @@ sol! {
         /// revoked. Persistent across cache overwrites.
         function revokedCerts(bytes32 certHash) external view returns (bool);
     }
+}
+
+/// The 4-byte selector for `CallerNotOwnerOrRevoker()`.
+pub const fn caller_not_owner_or_revoker_selector() -> [u8; 4] {
+    INitroEnclaveVerifier::CallerNotOwnerOrRevoker::SELECTOR
 }
 
 /// Reads the durable revocation sentinel from the onchain
@@ -102,6 +110,7 @@ mod tests {
     #[rstest]
     fn revocation_selectors_are_nonzero_and_distinct() {
         let selectors = [
+            caller_not_owner_or_revoker_selector(),
             INitroEnclaveVerifier::revokeCertCall::SELECTOR,
             INitroEnclaveVerifier::revokedCertsCall::SELECTOR,
         ];

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_proof_contracts::{INitroEnclaveVerifier, NitroEnclaveVerifierClient};
+use base_proof_contracts::{
+    INitroEnclaveVerifier, NitroEnclaveVerifierClient, caller_not_owner_or_revoker_selector,
+};
 use base_proof_tee_nitro_verifier::AttestationReport;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 use tracing::{info, warn};
@@ -29,14 +31,23 @@ where
 {
     /// Decodes known `NitroEnclaveVerifier` custom-error names from a tx-manager error.
     fn revoke_cert_revert_name(err: &TxManagerError) -> Option<&'static str> {
+        Self::revoke_cert_revert_selector(err)
+            .and_then(INitroEnclaveVerifier::INitroEnclaveVerifierErrors::name_by_selector)
+    }
+
+    /// Decodes the raw revert selector from a tx-manager execution revert.
+    fn revoke_cert_revert_selector(err: &TxManagerError) -> Option<[u8; 4]> {
         let TxManagerError::ExecutionReverted { data, .. } = err else {
             return None;
         };
 
-        data.as_ref()
-            .and_then(|d| d.get(..4))
-            .and_then(|selector| selector.try_into().ok())
-            .and_then(INitroEnclaveVerifier::INitroEnclaveVerifierErrors::name_by_selector)
+        data.as_ref().and_then(|d| d.get(..4)).and_then(|selector| selector.try_into().ok())
+    }
+
+    /// Returns whether a tx-manager error is `CallerNotOwnerOrRevoker()`.
+    fn is_revoke_cert_authorization_error(err: &TxManagerError) -> bool {
+        Self::revoke_cert_revert_selector(err)
+            .is_some_and(|selector| selector == caller_not_owner_or_revoker_selector())
     }
 
     /// Creates a certificate manager from CRL fetch timeout, verifier client, and transaction manager.
@@ -147,7 +158,7 @@ where
                 }
                 Err(e) => {
                     let nitro_error = Self::revoke_cert_revert_name(&e);
-                    if matches!(nitro_error, Some("CallerNotOwnerOrRevoker")) {
+                    if Self::is_revoke_cert_authorization_error(&e) {
                         warn!(
                             error = %e,
                             nitro_error = ?nitro_error,
@@ -177,7 +188,7 @@ mod tests {
 
     use alloy_primitives::{Address, B256, Bytes};
     use async_trait::async_trait;
-    use base_proof_contracts::{ContractError, caller_not_owner_or_revoker_selector};
+    use base_proof_contracts::ContractError;
     use base_tx_manager::TxManagerError;
 
     use super::*;
@@ -288,6 +299,7 @@ mod tests {
             CertManager::<NoopTxManager>::revoke_cert_revert_name(&err),
             Some("CallerNotOwnerOrRevoker"),
         );
+        assert!(CertManager::<NoopTxManager>::is_revoke_cert_authorization_error(&err));
     }
 
     #[test]
@@ -296,5 +308,8 @@ mod tests {
             CertManager::<NoopTxManager>::revoke_cert_revert_name(&TxManagerError::NonceTooLow),
             None,
         );
+        assert!(!CertManager::<NoopTxManager>::is_revoke_cert_authorization_error(
+            &TxManagerError::NonceTooLow,
+        ));
     }
 }

--- a/crates/proof/tee/registrar/src/cert_manager.rs
+++ b/crates/proof/tee/registrar/src/cert_manager.rs
@@ -10,7 +10,7 @@ use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
 use base_proof_contracts::{INitroEnclaveVerifier, NitroEnclaveVerifierClient};
 use base_proof_tee_nitro_verifier::AttestationReport;
-use base_tx_manager::{TxCandidate, TxManager};
+use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 use tracing::{info, warn};
 
 use crate::{ProverInstance, RegistrarError, RegistrarMetrics, Result, crl};
@@ -27,6 +27,18 @@ impl<T> CertManager<T>
 where
     T: TxManager,
 {
+    /// Decodes known `NitroEnclaveVerifier` custom-error names from a tx-manager error.
+    fn revoke_cert_revert_name(err: &TxManagerError) -> Option<&'static str> {
+        let TxManagerError::ExecutionReverted { data, .. } = err else {
+            return None;
+        };
+
+        data.as_ref()
+            .and_then(|d| d.get(..4))
+            .and_then(|selector| selector.try_into().ok())
+            .and_then(INitroEnclaveVerifier::INitroEnclaveVerifierErrors::name_by_selector)
+    }
+
     /// Creates a certificate manager from CRL fetch timeout, verifier client, and transaction manager.
     ///
     /// # Errors
@@ -121,7 +133,7 @@ where
                     warn!(
                         path_digest = %revoked.path_digest,
                         tx_hash = %receipt.transaction_hash,
-                        "revokeCert transaction reverted (cert may already be revoked)"
+                        "revokeCert transaction reverted after inclusion; receipt has no revert data"
                     );
                     RegistrarMetrics::revoke_cert_reverted_total().increment(1);
                 }
@@ -134,11 +146,22 @@ where
                     RegistrarMetrics::revoke_cert_success_total().increment(1);
                 }
                 Err(e) => {
-                    warn!(
-                        error = %e,
-                        path_digest = %revoked.path_digest,
-                        "failed to submit revokeCert transaction"
-                    );
+                    let nitro_error = Self::revoke_cert_revert_name(&e);
+                    if matches!(nitro_error, Some("CallerNotOwnerOrRevoker")) {
+                        warn!(
+                            error = %e,
+                            nitro_error = ?nitro_error,
+                            path_digest = %revoked.path_digest,
+                            "revokeCert sender is not authorized; configure registrar signer as Nitro owner or revoker"
+                        );
+                    } else {
+                        warn!(
+                            error = %e,
+                            nitro_error = ?nitro_error,
+                            path_digest = %revoked.path_digest,
+                            "failed to submit revokeCert transaction"
+                        );
+                    }
                     RegistrarMetrics::revoke_cert_tx_failures().increment(1);
                 }
             }
@@ -152,9 +175,10 @@ where
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::{Address, B256, Bytes};
     use async_trait::async_trait;
-    use base_proof_contracts::ContractError;
+    use base_proof_contracts::{ContractError, caller_not_owner_or_revoker_selector};
+    use base_tx_manager::TxManagerError;
 
     use super::*;
     use crate::test_utils::{EP1, NoopTxManager, healthy_prover_instance};
@@ -251,5 +275,26 @@ mod tests {
             .unwrap();
 
         assert!(!revoked);
+    }
+
+    #[test]
+    fn revoke_cert_revert_name_decodes_authorization_error() {
+        let err = TxManagerError::ExecutionReverted {
+            reason: None,
+            data: Some(Bytes::from(caller_not_owner_or_revoker_selector().to_vec())),
+        };
+
+        assert_eq!(
+            CertManager::<NoopTxManager>::revoke_cert_revert_name(&err),
+            Some("CallerNotOwnerOrRevoker"),
+        );
+    }
+
+    #[test]
+    fn revoke_cert_revert_name_ignores_unrelated_tx_errors() {
+        assert_eq!(
+            CertManager::<NoopTxManager>::revoke_cert_revert_name(&TxManagerError::NonceTooLow),
+            None,
+        );
     }
 }


### PR DESCRIPTION
## Gap
`CertManager` treated `revokeCert()` failures as generic tx-manager failures, and mined `status=false` receipts logged that the cert may already be revoked. That is misleading because `revokeCert()` is idempotent; the actionable failure for this path is usually registrar signer authorization, especially when the sender is not the Nitro owner or configured revoker.

## Value-add
- Adds the `NitroEnclaveVerifier.CallerNotOwnerOrRevoker` custom error selector to the revocation binding.
- Decodes that custom error from `TxManagerError::ExecutionReverted` and logs a direct operator remediation: configure the registrar signer as Nitro owner or revoker.
- Removes the misleading mined-revert log text that suggested an already-revoked certificate could explain the revert.

## Testing
- `cargo test -p base-proof-contracts --lib`
- `DOCS_RS=1 RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar revoke_cert_revert_name_decodes_authorization_error --lib`
- `DOCS_RS=1 RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar revoke_cert_revert_name_ignores_unrelated_tx_errors --lib`
- `DOCS_RS=1 RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar --lib`

`DOCS_RS=1 RISC0_SKIP_BUILD_KERNELS=1` avoids local RISC0 artifact/Metal-kernel build requirements while running the registrar library tests.