### PR TITLE
feat(basectl): add max peer count to basectl p2p info

### DIFF
--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -100,7 +100,8 @@ is one of `caught_up` (within ±N blocks of the reference, where N is the
 P2P inspection and single-peer management commands for execution and
 consensus layers.
 
-- `basectl p2p info` shows the advertised endpoint per layer plus peer counts.
+- `basectl p2p info` shows the advertised endpoint per layer plus peer counts,
+  and the CL max peer count when the consensus RPC reports it.
 - `basectl p2p peers` shows the connected peer list per layer.
 - `basectl p2p add-peer <TARGET>` connects one peer. `enode://...` routes to
   the execution layer; `enr:...` or `/.../p2p/<peer-id>` routes to the
@@ -148,6 +149,7 @@ Important EL RPC note:
 - EL advertised endpoint data (`admin_nodeInfo`) and EL peer listings (`admin_peers`) require an admin-enabled EL RPC.
 - If the EL RPC does not expose those admin methods, `basectl p2p` degrades gracefully: EL peer count still appears, but EL endpoint fields or EL peer listings show as unavailable / `null`.
 - CL data comes from `opp2p_self`, `opp2p_peerStats`, and `opp2p_peers(true)` on the consensus RPC.
+- When exposed by the node, `opp2p_peerStats` also additively reports `maxPeerCount`, the configured CL max peer count.
 - CL ban/unban commands use `opp2p_blockPeer`, `opp2p_unblockPeer`, and `opp2p_listBlockedPeers` underneath, but the basectl command surface uses ban/unban terminology so it can stay consistent when EL ban support is added later.
 
 ### `basectl txpool`

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -5,10 +5,10 @@ use std::io::{self, Write};
 use anyhow::Result;
 use base_consensus_peers::BootNode;
 use basectl_cli::{
-    JsonOutput, KeyValueTable, MonitoringConfig, NodeEndpoint, P2pCommandError, P2pTargetError,
-    PeerListReport, PeerStatsReport, PeerSummary, add_peer, ban_peer, connect_peer,
-    disconnect_peer, fetch_connected_peers, fetch_info, fetch_raw_info, fetch_raw_peers,
-    list_banned_peers, remove_peer, unban_peer,
+    JsonOutput, MonitoringConfig, P2pCommandError, P2pInfoJson, P2pInfoTable, P2pTargetError,
+    PeerListReport, PeerSummary, add_peer, ban_peer, connect_peer, disconnect_peer,
+    fetch_connected_peers, fetch_info, fetch_raw_info, fetch_raw_peers, list_banned_peers,
+    remove_peer, unban_peer,
 };
 use serde::Serialize;
 use url::Url;
@@ -248,11 +248,11 @@ async fn run_info(config: MonitoringConfig, args: P2pArgs) -> Result<()> {
         }
         (true, false) => {
             let (node_info, peer_stats) = fetch_info(&el_rpc, &cl_rpc).await?;
-            JsonOutput::print(&InfoJson::from_report(&config.name, &node_info, &peer_stats))?;
+            JsonOutput::print(&P2pInfoJson::from_report(&config.name, &node_info, &peer_stats))?;
         }
         (false, _) => {
             let (node_info, peer_stats) = fetch_info(&el_rpc, &cl_rpc).await?;
-            print_info_pretty(&config.name, &node_info, &peer_stats)?;
+            P2pInfoTable::from_report(&config.name, &node_info, &peer_stats).print()?;
         }
     }
 
@@ -572,46 +572,6 @@ fn print_peer_action_pretty(action: &PeerActionJson) -> Result<()> {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct LayerInfoJson {
-    advertised_ip: Option<String>,
-    tcp_port: Option<u16>,
-    discovery: Option<basectl_cli::DiscoveryInfo>,
-    peer_count: Option<u32>,
-}
-
-impl LayerInfoJson {
-    fn from_endpoint(endpoint: Option<NodeEndpoint>, peer_count: Option<u32>) -> Self {
-        let (advertised_ip, tcp_port, discovery) = endpoint.map_or((None, None, None), |ep| {
-            (Some(ep.advertised_ip.to_string()), Some(ep.tcp_port), Some(ep.discovery))
-        });
-        Self { advertised_ip, tcp_port, discovery, peer_count }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct InfoJson {
-    network: String,
-    el: LayerInfoJson,
-    cl: LayerInfoJson,
-}
-
-impl InfoJson {
-    fn from_report(
-        network: &str,
-        report: &basectl_cli::NodeInfoReport,
-        peer_stats: &PeerStatsReport,
-    ) -> Self {
-        Self {
-            network: network.to_string(),
-            el: LayerInfoJson::from_endpoint(report.el, peer_stats.el_count),
-            cl: LayerInfoJson::from_endpoint(report.cl, peer_stats.cl.map(|stats| stats.connected)),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct PeersJson {
     network: String,
     el: Option<Vec<PeerSummary>>,
@@ -622,87 +582,6 @@ impl PeersJson {
     fn from_report(network: &str, report: &PeerListReport) -> Self {
         Self { network: network.to_string(), el: report.el.clone(), cl: report.cl.clone() }
     }
-}
-
-fn print_info_pretty(
-    network: &str,
-    report: &basectl_cli::NodeInfoReport,
-    peer_stats: &PeerStatsReport,
-) -> Result<()> {
-    let mut table = KeyValueTable::new();
-    let el_discovery = report.el.map(|endpoint| {
-        format_discovery_flags(endpoint.discovery.v4_enabled, endpoint.discovery.v5_enabled)
-            .to_string()
-    });
-    let cl_discovery = report.cl.map(|endpoint| {
-        format_discovery_flags(endpoint.discovery.v4_enabled, endpoint.discovery.v5_enabled)
-            .to_string()
-    });
-    table
-        .row("network", network)
-        .row(
-            "el_advertised_ip",
-            report
-                .el
-                .map(|endpoint| endpoint.advertised_ip.to_string())
-                .unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
-        )
-        .row(
-            "el_p2p_port",
-            report
-                .el
-                .map(|endpoint| endpoint.tcp_port.to_string())
-                .unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
-        )
-        .row(
-            "el_discovery_port",
-            report
-                .el
-                .map(|endpoint| endpoint.discovery.udp_port.to_string())
-                .unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
-        )
-        .row(
-            "el_discovery",
-            el_discovery.unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
-        )
-        .row(
-            "el_peer_count",
-            peer_stats
-                .el_count
-                .map(|count| count.to_string())
-                .unwrap_or_else(unavailable_el_peer_count),
-        )
-        .row(
-            "cl_advertised_ip",
-            report
-                .cl
-                .map(|endpoint| endpoint.advertised_ip.to_string())
-                .unwrap_or_else(unavailable_cl_endpoint),
-        )
-        .row(
-            "cl_p2p_port",
-            report
-                .cl
-                .map(|endpoint| endpoint.tcp_port.to_string())
-                .unwrap_or_else(unavailable_cl_endpoint),
-        )
-        .row(
-            "cl_discovery_port",
-            report
-                .cl
-                .map(|endpoint| endpoint.discovery.udp_port.to_string())
-                .unwrap_or_else(unavailable_cl_endpoint),
-        )
-        .row("cl_discovery", cl_discovery.unwrap_or_else(unavailable_cl_endpoint))
-        .row(
-            "cl_peer_count",
-            peer_stats
-                .cl
-                .map(|stats| stats.connected.to_string())
-                .unwrap_or_else(unavailable_cl_peer_stats),
-        );
-    table.print()?;
-    Ok(())
 }
 
 fn print_peers_pretty(network: &str, report: &PeerListReport) -> Result<()> {
@@ -741,31 +620,6 @@ fn write_peer_section<W: Write>(
         )?;
     }
     Ok(())
-}
-
-const fn format_discovery_flags(v4_enabled: bool, v5_enabled: bool) -> &'static str {
-    match (v4_enabled, v5_enabled) {
-        (true, true) => "v4+v5",
-        (true, false) => "v4",
-        (false, true) => "v5",
-        (false, false) => "disabled",
-    }
-}
-
-fn unavailable_admin_method(method: &str) -> String {
-    format!("unavailable (`{method}` not exposed by this RPC)")
-}
-
-fn unavailable_el_peer_count() -> String {
-    "unavailable (`net_peerCount` not exposed by this RPC)".to_string()
-}
-
-fn unavailable_cl_endpoint() -> String {
-    "unavailable (could not parse advertised endpoint from `opp2p_self`)".to_string()
-}
-
-fn unavailable_cl_peer_stats() -> String {
-    "unavailable (`opp2p_peerStats` not exposed by this RPC)".to_string()
 }
 
 #[cfg(test)]

--- a/crates/consensus/gossip/src/builder.rs
+++ b/crates/consensus/gossip/src/builder.rs
@@ -272,6 +272,7 @@ impl GossipDriverBuilder {
                 GossipDriverConfig {
                     max_identify_peerstore_peers,
                     peer_monitoring: self.peer_monitoring,
+                    connection_limits_config,
                 },
             ),
             signer_tx,

--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -28,8 +28,8 @@ use lru::LruCache;
 use tokio::sync::Mutex;
 
 use crate::{
-    Behaviour, BlockHandler, ConnectionGate, ConnectionGater, Event, GossipDriverBuilder, Handler,
-    Metrics, PublishError,
+    Behaviour, BlockHandler, ConnectionGate, ConnectionGater, ConnectionLimitsConfig, Event,
+    GossipDriverBuilder, Handler, Metrics, PublishError,
 };
 
 /// Configuration applied when constructing a [`GossipDriver`].
@@ -39,6 +39,8 @@ pub struct GossipDriverConfig {
     pub max_identify_peerstore_peers: NonZeroUsize,
     /// Peer score monitoring config.
     pub peer_monitoring: Option<PeerMonitoring>,
+    /// The configured libp2p connection limits enforced by the swarm.
+    pub connection_limits_config: ConnectionLimitsConfig,
 }
 
 /// A driver for a [`Swarm`] instance.
@@ -74,6 +76,8 @@ pub struct GossipDriver<G: ConnectionGate> {
     pub peer_connection_start: HashMap<PeerId, Instant>,
     /// The connection gate.
     pub connection_gate: G,
+    /// The configured libp2p connection limits enforced by the swarm.
+    pub connection_limits_config: ConnectionLimitsConfig,
     /// Tracks ping times for peers.
     pub ping: Arc<Mutex<HashMap<PeerId, Duration>>>,
 }
@@ -112,6 +116,7 @@ where
             sync_handler,
             sync_protocol: Some(sync_protocol),
             connection_gate: gate,
+            connection_limits_config: config.connection_limits_config,
             ping: Arc::new(Mutex::new(Default::default())),
         }
     }

--- a/crates/consensus/gossip/src/rpc/request.rs
+++ b/crates/consensus/gossip/src/rpc/request.rs
@@ -544,6 +544,7 @@ impl P2pRpcRequest {
         let table_info = disc.peer_count();
 
         let banned_peers = gossip.connection_gate.list_blocked_peers().len();
+        let max_peer_count = gossip.connection_limits_config.max_established;
 
         let topics = gossip.swarm.behaviour().gossipsub.topics().collect::<HashSet<_>>();
 
@@ -625,6 +626,7 @@ impl P2pRpcRequest {
                 blocks_topic_v4: block_topics[3],
                 banned: banned_peers as u32,
                 known,
+                max_peer_count: Some(max_peer_count),
             };
 
             if let Err(e) = sender.send(stats) {

--- a/crates/consensus/gossip/src/rpc/types.rs
+++ b/crates/consensus/gossip/src/rpc/types.rs
@@ -215,6 +215,13 @@ pub struct PeerStats {
     pub banned: u32,
     /// The known count.
     pub known: u32,
+    /// Configured maximum number of established libp2p connections.
+    ///
+    /// This is an additive Base extension to `opp2p_peerStats`. Older nodes may
+    /// omit this field when they do not expose connection limits through that
+    /// RPC method.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_peer_count: Option<u32>,
 }
 
 /// Represents the connectivity state of a peer in a network, indicating the reachability and
@@ -424,5 +431,24 @@ mod tests {
             peer_info.peer_scores.req_resp.valid_responses,
             deserialized.peer_scores.req_resp.valid_responses
         );
+    }
+
+    #[test]
+    fn test_peer_stats_deserialize_legacy_payload_without_connection_limit() {
+        let stats: PeerStats = serde_json::from_value(serde_json::json!({
+            "connected": 7,
+            "table": 9,
+            "blocksTopic": 1,
+            "blocksTopicV2": 2,
+            "blocksTopicV3": 3,
+            "blocksTopicV4": 4,
+            "banned": 0,
+            "known": 11,
+        }))
+        .unwrap();
+
+        assert_eq!(stats.connected, 7);
+        assert_eq!(stats.known, 11);
+        assert_eq!(stats.max_peer_count, None);
     }
 }

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -15,10 +15,11 @@ mod output;
 pub use output::{
     COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL, COLOR_GROWTH,
     COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, JsonOutput, KeyValueTable,
-    L1BlocksTableParams, TimestampJson, backlog_size_color, block_color, block_color_bright,
-    build_gas_bar, format_bytes, format_duration, format_gas, format_gwei, format_rate,
-    format_unix_timestamp, render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table,
-    target_usage_color, time_diff_color, truncate_block_number,
+    L1BlocksTableParams, P2pInfoJson, P2pInfoTable, P2pLayerInfoJson, TimestampJson,
+    backlog_size_color, block_color, block_color_bright, build_gas_bar, format_bytes,
+    format_duration, format_gas, format_gwei, format_rate, format_unix_timestamp,
+    render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table, target_usage_color,
+    time_diff_color, truncate_block_number,
 };
 
 mod config;

--- a/crates/infra/basectl/src/output/mod.rs
+++ b/crates/infra/basectl/src/output/mod.rs
@@ -11,6 +11,9 @@ pub use format::{
 mod json;
 pub use json::{JsonOutput, TimestampJson};
 
+mod p2p;
+pub use p2p::{P2pInfoJson, P2pInfoTable, P2pLayerInfoJson};
+
 mod render;
 pub use render::{
     L1BlocksTableParams, build_gas_bar, render_da_backlog_bar, render_gas_usage_bar,

--- a/crates/infra/basectl/src/output/p2p.rs
+++ b/crates/infra/basectl/src/output/p2p.rs
@@ -108,16 +108,18 @@ impl P2pInfoTable {
             format_discovery_flags(endpoint.discovery.v4_enabled, endpoint.discovery.v5_enabled)
                 .to_string()
         });
-        let (cl_peer_count, cl_max_peer_count) = match peer_stats.cl {
-            Some(stats) => (
-                stats.connected.to_string(),
-                stats
-                    .max_peer_count
-                    .map(|count| count.to_string())
-                    .unwrap_or_else(unavailable_cl_max_peer_count),
-            ),
-            None => (unavailable_cl_peer_stats(), unavailable_cl_max_peer_count_without_rpc()),
-        };
+        let (cl_peer_count, cl_max_peer_count) = peer_stats.cl.map_or_else(
+            || (unavailable_cl_peer_stats(), unavailable_cl_max_peer_count_without_rpc()),
+            |stats| {
+                (
+                    stats.connected.to_string(),
+                    stats
+                        .max_peer_count
+                        .map(|count| count.to_string())
+                        .unwrap_or_else(unavailable_cl_max_peer_count),
+                )
+            },
+        );
 
         table
             .row("network", network)

--- a/crates/infra/basectl/src/output/p2p.rs
+++ b/crates/infra/basectl/src/output/p2p.rs
@@ -1,0 +1,294 @@
+//! P2P info output shapes and table rendering.
+
+use serde::Serialize;
+
+use super::KeyValueTable;
+use crate::{DiscoveryInfo, NodeEndpoint, NodeInfoReport, PeerStatsReport};
+
+/// Humanized per-layer JSON for `basectl p2p info --json`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct P2pLayerInfoJson {
+    /// Advertised public IP address.
+    pub advertised_ip: Option<String>,
+    /// Advertised TCP port.
+    pub tcp_port: Option<u16>,
+    /// Discovery configuration summary.
+    pub discovery: Option<DiscoveryInfo>,
+    /// Connected peer count.
+    pub peer_count: Option<u32>,
+    /// Configured maximum peer count.
+    pub max_peer_count: Option<u32>,
+}
+
+impl P2pLayerInfoJson {
+    /// Builds a per-layer JSON summary from the humanized basectl report types.
+    pub fn from_endpoint(
+        endpoint: Option<NodeEndpoint>,
+        peer_count: Option<u32>,
+        max_peer_count: Option<u32>,
+    ) -> Self {
+        let (advertised_ip, tcp_port, discovery) = endpoint.map_or((None, None, None), |ep| {
+            (Some(ep.advertised_ip.to_string()), Some(ep.tcp_port), Some(ep.discovery))
+        });
+        Self { advertised_ip, tcp_port, discovery, peer_count, max_peer_count }
+    }
+}
+
+/// Humanized JSON payload for `basectl p2p info --json`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct P2pInfoJson {
+    /// Selected basectl network/config name.
+    pub network: String,
+    /// Execution-layer p2p summary.
+    pub el: P2pLayerInfoJson,
+    /// Consensus-layer p2p summary.
+    pub cl: P2pLayerInfoJson,
+}
+
+impl P2pInfoJson {
+    /// Builds the humanized JSON payload for `basectl p2p info --json`.
+    pub fn from_report(
+        network: &str,
+        report: &NodeInfoReport,
+        peer_stats: &PeerStatsReport,
+    ) -> Self {
+        Self {
+            network: network.to_string(),
+            el: P2pLayerInfoJson::from_endpoint(report.el, peer_stats.el_count, None),
+            cl: P2pLayerInfoJson::from_endpoint(
+                report.cl,
+                peer_stats.cl.map(|stats| stats.connected),
+                peer_stats.cl.and_then(|stats| stats.max_peer_count),
+            ),
+        }
+    }
+}
+
+/// Pretty-table builder for `basectl p2p info`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct P2pInfoTable;
+
+impl P2pInfoTable {
+    /// Builds the pretty `KeyValueTable` for `basectl p2p info`.
+    pub fn from_report(
+        network: &str,
+        report: &NodeInfoReport,
+        peer_stats: &PeerStatsReport,
+    ) -> KeyValueTable {
+        let mut table = KeyValueTable::new();
+        let format_discovery_flags =
+            |v4_enabled: bool, v5_enabled: bool| match (v4_enabled, v5_enabled) {
+                (true, true) => "v4+v5",
+                (true, false) => "v4",
+                (false, true) => "v5",
+                (false, false) => "disabled",
+            };
+        let unavailable_admin_method =
+            |method: &str| format!("unavailable (`{method}` not exposed by this RPC)");
+        let unavailable_el_peer_count =
+            || "unavailable (`net_peerCount` not exposed by this RPC)".to_string();
+        let unavailable_cl_endpoint =
+            || "unavailable (could not parse advertised endpoint from `opp2p_self`)".to_string();
+        let unavailable_cl_peer_stats =
+            || "unavailable (`opp2p_peerStats` not exposed by this RPC)".to_string();
+        let unavailable_cl_max_peer_count =
+            || "unavailable (CL node did not report max peer count)".to_string();
+        let unavailable_cl_max_peer_count_without_rpc = || {
+            "unavailable (`opp2p_peerStats` not exposed by this RPC; cannot read max peer count)"
+                .to_string()
+        };
+
+        let el_discovery = report.el.map(|endpoint| {
+            format_discovery_flags(endpoint.discovery.v4_enabled, endpoint.discovery.v5_enabled)
+                .to_string()
+        });
+        let cl_discovery = report.cl.map(|endpoint| {
+            format_discovery_flags(endpoint.discovery.v4_enabled, endpoint.discovery.v5_enabled)
+                .to_string()
+        });
+        let (cl_peer_count, cl_max_peer_count) = match peer_stats.cl {
+            Some(stats) => (
+                stats.connected.to_string(),
+                stats
+                    .max_peer_count
+                    .map(|count| count.to_string())
+                    .unwrap_or_else(unavailable_cl_max_peer_count),
+            ),
+            None => (unavailable_cl_peer_stats(), unavailable_cl_max_peer_count_without_rpc()),
+        };
+
+        table
+            .row("network", network)
+            .row(
+                "el_advertised_ip",
+                report
+                    .el
+                    .map(|endpoint| endpoint.advertised_ip.to_string())
+                    .unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
+            )
+            .row(
+                "el_p2p_port",
+                report
+                    .el
+                    .map(|endpoint| endpoint.tcp_port.to_string())
+                    .unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
+            )
+            .row(
+                "el_discovery_port",
+                report
+                    .el
+                    .map(|endpoint| endpoint.discovery.udp_port.to_string())
+                    .unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
+            )
+            .row(
+                "el_discovery",
+                el_discovery.unwrap_or_else(|| unavailable_admin_method("admin_nodeInfo")),
+            )
+            .row(
+                "el_peer_count",
+                peer_stats
+                    .el_count
+                    .map(|count| count.to_string())
+                    .unwrap_or_else(unavailable_el_peer_count),
+            )
+            .row(
+                "cl_advertised_ip",
+                report
+                    .cl
+                    .map(|endpoint| endpoint.advertised_ip.to_string())
+                    .unwrap_or_else(unavailable_cl_endpoint),
+            )
+            .row(
+                "cl_p2p_port",
+                report
+                    .cl
+                    .map(|endpoint| endpoint.tcp_port.to_string())
+                    .unwrap_or_else(unavailable_cl_endpoint),
+            )
+            .row(
+                "cl_discovery_port",
+                report
+                    .cl
+                    .map(|endpoint| endpoint.discovery.udp_port.to_string())
+                    .unwrap_or_else(unavailable_cl_endpoint),
+            )
+            .row("cl_discovery", cl_discovery.unwrap_or_else(unavailable_cl_endpoint))
+            .row("cl_peer_count", cl_peer_count)
+            .row("cl_max_peer_count", cl_max_peer_count);
+
+        table
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{P2pInfoJson, P2pInfoTable};
+    use crate::{DiscoveryInfo, NodeEndpoint, NodeInfoReport, PeerStatsReport};
+
+    #[test]
+    fn info_json_keeps_max_peer_count_key_when_absent() {
+        let report = NodeInfoReport { el: None, cl: None };
+        let peer_stats = PeerStatsReport { el_count: None, cl: None };
+
+        let info =
+            serde_json::to_value(P2pInfoJson::from_report("devnet", &report, &peer_stats)).unwrap();
+
+        assert_eq!(info["el"]["peerCount"], serde_json::Value::Null);
+        assert_eq!(info["el"]["maxPeerCount"], serde_json::Value::Null);
+        assert_eq!(info["cl"]["peerCount"], serde_json::Value::Null);
+        assert_eq!(info["cl"]["maxPeerCount"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn info_json_includes_cl_max_peer_count() {
+        let report = NodeInfoReport {
+            el: None,
+            cl: Some(NodeEndpoint {
+                advertised_ip: "203.0.113.10".parse().unwrap(),
+                tcp_port: 9000,
+                discovery: DiscoveryInfo { udp_port: 9001, v4_enabled: true, v5_enabled: false },
+            }),
+        };
+        let peer_stats = PeerStatsReport {
+            el_count: Some(8),
+            cl: Some(
+                serde_json::from_value(json!({
+                    "connected": 17,
+                    "table": 20,
+                    "blocksTopic": 1,
+                    "blocksTopicV2": 2,
+                    "blocksTopicV3": 3,
+                    "blocksTopicV4": 4,
+                    "banned": 0,
+                    "known": 21,
+                    "maxPeerCount": 100,
+                }))
+                .unwrap(),
+            ),
+        };
+
+        let info =
+            serde_json::to_value(P2pInfoJson::from_report("devnet", &report, &peer_stats)).unwrap();
+
+        assert_eq!(info["cl"]["maxPeerCount"], json!(100));
+        assert_eq!(info["el"]["maxPeerCount"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn info_table_renders_specific_max_peer_count_message_when_rpc_missing() {
+        let report = NodeInfoReport { el: None, cl: None };
+        let peer_stats = PeerStatsReport { el_count: None, cl: None };
+
+        let mut buf = Vec::new();
+        P2pInfoTable::from_report("devnet", &report, &peer_stats).render(&mut buf).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+        let line = rendered
+            .lines()
+            .find(|line| line.contains("cl_max_peer_count"))
+            .expect("missing cl_max_peer_count row");
+
+        assert!(line.contains("cannot read max peer count"), "unexpected row: {line}");
+    }
+
+    #[test]
+    fn info_table_renders_specific_max_peer_count_message_when_field_missing() {
+        let report = NodeInfoReport {
+            el: None,
+            cl: Some(NodeEndpoint {
+                advertised_ip: "203.0.113.10".parse().unwrap(),
+                tcp_port: 9000,
+                discovery: DiscoveryInfo { udp_port: 9001, v4_enabled: true, v5_enabled: false },
+            }),
+        };
+        let peer_stats = PeerStatsReport {
+            el_count: None,
+            cl: Some(
+                serde_json::from_value(json!({
+                    "connected": 17,
+                    "table": 20,
+                    "blocksTopic": 1,
+                    "blocksTopicV2": 2,
+                    "blocksTopicV3": 3,
+                    "blocksTopicV4": 4,
+                    "banned": 0,
+                    "known": 21,
+                }))
+                .unwrap(),
+            ),
+        };
+
+        let mut buf = Vec::new();
+        P2pInfoTable::from_report("devnet", &report, &peer_stats).render(&mut buf).unwrap();
+        let rendered = String::from_utf8(buf).unwrap();
+        let line = rendered
+            .lines()
+            .find(|line| line.contains("cl_max_peer_count"))
+            .expect("missing cl_max_peer_count row");
+
+        assert!(line.contains("did not report max peer count"), "unexpected row: {line}");
+    }
+}


### PR DESCRIPTION
## Summary
- expose the CL max peer count through `opp2p_peerStats` as `maxPeerCount`
- show the max peer count in `basectl p2p info` JSON and pretty output
- move the `p2p info` rendering into the basectl library and add regression tests