### PR TITLE
fix(cli): Remove Dead CLI Flags

### DIFF
--- a/bin/base/README.md
+++ b/bin/base/README.md
@@ -61,9 +61,6 @@ Useful sequencer-specific flags include:
 - `--conductor.binary-commit` uses the conductor binary commit endpoint.
 - `--flashblocks.port` selects the Flashblocks websocket port.
 
-`--sequencer.max-safe-lag` is currently accepted for CLI compatibility, but it is not enforced by
-the sequencer runtime.
-
 ## `base update`
 
 `base update` updates the installed `base` binary by running `baseup --bin base` against the same

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -45,9 +45,6 @@ impl CliMetrics {
     /// The advertised udp port via P2P.
     pub const P2P_ADVERTISE_UDP_PORT: &'static str = "base_node_advertise_udp";
 
-    /// The low-tide peer count.
-    pub const P2P_PEERS_LO: &'static str = "base_node_peers_lo";
-
     /// The high-tide peer count.
     pub const P2P_PEERS_HI: &'static str = "base_node_peers_hi";
 
@@ -108,7 +105,6 @@ impl CliMetrics {
                     Self::P2P_ADVERTISE_UDP_PORT,
                     p2p.advertise_udp_port.map_or_else(|| "auto".to_string(), |p| p.to_string())
                 ),
-                (Self::P2P_PEERS_LO, p2p.peers_lo.to_string()),
                 (Self::P2P_PEERS_HI, p2p.peers_hi.to_string()),
                 (Self::P2P_MAX_PENDING_OUTGOING, p2p.max_pending_outgoing.to_string()),
                 (Self::P2P_IDENTIFY_PEERSTORE_SIZE, p2p.identify_peerstore_size.to_string()),

--- a/crates/consensus/cli/src/p2p.rs
+++ b/crates/consensus/cli/src/p2p.rs
@@ -108,9 +108,6 @@ pub struct P2PNetworkArgs {
     /// UDP port to bind Discv5 to. Same as TCP port if left 0.
     #[arg(long = "p2p.listen.udp", default_value = "9223", env = "BASE_NODE_P2P_LISTEN_UDP_PORT")]
     pub listen_udp_port: u16,
-    /// Deprecated: accepted for backwards compatibility, but no longer used by the P2P stack.
-    #[arg(long = "p2p.peers.lo", default_value = "20", env = "BASE_NODE_P2P_PEERS_LO")]
-    pub peers_lo: u32,
     /// High-tide peer count. The node starts pruning peer connections slowly after reaching this
     /// number.
     #[arg(long = "p2p.peers.hi", default_value = "30", env = "BASE_NODE_P2P_PEERS_HI")]

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -18,16 +18,6 @@ pub struct SequencerArgs {
     )]
     pub stopped: bool,
 
-    /// Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
-    ///
-    /// Currently accepted by the CLI but not enforced by the sequencer runtime. Disabled if 0.
-    #[arg(
-        long = "sequencer.max-safe-lag",
-        default_value = "0",
-        env = "BASE_NODE_SEQUENCER_MAX_SAFE_LAG"
-    )]
-    pub max_safe_lag: u64,
-
     /// Number of L1 blocks to keep distance from the L1 head as a sequencer when picking an L1
     /// origin.
     #[arg(long = "sequencer.l1-confs", default_value = "4", env = "BASE_NODE_SEQUENCER_L1_CONFS")]


### PR DESCRIPTION
## Summary

This removes two Base-owned CLI flags that were accepted without functional effect: `--sequencer.max-safe-lag` and `--p2p.peers.lo`. Old invocations now fail fast as unknown arguments instead of staying parseable. The change also removes the stale README note and deletes the unused low-tide peer CLI metric.