### PR TITLE
feat(basectl): show confirmed activation-registry admin activity in upgrades view

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -7,6 +7,8 @@ use base_common_genesis::{
     BaseUpgradeConfig, ChainGenesis, FeeConfig, RollupConfig, SystemConfig, UpgradeConfig,
 };
 
+use crate::BaseUpgrade;
+
 /// Complete configuration for a Base chain
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChainConfig {
@@ -223,6 +225,27 @@ impl ChainConfig {
             763360 => Some(&ZERONET),
             _ => None,
         }
+    }
+
+    /// Returns the activation registry admin address seeded for a specific scheduled upgrade.
+    pub const fn activation_admin_address_for_upgrade_by_chain_id(
+        id: u64,
+        upgrade: BaseUpgrade,
+    ) -> Option<Address> {
+        match upgrade {
+            BaseUpgrade::Beryl | BaseUpgrade::Cobalt => {
+                Self::beryl_activation_admin_address_by_chain_id(id)
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns the activation registry admin address seeded for a specific scheduled upgrade.
+    pub const fn activation_admin_address_for_upgrade(
+        &self,
+        upgrade: BaseUpgrade,
+    ) -> Option<Address> {
+        Self::activation_admin_address_for_upgrade_by_chain_id(self.chain_id, upgrade)
     }
 
     /// Returns the Beryl activation registry admin address for built-in chains that need one.
@@ -641,5 +664,24 @@ mod tests {
         assert_eq!(ChainConfig::zeronet().upgrade_config().base.beryl, Some(1_782_349_188));
         assert_eq!(ChainConfig::zeronet().cobalt_timestamp, None);
         assert_eq!(ChainConfig::zeronet().upgrade_config().base.cobalt, None);
+    }
+
+    #[test]
+    fn generic_upgrade_admin_seed_matches_beryl_mapping() {
+        assert_eq!(
+            ChainConfig::activation_admin_address_for_upgrade_by_chain_id(8453, BaseUpgrade::Beryl),
+            ChainConfig::beryl_activation_admin_address_by_chain_id(8453)
+        );
+        assert_eq!(
+            ChainConfig::activation_admin_address_for_upgrade_by_chain_id(
+                8453,
+                BaseUpgrade::Cobalt
+            ),
+            ChainConfig::beryl_activation_admin_address_by_chain_id(8453)
+        );
+        assert_eq!(
+            ChainConfig::activation_admin_address_for_upgrade_by_chain_id(84532, BaseUpgrade::Azul),
+            None
+        );
     }
 }

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -83,7 +83,7 @@ impl ChainUpgrades {
         let Some(timestamp) = timestamp else { return };
         let Some(spec) = self.specs.iter_mut().find(|spec| spec.upgrade == upgrade) else {
             tracing::warn!(
-                chain = self.display_name,
+                chain = %self.display_name,
                 upgrade = ?upgrade,
                 "missing upgrade spec while applying upgrade timestamp"
             );
@@ -119,9 +119,22 @@ impl ChainUpgrades {
     }
 
     fn seeded_expected_admin(&self, now: u64) -> Option<(&'static str, Address)> {
-        let spec = self.next_scheduled_spec(now)?;
-        ChainConfig::activation_admin_address_for_upgrade_by_chain_id(self.chain_id, spec.upgrade)
-            .map(|admin| (spec.name, admin))
+        // Scan future specs in ascending timestamp order and return the first one whose upgrade
+        // has a known seeded admin. This way the panel stays informative even when the
+        // immediately-next upgrade (e.g. Azul) predates the activation-registry pattern.
+        self.specs
+            .iter()
+            .filter_map(|spec| {
+                spec.timestamp.filter(|&ts| ts > now).and_then(|ts| {
+                    ChainConfig::activation_admin_address_for_upgrade_by_chain_id(
+                        self.chain_id,
+                        spec.upgrade,
+                    )
+                    .map(|admin| (ts, spec.name, admin))
+                })
+            })
+            .min_by_key(|(ts, _, _)| *ts)
+            .map(|(_, name, admin)| (name, admin))
     }
 }
 
@@ -791,13 +804,16 @@ impl UpgradesView {
             return;
         };
 
+        // Preserve the scan position before reset_for_rpc can clear it on an RPC URL change,
+        // so the new watcher resumes from where the old one left off rather than rescanning
+        // from the current safe head.
+        let last_scanned_safe_block = self.admin_activity[chain_idx].last_scanned_safe_block;
         self.admin_activity[chain_idx].reset_for_rpc(&rpc_url);
 
         if self.admin_activity_watcher.needs_restart(chain_idx, &rpc_url) {
             self.admin_activity_watcher.stop(&mut self.admin_activity);
             self.admin_activity[chain_idx].status =
                 "Connecting to confirmed activity watcher…".to_string();
-            let last_scanned_safe_block = self.admin_activity[chain_idx].last_scanned_safe_block;
             self.admin_activity_watcher.start(chain_idx, rpc_url, last_scanned_safe_block);
         }
     }
@@ -1570,12 +1586,7 @@ fn fmt_activity_timestamp(ts: u64) -> String {
 }
 
 fn short_hash(hash: B256) -> String {
-    let value = format!("{hash:#x}");
-    if value.len() <= 18 {
-        value
-    } else {
-        format!("{}..{}", &value[..12], &value[value.len() - 4..])
-    }
+    truncate_hex(format!("{hash:#x}"), 12)
 }
 
 fn activation_feature_detail(feature: B256) -> String {
@@ -1728,19 +1739,44 @@ async fn run_admin_activity_streaming(
             return;
         }
 
-        let provider = match ProviderBuilder::new().connect(&rpc_url).await {
-            Ok(provider) => provider,
-            Err(error) => {
-                if tx
-                    .send(AdminActivityUpdate::Status(format!("RPC connection failed: {error}")))
-                    .await
-                    .is_err()
-                {
+        let provider = {
+            let url = match rpc_url.parse::<alloy_transport_http::reqwest::Url>() {
+                Ok(u) => u,
+                Err(error) => {
+                    if tx
+                        .send(AdminActivityUpdate::Status(format!("Invalid RPC URL: {error}")))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    // An invalid URL won't be fixed by retrying, so stop the loop.
                     return;
                 }
-                tokio::time::sleep(ADMIN_ACTIVITY_RETRY_DELAY).await;
-                continue;
-            }
+            };
+            let http_client = match alloy_transport_http::reqwest::Client::builder()
+                .timeout(Duration::from_secs(12))
+                .build()
+            {
+                Ok(c) => c,
+                Err(error) => {
+                    if tx
+                        .send(AdminActivityUpdate::Status(format!(
+                            "RPC connection failed: {error}"
+                        )))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    tokio::time::sleep(ADMIN_ACTIVITY_RETRY_DELAY).await;
+                    continue;
+                }
+            };
+            let transport = alloy_transport_http::Http::with_client(http_client, url);
+            ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .connect_client(alloy_rpc_client::RpcClient::new(transport, false))
         };
 
         let live_admin_client = make_rpc_client(&rpc_url)
@@ -1926,13 +1962,17 @@ fn decode_rpc_bytes(value: &str) -> Result<Vec<u8>, String> {
     hex::decode(value.trim_start_matches("0x")).map_err(|e| format!("invalid hex response: {e}"))
 }
 
-fn short_address(address: Address) -> String {
-    let value = address.to_string();
-    if value.len() <= 14 {
+fn truncate_hex(value: String, prefix_len: usize) -> String {
+    const SUFFIX_LEN: usize = 4;
+    if value.len() <= prefix_len + 2 + SUFFIX_LEN {
         value
     } else {
-        format!("{}..{}", &value[..10], &value[value.len() - 4..])
+        format!("{}..{}", &value[..prefix_len], &value[value.len() - SUFFIX_LEN..])
     }
+}
+
+fn short_address(address: Address) -> String {
+    truncate_hex(address.to_string(), 10)
 }
 
 async fn activation_admin(client: &HttpClient) -> Result<Address, String> {
@@ -2620,7 +2660,8 @@ mod tests {
     }
 
     #[test]
-    fn seeded_expected_admin_uses_next_scheduled_upgrade() {
+    fn seeded_expected_admin_skips_upgrades_without_known_admin() {
+        // Azul has no seeded admin; seeded_expected_admin should look past it to Cobalt.
         let chain = ChainUpgrades {
             display_name: "Mainnet",
             chain_id: ChainConfig::mainnet().chain_id,
@@ -2630,14 +2671,16 @@ mod tests {
                 UpgradeSpec { upgrade: BaseUpgrade::Cobalt, name: "Cobalt", timestamp: Some(30) },
             ],
         };
+        let cobalt_admin = ChainConfig::mainnet()
+            .activation_admin_address_for_upgrade(BaseUpgrade::Cobalt)
+            .map(|admin| ("Cobalt", admin));
 
-        assert_eq!(chain.seeded_expected_admin(10), None);
-        assert_eq!(
-            chain.seeded_expected_admin(25),
-            ChainConfig::mainnet()
-                .activation_admin_address_for_upgrade(BaseUpgrade::Cobalt)
-                .map(|admin| ("Cobalt", admin))
-        );
+        // When Azul is next but has no seeded admin, Cobalt's admin is surfaced instead.
+        assert_eq!(chain.seeded_expected_admin(10), cobalt_admin);
+        // Once Azul has activated, Cobalt is the next with a known admin.
+        assert_eq!(chain.seeded_expected_admin(25), cobalt_admin);
+        // Once all future upgrades have passed, nothing is returned.
+        assert_eq!(chain.seeded_expected_admin(35), None);
     }
 
     #[test]

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -804,14 +804,13 @@ impl UpgradesView {
             return;
         };
 
-        // Preserve the scan position before reset_for_rpc can clear it on an RPC URL change,
-        // so the new watcher resumes from where the old one left off rather than rescanning
-        // from the current safe head.
-        let last_scanned_safe_block = self.admin_activity[chain_idx].last_scanned_safe_block;
         self.admin_activity[chain_idx].reset_for_rpc(&rpc_url);
 
         if self.admin_activity_watcher.needs_restart(chain_idx, &rpc_url) {
             self.admin_activity_watcher.stop(&mut self.admin_activity);
+            // Capture scan position *after* stop() has drained remaining channel
+            // messages, so we don't regress to a stale value.
+            let last_scanned_safe_block = self.admin_activity[chain_idx].last_scanned_safe_block;
             self.admin_activity[chain_idx].status =
                 "Connecting to confirmed activity watcher…".to_string();
             self.admin_activity_watcher.start(chain_idx, rpc_url, last_scanned_safe_block);

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -81,11 +81,14 @@ struct ChainUpgrades {
 impl ChainUpgrades {
     fn set_timestamp(&mut self, upgrade: BaseUpgrade, timestamp: Option<u64>) {
         let Some(timestamp) = timestamp else { return };
-        let spec = self
-            .specs
-            .iter_mut()
-            .find(|spec| spec.upgrade == upgrade)
-            .unwrap_or_else(|| panic!("missing upgrade spec for {upgrade:?}"));
+        let Some(spec) = self.specs.iter_mut().find(|spec| spec.upgrade == upgrade) else {
+            tracing::warn!(
+                chain = self.display_name,
+                upgrade = ?upgrade,
+                "missing upgrade spec while applying upgrade timestamp"
+            );
+            return;
+        };
         spec.timestamp = Some(timestamp);
     }
 
@@ -1737,7 +1740,18 @@ async fn run_admin_activity_streaming(
             }
         };
 
-        let live_admin_status = match send_safe_live_admin_update(&tx, &rpc_url).await {
+        let live_admin_client = match make_rpc_client(&rpc_url) {
+            Ok(client) => (Some(client), None),
+            Err(error) => (None, Some(format!("live-admin client build failed: {error}"))),
+        };
+
+        let live_admin_status = match send_safe_live_admin_update(
+            &tx,
+            live_admin_client.0.as_ref(),
+            live_admin_client.1.as_deref(),
+        )
+        .await
+        {
             Ok(status) => status,
             Err(()) => return,
         };
@@ -1799,7 +1813,13 @@ async fn run_admin_activity_streaming(
                 {
                     return;
                 }
-                let reset_status = match send_safe_live_admin_update(&tx, &rpc_url).await {
+                let reset_status = match send_safe_live_admin_update(
+                    &tx,
+                    live_admin_client.0.as_ref(),
+                    live_admin_client.1.as_deref(),
+                )
+                .await
+                {
                     Ok(Some(detail)) => {
                         format!(
                             "Safe head moved backwards; resetting confirmed activity cache. {detail}"
@@ -1930,10 +1950,8 @@ async fn activation_admin(client: &HttpClient) -> Result<Address, String> {
     activation_admin_at_tag(client, "latest").await
 }
 
-async fn fetch_safe_live_admin(rpc_url: &str) -> Result<Option<Address>, String> {
-    let client = make_rpc_client(rpc_url)
-        .map_err(|error| format!("live-admin client build failed: {error}"))?;
-    activation_admin_at_tag(&client, "safe")
+async fn fetch_safe_live_admin(client: &HttpClient) -> Result<Option<Address>, String> {
+    activation_admin_at_tag(client, "safe")
         .await
         .map(|admin| (!admin.is_zero()).then_some(admin))
         .map_err(|error| format!("safe live-admin query failed: {error}"))
@@ -1941,9 +1959,14 @@ async fn fetch_safe_live_admin(rpc_url: &str) -> Result<Option<Address>, String>
 
 async fn send_safe_live_admin_update(
     tx: &mpsc::Sender<AdminActivityUpdate>,
-    rpc_url: &str,
+    client: Option<&HttpClient>,
+    unavailable_reason: Option<&str>,
 ) -> Result<Option<String>, ()> {
-    match fetch_safe_live_admin(rpc_url).await {
+    let Some(client) = client else {
+        let detail = unavailable_reason.unwrap_or("live-admin client unavailable");
+        return Ok(Some(format!("Live admin unavailable: {detail}")));
+    };
+    match fetch_safe_live_admin(client).await {
         Ok(admin) => {
             if tx.send(AdminActivityUpdate::LiveAdmin(admin)).await.is_err() {
                 return Err(());
@@ -2627,6 +2650,27 @@ mod tests {
                 .activation_admin_address_for_upgrade(BaseUpgrade::Cobalt)
                 .map(|admin| ("Cobalt", admin))
         );
+    }
+
+    #[test]
+    fn missing_upgrade_spec_does_not_panic_when_applying_timestamp() {
+        let mut chain = ChainUpgrades {
+            display_name: "Mainnet",
+            chain_id: ChainConfig::mainnet().chain_id,
+            rpc: None,
+            specs: vec![UpgradeSpec {
+                upgrade: BaseUpgrade::Azul,
+                name: "Azul",
+                timestamp: Some(10),
+            }],
+        };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            chain.set_timestamp(BaseUpgrade::Beryl, Some(20));
+        }));
+
+        assert!(result.is_ok());
+        assert_eq!(chain.specs[0].timestamp, Some(10));
     }
 
     #[test]

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -465,11 +465,7 @@ impl AdminActivityChainState {
 #[derive(Debug)]
 enum AdminActivityUpdate {
     Reset(String),
-    ProcessedBlock {
-        block_number: u64,
-        entries: Vec<AdminActivityEntry>,
-        live_admin: Option<Address>,
-    },
+    ProcessedBlock { entries: Vec<AdminActivityEntry>, live_admin: Option<Address> },
     LiveAdmin(Option<Address>),
     LastScannedSafeBlock(u64),
     Status(String),
@@ -522,8 +518,9 @@ impl AdminActivityWatcher {
                     state.clear();
                     state.status = status;
                 }
-                Ok(AdminActivityUpdate::ProcessedBlock { block_number, entries, live_admin }) => {
+                Ok(AdminActivityUpdate::ProcessedBlock { entries, live_admin }) => {
                     let state = &mut states[chain_idx];
+                    let last_processed_block = entries.iter().map(|entry| entry.block_number).max();
                     for entry in entries.into_iter().rev() {
                         state.entries.push_front(entry);
                     }
@@ -533,7 +530,13 @@ impl AdminActivityWatcher {
                     if let Some(admin) = live_admin {
                         state.live_admin = Some(admin);
                     }
-                    state.last_scanned_safe_block = Some(block_number);
+                    if let Some(block_number) = last_processed_block {
+                        state.last_scanned_safe_block = Some(
+                            state
+                                .last_scanned_safe_block
+                                .map_or(block_number, |current| current.max(block_number)),
+                        );
+                    }
                 }
                 Ok(AdminActivityUpdate::LiveAdmin(admin)) => {
                     states[chain_idx].live_admin = admin;
@@ -1740,18 +1743,10 @@ async fn run_admin_activity_streaming(
             }
         };
 
-        let live_admin_client = match make_rpc_client(&rpc_url) {
-            Ok(client) => (Some(client), None),
-            Err(error) => (None, Some(format!("live-admin client build failed: {error}"))),
-        };
+        let live_admin_client = make_rpc_client(&rpc_url)
+            .map_err(|error| format!("live-admin client build failed: {error}"));
 
-        let live_admin_status = match send_safe_live_admin_update(
-            &tx,
-            live_admin_client.0.as_ref(),
-            live_admin_client.1.as_deref(),
-        )
-        .await
-        {
+        let live_admin_status = match send_safe_live_admin_update(&tx, &live_admin_client).await {
             Ok(status) => status,
             Err(()) => return,
         };
@@ -1813,12 +1808,7 @@ async fn run_admin_activity_streaming(
                 {
                     return;
                 }
-                let reset_status = match send_safe_live_admin_update(
-                    &tx,
-                    live_admin_client.0.as_ref(),
-                    live_admin_client.1.as_deref(),
-                )
-                .await
+                let reset_status = match send_safe_live_admin_update(&tx, &live_admin_client).await
                 {
                     Ok(Some(detail)) => {
                         format!(
@@ -1880,14 +1870,14 @@ async fn run_admin_activity_streaming(
                         live_admin_update = Some(admin);
                     }
                 }
-                if tx
-                    .send(AdminActivityUpdate::ProcessedBlock {
-                        block_number: next_block,
-                        entries: block_entries,
-                        live_admin: live_admin_update,
-                    })
-                    .await
-                    .is_err()
+                if !block_entries.is_empty()
+                    && tx
+                        .send(AdminActivityUpdate::ProcessedBlock {
+                            entries: block_entries,
+                            live_admin: live_admin_update,
+                        })
+                        .await
+                        .is_err()
                 {
                     return;
                 }
@@ -1896,8 +1886,7 @@ async fn run_admin_activity_streaming(
                 next_block += 1;
             }
 
-            let scanned = last_safe_block.unwrap_or(safe_number);
-            if tx.send(AdminActivityUpdate::LastScannedSafeBlock(scanned)).await.is_err() {
+            if tx.send(AdminActivityUpdate::LastScannedSafeBlock(scan_end)).await.is_err() {
                 return;
             }
         }
@@ -1959,12 +1948,11 @@ async fn fetch_safe_live_admin(client: &HttpClient) -> Result<Option<Address>, S
 
 async fn send_safe_live_admin_update(
     tx: &mpsc::Sender<AdminActivityUpdate>,
-    client: Option<&HttpClient>,
-    unavailable_reason: Option<&str>,
+    client: &Result<HttpClient, String>,
 ) -> Result<Option<String>, ()> {
-    let Some(client) = client else {
-        let detail = unavailable_reason.unwrap_or("live-admin client unavailable");
-        return Ok(Some(format!("Live admin unavailable: {detail}")));
+    let client = match client {
+        Ok(client) => client,
+        Err(error) => return Ok(Some(format!("Live admin unavailable: {error}"))),
     };
     match fetch_safe_live_admin(client).await {
         Ok(admin) => {
@@ -2700,10 +2688,9 @@ mod tests {
     }
 
     #[test]
-    fn processed_block_update_advances_progress_with_entries() {
+    fn processed_block_update_advances_progress_before_batch_end() {
         let (tx, rx) = mpsc::channel(1);
         tx.try_send(AdminActivityUpdate::ProcessedBlock {
-            block_number: 42,
             entries: vec![AdminActivityEntry {
                 block_number: 42,
                 timestamp: 1_725_000_000,
@@ -2727,6 +2714,19 @@ mod tests {
         watcher.poll(&mut states);
 
         assert_eq!(states[0].last_scanned_safe_block, Some(42));
+        assert_eq!(
+            states[0].live_admin,
+            Some(address!("2222222222222222222222222222222222222222"))
+        );
+        assert_eq!(states[0].entries.len(), 1);
+        assert_eq!(states[0].entries[0].block_number, 42);
+
+        tx.try_send(AdminActivityUpdate::LastScannedSafeBlock(45))
+            .expect("progress update fits in channel");
+
+        watcher.poll(&mut states);
+
+        assert_eq!(states[0].last_scanned_safe_block, Some(45));
         assert_eq!(
             states[0].live_admin,
             Some(address!("2222222222222222222222222222222222222222"))

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -1,7 +1,7 @@
 //! Network upgrade activation countdown and history view.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -1663,43 +1663,45 @@ where
         .ok_or_else(|| format!("block {block_number} not found"))
 }
 
-async fn fetch_admin_activity_for_block<P>(
+async fn fetch_admin_activity_for_range<P>(
     provider: &P,
-    block_number: u64,
-) -> Result<Vec<(AdminActivityEntry, Option<Address>)>, String>
+    start_block: u64,
+    end_block: u64,
+) -> Result<BTreeMap<u64, Vec<(AdminActivityEntry, Option<Address>)>>, String>
 where
     P: Provider + ?Sized,
 {
     let filter = Filter::new()
         .address(ActivationRegistryStorage::ADDRESS)
-        .from_block(block_number)
-        .to_block(block_number);
+        .from_block(start_block)
+        .to_block(end_block);
     let logs = provider.get_logs(&filter).await.map_err(|error| error.to_string())?;
     if logs.is_empty() {
-        return Ok(Vec::new());
+        return Ok(BTreeMap::new());
     }
 
-    let mut fallback_timestamp = None;
-    let mut entries = Vec::new();
+    let mut fallback_timestamps = HashMap::new();
+    let mut entries_by_block = BTreeMap::new();
     for log in logs.iter().filter(|log| !log.removed) {
+        let block_number = log.block_number.unwrap_or(start_block);
         let timestamp = if let Some(timestamp) = log.block_timestamp {
             timestamp
         } else {
-            match fallback_timestamp {
+            match fallback_timestamps.get(&block_number).copied() {
                 Some(timestamp) => timestamp,
                 None => {
                     let timestamp = fetch_block_timestamp(provider, block_number).await?;
-                    fallback_timestamp = Some(timestamp);
+                    fallback_timestamps.insert(block_number, timestamp);
                     timestamp
                 }
             }
         };
         if let Some(entry) = decode_admin_activity_log(log, block_number, timestamp) {
-            entries.push(entry);
+            entries_by_block.entry(block_number).or_insert_with(Vec::new).push(entry);
         }
     }
 
-    Ok(entries)
+    Ok(entries_by_block)
 }
 
 async fn run_admin_activity_streaming(
@@ -1827,23 +1829,28 @@ async fn run_admin_activity_streaming(
                 None => safe_number,
             };
             let scan_end = admin_activity_scan_end(next_block, safe_number);
-
-            while next_block <= scan_end {
-                let entries = match fetch_admin_activity_for_block(&provider, next_block).await {
-                    Ok(entries) => entries,
-                    Err(error) => {
-                        if tx
+            let mut entries_by_block = match fetch_admin_activity_for_range(
+                &provider, next_block, scan_end,
+            )
+            .await
+            {
+                Ok(entries_by_block) => entries_by_block,
+                Err(error) => {
+                    if tx
                             .send(AdminActivityUpdate::Status(format!(
-                                "Confirmed activity query failed for block {next_block}: {error}"
+                                "Confirmed activity query failed for blocks {next_block}-{scan_end}: {error}"
                             )))
                             .await
                             .is_err()
                         {
                             return;
                         }
-                        break 'watch;
-                    }
-                };
+                    break 'watch;
+                }
+            };
+
+            while next_block <= scan_end {
+                let entries = entries_by_block.remove(&next_block).unwrap_or_default();
 
                 let mut block_entries = Vec::with_capacity(entries.len());
                 let mut live_admin_update = None;

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -1,13 +1,15 @@
 //! Network upgrade activation countdown and history view.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use alloy_primitives::{Address, B256, hex};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::{BlockNumberOrTag, Filter};
 use alloy_sol_types::SolCall;
-use base_common_chains::ChainConfig;
+use base_common_chains::{BaseUpgrade, ChainConfig};
 use base_common_genesis::UpgradeConfig;
 use base_common_precompiles::{ActivationFeature, ActivationRegistryStorage, IActivationRegistry};
 use chrono::{DateTime, Utc};
@@ -60,6 +62,7 @@ const fn colon_row(r: usize) -> &'static str {
 
 #[derive(Debug)]
 struct UpgradeSpec {
+    upgrade: BaseUpgrade,
     name: &'static str,
     timestamp: Option<u64>,
 }
@@ -67,6 +70,7 @@ struct UpgradeSpec {
 #[derive(Debug)]
 struct ChainUpgrades {
     display_name: &'static str,
+    chain_id: u64,
     /// RPC URL for this chain, loaded from `~/.config/base/networks/{name}.yaml` at startup.
     /// Falls back to a hardcoded public URL only for mainnet and sepolia.
     /// `None` for internal networks (zeronet, devnet) when no user config is present.
@@ -75,40 +79,98 @@ struct ChainUpgrades {
 }
 
 impl ChainUpgrades {
-    fn set_timestamp(&mut self, name: &'static str, timestamp: Option<u64>) {
+    fn set_timestamp(&mut self, upgrade: BaseUpgrade, timestamp: Option<u64>) {
         let Some(timestamp) = timestamp else { return };
-        if let Some(spec) = self.specs.iter_mut().find(|spec| spec.name == name) {
-            spec.timestamp = Some(timestamp);
-        }
+        let spec = self
+            .specs
+            .iter_mut()
+            .find(|spec| spec.upgrade == upgrade)
+            .unwrap_or_else(|| panic!("missing upgrade spec for {upgrade:?}"));
+        spec.timestamp = Some(timestamp);
     }
 
     fn apply_upgrades(&mut self, upgrades: &UpgradeConfig) {
-        self.set_timestamp("Delta", upgrades.delta_time);
-        self.set_timestamp("Canyon", upgrades.canyon_time);
-        self.set_timestamp("Ecotone", upgrades.ecotone_time);
-        self.set_timestamp("Fjord", upgrades.fjord_time);
-        self.set_timestamp("Granite", upgrades.granite_time);
-        self.set_timestamp("Holocene", upgrades.holocene_time);
-        self.set_timestamp("Isthmus", upgrades.isthmus_time);
-        self.set_timestamp("Jovian", upgrades.jovian_time);
-        self.set_timestamp("Azul", upgrades.base.azul);
-        self.set_timestamp("Beryl", upgrades.base.beryl);
+        self.set_timestamp(BaseUpgrade::Delta, upgrades.delta_time);
+        self.set_timestamp(BaseUpgrade::Canyon, upgrades.canyon_time);
+        self.set_timestamp(BaseUpgrade::Ecotone, upgrades.ecotone_time);
+        self.set_timestamp(BaseUpgrade::Fjord, upgrades.fjord_time);
+        self.set_timestamp(BaseUpgrade::Granite, upgrades.granite_time);
+        self.set_timestamp(BaseUpgrade::Holocene, upgrades.holocene_time);
+        self.set_timestamp(BaseUpgrade::Isthmus, upgrades.isthmus_time);
+        self.set_timestamp(BaseUpgrade::Jovian, upgrades.jovian_time);
+        self.set_timestamp(BaseUpgrade::Azul, upgrades.base.azul);
+        self.set_timestamp(BaseUpgrade::Beryl, upgrades.base.beryl);
+        self.set_timestamp(BaseUpgrade::Cobalt, upgrades.base.cobalt);
+    }
+
+    fn next_scheduled_spec(&self, now: u64) -> Option<&UpgradeSpec> {
+        self.specs
+            .iter()
+            .filter_map(|spec| {
+                spec.timestamp
+                    .filter(|&timestamp| timestamp > now)
+                    .map(|timestamp| (spec, timestamp))
+            })
+            .min_by_key(|(_, timestamp)| *timestamp)
+            .map(|(spec, _)| spec)
+    }
+
+    fn seeded_expected_admin(&self, now: u64) -> Option<(&'static str, Address)> {
+        let spec = self.next_scheduled_spec(now)?;
+        ChainConfig::activation_admin_address_for_upgrade_by_chain_id(self.chain_id, spec.upgrade)
+            .map(|admin| (spec.name, admin))
     }
 }
 
 fn specs_from_config(cfg: &ChainConfig) -> Vec<UpgradeSpec> {
     vec![
-        UpgradeSpec { name: "Delta", timestamp: Some(cfg.delta_timestamp) },
-        UpgradeSpec { name: "Canyon", timestamp: Some(cfg.canyon_timestamp) },
-        UpgradeSpec { name: "Ecotone", timestamp: Some(cfg.ecotone_timestamp) },
-        UpgradeSpec { name: "Fjord", timestamp: Some(cfg.fjord_timestamp) },
-        UpgradeSpec { name: "Granite", timestamp: Some(cfg.granite_timestamp) },
-        UpgradeSpec { name: "Holocene", timestamp: Some(cfg.holocene_timestamp) },
-        UpgradeSpec { name: "Isthmus", timestamp: Some(cfg.isthmus_timestamp) },
-        UpgradeSpec { name: "Jovian", timestamp: Some(cfg.jovian_timestamp) },
-        UpgradeSpec { name: "Azul", timestamp: cfg.azul_timestamp },
-        UpgradeSpec { name: "Beryl", timestamp: cfg.beryl_timestamp },
-        UpgradeSpec { name: "Cobalt", timestamp: cfg.cobalt_timestamp },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Delta,
+            name: "Delta",
+            timestamp: Some(cfg.delta_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Canyon,
+            name: "Canyon",
+            timestamp: Some(cfg.canyon_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Ecotone,
+            name: "Ecotone",
+            timestamp: Some(cfg.ecotone_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Fjord,
+            name: "Fjord",
+            timestamp: Some(cfg.fjord_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Granite,
+            name: "Granite",
+            timestamp: Some(cfg.granite_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Holocene,
+            name: "Holocene",
+            timestamp: Some(cfg.holocene_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Isthmus,
+            name: "Isthmus",
+            timestamp: Some(cfg.isthmus_timestamp),
+        },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Jovian,
+            name: "Jovian",
+            timestamp: Some(cfg.jovian_timestamp),
+        },
+        UpgradeSpec { upgrade: BaseUpgrade::Azul, name: "Azul", timestamp: cfg.azul_timestamp },
+        UpgradeSpec { upgrade: BaseUpgrade::Beryl, name: "Beryl", timestamp: cfg.beryl_timestamp },
+        UpgradeSpec {
+            upgrade: BaseUpgrade::Cobalt,
+            name: "Cobalt",
+            timestamp: cfg.cobalt_timestamp,
+        },
     ]
 }
 
@@ -135,22 +197,26 @@ fn all_chains() -> [ChainUpgrades; 4] {
     [
         ChainUpgrades {
             display_name: "Devnet",
+            chain_id: ChainConfig::devnet().chain_id,
             rpc: user_config_rpc("devnet").or_else(|| Some(devnet_rpc())),
             specs: specs_from_config(ChainConfig::devnet()),
         },
         ChainUpgrades {
             display_name: "Zeronet",
+            chain_id: ChainConfig::zeronet().chain_id,
             rpc: user_config_rpc("zeronet"),
             specs: specs_from_config(ChainConfig::zeronet()),
         },
         ChainUpgrades {
             display_name: "Sepolia",
+            chain_id: ChainConfig::sepolia().chain_id,
             rpc: user_config_rpc("sepolia")
                 .or_else(|| Some("https://sepolia.base.org".to_string())),
             specs: specs_from_config(ChainConfig::sepolia()),
         },
         ChainUpgrades {
             display_name: "Mainnet",
+            chain_id: ChainConfig::mainnet().chain_id,
             rpc: user_config_rpc("mainnet")
                 .or_else(|| Some("https://mainnet.base.org".to_string())),
             specs: specs_from_config(ChainConfig::mainnet()),
@@ -353,6 +419,139 @@ impl ChecksPanel {
     }
 }
 
+const MAX_ADMIN_ACTIVITY_ENTRIES: usize = 32;
+const MAX_ADMIN_ACTIVITY_BLOCKS_PER_POLL: u64 = 64;
+const ADMIN_ACTIVITY_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const ADMIN_ACTIVITY_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone)]
+struct AdminActivityEntry {
+    block_number: u64,
+    timestamp: u64,
+    tx_hash: B256,
+    caller: Address,
+    action: &'static str,
+    detail: String,
+}
+
+#[derive(Debug, Default)]
+struct AdminActivityChainState {
+    watched_rpc_url: String,
+    entries: VecDeque<AdminActivityEntry>,
+    live_admin: Option<Address>,
+    last_scanned_safe_block: Option<u64>,
+    status: String,
+}
+
+impl AdminActivityChainState {
+    fn reset_for_rpc(&mut self, rpc_url: &str) {
+        if self.watched_rpc_url == rpc_url {
+            return;
+        }
+        self.clear();
+        self.watched_rpc_url = rpc_url.to_string();
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.live_admin = None;
+        self.last_scanned_safe_block = None;
+    }
+}
+
+#[derive(Debug)]
+enum AdminActivityUpdate {
+    Reset(String),
+    ProcessedBlock {
+        block_number: u64,
+        entries: Vec<AdminActivityEntry>,
+        live_admin: Option<Address>,
+    },
+    LiveAdmin(Option<Address>),
+    LastScannedSafeBlock(u64),
+    Status(String),
+}
+
+#[derive(Debug, Default)]
+struct AdminActivityWatcher {
+    chain_idx: Option<usize>,
+    rpc_url: String,
+    rx: Option<mpsc::Receiver<AdminActivityUpdate>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl AdminActivityWatcher {
+    fn start(&mut self, chain_idx: usize, rpc_url: String, last_scanned_safe_block: Option<u64>) {
+        let (tx, rx) = mpsc::channel(64);
+        debug_assert!(self.handle.is_none());
+        debug_assert!(self.rx.is_none());
+        self.chain_idx = Some(chain_idx);
+        self.rpc_url = rpc_url.clone();
+        self.rx = Some(rx);
+        self.handle =
+            Some(tokio::spawn(run_admin_activity_streaming(rpc_url, last_scanned_safe_block, tx)));
+    }
+
+    fn stop(&mut self, states: &mut [AdminActivityChainState; 4]) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+        self.poll(states);
+        self.chain_idx = None;
+        self.rpc_url.clear();
+        self.rx = None;
+    }
+
+    fn needs_restart(&self, chain_idx: usize, rpc_url: &str) -> bool {
+        self.chain_idx != Some(chain_idx)
+            || self.rpc_url != rpc_url
+            || self.handle.as_ref().is_some_and(tokio::task::JoinHandle::is_finished)
+    }
+
+    fn poll(&mut self, states: &mut [AdminActivityChainState; 4]) {
+        let Some(chain_idx) = self.chain_idx else { return };
+        let Some(ref mut rx) = self.rx else { return };
+
+        loop {
+            match rx.try_recv() {
+                Ok(AdminActivityUpdate::Reset(status)) => {
+                    let state = &mut states[chain_idx];
+                    state.clear();
+                    state.status = status;
+                }
+                Ok(AdminActivityUpdate::ProcessedBlock { block_number, entries, live_admin }) => {
+                    let state = &mut states[chain_idx];
+                    for entry in entries.into_iter().rev() {
+                        state.entries.push_front(entry);
+                    }
+                    while state.entries.len() > MAX_ADMIN_ACTIVITY_ENTRIES {
+                        state.entries.pop_back();
+                    }
+                    if let Some(admin) = live_admin {
+                        state.live_admin = Some(admin);
+                    }
+                    state.last_scanned_safe_block = Some(block_number);
+                }
+                Ok(AdminActivityUpdate::LiveAdmin(admin)) => {
+                    states[chain_idx].live_admin = admin;
+                }
+                Ok(AdminActivityUpdate::LastScannedSafeBlock(block_number)) => {
+                    states[chain_idx].last_scanned_safe_block = Some(block_number);
+                }
+                Ok(AdminActivityUpdate::Status(status)) => {
+                    states[chain_idx].status = status;
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    states[chain_idx].status = "Confirmed activity watcher stopped.".to_string();
+                    self.rx = None;
+                    break;
+                }
+            }
+        }
+    }
+}
+
 // ── Color zones ───────────────────────────────────────────────────────────────
 
 const SECS_PER_MINUTE: u64 = 60;
@@ -400,12 +599,18 @@ fn now_unix() -> u64 {
 }
 
 fn fmt_timestamp(ts: u64) -> String {
+    fmt_timestamp_with(ts, "%Y-%m-%d %H:%M UTC", "genesis")
+}
+
+fn fmt_timestamp_with(ts: u64, format: &str, zero_label: &str) -> String {
     if ts == 0 {
-        return "genesis".to_string();
+        return zero_label.to_string();
     }
-    DateTime::<Utc>::from_timestamp(ts as i64, 0)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
-        .unwrap_or_else(|| "-".to_string())
+    i64::try_from(ts)
+        .ok()
+        .and_then(|seconds| DateTime::<Utc>::from_timestamp(seconds, 0))
+        .map(|dt| dt.format(format).to_string())
+        .unwrap_or_else(|| ts.to_string())
 }
 
 fn fmt_elapsed(elapsed_secs: u64) -> String {
@@ -461,6 +666,8 @@ pub struct UpgradesView {
     selected_check_upgrades: [Option<&'static str>; 4],
     tick_count: u64,
     checks: ChecksPanel,
+    admin_activity: [AdminActivityChainState; 4],
+    admin_activity_watcher: AdminActivityWatcher,
     /// When true, re-run the activation checks on the configured cadence
     /// without requiring the user to press [r].
     auto_refresh: bool,
@@ -492,6 +699,8 @@ impl UpgradesView {
                 handle: None,
                 last_run_at: None,
             },
+            admin_activity: std::array::from_fn(|_| AdminActivityChainState::default()),
+            admin_activity_watcher: AdminActivityWatcher::default(),
             auto_refresh: true,
         }
     }
@@ -566,6 +775,26 @@ impl UpgradesView {
             chain.rpc.clone()
         }
     }
+
+    fn ensure_admin_activity_watcher(&mut self, resources: &Resources) {
+        let chain_idx = self.selected_chain;
+        let Some(rpc_url) = self.rpc_for_selected(resources) else {
+            self.admin_activity_watcher.stop(&mut self.admin_activity);
+            self.admin_activity[chain_idx].status =
+                "No RPC configured for confirmed activity.".to_string();
+            return;
+        };
+
+        self.admin_activity[chain_idx].reset_for_rpc(&rpc_url);
+
+        if self.admin_activity_watcher.needs_restart(chain_idx, &rpc_url) {
+            self.admin_activity_watcher.stop(&mut self.admin_activity);
+            self.admin_activity[chain_idx].status =
+                "Connecting to confirmed activity watcher…".to_string();
+            let last_scanned_safe_block = self.admin_activity[chain_idx].last_scanned_safe_block;
+            self.admin_activity_watcher.start(chain_idx, rpc_url, last_scanned_safe_block);
+        }
+    }
 }
 
 impl View for UpgradesView {
@@ -615,7 +844,9 @@ impl View for UpgradesView {
     fn tick(&mut self, resources: &mut Resources) -> Action {
         self.tick_count = self.tick_count.wrapping_add(1);
         self.checks.poll();
+        self.admin_activity_watcher.poll(&mut self.admin_activity);
         self.apply_live_upgrades(resources);
+        self.ensure_admin_activity_watcher(resources);
 
         if self.auto_refresh && !self.checks.running {
             let due = self.checks.last_run_at.is_none_or(|t| t.elapsed() >= AUTO_REFRESH_INTERVAL);
@@ -633,12 +864,9 @@ impl View for UpgradesView {
         let now = now_unix();
         let chain = &self.chains[self.selected_chain];
 
-        let upcoming = chain
-            .specs
-            .iter()
-            .filter_map(|s| s.timestamp.filter(|&ts| ts > 0).map(|ts| (s.name, ts)))
-            .filter(|(_, ts)| *ts > now)
-            .min_by_key(|(_, ts)| *ts);
+        let next_scheduled = chain.next_scheduled_spec(now);
+        let upcoming =
+            next_scheduled.and_then(|spec| spec.timestamp.map(|timestamp| (spec.name, timestamp)));
 
         let latest_activated = chain
             .specs
@@ -704,15 +932,26 @@ impl View for UpgradesView {
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
             .split(outer[2]);
+        let right = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(56), Constraint::Percentage(44)])
+            .split(bottom[1]);
 
         render_history(frame, bottom[0], chain, now, selected_upgrade);
         render_checks_panel(
             frame,
-            bottom[1],
+            right[0],
             &self.checks,
             self.tick_count,
             selected_check_spec,
             self.auto_refresh,
+        );
+        render_admin_activity_panel(
+            frame,
+            right[1],
+            &self.admin_activity[self.selected_chain],
+            next_scheduled.map(|spec| spec.name),
+            chain.seeded_expected_admin(now).map(|(_, admin)| admin),
         );
         render_footer(frame, outer[3], self.checks.running, self.auto_refresh);
     }
@@ -1104,6 +1343,121 @@ fn render_checks_panel(
     );
 }
 
+fn render_admin_activity_panel(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AdminActivityChainState,
+    next_scheduled_upgrade: Option<&'static str>,
+    expected_admin: Option<Address>,
+) {
+    let block = Block::default()
+        .title(" Admin Activity ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(0)])
+        .split(inner);
+
+    let expected_line = match (next_scheduled_upgrade, expected_admin) {
+        (Some(upgrade), Some(admin)) => Line::from(vec![
+            Span::styled("Expected: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(short_address(admin), Style::default().fg(Color::White)),
+            Span::styled(format!("  ({upgrade})"), Style::default().fg(Color::DarkGray)),
+        ]),
+        (Some(upgrade), None) => Line::from(vec![
+            Span::styled("Expected: ", Style::default().fg(Color::DarkGray)),
+            Span::styled("unknown", Style::default().fg(Color::DarkGray)),
+            Span::styled(format!("  ({upgrade})"), Style::default().fg(Color::DarkGray)),
+        ]),
+        (None, _) => Line::from(vec![
+            Span::styled("Expected: ", Style::default().fg(Color::DarkGray)),
+            Span::styled("none scheduled", Style::default().fg(Color::DarkGray)),
+        ]),
+    };
+    let live_line = Line::from(vec![
+        Span::styled("Live: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            state.live_admin.map(short_address).unwrap_or_else(|| "unknown".to_string()),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled("  ·  Safe: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            state
+                .last_scanned_safe_block
+                .map(|block_number| block_number.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            Style::default().fg(Color::White),
+        ),
+    ]);
+    frame.render_widget(
+        Paragraph::new(vec![expected_line, live_line]).alignment(Alignment::Left),
+        sections[0],
+    );
+
+    if state.entries.is_empty() {
+        let message = if state.status.is_empty() {
+            "No confirmed activation-admin activity yet.".to_string()
+        } else {
+            format!("No confirmed activation-admin activity yet. {}", state.status)
+        };
+        frame.render_widget(
+            Paragraph::new(message)
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(Alignment::Center),
+            sections[1],
+        );
+        return;
+    }
+
+    let rows: Vec<Row<'static>> = state
+        .entries
+        .iter()
+        .map(|entry| {
+            let caller_style = if expected_admin == Some(entry.caller) {
+                Style::default().fg(Color::LightGreen).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            Row::new([
+                Cell::from(entry.block_number.to_string()).style(Style::default().fg(Color::White)),
+                Cell::from(fmt_activity_timestamp(entry.timestamp))
+                    .style(Style::default().fg(Color::Gray)),
+                Cell::from(short_hash(entry.tx_hash)).style(Style::default().fg(Color::Cyan)),
+                Cell::from(short_address(entry.caller)).style(caller_style),
+                Cell::from(format!("{} {}", entry.action, entry.detail))
+                    .style(Style::default().fg(Color::Gray)),
+            ])
+        })
+        .collect();
+
+    let header = Row::new(["BLOCK", "TIME", "TX", "CALLER", "ACTION"])
+        .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
+    let widths = [
+        Constraint::Length(8),
+        Constraint::Length(14),
+        Constraint::Length(16),
+        Constraint::Length(14),
+        Constraint::Min(12),
+    ];
+
+    let table_sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(sections[1]);
+
+    frame.render_widget(Table::new(rows, widths).header(header), table_sections[0]);
+    frame.render_widget(
+        Paragraph::new(state.status.clone())
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Right),
+        table_sections[1],
+    );
+}
+
 fn render_footer(frame: &mut Frame<'_>, area: Rect, checks_running: bool, auto_refresh: bool) {
     let key_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
     let desc_style = Style::default().fg(Color::DarkGray);
@@ -1205,6 +1559,326 @@ fn clock_lines(
     lines
 }
 
+fn fmt_activity_timestamp(ts: u64) -> String {
+    fmt_timestamp_with(ts, "%m-%d %H:%M:%S", "-")
+}
+
+fn short_hash(hash: B256) -> String {
+    let value = format!("{hash:#x}");
+    if value.len() <= 18 {
+        value
+    } else {
+        format!("{}..{}", &value[..12], &value[value.len() - 4..])
+    }
+}
+
+fn activation_feature_detail(feature: B256) -> String {
+    if feature == ActivationFeature::PolicyRegistry.id() {
+        return "policy registry".to_string();
+    }
+    if feature == ActivationFeature::B20Stablecoin.id() {
+        return "B-20 stablecoin".to_string();
+    }
+    if feature == ActivationFeature::B20Asset.id() {
+        return "B-20 asset".to_string();
+    }
+    format!("feature {}", short_hash(feature))
+}
+
+fn decode_admin_activity_log(
+    log: &alloy_rpc_types_eth::Log,
+    block_number: u64,
+    fallback_timestamp: u64,
+) -> Option<(AdminActivityEntry, Option<Address>)> {
+    let tx_hash = log.transaction_hash?;
+    let timestamp = log.block_timestamp.unwrap_or(fallback_timestamp);
+    let block_number = log.block_number.unwrap_or(block_number);
+
+    if let Ok(decoded) = log.log_decode::<IActivationRegistry::FeatureActivated>() {
+        let event = decoded.data();
+        return Some((
+            AdminActivityEntry {
+                block_number,
+                timestamp,
+                tx_hash,
+                caller: event.caller,
+                action: "activate",
+                detail: activation_feature_detail(event.feature),
+            },
+            None,
+        ));
+    }
+
+    if let Ok(decoded) = log.log_decode::<IActivationRegistry::FeatureDeactivated>() {
+        let event = decoded.data();
+        return Some((
+            AdminActivityEntry {
+                block_number,
+                timestamp,
+                tx_hash,
+                caller: event.caller,
+                action: "deactivate",
+                detail: activation_feature_detail(event.feature),
+            },
+            None,
+        ));
+    }
+
+    if let Ok(decoded) = log.log_decode::<IActivationRegistry::AdminChanged>() {
+        let event = decoded.data();
+        return Some((
+            AdminActivityEntry {
+                block_number,
+                timestamp,
+                tx_hash,
+                caller: event.caller,
+                action: "setAdmin",
+                detail: format!(
+                    "{} → {}",
+                    short_address(event.previousAdmin),
+                    short_address(event.newAdmin)
+                ),
+            },
+            Some(event.newAdmin),
+        ));
+    }
+
+    None
+}
+
+const fn admin_activity_scan_end(next_block: u64, safe_number: u64) -> u64 {
+    let max_end = next_block.saturating_add(MAX_ADMIN_ACTIVITY_BLOCKS_PER_POLL.saturating_sub(1));
+    if max_end < safe_number { max_end } else { safe_number }
+}
+
+async fn fetch_block_timestamp<P>(provider: &P, block_number: u64) -> Result<u64, String>
+where
+    P: Provider + ?Sized,
+{
+    provider
+        .get_block_by_number(BlockNumberOrTag::Number(block_number))
+        .await
+        .map_err(|error| error.to_string())?
+        .map(|block| block.header.timestamp)
+        .ok_or_else(|| format!("block {block_number} not found"))
+}
+
+async fn fetch_admin_activity_for_block<P>(
+    provider: &P,
+    block_number: u64,
+) -> Result<Vec<(AdminActivityEntry, Option<Address>)>, String>
+where
+    P: Provider + ?Sized,
+{
+    let filter = Filter::new()
+        .address(ActivationRegistryStorage::ADDRESS)
+        .from_block(block_number)
+        .to_block(block_number);
+    let logs = provider.get_logs(&filter).await.map_err(|error| error.to_string())?;
+    if logs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut fallback_timestamp = None;
+    let mut entries = Vec::new();
+    for log in logs.iter().filter(|log| !log.removed) {
+        let timestamp = if let Some(timestamp) = log.block_timestamp {
+            timestamp
+        } else {
+            match fallback_timestamp {
+                Some(timestamp) => timestamp,
+                None => {
+                    let timestamp = fetch_block_timestamp(provider, block_number).await?;
+                    fallback_timestamp = Some(timestamp);
+                    timestamp
+                }
+            }
+        };
+        if let Some(entry) = decode_admin_activity_log(log, block_number, timestamp) {
+            entries.push(entry);
+        }
+    }
+
+    Ok(entries)
+}
+
+async fn run_admin_activity_streaming(
+    rpc_url: String,
+    last_scanned_safe_block: Option<u64>,
+    tx: mpsc::Sender<AdminActivityUpdate>,
+) {
+    let mut last_safe_block = last_scanned_safe_block;
+
+    loop {
+        if tx
+            .send(AdminActivityUpdate::Status(
+                "Connecting to confirmed activity watcher…".to_string(),
+            ))
+            .await
+            .is_err()
+        {
+            return;
+        }
+
+        let provider = match ProviderBuilder::new().connect(&rpc_url).await {
+            Ok(provider) => provider,
+            Err(error) => {
+                if tx
+                    .send(AdminActivityUpdate::Status(format!("RPC connection failed: {error}")))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                tokio::time::sleep(ADMIN_ACTIVITY_RETRY_DELAY).await;
+                continue;
+            }
+        };
+
+        let live_admin_status = match send_safe_live_admin_update(&tx, &rpc_url).await {
+            Ok(status) => status,
+            Err(()) => return,
+        };
+        if tx
+            .send(AdminActivityUpdate::Status(live_admin_status.map_or_else(
+                || "Watching confirmed activation activity".to_string(),
+                |detail| format!("Watching confirmed activation activity. {detail}"),
+            )))
+            .await
+            .is_err()
+        {
+            return;
+        }
+
+        let mut interval = tokio::time::interval(ADMIN_ACTIVITY_POLL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        'watch: loop {
+            interval.tick().await;
+
+            let safe_block = match provider.get_block_by_number(BlockNumberOrTag::Safe).await {
+                Ok(Some(block)) => block,
+                Ok(None) => {
+                    if tx
+                        .send(AdminActivityUpdate::Status(
+                            "Safe head is unavailable on this RPC.".to_string(),
+                        ))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    break 'watch;
+                }
+                Err(error) => {
+                    if tx
+                        .send(AdminActivityUpdate::Status(format!(
+                            "Safe head query failed: {error}"
+                        )))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    break 'watch;
+                }
+            };
+
+            let safe_number = safe_block.header.number;
+            if last_safe_block.is_some_and(|last| safe_number < last) {
+                last_safe_block = None;
+                if tx
+                    .send(AdminActivityUpdate::Reset(
+                        "Safe head moved backwards; resetting confirmed activity cache."
+                            .to_string(),
+                    ))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                let reset_status = match send_safe_live_admin_update(&tx, &rpc_url).await {
+                    Ok(Some(detail)) => {
+                        format!(
+                            "Safe head moved backwards; resetting confirmed activity cache. {detail}"
+                        )
+                    }
+                    Ok(None) => {
+                        "Safe head moved backwards; resetting confirmed activity cache.".to_string()
+                    }
+                    Err(()) => return,
+                };
+                if tx.send(AdminActivityUpdate::Status(reset_status)).await.is_err() {
+                    return;
+                }
+            }
+            let mut next_block = match last_safe_block {
+                Some(last) if last < safe_number => last + 1,
+                Some(_) => {
+                    if tx
+                        .send(AdminActivityUpdate::LastScannedSafeBlock(safe_number))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    continue;
+                }
+                None => safe_number,
+            };
+            let scan_end = admin_activity_scan_end(next_block, safe_number);
+
+            while next_block <= scan_end {
+                let entries = match fetch_admin_activity_for_block(&provider, next_block).await {
+                    Ok(entries) => entries,
+                    Err(error) => {
+                        if tx
+                            .send(AdminActivityUpdate::Status(format!(
+                                "Confirmed activity query failed for block {next_block}: {error}"
+                            )))
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                        break 'watch;
+                    }
+                };
+
+                let mut block_entries = Vec::with_capacity(entries.len());
+                let mut live_admin_update = None;
+                for (entry, maybe_live_admin) in entries {
+                    block_entries.push(entry);
+                    if let Some(admin) = maybe_live_admin {
+                        live_admin_update = Some(admin);
+                    }
+                }
+                if tx
+                    .send(AdminActivityUpdate::ProcessedBlock {
+                        block_number: next_block,
+                        entries: block_entries,
+                        live_admin: live_admin_update,
+                    })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+
+                last_safe_block = Some(next_block);
+                next_block += 1;
+            }
+
+            let scanned = last_safe_block.unwrap_or(safe_number);
+            if tx.send(AdminActivityUpdate::LastScannedSafeBlock(scanned)).await.is_err() {
+                return;
+            }
+        }
+
+        tokio::time::sleep(ADMIN_ACTIVITY_RETRY_DELAY).await;
+    }
+}
+
 // ── Activation checks ─────────────────────────────────────────────────────────
 
 /// Route to the correct upgrade's streaming check function.
@@ -1246,9 +1920,37 @@ fn short_address(address: Address) -> String {
 }
 
 async fn activation_admin(client: &HttpClient) -> Result<Address, String> {
+    activation_admin_at_tag(client, "latest").await
+}
+
+async fn fetch_safe_live_admin(rpc_url: &str) -> Result<Option<Address>, String> {
+    let client = make_rpc_client(rpc_url)
+        .map_err(|error| format!("live-admin client build failed: {error}"))?;
+    activation_admin_at_tag(&client, "safe")
+        .await
+        .map(|admin| (!admin.is_zero()).then_some(admin))
+        .map_err(|error| format!("safe live-admin query failed: {error}"))
+}
+
+async fn send_safe_live_admin_update(
+    tx: &mpsc::Sender<AdminActivityUpdate>,
+    rpc_url: &str,
+) -> Result<Option<String>, ()> {
+    match fetch_safe_live_admin(rpc_url).await {
+        Ok(admin) => {
+            if tx.send(AdminActivityUpdate::LiveAdmin(admin)).await.is_err() {
+                return Err(());
+            }
+            Ok(None)
+        }
+        Err(error) => Ok(Some(format!("Live admin unavailable: {error}"))),
+    }
+}
+
+async fn activation_admin_at_tag(client: &HttpClient, block_tag: &str) -> Result<Address, String> {
     let data = calldata_hex(IActivationRegistry::adminCall {}.abi_encode());
     let to = activation_registry_address();
-    let output = eth_call(client, &to, &data).await?;
+    let output = eth_call_at_tag(client, &to, &data, block_tag).await?;
     let bytes = decode_rpc_bytes(&output)?;
     IActivationRegistry::adminCall::abi_decode_returns(bytes.as_ref()).map_err(|e| e.to_string())
 }
@@ -1611,10 +2313,19 @@ fn make_rpc_client(rpc_url: &str) -> Result<HttpClient, String> {
 }
 
 async fn eth_call(client: &HttpClient, to: &str, data: &str) -> Result<String, String> {
+    eth_call_at_tag(client, to, data, "latest").await
+}
+
+async fn eth_call_at_tag(
+    client: &HttpClient,
+    to: &str,
+    data: &str,
+    block_tag: &str,
+) -> Result<String, String> {
     ClientT::request::<String, _>(
         client,
         "eth_call",
-        rpc_params![json!({"to": to, "data": data}), "latest"],
+        rpc_params![json!({"to": to, "data": data}), block_tag],
     )
     .await
     .map_err(|e| e.to_string())
@@ -1799,6 +2510,8 @@ async fn run_azul_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{Log as PrimitiveLog, address};
+    use alloy_sol_types::SolEvent;
     use base_common_genesis::BaseUpgradeConfig;
     use crossterm::event::KeyModifiers;
 
@@ -1809,6 +2522,7 @@ mod tests {
     fn unscheduled_beryl_follows_active_azul_checks() {
         let mut chain = ChainUpgrades {
             display_name: "Devnet",
+            chain_id: ChainConfig::devnet().chain_id,
             rpc: None,
             specs: specs_from_config(ChainConfig::devnet()),
         };
@@ -1828,6 +2542,7 @@ mod tests {
     fn upcoming_azul_remains_target_before_beryl() {
         let mut chain = ChainUpgrades {
             display_name: "Mainnet",
+            chain_id: ChainConfig::mainnet().chain_id,
             rpc: None,
             specs: specs_from_config(ChainConfig::mainnet()),
         };
@@ -1845,6 +2560,7 @@ mod tests {
     fn live_upgrades_do_not_clear_known_static_timestamps() {
         let mut chain = ChainUpgrades {
             display_name: "Mainnet",
+            chain_id: ChainConfig::mainnet().chain_id,
             rpc: None,
             specs: specs_from_config(ChainConfig::mainnet()),
         };
@@ -1875,6 +2591,7 @@ mod tests {
     fn checkable_specs_are_display_ordered() {
         let chain = ChainUpgrades {
             display_name: "Devnet",
+            chain_id: ChainConfig::devnet().chain_id,
             rpc: None,
             specs: specs_from_config(ChainConfig::devnet()),
         };
@@ -1882,6 +2599,135 @@ mod tests {
             checkable_specs_display(&chain).into_iter().map(|spec| spec.name).collect();
 
         assert_eq!(names, vec!["Beryl", "Azul", "Jovian"]);
+    }
+
+    #[test]
+    fn seeded_expected_admin_uses_next_scheduled_upgrade() {
+        let chain = ChainUpgrades {
+            display_name: "Mainnet",
+            chain_id: ChainConfig::mainnet().chain_id,
+            rpc: None,
+            specs: vec![
+                UpgradeSpec { upgrade: BaseUpgrade::Azul, name: "Azul", timestamp: Some(20) },
+                UpgradeSpec { upgrade: BaseUpgrade::Cobalt, name: "Cobalt", timestamp: Some(30) },
+            ],
+        };
+
+        assert_eq!(chain.seeded_expected_admin(10), None);
+        assert_eq!(
+            chain.seeded_expected_admin(25),
+            ChainConfig::mainnet()
+                .activation_admin_address_for_upgrade(BaseUpgrade::Cobalt)
+                .map(|admin| ("Cobalt", admin))
+        );
+    }
+
+    #[test]
+    fn admin_activity_state_resets_when_rpc_changes() {
+        let mut state = AdminActivityChainState {
+            watched_rpc_url: "https://rpc-one.example".to_string(),
+            entries: VecDeque::from([AdminActivityEntry {
+                block_number: 42,
+                timestamp: 1_725_000_000,
+                tx_hash: B256::repeat_byte(0x44),
+                caller: address!("3333333333333333333333333333333333333333"),
+                action: "setAdmin",
+                detail: "detail".to_string(),
+            }]),
+            live_admin: Some(address!("2222222222222222222222222222222222222222")),
+            last_scanned_safe_block: Some(42),
+            status: "Watching confirmed activation activity".to_string(),
+        };
+
+        state.reset_for_rpc("https://rpc-two.example");
+
+        assert_eq!(state.watched_rpc_url, "https://rpc-two.example");
+        assert!(state.entries.is_empty());
+        assert!(state.live_admin.is_none());
+        assert!(state.last_scanned_safe_block.is_none());
+        assert_eq!(state.status, "Watching confirmed activation activity");
+    }
+
+    #[test]
+    fn processed_block_update_advances_progress_with_entries() {
+        let (tx, rx) = mpsc::channel(1);
+        tx.try_send(AdminActivityUpdate::ProcessedBlock {
+            block_number: 42,
+            entries: vec![AdminActivityEntry {
+                block_number: 42,
+                timestamp: 1_725_000_000,
+                tx_hash: B256::repeat_byte(0x44),
+                caller: address!("3333333333333333333333333333333333333333"),
+                action: "setAdmin",
+                detail: "detail".to_string(),
+            }],
+            live_admin: Some(address!("2222222222222222222222222222222222222222")),
+        })
+        .expect("update fits in channel");
+
+        let mut watcher = AdminActivityWatcher {
+            chain_idx: Some(0),
+            rpc_url: String::new(),
+            rx: Some(rx),
+            handle: None,
+        };
+        let mut states = std::array::from_fn(|_| AdminActivityChainState::default());
+
+        watcher.poll(&mut states);
+
+        assert_eq!(states[0].last_scanned_safe_block, Some(42));
+        assert_eq!(
+            states[0].live_admin,
+            Some(address!("2222222222222222222222222222222222222222"))
+        );
+        assert_eq!(states[0].entries.len(), 1);
+        assert_eq!(states[0].entries[0].block_number, 42);
+    }
+
+    #[test]
+    fn admin_activity_scan_end_caps_catch_up_work_per_poll() {
+        assert_eq!(
+            admin_activity_scan_end(10, 10 + MAX_ADMIN_ACTIVITY_BLOCKS_PER_POLL * 2),
+            10 + MAX_ADMIN_ACTIVITY_BLOCKS_PER_POLL - 1
+        );
+        assert_eq!(admin_activity_scan_end(10, 20), 20);
+    }
+
+    #[test]
+    fn decode_admin_activity_log_decodes_admin_changed_event() {
+        let previous_admin = address!("1111111111111111111111111111111111111111");
+        let new_admin = address!("2222222222222222222222222222222222222222");
+        let caller = address!("3333333333333333333333333333333333333333");
+        let tx_hash = B256::repeat_byte(0x44);
+        let log = alloy_rpc_types_eth::Log {
+            inner: PrimitiveLog {
+                address: ActivationRegistryStorage::ADDRESS,
+                data: IActivationRegistry::AdminChanged {
+                    previousAdmin: previous_admin,
+                    newAdmin: new_admin,
+                    caller,
+                }
+                .encode_log_data(),
+            },
+            block_number: Some(42),
+            block_timestamp: Some(1_725_000_000),
+            transaction_hash: Some(tx_hash),
+            ..Default::default()
+        };
+
+        let (entry, live_admin) =
+            decode_admin_activity_log(&log, 42, 1_725_000_000).expect("log decodes");
+
+        assert_eq!(entry.block_number, 42);
+        assert_eq!(entry.timestamp, 1_725_000_000);
+        assert_eq!(entry.tx_hash, tx_hash);
+        assert_eq!(entry.caller, caller);
+        assert_eq!(entry.action, "setAdmin");
+        assert_eq!(
+            entry.detail,
+            format!("{} → {}", short_address(previous_admin), short_address(new_admin))
+        );
+        assert_eq!(live_admin, Some(new_admin));
     }
 
     #[test]

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -5,9 +5,11 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use alloy_primitives::{Address, B256, hex};
+use alloy_primitives::{Address, B256, Bytes, hex};
 use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_types_eth::{BlockNumberOrTag, Filter};
+use alloy_rpc_types_eth::{
+    BlockId, BlockNumberOrTag, Filter, TransactionInput, TransactionRequest,
+};
 use alloy_sol_types::SolCall;
 use base_common_chains::{BaseUpgrade, ChainConfig};
 use base_common_genesis::UpgradeConfig;
@@ -472,6 +474,7 @@ impl AdminActivityChainState {
         self.entries.clear();
         self.live_admin = None;
         self.last_scanned_safe_block = None;
+        self.status.clear();
     }
 }
 
@@ -495,8 +498,8 @@ struct AdminActivityWatcher {
 impl AdminActivityWatcher {
     fn start(&mut self, chain_idx: usize, rpc_url: String, last_scanned_safe_block: Option<u64>) {
         let (tx, rx) = mpsc::channel(64);
-        debug_assert!(self.handle.is_none());
-        debug_assert!(self.rx.is_none());
+        assert!(self.handle.is_none(), "AdminActivityWatcher::start called while already running");
+        assert!(self.rx.is_none(), "AdminActivityWatcher::start called with rx already set");
         self.chain_idx = Some(chain_idx);
         self.rpc_url = rpc_url.clone();
         self.rx = Some(rx);
@@ -967,12 +970,13 @@ impl View for UpgradesView {
             selected_check_spec,
             self.auto_refresh,
         );
+        let seeded_expected = chain.seeded_expected_admin(now);
         render_admin_activity_panel(
             frame,
             right[1],
             &self.admin_activity[self.selected_chain],
-            next_scheduled.map(|spec| spec.name),
-            chain.seeded_expected_admin(now).map(|(_, admin)| admin),
+            seeded_expected.map(|(name, _)| name),
+            seeded_expected.map(|(_, admin)| admin),
         );
         render_footer(frame, outer[3], self.checks.running, self.auto_refresh);
     }
@@ -1778,10 +1782,7 @@ async fn run_admin_activity_streaming(
                 .connect_client(alloy_rpc_client::RpcClient::new(transport, false))
         };
 
-        let live_admin_client = make_rpc_client(&rpc_url)
-            .map_err(|error| format!("live-admin client build failed: {error}"));
-
-        let live_admin_status = match send_safe_live_admin_update(&tx, &live_admin_client).await {
+        let live_admin_status = match send_safe_live_admin_update(&tx, &provider).await {
             Ok(status) => status,
             Err(()) => return,
         };
@@ -1843,8 +1844,7 @@ async fn run_admin_activity_streaming(
                 {
                     return;
                 }
-                let reset_status = match send_safe_live_admin_update(&tx, &live_admin_client).await
-                {
+                let reset_status = match send_safe_live_admin_update(&tx, &provider).await {
                     Ok(Some(detail)) => {
                         format!(
                             "Safe head moved backwards; resetting confirmed activity cache. {detail}"
@@ -1978,29 +1978,36 @@ async fn activation_admin(client: &HttpClient) -> Result<Address, String> {
     activation_admin_at_tag(client, "latest").await
 }
 
-async fn fetch_safe_live_admin(client: &HttpClient) -> Result<Option<Address>, String> {
-    activation_admin_at_tag(client, "safe")
+async fn fetch_safe_live_admin<P: Provider + ?Sized>(
+    provider: &P,
+) -> Result<Option<Address>, String> {
+    let request = TransactionRequest::default()
+        .to(ActivationRegistryStorage::ADDRESS)
+        .input(TransactionInput::new(Bytes::from(IActivationRegistry::adminCall {}.abi_encode())));
+    provider
+        .call(request)
+        .block(BlockId::Number(BlockNumberOrTag::Safe))
         .await
-        .map(|admin| (!admin.is_zero()).then_some(admin))
-        .map_err(|error| format!("safe live-admin query failed: {error}"))
+        .map_err(|e| format!("safe live-admin query failed: {e}"))
+        .and_then(|bytes| {
+            IActivationRegistry::adminCall::abi_decode_returns(&bytes)
+                .map(|admin| (!admin.is_zero()).then_some(admin))
+                .map_err(|e| format!("safe live-admin decode failed: {e}"))
+        })
 }
 
-async fn send_safe_live_admin_update(
+async fn send_safe_live_admin_update<P: Provider + ?Sized>(
     tx: &mpsc::Sender<AdminActivityUpdate>,
-    client: &Result<HttpClient, String>,
+    provider: &P,
 ) -> Result<Option<String>, ()> {
-    let client = match client {
-        Ok(client) => client,
-        Err(error) => return Ok(Some(format!("Live admin unavailable: {error}"))),
-    };
-    match fetch_safe_live_admin(client).await {
+    match fetch_safe_live_admin(provider).await {
         Ok(admin) => {
             if tx.send(AdminActivityUpdate::LiveAdmin(admin)).await.is_err() {
                 return Err(());
             }
             Ok(None)
         }
-        Err(error) => Ok(Some(format!("Live admin unavailable: {error}"))),
+        Err(error) => Ok(Some(error)),
     }
 }
 
@@ -2726,7 +2733,7 @@ mod tests {
         assert!(state.entries.is_empty());
         assert!(state.live_admin.is_none());
         assert!(state.last_scanned_safe_block.is_none());
-        assert_eq!(state.status, "Watching confirmed activation activity");
+        assert!(state.status.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a confirmed-only “Admin Activity” panel to the basectl upgrades view that watches safe L2 blocks and surfaces activation-registry FeatureActivated, FeatureDeactivated, and AdminChanged transactions as they land.
- Show the current safe-head activation-registry admin as Live, and seed Expected from the next scheduled upgrade when the chain config defines one.

## Screenshot
<img width="1709" height="1369" alt="image" src="https://github.com/user-attachments/assets/d28c0968-df25-4a7d-bad7-65479f89f18b" />
