### PR TITLE
fix(proof): Improve Succinct Utility Tracing

### DIFF
--- a/crates/proof/succinct/utils/host/src/network.rs
+++ b/crates/proof/succinct/utils/host/src/network.rs
@@ -50,7 +50,7 @@ pub async fn get_network_signer(use_kms_requester: bool) -> Result<NetworkSigner
         let kms_key_arn = env::var("NETWORK_PRIVATE_KEY")
             .context("NETWORK_PRIVATE_KEY must be set when USE_KMS_REQUESTER is true")?;
         let signer = NetworkSigner::aws_kms(&kms_key_arn).await?;
-        tracing::info!("Using KMS requester with address: {:?}", signer.address());
+        tracing::info!(address = ?signer.address(), "using KMS requester");
 
         signer
     } else {
@@ -62,7 +62,7 @@ pub async fn get_network_signer(use_kms_requester: bool) -> Result<NetworkSigner
             "0x0000000000000000000000000000000000000000000000000000000000000001".to_string()
         });
         let signer = NetworkSigner::local(&private_key)?;
-        tracing::info!("Using local requester with address: {:?}", signer.address());
+        tracing::info!(address = ?signer.address(), "using local requester");
 
         signer
     };

--- a/crates/proof/succinct/utils/proof/src/lib.rs
+++ b/crates/proof/succinct/utils/proof/src/lib.rs
@@ -118,7 +118,7 @@ async fn cluster_proof_blocking(
     stdin: SP1Stdin,
     label: &str,
 ) -> Result<SP1ProofWithPublicValues> {
-    tracing::info!("Generating {label} proof via cluster");
+    tracing::info!(label = %label, "generating proof via cluster");
     let timeout_hours = timeout_secs.div_ceil(3600).max(1);
     let cluster_elf = ClusterElf::NewElf(elf.to_vec());
     let ProofRequestResults { proof, .. } = tokio::time::timeout(


### PR DESCRIPTION
The proof succinct utilities had a few tracing calls that embedded dynamic signer and proof-label values directly in log messages, which drifted from the repo's structured logging guidance.

This keeps the same events but moves those values into tracing fields with static messages. Validated with cargo +nightly fmt and cargo check -p base-proof-succinct-host-utils -p base-proof-succinct-proof-utils.