### PR TITLE
fix(txpool): charge EIP-8130 admission operator fee on gas_limit + payer_auth

### DIFF
--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -77,6 +77,11 @@ struct Eip8130ValidationState {
     payer_balance_after_auth: U256,
     sender_nonce: u64,
     sender_bytecode_hash: Option<B256>,
+    /// Payer-authentication gas metered on top of `gas_limit`. The execution
+    /// path charges the operator fee on `gas_limit + payer_auth`, so admission
+    /// must do the same to avoid admitting operator-fee-underfunded sponsored
+    /// transactions. Zero for self-pay transactions.
+    payer_auth: u64,
 }
 
 /// Read-only precompile storage adapter backed by a reth state provider.
@@ -412,10 +417,10 @@ where
                 bytecode_hash: state.sender_bytecode_hash,
                 authorities: (state.payer != state.sender).then_some(vec![state.payer]),
             };
-            return self.apply_base_checks(outcome);
+            return self.apply_base_checks(outcome, state.payer_auth);
         }
         let outcome = self.inner.validate_one_with_state(origin, transaction, state);
-        self.apply_base_checks(outcome)
+        self.apply_base_checks(outcome, 0)
     }
 
     /// Runs full EIP-8130 admission checks that require account/precompile state:
@@ -553,6 +558,7 @@ where
             payer_balance_after_auth: payer_account.balance.saturating_sub(payer_auth_charge),
             sender_nonce,
             sender_bytecode_hash: sender_account.bytecode_hash,
+            payer_auth: intrinsic.payer_auth,
         })
     }
 
@@ -1107,9 +1113,18 @@ where
     }
 
     /// Performs the necessary Base-specific checks based on top of the regular eth outcome.
+    ///
+    /// `operator_fee_gas_addition` is gas charged the operator fee on top of the
+    /// transaction's signed `gas_limit`. It is zero for ordinary transactions; for
+    /// EIP-8130 it is the payer-authentication gas, because the execution path meters
+    /// the operator fee on `gas_limit + payer_auth` (the gas-price portion of that
+    /// payer-auth gas is already reflected in the reduced `balance`). Mirroring it here
+    /// prevents admitting sponsored transactions that are operator-fee-underfunded and
+    /// would never execute.
     fn apply_base_checks(
         &self,
         outcome: TransactionValidationOutcome<Tx>,
+        operator_fee_gas_addition: u64,
     ) -> TransactionValidationOutcome<Tx> {
         if !self.requires_l1_data_gas_fee() {
             // no need to check L1 gas fee
@@ -1156,7 +1171,9 @@ where
             let spec_id = BaseSpecId::from_timestamp(self.chain_spec(), self.block_timestamp());
             let cost_addition = l1_block_info.tx_cost(
                 &encoded,
-                U256::from(valid_tx.transaction().gas_limit()),
+                U256::from(
+                    valid_tx.transaction().gas_limit().saturating_add(operator_fee_gas_addition),
+                ),
                 spec_id,
             );
             let cost = valid_tx.transaction().cost().saturating_add(cost_addition);


### PR DESCRIPTION
## Summary

The EIP-8130 **execution** path meters the operator fee on the full chargeable gas — `max_chargeable_gas(gas_limit, payer_auth) = gas_limit + payer_auth` (`Eip8130Executor` pre-charge + settle, via `FeeCheck`). **Admission**'s `apply_base_checks`, though, computed the L1/operator `tx_cost` on the bare signed `gas_limit()`, so for a **sponsored** transaction it omitted the operator fee on the payer-authentication gas.

A payer funded for `operator_fee(gas_limit)` but not `operator_fee(gas_limit + payer_auth)` could be **admitted and then fail during execution** — the same admitted-but-never-executes hazard the post-Isthmus operator-fee affordability check was added to prevent.

## Why only the operator fee

The *gas-price* fee on `payer_auth` is already accounted for: `validate_eip8130_full` subtracts `payer_auth * max_fee_per_gas` from the payer balance (`payer_balance_after_auth`) before the affordability check. The only missing piece was the **operator-fee** component, which `tx_cost` derives from the gas amount.

## Change

- Carry the payer-auth gas on `Eip8130ValidationState` and thread it into `apply_base_checks` as `operator_fee_gas_addition`, adding it to the `gas_limit` passed to `tx_cost`. Mirrors execution exactly.
- Self-pay EIP-8130 and all non-8130 transactions are unaffected (`payer_auth == 0`).

## Test plan

- `cargo test -p base-execution-txpool`
- **Follow-up (recommended):** add a sponsored-8130 analog of `rejects_tx_underfunded_for_operator_fee_post_isthmus` — a payer funded for `gas_limit`-based operator fee but short by `operator_fee(payer_auth)` must be rejected at admission. Requires setting up `AccountConfiguration` precompile state for payer authorization; deferred to keep this fix isolated.

> Note: lint-clean; not yet locally compiled (avoiding contention with an in-progress local build). The change uses only existing fields/helpers and is mechanical.