### PR TITLE
refactor(proposer): clean up proof recovery

### DIFF
--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -311,7 +311,7 @@ mod tests {
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
             },
-            rollup.clone(),
+            Arc::<MockRollupClient>::clone(&rollup),
             anchor_registry,
             factory,
         ));

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -311,7 +311,7 @@ mod tests {
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
             },
-            Arc::clone(&rollup),
+            rollup.clone(),
             anchor_registry,
             factory,
         ));

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -310,7 +310,7 @@ mod tests {
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
             },
-            rollup.clone(),
+            Arc::<MockRollupClient>::clone(&rollup),
             anchor_registry,
             factory,
         ));

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -33,7 +33,7 @@ where
 {
     config: DriverConfig,
     proof_dispatcher: ProofDispatcher,
-    proof_recovery: Arc<ProofRecovery<R>>,
+    proof_recovery: Arc<ProofRecovery>,
     proof_collector: ProofCollector<L1, R>,
 }
 
@@ -56,7 +56,7 @@ where
     pub const fn new(
         config: DriverConfig,
         proof_dispatcher: ProofDispatcher,
-        proof_recovery: Arc<ProofRecovery<R>>,
+        proof_recovery: Arc<ProofRecovery>,
         proof_collector: ProofCollector<L1, R>,
     ) -> Self {
         Self { config, proof_dispatcher, proof_recovery, proof_collector }
@@ -310,7 +310,7 @@ mod tests {
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
             },
-            Arc::clone(&rollup),
+            rollup.clone(),
             anchor_registry,
             factory,
         ));

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -88,8 +88,16 @@ impl ProofRecovery {
         };
 
         if let Some(cached) = cache.as_ref() {
-            let next_proposal_block =
-                ProofTarget::next_block(cached.state.l2_block_number, self.config.block_interval)?;
+            let Some(next_proposal_block) =
+                ProofTarget::next_block(cached.state.l2_block_number, self.config.block_interval)
+            else {
+                warn!(
+                    cached_block = cached.state.l2_block_number,
+                    block_interval = self.config.block_interval,
+                    "Cannot compute next proposal block, skipping recovery"
+                );
+                return None;
+            };
 
             if safe_head < next_proposal_block {
                 debug!(

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -1,16 +1,19 @@
 //! Recovers proposer onchain state from submitted dispute games.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use base_proof_contracts::{
     AnchorStateRegistryClient, DisputeGameFactoryClient, encode_extra_data,
 };
 use base_proof_rpc::{RollupProvider, RpcError};
-use futures::{StreamExt, stream};
+use futures::{StreamExt, TryStreamExt, stream};
 use tracing::{debug, info, warn};
 
-use crate::{driver::RecoveredState, error::ProposerError, proposal_intervals::ProposalIntervals};
+use crate::{
+    driver::RecoveredState, error::ProposerError, proof_target::ProofTarget,
+    proposal_intervals::ProposalIntervals,
+};
 
 /// Runtime settings for proposer recovery.
 #[derive(Debug, Clone, Copy)]
@@ -39,33 +42,24 @@ pub struct ProofRecoveryCache {
 }
 
 /// Recovers the latest submitted proposer state from L1 and rollup RPCs.
-pub struct ProofRecovery<R>
-where
-    R: RollupProvider,
-{
+pub struct ProofRecovery {
     config: ProofRecoveryConfig,
-    rollup_client: Arc<R>,
+    rollup_client: Arc<dyn RollupProvider>,
     anchor_registry: Arc<dyn AnchorStateRegistryClient>,
     factory_client: Arc<dyn DisputeGameFactoryClient>,
 }
 
-impl<R> std::fmt::Debug for ProofRecovery<R>
-where
-    R: RollupProvider,
-{
+impl std::fmt::Debug for ProofRecovery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofRecovery").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
-impl<R> ProofRecovery<R>
-where
-    R: RollupProvider,
-{
+impl ProofRecovery {
     /// Creates a proposer recovery helper.
     pub fn new(
         config: ProofRecoveryConfig,
-        rollup_client: Arc<R>,
+        rollup_client: Arc<dyn RollupProvider>,
         anchor_registry: Arc<dyn AnchorStateRegistryClient>,
         factory_client: Arc<dyn DisputeGameFactoryClient>,
     ) -> Self {
@@ -80,27 +74,22 @@ where
         &self,
         cache: &mut Option<ProofRecoveryCache>,
     ) -> Option<(RecoveredState, u64)> {
-        if let Some(cached) = cache.as_ref() {
-            let safe_head = match self.latest_safe_block_number().await {
-                Ok(n) => n,
-                Err(e) => {
-                    warn!(error = %e, "Failed to fetch safe head, retrying next tick");
-                    return None;
-                }
-            };
+        let sync_status = match self.rollup_client.sync_status().await {
+            Ok(status) => status,
+            Err(e) => {
+                warn!(error = %e, "Failed to fetch safe head, retrying next tick");
+                return None;
+            }
+        };
+        let safe_head = if self.config.allow_non_finalized {
+            sync_status.safe_l2.number
+        } else {
+            sync_status.finalized_l2.number
+        };
 
+        if let Some(cached) = cache.as_ref() {
             let next_proposal_block =
-                match cached.state.l2_block_number.checked_add(self.config.block_interval) {
-                    Some(block) => block,
-                    None => {
-                        warn!(
-                            cached_block = cached.state.l2_block_number,
-                            block_interval = self.config.block_interval,
-                            "Cannot compute next proposal block, retrying next tick"
-                        );
-                        return None;
-                    }
-                };
+                ProofTarget::next_block(cached.state.l2_block_number, self.config.block_interval)?;
 
             if safe_head < next_proposal_block {
                 debug!(
@@ -111,33 +100,12 @@ where
                 );
                 return Some((cached.state, safe_head));
             }
-
-            let state = match self.recover_latest_state(cache).await {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!(error = %e, "Failed to recover onchain state, retrying next tick");
-                    return None;
-                }
-            };
-
-            return Some((state, safe_head));
         }
 
-        let (state_result, safe_head_result) =
-            tokio::join!(self.recover_latest_state(cache), self.latest_safe_block_number(),);
-
-        let state = match state_result {
+        let state = match self.recover_latest_state(cache).await {
             Ok(s) => s,
             Err(e) => {
                 warn!(error = %e, "Failed to recover onchain state, retrying next tick");
-                return None;
-            }
-        };
-
-        let safe_head = match safe_head_result {
-            Ok(n) => n,
-            Err(e) => {
-                warn!(error = %e, "Failed to fetch safe head, retrying next tick");
                 return None;
             }
         };
@@ -147,20 +115,10 @@ where
 
     /// Recovers the latest onchain state using a deterministic forward walk
     /// from the anchor root.
-    ///
-    /// # Strategy
-    ///
-    /// 1. Read `game_count` from the factory and anchor root from the registry
-    ///    once the safe head is high enough to need recovery.
-    /// 2. Cache check. If both `game_count` and `anchor_root` match the cache,
-    ///    return the cached state immediately.
-    /// 3. Forward walk. Walk from the anchor block, stepping by
-    ///    `block_interval`, and use UUID-based `games()` lookups to find the
-    ///    latest submitted game.
     pub async fn recover_latest_state(
         &self,
         cache: &mut Option<ProofRecoveryCache>,
-    ) -> std::result::Result<RecoveredState, ProposerError> {
+    ) -> Result<RecoveredState, ProposerError> {
         let count = self
             .factory_client
             .game_count()
@@ -175,23 +133,18 @@ where
             .await
             .map_err(|e| ProposerError::Contract(format!("anchor_snapshot failed: {e}")))?;
         let anchor = anchor_snapshot.anchor_root;
+        let usable_cache =
+            cache.as_ref().filter(|cached| anchor.l2_block_number <= cached.state.l2_block_number);
 
-        // The cached tip is valid as long as the anchor hasn't advanced past
-        // it. The anchor advances when games resolve, but it always stays
-        // behind the chain tip.
-        let tip_still_valid =
-            |cached: &ProofRecoveryCache| anchor.l2_block_number <= cached.state.l2_block_number;
-
-        if let Some(cached) = cache.as_ref()
-            && tip_still_valid(cached)
+        if let Some(cached) = usable_cache
             && cached.game_count == count
         {
             debug!(game_count = count, "No changes since last recovery, returning cached state");
             return Ok(cached.state);
         }
 
-        let start = match cache.as_ref() {
-            Some(cached) if tip_still_valid(cached) && count > cached.game_count => {
+        let start = match usable_cache {
+            Some(cached) if count > cached.game_count => {
                 debug!(
                     cached_block = cached.state.l2_block_number,
                     old_count = cached.game_count,
@@ -223,163 +176,96 @@ where
 
     /// Performs a deterministic forward walk to find the latest verified game
     /// using UUID-based `games()` lookups.
-    async fn forward_walk(
-        &self,
-        start: &RecoveredState,
-    ) -> std::result::Result<RecoveredState, ProposerError> {
-        let block_interval = self.config.block_interval;
-        let game_type = self.config.game_type;
+    async fn forward_walk(&self, start: &RecoveredState) -> Result<RecoveredState, ProposerError> {
+        let mut state = *start;
 
-        let log_interval = (block_interval / 5).max(1);
-
-        let mut parent_address = start.parent_address;
-        let mut parent_output_root = start.output_root;
-        let mut parent_block = start.l2_block_number;
-        let mut steps: u64 = 0;
-
-        while let Some(expected_block) = parent_block.checked_add(block_interval) {
+        while let Some(expected_block) =
+            ProofTarget::next_block(state.l2_block_number, self.config.block_interval)
+        {
             // Fetch all intermediate roots, including the canonical root for
             // `expected_block`, from the rollup node in one batch.
             let intermediate_blocks = ProposalIntervals::intermediate_block_numbers(
                 self.config.block_interval,
                 self.config.intermediate_block_interval,
-                parent_block,
+                state.l2_block_number,
             )?;
-            let intermediate_roots =
-                match self.fetch_canonical_roots(intermediate_blocks.clone()).await {
-                    Ok(roots) => roots,
-                    Err(ProposerError::Rpc(RpcError::BlockNotFound(_))) => {
-                        debug!(
-                            block = expected_block,
-                            "Block not available yet, treating as end of walk"
-                        );
-                        break;
-                    }
-                    Err(e) => {
-                        warn!(
-                            expected_block,
-                            parent_block,
-                            error = %e,
-                            "Forward walk failed to fetch canonical roots"
-                        );
-                        return Err(e);
-                    }
-                };
+            let rollup = &self.rollup_client;
+            let intermediate_roots = match stream::iter(intermediate_blocks.iter().copied())
+                .map(|block_number| async move {
+                    rollup
+                        .output_at_block(block_number)
+                        .await
+                        .map(|out| out.output_root)
+                        .map_err(ProposerError::Rpc)
+                })
+                .buffered(self.config.scan_concurrency)
+                .try_collect::<Vec<_>>()
+                .await
+            {
+                Ok(roots) => roots,
+                Err(ProposerError::Rpc(RpcError::BlockNotFound(_))) => {
+                    debug!(
+                        block = expected_block,
+                        "Block not available yet, treating as end of walk"
+                    );
+                    break;
+                }
+                Err(e) => {
+                    warn!(
+                        expected_block,
+                        parent_block = state.l2_block_number,
+                        error = %e,
+                        "Forward walk failed to fetch canonical roots"
+                    );
+                    return Err(e);
+                }
+            };
 
-            let canonical_root = *intermediate_roots.get(&expected_block).ok_or_else(|| {
+            let canonical_root = *intermediate_roots.last().ok_or_else(|| {
                 ProposerError::Internal(format!(
                     "missing canonical root for expected block {expected_block}"
                 ))
             })?;
 
-            let intermediate_root_vec: Vec<B256> = intermediate_blocks
-                .iter()
-                .map(|ib| {
-                    intermediate_roots.get(ib).copied().ok_or_else(|| {
-                        ProposerError::Internal(format!(
-                            "missing canonical root for intermediate block {ib}"
-                        ))
-                    })
-                })
-                .collect::<std::result::Result<Vec<_>, _>>()?;
-
             let extra_data =
-                encode_extra_data(expected_block, parent_address, &intermediate_root_vec);
+                encode_extra_data(expected_block, state.parent_address, &intermediate_roots);
 
-            let lookup =
-                self.factory_client.games(game_type, canonical_root, extra_data).await.map_err(
-                    |e| {
-                        ProposerError::Contract(format!(
-                            "games lookup failed at block {expected_block}: {e}"
-                        ))
-                    },
-                )?;
+            let lookup = self
+                .factory_client
+                .games(self.config.game_type, canonical_root, extra_data)
+                .await
+                .map_err(|e| {
+                    ProposerError::Contract(format!(
+                        "games lookup failed at block {expected_block}: {e}"
+                    ))
+                })?;
 
             if lookup == Address::ZERO {
                 info!(
                     gap_block = expected_block,
-                    parent_block,
-                    parent_address = %parent_address,
-                    games_verified = steps,
+                    parent_block = state.l2_block_number,
+                    parent_address = %state.parent_address,
                     "No game found at expected block, will propose from here"
                 );
                 break;
             }
 
-            parent_address = lookup;
-            parent_output_root = canonical_root;
-            parent_block = expected_block;
-            steps += 1;
-
-            if steps.is_multiple_of(log_interval) {
-                info!(
-                    games_verified = steps,
-                    latest_block = parent_block,
-                    "Recovery forward walk in progress"
-                );
-            }
+            state = RecoveredState {
+                parent_address: lookup,
+                output_root: canonical_root,
+                l2_block_number: expected_block,
+            };
         }
 
-        if steps > 0 {
+        if state.l2_block_number != start.l2_block_number {
             info!(
-                latest_block = parent_block,
-                parent_address = %parent_address,
-                games_verified = steps,
+                latest_block = state.l2_block_number,
+                parent_address = %state.parent_address,
                 "Recovery forward walk complete"
             );
         }
 
-        Ok(RecoveredState {
-            parent_address,
-            output_root: parent_output_root,
-            l2_block_number: parent_block,
-        })
-    }
-
-    /// Returns the latest safe L2 block number used for recovery planning.
-    async fn latest_safe_block_number(&self) -> std::result::Result<u64, ProposerError> {
-        let sync_status = self.rollup_client.sync_status().await?;
-        if self.config.allow_non_finalized {
-            Ok(sync_status.safe_l2.number)
-        } else {
-            Ok(sync_status.finalized_l2.number)
-        }
-    }
-
-    /// Concurrently fetches canonical output roots for the given block numbers.
-    async fn fetch_canonical_roots(
-        &self,
-        blocks: Vec<u64>,
-    ) -> std::result::Result<HashMap<u64, B256>, ProposerError> {
-        self.fetch_canonical_root_results(blocks)
-            .await
-            .into_iter()
-            .map(|(block_number, result)| result.map(|root| (block_number, root)))
-            .collect()
-    }
-
-    async fn fetch_canonical_root_results(
-        &self,
-        blocks: Vec<u64>,
-    ) -> HashMap<u64, std::result::Result<B256, ProposerError>> {
-        if blocks.is_empty() {
-            return HashMap::new();
-        }
-        stream::iter(blocks)
-            .map(|block_number| {
-                let rollup = &self.rollup_client;
-                async move {
-                    let result = rollup
-                        .output_at_block(block_number)
-                        .await
-                        .map(|out| out.output_root)
-                        .map_err(ProposerError::Rpc);
-                    (block_number, result)
-                }
-            })
-            .buffered(self.config.scan_concurrency)
-            .collect()
-            .await
+        Ok(state)
     }
 }
 
@@ -388,11 +274,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use alloy_primitives::{Address, B256};
-    use async_trait::async_trait;
-    use base_proof_contracts::{
-        AnchorSnapshot, AnchorStateRegistryClient, ContractError, encode_extra_data,
-    };
-    use rstest::rstest;
+    use base_proof_contracts::{AnchorRoot, encode_extra_data};
 
     use super::*;
     use crate::test_utils::{
@@ -404,24 +286,8 @@ mod tests {
     const TEST_BLOCK_INTERVAL: u64 = 512;
     const TEST_ANCHOR_BLOCK: u64 = 0;
 
-    type TestRecovery = ProofRecovery<MockRollupClient>;
-
-    #[derive(Debug)]
-    struct SnapshotOnlyAnchorStateRegistry {
-        snapshot: AnchorSnapshot,
-    }
-
-    #[async_trait]
-    impl AnchorStateRegistryClient for SnapshotOnlyAnchorStateRegistry {
-        async fn anchor_snapshot(&self) -> std::result::Result<AnchorSnapshot, ContractError> {
-            Ok(self.snapshot)
-        }
-    }
-
     fn proxy_addr(index: u64) -> Address {
-        let mut bytes = [0u8; 20];
-        bytes[12..20].copy_from_slice(&(index + 1).to_be_bytes());
-        Address::new(bytes)
+        Address::with_last_byte((index + 1) as u8)
     }
 
     fn game_chain(n: usize) -> (MockDisputeGameFactory, HashMap<u64, B256>) {
@@ -436,26 +302,24 @@ mod tests {
     ) -> (MockDisputeGameFactory, HashMap<u64, B256>) {
         let mut uuid_games = HashMap::new();
         let mut output_roots = HashMap::new();
-        let intermediate_count = block_interval / intermediate_block_interval;
-
         let mut parent = Address::ZERO;
         for i in 0..n {
             let block = anchor_block + block_interval * (i as u64 + 1);
             let root_claim = B256::repeat_byte((i as u8) + 1);
             let parent_block = block - block_interval;
-            let mut intermediate_roots = Vec::with_capacity(intermediate_count as usize);
-            for j in 1..=intermediate_count {
-                let intermediate_block = parent_block + j * intermediate_block_interval;
-                let intermediate_root = if intermediate_block == block {
-                    root_claim
-                } else {
-                    B256::repeat_byte(intermediate_block as u8)
-                };
-                output_roots.insert(intermediate_block, intermediate_root);
-                intermediate_roots.push(intermediate_root);
-            }
+            let intermediate_roots = ProposalIntervals::intermediate_block_numbers(
+                block_interval,
+                intermediate_block_interval,
+                parent_block,
+            )
+            .unwrap()
+            .into_iter()
+            .map(|intermediate_block| match intermediate_block {
+                n if n == block => root_claim,
+                n => B256::repeat_byte(n as u8),
+            })
+            .collect::<Vec<_>>();
             output_roots.insert(block, root_claim);
-
             let extra_data = encode_extra_data(block, parent, &intermediate_roots);
             let proxy = proxy_addr(i as u64);
 
@@ -475,11 +339,14 @@ mod tests {
         (factory, output_roots)
     }
 
-    fn recovery(factory: MockDisputeGameFactory, output_roots: HashMap<u64, B256>) -> TestRecovery {
+    fn recovery(
+        factory: MockDisputeGameFactory,
+        output_roots: HashMap<u64, B256>,
+    ) -> ProofRecovery {
         recovery_full(
             factory,
             output_roots,
-            TEST_ANCHOR_BLOCK,
+            test_anchor_root(TEST_ANCHOR_BLOCK),
             Address::ZERO,
             TEST_BLOCK_INTERVAL,
             TEST_BLOCK_INTERVAL,
@@ -490,12 +357,12 @@ mod tests {
     fn recovery_full(
         factory: MockDisputeGameFactory,
         output_roots: HashMap<u64, B256>,
-        anchor_block: u64,
+        anchor_root: AnchorRoot,
         anchor_game: Address,
         block_interval: u64,
         intermediate_block_interval: u64,
         max_safe_block: Option<u64>,
-    ) -> TestRecovery {
+    ) -> ProofRecovery {
         ProofRecovery::new(
             ProofRecoveryConfig {
                 block_interval,
@@ -510,52 +377,44 @@ mod tests {
                 output_roots,
                 max_safe_block,
             }),
-            Arc::new(MockAnchorStateRegistry {
-                anchor_root: test_anchor_root(anchor_block),
-                anchor_game,
-            }),
+            Arc::new(MockAnchorStateRegistry { anchor_root, anchor_game }),
             Arc::new(factory),
         )
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn recover_uncached(
+        recovery: &ProofRecovery,
+    ) -> (RecoveredState, Option<ProofRecoveryCache>) {
+        let mut cache: Option<ProofRecoveryCache> = None;
+        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        (state, cache)
+    }
+
+    fn cache(
+        game_count: u64,
+        parent_address: Address,
+        output_root: B256,
+        l2_block_number: u64,
+    ) -> Option<ProofRecoveryCache> {
+        Some(ProofRecoveryCache {
+            game_count,
+            state: RecoveredState { parent_address, output_root, l2_block_number },
+        })
+    }
+
+    #[tokio::test]
     async fn test_recovery_returns_anchor_when_no_games() {
         let factory = MockDisputeGameFactory::with_games(vec![]);
         let recovery = recovery(factory, HashMap::new());
 
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let (state, cache) = recover_uncached(&recovery).await;
 
         assert_eq!(state.parent_address, Address::ZERO, "should return anchor state registry");
         assert_eq!(state.l2_block_number, TEST_ANCHOR_BLOCK, "should return anchor block");
         assert!(cache.is_some(), "cache should still be populated");
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_recovery_cold_start_uses_anchor_game_after_anchor_advance() {
-        let anchor_game = proxy_addr(0);
-        let anchor_block = TEST_BLOCK_INTERVAL;
-
-        let mut factory = MockDisputeGameFactory::with_games(vec![]);
-        factory.game_count_override = Some(1);
-        let recovery = recovery_full(
-            factory,
-            HashMap::new(),
-            anchor_block,
-            anchor_game,
-            TEST_BLOCK_INTERVAL,
-            TEST_BLOCK_INTERVAL,
-            None,
-        );
-
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
-
-        assert_eq!(state.parent_address, anchor_game, "advanced anchor game should be the parent");
-        assert_eq!(state.l2_block_number, anchor_block, "should propose after the live anchor");
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_reads_anchor_root_and_game_from_one_snapshot() {
         let anchor_game = proxy_addr(0);
         let anchor_root = B256::repeat_byte(0xAA);
@@ -563,83 +422,43 @@ mod tests {
         let mut factory = MockDisputeGameFactory::with_games(vec![]);
         factory.game_count_override = Some(1);
 
-        let recovery = ProofRecovery::new(
-            ProofRecoveryConfig {
-                block_interval: TEST_BLOCK_INTERVAL,
-                intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                game_type: TEST_GAME_TYPE,
-                allow_non_finalized: false,
-                anchor_state_registry_address: Address::ZERO,
-                scan_concurrency: 8,
-            },
-            Arc::new(MockRollupClient {
-                sync_status: test_sync_status(TEST_BLOCK_INTERVAL * 2, B256::ZERO),
-                output_roots: HashMap::new(),
-                max_safe_block: None,
-            }),
-            Arc::new(SnapshotOnlyAnchorStateRegistry {
-                snapshot: AnchorSnapshot {
-                    anchor_root: base_proof_contracts::AnchorRoot {
-                        root: anchor_root,
-                        l2_block_number: anchor_block,
-                    },
-                    anchor_game,
-                },
-            }),
-            Arc::new(factory),
+        let recovery = recovery_full(
+            factory,
+            HashMap::new(),
+            AnchorRoot { root: anchor_root, l2_block_number: anchor_block },
+            anchor_game,
+            TEST_BLOCK_INTERVAL,
+            TEST_BLOCK_INTERVAL,
+            None,
         );
 
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let (state, _) = recover_uncached(&recovery).await;
 
         assert_eq!(state.parent_address, anchor_game);
         assert_eq!(state.output_root, anchor_root);
         assert_eq!(state.l2_block_number, anchor_block);
     }
 
-    #[rstest]
-    #[case::single_game(1, 0, TEST_BLOCK_INTERVAL, "single game at first interval")]
-    #[case::chain_of_two(2, 1, TEST_BLOCK_INTERVAL * 2, "chain of two sequential games")]
-    #[case::chain_of_five(5, 4, TEST_BLOCK_INTERVAL * 5, "chain of five sequential games")]
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_recovery_forward_walk_chain(
-        #[case] game_count: usize,
-        #[case] expected_proxy_index: u64,
-        #[case] expected_block: u64,
-        #[case] scenario: &str,
-    ) {
-        let (factory, output_roots) = game_chain(game_count);
-        let recovery = recovery(factory, output_roots);
+    #[tokio::test]
+    async fn test_recovery_forward_walk_chain() {
+        for (game_count, expected_proxy_index, expected_block) in [
+            (1, 0, TEST_BLOCK_INTERVAL),
+            (2, 1, TEST_BLOCK_INTERVAL * 2),
+            (5, 4, TEST_BLOCK_INTERVAL * 5),
+        ] {
+            let (factory, output_roots) = game_chain(game_count);
+            let recovery = recovery(factory, output_roots);
 
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+            let (state, cache) = recover_uncached(&recovery).await;
 
-        assert_eq!(state.parent_address, proxy_addr(expected_proxy_index), "{scenario}");
-        assert_eq!(state.l2_block_number, expected_block, "{scenario}");
-        assert!(cache.is_some(), "{scenario}: cache should be populated");
+            assert_eq!(state.parent_address, proxy_addr(expected_proxy_index));
+            assert_eq!(state.l2_block_number, expected_block);
+            assert_eq!(state.output_root, B256::repeat_byte((expected_proxy_index + 1) as u8));
+            assert!(cache.is_some());
+        }
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_recovery_forward_walk_stops_at_gap() {
-        let root_1 = B256::repeat_byte(0x01);
-        let extra_data_1 = encode_extra_data(TEST_BLOCK_INTERVAL, Address::ZERO, &[root_1]);
-
-        let mut factory = MockDisputeGameFactory::with_games(vec![]);
-        factory.game_count_override = Some(1);
-        factory.uuid_games.insert((TEST_GAME_TYPE, root_1, extra_data_1), proxy_addr(0));
-
-        let output_roots = HashMap::from([(TEST_BLOCK_INTERVAL, root_1)]);
-        let recovery = recovery(factory, output_roots);
-
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
-
-        assert_eq!(state.parent_address, proxy_addr(0), "should stop at first game before gap");
-        assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL);
-        assert_eq!(state.output_root, root_1);
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_propagates_games_lookup_failure() {
         let (mut factory, output_roots) = game_chain(2);
         factory.games_should_fail = true;
@@ -649,88 +468,51 @@ mod tests {
         let mut cache: Option<ProofRecoveryCache> = None;
         let result = recovery.recover_latest_state(&mut cache).await;
 
-        assert!(result.is_err(), "games() failure should propagate");
-        let err = result.unwrap_err();
-        assert!(
-            matches!(err, ProposerError::Contract(_)),
-            "expected ProposerError::Contract, got {err:?}"
-        );
+        assert!(matches!(result, Err(ProposerError::Contract(_))));
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_forward_walk_stops_at_safe_head() {
         let (factory, output_roots) = game_chain(3);
 
         let recovery = recovery_full(
             factory,
             output_roots,
-            TEST_ANCHOR_BLOCK,
+            test_anchor_root(TEST_ANCHOR_BLOCK),
             Address::ZERO,
             TEST_BLOCK_INTERVAL,
             TEST_BLOCK_INTERVAL,
             Some(TEST_BLOCK_INTERVAL * 2),
         );
 
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let (state, _) = recover_uncached(&recovery).await;
 
         assert_eq!(state.parent_address, proxy_addr(1), "should stop at game 1");
         assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL * 2);
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_cache_hit_equal_game_count() {
         let (factory, output_roots) = game_chain(1);
         let game_proxy = proxy_addr(0);
 
         let recovery = recovery(factory, output_roots);
 
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state1 = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let (state1, mut cache) = recover_uncached(&recovery).await;
         assert!(cache.is_some(), "cache should be populated after first call");
         assert_eq!(state1.parent_address, game_proxy);
         assert_eq!(state1.l2_block_number, TEST_BLOCK_INTERVAL);
         assert_eq!(cache.as_ref().unwrap().game_count, 1);
 
         let state2 = recovery.recover_latest_state(&mut cache).await.unwrap();
-        assert_eq!(state2.parent_address, state1.parent_address);
-        assert_eq!(state2.l2_block_number, state1.l2_block_number);
-        assert_eq!(state2.output_root, state1.output_root);
+        assert_eq!(state2, state1);
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_recovery_cache_incremental_on_count_increase() {
-        let (factory, output_roots) = game_chain(2);
-
-        let mut cache = Some(ProofRecoveryCache {
-            game_count: 1,
-            state: RecoveredState {
-                parent_address: proxy_addr(0),
-                output_root: B256::repeat_byte(0x01),
-                l2_block_number: TEST_BLOCK_INTERVAL,
-            },
-        });
-
-        let recovery = recovery(factory, output_roots);
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
-
-        assert_eq!(state.parent_address, proxy_addr(1), "should find game 1 incrementally");
-        assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL * 2);
-        assert_eq!(cache.as_ref().unwrap().game_count, 2, "cache should reflect new count");
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_cache_incremental_resumes_mid_chain() {
         let (factory, output_roots) = game_chain(5);
 
-        let mut cache = Some(ProofRecoveryCache {
-            game_count: 3,
-            state: RecoveredState {
-                parent_address: proxy_addr(2),
-                output_root: B256::repeat_byte(0x03),
-                l2_block_number: TEST_BLOCK_INTERVAL * 3,
-            },
-        });
+        let mut cache = cache(3, proxy_addr(2), B256::repeat_byte(0x03), TEST_BLOCK_INTERVAL * 3);
 
         let recovery = recovery(factory, output_roots);
         let state = recovery.recover_latest_state(&mut cache).await.unwrap();
@@ -740,7 +522,7 @@ mod tests {
         assert_eq!(cache.as_ref().unwrap().game_count, 5);
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_cache_incremental_unrelated_games() {
         let (factory, output_roots) = game_chain(1);
         let mut factory_with_extra_count = factory;
@@ -748,14 +530,7 @@ mod tests {
 
         let recovery = recovery(factory_with_extra_count, output_roots);
 
-        let mut cache = Some(ProofRecoveryCache {
-            game_count: 1,
-            state: RecoveredState {
-                parent_address: proxy_addr(0),
-                output_root: B256::repeat_byte(0x01),
-                l2_block_number: TEST_BLOCK_INTERVAL,
-            },
-        });
+        let mut cache = cache(1, proxy_addr(0), B256::repeat_byte(0x01), TEST_BLOCK_INTERVAL);
 
         let state = recovery.recover_latest_state(&mut cache).await.unwrap();
 
@@ -764,18 +539,11 @@ mod tests {
         assert_eq!(cache.as_ref().unwrap().game_count, 2, "cache updated to new count");
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_cache_invalidated_by_count_decrease() {
         let (factory, output_roots) = game_chain(1);
 
-        let mut cache = Some(ProofRecoveryCache {
-            game_count: 5,
-            state: RecoveredState {
-                parent_address: proxy_addr(99),
-                output_root: B256::repeat_byte(0xDD),
-                l2_block_number: 5 * TEST_BLOCK_INTERVAL,
-            },
-        });
+        let mut cache = cache(5, proxy_addr(99), B256::repeat_byte(0xDD), 5 * TEST_BLOCK_INTERVAL);
 
         let recovery = recovery(factory, output_roots);
         let state = recovery.recover_latest_state(&mut cache).await.unwrap();
@@ -785,25 +553,18 @@ mod tests {
         assert_eq!(cache.as_ref().unwrap().game_count, 1, "reorg: cache should reflect new count");
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_cache_full_walk_when_anchor_past_tip() {
         let anchor_block = TEST_BLOCK_INTERVAL * 4;
         let (factory, output_roots) =
             game_chain_full(1, anchor_block, TEST_BLOCK_INTERVAL, TEST_BLOCK_INTERVAL);
 
-        let mut cache = Some(ProofRecoveryCache {
-            game_count: 0,
-            state: RecoveredState {
-                parent_address: proxy_addr(99),
-                output_root: B256::repeat_byte(0xDD),
-                l2_block_number: TEST_BLOCK_INTERVAL,
-            },
-        });
+        let mut cache = cache(0, proxy_addr(99), B256::repeat_byte(0xDD), TEST_BLOCK_INTERVAL);
 
         let recovery = recovery_full(
             factory,
             output_roots,
-            anchor_block,
+            test_anchor_root(anchor_block),
             Address::ZERO,
             TEST_BLOCK_INTERVAL,
             TEST_BLOCK_INTERVAL,
@@ -815,7 +576,7 @@ mod tests {
         assert_eq!(state.l2_block_number, anchor_block + TEST_BLOCK_INTERVAL);
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test]
     async fn test_recovery_forward_walk_with_intermediate_roots() {
         const RECOVERY_BI: u64 = 4;
         const RECOVERY_IBI: u64 = 2;
@@ -826,15 +587,14 @@ mod tests {
         let recovery = recovery_full(
             factory,
             output_roots,
-            TEST_ANCHOR_BLOCK,
+            test_anchor_root(TEST_ANCHOR_BLOCK),
             Address::ZERO,
             RECOVERY_BI,
             RECOVERY_IBI,
             None,
         );
 
-        let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let (state, _) = recover_uncached(&recovery).await;
 
         assert_eq!(state.parent_address, proxy_addr(1));
         assert_eq!(state.l2_block_number, RECOVERY_BI * 2);

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -263,7 +263,7 @@ impl ProposerService {
                 anchor_state_registry_address: driver_config.anchor_state_registry_address,
                 scan_concurrency: driver_config.recovery_scan_concurrency,
             },
-            Arc::clone(&rollup_client),
+            rollup_client.clone(),
             anchor_registry,
             factory_client,
         ));

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -263,7 +263,7 @@ impl ProposerService {
                 anchor_state_registry_address: driver_config.anchor_state_registry_address,
                 scan_concurrency: driver_config.recovery_scan_concurrency,
             },
-            rollup_client.clone(),
+            Arc::<RollupClient>::clone(&rollup_client),
             anchor_registry,
             factory_client,
         ));


### PR DESCRIPTION
### What changed? Why?

Simplifies proof recovery by making ProofRecovery hold a dyn RollupProvider instead of being generic, consolidating safe/finalized head lookup into the recovery tick, reusing ProofTarget next-block math, and collecting ordered intermediate roots directly during the forward walk.

This keeps recovery cache handling smaller while preserving the existing proposer recovery behavior.

### Notes to reviewers

The main behavior change is in crates/proof/proposer/src/proof_recovery.rs. The driver, pipeline, and service changes are type glue for the non-generic recovery client.

The colocated recovery tests were reduced to direct tokio tests while still covering chain walking, cache reuse, cache invalidation, safe-head stopping, games lookup failures, and intermediate roots.

### How has it been tested?

cargo test -p base-proposer proof_recovery