### PR TITLE
fix(proof): validate intermediateRoots length is multiple of 32 in decode_packed

### DIFF
--- a/crates/proof/succinct/utils/client/src/types.rs
+++ b/crates/proof/succinct/utils/client/src/types.rs
@@ -72,6 +72,9 @@ impl AggregationOutputs {
         off += 8;
 
         let roots_len = data.len() - PREFIX - SUFFIX;
+        if roots_len % 32 != 0 {
+            return Err("intermediateRoots length is not a multiple of 32");
+        }
         let intermediate_roots = Bytes::copy_from_slice(&data[off..off + roots_len]);
         off += roots_len;
 


### PR DESCRIPTION
Closes #3811

    Add a length alignment check to prevent silently accepting malformed input where intermediateRoots does not divide evenly into B256 chunks.