### PR TITLE
chore(zk-host): orchestrate groth16 aggregation

### DIFF
--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -138,6 +138,14 @@ struct WorkerArgs {
     #[arg(long, env = "RANGE_GAS_LIMIT", default_value_t = 1_000_000_000_000)]
     range_gas_limit: u64,
 
+    /// Cycle limit for aggregation proof requests.
+    #[arg(long, env = "AGGREGATION_CYCLE_LIMIT", default_value_t = 1_000_000_000_000)]
+    aggregation_cycle_limit: u64,
+
+    /// Gas limit for aggregation proof requests.
+    #[arg(long, env = "AGGREGATION_GAS_LIMIT", default_value_t = 1_000_000_000_000)]
+    aggregation_gas_limit: u64,
+
     /// Delay after an empty or failed discovery attempt, in milliseconds.
     #[arg(long, env = "JOB_DISCOVERY_POLL_INTERVAL_MS", default_value_t = 5_000)]
     job_discovery_poll_interval_ms: u64,
@@ -233,6 +241,8 @@ impl WorkerArgs {
                     )?,
                     range_cycle_limit: self.range_cycle_limit,
                     range_gas_limit: self.range_gas_limit,
+                    aggregation_cycle_limit: self.aggregation_cycle_limit,
+                    aggregation_gas_limit: self.aggregation_gas_limit,
                 }))
             }
             ZkBackendArg::Network => {

--- a/crates/proof/zk/backend/src/lib.rs
+++ b/crates/proof/zk/backend/src/lib.rs
@@ -3,8 +3,8 @@
 mod succinct;
 pub use succinct::{
     ClusterSessionId, ClusterZkProver, ClusterZkProverConfig, DRY_RUN_PREFIX, DryRunZkProver,
-    L1HeadSource, MOCK_PROOF_BYTES, MOCK_SNARK_PREFIX, MockZkProver, NetworkZkProver,
-    NetworkZkProverConfig, OpSuccinctWitnessProvider, SuccinctClusterBackendConfig,
-    SuccinctNetworkBackendConfig, SuccinctRpcConfig, SuccinctZkBackendConfig,
-    SuccinctZkProverBuildError, SuccinctZkProverBuilder, WitnessError, WitnessParams,
+    L1HeadSource, MOCK_PROOF_BYTES, MockZkProver, NetworkZkProver, NetworkZkProverConfig,
+    OpSuccinctWitnessProvider, SuccinctClusterBackendConfig, SuccinctNetworkBackendConfig,
+    SuccinctRpcConfig, SuccinctZkBackendConfig, SuccinctZkProverBuildError,
+    SuccinctZkProverBuilder, WitnessError, WitnessParams,
 };

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -668,7 +668,6 @@ impl ClusterZkProver {
             proof_artifact_id: Some(proof_output_id.clone()),
             requester: vec![],
             deadline,
-            // Reuse the configured proof limits for both range and aggregation stages.
             cycle_limit: self.config.range_cycle_limit,
             gas_limit: self.config.range_gas_limit,
             scheduled_by: None,

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -13,7 +13,10 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::{ClusterArtifactStore, ClusterProofConfig};
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{
+    ProofResult, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, ZkProofResult,
+    ZkVm,
+};
 use serde::{Deserialize, Serialize};
 use sp1_cluster_common::{
     client::ClusterServiceClient,
@@ -23,7 +26,7 @@ use sp1_cluster_common::{
     },
 };
 use sp1_prover_types::{Artifact, ArtifactClient as _, ArtifactType};
-use sp1_sdk::{ProofFromNetwork, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{HashableKey, ProofFromNetwork, SP1ProofWithPublicValues, SP1Stdin, SP1VerifyingKey};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -55,6 +58,10 @@ pub struct SuccinctClusterBackendConfig {
     pub range_cycle_limit: u64,
     /// Gas limit for range proof requests.
     pub range_gas_limit: u64,
+    /// Cycle limit for aggregation proof requests.
+    pub aggregation_cycle_limit: u64,
+    /// Gas limit for aggregation proof requests.
+    pub aggregation_gas_limit: u64,
 }
 
 /// Configuration for [`ClusterZkProver`].
@@ -68,21 +75,30 @@ pub struct ClusterZkProverConfig {
     pub default_sequence_window: u64,
     /// Cluster proof submission and artifact configuration.
     pub cluster: Arc<ClusterProofConfig>,
+    /// Range program verification key used by the aggregation program.
+    pub range_vk: Arc<SP1VerifyingKey>,
     /// Proof timeout.
     pub timeout: Duration,
     /// Cycle limit for range proof requests.
     pub range_cycle_limit: u64,
     /// Gas limit for range proof requests.
     pub range_gas_limit: u64,
+    /// Cycle limit for aggregation proof requests.
+    pub aggregation_cycle_limit: u64,
+    /// Gas limit for aggregation proof requests.
+    pub aggregation_gas_limit: u64,
 }
 
 impl std::fmt::Debug for ClusterZkProverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClusterZkProverConfig")
             .field("default_sequence_window", &self.default_sequence_window)
+            .field("range_vk", &self.range_vk.bytes32())
             .field("timeout", &self.timeout)
             .field("range_cycle_limit", &self.range_cycle_limit)
             .field("range_gas_limit", &self.range_gas_limit)
+            .field("aggregation_cycle_limit", &self.aggregation_cycle_limit)
+            .field("aggregation_gas_limit", &self.aggregation_gas_limit)
             .finish_non_exhaustive()
     }
 }
@@ -144,12 +160,33 @@ impl ClusterZkProver {
             timeout,
             range_cycle_limit,
             range_gas_limit,
+            aggregation_cycle_limit,
+            aggregation_gas_limit,
         } = config;
         let base_consensus_url = rpc.base_consensus_rpc.as_str().to_owned();
         let l1_node_url = rpc.l1_rpc.as_str().to_owned();
         let default_sequence_window = rpc.default_sequence_window;
 
         info!(backend = "cluster", "using Succinct SP1 cluster backend");
+        info!("computing range verification key");
+        let Some((range_vk, _aggregation_vk)) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async {
+                base_proof_succinct_proof_utils::cluster_setup_vkeys().await.map_err(|error| {
+                    SuccinctZkProverBuildError::boxed_operation(
+                        "failed to compute proof verification keys",
+                        error.into_boxed_dyn_error(),
+                    )
+                })
+            },
+            "proof_verification_keys",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        info!("range verification key computed successfully");
+
         let Some(provider) = SuccinctZkProverBuilder::build_witness_provider(rpc, cancel).await?
         else {
             return Ok(None);
@@ -187,9 +224,12 @@ impl ClusterZkProver {
                 artifact_store_config,
                 service_client,
             }),
+            range_vk: range_vk.into(),
             timeout,
             range_cycle_limit,
             range_gas_limit,
+            aggregation_cycle_limit,
+            aggregation_gas_limit,
         };
 
         Ok(Some(Arc::new(Self::new(provider, prover_config))))
@@ -252,6 +292,16 @@ impl ClusterZkProver {
     /// Build the cluster proof id for a prover-service session attempt.
     pub fn proof_id_for_attempt(request_session_id: &str, attempt: u64) -> String {
         let base_proof_id = format!("prover_service_{request_session_id}");
+        if attempt == 0 {
+            return base_proof_id;
+        }
+
+        format!("{base_proof_id}_retry_{attempt}")
+    }
+
+    /// Build the deterministic cluster aggregation proof id for a prover-service session attempt.
+    pub fn aggregation_proof_id_for_attempt(request_session_id: &str, attempt: u64) -> String {
+        let base_proof_id = format!("prover_service_{request_session_id}_aggregation");
         if attempt == 0 {
             return base_proof_id;
         }
@@ -373,6 +423,43 @@ impl ClusterZkProver {
         ProofRequestStatus::try_from(req.proof_status).map_err(|_| {
             backend_error!("cluster proof {} has unknown proof status {}", req.id, req.proof_status)
         })
+    }
+
+    /// Validate that an existing cluster request is safe to resume after create raced.
+    pub fn validate_existing_cluster_request(
+        req: &ClusterProtoProofRequest,
+    ) -> Result<ProofRequestStatus, ZkProverError> {
+        let proof_status = Self::cluster_proof_status(req)?;
+        match proof_status {
+            ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
+                return Err(backend_error!(
+                    "cluster proof {} created concurrently but already terminal: {}",
+                    req.id,
+                    proof_status.as_str_name()
+                ));
+            }
+            ProofRequestStatus::Unspecified => {
+                return Err(backend_error!(
+                    "cluster proof {} created concurrently but has unspecified status",
+                    req.id
+                ));
+            }
+            ProofRequestStatus::Pending => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| backend_error!("invalid unix timestamp: {e}"))?
+                    .as_secs();
+                if req.deadline <= now {
+                    return Err(backend_error!(
+                        "cluster proof {} created concurrently but deadline already elapsed",
+                        req.id
+                    ));
+                }
+            }
+            ProofRequestStatus::Completed => {}
+        }
+
+        Ok(proof_status)
     }
 
     /// Convert a cluster proof request into a persisted session id.
@@ -581,6 +668,7 @@ impl ClusterZkProver {
             proof_artifact_id: Some(proof_output_id.clone()),
             requester: vec![],
             deadline,
+            // Reuse the configured proof limits for both range and aggregation stages.
             cycle_limit: self.config.range_cycle_limit,
             gas_limit: self.config.range_gas_limit,
             scheduled_by: None,
@@ -591,54 +679,11 @@ impl ClusterZkProver {
             Ok(()) => Ok(ClusterSessionId { proof_id, proof_output_id }),
             Err(e) => {
                 if let Some(existing) = self.get_cluster_request(&proof_id).await? {
-                    let proof_status = Self::cluster_proof_status(&existing)?;
-                    match proof_status {
-                        ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
-                            error!(
-                                proof_id = %proof_id,
-                                proof_status = %proof_status.as_str_name(),
-                                error = %e,
-                                "cluster proof create raced into terminal request"
-                            );
-                            return Err(backend_error!(
-                                "cluster proof {proof_id} created concurrently but already terminal: {}",
-                                proof_status.as_str_name()
-                            ));
-                        }
-                        ProofRequestStatus::Unspecified => {
-                            error!(
-                                proof_id = %proof_id,
-                                proof_status = %proof_status.as_str_name(),
-                                error = %e,
-                                "cluster proof create raced into unspecified request"
-                            );
-                            return Err(backend_error!(
-                                "cluster proof {proof_id} created concurrently but has unspecified status"
-                            ));
-                        }
-                        ProofRequestStatus::Pending => {
-                            let now = SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .map_err(|e| backend_error!("invalid unix timestamp: {e}"))?
-                                .as_secs();
-                            if existing.deadline <= now {
-                                error!(
-                                    proof_id = %proof_id,
-                                    deadline = existing.deadline,
-                                    now = now,
-                                    error = %e,
-                                    "cluster proof create raced into expired pending request"
-                                );
-                                return Err(backend_error!(
-                                    "cluster proof {proof_id} created concurrently but deadline already elapsed"
-                                ));
-                            }
-                        }
-                        ProofRequestStatus::Completed => {}
-                    }
+                    let proof_status = Self::validate_existing_cluster_request(&existing)?;
 
                     info!(
                         proof_id = %proof_id,
+                        proof_status = %proof_status.as_str_name(),
                         error = %e,
                         "cluster proof create raced, using existing request"
                     );
@@ -651,6 +696,190 @@ impl ClusterZkProver {
                     "cluster proof create failed with no existing request"
                 );
                 Err(backend_error!("failed to create cluster proof: {e}"))
+            }
+        }
+    }
+
+    /// Submit the Groth16 aggregation proof after the compressed range proof completes.
+    pub async fn submit_aggregation_proof(
+        &self,
+        request: &SnarkGroth16ProofRequest,
+        request_session_id: &str,
+        range_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        let mut proof_id = None;
+        for attempt in 0..Self::MAX_SUBMIT_ATTEMPTS {
+            let candidate = Self::aggregation_proof_id_for_attempt(request_session_id, attempt);
+            let Some(existing) = self.get_cluster_request_once(&candidate).await? else {
+                proof_id = Some(candidate);
+                break;
+            };
+
+            let proof_status = Self::cluster_proof_status(&existing)?;
+            match proof_status {
+                ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
+                    info!(
+                        proof_id = %candidate,
+                        proof_status = %proof_status.as_str_name(),
+                        "existing cluster aggregation request is terminal, trying next proof id"
+                    );
+                }
+                ProofRequestStatus::Pending => {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map_err(|e| backend_error!("invalid unix timestamp: {e}"))?
+                        .as_secs();
+                    if existing.deadline <= now {
+                        info!(
+                            proof_id = %candidate,
+                            deadline = existing.deadline,
+                            now = now,
+                            "existing cluster aggregation request deadline elapsed, trying next proof id"
+                        );
+                        continue;
+                    }
+
+                    info!(proof_id = %candidate, "cluster aggregation request already exists");
+                    return Self::session_id_from_request(&existing)?.to_backend_session_id();
+                }
+                ProofRequestStatus::Unspecified => {
+                    return Err(backend_error!(
+                        "cluster aggregation proof {} has unspecified status",
+                        candidate
+                    ));
+                }
+                ProofRequestStatus::Completed => {
+                    info!(proof_id = %candidate, "cluster aggregation request already exists");
+                    return Self::session_id_from_request(&existing)?.to_backend_session_id();
+                }
+            }
+        }
+        let proof_id = proof_id.ok_or_else(|| {
+            backend_error!(
+                "exhausted {} cluster aggregation submit attempts for request session id {}",
+                Self::MAX_SUBMIT_ATTEMPTS,
+                request_session_id
+            )
+        })?;
+
+        let range_session = ClusterSessionId::parse(range_backend_session_id)?;
+        let range_proof = self.download_cluster_proof(&range_session).await?;
+        let stdin = self
+            .provider
+            .generate_aggregation_witness(
+                range_proof,
+                self.config.range_vk.as_ref(),
+                request.prover_address,
+            )
+            .await
+            .map_err(|e| backend_error!("aggregation witness generation failed: {e}"))?;
+
+        let session = self.create_aggregation_request(proof_id, stdin).await?;
+        let backend_session_id = session.to_backend_session_id()?;
+        info!(
+            proof_id = %session.proof_id,
+            proof_output_id = %session.proof_output_id,
+            cycle_limit = self.config.aggregation_cycle_limit,
+            gas_limit = self.config.aggregation_gas_limit,
+            "aggregation proof request submitted to SP1 cluster"
+        );
+
+        Ok(backend_session_id)
+    }
+
+    /// Create the cluster request after uploading the aggregation ELF and stdin artifacts.
+    pub async fn create_aggregation_request(
+        &self,
+        proof_id: String,
+        stdin: SP1Stdin,
+    ) -> Result<ClusterSessionId, ZkProverError> {
+        match &self.config.cluster.artifact_store {
+            ClusterArtifactStore::Redis(client) => {
+                self.create_aggregation_request_with_client(client.clone(), proof_id, stdin).await
+            }
+            ClusterArtifactStore::S3(client) => {
+                self.create_aggregation_request_with_client(client.clone(), proof_id, stdin).await
+            }
+        }
+    }
+
+    /// Upload aggregation artifacts with the provided client and create the cluster request.
+    pub async fn create_aggregation_request_with_client<A>(
+        &self,
+        artifact_client: A,
+        proof_id: String,
+        stdin: SP1Stdin,
+    ) -> Result<ClusterSessionId, ZkProverError>
+    where
+        A: sp1_prover_types::ArtifactClient,
+    {
+        let elf_id = artifact_client
+            .create_artifact()
+            .map_err(|e| backend_error!("failed to create aggregation ELF artifact: {e}"))?;
+        artifact_client
+            .upload_with_type(
+                &elf_id,
+                ArtifactType::Program,
+                base_proof_succinct_elfs::AGGREGATION_ELF.to_vec(),
+            )
+            .await
+            .map_err(|e| backend_error!("failed to upload aggregation ELF: {e}"))?;
+
+        let stdin_id = artifact_client
+            .create_artifact()
+            .map_err(|e| backend_error!("failed to create aggregation stdin artifact: {e}"))?;
+        artifact_client
+            .upload_with_type(&stdin_id, ArtifactType::Stdin, stdin)
+            .await
+            .map_err(|e| backend_error!("failed to upload aggregation stdin: {e}"))?;
+
+        let proof_output_id = artifact_client
+            .create_artifact()
+            .map_err(|e| backend_error!("failed to create aggregation proof artifact: {e}"))?;
+        let proof_output_id = proof_output_id.to_id();
+        let deadline = SystemTime::now() + self.config.timeout;
+        let deadline = deadline
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| backend_error!("invalid cluster aggregation deadline: {e}"))?
+            .as_secs();
+
+        let request = ProofRequestCreateRequest {
+            proof_id: proof_id.clone(),
+            program_artifact_id: elf_id.to_id(),
+            stdin_artifact_id: stdin_id.to_id(),
+            options_artifact_id: Some(
+                (sp1_sdk::network::proto::types::ProofMode::Groth16 as i32).to_string(),
+            ),
+            proof_artifact_id: Some(proof_output_id.clone()),
+            requester: vec![],
+            deadline,
+            cycle_limit: self.config.aggregation_cycle_limit,
+            gas_limit: self.config.aggregation_gas_limit,
+            scheduled_by: None,
+            stdin_private: false,
+        };
+
+        match self.config.cluster.service_client.create_proof_request(request).await {
+            Ok(()) => Ok(ClusterSessionId { proof_id, proof_output_id }),
+            Err(e) => {
+                if let Some(existing) = self.get_cluster_request(&proof_id).await? {
+                    let proof_status = Self::validate_existing_cluster_request(&existing)?;
+
+                    info!(
+                        proof_id = %proof_id,
+                        proof_status = %proof_status.as_str_name(),
+                        error = %e,
+                        "cluster aggregation create raced, using existing request"
+                    );
+                    return Self::session_id_from_request(&existing);
+                }
+
+                error!(
+                    proof_id = %proof_id,
+                    error = %e,
+                    "cluster aggregation create failed with no existing request"
+                );
+                Err(backend_error!("failed to create cluster aggregation proof: {e}"))
             }
         }
     }
@@ -686,13 +915,17 @@ impl ZkProver for ClusterZkProver {
             ZkProofRequestKind::Compressed(request) => {
                 self.submit_range_proof(request, request_session_id).await
             }
-            ZkProofRequestKind::SnarkGroth16(_) => Err(backend_error!(
-                "SP1 cluster Groth16 aggregation is not yet supported in the stateless ZK host"
-            )),
+            ZkProofRequestKind::SnarkGroth16(request) => {
+                self.submit_range_proof(&request.proof, request_session_id).await
+            }
         }
     }
 
-    async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+    async fn poll(
+        &self,
+        _session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ZkSessionState, ZkProverError> {
         let session = ClusterSessionId::parse(backend_session_id)?;
         let Some(req) = self.get_cluster_request(&session.proof_id).await? else {
             return Ok(ZkSessionState::NotFound);
@@ -742,7 +975,24 @@ impl ZkProver for ClusterZkProver {
         }
     }
 
-    async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
+    async fn submit_next(
+        &self,
+        request: &SnarkGroth16ProofRequest,
+        request_session_id: &str,
+        completed_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        let backend_session_id = self
+            .submit_aggregation_proof(request, request_session_id, completed_backend_session_id)
+            .await?;
+
+        Ok(backend_session_id)
+    }
+
+    async fn download(
+        &self,
+        session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError> {
         let session = ClusterSessionId::parse(backend_session_id)?;
         let req = self
             .get_cluster_request(&session.proof_id)
@@ -761,11 +1011,12 @@ impl ZkProver for ClusterZkProver {
         let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
             .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
 
-        Ok(ProofResult::Compressed(ZkProofResult {
-            zk_vm: ZkVm::Sp1,
-            proof: proof.into(),
-            execution_stats: None,
-        }))
+        let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
+        if session_type == SessionType::Snark {
+            Ok(ProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof }))
+        } else {
+            Ok(ProofResult::Compressed(proof))
+        }
     }
 }
 
@@ -793,5 +1044,14 @@ mod tests {
 
         assert_eq!(first, "prover_service_session-1");
         assert_eq!(retry, "prover_service_session-1_retry_2");
+    }
+
+    #[test]
+    fn aggregation_proof_id_for_attempt_uses_stage_suffix() {
+        let first = ClusterZkProver::aggregation_proof_id_for_attempt("session-1", 0);
+        let retry = ClusterZkProver::aggregation_proof_id_for_attempt("session-1", 2);
+
+        assert_eq!(first, "prover_service_session-1_aggregation");
+        assert_eq!(retry, "prover_service_session-1_aggregation_retry_2");
     }
 }

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -9,7 +9,10 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::get_range_elf_embedded;
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ExecutionStats, ProofResult, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{
+    ExecutionStats, ProofResult, SessionType, SnarkGroth16ProofResult, ZkProofRequest,
+    ZkProofResult, ZkVm,
+};
 use sp1_sdk::{
     Elf, SP1Stdin,
     blocking::{LightProver, Prover},
@@ -28,7 +31,7 @@ macro_rules! backend_error {
     };
 }
 
-/// Prefix marking a dry-run backend session id.
+/// Prefix marking a dry-run STARK backend session id.
 pub const DRY_RUN_PREFIX: &str = "dry-run-stark-";
 
 /// [`ZkProver`] that generates a witness and executes the range program locally.
@@ -130,7 +133,7 @@ impl DryRunZkProver {
     /// Generate the witness, execute it locally, and return an empty-proof dry-run result.
     pub async fn prove_range(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<ProofResult, ZkProverError> {
         if request.number_of_blocks_to_prove == 0 {
@@ -206,6 +209,22 @@ impl DryRunZkProver {
             execution_stats: Some(execution_stats),
         }))
     }
+
+    /// Derive the deterministic backend session id for a request.
+    pub fn backend_session_id(request: &ZkProofRequestKind, request_session_id: &str) -> String {
+        Self::backend_session_id_for_type(request.initial_session_type(), request_session_id)
+    }
+
+    /// Derive the deterministic backend session id for a stage.
+    pub fn backend_session_id_for_type(
+        session_type: SessionType,
+        request_session_id: &str,
+    ) -> String {
+        match session_type {
+            SessionType::Stark => format!("{DRY_RUN_PREFIX}{request_session_id}"),
+            SessionType::Snark => format!("dry-run-snark-{request_session_id}"),
+        }
+    }
 }
 
 /// Dry-run submission is synchronous: `submit` generates the witness and runs local SP1 execution
@@ -220,14 +239,13 @@ impl ZkProver for DryRunZkProver {
         request: &ZkProofRequestKind,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
-        let ZkProofRequestKind::Compressed(request) = request else {
-            return Err(backend_error!(
-                "dry-run backend only supports compressed proof types; SNARK_GROTH16 requires a proof-producing backend"
-            ));
+        let range_request = match request {
+            ZkProofRequestKind::Compressed(request) => request,
+            ZkProofRequestKind::SnarkGroth16(request) => &request.proof,
         };
 
-        let backend_session_id = format!("{DRY_RUN_PREFIX}{request_session_id}");
-        let result = self.prove_range(request, request_session_id).await?;
+        let backend_session_id = Self::backend_session_id(request, request_session_id);
+        let result = self.prove_range(range_request, request_session_id).await?;
         self.completed_results
             .lock()
             .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?
@@ -236,7 +254,42 @@ impl ZkProver for DryRunZkProver {
         Ok(backend_session_id)
     }
 
-    async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+    async fn submit_next(
+        &self,
+        _request: &base_prover_service_protocol::SnarkGroth16ProofRequest,
+        request_session_id: &str,
+        completed_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        let range_result = self
+            .completed_results
+            .lock()
+            .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?
+            .remove(completed_backend_session_id)
+            .ok_or_else(|| ZkProverError::BackendSessionNotFound {
+                backend_session_id: completed_backend_session_id.to_owned(),
+            })?;
+        let execution_stats = match range_result {
+            ProofResult::Compressed(proof) => proof.execution_stats,
+            _ => return Err(backend_error!("dry-run range result had unexpected proof type")),
+        };
+        let backend_session_id =
+            Self::backend_session_id_for_type(SessionType::Snark, request_session_id);
+        let result = ProofResult::SnarkGroth16(SnarkGroth16ProofResult {
+            proof: ZkProofResult { zk_vm: ZkVm::Sp1, proof: Vec::new().into(), execution_stats },
+        });
+        self.completed_results
+            .lock()
+            .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?
+            .insert(backend_session_id.clone(), result);
+
+        Ok(backend_session_id)
+    }
+
+    async fn poll(
+        &self,
+        _session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ZkSessionState, ZkProverError> {
         let contains_result = self
             .completed_results
             .lock()
@@ -245,7 +298,11 @@ impl ZkProver for DryRunZkProver {
         if contains_result { Ok(ZkSessionState::Completed) } else { Ok(ZkSessionState::NotFound) }
     }
 
-    async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
+    async fn download(
+        &self,
+        _session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError> {
         self.completed_results
             .lock()
             .map_err(|e| backend_error!("dry-run result store lock poisoned: {e}"))?

--- a/crates/proof/zk/backend/src/succinct/mock.rs
+++ b/crates/proof/zk/backend/src/succinct/mock.rs
@@ -2,13 +2,13 @@
 
 use async_trait::async_trait;
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, SnarkGroth16ProofResult, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{
+    ProofResult, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, ZkProofResult,
+    ZkVm,
+};
 
 /// Placeholder proof bytes returned by the mock prover.
 pub const MOCK_PROOF_BYTES: &[u8] = b"mock-zk-proof";
-
-/// Prefix marking a mock backend session id for a SNARK proof.
-pub const MOCK_SNARK_PREFIX: &str = "mock-snark-";
 
 /// [`ZkProver`] producing instant placeholder proofs without a real backend.
 #[derive(Debug, Clone, Copy, Default)]
@@ -17,7 +17,18 @@ pub struct MockZkProver;
 impl MockZkProver {
     /// Derive the deterministic backend session id for a request.
     pub fn backend_session_id(request: &ZkProofRequestKind, request_session_id: &str) -> String {
-        let session_type = if request.is_snark_groth16() { "snark" } else { "stark" };
+        Self::backend_session_id_for_type(request.initial_session_type(), request_session_id)
+    }
+
+    /// Derive the deterministic backend session id for a stage.
+    pub fn backend_session_id_for_type(
+        session_type: SessionType,
+        request_session_id: &str,
+    ) -> String {
+        let session_type = match session_type {
+            SessionType::Stark => "stark",
+            SessionType::Snark => "snark",
+        };
         format!("mock-{session_type}-{request_session_id}")
     }
 }
@@ -32,18 +43,37 @@ impl ZkProver for MockZkProver {
         Ok(Self::backend_session_id(request, request_session_id))
     }
 
-    async fn poll(&self, _backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+    async fn poll(
+        &self,
+        _session_type: SessionType,
+        _backend_session_id: &str,
+    ) -> Result<ZkSessionState, ZkProverError> {
         Ok(ZkSessionState::Completed)
     }
 
-    async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
+    async fn submit_next(
+        &self,
+        _request: &SnarkGroth16ProofRequest,
+        request_session_id: &str,
+        _completed_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        let backend_session_id =
+            Self::backend_session_id_for_type(SessionType::Snark, request_session_id);
+        Ok(backend_session_id)
+    }
+
+    async fn download(
+        &self,
+        session_type: SessionType,
+        _backend_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError> {
         let zk_proof = ZkProofResult {
             zk_vm: ZkVm::Sp1,
             proof: MOCK_PROOF_BYTES.to_vec().into(),
             execution_stats: None,
         };
 
-        if backend_session_id.starts_with(MOCK_SNARK_PREFIX) {
+        if session_type == SessionType::Snark {
             Ok(ProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof: zk_proof }))
         } else {
             Ok(ProofResult::Compressed(zk_proof))
@@ -94,17 +124,31 @@ mod tests {
         let prover = MockZkProver;
         let id = prover.submit(&compressed(), "session-1").await.unwrap();
 
-        assert_eq!(prover.poll(&id).await.unwrap(), ZkSessionState::Completed);
-        assert!(matches!(prover.download(&id).await.unwrap(), ProofResult::Compressed(_)));
+        assert_eq!(prover.poll(SessionType::Stark, &id).await.unwrap(), ZkSessionState::Completed);
+        assert!(matches!(
+            prover.download(SessionType::Stark, &id).await.unwrap(),
+            ProofResult::Compressed(_)
+        ));
     }
 
     #[tokio::test]
-    async fn poll_completes_immediately_and_downloads_snark_groth16() {
+    async fn submit_next_advances_snark_groth16_to_snark_session() {
         let prover = MockZkProver;
-        let id = prover.submit(&snark_groth16(), "session-1").await.unwrap();
+        let request = snark_groth16();
+        let id = prover.submit(&request, "session-1").await.unwrap();
+        let ZkProofRequestKind::SnarkGroth16(proof_request) = &request else {
+            unreachable!("test request is Groth16");
+        };
 
-        assert_eq!(id, "mock-snark-session-1");
-        assert_eq!(prover.poll(&id).await.unwrap(), ZkSessionState::Completed);
-        assert!(matches!(prover.download(&id).await.unwrap(), ProofResult::SnarkGroth16(_)));
+        assert_eq!(id, "mock-stark-session-1");
+        assert_eq!(
+            prover.submit_next(proof_request, "session-1", &id).await.unwrap(),
+            "mock-snark-session-1"
+        );
+        let snark_id = MockZkProver::backend_session_id_for_type(SessionType::Snark, "session-1");
+        assert!(matches!(
+            prover.download(SessionType::Snark, &snark_id).await.unwrap(),
+            ProofResult::SnarkGroth16(_)
+        ));
     }
 }

--- a/crates/proof/zk/backend/src/succinct/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/mod.rs
@@ -23,4 +23,4 @@ mod dry_run;
 pub use dry_run::{DRY_RUN_PREFIX, DryRunZkProver};
 
 mod mock;
-pub use mock::{MOCK_PROOF_BYTES, MOCK_SNARK_PREFIX, MockZkProver};
+pub use mock::{MOCK_PROOF_BYTES, MockZkProver};

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -11,7 +11,9 @@ use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, SessionType, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{
+    ProofResult, SessionType, SnarkGroth16ProofResult, ZkProofResult, ZkVm,
+};
 use sp1_sdk::{
     HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey,
     SP1ProofWithPublicValues, SP1ProvingKey,
@@ -397,7 +399,7 @@ impl ZkProver for NetworkZkProver {
 
     async fn download(
         &self,
-        _session_type: SessionType,
+        session_type: SessionType,
         backend_session_id: &str,
     ) -> Result<ProofResult, ZkProverError> {
         let (state, proof) = self.get_network_proof_status(backend_session_id).await?;
@@ -420,10 +422,11 @@ impl ZkProver for NetworkZkProver {
         let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
             .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
 
-        Ok(ProofResult::Compressed(ZkProofResult {
-            zk_vm: ZkVm::Sp1,
-            proof: proof.into(),
-            execution_stats: None,
-        }))
+        let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
+        if session_type == SessionType::Snark {
+            Ok(ProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof }))
+        } else {
+            Ok(ProofResult::Compressed(proof))
+        }
     }
 }

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -11,7 +11,7 @@ use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{ProofResult, SessionType, ZkProofResult, ZkVm};
 use sp1_sdk::{
     HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey,
     SP1ProofWithPublicValues, SP1ProvingKey,
@@ -385,13 +385,21 @@ impl ZkProver for NetworkZkProver {
         }
     }
 
-    async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+    async fn poll(
+        &self,
+        _session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ZkSessionState, ZkProverError> {
         let (state, _proof) = self.get_network_proof_status(backend_session_id).await?;
 
         Ok(state)
     }
 
-    async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
+    async fn download(
+        &self,
+        _session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError> {
         let (state, proof) = self.get_network_proof_status(backend_session_id).await?;
         let proof = match state {
             ZkSessionState::Completed => proof.ok_or_else(|| {

--- a/crates/proof/zk/backend/src/succinct/provider.rs
+++ b/crates/proof/zk/backend/src/succinct/provider.rs
@@ -2,10 +2,13 @@
 
 use std::{error::Error as StdError, fmt, sync::Arc};
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use base_l1_head::{L1HeadCalculator, L1HeadError};
-use base_proof_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, host::SuccinctHost};
-use sp1_sdk::SP1Stdin;
+use base_proof_succinct_client_utils::boot::BootInfoStruct;
+use base_proof_succinct_host_utils::{
+    fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, host::SuccinctHost,
+};
+use sp1_sdk::{SP1ProofWithPublicValues, SP1Stdin, SP1VerifyingKey};
 use thiserror::Error;
 use tracing::{debug, info};
 
@@ -97,6 +100,27 @@ pub enum WitnessError {
     #[error("failed to build SP1 stdin from Succinct witness")]
     Stdin {
         /// Underlying witness conversion error.
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    /// Fetching the latest L1 checkpoint head for aggregation failed.
+    #[error("failed to fetch latest L1 checkpoint head for aggregation")]
+    AggregationL1Head {
+        /// Underlying header fetch error.
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    /// Fetching L1 header preimages for aggregation failed.
+    #[error("failed to fetch L1 header preimages for aggregation")]
+    AggregationHeaders {
+        /// Underlying header fetch error.
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    /// Building aggregation stdin failed.
+    #[error("failed to build aggregation stdin")]
+    AggregationStdin {
+        /// Underlying aggregation stdin error.
         #[source]
         source: Box<dyn StdError + Send + Sync>,
     },
@@ -194,5 +218,43 @@ impl OpSuccinctWitnessProvider {
         info!(start_block = start_block, end_block = end_block, "witness generation completed");
 
         Ok(stdin)
+    }
+
+    /// Generate aggregation stdin from completed compressed range proofs.
+    pub async fn generate_aggregation_witness(
+        &self,
+        range_proof: SP1ProofWithPublicValues,
+        range_vk: &SP1VerifyingKey,
+        prover_address: Address,
+    ) -> Result<SP1Stdin, WitnessError> {
+        let (boot_info, _): (BootInfoStruct, _) = bincode::serde::decode_from_slice(
+            range_proof.public_values.as_slice(),
+            bincode::config::legacy(),
+        )
+        .map_err(|source| WitnessError::AggregationStdin { source: source.into() })?;
+        let boot_infos = vec![boot_info];
+        let proofs = vec![range_proof.proof];
+
+        let header =
+            self.host.fetcher.get_latest_l1_head_in_batch(&boot_infos).await.map_err(|source| {
+                WitnessError::AggregationL1Head { source: source.into_boxed_dyn_error() }
+            })?;
+        let l1_head_hash = header.hash_slow();
+
+        let headers =
+            self.host.fetcher.get_header_preimages(&boot_infos, l1_head_hash).await.map_err(
+                |source| WitnessError::AggregationHeaders { source: source.into_boxed_dyn_error() },
+            )?;
+
+        info!(
+            l1_head_hash = %l1_head_hash,
+            num_headers = headers.len(),
+            "fetched L1 headers for aggregation proof"
+        );
+
+        get_agg_proof_stdin(proofs, boot_infos, headers, range_vk, l1_head_hash, prover_address)
+            .map_err(|source| WitnessError::AggregationStdin {
+                source: source.into_boxed_dyn_error(),
+            })
     }
 }

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -79,6 +79,7 @@ pub struct ProofGenerator<Client> {
 }
 
 struct ResolvedBackendSession {
+    session_type: SessionType,
     backend_session_id: String,
     needs_polling: bool,
 }
@@ -220,7 +221,6 @@ where
         &self,
         request: &ProofGeneratorRequest,
     ) -> Result<ProofResult, ZkProverError> {
-        let session_type = request.request.session_type();
         let handle = ProofSessionHandle::new(
             self.submitter.client().clone(),
             request.claim.session_id.clone(),
@@ -228,26 +228,60 @@ where
             request.claim.worker_id.clone(),
         );
 
-        let existing = handle
-            .get(session_type)
-            .await
-            .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+        let (session_type, existing) = self.resume_backend_session(request, &handle).await?;
         let resolved =
             self.resolve_backend_session(request, &handle, session_type, existing).await?;
 
-        if resolved.needs_polling {
+        let resolved = if resolved.needs_polling {
             self.wait_for_backend_session(
                 request,
                 &handle,
-                session_type,
-                &resolved.backend_session_id,
+                resolved.session_type,
+                resolved.backend_session_id,
             )
-            .await?;
-        }
+            .await?
+        } else {
+            resolved
+        };
 
-        let proof = self.prover.download(&resolved.backend_session_id).await?;
+        let proof =
+            self.prover.download(resolved.session_type, &resolved.backend_session_id).await?;
 
         Ok(proof)
+    }
+
+    async fn resume_backend_session(
+        &self,
+        request: &ProofGeneratorRequest,
+        handle: &ProofSessionHandle<Client>,
+    ) -> Result<(SessionType, Option<BackendSession>), ZkProverError> {
+        let initial_session_type = request.request.initial_session_type();
+        let result_session_type = request.request.session_type();
+
+        if result_session_type != initial_session_type {
+            // Failed result-stage sessions fall back to the initial stage; if it already
+            // completed, polling it will re-drive only the next stage via `submit_next`.
+            let existing = handle
+                .get(result_session_type)
+                .await
+                .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+            if let Some(
+                existing @ BackendSession {
+                    state: BackendSessionState::Running | BackendSessionState::Completed,
+                    ..
+                },
+            ) = existing
+            {
+                return Ok((result_session_type, Some(existing)));
+            }
+        }
+
+        let existing = handle
+            .get(initial_session_type)
+            .await
+            .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+
+        Ok((initial_session_type, existing))
     }
 
     async fn resolve_backend_session(
@@ -264,15 +298,17 @@ where
                     backend_session_id = %backend_session_id,
                     "resuming in-flight backend session"
                 );
-                Ok(ResolvedBackendSession { backend_session_id, needs_polling: true })
+                Ok(ResolvedBackendSession { session_type, backend_session_id, needs_polling: true })
             }
             Some(BackendSession { backend_session_id, state: BackendSessionState::Completed }) => {
+                let needs_polling = session_type != request.request.session_type();
                 info!(
                     session_id = %request.claim.session_id,
                     backend_session_id = %backend_session_id,
-                    "backend session already completed, skipping to download"
+                    needs_polling = needs_polling,
+                    "backend session already completed"
                 );
-                Ok(ResolvedBackendSession { backend_session_id, needs_polling: false })
+                Ok(ResolvedBackendSession { session_type, backend_session_id, needs_polling })
             }
             None
             | Some(BackendSession {
@@ -292,7 +328,7 @@ where
                     backend_session_id = %backend_session_id,
                     "submitted backend session and recorded it"
                 );
-                Ok(ResolvedBackendSession { backend_session_id, needs_polling: true })
+                Ok(ResolvedBackendSession { session_type, backend_session_id, needs_polling: true })
             }
         }
     }
@@ -301,11 +337,11 @@ where
         &self,
         request: &ProofGeneratorRequest,
         handle: &ProofSessionHandle<Client>,
-        session_type: SessionType,
-        backend_session_id: &str,
-    ) -> Result<(), ZkProverError> {
+        mut session_type: SessionType,
+        mut backend_session_id: String,
+    ) -> Result<ResolvedBackendSession, ZkProverError> {
         loop {
-            match self.prover.poll(backend_session_id).await? {
+            match self.prover.poll(session_type, &backend_session_id).await? {
                 ZkSessionState::Running => {
                     debug!(
                         session_id = %request.claim.session_id,
@@ -314,7 +350,56 @@ where
                     );
                     sleep(self.normalized_poll_interval()).await;
                 }
-                ZkSessionState::Completed => return Ok(()),
+                ZkSessionState::Completed => {
+                    handle
+                        .record(
+                            session_type,
+                            backend_session_id.clone(),
+                            BackendSessionState::Completed,
+                        )
+                        .await
+                        .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+
+                    if session_type == SessionType::Stark
+                        && let ZkProofRequestKind::SnarkGroth16(proof_request) = &request.request
+                    {
+                        let next_session_type = SessionType::Snark;
+                        let next_backend_session_id = self
+                            .prover
+                            .submit_next(
+                                proof_request,
+                                &request.claim.session_id,
+                                &backend_session_id,
+                            )
+                            .await?;
+                        handle
+                            .record(
+                                next_session_type,
+                                next_backend_session_id.clone(),
+                                BackendSessionState::Running,
+                            )
+                            .await
+                            .map_err(|error| ZkProverError::Session(Box::new(error)))?;
+
+                        info!(
+                            session_id = %request.claim.session_id,
+                            backend_session_id = %backend_session_id,
+                            next_backend_session_id = %next_backend_session_id,
+                            next_session_type = ?next_session_type,
+                            "backend session advanced"
+                        );
+
+                        session_type = next_session_type;
+                        backend_session_id = next_backend_session_id;
+                        continue;
+                    }
+
+                    return Ok(ResolvedBackendSession {
+                        session_type,
+                        backend_session_id,
+                        needs_polling: false,
+                    });
+                }
                 ZkSessionState::Failed(reason) => {
                     warn!(
                         session_id = %request.claim.session_id,
@@ -326,13 +411,10 @@ where
                         request,
                         handle,
                         session_type,
-                        backend_session_id,
+                        &backend_session_id,
                     )
                     .await;
-                    return Err(ZkProverError::BackendSessionFailed {
-                        backend_session_id: backend_session_id.to_owned(),
-                        reason,
-                    });
+                    return Err(ZkProverError::BackendSessionFailed { backend_session_id, reason });
                 }
                 ZkSessionState::NotFound => {
                     warn!(
@@ -344,12 +426,10 @@ where
                         request,
                         handle,
                         session_type,
-                        backend_session_id,
+                        &backend_session_id,
                     )
                     .await;
-                    return Err(ZkProverError::BackendSessionNotFound {
-                        backend_session_id: backend_session_id.to_owned(),
-                    });
+                    return Err(ZkProverError::BackendSessionNotFound { backend_session_id });
                 }
             }
         }

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -32,12 +32,14 @@ impl ZkProofRequestKind {
         }
     }
 
-    /// Returns whether this request asks for a Groth16 SNARK proof.
-    pub const fn is_snark_groth16(&self) -> bool {
-        matches!(self, Self::SnarkGroth16(_))
+    /// Returns the first backend session type used to prove this request.
+    pub const fn initial_session_type(&self) -> SessionType {
+        match self {
+            Self::Compressed(_) | Self::SnarkGroth16(_) => SessionType::Stark,
+        }
     }
 
-    /// Returns the backend session type tracked for this request.
+    /// Returns the backend session type that produces this request's final proof.
     pub const fn session_type(&self) -> SessionType {
         match self {
             Self::Compressed(_) => SessionType::Stark,
@@ -97,11 +99,29 @@ pub trait ZkProver: Send + Sync + std::fmt::Debug {
         request_session_id: &str,
     ) -> Result<String, ZkProverError>;
 
+    /// Submit the Groth16 aggregation backend session for a completed range proof.
+    async fn submit_next(
+        &self,
+        _request: &SnarkGroth16ProofRequest,
+        _request_session_id: &str,
+        _completed_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        Err(ZkProverError::Unimplemented)
+    }
+
     /// Poll the backend session, returning its current state.
-    async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError>;
+    async fn poll(
+        &self,
+        session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ZkSessionState, ZkProverError>;
 
     /// Download the completed proof for a backend session.
-    async fn download(&self, backend_session_id: &str) -> Result<ProofResult, ZkProverError>;
+    async fn download(
+        &self,
+        session_type: SessionType,
+        backend_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError>;
 }
 
 /// Placeholder [`ZkProver`] that always reports proving as unimplemented.
@@ -118,11 +138,19 @@ impl ZkProver for UnimplementedZkProver {
         Err(ZkProverError::Unimplemented)
     }
 
-    async fn poll(&self, _backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {
+    async fn poll(
+        &self,
+        _session_type: SessionType,
+        _backend_session_id: &str,
+    ) -> Result<ZkSessionState, ZkProverError> {
         Err(ZkProverError::Unimplemented)
     }
 
-    async fn download(&self, _backend_session_id: &str) -> Result<ProofResult, ZkProverError> {
+    async fn download(
+        &self,
+        _session_type: SessionType,
+        _backend_session_id: &str,
+    ) -> Result<ProofResult, ZkProverError> {
         Err(ZkProverError::Unimplemented)
     }
 }
@@ -149,26 +177,28 @@ mod tests {
         let compressed = ZkProofRequestKind::Compressed(zk_request());
         assert_eq!(compressed.start_block_number(), 100);
         assert_eq!(compressed.number_of_blocks_to_prove(), 5);
-        assert!(!compressed.is_snark_groth16());
 
         let snark = ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
             proof: zk_request(),
             prover_address: alloy_primitives::Address::ZERO,
         });
-        assert!(snark.is_snark_groth16());
+        assert_eq!(snark.start_block_number(), 100);
+        assert_eq!(snark.number_of_blocks_to_prove(), 5);
     }
 
     #[test]
     fn request_kind_maps_to_session_type() {
-        assert_eq!(ZkProofRequestKind::Compressed(zk_request()).session_type(), SessionType::Stark);
         assert_eq!(
-            ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
-                proof: zk_request(),
-                prover_address: alloy_primitives::Address::ZERO,
-            })
-            .session_type(),
-            SessionType::Snark
+            ZkProofRequestKind::Compressed(zk_request()).initial_session_type(),
+            SessionType::Stark
         );
+        assert_eq!(ZkProofRequestKind::Compressed(zk_request()).session_type(), SessionType::Stark);
+        let snark = ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+            proof: zk_request(),
+            prover_address: alloy_primitives::Address::ZERO,
+        });
+        assert_eq!(snark.initial_session_type(), SessionType::Stark);
+        assert_eq!(snark.session_type(), SessionType::Snark);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

ZK host now treats SnarkGroth16 jobs as a composed range-to-aggregation flow: it records the initial STARK range session, lets backends advance to a SNARK aggregation session, and resumes from the recorded SNARK session so prover-service continues handling a single generic proof request.