### PR TITLE
fix(flashblocks): handle empty flashblocks and prevent u64 underflow in build_pending_state

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -698,8 +698,13 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
-        let canonical_block = earliest_block_number - 1;
+        let earliest_block_number = match flashblocks_per_block.keys().min() {
+            None => return Ok(None),
+            Some(&num) => num,
+        };
+        let Some(canonical_block) = earliest_block_number.checked_sub(1) else {
+            return Ok(None);
+        };
         let mut last_block_header = self
             .client
             .header_by_number(canonical_block)


### PR DESCRIPTION
Closes #3796

    Return Ok(None) when flashblocks_per_block is empty after filtering, instead of panicking on .unwrap(). Use checked_sub(1) for the canonical block computation to prevent u64 underflow at genesis.