### PR TITLE
fix(txpool): admit EIP-8130 against pending state and retry on lag

### DIFF
--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -440,7 +440,24 @@ impl PrecompileStorageProvider for OverlayPrecompileStorage<'_> {
 
 impl PoolTransactionError for BaseTxPoolError {
     fn is_bad_transaction(&self) -> bool {
-        true
+        match self {
+            // Deterministic and state-independent: the DA footprint exceeds the
+            // block gas limit under every possible state, so the transaction can
+            // never be included. Penalize the peer and cache it as bad.
+            Self::DaFootprintExceedsBlockGasLimit { .. } => true,
+            // EIP-8130 admission is state-relative: it authorizes against the
+            // live account-configuration and nonce-channel precompile state and
+            // the sender's nonce/code. A pool state snapshot that trails the
+            // canonical tip can transiently reject a structurally valid
+            // transaction whose authorizing state was written by the preceding
+            // block, so these failures are retryable and must not be cached as
+            // permanently bad or penalize the relaying peer. The dominant
+            // structural invariants are surfaced separately as
+            // `InvalidTransactionError` variants (classified by the inner
+            // validator); the residual deterministic cases routed here are still
+            // rejected from the pool, they merely do not penalize the peer.
+            Self::Eip8130Validation { .. } => false,
+        }
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -642,7 +659,27 @@ where
     ) -> Result<Eip8130ValidationState, InvalidPoolTransactionError> {
         let local_chain_id = self.inner.chain_spec().chain().id();
         let now = self.block_timestamp();
-        let state = self.client().latest().map_err(|error| Self::provider_unavailable(error))?;
+        // Admit against the freshest available state. `pending()` is the state
+        // of the block currently being built (not yet committed), one block
+        // ahead of `latest()` (the last fully committed block). On the builder
+        // this reflects precompile state already mutated by the in-progress
+        // block; on non-builder nodes it may be unavailable. EIP-8130 admission
+        // authorizes against live precompile state (account configuration, nonce
+        // channels) and the sender's nonce/code, so using `pending()` reduces
+        // false rejections when authorizing state was written by the preceding
+        // committed block (e.g. an owner change immediately followed by a
+        // transaction from the new owner). Falls back to `latest()` when a
+        // pending snapshot is unavailable.
+        let state = match self.client().pending() {
+            Ok(state) => state,
+            Err(pending_error) => {
+                tracing::debug!(
+                    error = %pending_error,
+                    "EIP-8130 pending state unavailable; falling back to latest"
+                );
+                self.client().latest().map_err(|error| Self::provider_unavailable(error))?
+            }
+        };
 
         // Authorize *and apply* the account changes against a writable overlay so
         // the sender/payer and every config change are validated against the same


### PR DESCRIPTION
## Summary

EIP-8130 mempool admission authorizes against **live** precompile state (account configuration, nonce channels) and the sender's nonce/code. It previously read \`client().latest()\`, the last fully committed block, which can trail the block currently being built by one block. A snapshot that lags the in-progress block transiently rejects a *structurally valid* transaction whose authorizing state was written by the **preceding** committed block — e.g. an owner change immediately followed by a transaction signed by the new owner, which fails as \`actor … is not bound\` even though the binding is already canonical.

## Changes

- **Read \`client().pending()\`** for the admission state snapshot. \`pending()\` is the state of the block currently being built (not yet committed), one block ahead of \`latest()\`. On the builder this reflects precompile state already mutated by the in-progress block; on non-builder nodes it may be unavailable, so this falls back to \`latest()\`.
- **Reclassify \`BaseTxPoolError::Eip8130Validation\` as non-bad (retryable).** EIP-8130 admission is state-relative, so a lagging snapshot can yield a transient false rejection; caching the tx as permanently bad or penalizing the relaying peer would drop traffic that becomes valid moments later. The deterministic, state-independent DA-footprint failure stays penalizing. The dominant structural invariants are already surfaced as \`InvalidTransactionError\` variants and classified by the inner validator.

## Test plan

- \`cargo test -p base-execution-txpool\`
- Devnet: rebuild, run the EOA + smart-account 8130 suite, expect 6/6 with no inter-tx delay (previously 3/6).