### PR TITLE
fix(basectl): improve conductor table ordering

### DIFF
--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -33,6 +33,8 @@ const KEYBINDINGS: &[Keybinding] = &[
 
 type PauseRx = Option<(String, mpsc::Receiver<Result<(String, PausedPeers), String>>)>;
 
+const BLOCK_DELTA_RED_THRESHOLD: i128 = 100;
+
 /// Items rendered in the per-node action menu.
 ///
 /// Each variant maps either to a [`PendingAction`] (after confirmation) or to a
@@ -997,6 +999,29 @@ fn trim_prefix(input: &str) -> &str {
     input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")).unwrap_or(input)
 }
 
+fn latest_block<T>(nodes: &[T], extract: impl Copy + Fn(&T) -> Option<u64>) -> Option<u64> {
+    nodes.iter().filter_map(extract).max()
+}
+
+fn block_label(block: u64, baseline: Option<u64>) -> Line<'static> {
+    let Some(baseline) = baseline else { return Line::from(format!("   {block}")) };
+    let delta = i128::from(block) - i128::from(baseline);
+    if delta == 0 {
+        return Line::from(format!("   {block}"));
+    }
+
+    let delta_style = if delta < -BLOCK_DELTA_RED_THRESHOLD {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default()
+    };
+
+    Line::from(vec![
+        Span::raw(format!("   {block} ")),
+        Span::styled(format!("({delta:+})"), delta_style),
+    ])
+}
+
 fn render_cluster_table(
     f: &mut Frame<'_>,
     area: Rect,
@@ -1039,6 +1064,10 @@ fn render_cluster_table(
     let leader_safe: Option<(u64, alloy_primitives::B256)> = nodes.iter().find_map(|n| {
         if n.is_leader == Some(true) { n.safe_l2_block.zip(n.safe_l2_hash) } else { None }
     });
+    let unsafe_l2_baseline = latest_block(nodes, |node| node.unsafe_l2_block);
+    let safe_l2_baseline = latest_block(nodes, |node| node.safe_l2_block);
+    let finalized_l2_baseline = latest_block(nodes, |node| node.finalized_l2_block);
+    let el_block_baseline = latest_block(nodes, |node| node.el_block);
 
     // ── Header row: node names ─────────────────────────────────────────────
     let mut header_cells = vec![Cell::from("")];
@@ -1158,10 +1187,10 @@ fn render_cluster_table(
     for node in nodes {
         let (label, style) = match node.unsafe_l2_block {
             Some(n) if node.is_leader == Some(true) => {
-                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+                (block_label(n, unsafe_l2_baseline), Style::default().fg(Color::Yellow))
             }
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            Some(n) => (block_label(n, unsafe_l2_baseline), Style::default().fg(Color::White)),
+            None => (Line::from("   ?"), Style::default().fg(Color::DarkGray)),
         };
         l2_cells.push(Cell::from(label).style(style));
     }
@@ -1202,10 +1231,10 @@ fn render_cluster_table(
     for node in nodes {
         let (label, style) = match node.safe_l2_block {
             Some(n) if node.is_leader == Some(true) => {
-                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+                (block_label(n, safe_l2_baseline), Style::default().fg(Color::Yellow))
             }
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            Some(n) => (block_label(n, safe_l2_baseline), Style::default().fg(Color::White)),
+            None => (Line::from("   ?"), Style::default().fg(Color::DarkGray)),
         };
         safe_l2_cells.push(Cell::from(label).style(style));
     }
@@ -1246,10 +1275,10 @@ fn render_cluster_table(
     for node in nodes {
         let (label, style) = match node.finalized_l2_block {
             Some(n) if node.is_leader == Some(true) => {
-                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+                (block_label(n, finalized_l2_baseline), Style::default().fg(Color::Yellow))
             }
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            Some(n) => (block_label(n, finalized_l2_baseline), Style::default().fg(Color::White)),
+            None => (Line::from("   ?"), Style::default().fg(Color::DarkGray)),
         };
         finalized_l2_cells.push(Cell::from(label).style(style));
     }
@@ -1265,7 +1294,7 @@ fn render_cluster_table(
             (Some(cur), Some(head)) => {
                 let lag = head.saturating_sub(cur);
                 let color = if lag > 10 { Color::Yellow } else { Color::Green };
-                (format!("   #{cur} / #{head}"), Style::default().fg(color))
+                (format!("   {cur} / {head}"), Style::default().fg(color))
             }
             _ => ("   ? / ?".to_string(), Style::default().fg(Color::DarkGray)),
         };
@@ -1295,10 +1324,10 @@ fn render_cluster_table(
     for node in nodes {
         let (label, style) = match node.el_block {
             Some(n) if node.is_leader == Some(true) => {
-                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+                (block_label(n, el_block_baseline), Style::default().fg(Color::Yellow))
             }
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   -".to_string(), Style::default().fg(Color::DarkGray)),
+            Some(n) => (block_label(n, el_block_baseline), Style::default().fg(Color::White)),
+            None => (Line::from("   -"), Style::default().fg(Color::DarkGray)),
         };
         el_block_cells.push(Cell::from(label).style(style));
     }
@@ -1472,6 +1501,10 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
     for _ in 0..node_count {
         constraints.push(Constraint::Percentage(node_pct));
     }
+    let unsafe_l2_baseline = latest_block(nodes, |node| node.unsafe_l2_block);
+    let safe_l2_baseline = latest_block(nodes, |node| node.safe_l2_block);
+    let finalized_l2_baseline = latest_block(nodes, |node| node.finalized_l2_block);
+    let el_block_baseline = latest_block(nodes, |node| node.el_block);
 
     // ── Header row: node names ─────────────────────────────────────────────
     let mut header_cells = vec![Cell::from("")];
@@ -1507,8 +1540,8 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
     ];
     for node in nodes {
         let (label, style) = node.unsafe_l2_block.map_or_else(
-            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+            || (Line::from("   ?"), Style::default().fg(Color::DarkGray)),
+            |n| (block_label(n, unsafe_l2_baseline), Style::default().fg(Color::White)),
         );
         l2_cells.push(Cell::from(label).style(style));
     }
@@ -1538,8 +1571,8 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
     ];
     for node in nodes {
         let (label, style) = node.safe_l2_block.map_or_else(
-            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+            || (Line::from("   ?"), Style::default().fg(Color::DarkGray)),
+            |n| (block_label(n, safe_l2_baseline), Style::default().fg(Color::White)),
         );
         safe_l2_cells.push(Cell::from(label).style(style));
     }
@@ -1569,8 +1602,8 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
     ];
     for node in nodes {
         let (label, style) = node.finalized_l2_block.map_or_else(
-            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+            || (Line::from("   ?"), Style::default().fg(Color::DarkGray)),
+            |n| (block_label(n, finalized_l2_baseline), Style::default().fg(Color::White)),
         );
         finalized_l2_cells.push(Cell::from(label).style(style));
     }
@@ -1586,7 +1619,7 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
             (Some(cur), Some(head)) => {
                 let lag = head.saturating_sub(cur);
                 let color = if lag > 10 { Color::Yellow } else { Color::Green };
-                (format!("   #{cur} / #{head}"), Style::default().fg(color))
+                (format!("   {cur} / {head}"), Style::default().fg(color))
             }
             _ => ("   ? / ?".to_string(), Style::default().fg(Color::DarkGray)),
         };
@@ -1618,8 +1651,8 @@ fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeS
     ];
     for node in nodes {
         let (label, style) = node.el_block.map_or_else(
-            || ("   -".to_string(), Style::default().fg(Color::DarkGray)),
-            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+            || (Line::from("   -"), Style::default().fg(Color::DarkGray)),
+            |n| (block_label(n, el_block_baseline), Style::default().fg(Color::White)),
         );
         el_block_cells.push(Cell::from(label).style(style));
     }
@@ -1701,6 +1734,35 @@ mod tests {
 
     const SAMPLE_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+    fn conductor_status(
+        name: &str,
+        is_leader: Option<bool>,
+        unsafe_l2_block: Option<u64>,
+    ) -> ConductorNodeStatus {
+        ConductorNodeStatus {
+            name: name.to_string(),
+            is_leader,
+            conductor_active: None,
+            conductor_paused: None,
+            conductor_stopped: None,
+            sequencer_healthy: None,
+            sequencer_active: None,
+            unsafe_l2_block,
+            unsafe_l2_hash: None,
+            safe_l2_block: None,
+            safe_l2_hash: None,
+            finalized_l2_block: None,
+            current_l1_block: None,
+            head_l1_block: None,
+            cl_peer_count: None,
+            el_block: None,
+            el_syncing: None,
+            el_peer_count: None,
+            suffrage: None,
+            discovered: true,
+        }
+    }
+
     #[test]
     fn parses_bare_hex_hash() {
         let parsed = parse_hex_hash(SAMPLE_HEX).expect("bare 64-char hex parses");
@@ -1724,5 +1786,50 @@ mod tests {
     fn rejects_non_hex() {
         let bad = "g".repeat(64);
         assert!(parse_hex_hash(&bad).is_none());
+    }
+
+    #[test]
+    fn block_label_formats_signed_delta_from_baseline() {
+        assert_eq!(block_label(7, Some(10)).to_string(), "   7 (-3)");
+        assert_eq!(block_label(10, Some(10)).to_string(), "   10");
+        assert_eq!(block_label(12, Some(10)).to_string(), "   12 (+2)");
+        assert_eq!(block_label(7, None).to_string(), "   7");
+    }
+
+    #[test]
+    fn block_label_colors_delta_red_when_more_than_100_blocks_behind() {
+        let stale = block_label(899, Some(1000));
+        assert_eq!(stale.to_string(), "   899 (-101)");
+        assert_eq!(stale.spans[1].style.fg, Some(Color::Red));
+
+        let boundary = block_label(900, Some(1000));
+        assert_eq!(boundary.to_string(), "   900 (-100)");
+        assert_eq!(boundary.spans[1].style.fg, None);
+    }
+
+    #[test]
+    fn latest_block_uses_max_reported_block() {
+        let nodes = vec![
+            conductor_status("sequencer-0", Some(true), Some(10)),
+            conductor_status("sequencer-1", Some(false), Some(7)),
+            conductor_status("sequencer-2", Some(false), Some(12)),
+        ];
+
+        let baseline = latest_block(&nodes, |node| node.unsafe_l2_block);
+
+        assert_eq!(baseline, Some(12));
+    }
+
+    #[test]
+    fn latest_block_ignores_unknown_blocks() {
+        let nodes = vec![
+            conductor_status("sequencer-0", Some(false), None),
+            conductor_status("sequencer-1", Some(false), Some(7)),
+            conductor_status("sequencer-2", None, Some(12)),
+        ];
+
+        let baseline = latest_block(&nodes, |node| node.unsafe_l2_block);
+
+        assert_eq!(baseline, Some(12));
     }
 }

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{cmp::Ordering, path::PathBuf};
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
@@ -129,6 +129,39 @@ pub struct ConductorNodeConfig {
     pub flashblocks_ws: Option<Url>,
 }
 
+impl ConductorNodeConfig {
+    /// Sorts conductor nodes by server id, then display name.
+    pub fn sort_by_server_id(nodes: &mut [Self]) {
+        nodes.sort_by(Self::cmp_by_server_id);
+    }
+
+    /// Compares conductor nodes by server id, then display name.
+    pub fn cmp_by_server_id(left: &Self, right: &Self) -> Ordering {
+        Self::cmp_server_id(&left.server_id, &right.server_id)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.raft_addr.cmp(&right.raft_addr))
+    }
+
+    /// Compares server ids by numeric suffix when both ids share a dash-delimited prefix.
+    pub fn cmp_server_id(left: &str, right: &str) -> Ordering {
+        match (Self::server_id_suffix(left), Self::server_id_suffix(right)) {
+            (Some((left_prefix, left_number)), Some((right_prefix, right_number)))
+                if left_prefix == right_prefix =>
+            {
+                left_number.cmp(&right_number).then_with(|| left.cmp(right))
+            }
+            _ => left.cmp(right),
+        }
+    }
+
+    /// Returns the prefix and numeric suffix for ids like `sequencer-3`.
+    pub fn server_id_suffix(server_id: &str) -> Option<(&str, u64)> {
+        let (prefix, suffix) = server_id.rsplit_once('-')?;
+        let number = suffix.parse().ok()?;
+        Some((prefix, number))
+    }
+}
+
 /// Conductor cluster discovery configuration.
 ///
 /// When set, basectl can bootstrap a conductor cluster view from a single
@@ -256,7 +289,7 @@ impl ConductorSource {
         membership: &base_consensus_rpc::ClusterMembership,
     ) -> Option<Vec<ConductorNodeConfig>> {
         let Self::Discover { bootstrap, ports } = self else { return None };
-        let nodes = membership
+        let mut nodes = membership
             .servers
             .iter()
             .map(|srv| {
@@ -274,7 +307,8 @@ impl ConductorSource {
                     flashblocks_ws: None,
                 }
             })
-            .collect();
+            .collect::<Vec<_>>();
+        ConductorNodeConfig::sort_by_server_id(&mut nodes);
         Some(nodes)
     }
 }
@@ -732,7 +766,23 @@ impl MonitoringConfig {
 
 #[cfg(test)]
 mod tests {
+    use base_consensus_rpc::{ClusterMembership, ServerInfo, ServerSuffrage};
+
     use super::*;
+
+    fn membership(ids: &[&str]) -> ClusterMembership {
+        ClusterMembership {
+            version: 1,
+            servers: ids
+                .iter()
+                .map(|id| ServerInfo {
+                    id: (*id).to_string(),
+                    addr: format!("{id}:5050"),
+                    suffrage: ServerSuffrage::Voter,
+                })
+                .collect(),
+        }
+    }
 
     #[tokio::test]
     async fn test_builtin_configs() {
@@ -823,5 +873,36 @@ mod tests {
         };
 
         assert_eq!(resolved, bootstrap);
+    }
+
+    #[test]
+    fn discovered_conductor_nodes_use_natural_server_order() {
+        let source = ConductorSource::Discover {
+            bootstrap: Url::parse("http://127.0.0.1:5545").unwrap(),
+            ports: DiscoveryPorts::default(),
+        };
+        let membership = membership(&[
+            "sequencer-0",
+            "sequencer-2",
+            "sequencer-3",
+            "sequencer-1",
+            "sequencer-4",
+            "sequencer-10",
+        ]);
+
+        let nodes = source.synthesize_nodes(&membership).unwrap();
+        let names = nodes.iter().map(|node| node.name.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                "sequencer-0",
+                "sequencer-1",
+                "sequencer-2",
+                "sequencer-3",
+                "sequencer-4",
+                "sequencer-10",
+            ]
+        );
     }
 }

--- a/crates/infra/basectl/src/rpc/conductor.rs
+++ b/crates/infra/basectl/src/rpc/conductor.rs
@@ -306,6 +306,7 @@ impl ConductorControl {
                 if nodes.is_empty() {
                     anyhow::bail!("conductor cluster membership is empty");
                 }
+                ConductorNodeConfig::sort_by_server_id(&mut nodes);
                 Ok(nodes)
             }
         }
@@ -1184,6 +1185,32 @@ mod tests {
 
         assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0].name, "op-conductor-0");
+    }
+
+    #[test]
+    fn nodes_from_membership_sorts_static_nodes_naturally() {
+        let source = ConductorSource::Static(vec![
+            node("op-conductor-0", "sequencer-0"),
+            node("op-conductor-1", "sequencer-1"),
+            node("op-conductor-2", "sequencer-2"),
+            node("op-conductor-3", "sequencer-3"),
+            node("op-conductor-4", "sequencer-4"),
+        ]);
+        let membership = membership(&[
+            "sequencer-0",
+            "sequencer-2",
+            "sequencer-3",
+            "sequencer-1",
+            "sequencer-4",
+        ]);
+
+        let nodes = ConductorControl::nodes_from_membership(&source, &membership).unwrap();
+        let server_ids = nodes.iter().map(|node| node.server_id.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(
+            server_ids,
+            vec!["sequencer-0", "sequencer-1", "sequencer-2", "sequencer-3", "sequencer-4"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- sort conductor membership by natural sequencer/server id order
- show block deltas against the latest reported block in conductor and validator tables
- remove # prefixes from rendered block numbers