### PR TITLE
fix(challenger): retry ready TEE proofs on tx errors

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -103,6 +103,15 @@ pub struct ChallengerArgs {
     )]
     pub max_proof_duration: Duration,
 
+    /// Retryable TEE submission failures to tolerate before falling back to ZK.
+    /// Set to 0 to fall back immediately on the first retryable TEE tx error.
+    #[arg(
+        long = "tee-submit-retry-limit",
+        env = cli_env!("TEE_SUBMIT_RETRY_LIMIT"),
+        default_value = "3"
+    )]
+    pub tee_submit_retry_limit: u32,
+
     /// Signer configuration (local private key or remote sidecar).
     #[command(flatten)]
     pub signer: SignerCli,

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -101,6 +101,8 @@ pub struct ChallengerConfig {
     pub zk_request_timeout: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
     pub max_proof_duration: Duration,
+    /// Retryable TEE submission failures to tolerate before falling back to ZK.
+    pub tee_submit_retry_limit: u32,
     /// Signing configuration for L1 transaction submission.
     pub signing: SignerConfig,
     /// Transaction manager configuration (fee limits, confirmations, timeouts).
@@ -221,6 +223,7 @@ impl ChallengerConfig {
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
             max_proof_duration: cli.challenger.max_proof_duration,
+            tee_submit_retry_limit: cli.challenger.tee_submit_retry_limit,
             signing,
             tx_manager,
             bond_discovery_lookback_games: cli.challenger.bond_discovery_lookback_games,
@@ -290,6 +293,7 @@ mod tests {
         assert_eq!(config.poll_interval, Duration::from_secs(12));
         assert_eq!(config.zk_connect_timeout, Duration::from_secs(10));
         assert_eq!(config.zk_request_timeout, Duration::from_secs(30));
+        assert_eq!(config.tee_submit_retry_limit, 3);
         assert_eq!(
             config.anchor_state_registry_addr,
             "0x2234567890123456789012345678901234567890".parse::<Address>().unwrap()
@@ -310,6 +314,14 @@ mod tests {
         let cli = cli_from_args(&all_args);
         let config = ChallengerConfig::from_cli(cli).unwrap();
         assert_eq!(config.bond_discovery_lookback_games, 2048);
+    }
+
+    #[test]
+    fn test_tee_submit_retry_limit_configurable() {
+        let all_args = [&SIGNER_ARGS[..], &["--tee-submit-retry-limit", "7"]].concat();
+        let cli = cli_from_args(&all_args);
+        let config = ChallengerConfig::from_cli(cli).unwrap();
+        assert_eq!(config.tee_submit_retry_limit, 7);
     }
 
     #[rstest]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -29,7 +29,7 @@ use base_proof_submission::KnownRevert;
 use base_prover_service_client::ProofRequesterProvider;
 use base_prover_service_protocol::{SnarkGroth16ProofRequest, TeeKind, ZkProofRequest, ZkVm};
 use base_runtime::{Clock, TokioRuntime};
-use base_tx_manager::TxManager;
+use base_tx_manager::{TxManager, TxManagerError};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -870,12 +870,20 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                         self.pending_proofs.remove(&game_address);
                         return Ok(());
                     }
-                    _ if targets_tee => {
+                    _ if targets_tee && Self::should_fallback_from_tee_submit(&e) => {
                         warn!(
                             error = %e,
                             game = %game_address,
                             "TEE dispute tx failed, falling back to ZK"
                         );
+                    }
+                    _ if targets_tee => {
+                        warn!(
+                            error = %e,
+                            game = %game_address,
+                            "TEE dispute tx failed, will retry next tick"
+                        );
+                        return Ok(());
                     }
                     _ => {
                         warn!(
@@ -897,6 +905,15 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         }
 
         Ok(())
+    }
+
+    const fn should_fallback_from_tee_submit(error: &ChallengeSubmitError) -> bool {
+        matches!(
+            error,
+            ChallengeSubmitError::KnownRevert(KnownRevert::InvalidSigner)
+                | ChallengeSubmitError::TxReverted { .. }
+                | ChallengeSubmitError::TxManager(TxManagerError::ExecutionReverted { .. })
+        )
     }
 
     fn ignore_game(&mut self, game_address: Address) {
@@ -1016,6 +1033,7 @@ mod tests {
     use crate::test_utils::{
         MockAggregateVerifier, MockDisputeGameFactory, MockL2Provider, MockTxManager,
         MockZkProofProvider, addr, factory_game, mock_anchor_registry, mock_state,
+        receipt_with_status,
     };
 
     fn proof_request() -> SnarkGroth16ProofRequest {
@@ -1036,6 +1054,13 @@ mod tests {
         err: TxManagerError,
     ) -> (Driver<MockL2Provider, MockZkProofProvider, MockTxManager>, Arc<MockZkProofProvider>)
     {
+        driver_with_tx_manager(MockTxManager::new(Err(err)))
+    }
+
+    fn driver_with_tx_manager(
+        tx_manager: MockTxManager,
+    ) -> (Driver<MockL2Provider, MockZkProofProvider, MockTxManager>, Arc<MockZkProofProvider>)
+    {
         let game_address = addr(0);
         let mut verifier_games = HashMap::new();
         verifier_games.insert(game_address, mock_state(GameStatus::InProgress, Address::ZERO, 100));
@@ -1047,7 +1072,6 @@ mod tests {
             mock_anchor_registry(Address::ZERO),
         );
         let proof_requester = Arc::new(MockZkProofProvider::default());
-        let tx_manager = MockTxManager::new(Err(err));
         let components = DriverComponents {
             scanner,
             validator: OutputValidator::new(Arc::new(MockL2Provider::new())),
@@ -1117,6 +1141,23 @@ mod tests {
         }
     }
 
+    fn assert_ready_tee_proof(driver: &Driver<MockL2Provider, MockZkProofProvider, MockTxManager>) {
+        let pending = driver.pending_proofs.get(&addr(0)).expect("pending proof should remain");
+        assert!(matches!(pending.phase, ProofPhase::ReadyToSubmit { .. }));
+        assert!(pending.kind.is_tee());
+    }
+
+    fn assert_zk_fallback_requested(
+        driver: &Driver<MockL2Provider, MockZkProofProvider, MockTxManager>,
+        proof_requester: &MockZkProofProvider,
+    ) {
+        let pending = driver.pending_proofs.get(&addr(0)).expect("pending proof should remain");
+        assert!(matches!(pending.phase, ProofPhase::AwaitingProof { .. }));
+        assert!(!pending.kind.is_tee());
+        let state = proof_requester.state.lock().unwrap();
+        assert_eq!(state.prove_block_range_log.len(), 1);
+    }
+
     #[tokio::test]
     async fn proof_already_verified_revert_drops_pending_proof() {
         let (mut driver, _proof_requester) =
@@ -1177,6 +1218,44 @@ mod tests {
         assert!(driver.ignored_games.contains(&addr(0)));
         let state = proof_requester.state.lock().unwrap();
         assert!(state.prove_block_range_log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tee_submit_nonce_too_low_keeps_ready_proof_without_requesting_zk() {
+        let (mut driver, proof_requester) = driver_with_tx_error(TxManagerError::NonceTooLow);
+        insert_ready_tee_proof(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert_ready_tee_proof(&driver);
+        let state = proof_requester.state.lock().unwrap();
+        assert!(state.prove_block_range_log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tee_invalid_signer_revert_falls_back_to_zk() {
+        let (mut driver, proof_requester) =
+            driver_with_tx_error(TxManagerError::ExecutionReverted {
+                reason: Some("InvalidSigner()".to_string()),
+                data: None,
+            });
+        insert_ready_tee_proof(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert_zk_fallback_requested(&driver, &proof_requester);
+    }
+
+    #[tokio::test]
+    async fn tee_mined_tx_revert_falls_back_to_zk() {
+        let tx_hash = B256::repeat_byte(0x44);
+        let (mut driver, proof_requester) =
+            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(false, tx_hash))));
+        insert_ready_tee_proof(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert_zk_fallback_requested(&driver, &proof_requester);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -889,15 +889,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                         };
                         let has_zk_fallback = pending.kind.has_zk_fallback();
 
-                        if has_zk_fallback
-                            && pending.tee_submit_retry_count >= self.tee_submit_retry_limit
-                        {
+                        if pending.tee_submit_retry_count >= self.tee_submit_retry_limit {
                             warn!(
                                 error = %e,
                                 game = %game_address,
                                 retry_count = pending.tee_submit_retry_count,
                                 retry_limit = self.tee_submit_retry_limit,
-                                "TEE dispute tx retry limit reached, falling back to ZK"
+                                has_zk_fallback,
+                                "TEE dispute tx retry limit reached"
                             );
                             pending.phase = ProofPhase::NeedsRetry;
                             return self.handle_proof_retry(game_address).await;
@@ -1160,6 +1159,24 @@ mod tests {
         );
     }
 
+    fn insert_ready_tee_proof_without_fallback(
+        driver: &mut Driver<MockL2Provider, MockZkProofProvider, MockTxManager>,
+    ) {
+        let game_address = addr(0);
+        driver.pending_proofs.insert(
+            game_address,
+            PendingProof {
+                phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from(vec![0x00, 0xAA]) },
+                kind: ProofKind::Tee { zk_fallback_request: None, zk_fallback_intent: None },
+                invalid_index: 0,
+                expected_root: B256::repeat_byte(0x22),
+                retry_count: 0,
+                tee_submit_retry_count: 0,
+                intent: DisputeIntent::Nullify,
+            },
+        );
+    }
+
     fn candidate() -> CandidateGame {
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
         CandidateGame {
@@ -1288,6 +1305,27 @@ mod tests {
         driver.poll_or_submit(addr(0)).await.unwrap();
 
         assert_zk_fallback_requested(&driver, &proof_requester);
+    }
+
+    #[tokio::test]
+    async fn tee_submit_retry_limit_drops_proof_without_zk_fallback() {
+        let (mut driver, proof_requester) =
+            driver_with_tx_manager(MockTxManager::with_responses(vec![
+                Err(TxManagerError::NonceTooLow),
+                Err(TxManagerError::NonceTooLow),
+            ]));
+        driver.tee_submit_retry_limit = 1;
+        insert_ready_tee_proof_without_fallback(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert_ready_tee_proof(&driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert!(!driver.pending_proofs.contains_key(&addr(0)));
+        let state = proof_requester.state.lock().unwrap();
+        assert!(state.prove_block_range_log.is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -48,6 +48,8 @@ pub struct DriverConfig {
     pub poll_interval: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
     pub max_proof_duration: Duration,
+    /// Retryable TEE submission failures to tolerate before falling back to ZK.
+    pub tee_submit_retry_limit: u32,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -123,6 +125,8 @@ where
     pub poll_interval: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
     pub max_proof_duration: Duration,
+    /// Retryable TEE submission failures to tolerate before falling back to ZK.
+    pub tee_submit_retry_limit: u32,
     /// Token used to signal graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -134,6 +138,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt
         f.debug_struct("Driver")
             .field("pending_proofs", &self.pending_proofs.len())
             .field("poll_interval", &self.poll_interval)
+            .field("tee_submit_retry_limit", &self.tee_submit_retry_limit)
             .finish_non_exhaustive()
     }
 }
@@ -156,6 +161,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             bond_manager: components.bond_manager,
             poll_interval: config.poll_interval,
             max_proof_duration: config.max_proof_duration,
+            tee_submit_retry_limit: config.tee_submit_retry_limit,
             cancel: config.cancel,
         }
     }
@@ -878,9 +884,33 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                         );
                     }
                     _ if targets_tee => {
+                        let Some(pending) = self.pending_proofs.get_mut(&game_address) else {
+                            return Ok(());
+                        };
+                        let has_zk_fallback = pending.kind.has_zk_fallback();
+
+                        if has_zk_fallback
+                            && pending.tee_submit_retry_count >= self.tee_submit_retry_limit
+                        {
+                            warn!(
+                                error = %e,
+                                game = %game_address,
+                                retry_count = pending.tee_submit_retry_count,
+                                retry_limit = self.tee_submit_retry_limit,
+                                "TEE dispute tx retry limit reached, falling back to ZK"
+                            );
+                            pending.phase = ProofPhase::NeedsRetry;
+                            return self.handle_proof_retry(game_address).await;
+                        }
+
+                        pending.tee_submit_retry_count =
+                            pending.tee_submit_retry_count.saturating_add(1);
                         warn!(
                             error = %e,
                             game = %game_address,
+                            retry_count = pending.tee_submit_retry_count,
+                            retry_limit = self.tee_submit_retry_limit,
+                            has_zk_fallback,
                             "TEE dispute tx failed, will retry next tick"
                         );
                         return Ok(());
@@ -971,6 +1001,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                     p.kind = ProofKind::Zk { prove_request: fallback_request.clone() };
                     p.intent = fallback_intent;
                     p.retry_count = 0;
+                    p.tee_submit_retry_count = 0;
                 }
 
                 fallback_request
@@ -1085,6 +1116,7 @@ mod tests {
             DriverConfig {
                 poll_interval: Duration::from_millis(10),
                 max_proof_duration: Duration::from_secs(60),
+                tee_submit_retry_limit: 3,
                 cancel: CancellationToken::new(),
             },
             components,
@@ -1122,6 +1154,7 @@ mod tests {
                 invalid_index: 0,
                 expected_root: B256::repeat_byte(0x22),
                 retry_count: 0,
+                tee_submit_retry_count: 0,
                 intent: DisputeIntent::Nullify,
             },
         );
@@ -1228,8 +1261,33 @@ mod tests {
         driver.poll_or_submit(addr(0)).await.unwrap();
 
         assert_ready_tee_proof(&driver);
+        let pending = driver.pending_proofs.get(&addr(0)).expect("pending proof should remain");
+        assert_eq!(pending.tee_submit_retry_count, 1);
         let state = proof_requester.state.lock().unwrap();
         assert!(state.prove_block_range_log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tee_submit_retry_limit_falls_back_to_zk() {
+        let (mut driver, proof_requester) =
+            driver_with_tx_manager(MockTxManager::with_responses(vec![
+                Err(TxManagerError::NonceTooLow),
+                Err(TxManagerError::NonceTooLow),
+            ]));
+        driver.tee_submit_retry_limit = 1;
+        insert_ready_tee_proof(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert_ready_tee_proof(&driver);
+        {
+            let state = proof_requester.state.lock().unwrap();
+            assert!(state.prove_block_range_log.is_empty());
+        }
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert_zk_fallback_requested(&driver, &proof_requester);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -25,10 +25,9 @@ pub enum ProofKind {
     /// A TEE (Trusted Execution Environment) attestation proof.
     ///
     /// Carries an optional pre-built ZK fallback request and intent so the
-    /// driver can initiate a ZK proof if the TEE transaction submission fails
-    /// on-chain. The fallback is `None` when building the ZK request failed
-    /// (e.g. `checkpoint_start_block` error); in that case the driver drops
-    /// the entry on TEE submission failure instead of falling back.
+    /// driver can initiate a ZK proof after TEE proof or submission failures.
+    /// The fallback is `None` when building the ZK request failed (e.g.
+    /// `checkpoint_start_block` error); in that case no ZK fallback is possible.
     Tee {
         /// Pre-built ZK request for fallback if TEE submission fails.
         /// `None` when the fallback request could not be constructed.
@@ -51,6 +50,11 @@ impl ProofKind {
     /// Returns `true` if this is a TEE proof.
     pub const fn is_tee(&self) -> bool {
         matches!(self, Self::Tee { .. })
+    }
+
+    /// Returns `true` if this proof has a complete ZK fallback request.
+    pub const fn has_zk_fallback(&self) -> bool {
+        matches!(self, Self::Tee { zk_fallback_request: Some(_), zk_fallback_intent: Some(_) })
     }
 }
 
@@ -102,6 +106,8 @@ pub struct PendingProof {
     pub expected_root: B256,
     /// Number of times this proof has been retried after failure.
     pub retry_count: u32,
+    /// Number of retryable TEE submission failures already retried for this ready proof.
+    pub tee_submit_retry_count: u32,
     /// The intended on-chain dispute action once the proof is ready.
     pub intent: DisputeIntent,
 }
@@ -121,6 +127,7 @@ impl PendingProof {
             invalid_index,
             expected_root,
             retry_count: 0,
+            tee_submit_retry_count: 0,
             intent,
         }
     }
@@ -139,6 +146,7 @@ impl PendingProof {
             invalid_index,
             expected_root,
             retry_count: 0,
+            tee_submit_retry_count: 0,
             intent: DisputeIntent::Nullify,
         }
     }
@@ -157,6 +165,7 @@ impl PendingProof {
             invalid_index,
             expected_root,
             retry_count: 0,
+            tee_submit_retry_count: 0,
             intent,
         }
     }

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -193,6 +193,7 @@ impl ChallengerService {
         let driver_config = DriverConfig {
             poll_interval: config.poll_interval,
             max_proof_duration: config.max_proof_duration,
+            tee_submit_retry_limit: config.tee_submit_retry_limit,
             cancel: cancel.child_token(),
         };
         let driver = Driver::new(

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -862,10 +862,9 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
 }
 
 #[tokio::test]
-async fn test_step_tee_submission_failure_falls_back_to_zk() {
-    // TEE proof succeeds but the on-chain nullify() tx fails.
-    // The driver should immediately fall back to a ZK proof instead of
-    // retrying the same TEE proof indefinitely.
+async fn test_step_tee_contract_revert_falls_back_to_zk() {
+    // TEE proof succeeds but the on-chain nullify() call reverts.
+    // Contract-level failures are proof-specific enough to fall back to ZK.
     let (l2, factory, root_15, root_20) = base_game_mocks();
 
     let verifier = single_game_verifier(MockGameState {
@@ -895,9 +894,12 @@ async fn test_step_tee_submission_failure_falls_back_to_zk() {
         }),
     });
 
-    // TEE nullify() tx fails (NonceTooLow), ZK challenge() tx succeeds.
+    // TEE nullify() tx reverts, ZK challenge() tx succeeds.
     let tx_manager = MockTxManager::with_responses(vec![
-        Err(TxManagerError::NonceTooLow),
+        Err(TxManagerError::ExecutionReverted {
+            reason: Some("unexpected contract revert".to_string()),
+            data: None,
+        }),
         Ok(receipt_with_status(true, DEFAULT_TX_HASH)),
     ]);
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -904,7 +904,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     ]);
 
     let mut driver = test_driver_with_tee(
-        factory,
+        Arc::clone(&factory),
         Arc::clone(&verifier),
         l2,
         zk,
@@ -944,15 +944,12 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
         state.proof_status = ProofStatus::Succeeded;
     }
 
-    // Simulate the on-chain effect of a successful challenge: game is
-    // resolved. This prevents the scanner from re-discovering the game
-    // after the pending proof is submitted in step 2.
-    verifier.update_game(
-        addr(0),
-        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
-    );
+    // Keep the game in-progress so the pending fallback proof reaches
+    // submit_dispute(), but remove it from the scan batch so the same tick
+    // cannot re-discover it after the successful fallback submission.
+    factory.games.lock().unwrap().clear();
 
-    // Step 3: ZK proof polled → Succeeded → entry cleaned up.
+    // Step 3: ZK proof polled → Succeeded → challenge tx submitted → entry cleaned up.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -87,6 +87,7 @@ fn test_driver_with_tee(
     let config = DriverConfig {
         poll_interval: Duration::from_millis(10),
         max_proof_duration: Duration::from_secs(4 * 60 * 60),
+        tee_submit_retry_limit: 3,
         cancel: CancellationToken::new(),
     };
 
@@ -389,6 +390,7 @@ async fn test_step_scan_error_propagated() {
     let config = DriverConfig {
         poll_interval: Duration::from_millis(10),
         max_proof_duration: Duration::from_secs(4 * 60 * 60),
+        tee_submit_retry_limit: 3,
         cancel: CancellationToken::new(),
     };
 


### PR DESCRIPTION
## Summary
- Keep ready TEE proofs in ReadyToSubmit when submission fails due to tx-manager or infrastructure errors like NonceTooLow, instead of burning the TEE attempt and starting a ZK proof.
- Continue falling back from TEE to ZK for proof or contract-level failures: InvalidSigner, mined tx reverts, and unknown ExecutionReverted errors.
- Preserve terminal known-revert behavior from #3745 for L1OriginTooOld, InvalidParentGame, GameAlreadyExists, and ProofAlreadyVerified.

## Value / Risk Addressed
- Prevents transient L1 tx submission problems from triggering expensive ZK proving work and delaying a dispute that already has a ready TEE proof.
- Reduces unnecessary prover-service load while retaining ZK fallback when retrying the TEE proof is unlikely to help.

## Tests
- cargo test -p base-challenger
- cargo clippy -p base-challenger --all-targets -- -D warnings