### PR TITLE
refactor(proposer): clean up proof dispatcher

### DIFF
--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -281,9 +281,9 @@ mod tests {
 
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            l1.clone(),
-            l2.clone(),
-            rollup.clone(),
+            Arc::<MockL1>::clone(&l1),
+            l2,
+            Arc::<MockRollupClient>::clone(&rollup),
             ProofDispatcherConfig::from(&config),
         );
         let proof_submitter = ProofSubmitter::new(

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -237,8 +237,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ProofCollector, ProofDispatcher, ProofRecovery, ProofRecoveryConfig, ProofSubmitter,
-        ProofSubmitterConfig,
+        ProofCollector, ProofDispatcher, ProofDispatcherConfig, ProofRecovery, ProofRecoveryConfig,
+        ProofSubmitter, ProofSubmitterConfig,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockProofRequester, MockRollupClient, test_anchor_root,
@@ -281,9 +281,10 @@ mod tests {
 
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
+            l1.clone(),
             l2.clone(),
             rollup.clone(),
-            config.clone(),
+            ProofDispatcherConfig::from(&config),
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -15,7 +15,7 @@ use std::{
 
 use alloy_primitives::{Address, B256};
 use async_trait::async_trait;
-use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
+use base_proof_rpc::{L1Provider, RollupProvider};
 use eyre::Result;
 use tokio::{sync::Mutex as TokioMutex, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -32,15 +32,10 @@ use crate::pipeline::ProvingPipeline;
 pub struct DriverConfig {
     /// Polling interval for new blocks.
     pub poll_interval: Duration,
-    /// Maximum proof request dispatch retries for a single target block before
-    /// dropping the cached recovery. Collector-side proof/session failures and
-    /// submit errors do not count against this budget.
-    pub max_retries: u32,
     /// Maximum number of concurrent RPC calls during the recovery scan.
     pub recovery_scan_concurrency: usize,
     /// Optional maximum duration for a single inline submit (validation + L1
-    /// transaction). When exceeded, the pipeline restarts without counting
-    /// against the retry budget. `None` disables the outer pipeline timeout.
+    /// transaction). `None` disables the outer pipeline timeout.
     pub submit_timeout: Option<Duration>,
     /// Optional address of the `TEEProverRegistry` contract on L1.
     /// When set, the pipeline validates signers via `isValidSigner` before submission.
@@ -70,7 +65,6 @@ impl Default for DriverConfig {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(12),
-            max_retries: 8,
             recovery_scan_concurrency: 8,
             submit_timeout: None,
             tee_prover_registry_address: None,
@@ -127,22 +121,20 @@ struct Session {
 
 /// Manages the lifecycle of a [`ProvingPipeline`], allowing it to be started
 /// and stopped at runtime (e.g. via the admin RPC).
-pub struct PipelineHandle<L1, L2, R>
+pub struct PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
-    pipeline: Arc<ProvingPipeline<L1, L2, R>>,
+    pipeline: Arc<ProvingPipeline<L1, R>>,
     session: TokioMutex<Session>,
     global_cancel: CancellationToken,
     running: Arc<AtomicBool>,
 }
 
-impl<L1, L2, R> std::fmt::Debug for PipelineHandle<L1, L2, R>
+impl<L1, R> std::fmt::Debug for PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,14 +144,13 @@ where
     }
 }
 
-impl<L1, L2, R> PipelineHandle<L1, L2, R>
+impl<L1, R> PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     /// Creates a new [`PipelineHandle`] wrapping the given proving pipeline.
-    pub fn new(pipeline: ProvingPipeline<L1, L2, R>, global_cancel: CancellationToken) -> Self {
+    pub fn new(pipeline: ProvingPipeline<L1, R>, global_cancel: CancellationToken) -> Self {
         let session = Session { cancel: global_cancel.child_token(), task: None };
         Self {
             pipeline: Arc::new(pipeline),
@@ -171,10 +162,9 @@ where
 }
 
 #[async_trait]
-impl<L1, L2, R> ProposerDriverControl for PipelineHandle<L1, L2, R>
+impl<L1, R> ProposerDriverControl for PipelineHandle<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     async fn start_proposer(&self) -> Result<(), String> {
@@ -247,8 +237,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ProofCollector, ProofDispatcher, ProofDispatcherConfig, ProofRecovery, ProofRecoveryConfig,
-        ProofSubmitter, ProofSubmitterConfig,
+        ProofCollector, ProofDispatcher, ProofRecovery, ProofRecoveryConfig, ProofSubmitter,
+        ProofSubmitterConfig,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockProofRequester, MockRollupClient, test_anchor_root,
@@ -258,7 +248,7 @@ mod tests {
 
     fn test_pipeline_handle(
         global_cancel: CancellationToken,
-    ) -> PipelineHandle<MockL1, MockL2, MockRollupClient> {
+    ) -> PipelineHandle<MockL1, MockRollupClient> {
         let l1 = Arc::new(MockL1::new(1000));
         let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
         let rollup = Arc::new(MockRollupClient {
@@ -282,7 +272,6 @@ mod tests {
         let config = DriverConfig {
             poll_interval: Duration::from_secs(3600),
             submit_timeout: Some(std::time::Duration::from_secs(60)),
-            max_retries: 3,
             recovery_scan_concurrency: 8,
             tee_prover_registry_address: None,
             block_interval: 512,
@@ -292,15 +281,9 @@ mod tests {
 
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            Arc::clone(&l1),
-            Arc::clone(&l2),
-            Arc::clone(&rollup),
-            ProofDispatcherConfig {
-                proposer_address: config.proposer_address,
-                allow_non_finalized: config.allow_non_finalized,
-                intermediate_block_interval: config.intermediate_block_interval,
-                tee_image_hash: config.tee_image_hash,
-            },
+            l2.clone(),
+            rollup.clone(),
+            config.clone(),
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -33,10 +33,7 @@ mod proof_collector;
 pub use proof_collector::ProofCollector;
 
 mod proof_dispatcher;
-pub use proof_dispatcher::{
-    ProofDispatchAttempt, ProofDispatchOutcome, ProofDispatcher, ProofDispatcherConfig,
-    ProofDispatcherState,
-};
+pub use proof_dispatcher::ProofDispatcher;
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -33,7 +33,7 @@ mod proof_collector;
 pub use proof_collector::ProofCollector;
 
 mod proof_dispatcher;
-pub use proof_dispatcher::ProofDispatcher;
+pub use proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig};
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterConfig, SubmitAction};

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -29,9 +29,6 @@ base_metrics::define_metrics! {
     #[label(name = "status", default = ["queued", "running", "succeeded", "failed"])]
     proof_status_received_total: counter,
 
-    #[describe("Total number of proof retries scheduled after a failed dispatch or collection")]
-    proof_retries_total: counter,
-
     #[describe("Latest safe (or finalized) L2 block number")]
     #[no_zero]
     safe_head: gauge,

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -17,9 +17,6 @@ base_metrics::define_metrics! {
     #[no_zero]
     last_collected_block: gauge,
 
-    #[describe("Total pending retries across all target blocks")]
-    pipeline_retries: gauge,
-
     #[describe("Total proof dispatch outcomes from the prover service")]
     #[label(name = "outcome", default = ["accepted", "failed", "build_failed"])]
     proof_dispatch_total: counter,
@@ -94,7 +91,7 @@ impl Metrics {
     /// Label value for a dispatch attempt that failed before reaching the
     /// prover service (e.g. while building the request from L1/L2 RPC data).
     /// Build failures are transient infrastructure errors and do not count
-    /// against the per-target retry budget.
+    /// as prover-service dispatch failures.
     pub const DISPATCH_OUTCOME_BUILD_FAILED: &str = "build_failed";
 
     /// Label value for a ready (successfully collected) proof.

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -130,6 +130,9 @@ where
                     Metrics::safe_head().set(safe_head as f64);
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
+                    // Dispatch failures retry from the in-memory cursor. A fresh recovery walk is
+                    // only needed when onchain state changes; try_recover_and_plan returns that as
+                    // a different recovered state, which resets the cursor here.
                     if cursor_source != Some(recovered) || cursor.is_none() {
                         cursor_source = Some(recovered);
                         cursor = Some(recovered);

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -8,7 +8,7 @@ use std::{
     },
 };
 
-use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
+use base_proof_rpc::{L1Provider, RollupProvider};
 use futures::FutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -17,7 +17,7 @@ use crate::{
     Metrics,
     driver::{DriverConfig, RecoveredState},
     proof_collector::ProofCollector,
-    proof_dispatcher::{ProofDispatcher, ProofDispatcherState},
+    proof_dispatcher::ProofDispatcher,
     proof_recovery::{ProofRecovery, ProofRecoveryCache},
 };
 
@@ -25,24 +25,21 @@ use crate::{
 ///
 /// Runs concurrent dispatcher and collector tasks per [`Self::run`] session.
 /// The collector chains ready proofs internally and restarts both tasks only
-/// when it needs fresh onchain state; dispatcher retry exhaustion clears
-/// dispatcher recovery state without interrupting collection.
-pub struct ProvingPipeline<L1, L2, R>
+/// when it needs fresh onchain state.
+pub struct ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     config: DriverConfig,
-    proof_dispatcher: ProofDispatcher<L1, L2, R>,
+    proof_dispatcher: ProofDispatcher,
     proof_recovery: Arc<ProofRecovery<R>>,
     proof_collector: ProofCollector<L1, R>,
 }
 
-impl<L1, L2, R> std::fmt::Debug for ProvingPipeline<L1, L2, R>
+impl<L1, R> std::fmt::Debug for ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -50,16 +47,15 @@ where
     }
 }
 
-impl<L1, L2, R> ProvingPipeline<L1, L2, R>
+impl<L1, R> ProvingPipeline<L1, R>
 where
     L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
     R: RollupProvider + 'static,
 {
     /// Creates a new proving pipeline.
     pub const fn new(
         config: DriverConfig,
-        proof_dispatcher: ProofDispatcher<L1, L2, R>,
+        proof_dispatcher: ProofDispatcher,
         proof_recovery: Arc<ProofRecovery<R>>,
         proof_collector: ProofCollector<L1, R>,
     ) -> Self {
@@ -92,7 +88,7 @@ where
                 tokio::select! {
                     biased;
                     () = cancel.cancelled() => false,
-                    () = self.dispatcher_loop(&cancel, Arc::clone(&dispatched_through)) => true,
+                    () = self.dispatcher_loop(Arc::clone(&dispatched_through)) => true,
                     () = self.collector_loop(&cancel, Arc::clone(&dispatched_through)) => true,
                 }
             };
@@ -119,13 +115,10 @@ where
         info!("Proving pipeline stopped");
     }
 
-    async fn dispatcher_loop(
-        &self,
-        cancel: &CancellationToken,
-        dispatched_through: Arc<AtomicU64>,
-    ) {
+    async fn dispatcher_loop(&self, dispatched_through: Arc<AtomicU64>) {
         let mut cache: Option<ProofRecoveryCache> = None;
-        let mut state = ProofDispatcherState::new();
+        let mut cursor_source: Option<RecoveredState> = None;
+        let mut cursor: Option<RecoveredState> = None;
 
         loop {
             {
@@ -137,26 +130,17 @@ where
                     Metrics::safe_head().set(safe_head as f64);
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
-                    let drop_recovery_cache = self
-                        .proof_dispatcher
-                        .tick(
-                            &mut state,
-                            recovered,
-                            safe_head,
-                            self.config.block_interval,
-                            self.config.max_retries,
-                            cancel,
-                        )
-                        .await;
-
-                    if let Some(cursor) = state.cursor {
-                        dispatched_through.store(cursor.l2_block_number, Ordering::Relaxed);
+                    if cursor_source != Some(recovered) || cursor.is_none() {
+                        cursor_source = Some(recovered);
+                        cursor = Some(recovered);
                     }
 
-                    if drop_recovery_cache {
-                        cache = None;
-                        dispatched_through.store(0, Ordering::Relaxed);
-                    }
+                    let current = cursor
+                        .as_mut()
+                        .expect("dispatcher cursor initialized from recovered state");
+                    self.proof_dispatcher.tick(current, safe_head).await;
+
+                    dispatched_through.store(current.l2_block_number, Ordering::Relaxed);
                 }
             }
 
@@ -231,8 +215,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
-        ProofSubmitterConfig,
+        OutputProposer, ProofRecoveryConfig, ProofSubmitter, ProofSubmitterConfig,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
@@ -282,7 +265,7 @@ mod tests {
 
     fn test_pipeline(
         requester: Arc<RejectingProofRequester>,
-    ) -> ProvingPipeline<MockL1, MockL2, MockRollupClient> {
+    ) -> ProvingPipeline<MockL1, MockRollupClient> {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::<RejectingProofRequester>::clone(&requester);
         let l1 = Arc::new(MockL1::new(1000));
@@ -303,22 +286,15 @@ mod tests {
         let output_proposer: Arc<dyn OutputProposer> = Arc::new(MockOutputProposer::default());
         let config = DriverConfig {
             poll_interval: Duration::from_millis(10),
-            max_retries: 1,
             block_interval: 100,
             intermediate_block_interval: 100,
             ..Default::default()
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            Arc::clone(&l1),
-            Arc::clone(&l2),
-            Arc::clone(&rollup),
-            ProofDispatcherConfig {
-                proposer_address: config.proposer_address,
-                allow_non_finalized: config.allow_non_finalized,
-                intermediate_block_interval: config.intermediate_block_interval,
-                tee_image_hash: config.tee_image_hash,
-            },
+            l2.clone(),
+            rollup.clone(),
+            config.clone(),
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {
@@ -360,23 +336,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dispatcher_retry_exhaustion_keeps_dispatcher_loop_running() {
+    async fn dispatcher_failure_keeps_dispatcher_loop_running() {
         let requester = Arc::new(RejectingProofRequester::default());
         let pipeline = test_pipeline(Arc::clone(&requester));
-        let cancel = CancellationToken::new();
 
         assert!(
             tokio::time::timeout(
                 Duration::from_millis(100),
-                pipeline.dispatcher_loop(&cancel, Arc::new(AtomicU64::new(0)))
+                pipeline.dispatcher_loop(Arc::new(AtomicU64::new(0)))
             )
             .await
             .is_err(),
-            "dispatcher retry exhaustion should not end the dispatcher loop"
+            "dispatcher failures should not end the dispatcher loop"
         );
         assert!(
             requester.prove_count.load(Ordering::SeqCst) > 1,
-            "dispatcher should keep recovering and retrying after exhaustion"
+            "dispatcher should keep retrying after failures"
         );
     }
 

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -215,7 +215,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        OutputProposer, ProofRecoveryConfig, ProofSubmitter, ProofSubmitterConfig,
+        OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
+        ProofSubmitterConfig,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
@@ -292,9 +293,10 @@ mod tests {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
+            l1.clone(),
             l2.clone(),
             rollup.clone(),
-            config.clone(),
+            ProofDispatcherConfig::from(&config),
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -293,9 +293,9 @@ mod tests {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            l1.clone(),
-            l2.clone(),
-            rollup.clone(),
+            Arc::<MockL1>::clone(&l1),
+            l2,
+            Arc::<MockRollupClient>::clone(&rollup),
             ProofDispatcherConfig::from(&config),
         );
         let proof_recovery = Arc::new(ProofRecovery::new(

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -338,7 +338,7 @@ where
                 // Persistent submit failures intentionally keep the proof request
                 // so transient RPC/L1 issues can retry the same completed proof.
                 // Operators should alert on base_proposer_errors_total if this
-                // repeats; submit failures do not count against max_retries.
+                // repeats.
                 Metrics::errors_total(error.metric_label()).increment(1);
                 warn!(target_block, error = %error, "Submission failed");
             }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -205,7 +205,7 @@ impl ProofDispatcher {
             };
 
             let request =
-                match self.build_request(target_block, &current, claimed_l2_output_root).await {
+                match self.build_request(target_block, current, claimed_l2_output_root).await {
                     Ok(request) => request,
                     Err(error) => {
                         Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED)

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -234,12 +234,11 @@ impl ProofDispatcher {
                 Err(error) => {
                     Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
                     Metrics::errors_total(error.metric_label()).increment(1);
-                    Metrics::proof_retries_total().increment(1);
 
                     warn!(
                         target_block,
                         error = %error,
-                        "Proof failed, re-dispatching"
+                        "Proof dispatch failed, stopping tick at current cursor"
                     );
                     break;
                 }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -1,232 +1,114 @@
 //! Proof request construction and dispatch helpers for proposer TEE proofs.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, B256};
-use base_optimism_rpc::{L1BlockRef, L2BlockRef, SyncStatus};
+use alloy_primitives::B256;
+use base_optimism_rpc::{L1BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
-use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
+use base_proof_rpc::{L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::ProveBlockRangeRequest;
-use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
-    Metrics, driver::RecoveredState, error::ProposerError, proof_adapter::ProposerProofAdapter,
+    Metrics,
+    driver::{DriverConfig, RecoveredState},
+    error::ProposerError,
+    proof_adapter::ProposerProofAdapter,
     proof_target::ProofTarget,
 };
 
-/// Static parameters needed to build proposer proof requests.
-#[derive(Debug, Clone, Copy)]
-pub struct ProofDispatcherConfig {
-    /// Address of the proposer that will submit the proof onchain.
-    pub proposer_address: Address,
-    /// Whether requests may target safe, non-finalized L2 blocks.
-    pub allow_non_finalized: bool,
-    /// Number of L2 blocks between intermediate output root checkpoints.
-    pub intermediate_block_interval: u64,
-    /// Expected TEE enclave image hash.
-    pub tee_image_hash: B256,
-}
-
-/// Mutable dispatcher-side orchestration state.
-#[derive(Debug, Default)]
-pub struct ProofDispatcherState {
-    /// Recovered chain state that the current cursor was derived from.
-    pub recovered: Option<RecoveredState>,
-    /// Latest block the dispatcher has sent proof requests through.
-    pub cursor: Option<RecoveredState>,
-    /// Per-target proof/dispatch retry counts.
-    pub retry_counts: HashMap<u64, u32>,
-}
-
-/// Outcome of a single target dispatch attempt after retry accounting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProofDispatchOutcome {
-    /// The request was accepted by prover-service.
-    Accepted,
-    /// The request failed and exhausted the retry budget.
-    RetryExhausted,
-    /// The request was skipped because it could not be built or dispatched.
-    Skipped,
-}
-
-/// Outcome of attempting to dispatch a proof request.
-#[derive(Debug)]
-pub enum ProofDispatchAttempt {
-    /// The request was accepted by prover-service.
-    Accepted(String),
-    /// The request could not be built from local RPC data.
-    BuildFailed(ProposerError),
-    /// The request reached prover-service but dispatch failed.
-    DispatchFailed(ProposerError),
-}
-
-impl ProofDispatchAttempt {
-    /// Returns the metrics outcome label for this dispatch attempt.
-    pub const fn metric_label(&self) -> &'static str {
-        match self {
-            Self::Accepted(_) => Metrics::DISPATCH_OUTCOME_ACCEPTED,
-            Self::BuildFailed(_) => Metrics::DISPATCH_OUTCOME_BUILD_FAILED,
-            Self::DispatchFailed(_) => Metrics::DISPATCH_OUTCOME_FAILED,
-        }
-    }
-}
-
 /// Builds and dispatches proposer TEE proof requests.
-///
-/// This type intentionally holds only shared clients and static config. Mutable
-/// cursor and retry state belongs in [`ProofDispatcherState`] so cloned
-/// dispatchers do not diverge.
-pub struct ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider,
-    L2: L2Provider,
-    R: RollupProvider,
-{
+pub struct ProofDispatcher {
     proof_requester: Arc<dyn ProofRequesterProvider>,
-    l1_client: Arc<L1>,
-    l2_client: Arc<L2>,
-    rollup_client: Arc<R>,
-    config: ProofDispatcherConfig,
+    l2_client: Arc<dyn L2Provider>,
+    rollup_client: Arc<dyn RollupProvider>,
+    config: DriverConfig,
 }
 
-impl<L1, L2, R> std::fmt::Debug for ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider,
-    L2: L2Provider,
-    R: RollupProvider,
-{
+impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofDispatcher").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
-impl<L1, L2, R> Clone for ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider,
-    L2: L2Provider,
-    R: RollupProvider,
-{
-    fn clone(&self) -> Self {
-        Self {
-            proof_requester: Arc::clone(&self.proof_requester),
-            l1_client: Arc::clone(&self.l1_client),
-            l2_client: Arc::clone(&self.l2_client),
-            rollup_client: Arc::clone(&self.rollup_client),
-            config: self.config,
-        }
-    }
-}
-
-impl<L1, L2, R> ProofDispatcher<L1, L2, R>
-where
-    L1: L1Provider + 'static,
-    L2: L2Provider + 'static,
-    R: RollupProvider + 'static,
-{
+impl ProofDispatcher {
     /// Creates a proof dispatcher.
     pub fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
-        l1_client: Arc<L1>,
-        l2_client: Arc<L2>,
-        rollup_client: Arc<R>,
-        config: ProofDispatcherConfig,
+        l2_client: Arc<dyn L2Provider>,
+        rollup_client: Arc<dyn RollupProvider>,
+        config: DriverConfig,
     ) -> Self {
-        Self { proof_requester, l1_client, l2_client, rollup_client, config }
+        Self { proof_requester, l2_client, rollup_client, config }
     }
 
     /// Builds a proof request for `target_block` using `recovered` as the agreed parent.
-    pub async fn build_request(
+    async fn build_request(
         &self,
         target_block: u64,
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
     ) -> Result<ProofRequest, ProposerError> {
         let (sync_status, agreed_l2_head) = tokio::try_join!(
-            async { self.rollup_client.sync_status().await.map_err(ProposerError::Rpc) },
-            async {
-                self.l2_client
-                    .header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number))
-                    .await
-                    .map_err(ProposerError::Rpc)
-            },
-        )?;
-        let (l1_head_source, l1_head, l2_coverage) = Self::select_l1_head_for_target(
+            self.rollup_client.sync_status(),
+            self.l2_client.header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number)),
+        )
+        .map_err(ProposerError::Rpc)?;
+        let (l1_head_source, l1_head) = Self::select_l1_head_for_target(
             target_block,
             &sync_status,
             self.config.allow_non_finalized,
         )?;
-        let l1_header =
-            self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
-        if l1_header.hash != l1_head.hash || l1_header.number != l1_head.number {
-            return Err(ProposerError::Internal(format!(
-                "selected {l1_head_source} L1 head {}:{} does not match L1 RPC header {}:{}",
-                l1_head.number, l1_head.hash, l1_header.number, l1_header.hash
-            )));
-        }
-
-        let request = ProofRequest {
-            l1_head: l1_header.hash,
-            agreed_l2_head_hash: agreed_l2_head.hash,
-            agreed_l2_output_root: recovered.output_root,
-            claimed_l2_output_root,
-            claimed_l2_block_number: target_block,
-            proposer: self.config.proposer_address,
-            intermediate_block_interval: self.config.intermediate_block_interval,
-            l1_head_number: l1_header.number,
-            image_hash: self.config.tee_image_hash,
-        };
 
         info!(
             from_block = recovered.l2_block_number,
             to_block = target_block,
             allow_non_finalized = self.config.allow_non_finalized,
             l1_head_source = l1_head_source,
-            l1_head_number = l1_header.number,
-            l1_head_hash = %l1_header.hash,
-            l2_coverage_block = l2_coverage.number,
-            l2_coverage_hash = %l2_coverage.hash,
-            finalized_l1_number = sync_status.finalized_l1.number,
-            finalized_l1_hash = %sync_status.finalized_l1.hash,
-            finalized_l2_number = sync_status.finalized_l2.number,
-            finalized_l2_hash = %sync_status.finalized_l2.hash,
-            safe_l1_number = sync_status.safe_l1.number,
-            safe_l1_hash = %sync_status.safe_l1.hash,
-            safe_l2_number = sync_status.safe_l2.number,
-            safe_l2_hash = %sync_status.safe_l2.hash,
+            l1_head_number = l1_head.number,
+            l1_head_hash = %l1_head.hash,
             agreed_l2_head_hash = %agreed_l2_head.hash,
             agreed_l2_output_root = %recovered.output_root,
             claimed_l2_output_root = %claimed_l2_output_root,
             "Built proof request"
         );
 
-        Ok(request)
+        Ok(ProofRequest {
+            l1_head: l1_head.hash,
+            agreed_l2_head_hash: agreed_l2_head.hash,
+            agreed_l2_output_root: recovered.output_root,
+            claimed_l2_output_root,
+            claimed_l2_block_number: target_block,
+            proposer: self.config.proposer_address,
+            intermediate_block_interval: self.config.intermediate_block_interval,
+            l1_head_number: l1_head.number,
+            image_hash: self.config.tee_image_hash,
+        })
     }
 
     fn select_l1_head_for_target(
         target_block: u64,
         sync_status: &SyncStatus,
         allow_non_finalized: bool,
-    ) -> Result<(&'static str, L1BlockRef, L2BlockRef), ProposerError> {
-        let selected = if target_block <= sync_status.finalized_l2.number {
-            ("finalized", sync_status.finalized_l1, sync_status.finalized_l2)
-        } else if !allow_non_finalized {
-            return Err(ProposerError::Internal(format!(
-                "target block {target_block} is above rollup finalized head {}",
-                sync_status.finalized_l2.number
-            )));
-        } else if target_block <= sync_status.safe_l2.number {
-            ("safe", sync_status.safe_l1, sync_status.safe_l2)
-        } else {
-            return Err(ProposerError::Internal(format!(
-                "target block {target_block} is above rollup safe head {}",
-                sync_status.safe_l2.number
-            )));
-        };
+    ) -> Result<(&'static str, L1BlockRef), ProposerError> {
+        let (l1_head_source, l1_head, l2_coverage) =
+            if target_block <= sync_status.finalized_l2.number {
+                ("finalized", sync_status.finalized_l1, sync_status.finalized_l2)
+            } else if !allow_non_finalized {
+                return Err(ProposerError::Internal(format!(
+                    "target block {target_block} is above rollup finalized head {}",
+                    sync_status.finalized_l2.number
+                )));
+            } else if target_block <= sync_status.safe_l2.number {
+                ("safe", sync_status.safe_l1, sync_status.safe_l2)
+            } else {
+                return Err(ProposerError::Internal(format!(
+                    "target block {target_block} is above rollup safe head {}",
+                    sync_status.safe_l2.number
+                )));
+            };
 
-        let (l1_head_source, l1_head, l2_coverage) = selected;
         if l1_head.number < l2_coverage.l1origin.number {
             return Err(ProposerError::Internal(format!(
                 "selected {l1_head_source} L1 head {} is below {l1_head_source} L2 origin {}",
@@ -234,102 +116,34 @@ where
             )));
         }
 
-        Ok(selected)
+        Ok((l1_head_source, l1_head))
     }
 
-    /// Builds and dispatches a root-derived proof request for `target_block`.
-    pub async fn dispatch_for(
-        &self,
-        target_block: u64,
-        recovered: &RecoveredState,
-        claimed_l2_output_root: B256,
-    ) -> ProofDispatchAttempt {
-        let expected_session_id =
-            ProposerProofAdapter::tee_session_id_for_root(claimed_l2_output_root);
-        let request =
-            match self.build_request(target_block, recovered, claimed_l2_output_root).await {
-                Ok(request) => request,
-                Err(error) => return ProofDispatchAttempt::BuildFailed(error),
-            };
-
-        match self.dispatch_tee(request).await {
-            Ok(session_id) if session_id == expected_session_id => {
-                ProofDispatchAttempt::Accepted(session_id)
-            }
-            Ok(session_id) => ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(format!(
-                "prover service returned mismatched session_id: expected {expected_session_id}, got {session_id}"
-            ))),
-            Err(error) => ProofDispatchAttempt::DispatchFailed(error),
-        }
-    }
-
-    /// Submits a TEE proof request under an explicit session id.
-    pub async fn dispatch_tee_with_session_id(
-        &self,
-        request: ProofRequest,
-        session_id: String,
-    ) -> Result<String, ProposerError> {
-        let request = ProposerProofAdapter::tee_prove_block_range_request_with_session_id(
-            request, session_id,
-        );
-        self.dispatch_prepared(request).await
-    }
-
-    async fn dispatch_tee(&self, request: ProofRequest) -> Result<String, ProposerError> {
+    async fn dispatch_request(&self, request: ProofRequest) -> Result<String, ProposerError> {
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
-        self.dispatch_prepared(request).await
-    }
-
-    async fn dispatch_prepared(
-        &self,
-        request: ProveBlockRangeRequest,
-    ) -> Result<String, ProposerError> {
         let session_id = request.proof.session_id.clone();
-        let response = match self.proof_requester.prove_block_range(request).await {
-            Ok(response) => response,
+        match self.proof_requester.prove_block_range(request).await {
+            Ok(response) if response.session_id == session_id => Ok(response.session_id),
+            Ok(response) => Err(ProposerError::Prover(format!(
+                "prover service returned mismatched session_id: expected {session_id}, got {}",
+                response.session_id
+            ))),
             Err(e) if e.is_l1_head_conflict_for_session(&session_id) => {
                 debug!(
                     session_id = %session_id,
                     "prover-service already has this TEE proof session with a different l1_head"
                 );
-                return Ok(session_id);
+                Ok(session_id)
             }
-            Err(e) => return Err(ProposerError::Prover(e.to_string())),
-        };
-        debug!(
-            session_id = %response.session_id,
-            "dispatched TEE proof request"
-        );
-        Ok(response.session_id)
+            Err(e) => Err(ProposerError::Prover(e.to_string())),
+        }
     }
 
     /// Dispatches every target from the current dispatcher cursor up to `safe_head`.
-    pub async fn tick(
-        &self,
-        state: &mut ProofDispatcherState,
-        recovered: RecoveredState,
-        safe_head: u64,
-        block_interval: u64,
-        max_retries: u32,
-        cancel: &CancellationToken,
-    ) -> bool {
-        state.retry_counts.retain(|&target, _| target > recovered.l2_block_number);
-
-        if state.recovered != Some(recovered) || state.cursor.is_none() {
-            state.recovered = Some(recovered);
-            state.cursor = Some(recovered);
-        }
-
-        let mut current = state.cursor.expect("dispatcher cursor initialized from recovery");
-        let mut drop_recovery_cache = false;
-
+    pub async fn tick(&self, current: &mut RecoveredState, safe_head: u64) {
         loop {
-            if cancel.is_cancelled() {
-                break;
-            }
-
             let Some(target_block) =
-                ProofTarget::next_block(current.l2_block_number, block_interval)
+                ProofTarget::next_block(current.l2_block_number, self.config.block_interval)
             else {
                 break;
             };
@@ -353,535 +167,161 @@ where
                 break;
             };
 
-            match self
-                .dispatch_with_retry(
-                    target_block,
-                    &current,
-                    claimed_l2_output_root,
-                    state,
-                    max_retries,
-                    true,
-                )
-                .await
-            {
-                ProofDispatchOutcome::Accepted => {
+            let request =
+                match self.build_request(target_block, &current, claimed_l2_output_root).await {
+                    Ok(request) => request,
+                    Err(error) => {
+                        Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED)
+                            .increment(1);
+                        warn!(
+                            target_block,
+                            error = %error,
+                            "Failed to build proof request, will retry next iteration"
+                        );
+                        break;
+                    }
+                };
+
+            match self.dispatch_request(request).await {
+                Ok(session_id) => {
+                    Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_ACCEPTED).increment(1);
+                    info!(
+                        target_block,
+                        session_id = %session_id,
+                        from_block = current.l2_block_number,
+                        "Proof request accepted by prover service"
+                    );
                     current.l2_block_number = target_block;
                     current.output_root = claimed_l2_output_root;
-                    state.cursor = Some(current);
                 }
-                ProofDispatchOutcome::RetryExhausted => {
-                    drop_recovery_cache = true;
-                    break;
-                }
-                ProofDispatchOutcome::Skipped => break,
-            }
-        }
+                Err(error) => {
+                    Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_FAILED).increment(1);
+                    Metrics::errors_total(error.metric_label()).increment(1);
+                    Metrics::proof_retries_total().increment(1);
 
-        Metrics::pipeline_retries().set(state.retry_counts.values().sum::<u32>() as f64);
-        drop_recovery_cache
-    }
-
-    /// Builds and dispatches a fresh root-derived request with retry accounting.
-    pub async fn dispatch_with_retry(
-        &self,
-        target_block: u64,
-        recovered: &RecoveredState,
-        claimed_l2_output_root: B256,
-        state: &mut ProofDispatcherState,
-        max_retries: u32,
-        count_dispatch_failure: bool,
-    ) -> ProofDispatchOutcome {
-        let dispatch = self.dispatch_for(target_block, recovered, claimed_l2_output_root).await;
-        Metrics::proof_dispatch_total(dispatch.metric_label()).increment(1);
-
-        match dispatch {
-            ProofDispatchAttempt::Accepted(session_id) => {
-                info!(
-                    target_block,
-                    session_id = %session_id,
-                    from_block = recovered.l2_block_number,
-                    "Proof request accepted by prover service"
-                );
-                ProofDispatchOutcome::Accepted
-            }
-            ProofDispatchAttempt::BuildFailed(error) => {
-                warn!(
-                    target_block,
-                    error = %error,
-                    "Failed to build proof request, will retry next iteration"
-                );
-                ProofDispatchOutcome::Skipped
-            }
-            ProofDispatchAttempt::DispatchFailed(error) => {
-                if count_dispatch_failure {
-                    if state.handle_proof_failure(target_block, error, max_retries) {
-                        ProofDispatchOutcome::Skipped
-                    } else {
-                        ProofDispatchOutcome::RetryExhausted
-                    }
-                } else {
                     warn!(
                         target_block,
                         error = %error,
-                        "Immediate re-dispatch failed after failed proof session"
+                        "Proof failed, re-dispatching"
                     );
-                    ProofDispatchOutcome::Skipped
+                    break;
                 }
             }
-        }
-    }
-}
-
-impl ProofDispatcherState {
-    /// Creates empty dispatcher state.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Records a proof/dispatch failure and returns whether retrying is allowed.
-    pub fn handle_proof_failure(
-        &mut self,
-        target: u64,
-        error: ProposerError,
-        max_retries: u32,
-    ) -> bool {
-        Metrics::errors_total(error.metric_label()).increment(1);
-        Metrics::proof_retries_total().increment(1);
-
-        let count = self.retry_counts.entry(target).or_insert(0);
-        *count += 1;
-        if *count >= max_retries {
-            error!(
-                target_block = target,
-                attempts = *count,
-                error = %error,
-                "Proof failed after max retries, dropping cached recovery"
-            );
-            self.retry_counts.remove(&target);
-            self.recovered = None;
-            self.cursor = None;
-            false
-        } else {
-            warn!(
-                target_block = target,
-                attempt = *count,
-                error = %error,
-                "Proof failed, re-dispatching"
-            );
-            true
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use async_trait::async_trait;
-    use base_prover_service_client::ProverServiceClientError;
-    use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProofRequestIdCollisionMessage, ProveBlockRangeRequest,
-        ProveBlockRangeResponse,
-    };
-    use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
+    use alloy_primitives::Address;
 
     use super::*;
     use crate::test_utils::{
-        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l1_header,
-        test_l2_block_ref, test_sync_status,
+        MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l2_block_ref,
+        test_sync_status,
     };
 
-    #[derive(Debug)]
-    struct MismatchedProofRequester {
-        session_id: String,
-    }
-
-    #[derive(Debug)]
-    struct L1HeadConflictRequester;
-
-    #[async_trait]
-    impl ProofRequesterProvider for MismatchedProofRequester {
-        async fn prove_block_range(
-            &self,
-            _request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            Ok(ProveBlockRangeResponse { session_id: self.session_id.clone() })
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not poll proofs")
-        }
-
-        async fn delete_proof_request(
-            &self,
-            _request: DeleteProofRequest,
-        ) -> Result<(), ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not delete proofs")
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not list proofs")
-        }
-    }
-
-    #[async_trait]
-    impl ProofRequesterProvider for L1HeadConflictRequester {
-        async fn prove_block_range(
-            &self,
-            request: ProveBlockRangeRequest,
-        ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
-            let session_id = request.proof.session_id;
-            Err(ProverServiceClientError::from(JsonRpcClientError::Call(ErrorObjectOwned::owned(
-                ProverServiceClientError::ERROR_FAILED_PRECONDITION,
-                ProofRequestIdCollisionMessage::for_field(session_id, "l1_head"),
-                None::<()>,
-            ))))
-        }
-
-        async fn get_proof(
-            &self,
-            _request: GetProofRequest,
-        ) -> Result<GetProofResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not poll proofs")
-        }
-
-        async fn delete_proof_request(
-            &self,
-            _request: DeleteProofRequest,
-        ) -> Result<(), ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not delete proofs")
-        }
-
-        async fn list_proofs(
-            &self,
-            _request: ListProofsRequest,
-        ) -> Result<ListProofsResponse, ProverServiceClientError> {
-            unimplemented!("dispatcher tests do not list proofs")
-        }
-    }
-
-    fn dispatcher() -> (ProofDispatcher<MockL1, MockL2, MockRollupClient>, Arc<MockProofRequester>)
-    {
-        let requester = Arc::new(MockProofRequester::default());
-        let dispatcher =
-            dispatcher_for_requester(Arc::clone(&requester) as Arc<dyn ProofRequesterProvider>);
-        (dispatcher, requester)
-    }
-
-    fn dispatcher_for_requester(
-        requester: Arc<dyn ProofRequesterProvider>,
-    ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
-        dispatcher_for_requester_and_sync(requester, test_sync_status(10_000, B256::ZERO), false)
-    }
-
-    fn dispatcher_for_requester_and_sync(
-        requester: Arc<dyn ProofRequesterProvider>,
-        sync_status: SyncStatus,
-        allow_non_finalized: bool,
-    ) -> ProofDispatcher<MockL1, MockL2, MockRollupClient> {
-        let l1 = Arc::new(MockL1::with_headers(
-            sync_status.finalized_l1.number,
-            headers_for_sync_status(&sync_status),
-        ));
-        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status,
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
+    fn dispatcher(requester: Arc<MockProofRequester>) -> ProofDispatcher {
         ProofDispatcher::new(
             requester,
-            l1,
-            l2,
-            rollup,
-            ProofDispatcherConfig {
-                proposer_address: Address::repeat_byte(0x04),
-                allow_non_finalized,
-                intermediate_block_interval: 300,
-                tee_image_hash: B256::repeat_byte(0x05),
-            },
+            Arc::new(MockL2 { block_not_found: false, canonical_hash: None }),
+            Arc::new(MockRollupClient {
+                sync_status: test_sync_status(10_000, B256::ZERO),
+                output_roots: Default::default(),
+                max_safe_block: None,
+            }),
+            DriverConfig { block_interval: 100, ..Default::default() },
         )
     }
 
-    fn headers_for_sync_status(
-        sync_status: &SyncStatus,
-    ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
-        let mut headers = HashMap::new();
-        for l1_head in [sync_status.finalized_l1, sync_status.safe_l1] {
-            headers.insert(l1_head.hash, test_l1_header(l1_head.hash, l1_head.number));
-        }
-        headers
+    fn sync_status_with_distinct_heads(
+        finalized_l2_number: u64,
+        safe_l2_number: u64,
+    ) -> SyncStatus {
+        let mut sync_status = test_sync_status(safe_l2_number, B256::repeat_byte(0x52));
+        sync_status.finalized_l1 = test_l1_block_ref(10);
+        sync_status.finalized_l1.hash = B256::repeat_byte(0xf1);
+        sync_status.safe_l1 = test_l1_block_ref(20);
+        sync_status.safe_l1.hash = B256::repeat_byte(0x5a);
+        sync_status.finalized_l2 = test_l2_block_ref(finalized_l2_number, B256::repeat_byte(0xf2));
+        sync_status.finalized_l2.l1origin.number = sync_status.finalized_l1.number;
+        sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number;
+        sync_status
     }
 
-    fn sync_status_with_distinct_heads(finalized_l2: u64, safe_l2: u64) -> SyncStatus {
-        let mut finalized_l1 = test_l1_block_ref(10);
-        finalized_l1.hash = B256::repeat_byte(0xf1);
-        let mut safe_l1 = test_l1_block_ref(20);
-        safe_l1.hash = B256::repeat_byte(0x5a);
-        let mut finalized_l2 = test_l2_block_ref(finalized_l2, B256::repeat_byte(0xf2));
-        finalized_l2.l1origin.hash = finalized_l1.hash;
-        finalized_l2.l1origin.number = finalized_l1.number;
-        let mut safe_l2 = test_l2_block_ref(safe_l2, B256::repeat_byte(0x52));
-        safe_l2.l1origin.hash = safe_l1.hash;
-        safe_l2.l1origin.number = safe_l1.number;
+    #[test]
+    fn select_l1_head_selects_expected_head_or_rejects_target() {
+        let sync_status = sync_status_with_distinct_heads(300, 600);
+        let (source, finalized_l1) =
+            ProofDispatcher::select_l1_head_for_target(200, &sync_status, true).unwrap();
+        assert_eq!(source, "finalized");
+        assert_eq!(finalized_l1.hash, B256::repeat_byte(0xf1));
+        assert_eq!(finalized_l1.number, 10);
 
-        SyncStatus {
-            current_l1: safe_l1,
-            current_l1_finalized: Some(finalized_l1),
-            head_l1: safe_l1,
-            safe_l1,
-            finalized_l1,
-            unsafe_l2: safe_l2,
-            safe_l2,
-            finalized_l2,
-            pending_safe_l2: None,
-        }
+        let (source, safe_l1) =
+            ProofDispatcher::select_l1_head_for_target(400, &sync_status, true).unwrap();
+        assert_eq!(source, "safe");
+        assert_eq!(safe_l1.hash, B256::repeat_byte(0x5a));
+        assert_eq!(safe_l1.number, 20);
+
+        let err = ProofDispatcher::select_l1_head_for_target(700, &sync_status, true).unwrap_err();
+        assert!(err.to_string().contains("above rollup safe head"));
+
+        let err = ProofDispatcher::select_l1_head_for_target(400, &sync_status, false).unwrap_err();
+        assert!(err.to_string().contains("above rollup finalized head"));
     }
 
-    fn recovered() -> RecoveredState {
-        RecoveredState {
-            parent_address: Address::ZERO,
-            output_root: B256::repeat_byte(0x03),
-            l2_block_number: 100,
-        }
-    }
-
-    #[tokio::test]
-    async fn build_request_uses_finalized_l1_head_for_finalized_target() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            true,
-        );
-
-        let request = dispatcher
-            .build_request(200, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect("request should build for finalized target");
-
-        assert_eq!(request.l1_head, B256::repeat_byte(0xf1));
-        assert_eq!(request.l1_head_number, 10);
-    }
-
-    #[tokio::test]
-    async fn build_request_uses_safe_l1_head_for_safe_target() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            true,
-        );
-
-        let request = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect("request should build for safe target");
-
-        assert_eq!(request.l1_head, B256::repeat_byte(0x5a));
-        assert_eq!(request.l1_head_number, 20);
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_l2_coverage_beyond_selected_l1_head() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
+    #[test]
+    fn select_l1_head_rejects_l2_coverage_beyond_selected_l1_head() {
         let mut sync_status = sync_status_with_distinct_heads(300, 600);
         sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number + 1;
-        let dispatcher = dispatcher_for_requester_and_sync(requester, sync_status, true);
 
-        let err = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
+        let err = ProofDispatcher::select_l1_head_for_target(400, &sync_status, true)
             .expect_err("safe L1 must cover selected safe L2 origin");
 
         assert!(err.to_string().contains("below safe L2 origin"));
     }
 
     #[tokio::test]
-    async fn build_request_rejects_l1_rpc_header_mismatch() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let sync_status = sync_status_with_distinct_heads(300, 600);
-        let mut headers = headers_for_sync_status(&sync_status);
-        headers.insert(
-            sync_status.safe_l1.hash,
-            test_l1_header(sync_status.safe_l1.hash, sync_status.safe_l1.number + 1),
-        );
-        let l1 = Arc::new(MockL1::with_headers(sync_status.finalized_l1.number, headers));
-        let l2 = Arc::new(MockL2 { block_not_found: false, canonical_hash: None });
-        let rollup = Arc::new(MockRollupClient {
-            sync_status,
-            output_roots: HashMap::new(),
-            max_safe_block: None,
-        });
-        let dispatcher = ProofDispatcher::new(
-            requester,
-            l1,
-            l2,
-            rollup,
-            ProofDispatcherConfig {
-                proposer_address: Address::repeat_byte(0x04),
-                allow_non_finalized: true,
-                intermediate_block_interval: 300,
-                tee_image_hash: B256::repeat_byte(0x05),
-            },
-        );
+    async fn dispatch_request_rejects_mismatched_session_id() {
+        let requester = Arc::new(MockProofRequester::default());
+        *requester.accepted_session_id.lock().unwrap() = Some("wrong-session".to_owned());
+        let dispatcher = dispatcher(requester);
 
-        let err = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("L1 RPC header must match rollup-selected L1 head");
+        let request =
+            ProofRequest { claimed_l2_output_root: B256::repeat_byte(0xaa), ..Default::default() };
+        let error = dispatcher.dispatch_request(request).await.expect_err("dispatch should fail");
 
-        assert!(err.to_string().contains("does not match L1 RPC header"));
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_target_above_safe_l2() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            true,
-        );
-
-        let err = dispatcher
-            .build_request(700, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("target above safe L2 should not build");
-
-        assert!(err.to_string().contains("above rollup safe head"));
-    }
-
-    #[tokio::test]
-    async fn build_request_rejects_safe_target_when_non_finalized_disallowed() {
-        let requester: Arc<dyn ProofRequesterProvider> = Arc::new(MockProofRequester::default());
-        let dispatcher = dispatcher_for_requester_and_sync(
-            requester,
-            sync_status_with_distinct_heads(300, 600),
-            false,
-        );
-
-        let err = dispatcher
-            .build_request(400, &recovered(), B256::repeat_byte(0xaa))
-            .await
-            .expect_err("non-finalized target should not build when disabled");
-
-        assert!(err.to_string().contains("above rollup finalized head"));
-    }
-
-    #[tokio::test]
-    async fn dispatch_for_sends_root_derived_session() {
-        let (dispatcher, requester) = dispatcher();
-        let claimed_root = B256::repeat_byte(0xaa);
-
-        let outcome = dispatcher.dispatch_for(200, &recovered(), claimed_root).await;
-        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
-            panic!("expected accepted dispatch")
-        };
-
-        assert_eq!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
-        assert!(requester.requests.lock().unwrap().contains_key(&session_id));
-    }
-
-    #[tokio::test]
-    async fn dispatch_for_rejects_mismatched_session_id() {
-        let dispatcher = dispatcher_for_requester(Arc::new(MismatchedProofRequester {
-            session_id: "wrong-session".to_owned(),
-        }));
-
-        let outcome = dispatcher.dispatch_for(200, &recovered(), B256::repeat_byte(0xaa)).await;
-
-        let ProofDispatchAttempt::DispatchFailed(ProposerError::Prover(message)) = outcome else {
+        let ProposerError::Prover(message) = error else {
             panic!("expected mismatched session id to fail dispatch")
         };
         assert!(message.contains("mismatched session_id"));
     }
 
     #[tokio::test]
-    async fn dispatch_for_accepts_existing_l1_head_conflict() {
-        let dispatcher = dispatcher_for_requester(Arc::new(L1HeadConflictRequester));
-        let claimed_root = B256::repeat_byte(0xaa);
+    async fn dispatch_request_accepts_existing_l1_head_conflict() {
+        let requester = Arc::new(MockProofRequester::default());
+        requester.reject_l1_head_conflict.store(true, std::sync::atomic::Ordering::SeqCst);
+        let dispatcher = dispatcher(requester);
 
-        let outcome = dispatcher.dispatch_for(200, &recovered(), claimed_root).await;
-
-        let ProofDispatchAttempt::Accepted(session_id) = outcome else {
-            panic!("expected accepted dispatch")
-        };
-        assert_eq!(session_id, ProposerProofAdapter::tee_session_id_for_root(claimed_root));
+        let request =
+            ProofRequest { claimed_l2_output_root: B256::repeat_byte(0xaa), ..Default::default() };
+        dispatcher.dispatch_request(request).await.expect("dispatch should accept");
     }
 
     #[tokio::test]
     async fn tick_dispatches_all_targets_up_to_safe_head() {
-        let (dispatcher, requester) = dispatcher();
-        let mut state = ProofDispatcherState::new();
-        let cancel = CancellationToken::new();
-
-        let result = dispatcher.tick(&mut state, recovered(), 400, 100, 3, &cancel).await;
-
-        assert!(!result);
-        assert_eq!(requester.requests.lock().unwrap().len(), 3);
-        assert_eq!(state.cursor.map(|cursor| cursor.l2_block_number), Some(400));
-        assert!(state.retry_counts.is_empty());
-    }
-
-    #[tokio::test]
-    async fn tick_resets_cursor_when_recovery_rewinds() {
-        let (dispatcher, requester) = dispatcher();
-        let cancel = CancellationToken::new();
-        let mut state = ProofDispatcherState {
-            recovered: Some(RecoveredState {
-                parent_address: Address::repeat_byte(0x01),
-                output_root: B256::repeat_byte(0x01),
-                l2_block_number: 300,
-            }),
-            cursor: Some(RecoveredState {
-                parent_address: Address::repeat_byte(0x02),
-                output_root: B256::repeat_byte(0x02),
-                l2_block_number: 500,
-            }),
-            retry_counts: HashMap::new(),
-        };
-
-        let result = dispatcher.tick(&mut state, recovered(), 200, 100, 3, &cancel).await;
-
-        assert!(!result);
-        assert_eq!(state.recovered, Some(recovered()));
-        assert_eq!(state.cursor.map(|cursor| cursor.l2_block_number), Some(200));
-        assert_eq!(requester.requests.lock().unwrap().len(), 1);
-    }
-
-    #[test]
-    fn handle_proof_failure_clears_cursor_on_retry_exhaustion() {
-        let mut state = ProofDispatcherState::new();
-        state.cursor = Some(RecoveredState {
+        let requester = Arc::new(MockProofRequester::default());
+        let dispatcher = dispatcher(Arc::clone(&requester));
+        let mut current = RecoveredState {
             parent_address: Address::ZERO,
-            output_root: B256::repeat_byte(0x09),
-            l2_block_number: 300,
-        });
-        state.retry_counts.insert(200, 1);
-
-        let should_retry = state.handle_proof_failure(200, ProposerError::Prover("boom".into()), 2);
-
-        assert!(!should_retry);
-        assert!(state.recovered.is_none());
-        assert!(state.cursor.is_none());
-        assert!(!state.retry_counts.contains_key(&200));
-    }
-
-    #[test]
-    fn config_is_copyable() {
-        let config = ProofDispatcherConfig {
-            proposer_address: Address::ZERO,
-            allow_non_finalized: false,
-            intermediate_block_interval: 1,
-            tee_image_hash: B256::ZERO,
+            output_root: B256::repeat_byte(0x03),
+            l2_block_number: 100,
         };
-        let _copy = config;
+
+        dispatcher.tick(&mut current, 400).await;
+
+        assert_eq!(requester.requests.lock().unwrap().len(), 3);
+        assert_eq!(current.l2_block_number, 400);
     }
 }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -3,10 +3,10 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use base_optimism_rpc::{L1BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
-use base_proof_rpc::{L2Provider, RollupProvider};
+use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
 use tracing::{debug, info, warn};
 
@@ -18,12 +18,40 @@ use crate::{
     proof_target::ProofTarget,
 };
 
+/// Static parameters needed to build and dispatch proposer proof requests.
+#[derive(Debug, Clone, Copy)]
+pub struct ProofDispatcherConfig {
+    /// Whether requests may target safe, non-finalized L2 blocks.
+    pub allow_non_finalized: bool,
+    /// Number of L2 blocks between proof targets.
+    pub block_interval: u64,
+    /// Address of the proposer that will submit the proof onchain.
+    pub proposer_address: Address,
+    /// Number of L2 blocks between intermediate output root checkpoints.
+    pub intermediate_block_interval: u64,
+    /// Expected TEE enclave image hash.
+    pub tee_image_hash: B256,
+}
+
+impl From<&DriverConfig> for ProofDispatcherConfig {
+    fn from(config: &DriverConfig) -> Self {
+        Self {
+            allow_non_finalized: config.allow_non_finalized,
+            block_interval: config.block_interval,
+            proposer_address: config.proposer_address,
+            intermediate_block_interval: config.intermediate_block_interval,
+            tee_image_hash: config.tee_image_hash,
+        }
+    }
+}
+
 /// Builds and dispatches proposer TEE proof requests.
 pub struct ProofDispatcher {
     proof_requester: Arc<dyn ProofRequesterProvider>,
+    l1_client: Arc<dyn L1Provider>,
     l2_client: Arc<dyn L2Provider>,
     rollup_client: Arc<dyn RollupProvider>,
-    config: DriverConfig,
+    config: ProofDispatcherConfig,
 }
 
 impl std::fmt::Debug for ProofDispatcher {
@@ -36,11 +64,12 @@ impl ProofDispatcher {
     /// Creates a proof dispatcher.
     pub fn new(
         proof_requester: Arc<dyn ProofRequesterProvider>,
+        l1_client: Arc<dyn L1Provider>,
         l2_client: Arc<dyn L2Provider>,
         rollup_client: Arc<dyn RollupProvider>,
-        config: DriverConfig,
+        config: ProofDispatcherConfig,
     ) -> Self {
-        Self { proof_requester, l2_client, rollup_client, config }
+        Self { proof_requester, l1_client, l2_client, rollup_client, config }
     }
 
     /// Builds a proof request for `target_block` using `recovered` as the agreed parent.
@@ -60,14 +89,22 @@ impl ProofDispatcher {
             &sync_status,
             self.config.allow_non_finalized,
         )?;
+        let l1_header =
+            self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
+        if l1_header.hash != l1_head.hash || l1_header.number != l1_head.number {
+            return Err(ProposerError::Internal(format!(
+                "selected {l1_head_source} L1 head {}:{} does not match L1 RPC header {}:{}",
+                l1_head.number, l1_head.hash, l1_header.number, l1_header.hash
+            )));
+        }
 
         info!(
             from_block = recovered.l2_block_number,
             to_block = target_block,
             allow_non_finalized = self.config.allow_non_finalized,
             l1_head_source = l1_head_source,
-            l1_head_number = l1_head.number,
-            l1_head_hash = %l1_head.hash,
+            l1_head_number = l1_header.number,
+            l1_head_hash = %l1_header.hash,
             agreed_l2_head_hash = %agreed_l2_head.hash,
             agreed_l2_output_root = %recovered.output_root,
             claimed_l2_output_root = %claimed_l2_output_root,
@@ -75,14 +112,14 @@ impl ProofDispatcher {
         );
 
         Ok(ProofRequest {
-            l1_head: l1_head.hash,
+            l1_head: l1_header.hash,
             agreed_l2_head_hash: agreed_l2_head.hash,
             agreed_l2_output_root: recovered.output_root,
             claimed_l2_output_root,
             claimed_l2_block_number: target_block,
             proposer: self.config.proposer_address,
             intermediate_block_interval: self.config.intermediate_block_interval,
-            l1_head_number: l1_head.number,
+            l1_head_number: l1_header.number,
             image_hash: self.config.tee_image_hash,
         })
     }
@@ -213,24 +250,31 @@ impl ProofDispatcher {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy_primitives::Address;
 
     use super::*;
     use crate::test_utils::{
-        MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l2_block_ref,
-        test_sync_status,
+        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l1_header,
+        test_l2_block_ref, test_sync_status,
     };
 
     fn dispatcher(requester: Arc<MockProofRequester>) -> ProofDispatcher {
+        let sync_status = test_sync_status(10_000, B256::ZERO);
         ProofDispatcher::new(
             requester,
+            Arc::new(MockL1::new(sync_status.finalized_l1.number)),
             Arc::new(MockL2 { block_not_found: false, canonical_hash: None }),
             Arc::new(MockRollupClient {
-                sync_status: test_sync_status(10_000, B256::ZERO),
+                sync_status,
                 output_roots: Default::default(),
                 max_safe_block: None,
             }),
-            DriverConfig { block_interval: 100, ..Default::default() },
+            ProofDispatcherConfig::from(&DriverConfig {
+                block_interval: 100,
+                ..Default::default()
+            }),
         )
     }
 
@@ -247,6 +291,15 @@ mod tests {
         sync_status.finalized_l2.l1origin.number = sync_status.finalized_l1.number;
         sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number;
         sync_status
+    }
+
+    fn headers_for_sync_status(
+        sync_status: &SyncStatus,
+    ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
+        [sync_status.finalized_l1, sync_status.safe_l1]
+            .into_iter()
+            .map(|l1_head| (l1_head.hash, test_l1_header(l1_head.hash, l1_head.number)))
+            .collect()
     }
 
     #[test]
@@ -280,6 +333,45 @@ mod tests {
             .expect_err("safe L1 must cover selected safe L2 origin");
 
         assert!(err.to_string().contains("below safe L2 origin"));
+    }
+
+    #[tokio::test]
+    async fn build_request_rejects_l1_rpc_header_mismatch() {
+        let sync_status = sync_status_with_distinct_heads(300, 600);
+        let mut headers = headers_for_sync_status(&sync_status);
+        headers.insert(
+            sync_status.safe_l1.hash,
+            test_l1_header(sync_status.safe_l1.hash, sync_status.safe_l1.number + 1),
+        );
+        let dispatcher = ProofDispatcher::new(
+            Arc::new(MockProofRequester::default()),
+            Arc::new(MockL1::with_headers(sync_status.finalized_l1.number, headers)),
+            Arc::new(MockL2 { block_not_found: false, canonical_hash: None }),
+            Arc::new(MockRollupClient {
+                sync_status,
+                output_roots: Default::default(),
+                max_safe_block: None,
+            }),
+            ProofDispatcherConfig {
+                allow_non_finalized: true,
+                block_interval: 100,
+                proposer_address: Address::repeat_byte(0x04),
+                intermediate_block_interval: 300,
+                tee_image_hash: B256::repeat_byte(0x05),
+            },
+        );
+        let recovered = RecoveredState {
+            parent_address: Address::ZERO,
+            output_root: B256::repeat_byte(0x03),
+            l2_block_number: 100,
+        };
+
+        let err = dispatcher
+            .build_request(400, &recovered, B256::repeat_byte(0xaa))
+            .await
+            .expect_err("L1 RPC header must match rollup-selected L1 head");
+
+        assert!(err.to_string().contains("does not match L1 RPC header"));
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_target.rs
+++ b/crates/proof/proposer/src/proof_target.rs
@@ -32,7 +32,7 @@ impl ProofTarget {
         caller: &'static str,
     ) -> Option<B256>
     where
-        R: RollupProvider,
+        R: RollupProvider + ?Sized,
     {
         match rollup_client.output_at_block(target_block).await {
             Ok(output) => Some(output.output_root),

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -233,9 +233,9 @@ impl ProposerService {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            l1_client.clone(),
-            l2_client.clone(),
-            rollup_client.clone(),
+            Arc::<L1Client>::clone(&l1_client),
+            Arc::<L2Client>::clone(&l2_client),
+            Arc::<RollupClient>::clone(&rollup_client),
             ProofDispatcherConfig::from(&driver_config),
         );
         let proof_submitter = ProofSubmitter::new(

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -36,7 +36,7 @@ use crate::{
     output_proposer::{OutputProposer, ProposalSubmitter},
     pipeline::ProvingPipeline,
     proof_collector::ProofCollector,
-    proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
+    proof_dispatcher::ProofDispatcher,
     proof_recovery::{ProofRecovery, ProofRecoveryConfig},
     proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
 };
@@ -220,7 +220,6 @@ impl ProposerService {
 
         let driver_config = DriverConfig {
             poll_interval: config.poll_interval,
-            max_retries: 8,
             recovery_scan_concurrency: config.recovery_scan_concurrency,
             submit_timeout,
             tee_prover_registry_address: config.tee_prover_registry_address,
@@ -234,15 +233,9 @@ impl ProposerService {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
-            Arc::clone(&l1_client),
-            Arc::clone(&l2_client),
-            Arc::clone(&rollup_client),
-            ProofDispatcherConfig {
-                proposer_address: driver_config.proposer_address,
-                allow_non_finalized: driver_config.allow_non_finalized,
-                intermediate_block_interval: driver_config.intermediate_block_interval,
-                tee_image_hash: driver_config.tee_image_hash,
-            },
+            l2_client.clone(),
+            rollup_client.clone(),
+            driver_config.clone(),
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -36,7 +36,7 @@ use crate::{
     output_proposer::{OutputProposer, ProposalSubmitter},
     pipeline::ProvingPipeline,
     proof_collector::ProofCollector,
-    proof_dispatcher::ProofDispatcher,
+    proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
     proof_recovery::{ProofRecovery, ProofRecoveryConfig},
     proof_submitter::{ProofSubmitter, ProofSubmitterConfig},
 };
@@ -233,9 +233,10 @@ impl ProposerService {
         };
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
+            l1_client.clone(),
             l2_client.clone(),
             rollup_client.clone(),
-            driver_config.clone(),
+            ProofDispatcherConfig::from(&driver_config),
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -24,9 +24,9 @@ use base_proof_rpc::{BaseBlock, L1Provider, L2Provider, RollupProvider, RpcError
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
     DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestKind as ApiProofRequestKind,
-    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
-    TeeKind, TeeProofResult,
+    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestIdCollisionMessage,
+    ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
 };
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
@@ -467,6 +467,8 @@ pub struct MockProofRequester {
     pub failed_sessions: std::sync::Mutex<HashMap<String, String>>,
     /// Reject every `prove_block_range` call with a timeout.
     pub reject_prove: AtomicBool,
+    /// Reject every `prove_block_range` call with an L1 head conflict.
+    pub reject_l1_head_conflict: AtomicBool,
     /// Override the accepted session id returned by `prove_block_range`.
     pub accepted_session_id: std::sync::Mutex<Option<String>>,
     /// Number of `prove_block_range` calls accepted.
@@ -486,6 +488,16 @@ impl ProofRequesterProvider for MockProofRequester {
         }
 
         let session_id = request.proof.session_id.clone();
+        if self.reject_l1_head_conflict.load(Ordering::SeqCst) {
+            return Err(ProverServiceClientError::from(JsonRpcClientError::Call(
+                ErrorObjectOwned::owned(
+                    ProverServiceClientError::ERROR_FAILED_PRECONDITION,
+                    ProofRequestIdCollisionMessage::for_field(session_id, "l1_head"),
+                    None::<()>,
+                ),
+            )));
+        }
+
         self.prove_count.fetch_add(1, Ordering::SeqCst);
         self.requests.lock().unwrap().insert(session_id.clone(), request);
         if let Some(session_id) = self.accepted_session_id.lock().unwrap().clone() {


### PR DESCRIPTION
### What changed? Why?

Cleaned up the proposer proof dispatcher by simplifying dispatcher state, metrics wiring, and the pipeline/service call sites around proof targets.

### Notes to reviewers

The main review surface is `crates/proof/proposer/src/proof_dispatcher.rs`; the surrounding changes keep the driver, pipeline, service, metrics, and test utilities aligned with the simpler dispatcher shape.