### PR TITLE
feat(snapshotter): prune old snapshot runs

### DIFF
--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -1,6 +1,6 @@
 //! CLI configuration for the snapshotter sidecar.
 
-use std::path::PathBuf;
+use std::{num::NonZeroUsize, path::PathBuf};
 
 use clap::{Parser, ValueEnum};
 
@@ -66,6 +66,13 @@ pub struct SnapshotterConfig {
     /// Defaults to half the available CPUs.
     #[arg(long)]
     pub snapshot_threads: Option<usize>,
+
+    /// Number of completed timestamped snapshot run directories to retain remotely.
+    ///
+    /// Older `{prefix}/{timestamp}/` directories are deleted after a successful
+    /// upload. The append-only `{prefix}/static_files/` directory is never pruned.
+    #[arg(long, env = "SNAPSHOTTER_RETAIN_RUNS", default_value = "3")]
+    pub retain_runs: NonZeroUsize,
 
     /// Docker socket path.
     #[arg(long, default_value = "/var/run/docker.sock")]

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -23,7 +23,7 @@ pub use snapshot::{
 };
 
 mod upload;
-pub use upload::{SnapshotUploader, UploadStrategy};
+pub use upload::{SnapshotRun, SnapshotUploader, UploadStrategy};
 
 mod orchestrator;
 pub use orchestrator::Snapshotter;

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -149,6 +149,7 @@ impl<C: ContainerManager> Snapshotter<C> {
                 &run_output_dir,
                 &files,
                 run_timestamp,
+                self.config.retain_runs.get(),
                 &local_manifest,
                 remote_manifest.as_ref(),
             )

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -191,7 +191,6 @@ impl SnapshotUploader {
             }
         }
 
-        runs.sort_unstable_by(|a, b| b.timestamp.cmp(&a.timestamp));
         Ok(runs)
     }
 
@@ -205,10 +204,22 @@ impl SnapshotUploader {
             return Ok(());
         }
 
+        let mut last_error = None;
         for timestamp in expired {
             let run_prefix = self.run_prefix(timestamp);
-            let deleted_objects = self.delete_prefix(&run_prefix).await?;
-            info!(timestamp, run_prefix = %run_prefix, deleted_objects, "pruned old snapshot run");
+            match self.delete_prefix(&run_prefix).await {
+                Ok(deleted_objects) => {
+                    info!(timestamp, run_prefix = %run_prefix, deleted_objects, "pruned old snapshot run");
+                }
+                Err(e) => {
+                    warn!(error = %e, timestamp, run_prefix = %run_prefix, "failed to prune old snapshot run, continuing");
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        if let Some(e) = last_error {
+            return Err(e);
         }
 
         Ok(())
@@ -471,17 +482,11 @@ impl SnapshotUploader {
 
     /// Returns whether a full object key exists remotely.
     async fn remote_key_exists(&self, key: &str) -> Result<bool> {
-        let resp = self
-            .client
-            .list_objects_v2()
-            .bucket(&self.bucket)
-            .prefix(key)
-            .max_keys(1)
-            .send()
-            .await
-            .with_context(|| format!("failed to check object existence for {key}"))?;
-
-        Ok(resp.contents().iter().any(|obj| obj.key() == Some(key)))
+        match self.client.head_object().bucket(&self.bucket).key(key).send().await {
+            Ok(_) => Ok(true),
+            Err(err) if err.as_service_error().is_some_and(|e| e.is_not_found()) => Ok(false),
+            Err(err) => Err(anyhow::anyhow!("failed to check object existence for {key}: {err}")),
+        }
     }
 
     /// Deletes all objects under a prefix and returns the number of deleted keys.

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -20,7 +20,7 @@ use anyhow::{Context, Result, bail};
 use aws_sdk_s3::{
     Client as S3Client,
     primitives::ByteStream,
-    types::{CompletedMultipartUpload, CompletedPart},
+    types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier},
 };
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tracing::{debug, info, warn};
@@ -39,6 +39,18 @@ const MULTIPART_THRESHOLD: u64 = 100 * 1024 * 1024;
 
 /// Part size for multipart uploads (100 `MiB`).
 const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Maximum number of objects per S3-compatible delete batch.
+const DELETE_OBJECT_BATCH_SIZE: usize = 1000;
+
+/// Completed timestamped snapshot run discovered from a published manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotRun {
+    /// Unix timestamp used as the run directory name.
+    pub timestamp: u64,
+    /// Full object key for the run's `manifest.json`.
+    pub manifest_key: String,
+}
 
 /// Determines whether a snapshot component is re-uploaded every run
 /// or can be skipped when the remote copy already matches.
@@ -98,11 +110,46 @@ impl SnapshotUploader {
     /// found manifest is logged and treated as no-previous (so we fall back to
     /// re-uploading everything rather than failing the run).
     pub async fn fetch_previous_manifest(&self) -> Result<Option<SnapshotManifest>> {
-        let manifest_suffix = "/manifest.json";
+        let runs = self.list_completed_runs().await?;
+        let best = runs.into_iter().max_by_key(|run| run.timestamp);
+
+        let Some(run) = best else {
+            debug!("no previous manifest found");
+            return Ok(None);
+        };
+
+        debug!(timestamp = run.timestamp, key = %run.manifest_key, "fetching previous manifest");
+        let resp = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&run.manifest_key)
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch previous manifest {}", run.manifest_key))?;
+
+        let bytes = resp
+            .body
+            .collect()
+            .await
+            .with_context(|| format!("failed to read previous manifest body {}", run.manifest_key))?
+            .into_bytes();
+
+        match serde_json::from_slice::<SnapshotManifest>(&bytes) {
+            Ok(manifest) => Ok(Some(manifest)),
+            Err(e) => {
+                warn!(error = %e, key = %run.manifest_key, "failed to parse previous manifest, treating as missing");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Lists completed timestamped run directories by looking for published manifests.
+    pub async fn list_completed_runs(&self) -> Result<Vec<SnapshotRun>> {
         let list_prefix =
             if self.prefix.is_empty() { String::new() } else { format!("{}/", self.prefix) };
 
-        let mut best: Option<(u64, String)> = None;
+        let mut runs = Vec::new();
         let mut continuation_token = None;
 
         loop {
@@ -121,14 +168,8 @@ impl SnapshotUploader {
 
             for obj in resp.contents() {
                 let Some(key) = obj.key() else { continue };
-                let Some(rest) = key.strip_prefix(list_prefix.as_str()) else { continue };
-                let Some(timestamp_str) = rest.strip_suffix(manifest_suffix) else { continue };
-                if timestamp_str.contains('/') {
-                    continue;
-                }
-                let Ok(timestamp) = timestamp_str.parse::<u64>() else { continue };
-                if best.as_ref().is_none_or(|(prev, _)| timestamp > *prev) {
-                    best = Some((timestamp, key.to_string()));
+                if let Some(run) = Self::parse_completed_run_manifest_key(key, &list_prefix) {
+                    runs.push(run);
                 }
             }
 
@@ -139,35 +180,46 @@ impl SnapshotUploader {
             }
         }
 
-        let Some((timestamp, key)) = best else {
-            debug!("no previous manifest found");
-            return Ok(None);
-        };
+        runs.sort_unstable_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        Ok(runs)
+    }
 
-        debug!(timestamp, key = %key, "fetching previous manifest");
-        let resp = self
-            .client
-            .get_object()
-            .bucket(&self.bucket)
-            .key(&key)
-            .send()
-            .await
-            .with_context(|| format!("failed to fetch previous manifest {key}"))?;
+    /// Prunes old completed timestamped run directories, retaining the newest `retain_runs`.
+    pub async fn prune_old_runs(&self, retain_runs: usize) -> Result<()> {
+        let runs = self.list_completed_runs().await?;
+        let expired = Self::expired_run_timestamps(&runs, retain_runs);
 
-        let bytes = resp
-            .body
-            .collect()
-            .await
-            .with_context(|| format!("failed to read previous manifest body {key}"))?
-            .into_bytes();
-
-        match serde_json::from_slice::<SnapshotManifest>(&bytes) {
-            Ok(manifest) => Ok(Some(manifest)),
-            Err(e) => {
-                warn!(error = %e, key = %key, "failed to parse previous manifest, treating as missing");
-                Ok(None)
-            }
+        if expired.is_empty() {
+            info!(retain_runs, total_runs = runs.len(), "no old snapshot runs to prune");
+            return Ok(());
         }
+
+        for timestamp in expired {
+            let run_prefix = self.run_prefix(timestamp);
+            let deleted_objects = self.delete_prefix(&run_prefix).await?;
+            info!(timestamp, run_prefix = %run_prefix, deleted_objects, "pruned old snapshot run");
+        }
+
+        Ok(())
+    }
+
+    /// Parses a run manifest key of the form `{list_prefix}{timestamp}/manifest.json`.
+    pub fn parse_completed_run_manifest_key(key: &str, list_prefix: &str) -> Option<SnapshotRun> {
+        let rest = key.strip_prefix(list_prefix)?;
+        let timestamp_str = rest.strip_suffix("/manifest.json")?;
+        if timestamp_str.contains('/') {
+            return None;
+        }
+        let timestamp = timestamp_str.parse::<u64>().ok()?;
+        Some(SnapshotRun { timestamp, manifest_key: key.to_string() })
+    }
+
+    /// Returns the completed run timestamps that exceed the retention window.
+    pub fn expired_run_timestamps(runs: &[SnapshotRun], retain_runs: usize) -> Vec<u64> {
+        let mut timestamps: Vec<u64> = runs.iter().map(|run| run.timestamp).collect();
+        timestamps.sort_unstable_by(|a, b| b.cmp(a));
+        timestamps.dedup();
+        timestamps.into_iter().skip(retain_runs).collect()
     }
 
     /// Uploads snapshot artifacts with diff-based optimization.
@@ -182,6 +234,7 @@ impl SnapshotUploader {
         output_dir: &Path,
         files: &[PathBuf],
         timestamp: u64,
+        retain_runs: usize,
         local_manifest: &SnapshotManifest,
         remote_manifest: Option<&SnapshotManifest>,
     ) -> Result<String> {
@@ -291,6 +344,10 @@ impl SnapshotUploader {
         progress_logger.abort();
         upload_result?;
 
+        if let Err(e) = self.prune_old_runs(retain_runs).await {
+            warn!(error = %e, retain_runs, "failed to prune old snapshot runs");
+        }
+
         info!(
             run_prefix = %run_prefix,
             manifest_key = %manifest_key,
@@ -364,6 +421,79 @@ impl SnapshotUploader {
 
         debug!(prefix = %prefix, count = remote.len(), "listed remote objects");
         Ok(remote)
+    }
+
+    /// Lists full object keys under a prefix.
+    async fn list_remote_keys(&self, prefix: &str) -> Result<Vec<String>> {
+        let prefix_with_slash = format!("{prefix}/");
+        let mut keys = Vec::new();
+        let mut continuation_token = None;
+
+        loop {
+            let mut req =
+                self.client.list_objects_v2().bucket(&self.bucket).prefix(&prefix_with_slash);
+
+            if let Some(token) = continuation_token.take() {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .with_context(|| format!("failed to list objects under {prefix_with_slash}"))?;
+
+            for obj in resp.contents() {
+                if let Some(key) = obj.key() {
+                    keys.push(key.to_string());
+                }
+            }
+
+            if resp.is_truncated() == Some(true) {
+                continuation_token = resp.next_continuation_token().map(String::from);
+            } else {
+                break;
+            }
+        }
+
+        Ok(keys)
+    }
+
+    /// Deletes all objects under a prefix and returns the number of deleted keys.
+    async fn delete_prefix(&self, prefix: &str) -> Result<usize> {
+        let keys = self.list_remote_keys(prefix).await?;
+        if keys.is_empty() {
+            return Ok(0);
+        }
+
+        for batch in keys.chunks(DELETE_OBJECT_BATCH_SIZE) {
+            let objects = batch
+                .iter()
+                .map(|key| ObjectIdentifier::builder().key(key).build())
+                .collect::<Result<Vec<_>, _>>()?;
+            let delete = Delete::builder().set_objects(Some(objects)).quiet(true).build()?;
+            let resp = self
+                .client
+                .delete_objects()
+                .bucket(&self.bucket)
+                .delete(delete)
+                .send()
+                .await
+                .with_context(|| format!("failed to delete objects under {prefix}"))?;
+
+            if !resp.errors().is_empty() {
+                for err in resp.errors() {
+                    warn!(
+                        key = %err.key().unwrap_or("<unknown>"),
+                        code = %err.code().unwrap_or("<unknown>"),
+                        message = %err.message().unwrap_or("<unknown>"),
+                        "failed to delete snapshot run object"
+                    );
+                }
+                bail!("failed to delete one or more objects under {prefix}");
+            }
+        }
+
+        Ok(keys.len())
     }
 
     /// Uploads a single file, using multipart upload for files above the threshold.
@@ -631,5 +761,66 @@ mod tests {
             UploadStrategy::classify("custom_component-100-200.tar.zst"),
             UploadStrategy::DiffByHash
         );
+    }
+
+    #[test]
+    fn parse_completed_run_manifest_key_accepts_timestamp_dirs() {
+        assert_eq!(
+            SnapshotUploader::parse_completed_run_manifest_key(
+                "mainnet/1710000002/manifest.json",
+                "mainnet/"
+            ),
+            Some(SnapshotRun {
+                timestamp: 1_710_000_002,
+                manifest_key: "mainnet/1710000002/manifest.json".to_string(),
+            })
+        );
+
+        assert_eq!(
+            SnapshotUploader::parse_completed_run_manifest_key("1710000002/manifest.json", ""),
+            Some(SnapshotRun {
+                timestamp: 1_710_000_002,
+                manifest_key: "1710000002/manifest.json".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_completed_run_manifest_key_rejects_non_run_keys() {
+        assert_eq!(
+            SnapshotUploader::parse_completed_run_manifest_key(
+                "mainnet/static_files/manifest.json",
+                "mainnet/"
+            ),
+            None
+        );
+        assert_eq!(
+            SnapshotUploader::parse_completed_run_manifest_key(
+                "mainnet/1710000002/state.tar.zst",
+                "mainnet/"
+            ),
+            None
+        );
+        assert_eq!(
+            SnapshotUploader::parse_completed_run_manifest_key(
+                "other/1710000002/manifest.json",
+                "mainnet/"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn expired_run_timestamps_keeps_latest_n() {
+        let runs = vec![
+            SnapshotRun { timestamp: 10, manifest_key: "10/manifest.json".to_string() },
+            SnapshotRun { timestamp: 30, manifest_key: "30/manifest.json".to_string() },
+            SnapshotRun { timestamp: 20, manifest_key: "20/manifest.json".to_string() },
+            SnapshotRun { timestamp: 40, manifest_key: "40/manifest.json".to_string() },
+        ];
+
+        assert_eq!(SnapshotUploader::expired_run_timestamps(&runs, 3), vec![10]);
+        assert_eq!(SnapshotUploader::expired_run_timestamps(&runs, 2), vec![20, 10]);
+        assert!(SnapshotUploader::expired_run_timestamps(&runs, 4).is_empty());
     }
 }

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -149,11 +149,11 @@ impl SnapshotUploader {
         let list_prefix =
             if self.prefix.is_empty() { String::new() } else { format!("{}/", self.prefix) };
 
-        let mut runs = Vec::new();
+        let mut run_prefixes = Vec::new();
         let mut continuation_token = None;
 
         loop {
-            let mut req = self.client.list_objects_v2().bucket(&self.bucket);
+            let mut req = self.client.list_objects_v2().bucket(&self.bucket).delimiter("/");
             if !list_prefix.is_empty() {
                 req = req.prefix(&list_prefix);
             }
@@ -166,10 +166,11 @@ impl SnapshotUploader {
                 .await
                 .with_context(|| format!("failed to list objects under {list_prefix}"))?;
 
-            for obj in resp.contents() {
-                let Some(key) = obj.key() else { continue };
-                if let Some(run) = Self::parse_completed_run_manifest_key(key, &list_prefix) {
-                    runs.push(run);
+            for common_prefix in resp.common_prefixes() {
+                let Some(prefix) = common_prefix.prefix() else { continue };
+                if let Some((timestamp, run_prefix)) = Self::parse_run_prefix(prefix, &list_prefix)
+                {
+                    run_prefixes.push((timestamp, run_prefix));
                 }
             }
 
@@ -177,6 +178,16 @@ impl SnapshotUploader {
                 continuation_token = resp.next_continuation_token().map(String::from);
             } else {
                 break;
+            }
+        }
+
+        run_prefixes.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+
+        let mut runs = Vec::new();
+        for (timestamp, run_prefix) in run_prefixes {
+            let manifest_key = format!("{run_prefix}/manifest.json");
+            if self.remote_key_exists(&manifest_key).await? {
+                runs.push(SnapshotRun { timestamp, manifest_key });
             }
         }
 
@@ -212,6 +223,17 @@ impl SnapshotUploader {
         }
         let timestamp = timestamp_str.parse::<u64>().ok()?;
         Some(SnapshotRun { timestamp, manifest_key: key.to_string() })
+    }
+
+    /// Parses a common prefix of the form `{list_prefix}{timestamp}/`.
+    pub fn parse_run_prefix(prefix: &str, list_prefix: &str) -> Option<(u64, String)> {
+        let rest = prefix.strip_prefix(list_prefix)?;
+        let timestamp_str = rest.strip_suffix('/')?;
+        if timestamp_str.contains('/') {
+            return None;
+        }
+        let timestamp = timestamp_str.parse::<u64>().ok()?;
+        Some((timestamp, prefix.trim_end_matches('/').to_string()))
     }
 
     /// Returns the completed run timestamps that exceed the retention window.
@@ -456,6 +478,21 @@ impl SnapshotUploader {
         }
 
         Ok(keys)
+    }
+
+    /// Returns whether a full object key exists remotely.
+    async fn remote_key_exists(&self, key: &str) -> Result<bool> {
+        let resp = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.bucket)
+            .prefix(key)
+            .max_keys(1)
+            .send()
+            .await
+            .with_context(|| format!("failed to check object existence for {key}"))?;
+
+        Ok(resp.contents().iter().any(|obj| obj.key() == Some(key)))
     }
 
     /// Deletes all objects under a prefix and returns the number of deleted keys.
@@ -808,6 +845,28 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn parse_run_prefix_accepts_timestamp_prefixes() {
+        assert_eq!(
+            SnapshotUploader::parse_run_prefix("mainnet/1710000002/", "mainnet/"),
+            Some((1_710_000_002, "mainnet/1710000002".to_string()))
+        );
+        assert_eq!(
+            SnapshotUploader::parse_run_prefix("1710000002/", ""),
+            Some((1_710_000_002, "1710000002".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_run_prefix_rejects_non_run_prefixes() {
+        assert_eq!(SnapshotUploader::parse_run_prefix("mainnet/static_files/", "mainnet/"), None);
+        assert_eq!(
+            SnapshotUploader::parse_run_prefix("mainnet/1710000002/nested/", "mainnet/"),
+            None
+        );
+        assert_eq!(SnapshotUploader::parse_run_prefix("other/1710000002/", "mainnet/"), None);
     }
 
     #[test]

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -214,17 +214,6 @@ impl SnapshotUploader {
         Ok(())
     }
 
-    /// Parses a run manifest key of the form `{list_prefix}{timestamp}/manifest.json`.
-    pub fn parse_completed_run_manifest_key(key: &str, list_prefix: &str) -> Option<SnapshotRun> {
-        let rest = key.strip_prefix(list_prefix)?;
-        let timestamp_str = rest.strip_suffix("/manifest.json")?;
-        if timestamp_str.contains('/') {
-            return None;
-        }
-        let timestamp = timestamp_str.parse::<u64>().ok()?;
-        Some(SnapshotRun { timestamp, manifest_key: key.to_string() })
-    }
-
     /// Parses a common prefix of the form `{list_prefix}{timestamp}/`.
     pub fn parse_run_prefix(prefix: &str, list_prefix: &str) -> Option<(u64, String)> {
         let rest = prefix.strip_prefix(list_prefix)?;
@@ -797,53 +786,6 @@ mod tests {
         assert_eq!(
             UploadStrategy::classify("custom_component-100-200.tar.zst"),
             UploadStrategy::DiffByHash
-        );
-    }
-
-    #[test]
-    fn parse_completed_run_manifest_key_accepts_timestamp_dirs() {
-        assert_eq!(
-            SnapshotUploader::parse_completed_run_manifest_key(
-                "mainnet/1710000002/manifest.json",
-                "mainnet/"
-            ),
-            Some(SnapshotRun {
-                timestamp: 1_710_000_002,
-                manifest_key: "mainnet/1710000002/manifest.json".to_string(),
-            })
-        );
-
-        assert_eq!(
-            SnapshotUploader::parse_completed_run_manifest_key("1710000002/manifest.json", ""),
-            Some(SnapshotRun {
-                timestamp: 1_710_000_002,
-                manifest_key: "1710000002/manifest.json".to_string(),
-            })
-        );
-    }
-
-    #[test]
-    fn parse_completed_run_manifest_key_rejects_non_run_keys() {
-        assert_eq!(
-            SnapshotUploader::parse_completed_run_manifest_key(
-                "mainnet/static_files/manifest.json",
-                "mainnet/"
-            ),
-            None
-        );
-        assert_eq!(
-            SnapshotUploader::parse_completed_run_manifest_key(
-                "mainnet/1710000002/state.tar.zst",
-                "mainnet/"
-            ),
-            None
-        );
-        assert_eq!(
-            SnapshotUploader::parse_completed_run_manifest_key(
-                "other/1710000002/manifest.json",
-                "mainnet/"
-            ),
-            None
         );
     }
 

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -260,7 +261,7 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     let local_manifest = parse_local_manifest(&output_dir)?;
 
     let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, &local_manifest, None).await?;
+        uploader.upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, None).await?;
     assert_eq!(upload_prefix, "mainnet/1700000000", "run prefix should be date-based");
 
     let s3 = &harness.storage_client;
@@ -326,7 +327,7 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let local_manifest = parse_local_manifest(&output_dir)?;
 
     let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, &local_manifest, None).await?;
+        uploader.upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, None).await?;
     assert_eq!(upload_prefix, "1700000000", "empty prefix should produce bare date");
 
     let s3 = &harness.storage_client;
@@ -454,7 +455,7 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
     assert!(remote_manifest.is_some(), "should find the pre-seeded previous manifest");
 
     uploader
-        .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
+        .upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, remote_manifest.as_ref())
         .await?;
 
     // Verify: pre-seeded chunks were NOT overwritten (skipped due to blake3 match).
@@ -549,7 +550,7 @@ async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Re
     let remote_manifest = uploader.fetch_previous_manifest().await?;
 
     uploader
-        .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
+        .upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, remote_manifest.as_ref())
         .await?;
 
     // Verify every chunk was re-uploaded with the fresh bytes.
@@ -592,7 +593,7 @@ async fn diff_upload_uploads_everything_on_first_run() -> Result<()> {
     assert!(remote_manifest.is_none(), "fresh bucket should have no previous manifest");
 
     uploader
-        .upload(&output_dir, &files, 1_700_000_000, &local_manifest, remote_manifest.as_ref())
+        .upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, remote_manifest.as_ref())
         .await?;
 
     let body =
@@ -734,7 +735,7 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
     ];
 
     let upload_prefix = uploader
-        .upload(&output_dir, &files, 1_700_000_000, &empty_manifest(2_000_000), None)
+        .upload(&output_dir, &files, 1_700_000_000, 100, &empty_manifest(2_000_000), None)
         .await?;
     assert_eq!(upload_prefix, "overwrite-test/1700000000");
 
@@ -800,6 +801,7 @@ async fn orchestrator_always_restarts_on_failure() -> Result<()> {
         block: Some(100),
         blocks_per_file: Some(500_000),
         snapshot_threads: None,
+        retain_runs: NonZeroUsize::new(3).expect("retain runs should be non-zero"),
         docker_socket: "/var/run/docker.sock".to_string(),
         s3_config_type: base_snapshotter::S3ConfigType::Aws,
         s3_endpoint: None,
@@ -868,7 +870,7 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
         None,
     );
     let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, &local_manifest, None).await?;
+        uploader.upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, None).await?;
 
     let manifest_body = get_object_bytes(
         &harness.storage_client,


### PR DESCRIPTION
## Summary
- Add a `--retain-runs` / `SNAPSHOTTER_RETAIN_RUNS` option that defaults to keeping the latest 3 completed snapshot run directories.
- Prune old timestamped run prefixes after the new run manifest is published, while leaving `static_files/` append-only.
- Batch R2/S3 object deletion and keep cleanup failures non-fatal for completed uploads.