### PR TITLE
fix(eip8130): surface mid-call database errors as fatal, not reverts

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -731,8 +731,8 @@ impl Eip8130Executor {
     where
         DB: AlloyDatabase,
         P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
-        BaseContext<DB>: BaseContextTr
-            + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
+        BaseContext<DB>:
+            BaseContextTr + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
     {
         let (ctx, precompiles) = evm.ctx_precompiles();
 
@@ -764,8 +764,8 @@ impl Eip8130Executor {
     where
         DB: AlloyDatabase,
         P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
-        BaseContext<DB>: BaseContextTr
-            + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
+        BaseContext<DB>:
+            BaseContextTr + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
     {
         let ctx = evm.ctx_mut();
         ctx.journal_mut().checkpoint_revert(checkpoint);
@@ -1142,10 +1142,7 @@ mod tests {
         let mut db = InMemoryDB::default();
         db.insert_account_info(
             sender,
-            AccountInfo {
-                balance: U256::from(10u64).pow(U256::from(18u64)),
-                ..Default::default()
-            },
+            AccountInfo { balance: U256::from(10u64).pow(U256::from(18u64)), ..Default::default() },
         );
         db.insert_account_info(
             target,

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -56,6 +56,7 @@ use revm::{
     context::{BlockEnv, LocalContextTr, TxEnv, journaled_state::account::JournaledAccountTr},
     context_interface::{
         Block, Cfg, ContextTr, JournalTr,
+        context::take_error,
         result::{EVMError, ExecutionResult, Output, ResultGas, SuccessReason},
     },
     handler::{EthFrame, EvmTr, FrameResult, Handler, PrecompileProvider},
@@ -686,7 +687,19 @@ impl Eip8130Executor {
             EVMError<DB::Error, BaseTransactionError>,
             EthFrame<EthInterpreter>,
         >::new();
-        handler.run_exec_loop(evm, frame_init)
+        let frame = handler.run_exec_loop(evm, frame_init)?;
+
+        // A top-level frame's database error is recorded on the context and the
+        // interpreter halts with `FatalExternalError`; unlike a nested frame
+        // (whose error is surfaced when its outcome is folded into the parent
+        // via `EthFrame::return_result`), the root frame is returned directly by
+        // `run_exec_loop` without that check. Mirror the mainnet
+        // `Handler::execution_result` guard so a node-local DB failure raised
+        // mid-call propagates as a fatal `Err` instead of being misread as a
+        // deterministic call revert on this consensus-critical path.
+        take_error::<EVMError<DB::Error, BaseTransactionError>, _>(evm.ctx_mut().error())?;
+
+        Ok(frame)
     }
 
     /// Settles the final fee against the pre-charged amount: caps the gas refund,
@@ -802,9 +815,11 @@ mod tests {
     use base_common_consensus::{BaseTxEnvelope, Call, Eip8130Signed, Predeploys, TxEip8130};
     use k256::ecdsa::SigningKey;
     use revm::{
+        Database,
         bytecode::Bytecode,
         context::{BlockEnv, CfgEnv, Context},
         database::InMemoryDB,
+        database_interface::DBErrorMarker,
         inspector::NoOpInspector,
         state::AccountInfo,
     };
@@ -984,6 +999,112 @@ mod tests {
         let sender_acc = outcome.state.get(&sender).expect("sender in state");
         assert_eq!(sender_acc.info.nonce, 1);
         assert!(sender_acc.info.balance < initial, "payer should still be charged");
+    }
+
+    /// Database error returned by [`StorageFailDb`] when a gated address is read.
+    #[derive(Debug)]
+    struct StorageUnavailable;
+
+    impl core::fmt::Display for StorageUnavailable {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str("storage temporarily unavailable")
+        }
+    }
+
+    impl core::error::Error for StorageUnavailable {}
+
+    impl DBErrorMarker for StorageUnavailable {}
+
+    /// Wraps an [`InMemoryDB`] and fails every `storage` read for a single
+    /// address, modelling a node-local backend failure (e.g. a missing trie
+    /// node) encountered while an EVM call executes an `SLOAD`. All other reads
+    /// delegate to the inner database.
+    #[derive(Debug)]
+    struct StorageFailDb {
+        inner: InMemoryDB,
+        fail_storage_at: Address,
+    }
+
+    impl Database for StorageFailDb {
+        type Error = StorageUnavailable;
+
+        fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(self.inner.basic(address).expect("infallible"))
+        }
+
+        fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(self.inner.code_by_hash(code_hash).expect("infallible"))
+        }
+
+        fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+            if address == self.fail_storage_at {
+                return Err(StorageUnavailable);
+            }
+            Ok(self.inner.storage(address, index).expect("infallible"))
+        }
+
+        fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+            Ok(self.inner.block_hash(number).expect("infallible"))
+        }
+    }
+
+    #[test]
+    fn db_failure_during_call_propagates_as_error_not_revert() {
+        // A node-local database failure raised *inside* a call's execution (here
+        // an `SLOAD` the backend cannot serve) must abort the whole transaction
+        // as a fatal `EVMError::Database`, never be folded into the deterministic
+        // "phase reverted" path — otherwise a node that hits the failure would
+        // include the tx as reverted while a healthy node would execute it,
+        // forking consensus.
+        let target = address!("0x00000000000000000000000000000000000000c7");
+        let key = signing_key(0x77);
+        let sender = eoa_address(&key);
+
+        let mut tx = base_tx();
+        tx.calls = vec![vec![Call { to: target, data: Bytes::new() }]];
+        let signed = eoa_signed(tx, &key);
+
+        // Target code: PUSH1 0x00, SLOAD, STOP. The `SLOAD` forces a storage read
+        // of `target`, which the wrapping database refuses to serve.
+        let code = bytes!("60005400");
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            sender,
+            AccountInfo {
+                balance: U256::from(10u64).pow(U256::from(18u64)),
+                ..Default::default()
+            },
+        );
+        db.insert_account_info(
+            target,
+            AccountInfo {
+                code_hash: keccak256(&code),
+                code: Some(Bytecode::new_raw(code)),
+                ..Default::default()
+            },
+        );
+        let db = StorageFailDb { inner: db, fail_storage_at: target };
+
+        let mut evm = Context::base()
+            .with_db(db)
+            .with_cfg(
+                CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Isthmus))
+                    .with_chain_id(CHAIN_ID),
+            )
+            .with_block(BlockEnv {
+                number: U256::from(1u64),
+                timestamp: U256::from(NOW),
+                basefee: BASE_FEE,
+                beneficiary: BENEFICIARY,
+                ..Default::default()
+            })
+            .build_with_inspector(NoOpInspector);
+
+        let err = evm.transact_raw(into_base_tx(&signed)).unwrap_err();
+        assert!(
+            matches!(err, EVMError::Database(_)),
+            "DB failure during a call must surface as a fatal database error, got {err:?}",
+        );
     }
 
     #[test]

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -53,7 +53,10 @@ use base_execution_eip8130::{
 };
 use base_precompile_storage::{JournalStorageProvider, StorageCtx};
 use revm::{
-    context::{BlockEnv, LocalContextTr, TxEnv, journaled_state::account::JournaledAccountTr},
+    context::{
+        BlockEnv, LocalContextTr, TxEnv,
+        journaled_state::{JournalCheckpoint, account::JournaledAccountTr},
+    },
     context_interface::{
         Block, Cfg, ContextTr, JournalTr,
         context::take_error,
@@ -64,6 +67,7 @@ use revm::{
         CallInput, CallInputs, CallScheme, CallValue, FrameInput, InterpreterResult, SharedMemory,
         interpreter::EthInterpreter, interpreter_action::FrameInit,
     },
+    primitives::hardfork::SpecId,
     state::Bytecode,
 };
 
@@ -233,26 +237,38 @@ impl Eip8130Executor {
             }
         };
 
+        // Mirror the mainnet handler's `load_accounts` pre-execution step, which
+        // the 8130 path bypasses: set the journal's EVM spec id and warm the
+        // precompiles and (EIP-3651) the coinbase before dispatching calls, so a
+        // call is charged identically to one in a normal transaction on the same
+        // chain.
+        Self::warm_pre_call_accounts(evm);
+
         let calls = match Self::execute_calls(evm, &signed, &outcome) {
             Ok(calls) => calls,
             Err(err) => {
-                let ctx = evm.ctx_mut();
-                ctx.journal_mut().checkpoint_revert(checkpoint);
-                ctx.chain_mut().clear_tx_l1_cost();
+                Self::teardown_after_error(evm, checkpoint);
+                return Err(err);
+            }
+        };
+
+        let gas_used = match Self::settle_fees(
+            evm.ctx_mut(),
+            &outcome,
+            &calls,
+            prepay,
+            &encoded,
+            spec,
+            beneficiary,
+        ) {
+            Ok(gas_used) => gas_used,
+            Err(err) => {
+                Self::teardown_after_error(evm, checkpoint);
                 return Err(err);
             }
         };
 
         let ctx = evm.ctx_mut();
-        let gas_used =
-            match Self::settle_fees(ctx, &outcome, &calls, prepay, &encoded, spec, beneficiary) {
-                Ok(gas_used) => gas_used,
-                Err(err) => {
-                    ctx.journal_mut().checkpoint_revert(checkpoint);
-                    ctx.chain_mut().clear_tx_l1_cost();
-                    return Err(err);
-                }
-            };
 
         let logs = ctx.journal_mut().take_logs();
 
@@ -702,6 +718,62 @@ impl Eip8130Executor {
         Ok(frame)
     }
 
+    /// Mirrors the mainnet handler's `load_accounts` pre-execution step (minus
+    /// the access-list handling, for which an EIP-8130 transaction has no
+    /// analogue): sets the journal's EVM spec id, warms the precompile address
+    /// set, and warms the coinbase per EIP-3651 (Shanghai+). The 8130 path runs
+    /// `calls` directly without the single-frame handler, so without this the
+    /// dispatched calls would execute against the journal's default spec id and
+    /// a cold coinbase / precompile set — charging cold-access gas (2600) where a
+    /// call in a normal transaction is charged warm (100) and otherwise drifting
+    /// from EVM equivalence on the same chain.
+    fn warm_pre_call_accounts<DB, I, P>(evm: &mut BaseEvm<DB, I, P>)
+    where
+        DB: AlloyDatabase,
+        P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
+        BaseContext<DB>: BaseContextTr
+            + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
+    {
+        let (ctx, precompiles) = evm.ctx_precompiles();
+
+        let gen_spec = ctx.cfg().spec();
+        let eth_spec: SpecId = gen_spec.into();
+        ctx.journal_mut().set_spec_id(eth_spec);
+
+        // Inject the precompile addresses when the spec changed them or the
+        // journal has not been warmed yet, matching `pre_execution::load_accounts`.
+        let precompiles_changed = precompiles.set_spec(gen_spec);
+        if precompiles_changed || ctx.journal_mut().precompile_addresses().is_empty() {
+            ctx.journal_mut().warm_precompiles(precompiles.warm_addresses());
+        }
+
+        // EIP-3651: the COINBASE address starts warm from Shanghai onward.
+        if eth_spec.is_enabled_in(SpecId::SHANGHAI) {
+            let coinbase = ctx.block().beneficiary();
+            ctx.journal_mut().warm_coinbase_account(coinbase);
+        }
+    }
+
+    /// Centralized post-error teardown mirroring the mainnet handler's
+    /// `catch_error` cleanup: reverts the transaction checkpoint, clears the
+    /// cached L1 cost, and drains the frame stack and local context. A database
+    /// error raised inside a nested subcall surfaces while the parent frame is
+    /// still on the stack, so draining both prevents stale frame/local state
+    /// from leaking into the next transaction when a `BaseEvm` is reused.
+    fn teardown_after_error<DB, I, P>(evm: &mut BaseEvm<DB, I, P>, checkpoint: JournalCheckpoint)
+    where
+        DB: AlloyDatabase,
+        P: PrecompileProvider<BaseContext<DB>, Output = InterpreterResult>,
+        BaseContext<DB>: BaseContextTr
+            + ContextTr<Db = DB, Tx = BaseTransaction<TxEnv>, Block = BlockEnv>,
+    {
+        let ctx = evm.ctx_mut();
+        ctx.journal_mut().checkpoint_revert(checkpoint);
+        ctx.chain_mut().clear_tx_l1_cost();
+        evm.ctx().local_mut().clear();
+        evm.frame_stack().clear();
+    }
+
     /// Settles the final fee against the pre-charged amount: caps the gas refund,
     /// computes the billable gas, refunds the surplus to the payer, and routes
     /// the base fee, priority tip, L1 cost, and operator fee to their vaults.
@@ -1104,6 +1176,55 @@ mod tests {
         assert!(
             matches!(err, EVMError::Database(_)),
             "DB failure during a call must surface as a fatal database error, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn call_warms_coinbase_per_eip3651() {
+        // EIP-3651: a dispatched call must see the coinbase pre-warmed, exactly
+        // as a call in a normal transaction does. `BALANCE(coinbase)` therefore
+        // costs warm access (100) rather than cold (2600). We compare it against
+        // an otherwise-identical `BALANCE` of an untouched address (cold) and
+        // require the coinbase read to be strictly cheaper; without coinbase
+        // warming both reads are cold and the gas is identical.
+        fn balance_of(addr: Address) -> Bytes {
+            // PUSH20 <addr>, BALANCE, STOP
+            let mut code = Vec::with_capacity(23);
+            code.push(0x73);
+            code.extend_from_slice(addr.as_slice());
+            code.push(0x31);
+            code.push(0x00);
+            Bytes::from(code)
+        }
+
+        let target = address!("0x00000000000000000000000000000000000000c8");
+        let cold_account = address!("0x00000000000000000000000000000000000000dd");
+
+        let run = |code: Bytes, signer: u8| -> u64 {
+            let key = signing_key(signer);
+            let sender = eoa_address(&key);
+            let mut tx = base_tx();
+            tx.calls = vec![vec![Call { to: target, data: Bytes::new() }]];
+            let signed = eoa_signed(tx, &key);
+            let mut evm = evm_with_accounts(
+                U256::from(10u64).pow(U256::from(18u64)),
+                sender,
+                &[(target, code)],
+            );
+            let outcome = evm.transact_raw(into_base_tx(&signed)).expect("call should execute");
+            assert!(outcome.result.is_success(), "expected success, got {:?}", outcome.result);
+            outcome.result.gas().tx_gas_used()
+        };
+
+        // Both calls are byte-for-byte identical except the address read, so the
+        // only gas difference is the cold-vs-warm access cost of that address.
+        let warm_coinbase_gas = run(balance_of(BENEFICIARY), 0x78);
+        let cold_account_gas = run(balance_of(cold_account), 0x79);
+
+        assert!(
+            warm_coinbase_gas < cold_account_gas,
+            "BALANCE(coinbase) ({warm_coinbase_gas}) must be cheaper than a cold \
+             BALANCE ({cold_account_gas}) because EIP-3651 pre-warms the coinbase",
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #3696. Three fixes to the EIP-8130 phased-call executor, which runs `calls` directly and bypasses the mainnet single-frame handler — and with it several of the handler's steps.

### 1. Mid-call DB errors must be fatal, not reverts (consensus-critical)

EIP-8130 calls are dispatched as depth-0 top-level frames via `run_call`. revm only converts a frame's recorded DB error into an `Err` when a *child* frame's outcome is folded into its parent (`EthFrame::return_result` → `take_error`); the **root** frame is returned directly by `run_exec_loop` without that check. So a DB failure during a call (e.g. an `SLOAD` against a missing trie node) halted the interpreter with `FatalExternalError` and came back as a non-ok `InterpreterResult`, which `execute_calls` folded into the `phase_reverted` path.

This is consensus-unsafe: a node hitting the DB failure would include the tx as reverted (nonce consumed, fee paid), while a healthy node would execute it normally — a fork. Every other tx type is protected via `Handler::execution_result`'s `take_error` guard; the 8130 path bypasses it.

**Fix:** call `take_error` after `run_exec_loop` in `run_call`.

### 2. Warm coinbase + precompiles + set journal spec before calls (EVM equivalence)

The 8130 path skips the handler's `load_accounts`, so dispatched calls ran against the journal's default spec id with a **cold coinbase** and an unwarmed precompile set — charging cold access (2600) where a call in a normal tx is charged warm (100). Deterministic, but a gas/EVM-equivalence bug.

**Fix:** `warm_pre_call_accounts` mirrors `pre_execution::load_accounts` (minus access-list handling, which 8130 has no analogue for): sets the journal EVM spec id, warms precompiles, and warms the coinbase (Shanghai+), invoked right before `execute_calls`.

### 3. Centralized post-error teardown (defensive)

The `execute_calls` / `settle_fees` error paths only reverted the checkpoint and cleared the L1 cost. A DB error inside a *nested subcall* surfaces while the parent frame is still on the stack, so stale frame/local state could leak into the next tx reusing the same `BaseEvm`.

**Fix:** `teardown_after_error` mirrors the mainnet `catch_error` cleanup (checkpoint revert + clear L1 cost + `local_mut().clear()` + `frame_stack().clear()`), used on both error paths.

## Tests
- `db_failure_during_call_propagates_as_error_not_revert` — a call whose `SLOAD` is refused by a wrapping DB must fail with `EVMError::Database`, not be included as a revert. (Verified it fails without fix #1.)
- `call_warms_coinbase_per_eip3651` — `BALANCE(coinbase)` must be strictly cheaper than a byte-identical `BALANCE` of an untouched address, which only holds when the coinbase is pre-warmed. (Verified it fails without fix #2.)

## Test plan
- [x] `cargo test -p base-common-evm --features std eip8130` (13 passed)
- [x] `cargo clippy -p base-common-evm --features std --all-targets` clean
- [x] `cargo check -p base-common-evm --no-default-features` (no_std) compiles