### PR TITLE
fix(consensus-engine): preserve safe heads on syncing FCU

### DIFF
--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -72,6 +72,17 @@ impl EngineSyncState {
         }
     }
 
+    /// Computes the new sync state using the current state values when the update is not
+    /// specified.
+    pub fn updated(self, sync_state_update: EngineSyncStateUpdate) -> Self {
+        Self {
+            unsafe_head: sync_state_update.unsafe_head.unwrap_or(self.unsafe_head),
+            local_safe_head: sync_state_update.local_safe_head.unwrap_or(self.local_safe_head),
+            safe_head: sync_state_update.safe_head.unwrap_or(self.safe_head),
+            finalized_head: sync_state_update.finalized_head.unwrap_or(self.finalized_head),
+        }
+    }
+
     /// Applies the update to the provided sync state, using the current state values if the update
     /// is not specified. Returns the new sync state.
     pub fn apply_update(self, sync_state_update: EngineSyncStateUpdate) -> Self {
@@ -100,12 +111,7 @@ impl EngineSyncState {
                 .set(now_secs - finalized_head.block_info.timestamp as f64);
         }
 
-        Self {
-            unsafe_head: sync_state_update.unsafe_head.unwrap_or(self.unsafe_head),
-            local_safe_head: sync_state_update.local_safe_head.unwrap_or(self.local_safe_head),
-            safe_head: sync_state_update.safe_head.unwrap_or(self.safe_head),
-            finalized_head: sync_state_update.finalized_head.unwrap_or(self.finalized_head),
-        }
+        self.updated(sync_state_update)
     }
 }
 

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadStatusEnum};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
+use base_protocol::L2BlockInfo;
 use derive_more::Constructor;
 use tokio::time::Instant;
 
@@ -46,6 +47,32 @@ pub struct SynchronizeTask<EngineClient_: EngineClient> {
 }
 
 impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
+    /// Computes the sync-state update to apply when the EL responds with `Syncing`.
+    ///
+    /// Until the EL has finished syncing, the state is left untouched. Once EL sync has
+    /// completed, already-consolidated safe/local-safe/finalized progress is preserved,
+    /// but only for heads at or behind the current unsafe head. `unsafe_head` is never
+    /// advanced beyond what the EL can serve.
+    fn safe_only_sync_update(&self, state: &EngineState) -> EngineSyncStateUpdate {
+        if !state.el_sync_finished {
+            return EngineSyncStateUpdate::default();
+        }
+
+        let current_unsafe = state.sync_state.unsafe_head();
+        let is_not_ahead_of_unsafe = |head: &L2BlockInfo| {
+            head.block_info.number < current_unsafe.block_info.number
+                || (head.block_info.number == current_unsafe.block_info.number
+                    && head.block_info.hash == current_unsafe.block_info.hash)
+        };
+        EngineSyncStateUpdate {
+            // Never advance the unsafe head on a `Syncing` response.
+            unsafe_head: None,
+            local_safe_head: self.state_update.local_safe_head.filter(is_not_ahead_of_unsafe),
+            safe_head: self.state_update.safe_head.filter(is_not_ahead_of_unsafe),
+            finalized_head: self.state_update.finalized_head.filter(is_not_ahead_of_unsafe),
+        }
+    }
+
     /// Checks the response of the `engine_forkchoiceUpdated` call, and updates the sync status if
     /// necessary.
     ///
@@ -96,7 +123,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
 
     async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, SynchronizeTaskError> {
         // Apply the sync state update to the engine state.
-        let new_sync_state = state.sync_state.apply_update(self.state_update);
+        let new_sync_state = state.sync_state.updated(self.state_update);
 
         // Check if a forkchoice update is not needed, return early.
         // A forkchoice update is not needed if...
@@ -152,13 +179,11 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         let confirmed =
             self.check_forkchoice_updated_status(state, &valid_response.payload_status.status)?;
 
-        // Only apply the sync-state update when the EL confirmed the forkchoice
-        // (`Valid`).  When the EL returns `Syncing` the block is merely stored —
-        // advancing `sync_state` here would move `unsafe_head` beyond what the EL
-        // can serve, creating a gap that breaks derivation consolidation.
-        if confirmed {
-            state.sync_state = new_sync_state;
-        }
+        // On `Valid`, commit the full sync-state update. On `Syncing`, commit only
+        // the filtered safe-side update that is actually allowed to survive.
+        let applied_update =
+            if confirmed { self.state_update } else { self.safe_only_sync_update(state) };
+        state.sync_state = state.sync_state.apply_update(applied_update);
 
         let fcu_duration = fcu_time_start.elapsed();
         debug!(

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task_test.rs
@@ -82,6 +82,176 @@ async fn syncing_response_does_not_advance_sync_state() {
 }
 
 #[tokio::test]
+async fn syncing_response_preserves_safe_head_when_it_is_behind_unsafe() {
+    let unsafe_head = test_block_info(100);
+    let safe_head = test_block_info(90);
+    let cfg = Arc::new(RollupConfig::default());
+    let client = Arc::new(
+        test_engine_client_builder().with_fork_choice_updated_v3_response(syncing_fcu()).build(),
+    );
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_head)
+        .with_safe_head(test_block_info(89))
+        .with_el_sync_finished(true)
+        .build();
+    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+        local_safe_head: Some(test_block_info(89)),
+        ..Default::default()
+    });
+
+    let task = SynchronizeTask::new(
+        client,
+        cfg,
+        EngineSyncStateUpdate {
+            local_safe_head: Some(safe_head),
+            safe_head: Some(safe_head),
+            ..Default::default()
+        },
+    );
+
+    task.execute(&mut state).await.expect("should succeed");
+
+    assert_eq!(state.sync_state.unsafe_head(), unsafe_head);
+    assert_eq!(state.sync_state.local_safe_head(), safe_head);
+    assert_eq!(state.sync_state.safe_head(), safe_head);
+    assert!(state.el_sync_finished, "el_sync_finished should remain sticky after Syncing");
+}
+
+#[tokio::test]
+async fn syncing_response_does_not_preserve_safe_head_before_el_sync_finishes() {
+    let unsafe_head = test_block_info(100);
+    let safe_head = test_block_info(90);
+    let cfg = Arc::new(RollupConfig::default());
+    let client = Arc::new(
+        test_engine_client_builder().with_fork_choice_updated_v3_response(syncing_fcu()).build(),
+    );
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_head)
+        .with_safe_head(test_block_info(89))
+        .with_el_sync_finished(false)
+        .build();
+    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+        local_safe_head: Some(test_block_info(89)),
+        ..Default::default()
+    });
+
+    let task = SynchronizeTask::new(
+        client,
+        cfg,
+        EngineSyncStateUpdate {
+            local_safe_head: Some(safe_head),
+            safe_head: Some(safe_head),
+            ..Default::default()
+        },
+    );
+
+    task.execute(&mut state).await.expect("should succeed");
+
+    assert_eq!(state.sync_state.unsafe_head(), unsafe_head);
+    assert_eq!(state.sync_state.local_safe_head().block_info.number, 89);
+    assert_eq!(state.sync_state.safe_head().block_info.number, 89);
+    assert!(!state.el_sync_finished);
+}
+
+#[tokio::test]
+async fn syncing_response_does_not_advance_safe_head_past_unsafe() {
+    let unsafe_head = test_block_info(100);
+    let safe_head = test_block_info(101);
+    let mut preserved_finalized_head = test_block_info(100);
+    preserved_finalized_head.block_info.hash = unsafe_head.block_info.hash;
+    let cfg = Arc::new(RollupConfig::default());
+    let client = Arc::new(
+        test_engine_client_builder().with_fork_choice_updated_v3_response(syncing_fcu()).build(),
+    );
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_head)
+        .with_safe_head(test_block_info(95))
+        .with_finalized_head(test_block_info(90))
+        .with_el_sync_finished(true)
+        .build();
+    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+        local_safe_head: Some(unsafe_head),
+        ..Default::default()
+    });
+
+    let task = SynchronizeTask::new(
+        client,
+        cfg,
+        EngineSyncStateUpdate {
+            local_safe_head: Some(safe_head),
+            safe_head: Some(safe_head),
+            finalized_head: Some(preserved_finalized_head),
+            ..Default::default()
+        },
+    );
+
+    task.execute(&mut state).await.expect("should succeed");
+
+    assert_eq!(state.sync_state.unsafe_head(), unsafe_head);
+    assert_eq!(state.sync_state.local_safe_head(), unsafe_head);
+    assert_eq!(state.sync_state.safe_head().block_info.number, 95);
+    assert_eq!(state.sync_state.finalized_head(), preserved_finalized_head);
+}
+
+#[tokio::test]
+async fn syncing_response_preserves_equal_height_safe_head_only_on_same_hash() {
+    let unsafe_head = test_block_info(100);
+    let matching_safe_head = unsafe_head;
+    let mismatched_safe_head = test_block_info(100);
+    let cfg = Arc::new(RollupConfig::default());
+    let client = Arc::new(
+        test_engine_client_builder().with_fork_choice_updated_v3_response(syncing_fcu()).build(),
+    );
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_head)
+        .with_safe_head(test_block_info(99))
+        .with_el_sync_finished(true)
+        .build();
+    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+        local_safe_head: Some(test_block_info(99)),
+        ..Default::default()
+    });
+
+    let matching_task = SynchronizeTask::new(
+        Arc::clone(&client),
+        Arc::clone(&cfg),
+        EngineSyncStateUpdate {
+            local_safe_head: Some(matching_safe_head),
+            safe_head: Some(matching_safe_head),
+            ..Default::default()
+        },
+    );
+    matching_task.execute(&mut state).await.expect("should succeed");
+    assert_eq!(state.sync_state.safe_head(), matching_safe_head);
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_head)
+        .with_safe_head(test_block_info(99))
+        .with_el_sync_finished(true)
+        .build();
+    state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+        local_safe_head: Some(test_block_info(99)),
+        ..Default::default()
+    });
+    let mismatched_task = SynchronizeTask::new(
+        client,
+        cfg,
+        EngineSyncStateUpdate {
+            local_safe_head: Some(mismatched_safe_head),
+            safe_head: Some(mismatched_safe_head),
+            ..Default::default()
+        },
+    );
+    mismatched_task.execute(&mut state).await.expect("should succeed");
+    assert_eq!(state.sync_state.local_safe_head().block_info.number, 99);
+    assert_eq!(state.sync_state.safe_head().block_info.number, 99);
+}
+
+#[tokio::test]
 async fn syncing_then_valid_advances_state_on_second_call() {
     let head_a = test_block_info(100);
     let head_b = test_block_info(101);


### PR DESCRIPTION
## Summary

Backport of #3803 to `releases/v1.1.2`.

This fixes a wedge where safe-head confirmation can be lost when a consolidation forkchoice update returns `Syncing`.

## Original RCA

1. Consolidation produced a safe-head update and passed it into `SynchronizeTask`.
2. `SynchronizeTask::execute()` built a forkchoice from the fully updated state and sent it to EL.
3. EL returned `Syncing`, typically because the unsafe head was still ahead of what EL could fully validate.
4. On `Syncing`, `SynchronizeTask` kept none of the update, so the engine dropped the safe/local-safe/finalized progress together with the rejected unsafe-head advance.
5. The derivation side never observed confirmation of the safe head it had just consolidated, and could remain stuck waiting for a confirmation that had effectively been discarded.

## Backport Notes

This backport keeps the fix local to the consensus engine:

- preserve safe/local-safe/finalized progress on `Syncing` only after `el_sync_finished`
- never advance `unsafe_head` on `Syncing`
- only preserve heads at or behind current unsafe
- keep speculative sync-state computation side-effect free so metrics only reflect the committed update

## Validation

- `cargo test -p base-consensus-engine synchronize -- --nocapture`
- `cargo test -p base-consensus-engine`
