### PR TITLE
fix: keep initial reset future alive across admin queries

### DIFF
--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -1,6 +1,8 @@
 //! The [`SequencerActor`].
 
 use std::{
+    future::Future,
+    pin::Pin,
     sync::Arc,
     time::{Duration, Instant, UNIX_EPOCH},
 };
@@ -193,29 +195,56 @@ where
     /// return [`EngineClientError::ELSyncing`]. In that case we wait one block time and retry,
     /// so we never send a `forkchoice_updated` that would abort reth's in-progress EL sync.
     ///
-    /// Admin API queries are serviced throughout — both during reset attempts and during the
-    /// backoff sleep — so that control can reach the sequencer while EL sync is in progress.
+    /// Admin API queries are serviced throughout so that control can reach the sequencer while EL
+    /// sync is in progress. The in-flight reset future is kept alive across admin queries so the
+    /// engine's reset response receiver is not dropped.
     async fn schedule_initial_reset(
         &mut self,
         next_payload: &mut Option<UnsealedPayloadHandle>,
     ) -> Result<(), SequencerActorError> {
+        let mut resetting: Option<
+            Pin<Box<dyn Future<Output = Result<(), EngineClientError>> + Send + '_>>,
+        > = None;
+
         loop {
-            select! {
-                biased;
-                _ = self.cancellation_token.cancelled() => return Ok(()),
-                Some(query) = self.admin_api_rx.recv() => {
-                    self.handle_admin_query(next_payload, query).await;
+            if resetting.is_none() {
+                let engine_client = Arc::clone(&self.engine_client);
+                resetting =
+                    Some(Box::pin(async move { engine_client.reset_engine_forkchoice().await }));
+            }
+
+            let reset_result = {
+                let reset = resetting.as_mut().expect("reset future initialized before polling");
+                let mut reset_result = None;
+
+                select! {
+                    biased;
+                    _ = self.cancellation_token.cancelled() => return Ok(()),
+                    result = reset => {
+                        reset_result = Some(result);
+                    }
+                    Some(query) = self.admin_api_rx.recv() => {
+                        self.handle_admin_query(next_payload, query).await;
+                    }
                 }
-                result = self.engine_client.reset_engine_forkchoice() => match result {
-                    Ok(()) => return Ok(()),
-                    Err(EngineClientError::ELSyncing) => {
-                        info!(target: "sequencer", "EL sync in progress; deferring initial engine reset");
-                    }
-                    Err(err) => {
-                        error!(target: "sequencer", error = ?err, "Failed to send reset request to engine");
-                        return Err(err.into());
-                    }
-                },
+
+                reset_result
+            };
+
+            let Some(result) = reset_result else {
+                continue;
+            };
+            resetting = None;
+
+            match result {
+                Ok(()) => return Ok(()),
+                Err(EngineClientError::ELSyncing) => {
+                    info!(target: "sequencer", "EL sync in progress; deferring initial engine reset");
+                }
+                Err(err) => {
+                    error!(target: "sequencer", error = ?err, "Failed to send reset request to engine");
+                    return Err(err.into());
+                }
             }
             // Wait one block time before retrying the reset, but service admin queries
             // and honour cancellation throughout the backoff window.

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -1,8 +1,7 @@
 //! The [`SequencerActor`].
 
 use std::{
-    future::Future,
-    pin::Pin,
+    future,
     sync::Arc,
     time::{Duration, Instant, UNIX_EPOCH},
 };
@@ -12,6 +11,7 @@ use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::AttributesBuilder;
 use base_consensus_rpc::SequencerAdminAPIError;
+use futures::future::BoxFuture;
 use tokio::{
     select,
     sync::{mpsc, oneshot},
@@ -202,9 +202,7 @@ where
         &mut self,
         next_payload: &mut Option<UnsealedPayloadHandle>,
     ) -> Result<(), SequencerActorError> {
-        let mut resetting: Option<
-            Pin<Box<dyn Future<Output = Result<(), EngineClientError>> + Send + '_>>,
-        > = None;
+        let mut resetting: Option<BoxFuture<'_, Result<(), EngineClientError>>> = None;
 
         loop {
             if resetting.is_none() {
@@ -334,7 +332,7 @@ where
                             &self.unsafe_payload_gossip_client,
                             &self.engine_client,
                         ).await),
-                        None => std::future::pending().await,
+                        None => future::pending().await,
                     }
                 } => {
                     match result {


### PR DESCRIPTION
Summary
- Keeps the in-flight initial engine reset future alive while serving admin API queries.
- Retries after EL syncing responses without dropping the reset response receiver early.

Credit to @refcell 