### PR TITLE
feat(eip8130): add 0x7B span batch codec

### DIFF
--- a/crates/consensus/protocol/src/batch/errors.rs
+++ b/crates/consensus/protocol/src/batch/errors.rs
@@ -85,6 +85,9 @@ pub enum SpanDecodingError {
     /// Invalid transaction data
     #[error("Invalid transaction data")]
     InvalidTransactionData,
+    /// Invalid EIP-8130 authentication data
+    #[error("Invalid EIP-8130 auth data")]
+    InvalidAuthData,
     /// Invalid transaction signature
     #[error("Invalid transaction signature")]
     InvalidTransactionSignature,

--- a/crates/consensus/protocol/src/batch/mod.rs
+++ b/crates/consensus/protocol/src/batch/mod.rs
@@ -77,7 +77,8 @@ pub use single::SingleBatch;
 mod tx_data;
 pub use tx_data::{
     SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
-    SpanBatchEip7702TransactionData, SpanBatchLegacyTransactionData, SpanBatchTransactionData,
+    SpanBatchEip7702TransactionData, SpanBatchEip8130TransactionData,
+    SpanBatchLegacyTransactionData, SpanBatchTransactionData,
 };
 
 mod traits;

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -3,14 +3,15 @@
 
 use alloc::vec::Vec;
 
-use alloy_consensus::{Transaction, TxEnvelope, TxType};
+use alloy_consensus::Transaction;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bytes, Signature, U256, bytes};
 use alloy_rlp::{Buf, Decodable, Encodable};
+use base_common_consensus::{BaseTxEnvelope, OpTxType};
 
 use crate::{
-    SpanBatchBits, SpanBatchElement, SpanBatchError, SpanBatchTransactionData, SpanDecodingError,
-    read_tx_data,
+    SpanBatchBits, SpanBatchEip8130TransactionData, SpanBatchElement, SpanBatchError,
+    SpanBatchTransactionData, SpanDecodingError, read_tx_data,
 };
 
 /// This struct contains the decoded information for transactions in a span batch.
@@ -33,9 +34,12 @@ pub struct SpanBatchTransactions {
     /// The protected bits, standard span-batch bitlist.
     pub protected_bits: SpanBatchBits,
     /// The types of the transactions.
-    pub tx_types: Vec<TxType>,
+    pub tx_types: Vec<OpTxType>,
     /// Total legacy transaction count in the span batch.
     pub legacy_tx_count: u64,
+    /// The EIP-8130 auth proofs, one `(sender_proof, payer_proof)` pair per
+    /// EIP-8130 transaction in transaction order.
+    pub eip8130_auth_data: Vec<(Bytes, Bytes)>,
 }
 
 impl SpanBatchTransactions {
@@ -48,6 +52,7 @@ impl SpanBatchTransactions {
         self.encode_tx_nonces(w)?;
         self.encode_tx_gases(w)?;
         self.encode_protected_bits(w)?;
+        self.encode_eip8130_auth_data(w)?;
         Ok(())
     }
 
@@ -60,6 +65,7 @@ impl SpanBatchTransactions {
         self.decode_tx_nonces(r)?;
         self.decode_tx_gases(r)?;
         self.decode_protected_bits(r)?;
+        self.decode_eip8130_auth_data(r)?;
         Ok(())
     }
 
@@ -125,6 +131,23 @@ impl SpanBatchTransactions {
     pub fn encode_tx_data(&self, w: &mut dyn bytes::BufMut) -> Result<(), SpanBatchError> {
         for data in &self.tx_data {
             w.put_slice(data);
+        }
+        Ok(())
+    }
+
+    /// Encode the EIP-8130 auth proofs into a writer. Each bundle is the
+    /// uvarint-prefixed sender proof followed by the uvarint-prefixed payer proof.
+    pub fn encode_eip8130_auth_data(
+        &self,
+        w: &mut dyn bytes::BufMut,
+    ) -> Result<(), SpanBatchError> {
+        let mut buf = [0u8; 10];
+        for (sender_proof, payer_proof) in &self.eip8130_auth_data {
+            for proof in [sender_proof, payer_proof] {
+                let len = unsigned_varint::encode::u64(proof.len() as u64, &mut buf);
+                w.put_slice(len);
+                w.put_slice(proof);
+            }
         }
         Ok(())
     }
@@ -220,7 +243,7 @@ impl SpanBatchTransactions {
             let (tx_data_item, tx_type) = read_tx_data(r)?;
             tx_data.push(tx_data_item);
             tx_types.push(tx_type);
-            if matches!(tx_type, TxType::Legacy) {
+            if matches!(tx_type, OpTxType::Legacy) {
                 self.legacy_tx_count += 1;
             }
         }
@@ -229,6 +252,40 @@ impl SpanBatchTransactions {
         self.tx_types = tx_types;
 
         Ok(())
+    }
+
+    /// Decode the EIP-8130 auth proofs from a reader, reading one
+    /// `(sender_proof, payer_proof)` bundle for each EIP-8130 transaction in
+    /// transaction order.
+    pub fn decode_eip8130_auth_data(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
+        let mut auth_data = Vec::new();
+        for tx_type in &self.tx_types {
+            if !matches!(tx_type, OpTxType::Eip8130) {
+                continue;
+            }
+            let sender_proof = Self::decode_eip8130_proof(r)?;
+            let payer_proof = Self::decode_eip8130_proof(r)?;
+            auth_data.push((sender_proof, payer_proof));
+        }
+        self.eip8130_auth_data = auth_data;
+        Ok(())
+    }
+
+    /// Decode a single uvarint-prefixed EIP-8130 auth proof from a reader.
+    fn decode_eip8130_proof(r: &mut &[u8]) -> Result<Bytes, SpanBatchError> {
+        let (n, remaining) = unsigned_varint::decode::u64(r)
+            .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::InvalidAuthData))?;
+        *r = remaining;
+        if n > SpanBatchEip8130TransactionData::MAX_AUTH_PROOF_BYTES {
+            return Err(SpanBatchError::TooBigSpanBatchSize);
+        }
+        let n = n as usize;
+        if r.len() < n {
+            return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
+        }
+        let proof = Bytes::copy_from_slice(&r[..n]);
+        r.advance(n);
+        Ok(proof)
     }
 
     /// Returns the number of contract creation transactions in the span batch.
@@ -241,6 +298,7 @@ impl SpanBatchTransactions {
         let mut txs = Vec::new();
         let mut to_idx = 0;
         let mut protected_bit_idx = 0;
+        let mut eip8130_idx = 0;
         for idx in 0..self.total_block_tx_count {
             let mut data = self.tx_data[idx as usize].as_slice();
             let tx = SpanBatchTransactionData::decode(&mut data)
@@ -268,11 +326,28 @@ impl SpanBatchTransactions {
             } else {
                 None
             };
+
+            // EIP-8130 transactions are reassembled from the remainder and the auth proofs
+            // carried in the trailing column, then re-encoded directly.
+            if let SpanBatchTransactionData::Eip8130(data) = &tx {
+                let (sender_proof, payer_proof) = self
+                    .eip8130_auth_data
+                    .get(eip8130_idx)
+                    .ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
+                eip8130_idx += 1;
+                let signed =
+                    data.to_tx(chain_id, *nonce, *gas, sender_proof.clone(), payer_proof.clone());
+                let mut buf = Vec::new();
+                BaseTxEnvelope::Eip8130(signed).encode_2718(&mut buf);
+                txs.push(buf);
+                continue;
+            }
+
             let sig = *self
                 .tx_sigs
                 .get(idx as usize)
                 .ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
-            let is_protected = if tx.tx_type() == TxType::Legacy {
+            let is_protected = if tx.tx_type() == OpTxType::Legacy {
                 protected_bit_idx += 1;
                 self.protected_bits.get_bit(protected_bit_idx - 1).unwrap_or_default() == 1
             } else {
@@ -292,48 +367,82 @@ impl SpanBatchTransactions {
         let offset = self.total_block_tx_count;
 
         for i in 0..total_block_tx_count {
-            let tx_enveloped = TxEnvelope::decode(&mut txs[i as usize].as_ref())
+            let tx_enveloped = BaseTxEnvelope::decode(&mut txs[i as usize].as_ref())
                 .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;
             let span_batch_tx = SpanBatchTransactionData::try_from(&tx_enveloped)?;
-
             let tx_type = tx_enveloped.tx_type();
-            if matches!(tx_type, TxType::Legacy) {
-                let protected_bit = tx_enveloped.is_replay_protected();
-                self.protected_bits.set_bit(self.legacy_tx_count as usize, protected_bit);
-                self.legacy_tx_count += 1;
-            }
 
-            let (signature, to, nonce, gas, tx_chain_id) = match &tx_enveloped {
-                TxEnvelope::Legacy(tx) => {
+            let (signature, to, nonce, gas) = match &tx_enveloped {
+                BaseTxEnvelope::Legacy(tx) => {
                     let (tx, sig) = (tx.tx(), tx.signature());
-                    (sig, tx.to(), tx.nonce(), tx.gas_limit(), tx.chain_id())
+                    let protected = tx.chain_id.is_some();
+                    if protected && tx.chain_id != Some(chain_id) {
+                        return Err(SpanBatchError::Decoding(
+                            SpanDecodingError::InvalidTransactionData,
+                        ));
+                    }
+                    self.protected_bits.set_bit(self.legacy_tx_count as usize, protected);
+                    self.legacy_tx_count += 1;
+                    (*sig, tx.to(), tx.nonce(), tx.gas_limit())
                 }
-                TxEnvelope::Eip2930(tx) => {
+                BaseTxEnvelope::Eip2930(tx) => {
                     let (tx, sig) = (tx.tx(), tx.signature());
-                    (sig, tx.to(), tx.nonce(), tx.gas_limit(), tx.chain_id())
+                    if tx.chain_id != chain_id {
+                        return Err(SpanBatchError::Decoding(
+                            SpanDecodingError::InvalidTransactionData,
+                        ));
+                    }
+                    (*sig, tx.to(), tx.nonce(), tx.gas_limit())
                 }
-                TxEnvelope::Eip1559(tx) => {
+                BaseTxEnvelope::Eip1559(tx) => {
                     let (tx, sig) = (tx.tx(), tx.signature());
-                    (sig, tx.to(), tx.nonce(), tx.gas_limit(), tx.chain_id())
+                    if tx.chain_id != chain_id {
+                        return Err(SpanBatchError::Decoding(
+                            SpanDecodingError::InvalidTransactionData,
+                        ));
+                    }
+                    (*sig, tx.to(), tx.nonce(), tx.gas_limit())
                 }
-                TxEnvelope::Eip7702(tx) => {
+                BaseTxEnvelope::Eip7702(tx) => {
                     let (tx, sig) = (tx.tx(), tx.signature());
-                    (sig, tx.to(), tx.nonce(), tx.gas_limit(), tx.chain_id())
+                    if tx.chain_id != chain_id {
+                        return Err(SpanBatchError::Decoding(
+                            SpanDecodingError::InvalidTransactionData,
+                        ));
+                    }
+                    (*sig, tx.to(), tx.nonce(), tx.gas_limit())
                 }
-                _ => {
+                BaseTxEnvelope::Eip8130(signed) => {
+                    let inner = signed.tx();
+                    if inner.chain_id != chain_id {
+                        return Err(SpanBatchError::Decoding(
+                            SpanDecodingError::InvalidTransactionData,
+                        ));
+                    }
+                    let sender_proof = SpanBatchEip8130TransactionData::split_auth(
+                        signed.sender_auth(),
+                        inner.sender.is_some(),
+                    )?
+                    .1;
+                    let payer_proof = SpanBatchEip8130TransactionData::split_auth(
+                        signed.payer_auth(),
+                        inner.payer.is_some(),
+                    )?
+                    .1;
+                    self.eip8130_auth_data.push((sender_proof, payer_proof));
+                    (
+                        Signature::new(U256::ZERO, U256::ZERO, false),
+                        None,
+                        inner.nonce_sequence,
+                        inner.gas_limit,
+                    )
+                }
+                BaseTxEnvelope::Deposit(_) => {
                     return Err(SpanBatchError::Decoding(
-                        SpanDecodingError::InvalidTransactionData,
+                        SpanDecodingError::InvalidTransactionType,
                     ));
                 }
             };
-
-            if tx_enveloped.is_replay_protected()
-                && tx_chain_id
-                    .ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?
-                    != chain_id
-            {
-                return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
-            }
 
             let contract_creation_bit = match to {
                 Some(address) => {
@@ -345,7 +454,7 @@ impl SpanBatchTransactions {
             let mut tx_data_buf = Vec::new();
             span_batch_tx.encode(&mut tx_data_buf);
 
-            self.tx_sigs.push(*signature);
+            self.tx_sigs.push(signature);
             self.contract_creation_bits.set_bit((i + offset) as usize, contract_creation_bit == 1);
             self.tx_nonces.push(nonce);
             self.tx_data.push(tx_data_buf);
@@ -361,10 +470,16 @@ impl SpanBatchTransactions {
 mod tests {
     use alloc::vec;
 
-    use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxEip7702};
-    use alloy_primitives::{Signature, TxKind, address};
+    use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy};
+    use alloy_primitives::{B256, Signature, TxKind, address};
+    use base_common_consensus::{
+        AccountChange, ActorChange, ActorChangeType, Call, ConfigChange, CreateEntry, Delegation,
+        Eip8130Signed, InitialActor, TxEip8130,
+    };
 
     use super::*;
+
+    const EIP8130_CHAIN_ID: u64 = 8453;
 
     /// Regression: truncated input to `decode_tx_sigs` must return an error, not panic.
     /// A dishonest batcher can craft a span batch with fewer bytes than the declared tx count
@@ -393,6 +508,31 @@ mod tests {
         assert_eq!(
             txs.decode_tx_tos(&mut truncated.as_ref()),
             Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))
+        );
+    }
+
+    /// Regression: a length-prefix uvarint that never terminates must error as
+    /// auth data, not as nonce data.
+    #[test]
+    fn test_decode_eip8130_proof_truncated_length_prefix() {
+        let mut buf: &[u8] = &[0xff, 0xff, 0xff];
+        assert_eq!(
+            SpanBatchTransactions::decode_eip8130_proof(&mut buf),
+            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidAuthData))
+        );
+    }
+
+    /// Regression: a declared proof length above the byte cap fails fast before
+    /// any copy is attempted.
+    #[test]
+    fn test_decode_eip8130_proof_rejects_oversized_length() {
+        let oversized = SpanBatchEip8130TransactionData::MAX_AUTH_PROOF_BYTES + 1;
+        let mut varint_buf = unsigned_varint::encode::u64_buffer();
+        let prefix = unsigned_varint::encode::u64(oversized, &mut varint_buf);
+        let mut buf: &[u8] = prefix;
+        assert_eq!(
+            SpanBatchTransactions::decode_eip8130_proof(&mut buf),
+            Err(SpanBatchError::TooBigSpanBatchSize)
         );
     }
 
@@ -444,5 +584,221 @@ mod tests {
         let result = span_batch_txs.add_txs(vec![Bytes::from(buf)], 1);
         assert_eq!(result, Ok(()));
         assert_eq!(span_batch_txs.total_block_tx_count, 1);
+    }
+
+    /// Encodes an EIP-8130 transaction to its raw EIP-2718 form for round-trip inputs.
+    fn eip8130_raw(tx: TxEip8130, sender_auth: Bytes, payer_auth: Bytes) -> Bytes {
+        let mut buf = Vec::new();
+        BaseTxEnvelope::Eip8130(Eip8130Signed::new(tx, sender_auth, payer_auth))
+            .encode_2718(&mut buf);
+        Bytes::from(buf)
+    }
+
+    /// EOA self-pay EIP-8130 body; variants clone it and override individual fields.
+    fn eip8130_body() -> TxEip8130 {
+        TxEip8130 {
+            chain_id: EIP8130_CHAIN_ID,
+            sender: None,
+            nonce_key: U256::ZERO,
+            nonce_sequence: 0,
+            expiry: 0,
+            max_priority_fee_per_gas: 0,
+            max_fee_per_gas: 0,
+            gas_limit: 21_000,
+            account_changes: vec![],
+            calls: vec![],
+            metadata: Bytes::new(),
+            payer: None,
+        }
+    }
+
+    /// Drives one `add_txs -> encode -> decode -> full_txs` cycle and asserts the
+    /// reconstructed raw transactions are identical to the inputs.
+    fn assert_span_batch_roundtrip(raws: Vec<Bytes>, chain_id: u64) {
+        let count = raws.len() as u64;
+        let mut batch = SpanBatchTransactions::default();
+        batch.add_txs(raws.clone(), chain_id).unwrap();
+        let mut buf = Vec::new();
+        batch.encode(&mut buf).unwrap();
+
+        let mut decoded =
+            SpanBatchTransactions { total_block_tx_count: count, ..Default::default() };
+        decoded.decode(&mut buf.as_slice()).unwrap();
+        let rebuilt: Vec<Bytes> =
+            decoded.full_txs(chain_id).unwrap().into_iter().map(Bytes::from).collect();
+
+        assert_eq!(rebuilt, raws);
+    }
+
+    #[test]
+    fn test_eip8130_span_batch_roundtrip() {
+        let sender = address!("00000000000000000000000000000000000000aa");
+        let payer = address!("00000000000000000000000000000000000000bb");
+
+        // EOA self-pay: no explicit sender/payer, so the whole sender_auth is the proof.
+        let eoa = {
+            let mut tx = eip8130_body();
+            tx.nonce_sequence = 7;
+            tx.max_priority_fee_per_gas = 1_000_000_000;
+            tx.max_fee_per_gas = 5_000_000_000;
+            tx.calls = vec![vec![Call {
+                to: address!("00000000000000000000000000000000000000dd"),
+                data: bytes!("deadbeef"),
+            }]];
+            eip8130_raw(tx, Bytes::from_static(&[0xab; 65]), Bytes::new())
+        };
+
+        // Configured sender and explicit payer: each auth is a 20-byte authenticator
+        // address followed by a proof, which the codec splits across the remainder and
+        // the trailing auth column.
+        let configured = {
+            let mut tx = eip8130_body();
+            tx.sender = Some(sender);
+            tx.payer = Some(payer);
+            tx.nonce_key = U256::from(0x1234u64);
+            tx.nonce_sequence = 3;
+            tx.expiry = 1_900_000_000;
+            let mut sender_auth = sender.as_slice().to_vec();
+            sender_auth.extend_from_slice(&[0xcd; 32]);
+            let mut payer_auth = payer.as_slice().to_vec();
+            payer_auth.extend_from_slice(&[0xef; 16]);
+            eip8130_raw(tx, Bytes::from(sender_auth), Bytes::from(payer_auth))
+        };
+
+        // Every account-change variant plus multi-phase calls and metadata.
+        let rich = {
+            let mut tx = eip8130_body();
+            tx.sender = Some(sender);
+            tx.nonce_sequence = 11;
+            tx.account_changes = vec![
+                AccountChange::Create(CreateEntry {
+                    user_salt: B256::repeat_byte(0x01),
+                    code: bytes!("60006000fd"),
+                    initial_actors: vec![InitialActor {
+                        actor_id: B256::repeat_byte(0x02),
+                        authenticator: address!("00000000000000000000000000000000000000cc"),
+                    }],
+                }),
+                AccountChange::ConfigChange(ConfigChange {
+                    chain_id: EIP8130_CHAIN_ID,
+                    sequence: 1,
+                    actor_changes: vec![
+                        ActorChange {
+                            change_type: ActorChangeType::Authorize,
+                            actor_id: B256::repeat_byte(0x03),
+                            data: bytes!("aabbcc"),
+                        },
+                        ActorChange {
+                            change_type: ActorChangeType::Revoke,
+                            actor_id: B256::repeat_byte(0x04),
+                            data: Bytes::new(),
+                        },
+                    ],
+                    auth: bytes!("c0ffee"),
+                }),
+                AccountChange::Delegation(Delegation {
+                    target: address!("00000000000000000000000000000000000000ee"),
+                }),
+            ];
+            tx.calls = vec![
+                vec![
+                    Call {
+                        to: address!("0000000000000000000000000000000000000001"),
+                        data: bytes!("11"),
+                    },
+                    Call {
+                        to: address!("0000000000000000000000000000000000000002"),
+                        data: bytes!("2222"),
+                    },
+                ],
+                vec![Call { to: Address::ZERO, data: Bytes::new() }],
+            ];
+            tx.metadata = bytes!("decafbad");
+            let mut sender_auth = sender.as_slice().to_vec();
+            sender_auth.extend_from_slice(&[0x99; 48]);
+            eip8130_raw(tx, Bytes::from(sender_auth), Bytes::new())
+        };
+
+        // Minimal body: empty auth, no account changes or calls.
+        let minimal = eip8130_raw(eip8130_body(), Bytes::new(), Bytes::new());
+
+        assert_span_batch_roundtrip(vec![eoa, configured, rich, minimal], EIP8130_CHAIN_ID);
+    }
+
+    #[test]
+    fn test_span_batch_mixed_eip8130_roundtrip() {
+        let to = address!("0123456789012345678901234567890123456789");
+        let sig = Signature::test_signature();
+
+        let mut legacy = Vec::new();
+        TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy {
+                chain_id: Some(EIP8130_CHAIN_ID),
+                nonce: 1,
+                gas_price: 1_000_000_000,
+                gas_limit: 21_000,
+                to: TxKind::Call(to),
+                value: U256::from(1u64),
+                input: bytes!("00"),
+            },
+            sig,
+            Default::default(),
+        ))
+        .encode_2718(&mut legacy);
+
+        let mut eip1559 = Vec::new();
+        TxEnvelope::Eip1559(Signed::new_unchecked(
+            TxEip1559 {
+                chain_id: EIP8130_CHAIN_ID,
+                nonce: 2,
+                gas_limit: 50_000,
+                max_fee_per_gas: 5_000_000_000,
+                max_priority_fee_per_gas: 1_000_000_000,
+                to: TxKind::Call(to),
+                ..Default::default()
+            },
+            sig,
+            Default::default(),
+        ))
+        .encode_2718(&mut eip1559);
+
+        let mut eip7702 = Vec::new();
+        TxEnvelope::Eip7702(Signed::new_unchecked(
+            TxEip7702 {
+                to,
+                chain_id: EIP8130_CHAIN_ID,
+                nonce: 3,
+                gas_limit: 60_000,
+                ..Default::default()
+            },
+            sig,
+            Default::default(),
+        ))
+        .encode_2718(&mut eip7702);
+
+        let aa_eoa = {
+            let mut tx = eip8130_body();
+            tx.nonce_sequence = 4;
+            eip8130_raw(tx, Bytes::from_static(&[0x01; 65]), Bytes::new())
+        };
+        let aa_configured = {
+            let mut tx = eip8130_body();
+            tx.sender = Some(to);
+            tx.nonce_sequence = 5;
+            let mut sender_auth = to.as_slice().to_vec();
+            sender_auth.extend_from_slice(&[0x02; 16]);
+            eip8130_raw(tx, Bytes::from(sender_auth), Bytes::new())
+        };
+
+        assert_span_batch_roundtrip(
+            vec![
+                Bytes::from(legacy),
+                aa_eoa,
+                Bytes::from(eip1559),
+                aa_configured,
+                Bytes::from(eip7702),
+            ],
+            EIP8130_CHAIN_ID,
+        );
     }
 }

--- a/crates/consensus/protocol/src/batch/tx_data/eip8130.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/eip8130.rs
@@ -1,0 +1,293 @@
+//! This module contains the eip8130 transaction data type for a span batch.
+
+use alloc::vec::Vec;
+
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header};
+use base_common_consensus::{AccountChange, Call, Eip8130Signed, TxEip8130};
+
+use crate::{Channel, SpanBatchError, SpanDecodingError};
+
+/// The low-entropy remainder of an EIP-8130 transaction within a span batch.
+///
+/// The chain id is dropped from the wire and reinjected from the batch chain id;
+/// the nonce sequence and gas limit are carried in the shared nonce and gas
+/// columns; the high-entropy authentication proofs are carried in a separate
+/// trailing column. The two authenticator fields hold the leading 20-byte
+/// account address on the configured-actor path and are empty on the EOA path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpanBatchEip8130TransactionData {
+    /// Explicit sender account address, or `None` for the EOA path.
+    pub sender: Option<Address>,
+    /// High bits of the compound nonce.
+    pub nonce_key: U256,
+    /// Unix-seconds expiry timestamp; `0` means no expiry.
+    pub expiry: u64,
+    /// Max priority fee per gas (tip).
+    pub max_priority_fee_per_gas: u128,
+    /// Max total fee per gas.
+    pub max_fee_per_gas: u128,
+    /// Optional explicit payer; `None` means the resolved sender pays gas.
+    pub payer: Option<Address>,
+    /// Account-mutation entries applied before calls execute.
+    pub account_changes: Vec<AccountChange>,
+    /// Calls dispatched by the protocol, grouped into phases.
+    pub calls: Vec<Vec<Call>>,
+    /// Opaque attribution bytes.
+    pub metadata: Bytes,
+    /// Sender authenticator (leading account address on the configured path,
+    /// empty on the EOA path).
+    pub sender_authenticator: Bytes,
+    /// Payer authenticator (leading account address on the configured path,
+    /// empty on the EOA path).
+    pub payer_authenticator: Bytes,
+}
+
+impl SpanBatchEip8130TransactionData {
+    /// Fail-fast upper bound, in bytes, on a single EIP-8130 auth proof.
+    ///
+    /// A single proof cannot exceed the byte budget of the channel that carries
+    /// the whole span batch, so it is derived from [`Channel::MAX_RLP_BYTES`].
+    /// The genuine allocation bound is the subsequent `r.len() < n` check in the
+    /// decoder; this constant only rejects an obviously corrupt length prefix
+    /// before any copy is attempted.
+    pub const MAX_AUTH_PROOF_BYTES: u64 = Channel::MAX_RLP_BYTES;
+
+    /// Encodes an `Option<Address>` as a zero-length byte string when `None` and
+    /// a 20-byte string when `Some`.
+    fn encode_address_opt(addr: &Option<Address>, out: &mut dyn BufMut) {
+        match addr {
+            None => Bytes::new().encode(out),
+            Some(a) => Bytes::copy_from_slice(a.as_slice()).encode(out),
+        }
+    }
+
+    /// Length contribution of an `Option<Address>` under [`Self::encode_address_opt`].
+    const fn address_opt_encoded_length(addr: &Option<Address>) -> usize {
+        match addr {
+            None => 1,
+            Some(_) => 21,
+        }
+    }
+
+    /// Decodes the [`Self::encode_address_opt`] wire format.
+    fn decode_address_opt(buf: &mut &[u8]) -> alloy_rlp::Result<Option<Address>> {
+        let raw = Bytes::decode(buf)?;
+        match raw.len() {
+            0 => Ok(None),
+            20 => Ok(Some(Address::from_slice(&raw))),
+            _ => Err(alloy_rlp::Error::Custom("invalid Option<Address> length")),
+        }
+    }
+
+    fn rlp_encoded_fields_length(&self) -> usize {
+        Self::address_opt_encoded_length(&self.sender)
+            + self.nonce_key.length()
+            + self.expiry.length()
+            + self.max_priority_fee_per_gas.length()
+            + self.max_fee_per_gas.length()
+            + Self::address_opt_encoded_length(&self.payer)
+            + self.account_changes.length()
+            + self.calls.length()
+            + self.metadata.length()
+            + self.sender_authenticator.length()
+            + self.payer_authenticator.length()
+    }
+
+    /// Splits an authentication blob into its authenticator and proof parts.
+    ///
+    /// Inverse of `join_auth`. On the EOA path (`configured` is false)
+    /// the authenticator is empty and the whole blob is the proof. On the
+    /// configured-actor path the blob is `authenticator(20) || proof`; a
+    /// configured blob shorter than 20 bytes is rejected.
+    pub fn split_auth(blob: &Bytes, configured: bool) -> Result<(Bytes, Bytes), SpanBatchError> {
+        if !configured {
+            return Ok((Bytes::new(), blob.clone()));
+        }
+        if blob.len() < 20 {
+            return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidAuthData));
+        }
+        Ok((blob.slice(..20), blob.slice(20..)))
+    }
+
+    /// Reassembles an authentication blob from its authenticator and proof parts.
+    ///
+    /// Inverse of `split_auth`.
+    fn join_auth(authenticator: &Bytes, proof: &Bytes, configured: bool) -> Bytes {
+        if !configured {
+            proof.clone()
+        } else if proof.is_empty() {
+            authenticator.clone()
+        } else {
+            let mut out = Vec::with_capacity(authenticator.len() + proof.len());
+            out.extend_from_slice(authenticator);
+            out.extend_from_slice(proof);
+            Bytes::from(out)
+        }
+    }
+
+    /// Reconstructs the signed [`Eip8130Signed`] from the remainder, the shared
+    /// columns, and the trailing-column auth proofs.
+    pub fn to_tx(
+        &self,
+        chain_id: u64,
+        nonce: u64,
+        gas: u64,
+        sender_proof: Bytes,
+        payer_proof: Bytes,
+    ) -> Eip8130Signed {
+        let sender_auth =
+            Self::join_auth(&self.sender_authenticator, &sender_proof, self.sender.is_some());
+        let payer_auth =
+            Self::join_auth(&self.payer_authenticator, &payer_proof, self.payer.is_some());
+        let tx = TxEip8130 {
+            chain_id,
+            sender: self.sender,
+            nonce_key: self.nonce_key,
+            nonce_sequence: nonce,
+            expiry: self.expiry,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            max_fee_per_gas: self.max_fee_per_gas,
+            gas_limit: gas,
+            account_changes: self.account_changes.clone(),
+            calls: self.calls.clone(),
+            metadata: self.metadata.clone(),
+            payer: self.payer,
+        };
+        Eip8130Signed::new(tx, sender_auth, payer_auth)
+    }
+}
+
+impl Encodable for SpanBatchEip8130TransactionData {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }.encode(out);
+        Self::encode_address_opt(&self.sender, out);
+        self.nonce_key.encode(out);
+        self.expiry.encode(out);
+        self.max_priority_fee_per_gas.encode(out);
+        self.max_fee_per_gas.encode(out);
+        Self::encode_address_opt(&self.payer, out);
+        self.account_changes.encode(out);
+        self.calls.encode(out);
+        self.metadata.encode(out);
+        self.sender_authenticator.encode(out);
+        self.payer_authenticator.encode(out);
+    }
+}
+
+impl Decodable for SpanBatchEip8130TransactionData {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started = buf.len();
+        let this = Self {
+            sender: Self::decode_address_opt(buf)?,
+            nonce_key: Decodable::decode(buf)?,
+            expiry: Decodable::decode(buf)?,
+            max_priority_fee_per_gas: Decodable::decode(buf)?,
+            max_fee_per_gas: Decodable::decode(buf)?,
+            payer: Self::decode_address_opt(buf)?,
+            account_changes: Decodable::decode(buf)?,
+            calls: Decodable::decode(buf)?,
+            metadata: Decodable::decode(buf)?,
+            sender_authenticator: Decodable::decode(buf)?,
+            payer_authenticator: Decodable::decode(buf)?,
+        };
+        let consumed = started - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(this)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use alloy_primitives::{address, bytes};
+    use base_common_consensus::Delegation;
+
+    use super::*;
+    use crate::SpanBatchTransactionData;
+
+    #[test]
+    fn encode_eip8130_tx_data_roundtrip() {
+        let tx = SpanBatchEip8130TransactionData {
+            sender: Some(address!("0x00000000000000000000000000000000000000aa")),
+            nonce_key: U256::from(0x1234u64),
+            expiry: 99,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 5_000_000_000,
+            payer: Some(address!("0x00000000000000000000000000000000000000bb")),
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: address!("0x00000000000000000000000000000000000000cc"),
+            })],
+            calls: vec![
+                vec![Call {
+                    to: address!("0x00000000000000000000000000000000000000dd"),
+                    data: bytes!("deadbeef"),
+                }],
+                vec![
+                    Call { to: Address::ZERO, data: bytes!("01") },
+                    Call { to: Address::ZERO, data: bytes!("02") },
+                ],
+            ],
+            metadata: bytes!("c0ffee"),
+            sender_authenticator: Bytes::from_static(&[0x11; 20]),
+            payer_authenticator: Bytes::from_static(&[0x22; 20]),
+        };
+
+        let mut encoded_buf = Vec::new();
+        SpanBatchTransactionData::Eip8130(tx.clone()).encode(&mut encoded_buf);
+
+        let decoded = SpanBatchTransactionData::decode(&mut encoded_buf.as_slice()).unwrap();
+        let SpanBatchTransactionData::Eip8130(decoded) = decoded else {
+            panic!("Expected SpanBatchEip8130TransactionData, got {decoded:?}");
+        };
+
+        assert_eq!(tx, decoded);
+    }
+
+    #[test]
+    fn split_auth_rejects_short_configured_blob() {
+        // A configured-path auth blob shorter than the 20-byte account address
+        // must error instead of panicking on the slice.
+        let blob = Bytes::from(vec![0u8; 19]);
+        assert_eq!(
+            SpanBatchEip8130TransactionData::split_auth(&blob, true),
+            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidAuthData))
+        );
+    }
+
+    #[test]
+    fn split_auth_is_inverse_of_join_auth() {
+        // EOA path: authenticator empty, proof is the whole blob.
+        let eoa = Bytes::from(vec![7u8; 65]);
+        let (auth, proof) = SpanBatchEip8130TransactionData::split_auth(&eoa, false).unwrap();
+        assert!(auth.is_empty());
+        assert_eq!(proof, eoa);
+        assert_eq!(SpanBatchEip8130TransactionData::join_auth(&auth, &proof, false), eoa);
+
+        // Configured path, exactly 20 bytes: proof empty, join rebuilds the blob.
+        let exact = Bytes::from(vec![3u8; 20]);
+        let (auth, proof) = SpanBatchEip8130TransactionData::split_auth(&exact, true).unwrap();
+        assert_eq!(auth, exact);
+        assert!(proof.is_empty());
+        assert_eq!(SpanBatchEip8130TransactionData::join_auth(&auth, &proof, true), exact);
+
+        // Configured path, 20-byte authenticator + proof.
+        let mut full = vec![1u8; 20];
+        full.extend_from_slice(&[9u8; 32]);
+        let full = Bytes::from(full);
+        let (auth, proof) = SpanBatchEip8130TransactionData::split_auth(&full, true).unwrap();
+        assert_eq!(&auth[..], &[1u8; 20]);
+        assert_eq!(&proof[..], &[9u8; 32]);
+        assert_eq!(SpanBatchEip8130TransactionData::join_auth(&auth, &proof, true), full);
+    }
+}

--- a/crates/consensus/protocol/src/batch/tx_data/mod.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/mod.rs
@@ -14,3 +14,6 @@ pub use eip2930::SpanBatchEip2930TransactionData;
 
 mod eip7702;
 pub use eip7702::SpanBatchEip7702TransactionData;
+
+mod eip8130;
+pub use eip8130::SpanBatchEip8130TransactionData;

--- a/crates/consensus/protocol/src/batch/tx_data/wrapper.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/wrapper.rs
@@ -1,13 +1,14 @@
 //! This module contains the top level span batch transaction data type.
 
-use alloy_consensus::{Transaction, TxEnvelope, TxType};
+use alloy_consensus::Transaction;
 use alloy_primitives::{Address, Signature, U256};
 use alloy_rlp::{Bytes, Decodable, Encodable};
+use base_common_consensus::{BaseTxEnvelope, OpTxType};
 
 use crate::{
     SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
-    SpanBatchEip7702TransactionData, SpanBatchError, SpanBatchLegacyTransactionData,
-    SpanDecodingError,
+    SpanBatchEip7702TransactionData, SpanBatchEip8130TransactionData, SpanBatchError,
+    SpanBatchLegacyTransactionData, SpanDecodingError,
 };
 
 /// The typed transaction data for a transaction within a span batch.
@@ -21,6 +22,8 @@ pub enum SpanBatchTransactionData {
     Eip1559(SpanBatchEip1559TransactionData),
     /// EIP-7702 transaction data.
     Eip7702(SpanBatchEip7702TransactionData),
+    /// EIP-8130 transaction data.
+    Eip8130(SpanBatchEip8130TransactionData),
 }
 
 impl Encodable for SpanBatchTransactionData {
@@ -30,15 +33,19 @@ impl Encodable for SpanBatchTransactionData {
                 data.encode(out);
             }
             Self::Eip2930(data) => {
-                out.put_u8(TxType::Eip2930 as u8);
+                out.put_u8(OpTxType::Eip2930 as u8);
                 data.encode(out);
             }
             Self::Eip1559(data) => {
-                out.put_u8(TxType::Eip1559 as u8);
+                out.put_u8(OpTxType::Eip1559 as u8);
                 data.encode(out);
             }
             Self::Eip7702(data) => {
-                out.put_u8(TxType::Eip7702 as u8);
+                out.put_u8(OpTxType::Eip7702 as u8);
+                data.encode(out);
+            }
+            Self::Eip8130(data) => {
+                out.put_u8(OpTxType::Eip8130 as u8);
                 data.encode(out);
             }
         }
@@ -56,12 +63,12 @@ impl Decodable for SpanBatchTransactionData {
     }
 }
 
-impl TryFrom<&TxEnvelope> for SpanBatchTransactionData {
+impl TryFrom<&BaseTxEnvelope> for SpanBatchTransactionData {
     type Error = SpanBatchError;
 
-    fn try_from(tx_envelope: &TxEnvelope) -> Result<Self, Self::Error> {
+    fn try_from(tx_envelope: &BaseTxEnvelope) -> Result<Self, Self::Error> {
         match tx_envelope {
-            TxEnvelope::Legacy(s) => {
+            BaseTxEnvelope::Legacy(s) => {
                 let s = s.tx();
                 Ok(Self::Legacy(SpanBatchLegacyTransactionData {
                     value: s.value,
@@ -69,7 +76,7 @@ impl TryFrom<&TxEnvelope> for SpanBatchTransactionData {
                     data: Bytes::from(s.input().to_vec()),
                 }))
             }
-            TxEnvelope::Eip2930(s) => {
+            BaseTxEnvelope::Eip2930(s) => {
                 let s = s.tx();
                 Ok(Self::Eip2930(SpanBatchEip2930TransactionData {
                     value: s.value,
@@ -78,7 +85,7 @@ impl TryFrom<&TxEnvelope> for SpanBatchTransactionData {
                     access_list: s.access_list.clone(),
                 }))
             }
-            TxEnvelope::Eip1559(s) => {
+            BaseTxEnvelope::Eip1559(s) => {
                 let s = s.tx();
                 Ok(Self::Eip1559(SpanBatchEip1559TransactionData {
                     value: s.value,
@@ -88,7 +95,7 @@ impl TryFrom<&TxEnvelope> for SpanBatchTransactionData {
                     access_list: s.access_list.clone(),
                 }))
             }
-            TxEnvelope::Eip7702(s) => {
+            BaseTxEnvelope::Eip7702(s) => {
                 let s = s.tx();
                 Ok(Self::Eip7702(SpanBatchEip7702TransactionData {
                     value: s.value,
@@ -99,19 +106,46 @@ impl TryFrom<&TxEnvelope> for SpanBatchTransactionData {
                     authorization_list: s.authorization_list.clone(),
                 }))
             }
-            _ => Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType)),
+            BaseTxEnvelope::Eip8130(signed) => {
+                let tx = signed.tx();
+                Ok(Self::Eip8130(SpanBatchEip8130TransactionData {
+                    sender: tx.sender,
+                    nonce_key: tx.nonce_key,
+                    expiry: tx.expiry,
+                    max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+                    max_fee_per_gas: tx.max_fee_per_gas,
+                    payer: tx.payer,
+                    account_changes: tx.account_changes.clone(),
+                    calls: tx.calls.clone(),
+                    metadata: tx.metadata.clone(),
+                    sender_authenticator: SpanBatchEip8130TransactionData::split_auth(
+                        signed.sender_auth(),
+                        tx.sender.is_some(),
+                    )?
+                    .0,
+                    payer_authenticator: SpanBatchEip8130TransactionData::split_auth(
+                        signed.payer_auth(),
+                        tx.payer.is_some(),
+                    )?
+                    .0,
+                }))
+            }
+            BaseTxEnvelope::Deposit(_) => {
+                Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType))
+            }
         }
     }
 }
 
 impl SpanBatchTransactionData {
     /// Returns the transaction type of the [`SpanBatchTransactionData`].
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn tx_type(&self) -> OpTxType {
         match self {
-            Self::Legacy(_) => TxType::Legacy,
-            Self::Eip2930(_) => TxType::Eip2930,
-            Self::Eip1559(_) => TxType::Eip1559,
-            Self::Eip7702(_) => TxType::Eip7702,
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Eip8130(_) => OpTxType::Eip8130,
         }
     }
 
@@ -122,20 +156,24 @@ impl SpanBatchTransactionData {
         }
 
         match b[0].try_into().map_err(|_| alloy_rlp::Error::Custom("Invalid tx type"))? {
-            TxType::Eip2930 => {
+            OpTxType::Eip2930 => {
                 Ok(Self::Eip2930(SpanBatchEip2930TransactionData::decode(&mut &b[1..])?))
             }
-            TxType::Eip1559 => {
+            OpTxType::Eip1559 => {
                 Ok(Self::Eip1559(SpanBatchEip1559TransactionData::decode(&mut &b[1..])?))
             }
-            TxType::Eip7702 => {
+            OpTxType::Eip7702 => {
                 Ok(Self::Eip7702(SpanBatchEip7702TransactionData::decode(&mut &b[1..])?))
+            }
+            OpTxType::Eip8130 => {
+                Ok(Self::Eip8130(SpanBatchEip8130TransactionData::decode(&mut &b[1..])?))
             }
             _ => Err(alloy_rlp::Error::Custom("Invalid transaction type")),
         }
     }
 
-    /// Converts the [`SpanBatchTransactionData`] into a signed transaction as [`TxEnvelope`].
+    /// Converts the [`SpanBatchTransactionData`] into a signed transaction as
+    /// [`BaseTxEnvelope`].
     pub fn to_signed_tx(
         &self,
         nonce: u64,
@@ -144,9 +182,9 @@ impl SpanBatchTransactionData {
         chain_id: u64,
         signature: Signature,
         is_protected: bool,
-    ) -> Result<TxEnvelope, SpanBatchError> {
+    ) -> Result<BaseTxEnvelope, SpanBatchError> {
         Ok(match self {
-            Self::Legacy(data) => TxEnvelope::Legacy(data.to_signed_tx(
+            Self::Legacy(data) => BaseTxEnvelope::Legacy(data.to_signed_tx(
                 nonce,
                 gas,
                 to,
@@ -155,10 +193,10 @@ impl SpanBatchTransactionData {
                 is_protected,
             )?),
             Self::Eip2930(data) => {
-                TxEnvelope::Eip2930(data.to_signed_tx(nonce, gas, to, chain_id, signature)?)
+                BaseTxEnvelope::Eip2930(data.to_signed_tx(nonce, gas, to, chain_id, signature)?)
             }
             Self::Eip1559(data) => {
-                TxEnvelope::Eip1559(data.to_signed_tx(nonce, gas, to, chain_id, signature)?)
+                BaseTxEnvelope::Eip1559(data.to_signed_tx(nonce, gas, to, chain_id, signature)?)
             }
             Self::Eip7702(data) => {
                 let Some(addr) = to else {
@@ -166,7 +204,12 @@ impl SpanBatchTransactionData {
                         SpanDecodingError::InvalidTransactionData,
                     ));
                 };
-                TxEnvelope::Eip7702(data.to_signed_tx(nonce, gas, addr, chain_id, signature)?)
+                BaseTxEnvelope::Eip7702(data.to_signed_tx(nonce, gas, addr, chain_id, signature)?)
+            }
+            // EIP-8130 transactions are reconstructed through their dedicated path in
+            // `full_txs`, which supplies the auth proofs carried in the trailing column.
+            Self::Eip8130(_) => {
+                return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType));
             }
         })
     }

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -16,9 +16,9 @@ pub use batch::{
     BatchTransaction, BatchType, BatchValidationProvider, BatchValidity, BatchWithInclusionBlock,
     DecompressionError, RawSpanBatch, SingleBatch, SpanBatch, SpanBatchBits,
     SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
-    SpanBatchEip7702TransactionData, SpanBatchElement, SpanBatchError,
-    SpanBatchLegacyTransactionData, SpanBatchPayload, SpanBatchPrefix, SpanBatchTransactionData,
-    SpanBatchTransactions, SpanDecodingError,
+    SpanBatchEip7702TransactionData, SpanBatchEip8130TransactionData, SpanBatchElement,
+    SpanBatchError, SpanBatchLegacyTransactionData, SpanBatchPayload, SpanBatchPrefix,
+    SpanBatchTransactionData, SpanBatchTransactions, SpanDecodingError,
 };
 
 mod brotli;

--- a/crates/consensus/protocol/src/utils.rs
+++ b/crates/consensus/protocol/src/utils.rs
@@ -2,10 +2,10 @@
 
 use alloc::vec::Vec;
 
-use alloy_consensus::{Transaction, TxType, Typed2718};
+use alloy_consensus::{Transaction, Typed2718};
 use alloy_primitives::{B256, U256};
 use alloy_rlp::{Buf, Header};
-use base_common_consensus::{BaseBlock, HoloceneExtraData, JovianExtraData};
+use base_common_consensus::{BaseBlock, HoloceneExtraData, JovianExtraData, OpTxType};
 use base_common_genesis::{RollupConfig, SystemConfig};
 
 use crate::{
@@ -97,7 +97,7 @@ fn encode_scalar(blob_base_fee_scalar: u32, base_fee_scalar: u32) -> U256 {
 }
 
 /// Reads transaction data from a reader.
-pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, TxType), SpanBatchError> {
+pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, OpTxType), SpanBatchError> {
     let mut tx_data = Vec::new();
     let first_byte =
         *r.first().ok_or(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))?;


### PR DESCRIPTION
Span-batch DA codec for EIP-8130 (tx type `0x7B`) account-abstraction transactions in
base-reth derivation: decodes 0x7B transactions out of span batches, byte-for-byte with
the op-batcher encode side.

## Layout

The columnar span batch is reused as-is:

```
contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits
```

0x7B reuses those columns where it can:

- `nonce_sequence` goes in `tx_nonces`, `gas_limit` in `tx_gases`.
- No `to`: the contract-creation bit is set and the `tx_tos` entry is skipped.
- Unsigned: the `tx_sigs` slot is still written, as 64 zero bytes with y-parity 0, to
  keep every column aligned across tx types.
- `chain_id` is not put on the wire; it is reinjected from the batch chain id at decode.

The per-tx body in `tx_datas` is `0x7B ++ rlp(...)` of the low-entropy fields:

```
[ sender, nonce_key, expiry, max_priority_fee_per_gas, max_fee_per_gas,
  payer, account_changes, calls, metadata,
  sender_authenticator, payer_authenticator ]
```

The one new piece is a trailing column, `eip8130_auth_data`. 0x7B carries large
high-entropy auth proofs, so those are split out of the body and stored here, one bundle
per 0x7B tx in tx order (empty if the batch has none):

```
bundle := uvarint(len(sender_proof)) ++ sender_proof ++ uvarint(len(payer_proof)) ++ payer_proof
```

So the full layout becomes:

```
... ++ tx_gases ++ protected_bits ++ eip8130_auth_data
```

This keeps the low-entropy fields in `tx_datas` (which compress well) and isolates the
incompressible proofs in their own column so they do not tank compression of the rest. On
decode each bundle is rejoined with its authenticator to rebuild the full auth blob.

## Backward compatibility

`eip8130_auth_data` is the last column and writes zero bytes when a batch has no 0x7B
transaction, so existing / non-8130 span batches encode and decode byte-identically. 0x7B
is Cobalt-gated at validity and rejected at RPC ingress today.

## Testing

`cargo test / clippy / fmt -p base-protocol` green. Remainder field order and AA-nil
`Option<Address>` encoding verified against the Go `spanBatchEip8130TxData` struct.

## Related

- op-batcher encode side: [base/optimism `bo/eip8130-span-batch`](https://github.com/base/optimism/tree/bo/eip8130-span-batch)
- op-geth 0x7B tx type: [base/op-geth `bo/eip8130`](https://github.com/base/op-geth/tree/bo/eip8130) (tag `v1.101701.0-rc.3-eip8130.1`)

