### PR TITLE
chore(proof): dry-run review cleanup

### DIFF
--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -7,7 +7,7 @@ use base_prover_service_protocol::{
     ProofResult, ProofStatus, ZkProofResult, ZkVm,
 };
 use jsonrpsee::core::RpcResult;
-use tracing::{info, warn};
+use tracing::info;
 use uuid::Uuid;
 
 use crate::{
@@ -15,45 +15,13 @@ use crate::{
     server::{ProverServiceServer, internal, invalid_argument, not_found, record_rpc_result},
 };
 
-#[cfg(test)]
 fn execution_stats_from_metadata(metadata: &serde_json::Value) -> Option<ExecutionStats> {
-    is_dry_run_result_metadata(metadata).then_some(())?;
-    let stats = metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)?;
-    execution_stats_from_value(stats)
-}
-
-fn execution_stats_from_value(stats: &serde_json::Value) -> Option<ExecutionStats> {
-    Some(ExecutionStats {
-        total_instruction_cycles: stats.get("total_instruction_cycles")?.as_u64()?,
-        total_sp1_gas: stats.get("total_sp1_gas")?.as_u64()?,
-        cycle_tracker: serde_json::from_value(stats.get("cycle_tracker")?.clone()).ok()?,
-        witness_generation_ms: milliseconds_from_metadata(stats.get("witness_generation_ms")?)?,
-        execution_ms: milliseconds_from_metadata(stats.get("execution_ms")?)?,
-    })
-}
-
-fn is_dry_run_result_metadata(metadata: &serde_json::Value) -> bool {
     metadata
         .get(OP_SUCCINCT_DRY_RUN_METADATA_KEY)
         .and_then(serde_json::Value::as_bool)
         .unwrap_or_default()
-        && metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY).is_some()
-}
-
-fn milliseconds_from_metadata(value: &serde_json::Value) -> Option<u64> {
-    if let Some(milliseconds) = value.as_u64() {
-        return Some(milliseconds);
-    }
-
-    let milliseconds = value.as_f64()?;
-    if milliseconds.is_sign_negative()
-        || !milliseconds.is_finite()
-        || milliseconds > u64::MAX as f64
-    {
-        return None;
-    }
-
-    Some(milliseconds as u64)
+        .then_some(())?;
+    serde_json::from_value(metadata.get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)?.clone()).ok()
 }
 
 const fn should_use_dry_run_result(proof_req: &ProofRequest) -> bool {
@@ -75,51 +43,30 @@ impl ProverServiceServer {
     async fn dry_run_execution_stats_for_request(
         &self,
         proof_request_id: Uuid,
-    ) -> RpcResult<(bool, Option<ExecutionStats>)> {
+    ) -> RpcResult<Option<ExecutionStats>> {
         let sessions = self
             .repo
             .get_sessions_for_request(proof_request_id)
             .await
             .map_err(|e| internal(format!("Database error: {e}")))?;
 
-        let mut has_dry_run_result = false;
-        for metadata in sessions
+        Ok(sessions
             .iter()
             .filter(|session| session.status == DbSessionStatus::Completed)
             .filter_map(|session| session.metadata.as_ref())
-        {
-            if is_dry_run_result_metadata(metadata) {
-                has_dry_run_result = true;
-                if let Some(execution_stats) = metadata
-                    .get(OP_SUCCINCT_EXECUTION_STATS_METADATA_KEY)
-                    .and_then(execution_stats_from_value)
-                {
-                    return Ok((true, Some(execution_stats)));
-                }
-            }
-        }
-
-        Ok((has_dry_run_result, None))
+            .find_map(execution_stats_from_metadata))
     }
 
     async fn succeeded_result(&self, proof_req: ProofRequest) -> RpcResult<Option<ProofResult>> {
-        if should_use_dry_run_result(&proof_req) {
-            let (is_dry_run, execution_stats) =
-                self.dry_run_execution_stats_for_request(proof_req.id).await?;
-            if is_dry_run {
-                if execution_stats.is_none() {
-                    warn!(
-                        proof_request_id = %proof_req.id,
-                        "dry-run proof has no valid execution stats in session metadata"
-                    );
-                }
-
-                return Ok(Some(ProofResult::Compressed(ZkProofResult {
-                    zk_vm: ZkVm::Sp1,
-                    proof: Vec::new().into(),
-                    execution_stats,
-                })));
-            }
+        if should_use_dry_run_result(&proof_req)
+            && let Some(execution_stats) =
+                self.dry_run_execution_stats_for_request(proof_req.id).await?
+        {
+            return Ok(Some(ProofResult::Compressed(ZkProofResult {
+                zk_vm: ZkVm::Sp1,
+                proof: Vec::new().into(),
+                execution_stats: Some(execution_stats),
+            })));
         }
 
         let result = proof_req
@@ -236,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn dry_run_execution_stats_from_metadata_truncates_fractional_milliseconds() {
+    fn dry_run_execution_stats_from_metadata_rejects_fractional_milliseconds() {
         let metadata = metadata_with_execution_stats(serde_json::json!({
             "total_instruction_cycles": 100,
             "total_sp1_gas": 200,
@@ -247,10 +194,7 @@ mod tests {
             "execution_ms": 34.9
         }));
 
-        let stats = execution_stats_from_metadata(&metadata).expect("execution stats");
-
-        assert_eq!(stats.witness_generation_ms, 12);
-        assert_eq!(stats.execution_ms, 34);
+        assert!(execution_stats_from_metadata(&metadata).is_none());
     }
 
     #[test]
@@ -265,30 +209,6 @@ mod tests {
             "execution_ms": 34
         }));
 
-        assert!(execution_stats_from_metadata(&metadata).is_none());
-
-        let metadata = metadata_with_execution_stats(serde_json::json!({
-            "total_instruction_cycles": 100,
-            "total_sp1_gas": 200,
-            "cycle_tracker": {},
-            "witness_generation_ms": -12.5,
-            "execution_ms": 34.5
-        }));
-
-        assert!(execution_stats_from_metadata(&metadata).is_none());
-    }
-
-    #[test]
-    fn dry_run_result_metadata_accepts_malformed_stats_for_empty_result_compatibility() {
-        let metadata = metadata_with_execution_stats(serde_json::json!({
-            "total_instruction_cycles": "100",
-            "total_sp1_gas": 200,
-            "cycle_tracker": {},
-            "witness_generation_ms": 12,
-            "execution_ms": 34
-        }));
-
-        assert!(is_dry_run_result_metadata(&metadata));
         assert!(execution_stats_from_metadata(&metadata).is_none());
     }
 

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -32,7 +32,7 @@ macro_rules! backend_error {
 pub const DRY_RUN_PREFIX: &str = "dry-run-stark-";
 
 /// [`ZkProver`] that generates a witness and executes the range program locally.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DryRunZkProver {
     provider: OpSuccinctWitnessProvider,
     base_consensus_url: String,
@@ -40,17 +40,6 @@ pub struct DryRunZkProver {
     default_sequence_window: u64,
     range_cycle_limit: u64,
     completed_results: Arc<Mutex<HashMap<String, ProofResult>>>,
-}
-
-impl std::fmt::Debug for DryRunZkProver {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DryRunZkProver")
-            .field("base_consensus_url", &self.base_consensus_url)
-            .field("l1_node_url", &self.l1_node_url)
-            .field("default_sequence_window", &self.default_sequence_window)
-            .field("range_cycle_limit", &self.range_cycle_limit)
-            .finish_non_exhaustive()
-    }
 }
 
 impl DryRunZkProver {


### PR DESCRIPTION
## Summary
Simplify dry-run execution stats metadata parsing to use the protocol serde type directly

