### PR TITLE
fix(zk-host): claim all ZK proof jobs

### DIFF
--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -13,7 +13,7 @@ use base_proof_zk_backend::{
 use base_proof_zk_host::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
     DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, ProofGeneratorHeartbeatConfig,
-    ZkHost, ZkHostConfig, ZkProofClaimType,
+    ZkHost, ZkHostConfig,
 };
 use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::{Parser, ValueEnum};
@@ -56,10 +56,6 @@ struct WorkerArgs {
     /// Worker identifier used when claiming prover-service jobs.
     #[arg(long, env = "PROVER_WORKER_ID")]
     worker_id: Option<String>,
-
-    /// ZK proof type to claim: `compressed` or `snark_groth16`.
-    #[arg(long, env = "PROOF_TYPE", value_enum, default_value = "compressed")]
-    proof_type: ZkProofTypeArg,
 
     /// Proving backend to run: `mock`, `dry-run`, `cluster`, or `network`.
     #[arg(long, env = "ZK_BACKEND", value_enum)]
@@ -183,25 +179,6 @@ struct WorkerArgs {
     proof_generator_max_consecutive_heartbeat_failures: u32,
 }
 
-/// ZK proof type argument.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-enum ZkProofTypeArg {
-    /// Claim compressed ZK proofs.
-    Compressed,
-    /// Claim SNARK Groth16 proofs.
-    #[value(alias = "snark_groth16", alias = "groth16")]
-    SnarkGroth16,
-}
-
-impl From<ZkProofTypeArg> for ZkProofClaimType {
-    fn from(proof_type: ZkProofTypeArg) -> Self {
-        match proof_type {
-            ZkProofTypeArg::Compressed => Self::Compressed,
-            ZkProofTypeArg::SnarkGroth16 => Self::SnarkGroth16,
-        }
-    }
-}
-
 /// ZK proving backend argument.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum ZkBackendArg {
@@ -230,17 +207,6 @@ impl AsRef<str> for ZkBackendArg {
 impl fmt::Display for ZkBackendArg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_ref())
-    }
-}
-
-impl ZkBackendArg {
-    const fn supports_proof_type(self, proof_type: ZkProofTypeArg) -> bool {
-        match self {
-            Self::Mock => true,
-            Self::DryRun | Self::Cluster | Self::Network => {
-                matches!(proof_type, ZkProofTypeArg::Compressed)
-            }
-        }
     }
 }
 
@@ -338,16 +304,8 @@ impl Cli {
 impl WorkerArgs {
     async fn run(self, cancel: CancellationToken) -> eyre::Result<()> {
         let args = &self;
-        if !args.backend.supports_proof_type(args.proof_type) {
-            return Err(eyre!(
-                "ZK_BACKEND={} currently supports PROOF_TYPE=compressed only",
-                args.backend
-            ));
-        }
-        let proof_type = ZkProofClaimType::from(args.proof_type);
         info!(
             prover_service_endpoint = %args.prover_service_endpoint,
-            proof_type = ?proof_type,
             backend = %args.backend,
             "initializing zk prover host worker"
         );
@@ -359,7 +317,6 @@ impl WorkerArgs {
             .wrap_err("failed to initialize zk proving backend")?
         else {
             info!(
-                proof_type = ?proof_type,
                 backend = %args.backend,
                 "zk prover host worker initialization cancelled"
             );
@@ -371,7 +328,6 @@ impl WorkerArgs {
         let Some(client) = Self::connect_prover_service_client(&client_config, &cancel).await?
         else {
             info!(
-                proof_type = ?proof_type,
                 backend = %args.backend,
                 "zk prover host worker startup cancelled"
             );
@@ -386,7 +342,7 @@ impl WorkerArgs {
 
         let worker_id =
             args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
-        let host_config = ZkHostConfig::sp1(worker_id.clone(), proof_type)
+        let host_config = ZkHostConfig::sp1(worker_id.clone())
             .with_job_discovery_poll_interval(Duration::from_millis(
                 args.job_discovery_poll_interval_ms,
             ))
@@ -398,7 +354,6 @@ impl WorkerArgs {
         info!(
             worker_id = %worker_id,
             prover_service_endpoint = %args.prover_service_endpoint,
-            proof_type = ?proof_type,
             backend = %args.backend,
             "starting zk prover host worker"
         );

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -1,6 +1,14 @@
 //! Job discovery loop for prover-service worker claims.
 
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkVm};
@@ -82,6 +90,16 @@ impl JobClaimFilter {
         worker_id: String,
         lock_duration_seconds: u32,
     ) -> impl Iterator<Item = GetNextProofRequest> {
+        self.get_next_proof_requests_starting_at(worker_id, lock_duration_seconds, 0)
+    }
+
+    /// Builds the worker claim requests for this filter with a proof-type rotation offset.
+    pub fn get_next_proof_requests_starting_at(
+        &self,
+        worker_id: String,
+        lock_duration_seconds: u32,
+        proof_type_offset: usize,
+    ) -> impl Iterator<Item = GetNextProofRequest> {
         let requests = match self {
             Self::Tee { tee_kinds } => [
                 Some(GetNextProofRequest {
@@ -95,19 +113,24 @@ impl JobClaimFilter {
             ],
             Self::Zk { zk_vms } => {
                 let zk_vms = zk_vms.clone();
-                let [compressed_proof_type, snark_proof_type] = ZK_PROOF_TYPES;
+                let proof_types = if proof_type_offset.is_multiple_of(ZK_PROOF_TYPES.len()) {
+                    ZK_PROOF_TYPES
+                } else {
+                    [ProofType::SnarkGroth16, ProofType::Compressed]
+                };
+                let [first_proof_type, second_proof_type] = proof_types;
 
                 [
                     Some(GetNextProofRequest {
                         worker_id: worker_id.clone(),
-                        proof_type: compressed_proof_type,
+                        proof_type: first_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
                         worker_id,
-                        proof_type: snark_proof_type,
+                        proof_type: second_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms,
                         lock_duration_seconds,
@@ -197,8 +220,19 @@ impl JobDiscoveryConfig {
 
     /// Builds the worker claim requests for this host.
     pub fn get_next_proof_requests(&self) -> impl Iterator<Item = GetNextProofRequest> {
-        self.claim_filter
-            .get_next_proof_requests(self.worker_id.clone(), self.lock_duration_seconds)
+        self.get_next_proof_requests_starting_at(0)
+    }
+
+    /// Builds the worker claim requests for this host with a proof-type rotation offset.
+    pub fn get_next_proof_requests_starting_at(
+        &self,
+        proof_type_offset: usize,
+    ) -> impl Iterator<Item = GetNextProofRequest> {
+        self.claim_filter.get_next_proof_requests_starting_at(
+            self.worker_id.clone(),
+            self.lock_duration_seconds,
+            proof_type_offset,
+        )
     }
 }
 
@@ -209,6 +243,7 @@ pub struct JobDiscovery<Client, Generator> {
     proof_generator: Arc<Generator>,
     config: JobDiscoveryConfig,
     generator_permits: Arc<Semaphore>,
+    claim_offset: AtomicUsize,
 }
 
 /// Outcome of one job discovery poll.
@@ -240,7 +275,13 @@ impl<Client, Generator> JobDiscovery<Client, Generator> {
     ) -> Self {
         let generator_permits = Arc::new(Semaphore::new(config.normalized_max_concurrent_jobs()));
 
-        Self { client, proof_generator, config, generator_permits }
+        Self {
+            client,
+            proof_generator,
+            config,
+            generator_permits,
+            claim_offset: AtomicUsize::new(0),
+        }
     }
 
     /// Returns the discovery config.
@@ -340,8 +381,8 @@ where
             return Ok(JobDiscoveryPollOutcome::Empty);
         }
 
-        let mut last_error = None;
-        for request in self.config.get_next_proof_requests() {
+        let proof_type_offset = self.claim_offset.fetch_add(1, Ordering::Relaxed);
+        for request in self.config.get_next_proof_requests_starting_at(proof_type_offset) {
             let proof_type = request.proof_type;
             let response = match self.client.get_next_proof(request).await {
                 Ok(response) => response,
@@ -354,8 +395,7 @@ where
                         error = %error,
                         "job discovery claim failed for proof type"
                     );
-                    last_error = Some(error);
-                    continue;
+                    return Err(error);
                 }
             };
 
@@ -366,10 +406,6 @@ where
         }
 
         drop(permit);
-        if let Some(error) = last_error {
-            return Err(error);
-        }
-
         debug!(
             worker_id = %self.config.worker_id,
             worker_kind = self.config.claim_filter.log_label(),
@@ -717,7 +753,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claim_once_checks_snark_after_compressed_claim_error() {
+    async fn claim_once_rotates_zk_claim_order() {
+        let client = MockWorkerClient::new(Some(snark_job()));
+        let generator = Arc::new(MockGenerator { can_claim: true, ..Default::default() });
+        let generated = Arc::clone(&generator.generated);
+        let discovery = JobDiscovery::new(
+            client.clone(),
+            generator,
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+        );
+        discovery.claim_offset.store(1, Ordering::Relaxed);
+
+        let outcome = discovery.claim_once().await.expect("claim should succeed");
+
+        let JobDiscoveryPollOutcome::Claimed { task } = outcome else {
+            panic!("expected proof generator task to be returned");
+        };
+        timeout(Duration::from_secs(1), task).await.expect("proof generator task should finish");
+        let requests = client.get_next_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].proof_type, ProofType::SnarkGroth16);
+        assert_eq!(
+            *generated.lock().expect("generated jobs lock should not be poisoned"),
+            vec!["session-1".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_once_returns_error_after_claim_failure_without_trying_next_type() {
         let client =
             MockWorkerClient::with_failed_claims(Some(snark_job()), vec![ProofType::Compressed]);
         let generator = Arc::new(MockGenerator { can_claim: true, ..Default::default() });
@@ -728,39 +791,16 @@ mod tests {
             JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
         );
 
-        let outcome = discovery.claim_once().await.expect("claim should succeed");
+        let error =
+            discovery.claim_once().await.expect_err("claim should surface the ambiguous failure");
 
-        let JobDiscoveryPollOutcome::Claimed { task } = outcome else {
-            panic!("expected proof generator task to be returned");
-        };
-        timeout(Duration::from_secs(1), task).await.expect("proof generator task should finish");
+        assert!(error.to_string().contains("simulated Compressed claim failure"));
         let requests = client.get_next_requests();
-        assert_eq!(requests.len(), 2);
+        assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].proof_type, ProofType::Compressed);
-        assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
         assert_eq!(
             *generated.lock().expect("generated jobs lock should not be poisoned"),
-            vec!["session-1".to_string()]
+            Vec::<String>::new()
         );
-    }
-
-    #[tokio::test]
-    async fn claim_once_returns_error_when_any_claim_fails_without_job() {
-        let client = MockWorkerClient::with_failed_claims(None, vec![ProofType::SnarkGroth16]);
-        let generator = Arc::new(MockGenerator { can_claim: true, ..Default::default() });
-        let discovery = JobDiscovery::new(
-            client.clone(),
-            generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
-        );
-
-        let error =
-            discovery.claim_once().await.expect_err("claim should surface the failed proof type");
-
-        assert!(error.to_string().contains("simulated SnarkGroth16 claim failure"));
-        let requests = client.get_next_requests();
-        assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0].proof_type, ProofType::Compressed);
-        assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
     }
 }

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -31,23 +31,8 @@ pub const DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS: usize = 1;
 /// Future that generates a claimed proof job and starts proof submission.
 pub type JobDiscoveryTask = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
-/// ZK proof types that can be claimed by a prover-service worker.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ZkProofClaimType {
-    /// Claim compressed ZK proof jobs.
-    Compressed,
-    /// Claim SNARK Groth16 proof jobs.
-    SnarkGroth16,
-}
-
-impl From<ZkProofClaimType> for ProofType {
-    fn from(proof_type: ZkProofClaimType) -> Self {
-        match proof_type {
-            ZkProofClaimType::Compressed => Self::Compressed,
-            ZkProofClaimType::SnarkGroth16 => Self::SnarkGroth16,
-        }
-    }
-}
+/// ZK proof types claimed by every ZK host.
+pub const ZK_PROOF_TYPES: [ProofType; 2] = [ProofType::Compressed, ProofType::SnarkGroth16];
 
 /// Prover-service claim filter for a worker host.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -57,10 +42,8 @@ pub enum JobClaimFilter {
         /// TEE kinds this worker can execute.
         tee_kinds: Vec<TeeKind>,
     },
-    /// Claim ZK proof jobs for the configured proof type and virtual machines.
+    /// Claim ZK proof jobs for the configured virtual machines.
     Zk {
-        /// ZK proof type this worker claims.
-        proof_type: ZkProofClaimType,
         /// ZK virtual machines this worker can execute.
         zk_vms: Vec<ZkVm>,
     },
@@ -73,18 +56,15 @@ impl JobClaimFilter {
     }
 
     /// Creates a ZK claim filter.
-    pub fn zk(proof_type: ZkProofClaimType, zk_vms: impl Into<Vec<ZkVm>>) -> Self {
-        Self::Zk { proof_type, zk_vms: zk_vms.into() }
+    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>) -> Self {
+        Self::Zk { zk_vms: zk_vms.into() }
     }
 
-    /// Returns the prover-service proof type for this claim filter.
-    pub const fn proof_type(&self) -> ProofType {
+    /// Returns the prover-service proof types for this claim filter.
+    pub fn proof_types(&self) -> Vec<ProofType> {
         match self {
-            Self::Tee { .. } => ProofType::Tee,
-            Self::Zk { proof_type, .. } => match proof_type {
-                ZkProofClaimType::Compressed => ProofType::Compressed,
-                ZkProofClaimType::SnarkGroth16 => ProofType::SnarkGroth16,
-            },
+            Self::Tee { .. } => vec![ProofType::Tee],
+            Self::Zk { .. } => ZK_PROOF_TYPES.to_vec(),
         }
     }
 
@@ -96,27 +76,46 @@ impl JobClaimFilter {
         }
     }
 
-    /// Builds the worker claim request for this filter.
-    pub fn get_next_proof_request(
+    /// Builds the worker claim requests for this filter.
+    pub fn get_next_proof_requests(
         &self,
         worker_id: String,
         lock_duration_seconds: u32,
-    ) -> GetNextProofRequest {
+    ) -> Vec<GetNextProofRequest> {
         match self {
-            Self::Tee { tee_kinds } => GetNextProofRequest {
+            Self::Tee { tee_kinds } => vec![GetNextProofRequest {
                 worker_id,
                 proof_type: ProofType::Tee,
                 tee_kinds: tee_kinds.clone(),
                 zk_vms: Vec::new(),
                 lock_duration_seconds,
-            },
-            Self::Zk { proof_type, zk_vms } => GetNextProofRequest {
-                worker_id,
-                proof_type: (*proof_type).into(),
-                tee_kinds: Vec::new(),
-                zk_vms: zk_vms.clone(),
-                lock_duration_seconds,
-            },
+            }],
+            Self::Zk { zk_vms } => {
+                let proof_types = ZK_PROOF_TYPES;
+                let (last_proof_type, proof_types) =
+                    proof_types.split_last().expect("ZK proof types should not be empty");
+                let mut requests = Vec::with_capacity(ZK_PROOF_TYPES.len());
+
+                for proof_type in proof_types {
+                    requests.push(GetNextProofRequest {
+                        worker_id: worker_id.clone(),
+                        proof_type: *proof_type,
+                        tee_kinds: Vec::new(),
+                        zk_vms: zk_vms.clone(),
+                        lock_duration_seconds,
+                    });
+                }
+
+                requests.push(GetNextProofRequest {
+                    worker_id,
+                    proof_type: *last_proof_type,
+                    tee_kinds: Vec::new(),
+                    zk_vms: zk_vms.clone(),
+                    lock_duration_seconds,
+                });
+
+                requests
+            }
         }
     }
 }
@@ -138,12 +137,8 @@ impl JobDiscoveryConfig {
     }
 
     /// Creates a ZK job discovery config using default timings.
-    pub fn zk(
-        worker_id: impl Into<String>,
-        proof_type: ZkProofClaimType,
-        zk_vms: impl Into<Vec<ZkVm>>,
-    ) -> Self {
-        Self::new(worker_id, JobClaimFilter::zk(proof_type, zk_vms))
+    pub fn zk(worker_id: impl Into<String>, zk_vms: impl Into<Vec<ZkVm>>) -> Self {
+        Self::new(worker_id, JobClaimFilter::zk(zk_vms))
     }
 
     /// Creates a job discovery config using default timings.
@@ -200,9 +195,10 @@ impl JobDiscoveryConfig {
         if self.max_concurrent_jobs == 0 { 1 } else { self.max_concurrent_jobs }
     }
 
-    /// Builds the worker claim request for this host.
-    pub fn get_next_proof_request(&self) -> GetNextProofRequest {
-        self.claim_filter.get_next_proof_request(self.worker_id.clone(), self.lock_duration_seconds)
+    /// Builds the worker claim requests for this host.
+    pub fn get_next_proof_requests(&self) -> Vec<GetNextProofRequest> {
+        self.claim_filter
+            .get_next_proof_requests(self.worker_id.clone(), self.lock_duration_seconds)
     }
 }
 
@@ -264,7 +260,7 @@ where
 
         info!(
             worker_id = %self.config.worker_id,
-            proof_type = ?self.config.claim_filter.proof_type(),
+            proof_types = ?self.config.claim_filter.proof_types(),
             poll_interval_ms = self.config.normalized_poll_interval().as_millis(),
             lock_duration_seconds = self.config.lock_duration_seconds,
             worker_kind = self.config.claim_filter.log_label(),
@@ -344,21 +340,49 @@ where
             return Ok(JobDiscoveryPollOutcome::Empty);
         }
 
-        let request = self.config.get_next_proof_request();
-        let response = self.client.get_next_proof(request).await?;
+        let mut last_error = None;
+        let mut claim_attempt_succeeded = false;
 
-        let Some(job) = response.job else {
-            drop(permit);
-            debug!(
-                worker_id = %self.config.worker_id,
-                worker_kind = self.config.claim_filter.log_label(),
-                "no proof job available"
-            );
-            return Ok(JobDiscoveryPollOutcome::Empty);
-        };
+        for request in self.config.get_next_proof_requests() {
+            let proof_type = request.proof_type;
+            let response = match self.client.get_next_proof(request).await {
+                Ok(response) => {
+                    claim_attempt_succeeded = true;
+                    response
+                }
+                Err(error) => {
+                    warn!(
+                        worker_id = %self.config.worker_id,
+                        worker_kind = self.config.claim_filter.log_label(),
+                        proof_type = ?proof_type,
+                        retryable = error.is_retryable(),
+                        error = %error,
+                        "job discovery claim failed for proof type"
+                    );
+                    last_error = Some(error);
+                    continue;
+                }
+            };
 
-        let task = self.proof_generator_task(job, permit);
-        Ok(JobDiscoveryPollOutcome::Claimed { task })
+            if let Some(job) = response.job {
+                let task = self.proof_generator_task(job, permit);
+                return Ok(JobDiscoveryPollOutcome::Claimed { task });
+            }
+        }
+
+        drop(permit);
+        if !claim_attempt_succeeded {
+            if let Some(error) = last_error {
+                return Err(error);
+            }
+        }
+
+        debug!(
+            worker_id = %self.config.worker_id,
+            worker_kind = self.config.claim_filter.log_label(),
+            "no proof job available"
+        );
+        Ok(JobDiscoveryPollOutcome::Empty)
     }
 
     /// Builds a proof generator task for a claimed prover-service job.
@@ -420,8 +444,8 @@ mod tests {
     use base_prover_service_protocol::{
         GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
         HeartbeatResponse, ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind,
-        RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
-        WorkerSubmitProofResponse, ZkProofRequest,
+        RecordProofSessionRequest, RecordProofSessionResponse, SnarkGroth16ProofRequest,
+        WorkerSubmitProofRequest, WorkerSubmitProofResponse, ZkProofRequest,
     };
     use chrono::Utc;
     use tokio::time::timeout;
@@ -437,14 +461,20 @@ mod tests {
     struct MockWorkerState {
         get_next_requests: Vec<GetNextProofRequest>,
         next_job: Option<ProofJob>,
+        failed_claims: Vec<ProofType>,
     }
 
     impl MockWorkerClient {
         fn new(next_job: Option<ProofJob>) -> Self {
+            Self::with_failed_claims(next_job, Vec::new())
+        }
+
+        fn with_failed_claims(next_job: Option<ProofJob>, failed_claims: Vec<ProofType>) -> Self {
             Self {
                 state: Arc::new(Mutex::new(MockWorkerState {
                     get_next_requests: Vec::new(),
                     next_job,
+                    failed_claims,
                 })),
             }
         }
@@ -464,11 +494,21 @@ mod tests {
             &self,
             request: GetNextProofRequest,
         ) -> Result<GetNextProofResponse, ProverServiceClientError> {
+            let proof_type = request.proof_type;
             let mut state =
                 self.state.lock().expect("mock worker state lock should not be poisoned");
             state.get_next_requests.push(request);
 
-            Ok(GetNextProofResponse { job: state.next_job.take() })
+            if state.failed_claims.contains(&proof_type) {
+                return Err(ProverServiceClientError::Timeout(format!(
+                    "simulated {proof_type:?} claim failure"
+                )));
+            }
+
+            let job = state.next_job.as_ref().is_some_and(|job| job_proof_type(job) == proof_type);
+            let job = if job { state.next_job.take() } else { None };
+
+            Ok(GetNextProofResponse { job })
         }
 
         async fn heartbeat(
@@ -524,23 +564,35 @@ mod tests {
     }
 
     fn compressed_job() -> ProofJob {
+        proof_job(ProofRequestKind::Compressed(zk_request()))
+    }
+
+    fn snark_job() -> ProofJob {
+        proof_job(ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+            proof: zk_request(),
+            prover_address: Default::default(),
+        }))
+    }
+
+    fn zk_request() -> ZkProofRequest {
+        ZkProofRequest {
+            start_block_number: 1,
+            number_of_blocks_to_prove: 1,
+            sequence_window: None,
+            l1_head: None,
+            intermediate_root_interval: None,
+            zk_vm: ZkVm::Sp1,
+        }
+    }
+
+    fn proof_job(request: ProofRequestKind) -> ProofJob {
         let session_id = "session-1".to_string();
         let now = Utc::now();
 
         ProofJob {
             session_id: session_id.clone(),
             status: ProofJobStatus::Claimed,
-            request: ProofRequest {
-                session_id,
-                request: ProofRequestKind::Compressed(ZkProofRequest {
-                    start_block_number: 1,
-                    number_of_blocks_to_prove: 1,
-                    sequence_window: None,
-                    l1_head: None,
-                    intermediate_root_interval: None,
-                    zk_vm: ZkVm::Sp1,
-                }),
-            },
+            request: ProofRequest { session_id, request },
             attempt: 1,
             lock_id: Some("lock-1".to_string()),
             worker_id: Some("worker-1".to_string()),
@@ -552,20 +604,33 @@ mod tests {
         }
     }
 
+    fn job_proof_type(job: &ProofJob) -> ProofType {
+        match job.request.request {
+            ProofRequestKind::Compressed(_) => ProofType::Compressed,
+            ProofRequestKind::SnarkGroth16(_) => ProofType::SnarkGroth16,
+            ProofRequestKind::Tee(_) => ProofType::Tee,
+        }
+    }
+
     #[test]
-    fn config_builds_zk_claim_request() {
-        let config =
-            JobDiscoveryConfig::zk("worker-a", ZkProofClaimType::Compressed, vec![ZkVm::Sp1])
-                .with_lock_duration_seconds(30)
-                .with_max_concurrent_jobs(0);
+    fn config_builds_zk_claim_requests() {
+        let config = JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1])
+            .with_lock_duration_seconds(30)
+            .with_max_concurrent_jobs(0);
 
-        let request = config.get_next_proof_request();
+        let requests = config.get_next_proof_requests();
 
-        assert_eq!(request.worker_id, "worker-a");
-        assert_eq!(request.proof_type, ProofType::Compressed);
-        assert!(request.tee_kinds.is_empty());
-        assert_eq!(request.zk_vms, vec![ZkVm::Sp1]);
-        assert_eq!(request.lock_duration_seconds, 30);
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].worker_id, "worker-a");
+        assert_eq!(requests[0].proof_type, ProofType::Compressed);
+        assert!(requests[0].tee_kinds.is_empty());
+        assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
+        assert_eq!(requests[0].lock_duration_seconds, 30);
+        assert_eq!(requests[1].worker_id, "worker-a");
+        assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
+        assert!(requests[1].tee_kinds.is_empty());
+        assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
+        assert_eq!(requests[1].lock_duration_seconds, 30);
         assert_eq!(config.normalized_max_concurrent_jobs(), 1);
     }
 
@@ -574,7 +639,9 @@ mod tests {
         let config = JobDiscoveryConfig::tee("worker-a", vec![TeeKind::AwsNitro])
             .with_lock_duration_seconds(45);
 
-        let request = config.get_next_proof_request();
+        let requests = config.get_next_proof_requests();
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
 
         assert_eq!(request.worker_id, "worker-a");
         assert_eq!(request.proof_type, ProofType::Tee);
@@ -590,13 +657,16 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", ZkProofClaimType::Compressed, vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
 
         assert!(matches!(outcome, JobDiscoveryPollOutcome::Empty));
-        assert_eq!(client.get_next_requests().len(), 1);
+        let requests = client.get_next_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].proof_type, ProofType::Compressed);
+        assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
     }
 
     #[tokio::test]
@@ -605,7 +675,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator::default()),
-            JobDiscoveryConfig::zk("worker-a", ZkProofClaimType::Compressed, vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -620,7 +690,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator { can_claim: true, ..Default::default() }),
-            JobDiscoveryConfig::zk("worker-a", ZkProofClaimType::Compressed, vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
         );
         discovery.generator_permits.close();
 
@@ -638,7 +708,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client,
             generator,
-            JobDiscoveryConfig::zk("worker-a", ZkProofClaimType::Compressed, vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -647,6 +717,34 @@ mod tests {
             panic!("expected proof generator task to be returned");
         };
         timeout(Duration::from_secs(1), task).await.expect("proof generator task should finish");
+        assert_eq!(
+            *generated.lock().expect("generated jobs lock should not be poisoned"),
+            vec!["session-1".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_once_checks_snark_after_compressed_claim_error() {
+        let client =
+            MockWorkerClient::with_failed_claims(Some(snark_job()), vec![ProofType::Compressed]);
+        let generator = Arc::new(MockGenerator { can_claim: true, ..Default::default() });
+        let generated = Arc::clone(&generator.generated);
+        let discovery = JobDiscovery::new(
+            client.clone(),
+            generator,
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+        );
+
+        let outcome = discovery.claim_once().await.expect("claim should succeed");
+
+        let JobDiscoveryPollOutcome::Claimed { task } = outcome else {
+            panic!("expected proof generator task to be returned");
+        };
+        timeout(Duration::from_secs(1), task).await.expect("proof generator task should finish");
+        let requests = client.get_next_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].proof_type, ProofType::Compressed);
+        assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
         assert_eq!(
             *generated.lock().expect("generated jobs lock should not be poisoned"),
             vec!["session-1".to_string()]

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -61,10 +61,10 @@ impl JobClaimFilter {
     }
 
     /// Returns the prover-service proof types for this claim filter.
-    pub fn proof_types(&self) -> Vec<ProofType> {
+    pub const fn proof_types(&self) -> &'static [ProofType] {
         match self {
-            Self::Tee { .. } => vec![ProofType::Tee],
-            Self::Zk { .. } => ZK_PROOF_TYPES.to_vec(),
+            Self::Tee { .. } => &[ProofType::Tee],
+            Self::Zk { .. } => &ZK_PROOF_TYPES,
         }
     }
 
@@ -81,42 +81,42 @@ impl JobClaimFilter {
         &self,
         worker_id: String,
         lock_duration_seconds: u32,
-    ) -> Vec<GetNextProofRequest> {
-        match self {
-            Self::Tee { tee_kinds } => vec![GetNextProofRequest {
-                worker_id,
-                proof_type: ProofType::Tee,
-                tee_kinds: tee_kinds.clone(),
-                zk_vms: Vec::new(),
-                lock_duration_seconds,
-            }],
+    ) -> impl Iterator<Item = GetNextProofRequest> {
+        let requests = match self {
+            Self::Tee { tee_kinds } => [
+                Some(GetNextProofRequest {
+                    worker_id,
+                    proof_type: ProofType::Tee,
+                    tee_kinds: tee_kinds.clone(),
+                    zk_vms: Vec::new(),
+                    lock_duration_seconds,
+                }),
+                None,
+            ],
             Self::Zk { zk_vms } => {
-                let proof_types = ZK_PROOF_TYPES;
-                let (last_proof_type, proof_types) =
-                    proof_types.split_last().expect("ZK proof types should not be empty");
-                let mut requests = Vec::with_capacity(ZK_PROOF_TYPES.len());
+                let zk_vms = zk_vms.clone();
+                let [compressed_proof_type, snark_proof_type] = ZK_PROOF_TYPES;
 
-                for proof_type in proof_types {
-                    requests.push(GetNextProofRequest {
+                [
+                    Some(GetNextProofRequest {
                         worker_id: worker_id.clone(),
-                        proof_type: *proof_type,
+                        proof_type: compressed_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
                         lock_duration_seconds,
-                    });
-                }
-
-                requests.push(GetNextProofRequest {
-                    worker_id,
-                    proof_type: *last_proof_type,
-                    tee_kinds: Vec::new(),
-                    zk_vms: zk_vms.clone(),
-                    lock_duration_seconds,
-                });
-
-                requests
+                    }),
+                    Some(GetNextProofRequest {
+                        worker_id,
+                        proof_type: snark_proof_type,
+                        tee_kinds: Vec::new(),
+                        zk_vms,
+                        lock_duration_seconds,
+                    }),
+                ]
             }
-        }
+        };
+
+        requests.into_iter().flatten()
     }
 }
 
@@ -196,7 +196,7 @@ impl JobDiscoveryConfig {
     }
 
     /// Builds the worker claim requests for this host.
-    pub fn get_next_proof_requests(&self) -> Vec<GetNextProofRequest> {
+    pub fn get_next_proof_requests(&self) -> impl Iterator<Item = GetNextProofRequest> {
         self.claim_filter
             .get_next_proof_requests(self.worker_id.clone(), self.lock_duration_seconds)
     }
@@ -341,15 +341,10 @@ where
         }
 
         let mut last_error = None;
-        let mut claim_attempt_succeeded = false;
-
         for request in self.config.get_next_proof_requests() {
             let proof_type = request.proof_type;
             let response = match self.client.get_next_proof(request).await {
-                Ok(response) => {
-                    claim_attempt_succeeded = true;
-                    response
-                }
+                Ok(response) => response,
                 Err(error) => {
                     warn!(
                         worker_id = %self.config.worker_id,
@@ -371,10 +366,8 @@ where
         }
 
         drop(permit);
-        if !claim_attempt_succeeded {
-            if let Some(error) = last_error {
-                return Err(error);
-            }
+        if let Some(error) = last_error {
+            return Err(error);
         }
 
         debug!(
@@ -618,7 +611,7 @@ mod tests {
             .with_lock_duration_seconds(30)
             .with_max_concurrent_jobs(0);
 
-        let requests = config.get_next_proof_requests();
+        let requests = config.get_next_proof_requests().collect::<Vec<_>>();
 
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].worker_id, "worker-a");
@@ -639,7 +632,7 @@ mod tests {
         let config = JobDiscoveryConfig::tee("worker-a", vec![TeeKind::AwsNitro])
             .with_lock_duration_seconds(45);
 
-        let requests = config.get_next_proof_requests();
+        let requests = config.get_next_proof_requests().collect::<Vec<_>>();
         assert_eq!(requests.len(), 1);
         let request = &requests[0];
 
@@ -749,5 +742,25 @@ mod tests {
             *generated.lock().expect("generated jobs lock should not be poisoned"),
             vec!["session-1".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn claim_once_returns_error_when_any_claim_fails_without_job() {
+        let client = MockWorkerClient::with_failed_claims(None, vec![ProofType::SnarkGroth16]);
+        let generator = Arc::new(MockGenerator { can_claim: true, ..Default::default() });
+        let discovery = JobDiscovery::new(
+            client.clone(),
+            generator,
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+        );
+
+        let error =
+            discovery.claim_once().await.expect_err("claim should surface the failed proof type");
+
+        assert!(error.to_string().contains("simulated SnarkGroth16 claim failure"));
+        let requests = client.get_next_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].proof_type, ProofType::Compressed);
+        assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
     }
 }

--- a/crates/proof/worker/src/lib.rs
+++ b/crates/proof/worker/src/lib.rs
@@ -16,7 +16,7 @@ mod job_discovery;
 pub use job_discovery::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
     DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobClaimFilter, JobDiscovery, JobDiscoveryConfig,
-    JobDiscoveryPollOutcome, JobDiscoveryTask, MIN_JOB_DISCOVERY_POLL_INTERVAL, ZkProofClaimType,
+    JobDiscoveryPollOutcome, JobDiscoveryTask, MIN_JOB_DISCOVERY_POLL_INTERVAL, ZK_PROOF_TYPES,
 };
 
 mod proof_submitter;

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -9,13 +9,12 @@ use base_proof_worker::{
 use base_prover_service_client::ProverWorkerProvider;
 use tokio_util::sync::CancellationToken;
 
-use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkProofClaimType, ZkProver, ZkVm};
+use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkProver, ZkVm};
 
 /// Settings for running a ZK host against the prover service.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ZkHostConfig {
     worker_id: String,
-    proof_type: ZkProofClaimType,
     zk_vms: Vec<ZkVm>,
     job_discovery_poll_interval: Duration,
     job_discovery_lock_duration_seconds: u32,
@@ -25,14 +24,9 @@ pub struct ZkHostConfig {
 
 impl ZkHostConfig {
     /// Creates a ZK host config with default timing settings.
-    pub fn new(
-        worker_id: impl Into<String>,
-        proof_type: ZkProofClaimType,
-        zk_vms: impl Into<Vec<ZkVm>>,
-    ) -> Self {
+    pub fn new(worker_id: impl Into<String>, zk_vms: impl Into<Vec<ZkVm>>) -> Self {
         Self {
             worker_id: worker_id.into(),
-            proof_type,
             zk_vms: zk_vms.into(),
             job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
@@ -42,18 +36,13 @@ impl ZkHostConfig {
     }
 
     /// Creates an SP1 ZK host config with default timing settings.
-    pub fn sp1(worker_id: impl Into<String>, proof_type: ZkProofClaimType) -> Self {
-        Self::new(worker_id, proof_type, vec![ZkVm::Sp1])
+    pub fn sp1(worker_id: impl Into<String>) -> Self {
+        Self::new(worker_id, vec![ZkVm::Sp1])
     }
 
     /// Returns the worker identifier used for prover-service claims.
     pub fn worker_id(&self) -> &str {
         &self.worker_id
-    }
-
-    /// Returns the proof type claimed by the worker.
-    pub const fn proof_type(&self) -> ZkProofClaimType {
-        self.proof_type
     }
 
     /// Returns the ZK VMs claimed by the worker.
@@ -123,7 +112,7 @@ impl ZkHostConfig {
 
     /// Builds the shared worker discovery config.
     pub fn job_discovery_config(&self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id.clone(), self.proof_type, self.zk_vms.clone())
+        JobDiscoveryConfig::zk(self.worker_id.clone(), self.zk_vms.clone())
             .with_poll_interval(self.job_discovery_poll_interval)
             .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
             .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
@@ -131,7 +120,7 @@ impl ZkHostConfig {
 
     /// Converts this config into the shared worker discovery config.
     pub fn into_job_discovery_config(self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id, self.proof_type, self.zk_vms)
+        JobDiscoveryConfig::zk(self.worker_id, self.zk_vms)
             .with_poll_interval(self.job_discovery_poll_interval)
             .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
             .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)

--- a/crates/proof/zk/host/src/lib.rs
+++ b/crates/proof/zk/host/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-pub use base_proof_worker::ZkProofClaimType;
 pub use base_prover_service_protocol::ZkVm;
 
 mod prover;


### PR DESCRIPTION
## Summary
- remove the zk-host proof-type mode and PROOF_TYPE CLI/env selection
- make shared ZK worker discovery claim both compressed and SNARK Groth16 jobs for the configured ZK VM
- keep the claimed request variants intact so generation still handles the actual compressed/SNARK request shape

