### PR TITLE
fix: detect new pruned history error from EL

### DIFF
--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -310,10 +310,13 @@ async fn get_block_compat<EngineClient_: EngineClient>(
     match engine_client.get_l2_block(block_id).full().await {
         Err(e) => {
             let err_str = e.to_string();
-            // EIP-4444 error code for pruned state unavailable
-            if e.as_error_resp().is_some_and(|err| err.code == 4444) {
-                Ok(None)
-            } else if err_str.contains("block not found") || err_str.contains("Unknown block") {
+            // EIP-4444 error code for pruned state unavailable, or known string-based
+            // "not found" responses from geth/erigon for safe/finalized when the chain
+            // has just started and nothing is marked safe or finalized yet.
+            if e.as_error_resp().is_some_and(|err| err.code == 4444)
+                || err_str.contains("block not found")
+                || err_str.contains("Unknown block")
+            {
                 Ok(None)
             } else {
                 Err(e)

--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -300,10 +300,9 @@ async fn find_earliest_unpruned_block<EngineClient_: EngineClient>(
     Ok(last_known_unpruned)
 }
 
-/// Wrapper function around [`EngineClient::get_l2_block`] to handle compatibility issues with geth
-/// and erigon. When serving a block-by-number request, these clients will return non-standard
-/// errors for the safe and finalized heads when the chain has just started and nothing is marked as
-/// safe or finalized yet.
+/// Wrapper function around [`EngineClient::get_l2_block`] to handle compatibility issues with clients.
+/// When serving a block-by-number request, these clients will return non-standard errors for the safe
+/// and finalized heads when the chain has just started and nothing is marked as safe or finalized yet.
 async fn get_block_compat<EngineClient_: EngineClient>(
     engine_client: &EngineClient_,
     block_id: BlockId,
@@ -311,12 +310,68 @@ async fn get_block_compat<EngineClient_: EngineClient>(
     match engine_client.get_l2_block(block_id).full().await {
         Err(e) => {
             let err_str = e.to_string();
-            if err_str.contains("block not found") || err_str.contains("Unknown block") {
+            // EIP-4444 error code for pruned state unavailable
+            if e.as_error_resp().is_some_and(|err| err.code == 4444) {
+                Ok(None)
+            } else if err_str.contains("block not found") || err_str.contains("Unknown block") {
                 Ok(None)
             } else {
                 Err(e)
             }
         }
         r => r,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_eips::BlockNumberOrTag;
+    use alloy_json_rpc::ErrorPayload;
+
+    use super::get_block_compat;
+    use crate::test_utils::{MockL2BlockError, test_engine_client_builder};
+
+    #[tokio::test]
+    async fn get_block_compat_eip4444_error_code_returns_none() {
+        let client = test_engine_client_builder()
+            .with_l2_block_error(MockL2BlockError::ErrorResp(ErrorPayload {
+                code: 4444,
+                message: "history unavailable".into(),
+                data: None,
+            }))
+            .build();
+
+        let result = get_block_compat(&client, BlockNumberOrTag::Finalized.into()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_block_compat_block_not_found_string_returns_none() {
+        let client = test_engine_client_builder()
+            .with_l2_block_error(MockL2BlockError::Custom("block not found".into()))
+            .build();
+
+        let result = get_block_compat(&client, BlockNumberOrTag::Safe.into()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_block_compat_unknown_block_string_returns_none() {
+        let client = test_engine_client_builder()
+            .with_l2_block_error(MockL2BlockError::Custom("Unknown block".into()))
+            .build();
+
+        let result = get_block_compat(&client, BlockNumberOrTag::Safe.into()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_block_compat_unrecognized_error_propagates() {
+        let client = test_engine_client_builder()
+            .with_l2_block_error(MockL2BlockError::Custom("connection refused".into()))
+            .build();
+
+        let err = get_block_compat(&client, BlockNumberOrTag::Latest.into()).await.unwrap_err();
+        assert!(err.to_string().contains("connection refused"));
     }
 }

--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -31,6 +31,15 @@ pub fn test_engine_client_builder() -> MockEngineClientBuilder {
     MockEngineClientBuilder::new().with_config(Arc::new(RollupConfig::default()))
 }
 
+/// A configurable error for [`MockEngineClient::get_l2_block`].
+#[derive(Debug, Clone)]
+pub enum MockL2BlockError {
+    /// JSON-RPC error response with a structured [`ErrorPayload`].
+    ErrorResp(ErrorPayload),
+    /// Transport-layer custom error whose `to_string()` contains the given string.
+    Custom(String),
+}
+
 /// Mock storage for engine client responses.
 ///
 /// Each API method has version-specific storage to allow tests to verify
@@ -95,6 +104,8 @@ pub struct MockEngineStorage {
     pub l2_blocks_by_id: HashMap<String, Block<BaseTransaction>>,
     /// Storage for proofs by (address, stringified `BlockId`) key.
     pub proofs_by_address: HashMap<(Address, String), EIP1186AccountProofResponse>,
+    /// Error to return from `get_l2_block` instead of block data, if set.
+    pub l2_block_error: Option<MockL2BlockError>,
 }
 
 /// Builder for constructing a [`MockEngineClient`] with pre-configured responses.
@@ -275,6 +286,12 @@ impl MockEngineClientBuilder {
         self
     }
 
+    /// Sets an error to return for all `get_l2_block` calls.
+    pub fn with_l2_block_error(mut self, error: MockL2BlockError) -> Self {
+        self.storage.l2_block_error = Some(error);
+        self
+    }
+
     /// Builds the [`MockEngineClient`] with the configured values.
     ///
     /// # Panics
@@ -428,6 +445,11 @@ impl MockEngineClient {
         let key = block_id_to_key(&block_id);
         self.storage.write().await.proofs_by_address.insert((address, key), proof);
     }
+
+    /// Sets an error to return for all `get_l2_block` calls.
+    pub async fn set_l2_block_error(&self, error: MockL2BlockError) {
+        self.storage.write().await.l2_block_error = Some(error);
+    }
 }
 
 #[async_trait]
@@ -466,6 +488,16 @@ impl EngineClient for MockEngineClient {
 
                 ProviderCall::BoxedFuture(Box::pin(async move {
                     let storage_guard = storage.read().await;
+                    if let Some(err) = storage_guard.l2_block_error.clone() {
+                        return Err(match err {
+                            MockL2BlockError::ErrorResp(payload) => {
+                                TransportError::ErrorResp(payload)
+                            }
+                            MockL2BlockError::Custom(msg) => {
+                                TransportError::from(TransportErrorKind::custom_str(&msg))
+                            }
+                        });
+                    }
                     Ok(storage_guard.l2_blocks_by_id.get(&block_key).cloned())
                 }))
             }),

--- a/crates/consensus/engine/src/test_utils/mod.rs
+++ b/crates/consensus/engine/src/test_utils/mod.rs
@@ -5,7 +5,8 @@ pub use attributes::TestAttributesBuilder;
 
 mod engine_client;
 pub use engine_client::{
-    MockEngineClient, MockEngineClientBuilder, MockEngineStorage, test_engine_client_builder,
+    MockEngineClient, MockEngineClientBuilder, MockEngineStorage, MockL2BlockError,
+    test_engine_client_builder,
 };
 
 mod engine_state;


### PR DESCRIPTION
## What

`get_block_compat` previously only matched errors from geth/erigon by string — `"block not found"` and `"Unknown block"`. This misses clients that conform to EIP-4444 and return a structured JSON-RPC error with code `4444` when queried for pruned history.

This PR adds that check before the existing string fallbacks.

## Why

EL clients implementing EIP-4444 can prune historical block bodies. When the sync-start logic queries the `safe` or `finalized` head and the chain has just started (nothing marked safe/finalized yet), some clients return a `4444` error code instead of a string message. Without this fix those errors bubble up as unexpected failures, breaking node startup.

## Testing

Added unit tests for all branches of `get_block_compat` using a new `MockL2BlockError` helper on `MockEngineClient`:

| Test | Error input | Expected |
|---|---|---|
| `get_block_compat_eip4444_error_code_returns_none` | `ErrorResp { code: 4444 }` | `Ok(None)` |
| `get_block_compat_block_not_found_string_returns_none` | `"block not found"` | `Ok(None)` |
| `get_block_compat_unknown_block_string_returns_none` | `"Unknown block"` | `Ok(None)` |
| `get_block_compat_unrecognized_error_propagates` | `"connection refused"` | `Err` |