### PR TITLE
fix(batcher): skip advance_l1_head when confirmed receipt lacks block_number

### DIFF
--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -227,7 +227,9 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                 for id in &ids {
                     pipeline.confirm(*id, l1_block);
                 }
-                pipeline.advance_l1_head(l1_block);
+                if l1_block > 0 {
+                    pipeline.advance_l1_head(l1_block);
+                }
                 BatcherMetrics::submission_total(BatcherMetrics::OUTCOME_CONFIRMED)
                     .increment(ids.len() as u64);
                 info!(submissions = %ids.len(), l1_block = %l1_block, "submission confirmed on L1");


### PR DESCRIPTION
Closes #3798

    When receipt.block_number is missing (rare edge case), the code falls back to 0, which makes advance_l1_head(0) a silent no-op. Skip the advance_l1_head call entirely when block_number is 0.