### PR TITLE
fix(builder): propagate DA footprint fetch error instead of panicking

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -635,8 +635,9 @@ impl BasePayloadBuilderCtx {
             .is_jovian_active_at_timestamp(self.attributes().timestamp())
             .then(|| {
                 L1BlockInfo::fetch_da_footprint_gas_scalar(evm.db_mut())
-                    .expect("DA footprint should always be available from the database post jovian")
-            });
+                    .map_err(|e| PayloadBuilderError::Other(e.into()))
+            })
+            .transpose()?;
 
         info.da_footprint_scalar = da_footprint_gas_scalar;
 


### PR DESCRIPTION
Replace .expect() with proper error propagation via .map_err() so that a DB failure returns PayloadBuilderError instead of panicking the entire builder task.

Closes #3795