### PR TITLE
feat: post alt-DA commitment as the only L1 submission

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -130,13 +130,15 @@ pub(crate) struct BatcherArgs {
     batch_type: BatchTypeArg,
     /// Data availability mode for L1 submissions.
     ///
-    /// Accepts `blobs` (default) or `calldata`.
+    /// Accepts `blobs` (default), `calldata`, or `altda`. With `altda`, batch
+    /// bytes are uploaded to the DA server and only the commitment is posted on
+    /// L1 (calldata is not posted); requires `--altda-da-server`.
     #[arg(
         long = "data-availability-type",
         default_value = "blobs",
         env = "BATCHER_DATA_AVAILABILITY_TYPE"
     )]
-    da_type: base_batcher_encoder::DaType,
+    da_type: DaTypeArg,
 
     /// Approximate compression ratio used for span batch size estimation.
     ///
@@ -262,15 +264,9 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "no-force-blobs-when-throttling", env = "BATCHER_NO_FORCE_BLOBS_WHEN_THROTTLING")]
     pub no_force_blobs_when_throttling: bool,
 
-    /// Enable alt-DA dual-write alongside calldata submissions.
-    ///
-    /// Uploads the same calldata bytes to the DA server and posts a generic
-    /// commitment transaction on L1. Requires `--data-availability-type=calldata`
-    /// and `--altda-da-server`.
-    #[arg(long = "altda-enabled", env = "BATCHER_ALTDA_ENABLED", default_value_t = false)]
-    pub altda_enabled: bool,
-
     /// Alt-DA HTTP server base URL (e.g. `http://base-da-server:2583`).
+    ///
+    /// Required when `--data-availability-type=altda`; ignored otherwise.
     #[arg(long = "altda-da-server", env = "BATCHER_ALTDA_DA_SERVER")]
     pub altda_da_server: Option<Url>,
 
@@ -286,19 +282,19 @@ pub(crate) struct BatcherArgs {
 impl BatcherArgs {
     /// Convert CLI arguments into a [`BatcherConfig`].
     fn into_config(self) -> eyre::Result<BatcherConfig> {
-        if !self.altda_enabled && self.altda_da_server.is_some() {
+        let altda = matches!(self.da_type, DaTypeArg::Altda);
+        if !altda && self.altda_da_server.is_some() {
             warn!(
-                "--altda-da-server is set but --altda-enabled is false; alt-DA dual-write is disabled"
-            );
-        }
-        if self.altda_enabled && !self.no_force_blobs_when_throttling {
-            warn!(
-                "alt-DA dual-write is enabled while force-blobs-when-throttling is on; \
-                 throttled batches may switch to blobs and skip the shadow S3 path"
+                "--altda-da-server is set but --data-availability-type is not altda; it is ignored"
             );
         }
 
-        let frame_size = match self.da_type {
+        // alt-DA frames as calldata; only the L1 submission target differs.
+        let encoder_da_type = match self.da_type {
+            DaTypeArg::Blobs => base_batcher_encoder::DaType::Blob,
+            DaTypeArg::Calldata | DaTypeArg::Altda => base_batcher_encoder::DaType::Calldata,
+        };
+        let frame_size = match encoder_da_type {
             base_batcher_encoder::DaType::Blob => self
                 .target_frame_size
                 .saturating_sub(base_batcher_encoder::EncoderConfig::BLOB_DERIVATION_PREFIX_SIZE),
@@ -311,7 +307,7 @@ impl BatcherArgs {
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
             batch_type: self.batch_type.into(),
-            da_type: self.da_type,
+            da_type: encoder_da_type,
             approx_compr_ratio: self.approx_compr_ratio,
             max_l1_tx_size_bytes: self.max_l1_tx_size_bytes,
         };
@@ -342,11 +338,13 @@ impl BatcherArgs {
             stopped: self.stopped,
             wait_node_sync: self.wait_node_sync,
             wait_node_sync_timeout: Duration::from_secs(self.wait_node_sync_timeout_secs),
-            force_blobs_when_throttling: !self.no_force_blobs_when_throttling,
-            alt_da: if self.altda_enabled {
-                let server_url = self
-                    .altda_da_server
-                    .ok_or_else(|| eyre::eyre!("--altda-enabled requires --altda-da-server"))?;
+            // alt-DA frames as calldata and has no blob commitment path, so a
+            // throttle-driven blob switch is never valid; force it off in altda mode.
+            force_blobs_when_throttling: !self.no_force_blobs_when_throttling && !altda,
+            alt_da: if altda {
+                let server_url = self.altda_da_server.ok_or_else(|| {
+                    eyre::eyre!("--data-availability-type altda requires --altda-da-server")
+                })?;
                 let client = base_alt_da::Client::new(server_url)
                     .map_err(|e| eyre::eyre!("failed to create alt-da client: {e}"))?;
                 Some(std::sync::Arc::new(AltDaClientAdapter(client))
@@ -375,6 +373,18 @@ impl BatcherArgs {
         let service = BatcherService::new(config);
         service.setup(rt).await?.run().await
     }
+}
+
+/// Operator-facing data-availability selection for `--data-availability-type`.
+///
+/// `Altda` frames identically to `Calldata`; the difference is the L1 submission
+/// target (DA server + commitment vs. inline calldata), resolved in `into_config`.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DaTypeArg {
+    #[value(name = "blobs", alias = "blob")]
+    Blobs,
+    Calldata,
+    Altda,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -608,30 +618,24 @@ mod tests {
     }
 
     #[test]
-    fn altda_enabled_requires_server_url() {
-        let cli = parse_cli(&["--altda-enabled", "--data-availability-type", "calldata"]);
+    fn altda_requires_server_url() {
+        let cli = parse_cli(&["--data-availability-type", "altda"]);
         let err = cli.args.into_config().unwrap_err();
         assert!(err.to_string().contains("altda-da-server"));
     }
 
     #[test]
-    fn altda_config_parses_with_calldata() {
+    fn altda_config_parses_and_uses_calldata_framing() {
         let cli = parse_cli(&[
             "--data-availability-type",
-            "calldata",
-            "--altda-enabled",
+            "altda",
             "--altda-da-server",
             "http://base-da-server:2583",
         ]);
         let config = cli.args.into_config().expect("config should build");
         assert!(config.alt_da.is_some());
-    }
-
-    #[test]
-    fn altda_rejected_with_blob_da() {
-        let cli =
-            parse_cli(&["--altda-enabled", "--altda-da-server", "http://base-da-server:2583"]);
-        let err = cli.args.into_config().unwrap_err();
-        assert!(err.to_string().contains("calldata"));
+        assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Calldata);
+        // alt-DA must not force blobs under throttling.
+        assert!(!config.force_blobs_when_throttling);
     }
 }

--- a/crates/batcher/core/src/config.rs
+++ b/crates/batcher/core/src/config.rs
@@ -21,6 +21,8 @@ pub struct BatchDriverConfig {
     /// No-op when the encoder is already configured for blob DA.
     /// Default: `true`.
     pub force_blobs_when_throttling: bool,
-    /// Optional alt-DA client for dual-write (calldata + commitment txs).
+    /// Optional alt-DA client. When set, batch bytes are uploaded to the DA
+    /// server and only the commitment is posted on L1 (calldata is not posted).
+    /// The presence of the client selects alt-DA mode.
     pub alt_da: Option<crate::DynAltDaClient>,
 }

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -7,13 +7,10 @@ use base_batcher_encoder::{BatchPipeline, BatcherMetrics, DaType, FrameEncoder, 
 use base_blobs::BlobEncoder;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 use futures::stream::{FuturesUnordered, StreamExt};
-use tokio::{sync::Semaphore, task::JoinSet};
+use tokio::sync::Semaphore;
 use tracing::{info, warn};
 
 use crate::{DynAltDaClient, TxOutcome};
-
-/// Max concurrent alt-DA shadow writes detached from the primary submission semaphore.
-const ALT_DA_MAX_IN_FLIGHT: usize = 2;
 
 /// Type alias for the in-flight receipt future collection.
 type InFlight =
@@ -31,11 +28,9 @@ pub struct SubmissionQueue<TM: TxManager + 'static> {
     semaphore: Arc<Semaphore>,
     inbox: Address,
     txpool_blocked: bool,
+    /// When set, batch bytes are uploaded here and only the commitment is posted
+    /// on L1 (calldata is not posted). The presence of the client is the mode.
     alt_da: Option<DynAltDaClient>,
-    /// Limits concurrent shadow PUT + commitment work without touching primary capacity.
-    alt_da_semaphore: Option<Arc<Semaphore>>,
-    /// Detached alt-DA shadow-write tasks, tracked so a reorg can cancel them.
-    alt_da_tasks: JoinSet<()>,
 }
 
 impl<TM: TxManager + 'static> SubmissionQueue<TM> {
@@ -46,8 +41,6 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
         max_pending: usize,
         alt_da: Option<DynAltDaClient>,
     ) -> Self {
-        let alt_da_semaphore =
-            alt_da.is_some().then(|| Arc::new(Semaphore::new(ALT_DA_MAX_IN_FLIGHT)));
         Self {
             tx_manager: Arc::new(tx_manager),
             in_flight: FuturesUnordered::new(),
@@ -55,8 +48,6 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
             inbox,
             txpool_blocked: false,
             alt_da,
-            alt_da_semaphore,
-            alt_da_tasks: JoinSet::new(),
         }
     }
 
@@ -124,7 +115,7 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
                 DaType::Blob => BatcherMetrics::DA_TYPE_BLOB,
                 DaType::Calldata => BatcherMetrics::DA_TYPE_CALLDATA,
             };
-            let candidate = match da_type {
+            let mut candidate = match da_type {
                 DaType::Blob => match BlobEncoder::encode_packed(&frames) {
                     Ok(blob) => TxCandidate {
                         to: Some(self.inbox),
@@ -150,11 +141,38 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
                     blobs: vec![].into(),
                 },
             };
-            let alt_da_body = match da_type {
-                DaType::Calldata if self.alt_da.is_some() => Some(candidate.tx_data.clone()),
-                _ => None,
-            };
-            let shadow_ids = alt_da_body.as_ref().map(|_| ids.clone());
+
+            // Alt-DA mode: upload the batch bytes and post only the commitment on L1.
+            // The commitment rides the primary submission lifecycle (nonce, requeue,
+            // confirm), so calldata is never posted and there is a single ordered stream.
+            if let Some(alt_da) = self.alt_da.clone() {
+                if !matches!(da_type, DaType::Calldata) {
+                    // Config validation pins alt-DA to calldata framing; a blob here has no
+                    // commitment path, so requeue rather than post uncommitted data.
+                    warn!("alt-da received non-calldata submission, requeueing");
+                    for id in ids {
+                        pipeline.requeue(id);
+                    }
+                    drop(permit);
+                    break;
+                }
+                match alt_da.put(candidate.tx_data.clone()).await {
+                    Ok(commitment) => candidate.tx_data = commitment.encode_tx_data(),
+                    Err(error) => {
+                        // PUT failed: post nothing and requeue so the same batch retries next
+                        // tick. No nonce is consumed, so the commitment stream stays gap-free.
+                        warn!(submission_ids = ?ids, %error, "alt-da put failed, requeueing batch");
+                        BatcherMetrics::alt_da_commitment_total(BatcherMetrics::OUTCOME_PUT_FAILED)
+                            .increment(1);
+                        for id in ids {
+                            pipeline.requeue(id);
+                        }
+                        drop(permit);
+                        break;
+                    }
+                }
+            }
+
             info!(
                 submissions = %ids.len(),
                 da_type = %da_type_label,
@@ -196,96 +214,6 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
                     (ids, outcome)
                 });
             self.in_flight.push(fut);
-
-            if let Some(body) = alt_da_body {
-                // alt_da_body is only Some when self.alt_da.is_some(); surface the invariant
-                // rather than silently dropping the shadow write if that ever changes.
-                let alt_da = self.alt_da.clone().expect("alt_da present when alt_da_body is Some");
-                let shadow_ids = shadow_ids.expect("shadow ids when alt-da body present");
-                let alt_da_semaphore =
-                    self.alt_da_semaphore.as_ref().expect("shadow semaphore when alt-da enabled");
-                if let Ok(alt_da_permit) = Arc::clone(alt_da_semaphore).try_acquire_owned() {
-                    let tx_manager = Arc::clone(&self.tx_manager);
-                    let inbox = self.inbox;
-                    // Reap finished shadow tasks so the JoinSet stays bounded.
-                    while self.alt_da_tasks.try_join_next().is_some() {}
-                    self.alt_da_tasks.spawn(async move {
-                        let _alt_da_permit = alt_da_permit;
-                        let commitment = match alt_da.put(body).await {
-                            Ok(commitment) => commitment,
-                            Err(error) => {
-                                // A failed PUT leaves this batch absent from S3. Harmless while
-                                // calldata is primary, but it is a gap that would block the S3-only
-                                // cutover, so surface it as a metric, not just a log line.
-                                warn!(submission_ids = ?shadow_ids, %error, "alt-da put failed; calldata submission unchanged");
-                                BatcherMetrics::alt_da_commitment_total(
-                                    BatcherMetrics::OUTCOME_PUT_FAILED,
-                                )
-                                .increment(1);
-                                return;
-                            }
-                        };
-
-                        let tx_data = commitment.encode_tx_data();
-                        info!(
-                            submission_ids = ?shadow_ids,
-                            commitment_bytes = %tx_data.len(),
-                            "submitting alt-da commitment to L1"
-                        );
-                        let candidate = TxCandidate {
-                            to: Some(inbox),
-                            tx_data,
-                            value: U256::ZERO,
-                            gas_limit: 0,
-                            blobs: vec![].into(),
-                        };
-
-                        // Shadow commitments share the primary TxManager signer + nonce pool today:
-                        // a slow PUT/commitment can stall primary submissions, and an abort_all
-                        // between these two awaits can leave a reserved nonce unconfirmed. Accepted
-                        // for the calldata-primary shadow phase; a separate shadow signer is the
-                        // S3-only cutover follow-up (PRIV-1972).
-                        match tx_manager.send_async(candidate).await.await {
-                            Ok(receipt) => {
-                                let l1_block = receipt.block_number.unwrap_or_else(|| {
-                                    warn!(
-                                        submission_ids = ?shadow_ids,
-                                        "alt-da commitment receipt missing block number"
-                                    );
-                                    0
-                                });
-                                info!(
-                                    submission_ids = ?shadow_ids,
-                                    l1_block = %l1_block,
-                                    "alt-da commitment confirmed on L1"
-                                );
-                                BatcherMetrics::alt_da_commitment_total(
-                                    BatcherMetrics::OUTCOME_CONFIRMED,
-                                )
-                                .increment(1);
-                            }
-                            Err(error) => {
-                                warn!(
-                                    submission_ids = ?shadow_ids,
-                                    %error,
-                                    "alt-da commitment submission failed"
-                                );
-                                BatcherMetrics::alt_da_commitment_total(
-                                    BatcherMetrics::OUTCOME_FAILED,
-                                )
-                                .increment(1);
-                            }
-                        }
-                    });
-                } else {
-                    warn!(
-                        submission_ids = ?shadow_ids,
-                        "alt-da shadow write skipped: shadow capacity exhausted"
-                    );
-                    BatcherMetrics::alt_da_commitment_total(BatcherMetrics::OUTCOME_SKIPPED)
-                        .increment(1);
-                }
-            }
         }
     }
 
@@ -362,9 +290,6 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
         pipeline: &mut P,
         mut timeout_fut: Pin<Box<dyn Future<Output = ()> + Send>>,
     ) {
-        // Shadow commitments are not tied to pipeline confirmation; cancel on shutdown.
-        self.alt_da_tasks.abort_all();
-
         loop {
             if self.in_flight.is_empty() {
                 break;
@@ -410,8 +335,6 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
             BatcherMetrics::in_flight_submissions().set(0.0);
         }
         self.in_flight = FuturesUnordered::new();
-        // Cancel pending shadow commitments so a reorged batch can't still land on L1.
-        self.alt_da_tasks.abort_all();
     }
 
     /// Returns a future for the next settled `(ids, outcome)` pair.
@@ -600,7 +523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn alt_da_shadow_write_puts_bytes_and_posts_commitment() {
+    async fn alt_da_posts_commitment_as_primary() {
         let client = Arc::new(RecordingAltDaClient::default());
         let puts = Arc::clone(&client.puts);
         let alt_da: DynAltDaClient = client;
@@ -615,9 +538,8 @@ mod tests {
         assert_eq!(ids, vec![SubmissionId(1)]);
         assert!(matches!(outcome, TxOutcome::Confirmed { .. }));
 
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        assert_eq!(sends.load(Ordering::SeqCst), 2);
+        // Exactly one L1 tx — the commitment — and the calldata body went to the DA server.
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
         assert_eq!(commitment_sends.load(Ordering::SeqCst), 1);
         let puts = puts.lock().unwrap();
         assert_eq!(puts.len(), 1);
@@ -625,37 +547,28 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct GatedAltDaClient {
-        gate: Arc<tokio::sync::Notify>,
-    }
+    struct FailingAltDaClient;
 
     #[async_trait]
-    impl AltDaClient for GatedAltDaClient {
+    impl AltDaClient for FailingAltDaClient {
         async fn put(&self, _: Bytes) -> Result<GenericCommitment, AltDaError> {
-            self.gate.notified().await;
-            Ok(sample_commitment())
+            Err(AltDaError("put failed".into()))
         }
     }
 
     #[tokio::test]
-    async fn drain_aborts_pending_shadow_tasks() {
-        let gate = Arc::new(tokio::sync::Notify::new());
-        let alt_da: DynAltDaClient = Arc::new(GatedAltDaClient { gate });
-        let (tx_manager, _, commitment_sends) = CountingTxManager::new();
+    async fn alt_da_put_failure_posts_nothing() {
+        let alt_da: DynAltDaClient = Arc::new(FailingAltDaClient);
+        let (tx_manager, sends, _) = CountingTxManager::new();
         let mut queue = SubmissionQueue::new(tx_manager, Address::ZERO, 1, Some(alt_da));
         let mut pipeline = CalldataPipeline {
             submissions: std::collections::VecDeque::from([calldata_submission()]),
         };
 
         queue.submit_pending(&mut pipeline).await;
-        let timeout = Box::pin(std::future::ready(()));
-        queue.drain(&mut pipeline, timeout).await;
 
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(
-            commitment_sends.load(Ordering::SeqCst),
-            0,
-            "drain should abort shadow tasks before commitment txs are sent"
-        );
+        // PUT failed → no L1 tx posted and nothing in flight (the batch is requeued).
+        assert_eq!(sends.load(Ordering::SeqCst), 0);
+        assert_eq!(queue.in_flight_count(), 0);
     }
 }

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -157,7 +157,11 @@ impl<TM: TxManager + 'static> SubmissionQueue<TM> {
                     break;
                 }
                 match alt_da.put(candidate.tx_data.clone()).await {
-                    Ok(commitment) => candidate.tx_data = commitment.encode_tx_data(),
+                    Ok(commitment) => {
+                        BatcherMetrics::alt_da_commitment_total(BatcherMetrics::OUTCOME_PUT_OK)
+                            .increment(1);
+                        candidate.tx_data = commitment.encode_tx_data();
+                    }
                     Err(error) => {
                         // PUT failed: post nothing and requeue so the same batch retries next
                         // tick. No nonce is consumed, so the commitment stream stays gap-free.

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -13,7 +13,7 @@ base_metrics::define_metrics! {
     #[describe("Total number of L1 batch submissions")]
     #[label(outcome)]
     submission_total: counter,
-    #[describe("Total alt-DA commitment shadow-write outcomes")]
+    #[describe("Total alt-DA DA-server upload (PUT) outcomes")]
     #[label(outcome)]
     alt_da_commitment_total: counter,
     #[describe("Total bytes of frame payload submitted to the DA layer")]
@@ -60,11 +60,11 @@ impl BatcherMetrics {
     /// Submission requeued due to txpool blockage.
     pub const OUTCOME_REQUEUED: &'static str = "requeued";
 
-    /// Alt-DA shadow write: PUT to the DA server failed, so no commitment was posted.
-    pub const OUTCOME_PUT_FAILED: &'static str = "put_failed";
+    /// Alt-DA: batch bytes uploaded to the DA server (PUT succeeded).
+    pub const OUTCOME_PUT_OK: &'static str = "put_ok";
 
-    /// Alt-DA shadow write skipped because shadow concurrency limit was reached.
-    pub const OUTCOME_SKIPPED: &'static str = "skipped";
+    /// Alt-DA: PUT to the DA server failed, so the batch was requeued without posting.
+    pub const OUTCOME_PUT_FAILED: &'static str = "put_failed";
 
     /// Blob DA: frames encoded into EIP-4844 blobs.
     pub const DA_TYPE_BLOB: &'static str = "blob";

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -104,11 +104,11 @@ pub struct BatcherConfig {
     /// emit blob-typed submissions even when its configured `da_type` is
     /// calldata. No-op for blob-configured batchers. Default: `true`.
     pub force_blobs_when_throttling: bool,
-    /// Alt-DA dual-write: upload calldata bytes to the DA server and post commitments on L1.
-    ///
-    /// Requires [`EncoderConfig::da_type`](base_batcher_encoder::EncoderConfig::da_type) ==
-    /// [`DaType::Calldata`](base_batcher_encoder::DaType::Calldata). Calldata remains the
-    /// primary derivation path; alt-DA is a shadow path for validation. The concrete
+    /// Optional alt-DA client. When set, the batcher uploads each batch's
+    /// calldata-framed bytes to the DA server and posts only the commitment on L1
+    /// (calldata is not posted). Requires
+    /// [`EncoderConfig::da_type`](base_batcher_encoder::EncoderConfig::da_type) ==
+    /// [`DaType::Calldata`](base_batcher_encoder::DaType::Calldata). The concrete
     /// client is constructed by the binary and injected here.
     pub alt_da: Option<DynAltDaClient>,
 }

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -162,8 +162,15 @@ impl BatcherConfig {
 
         if self.alt_da.is_some() && self.encoder_config.da_type != DaType::Calldata {
             eyre::bail!(
-                "alt-da dual-write requires --data-availability-type calldata; \
-                 blob submissions are not dual-written to the DA server"
+                "alt-da requires calldata framing; the batcher uploads calldata-framed \
+                 bytes to the DA server and posts the commitment on L1"
+            );
+        }
+
+        if self.alt_da.is_some() && self.force_blobs_when_throttling {
+            eyre::bail!(
+                "alt-da requires --no-force-blobs-when-throttling; a throttle-driven switch \
+                 to blobs has no commitment path and would stall the batcher"
             );
         }
 


### PR DESCRIPTION
## Summary
Adds `altda` as a `--data-availability-type` for the batcher. In this mode each batch is uploaded to the DA server and only the commitment is posted on L1 (calldata off), so calldata and alt-DA are mutually exclusive. This is what lets an L3 run on base/base with S3 as its DA layer rather than calldata.

Removes the temporary best-effort dual-write shadow path. The commitment now rides the normal submission lifecycle (nonce, requeue, confirm), so a failed upload requeues the batch instead of leaving a gap or posting an uncommitted tx. `altda` frames as calldata and auto-disables force-blobs (no blob commitment path).

## Test plan
- `cargo test -p base-batcher-core -p base-batcher-service -p base-batcher-bin` (incl. new commitment-as-primary and PUT-failure-posts-nothing tests)
- fmt, clippy `-D warnings`, and the crate-dep boundary check

type=routine
risk=low
impact=sev5