### PR TITLE
chore(requester): model Groth16 aggregation over range proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,6 +3622,7 @@ dependencies = [
  "base-proof-contracts",
  "base-proof-primitives",
  "base-proof-rpc",
+ "base-proof-zk-requester",
  "base-protocol",
  "base-prover-service-client",
  "base-prover-service-protocol",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -31,6 +31,7 @@ base-balance-monitor.workspace = true
 # Proof
 base-proof-rpc.workspace = true
 base-proof-contracts.workspace = true
+base-proof-zk-requester.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -24,8 +24,9 @@ use alloy_primitives::{Address, B256};
 use base_proof_contracts::{AggregateVerifierClient, GameStatus};
 use base_proof_primitives::ProofRequest as TeeProofRequest;
 use base_proof_rpc::L2Provider;
+use base_proof_zk_requester::{Groth16RangeProofRequest, ZkProofRequester};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{SnarkGroth16ProofRequest, TeeKind, ZkProofRequest, ZkVm};
+use base_prover_service_protocol::{TeeKind, ZkProofRequest, ZkVm};
 use base_runtime::{Clock, TokioRuntime};
 use base_tx_manager::TxManager;
 use tokio::select;
@@ -33,9 +34,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    BondManager, CandidateGame, ChallengeSubmitter, ChallengerMetrics, DisputeIntent, GameCategory,
-    GameScanner, IntermediateValidationParams, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofKind, ProofPhase, ProofUpdate, ValidatorError,
+    BondManager, CandidateGame, ChallengeSubmitter, ChallengerMetrics, ChallengerProofAdapter,
+    DisputeIntent, GameCategory, GameScanner, IntermediateValidationParams, L1HeadProvider,
+    OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate,
+    ValidatorError,
 };
 
 /// Configuration for the challenger [`Driver`].
@@ -610,16 +612,21 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         })
     }
 
-    /// Builds a [`SnarkGroth16ProofRequest`] for the given candidate and invalid index.
+    /// Builds a logical Groth16 proof request for the given candidate and invalid index.
     fn build_zk_request(
         &self,
         candidate: &CandidateGame,
         invalid_index: u64,
-    ) -> eyre::Result<SnarkGroth16ProofRequest> {
+    ) -> eyre::Result<Groth16RangeProofRequest> {
         let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
+        let session_id = ChallengerProofAdapter::snark_groth16_session_id(
+            candidate.factory.proxy,
+            invalid_index,
+        );
 
-        Ok(SnarkGroth16ProofRequest {
-            proof: ZkProofRequest {
+        Ok(Groth16RangeProofRequest::new(
+            session_id,
+            ZkProofRequest {
                 start_block_number,
                 number_of_blocks_to_prove: candidate.intermediate_block_interval,
                 sequence_window: None,
@@ -627,8 +634,8 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                 intermediate_root_interval: Some(candidate.intermediate_block_interval),
                 zk_vm: ZkVm::Sp1,
             },
-            prover_address: self.submitter.sender_address(),
-        })
+            self.submitter.sender_address(),
+        ))
     }
 
     /// Requests a ZK proof, stores the session, and polls for the result.
@@ -646,25 +653,19 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         // needs to cover the single interval that contains the invalid
         // checkpoint: [prior_checkpoint .. invalid_checkpoint].
         let proof_request = self.build_zk_request(&candidate, invalid_index)?;
-        let request = crate::ChallengerProofAdapter::snark_groth16_prove_block_range_request(
-            game_address,
-            invalid_index,
-            proof_request.clone(),
-        );
+        let prove_response =
+            ZkProofRequester::request_groth16_proof_with(&*self.proof_requester, &proof_request)
+                .await?;
 
-        let prove_response = self.proof_requester.prove_block_range(request).await?;
-
-        info!(
-            game = %game_address,
-            session_id = %prove_response.session_id,
-            "proof job initiated"
-        );
+        let session_id = prove_response.state.range_session_id().to_owned();
+        info!(game = %game_address, session_id = %session_id, "proof job initiated");
 
         let pending = PendingProof::awaiting(
-            prove_response.session_id,
+            session_id,
             invalid_index,
             expected_root,
             proof_request,
+            prove_response.state,
             intent,
         );
         self.pending_proofs.insert(game_address, pending);
@@ -840,7 +841,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         };
 
         let retry_count = pending.retry_count;
-        let invalid_index = pending.invalid_index;
 
         if retry_count > Self::MAX_PROOF_RETRIES {
             warn!(
@@ -875,37 +875,34 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
                 // Transition eagerly so retries use the ZK path.
                 if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.kind = ProofKind::Zk { prove_request: fallback_request.clone() };
+                    p.kind = ProofKind::Zk {
+                        prove_request: fallback_request.clone(),
+                        proof_state: None,
+                    };
                     p.intent = fallback_intent;
                     p.retry_count = 0;
                 }
 
                 fallback_request
             }
-            ProofKind::Zk { prove_request } => prove_request.clone(),
+            ProofKind::Zk { prove_request, .. } => prove_request.clone(),
         };
 
         ChallengerMetrics::proof_retries_total().increment(1);
 
-        let prove_request = crate::ChallengerProofAdapter::snark_groth16_prove_block_range_request(
-            game_address,
-            invalid_index,
-            request,
-        );
-
-        match self.proof_requester.prove_block_range(prove_request).await {
+        match ZkProofRequester::request_groth16_proof_with(&*self.proof_requester, &request).await {
             Ok(response) => {
+                let session_id = response.state.range_session_id().to_owned();
                 info!(
                     game = %game_address,
-                    session_id = %response.session_id,
+                    session_id = %session_id,
                     retry_count = retry_count,
                     "proof job re-initiated"
                 );
                 if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.phase = ProofPhase::AwaitingProof {
-                        session_id: response.session_id,
-                        started_at: Instant::now(),
-                    };
+                    p.phase = ProofPhase::AwaitingProof { session_id, started_at: Instant::now() };
+                    p.kind =
+                        ProofKind::Zk { prove_request: request, proof_state: Some(response.state) };
                 }
             }
             Err(e) => {

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -13,8 +13,11 @@ use std::{
 };
 
 use alloy_primitives::{Address, B256, Bytes};
+use base_proof_zk_requester::{
+    Groth16ProofState, Groth16RangeProofRequest, ZkProofRequester, ZkProofRequesterError,
+};
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{GetProofRequest, ProofStatus, SnarkGroth16ProofRequest};
+use base_prover_service_protocol::{GetProofRequest, ProofResult, ProofStatus};
 use tracing::warn;
 
 use crate::{ChallengerMetrics, ChallengerProofAdapter};
@@ -32,7 +35,7 @@ pub enum ProofKind {
     Tee {
         /// Pre-built ZK request for fallback if TEE submission fails.
         /// `None` when the fallback request could not be constructed.
-        zk_fallback_request: Option<SnarkGroth16ProofRequest>,
+        zk_fallback_request: Option<Groth16RangeProofRequest>,
         /// The dispute intent to use for the ZK fallback path.
         /// `None` when the fallback request could not be constructed.
         zk_fallback_intent: Option<DisputeIntent>,
@@ -43,7 +46,9 @@ pub enum ProofKind {
     /// `proveBlockRange` on failure.
     Zk {
         /// Original request parameters for retry.
-        prove_request: SnarkGroth16ProofRequest,
+        prove_request: Groth16RangeProofRequest,
+        /// Current requester orchestration state.
+        proof_state: Option<Groth16ProofState>,
     },
 }
 
@@ -112,12 +117,13 @@ impl PendingProof {
         session_id: String,
         invalid_index: u64,
         expected_root: B256,
-        prove_request: SnarkGroth16ProofRequest,
+        prove_request: Groth16RangeProofRequest,
+        proof_state: Groth16ProofState,
         intent: DisputeIntent,
     ) -> Self {
         Self {
             phase: ProofPhase::AwaitingProof { session_id, started_at: Instant::now() },
-            kind: ProofKind::Zk { prove_request },
+            kind: ProofKind::Zk { prove_request, proof_state: Some(proof_state) },
             invalid_index,
             expected_root,
             retry_count: 0,
@@ -130,7 +136,7 @@ impl PendingProof {
         session_id: String,
         invalid_index: u64,
         expected_root: B256,
-        zk_fallback_request: Option<SnarkGroth16ProofRequest>,
+        zk_fallback_request: Option<Groth16RangeProofRequest>,
         zk_fallback_intent: Option<DisputeIntent>,
     ) -> Self {
         Self {
@@ -144,16 +150,16 @@ impl PendingProof {
     }
 
     /// Creates a new ZK `PendingProof` in the `ReadyToSubmit` phase.
-    pub const fn ready(
+    pub fn ready(
         proof_bytes: Bytes,
         invalid_index: u64,
         expected_root: B256,
-        prove_request: SnarkGroth16ProofRequest,
+        prove_request: Groth16RangeProofRequest,
         intent: DisputeIntent,
     ) -> Self {
         Self {
             phase: ProofPhase::ReadyToSubmit { proof_bytes },
-            kind: ProofKind::Zk { prove_request },
+            kind: ProofKind::Zk { prove_request, proof_state: None },
             invalid_index,
             expected_root,
             retry_count: 0,
@@ -267,6 +273,102 @@ impl PendingProofs {
             pending.retry_count += 1;
             pending.phase = ProofPhase::NeedsRetry;
             return Ok(Some(ProofUpdate::NeedsRetry));
+        }
+
+        let zk_request = match &pending.kind {
+            ProofKind::Zk { prove_request, proof_state: Some(proof_state) } => {
+                Some((prove_request.clone(), proof_state.clone()))
+            }
+            ProofKind::Zk { proof_state: None, .. } => {
+                let pending = self.0.get_mut(&game).expect("entry just inspected");
+                warn!(game = %game, "ZK proof missing requester state, treating as retryable failure");
+                ChallengerMetrics::proof_session_failures_total(
+                    ChallengerMetrics::PROOF_FAILURE_MALFORMED,
+                )
+                .increment(1);
+                pending.retry_count += 1;
+                pending.phase = ProofPhase::NeedsRetry;
+                return Ok(Some(ProofUpdate::NeedsRetry));
+            }
+            ProofKind::Tee { .. } => None,
+        };
+
+        if let Some((prove_request, mut proof_state)) = zk_request {
+            let result = ZkProofRequester::groth16_result_with(
+                proof_requester,
+                &prove_request,
+                &mut proof_state,
+            )
+            .await;
+
+            let pending = match self.0.get_mut(&game) {
+                Some(p) => p,
+                None => return Ok(None),
+            };
+            if let ProofKind::Zk { proof_state: state, .. } = &mut pending.kind {
+                *state = Some(proof_state);
+            }
+
+            let update = match result {
+                Ok(Some(result)) => {
+                    let proof_bytes = ChallengerProofAdapter::snark_groth16_dispute_proof_bytes(
+                        ProofResult::SnarkGroth16(result),
+                    )?;
+                    pending.phase = ProofPhase::ReadyToSubmit { proof_bytes: proof_bytes.clone() };
+                    ProofUpdate::Ready(proof_bytes)
+                }
+                Ok(None) => ProofUpdate::Pending,
+                Err(ZkProofRequesterError::AggregationRequestFailed {
+                    range_session_id,
+                    source,
+                    ..
+                }) => {
+                    warn!(
+                        game = %game,
+                        range_session_id = %range_session_id,
+                        error = %source,
+                        "aggregation request failed, will retry proof request"
+                    );
+                    ChallengerMetrics::proof_session_failures_total(
+                        ChallengerMetrics::PROOF_FAILURE_FAILED,
+                    )
+                    .increment(1);
+                    pending.retry_count += 1;
+                    pending.phase = ProofPhase::NeedsRetry;
+                    ProofUpdate::NeedsRetry
+                }
+                Err(ZkProofRequesterError::ProofFailed { session_id, message }) => {
+                    warn!(
+                        game = %game,
+                        session_id = %session_id,
+                        error_message = %message,
+                        "proof job failed"
+                    );
+                    ChallengerMetrics::proof_session_failures_total(
+                        ChallengerMetrics::PROOF_FAILURE_FAILED,
+                    )
+                    .increment(1);
+                    pending.retry_count += 1;
+                    pending.phase = ProofPhase::NeedsRetry;
+                    ProofUpdate::NeedsRetry
+                }
+                Err(
+                    ZkProofRequesterError::MissingResult { .. }
+                    | ZkProofRequesterError::UnexpectedResult { .. },
+                ) => {
+                    warn!(game = %game, "proof response malformed, treating as retryable failure");
+                    ChallengerMetrics::proof_session_failures_total(
+                        ChallengerMetrics::PROOF_FAILURE_MALFORMED,
+                    )
+                    .increment(1);
+                    pending.retry_count += 1;
+                    pending.phase = ProofPhase::NeedsRetry;
+                    ProofUpdate::NeedsRetry
+                }
+                Err(ZkProofRequesterError::Client(e)) => return Err(e.into()),
+            };
+
+            return Ok(Some(update));
         }
 
         let request = GetProofRequest { session_id };

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -3,8 +3,8 @@
 use alloy_primitives::{Address, B256, Bytes};
 use base_proof_primitives::{ProofEncoder, ProofRequest as PrimitiveProofRequest};
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest,
-    SnarkGroth16ProofRequest, TeeKind, TeeProofRequest,
+    ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest, TeeKind,
+    TeeProofRequest,
 };
 use eyre::{Result, WrapErr, bail};
 
@@ -46,18 +46,6 @@ impl ChallengerProofAdapter {
             Self::tee_session_label(tee_kind),
             &[game_address.as_slice(), &invalid_index],
         )
-    }
-
-    /// Builds a prover-service request for a challenger SNARK proof.
-    pub fn snark_groth16_prove_block_range_request(
-        game_address: Address,
-        invalid_index: u64,
-        request: SnarkGroth16ProofRequest,
-    ) -> ProveBlockRangeRequest {
-        let session_id = Self::snark_groth16_session_id(game_address, invalid_index);
-        ProveBlockRangeRequest {
-            proof: ProofRequest { session_id, request: ProofRequestKind::SnarkGroth16(request) },
-        }
     }
 
     /// Builds a prover-service request for a challenger TEE proof.
@@ -120,8 +108,8 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use base_proof_primitives::{PROOF_TYPE_TEE, Proposal};
     use base_prover_service_protocol::{
-        ProofRequestKind, ProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind,
-        TeeProofResult, ZkProofRequest, ZkProofResult, ZkVm,
+        ProofRequestKind, ProofResult, SnarkGroth16ProofResult, TeeKind, TeeProofResult,
+        ZkProofResult, ZkVm,
     };
 
     use super::ChallengerProofAdapter;
@@ -181,45 +169,6 @@ mod tests {
             ChallengerProofAdapter::snark_groth16_session_id(game_address, 1),
             ChallengerProofAdapter::snark_groth16_session_id(Address::repeat_byte(0xbb), 1)
         );
-    }
-
-    #[test]
-    fn snark_groth16_prove_block_range_request_converts_zk_request() {
-        let game_address = Address::repeat_byte(0xaa);
-        let invalid_index = 1;
-        let session_id =
-            ChallengerProofAdapter::snark_groth16_session_id(game_address, invalid_index);
-        let prover_address = Address::repeat_byte(0x11);
-        let l1_head = B256::repeat_byte(0x22);
-        let proof = ZkProofRequest {
-            start_block_number: 100,
-            number_of_blocks_to_prove: 300,
-            sequence_window: Some(10),
-            l1_head: Some(l1_head),
-            intermediate_root_interval: Some(150),
-            zk_vm: ZkVm::Sp1,
-        };
-        let request = SnarkGroth16ProofRequest { proof, prover_address };
-
-        let wrapped = ChallengerProofAdapter::snark_groth16_prove_block_range_request(
-            game_address,
-            invalid_index,
-            request,
-        );
-
-        assert_eq!(wrapped.proof.session_id, session_id);
-        match wrapped.proof.request {
-            ProofRequestKind::SnarkGroth16(snark) => {
-                assert_eq!(snark.prover_address, prover_address);
-                assert_eq!(snark.proof.start_block_number, 100);
-                assert_eq!(snark.proof.number_of_blocks_to_prove, 300);
-                assert_eq!(snark.proof.sequence_window, Some(10));
-                assert_eq!(snark.proof.l1_head, Some(l1_head));
-                assert_eq!(snark.proof.intermediate_root_interval, Some(150));
-                assert_eq!(snark.proof.zk_vm, ZkVm::Sp1);
-            }
-            other => panic!("unexpected proof request kind: {other:?}"),
-        }
     }
 
     #[test]

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -745,7 +745,7 @@ impl ProofRequesterProvider for MockZkProofProvider {
 
     async fn get_proof(
         &self,
-        _request: GetProofRequest,
+        request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError> {
         let state = self.state.lock().unwrap().clone();
         let result = if state.proof_status == ProofStatus::Succeeded {
@@ -753,9 +753,12 @@ impl ProofRequesterProvider for MockZkProofProvider {
                 None
             } else {
                 state.result.or_else(|| {
-                    Some(ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult {
-                        proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: state.proof.into() },
-                    }))
+                    let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: state.proof.into() };
+                    if request.session_id.ends_with(":range") {
+                        Some(ApiProofResult::Compressed(proof))
+                    } else {
+                        Some(ApiProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof }))
+                    }
                 })
             }
         } else {

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -21,9 +21,10 @@ use base_challenger::{
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex, GameStatus};
 use base_proof_primitives::Proposal;
+use base_proof_zk_requester::{Groth16ProofState, Groth16RangeProofRequest};
 use base_protocol::OutputRoot;
 use base_prover_service_protocol::{
-    ProofResult as ApiProofResult, ProofStatus, SnarkGroth16ProofRequest, TeeKind, TeeProofResult,
+    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeResponse, TeeKind, TeeProofResult,
     ZkProofRequest, ZkVm,
 };
 use base_runtime::TokioRuntime;
@@ -137,8 +138,9 @@ const fn tee_api_result(aggregate_proposal: Proposal) -> ApiProofResult {
 }
 
 fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
-    let request = SnarkGroth16ProofRequest {
-        proof: ZkProofRequest {
+    let request = Groth16RangeProofRequest::new(
+        "ready-session",
+        ZkProofRequest {
             start_block_number: 15,
             number_of_blocks_to_prove: 5,
             sequence_window: None,
@@ -146,8 +148,8 @@ fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
         },
-        prover_address: addr(0),
-    };
+        addr(0),
+    );
 
     PendingProof::ready(
         Bytes::from_static(&[0x01, 0xDE, 0xAD]),
@@ -298,7 +300,10 @@ async fn test_step_invalid_game_proof_succeeded() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
-    // Step 2: proof polled → Succeeded → nullification submitted → entry removed.
+    // Step 2: range proof succeeds and aggregation proof is requested.
+    driver.step().await.unwrap();
+
+    // Step 3: aggregation proof succeeds → nullification submitted → entry removed.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -439,8 +444,10 @@ async fn test_step_pending_proof_skips_prove_block() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
-    // Step 2: same game re-discovered → polls existing session, proof succeeds,
-    // challenge tx submitted, session removed from pending_proofs.
+    // Step 2: same game re-discovered → range proof succeeds and aggregation is requested.
+    driver.step().await.unwrap();
+
+    // Step 3: aggregation proof succeeds, challenge tx submitted, session removed.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -469,7 +476,10 @@ async fn test_step_nullification_failure_preserves_proof() {
         "proof should be pending after initiation"
     );
 
-    // Step 2: proof polled → Succeeded → ReadyToSubmit → dispute tx fails.
+    // Step 2: range proof succeeds and aggregation proof is requested.
+    driver.step().await.unwrap();
+
+    // Step 3: aggregation proof succeeds → ReadyToSubmit → dispute tx fails.
     driver.step().await.unwrap();
 
     // Entry must still be in pending_proofs as ReadyToSubmit.
@@ -482,7 +492,7 @@ async fn test_step_nullification_failure_preserves_proof() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
-    // Step 3: poll_pending_proofs re-submits the challenge tx, now it succeeds.
+    // Step 4: poll_pending_proofs re-submits the challenge tx, now it succeeds.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -590,7 +600,10 @@ async fn test_step_proof_retry_succeeds() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
-    // Step 3: proof succeeds, challenge tx submitted, entry removed.
+    // Step 3: range proof succeeds and aggregation proof is requested.
+    driver.step().await.unwrap();
+
+    // Step 4: aggregation proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -619,7 +632,8 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
     let tx_manager = default_tx_manager();
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
-    let expected_session_id = ChallengerProofAdapter::snark_groth16_session_id(addr(0), 1);
+    let expected_session_id =
+        format!("{}:range", ChallengerProofAdapter::snark_groth16_session_id(addr(0), 1));
 
     // Step 1: initial proveBlockRange call from initiate_zk_proof.
     driver.step().await.unwrap();
@@ -629,7 +643,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
         assert_eq!(
             log[0].proof.session_id.as_str(),
             expected_session_id.as_str(),
-            "challenger must use game-address/invalid-index session_id on initiation",
+            "challenger must use deterministic range session_id on initiation",
         );
     }
 
@@ -642,7 +656,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
         assert_eq!(
             log[1].proof.session_id.as_str(),
             expected_session_id.as_str(),
-            "retry must reuse the deterministic session_id so the service can requeue",
+            "retry must reuse the deterministic range session_id so the service can requeue",
         );
         assert_eq!(
             log[0].proof.session_id.as_str(),
@@ -671,6 +685,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
+    driver.step().await.unwrap();
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -793,7 +808,10 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
-    // Step 2: proof polled → Succeeded → challenge tx submitted → entry removed.
+    // Step 2: range proof succeeds and aggregation proof is requested.
+    driver.step().await.unwrap();
+
+    // Step 3: aggregation proof succeeds → challenge tx submitted → entry removed.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -950,7 +968,10 @@ async fn test_step_tee_submission_failure_falls_back_to_zk() {
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
     );
 
-    // Step 3: ZK proof polled → Succeeded → entry cleaned up.
+    // Step 3: range proof succeeds and aggregation proof is requested.
+    driver.step().await.unwrap();
+
+    // Step 4: aggregation proof succeeds → entry cleaned up.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -1642,7 +1663,10 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
         "proof should be pending after initiation"
     );
 
-    // Step 2: proof polled → Succeeded → challenge tx submitted → bond tracked.
+    // Step 2: range proof succeeds and aggregation proof is requested.
+    driver.step().await.unwrap();
+
+    // Step 3: aggregation proof succeeds → challenge tx submitted → bond tracked.
     driver.step().await.unwrap();
 
     let bond_mgr = driver.bond_manager.as_ref().expect("bond_manager should be Some");
@@ -1697,9 +1721,10 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
     );
 }
 
-const fn minimal_prove_request() -> SnarkGroth16ProofRequest {
-    SnarkGroth16ProofRequest {
-        proof: ZkProofRequest {
+fn minimal_prove_request() -> Groth16RangeProofRequest {
+    Groth16RangeProofRequest::new(
+        "minimal-session",
+        ZkProofRequest {
             start_block_number: 0,
             number_of_blocks_to_prove: 1,
             sequence_window: None,
@@ -1707,7 +1732,13 @@ const fn minimal_prove_request() -> SnarkGroth16ProofRequest {
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
         },
-        prover_address: Address::ZERO,
+        Address::ZERO,
+    )
+}
+
+fn minimal_proof_state() -> Groth16ProofState {
+    Groth16ProofState::AwaitingRange {
+        range: ProveBlockRangeResponse { session_id: minimal_prove_request().range_session_id() },
     }
 }
 
@@ -1729,6 +1760,7 @@ async fn test_poll_failed_status_triggers_retry() {
             0,
             B256::ZERO,
             minimal_prove_request(),
+            minimal_proof_state(),
             DisputeIntent::Challenge,
         ),
     );
@@ -1758,6 +1790,7 @@ async fn test_poll_running_within_timeout_stays_pending() {
             0,
             B256::ZERO,
             minimal_prove_request(),
+            minimal_proof_state(),
             DisputeIntent::Challenge,
         ),
     );
@@ -1790,6 +1823,7 @@ async fn test_poll_running_timeout_triggers_retry() {
             0,
             B256::ZERO,
             minimal_prove_request(),
+            minimal_proof_state(),
             DisputeIntent::Challenge,
         ),
     );
@@ -1888,6 +1922,7 @@ mod metrics_emission {
                         0,
                         B256::ZERO,
                         minimal_prove_request(),
+                        minimal_proof_state(),
                         DisputeIntent::Challenge,
                     ),
                 );
@@ -1929,6 +1964,7 @@ mod metrics_emission {
                         0,
                         B256::ZERO,
                         minimal_prove_request(),
+                        minimal_proof_state(),
                         DisputeIntent::Challenge,
                     ),
                 );
@@ -1972,6 +2008,7 @@ mod metrics_emission {
                         0,
                         B256::ZERO,
                         minimal_prove_request(),
+                        minimal_proof_state(),
                         DisputeIntent::Challenge,
                     ),
                 );

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -296,6 +296,9 @@ pub enum CreateProofRequestValidationError {
     /// The protocol request payload could not be serialized for storage.
     #[error("failed to serialize request_payload")]
     RequestPayloadSerialization,
+    /// A Groth16 aggregation request did not include any compressed range proofs.
+    #[error("snark_groth16 request must include at least one range proof")]
+    EmptyRangeProofs,
     /// A backend proof type is required for the requested protocol proof type.
     #[error("missing backend proof_type for {api_proof_type}")]
     MissingBackendProofType {
@@ -885,18 +888,23 @@ impl DerivedProofRequestFields {
                 l1_head: proof.l1_head.map(|hash| format!("{hash:#x}")),
                 intermediate_root_interval: proof.intermediate_root_interval,
             }),
-            ProtocolProofRequestKind::SnarkGroth16(request) => Ok(Self {
-                api_proof_type: ApiProofType::SnarkGroth16,
-                zk_vm: Some(protocol_zk_vm(request.proof.zk_vm)),
-                tee_kind: None,
-                proof_type: Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16),
-                start_block_number: request.proof.start_block_number,
-                number_of_blocks_to_prove: request.proof.number_of_blocks_to_prove,
-                sequence_window: request.proof.sequence_window,
-                prover_address: Some(format!("{:#x}", request.prover_address)),
-                l1_head: request.proof.l1_head.map(|hash| format!("{hash:#x}")),
-                intermediate_root_interval: request.proof.intermediate_root_interval,
-            }),
+            ProtocolProofRequestKind::SnarkGroth16(request) => {
+                let Some(first_proof) = request.range_proofs.first() else {
+                    return Err(CreateProofRequestValidationError::EmptyRangeProofs);
+                };
+                Ok(Self {
+                    api_proof_type: ApiProofType::SnarkGroth16,
+                    zk_vm: Some(protocol_zk_vm(first_proof.zk_vm)),
+                    tee_kind: None,
+                    proof_type: Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16),
+                    start_block_number: 0,
+                    number_of_blocks_to_prove: request.range_proofs.len() as u64,
+                    sequence_window: None,
+                    prover_address: Some(format!("{:#x}", request.prover_address)),
+                    l1_head: None,
+                    intermediate_root_interval: None,
+                })
+            }
             ProtocolProofRequestKind::Tee(request) => Ok(Self {
                 api_proof_type: ApiProofType::Tee,
                 zk_vm: None,

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -89,18 +89,7 @@ fn snark_request() -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
         request: ProtocolProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-            proof: ZkProofRequest {
-                start_block_number: 200,
-                number_of_blocks_to_prove: 10,
-                sequence_window: Some(100),
-                l1_head: Some(
-                    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-                        .parse()
-                        .expect("valid hash"),
-                ),
-                intermediate_root_interval: None,
-                zk_vm: ZkVm::Sp1,
-            },
+            range_proofs: vec![ZkProofResult { zk_vm: ZkVm::Sp1, proof: vec![1, 2, 3].into() }],
             prover_address: "0x1234567890abcdef1234567890abcdef12345678"
                 .parse()
                 .expect("valid address"),
@@ -187,14 +176,11 @@ async fn test_create_and_get_snark() {
     let id = repo.create(snark_request()).await.unwrap();
     let req = repo.get(id).await.unwrap().expect("should find request");
 
-    assert_eq!(req.start_block_number, 200);
-    assert_eq!(req.number_of_blocks_to_prove, 10);
+    assert_eq!(req.start_block_number, 0);
+    assert_eq!(req.number_of_blocks_to_prove, 1);
     assert_eq!(req.proof_type, Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16));
     assert_eq!(req.prover_address.as_deref(), Some("0x1234567890abcdef1234567890abcdef12345678"));
-    assert_eq!(
-        req.l1_head.as_deref(),
-        Some("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-    );
+    assert_eq!(req.l1_head.as_deref(), None);
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -142,8 +142,8 @@ pub struct ZkProofRequest {
 /// Groth16 SNARK proof request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SnarkGroth16ProofRequest {
-    /// Underlying ZK proof request.
-    pub proof: ZkProofRequest,
+    /// Completed compressed range proofs consumed by the aggregation program.
+    pub range_proofs: Vec<ZkProofResult>,
     /// On-chain prover address.
     pub prover_address: Address,
 }

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -46,7 +46,9 @@ impl ZkProver for DryRunZkProver {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
+    use base_prover_service_protocol::{
+        SnarkGroth16ProofRequest, ZkProofRequest, ZkProofResult, ZkVm,
+    };
 
     use super::*;
 
@@ -67,7 +69,7 @@ mod tests {
 
     fn snark_groth16() -> ZkProofRequestKind {
         ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-            proof: zk_request(),
+            range_proofs: vec![ZkProofResult { zk_vm: ZkVm::Sp1, proof: Vec::new().into() }],
             prover_address: Default::default(),
         })
     }

--- a/crates/proof/zk/backend/src/succinct/mock.rs
+++ b/crates/proof/zk/backend/src/succinct/mock.rs
@@ -49,7 +49,9 @@ impl ZkProver for MockZkProver {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
+    use base_prover_service_protocol::{
+        SnarkGroth16ProofRequest, ZkProofRequest, ZkProofResult, ZkVm,
+    };
 
     use super::*;
 
@@ -70,7 +72,10 @@ mod tests {
 
     fn snark_groth16() -> ZkProofRequestKind {
         ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-            proof: zk_request(),
+            range_proofs: vec![ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: MOCK_PROOF_BYTES.to_vec().into(),
+            }],
             prover_address: Default::default(),
         })
     }

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -20,7 +20,7 @@ impl ZkProofRequestKind {
     pub const fn start_block_number(&self) -> u64 {
         match self {
             Self::Compressed(request) => request.start_block_number,
-            Self::SnarkGroth16(request) => request.proof.start_block_number,
+            Self::SnarkGroth16(_) => 0,
         }
     }
 
@@ -28,7 +28,7 @@ impl ZkProofRequestKind {
     pub const fn number_of_blocks_to_prove(&self) -> u64 {
         match self {
             Self::Compressed(request) => request.number_of_blocks_to_prove,
-            Self::SnarkGroth16(request) => request.proof.number_of_blocks_to_prove,
+            Self::SnarkGroth16(request) => request.range_proofs.len() as u64,
         }
     }
 
@@ -152,7 +152,7 @@ mod tests {
         assert!(!compressed.is_snark_groth16());
 
         let snark = ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-            proof: zk_request(),
+            range_proofs: Vec::new(),
             prover_address: alloy_primitives::Address::ZERO,
         });
         assert!(snark.is_snark_groth16());
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(ZkProofRequestKind::Compressed(zk_request()).session_type(), SessionType::Stark);
         assert_eq!(
             ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-                proof: zk_request(),
+                range_proofs: Vec::new(),
                 prover_address: alloy_primitives::Address::ZERO,
             })
             .session_type(),

--- a/crates/proof/zk/requester/src/lib.rs
+++ b/crates/proof/zk/requester/src/lib.rs
@@ -7,4 +7,4 @@ mod request;
 pub use request::Groth16RangeProofRequest;
 
 mod requester;
-pub use requester::{Groth16ProofRequestResponse, ZkProofRequester};
+pub use requester::{Groth16ProofRequestResponse, Groth16ProofState, ZkProofRequester};

--- a/crates/proof/zk/requester/src/request.rs
+++ b/crates/proof/zk/requester/src/request.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Address;
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProveBlockRangeRequest, SnarkGroth16ProofRequest,
-    ZkProofRequest,
+    ZkProofRequest, ZkProofResult,
 };
 
 const RANGE_SESSION_LABEL: &str = "range";
@@ -52,12 +52,15 @@ impl Groth16RangeProofRequest {
     }
 
     /// Build the prover-service request for the Groth16 aggregation proof stage.
-    pub fn aggregation_prove_block_request(&self) -> ProveBlockRangeRequest {
+    pub fn aggregation_prove_block_request(
+        &self,
+        range_proof: ZkProofResult,
+    ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id: self.aggregation_session_id(),
                 request: ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-                    proof: self.proof.clone(),
+                    range_proofs: vec![range_proof],
                     prover_address: self.prover_address,
                 }),
             },
@@ -92,11 +95,16 @@ mod tests {
         assert_eq!(range.proof.session_id, "parent-session:range");
         assert!(matches!(range.proof.request, ProofRequestKind::Compressed(_)));
 
-        let aggregation = request.aggregation_prove_block_request();
+        let aggregation = request.aggregation_prove_block_request(ZkProofResult {
+            zk_vm: ZkVm::Sp1,
+            proof: vec![1, 2, 3].into(),
+        });
         assert_eq!(aggregation.proof.session_id, "parent-session:aggregation");
         let ProofRequestKind::SnarkGroth16(aggregation) = aggregation.proof.request else {
             panic!("expected Groth16 aggregation request");
         };
         assert_eq!(aggregation.prover_address, prover_address);
+        assert_eq!(aggregation.range_proofs.len(), 1);
+        assert_eq!(aggregation.range_proofs[0].proof, vec![1_u8, 2, 3]);
     }
 }

--- a/crates/proof/zk/requester/src/requester.rs
+++ b/crates/proof/zk/requester/src/requester.rs
@@ -11,10 +11,39 @@ use crate::{Groth16RangeProofRequest, ZkProofRequesterError};
 /// Accepted prover-service sessions for a requested Groth16 proof flow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Groth16ProofRequestResponse {
-    /// Accepted compressed range proof session.
-    pub range: ProveBlockRangeResponse,
-    /// Accepted Groth16 aggregation proof session.
-    pub aggregation: ProveBlockRangeResponse,
+    /// Current state of the composed Groth16 proof flow.
+    pub state: Groth16ProofState,
+}
+
+/// Current state for a requested Groth16 proof flow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Groth16ProofState {
+    /// The range proof has been submitted and aggregation is waiting on its result.
+    AwaitingRange {
+        /// Accepted compressed range proof session.
+        range: ProveBlockRangeResponse,
+    },
+    /// The aggregation proof has been submitted and is waiting on its result.
+    AwaitingAggregation {
+        /// Accepted compressed range proof session.
+        range: ProveBlockRangeResponse,
+        /// Accepted Groth16 aggregation proof session.
+        aggregation: ProveBlockRangeResponse,
+    },
+}
+
+impl Groth16ProofState {
+    /// Return the accepted compressed range proof session.
+    pub const fn range(&self) -> &ProveBlockRangeResponse {
+        match self {
+            Self::AwaitingRange { range } | Self::AwaitingAggregation { range, .. } => range,
+        }
+    }
+
+    /// Return the accepted compressed range proof session identifier.
+    pub fn range_session_id(&self) -> &str {
+        &self.range().session_id
+    }
 }
 
 /// Higher-level requester for ZK proof flows backed by prover-service requests.
@@ -35,70 +64,103 @@ impl<Client> ZkProofRequester<Client> {
     }
 }
 
-impl<Client> ZkProofRequester<Client>
-where
-    Client: ProofRequesterProvider,
-{
-    /// Request range proof and Groth16 aggregation stages.
-    ///
-    /// If aggregation submission fails after range acceptance, the error includes
-    /// the accepted range response.
-    ///
-    /// This method is not cancellation-safe between the range and aggregation
-    /// submissions.
+impl<Client> ZkProofRequester<Client> {
+    /// Request the range proof stage for a composed Groth16 proof.
     pub async fn request_groth16_proof(
         &self,
         request: &Groth16RangeProofRequest,
-    ) -> Result<Groth16ProofRequestResponse, ZkProofRequesterError> {
-        let range = self.client.prove_block_range(request.range_prove_block_request()).await?;
-        let aggregation =
-            match self.client.prove_block_range(request.aggregation_prove_block_request()).await {
-                Ok(response) => response,
-                Err(source) => {
-                    return Err(ZkProofRequesterError::AggregationRequestFailed {
-                        range_session_id: range.session_id.clone(),
-                        range,
-                        source,
-                    });
-                }
-            };
-        Ok(Groth16ProofRequestResponse { range, aggregation })
+    ) -> Result<Groth16ProofRequestResponse, ZkProofRequesterError>
+    where
+        Client: ProofRequesterProvider,
+    {
+        ZkProofRequester::request_groth16_proof_with(&self.client, request).await
     }
 
     /// Return the completed Groth16 proof if the aggregation stage has finished.
     pub async fn groth16_result(
         &self,
         request: &Groth16RangeProofRequest,
-    ) -> Result<Option<SnarkGroth16ProofResult>, ZkProofRequesterError> {
-        let range_session_id = request.range_session_id();
-        match self.proof_result(&range_session_id).await? {
-            Some(ProofResult::Compressed(_)) => {}
-            Some(result) => {
-                return Err(Self::unexpected_result(
-                    range_session_id,
-                    &result,
-                    ProofType::Compressed,
-                ));
-            }
-            None => return Ok(None),
-        }
+        state: &mut Groth16ProofState,
+    ) -> Result<Option<SnarkGroth16ProofResult>, ZkProofRequesterError>
+    where
+        Client: ProofRequesterProvider,
+    {
+        ZkProofRequester::groth16_result_with(&self.client, request, state).await
+    }
+}
 
-        let session_id = request.aggregation_session_id();
-        match self.proof_result(&session_id).await? {
-            Some(ProofResult::SnarkGroth16(result)) => Ok(Some(result)),
-            Some(result) => {
-                Err(Self::unexpected_result(session_id, &result, ProofType::SnarkGroth16))
+impl ZkProofRequester<()> {
+    /// Request the range proof stage using an explicitly provided prover-service client.
+    pub async fn request_groth16_proof_with<P>(
+        client: &P,
+        request: &Groth16RangeProofRequest,
+    ) -> Result<Groth16ProofRequestResponse, ZkProofRequesterError>
+    where
+        P: ProofRequesterProvider + ?Sized,
+    {
+        let range = client.prove_block_range(request.range_prove_block_request()).await?;
+        Ok(Groth16ProofRequestResponse { state: Groth16ProofState::AwaitingRange { range } })
+    }
+
+    /// Return the completed Groth16 proof using an explicitly provided prover-service client.
+    pub async fn groth16_result_with<P>(
+        client: &P,
+        request: &Groth16RangeProofRequest,
+        state: &mut Groth16ProofState,
+    ) -> Result<Option<SnarkGroth16ProofResult>, ZkProofRequesterError>
+    where
+        P: ProofRequesterProvider + ?Sized,
+    {
+        match state {
+            Groth16ProofState::AwaitingRange { range } => {
+                let range = range.clone();
+                let range_session_id = range.session_id.clone();
+                let range_proof = match Self::proof_result_with(client, &range_session_id).await? {
+                    Some(ProofResult::Compressed(result)) => result,
+                    Some(result) => {
+                        return Err(Self::unexpected_result(
+                            range_session_id,
+                            &result,
+                            ProofType::Compressed,
+                        ));
+                    }
+                    None => return Ok(None),
+                };
+
+                let aggregation_request = request.aggregation_prove_block_request(range_proof);
+                let aggregation =
+                    client.prove_block_range(aggregation_request).await.map_err(|source| {
+                        ZkProofRequesterError::AggregationRequestFailed {
+                            range_session_id: range_session_id.clone(),
+                            range: range.clone(),
+                            source,
+                        }
+                    })?;
+                *state = Groth16ProofState::AwaitingAggregation { range, aggregation };
+                Ok(None)
             }
-            None => Ok(None),
+            Groth16ProofState::AwaitingAggregation { aggregation, .. } => {
+                let session_id = aggregation.session_id.clone();
+                match Self::proof_result_with(client, &session_id).await? {
+                    Some(ProofResult::SnarkGroth16(result)) => Ok(Some(result)),
+                    Some(result) => {
+                        Err(Self::unexpected_result(session_id, &result, ProofType::SnarkGroth16))
+                    }
+                    None => Ok(None),
+                }
+            }
         }
     }
 
-    async fn proof_result(
-        &self,
+    async fn proof_result_with<P>(
+        client: &P,
         session_id: &str,
-    ) -> Result<Option<ProofResult>, ZkProofRequesterError> {
+    ) -> Result<Option<ProofResult>, ZkProofRequesterError>
+    where
+        P: ProofRequesterProvider + ?Sized,
+    {
         let response =
-            self.client.get_proof(GetProofRequest { session_id: session_id.to_owned() }).await?;
+            client.get_proof(GetProofRequest { session_id: session_id.to_owned() }).await?;
         Self::resolve_get_proof_response(session_id, response)
     }
 
@@ -267,12 +329,21 @@ mod tests {
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
 
-        let proof = requester.request_groth16_proof(&request).await.unwrap();
-        assert_eq!(proof.range.session_id, "parent:range");
-        assert_eq!(proof.aggregation.session_id, "parent:aggregation");
-        assert!(requester.groth16_result(&request).await.unwrap().is_none());
+        let mut proof = requester.request_groth16_proof(&request).await.unwrap();
+        assert_eq!(proof.state.range_session_id(), "parent:range");
+        assert!(matches!(proof.state, Groth16ProofState::AwaitingRange { .. }));
+        assert!(requester.groth16_result(&request, &mut proof.state).await.unwrap().is_none());
+        assert!(matches!(proof.state, Groth16ProofState::AwaitingRange { .. }));
+        assert!(requester.groth16_result(&request, &mut proof.state).await.unwrap().is_none());
+        assert!(matches!(proof.state, Groth16ProofState::AwaitingAggregation { .. }));
         assert_eq!(
-            requester.groth16_result(&request).await.unwrap().unwrap().proof.proof,
+            requester
+                .groth16_result(&request, &mut proof.state)
+                .await
+                .unwrap()
+                .unwrap()
+                .proof
+                .proof,
             Bytes::from(vec![2])
         );
 
@@ -280,7 +351,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_groth16_proof_reports_accepted_range_on_aggregation_submit_failure() {
+    async fn groth16_result_reports_accepted_range_on_aggregation_submit_failure() {
         let requester = MockProofRequester::with_prove_outcomes(VecDeque::from([
             ProveOutcome::Success,
             ProveOutcome::Error(ProverServiceClientError::Timeout(
@@ -291,7 +362,9 @@ mod tests {
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
 
-        let error = requester.request_groth16_proof(&request).await.unwrap_err();
+        requester.client().responses.lock().unwrap().push_back(succeeded(compressed_result()));
+        let mut proof = requester.request_groth16_proof(&request).await.unwrap();
+        let error = requester.groth16_result(&request, &mut proof.state).await.unwrap_err();
 
         let ZkProofRequesterError::AggregationRequestFailed { range, range_session_id, source } =
             error
@@ -315,26 +388,30 @@ mod tests {
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
 
-        let error = requester.groth16_result(&request).await.unwrap_err();
+        let mut state = Groth16ProofState::AwaitingRange {
+            range: ProveBlockRangeResponse { session_id: "parent:range".to_owned() },
+        };
+        let error = requester.groth16_result(&request, &mut state).await.unwrap_err();
 
         assert!(matches!(error, ZkProofRequesterError::ProofFailed { .. }));
     }
 
     #[tokio::test]
     async fn failed_aggregation_status_returns_error_after_range_succeeds() {
-        let requester = MockProofRequester::with_responses(VecDeque::from([
-            succeeded(compressed_result()),
-            GetProofResponse {
-                status: ProofStatus::Failed,
-                error_message: Some("aggregation failed".to_owned()),
-                result: None,
-            },
-        ]));
+        let requester = MockProofRequester::with_responses(VecDeque::from([GetProofResponse {
+            status: ProofStatus::Failed,
+            error_message: Some("aggregation failed".to_owned()),
+            result: None,
+        }]));
         let requester = ZkProofRequester::new(requester);
         let request =
             Groth16RangeProofRequest::new("parent", proof_request(), Address::repeat_byte(0x11));
 
-        let error = requester.groth16_result(&request).await.unwrap_err();
+        let mut state = Groth16ProofState::AwaitingAggregation {
+            range: ProveBlockRangeResponse { session_id: "parent:range".to_owned() },
+            aggregation: ProveBlockRangeResponse { session_id: "parent:aggregation".to_owned() },
+        };
+        let error = requester.groth16_result(&request, &mut state).await.unwrap_err();
 
         assert!(matches!(
             error,


### PR DESCRIPTION
## Summary

SnarkGroth16 requests now model aggregation over completed compressed range proofs instead of block-range parameters. The ZK requester keeps the composed flow by requesting the compressed range proof first, then submitting aggregation with that result, so prover-service and zk-host jobs stay focused on executing a single proof program.