### PR TITLE
refactor(challenger): simplify anchor updater

### DIFF
--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -13,17 +13,25 @@ use tracing::{debug, info, warn};
 use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
 
 /// Best-effort updater for the `AnchorStateRegistry`.
-#[derive(derive_more::Debug)]
 pub struct AnchorUpdater {
-    #[debug(skip)]
     factory_client: Arc<dyn DisputeGameFactoryClient>,
-    #[debug(skip)]
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
     output_validator: OutputValidator<dyn L2Provider>,
     anchor_state_registry_address: Address,
     game_type: u32,
     block_interval: u64,
     intermediate_block_interval: u64,
+}
+
+impl std::fmt::Debug for AnchorUpdater {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnchorUpdater")
+            .field("anchor_state_registry_address", &self.anchor_state_registry_address)
+            .field("game_type", &self.game_type)
+            .field("block_interval", &self.block_interval)
+            .field("intermediate_block_interval", &self.intermediate_block_interval)
+            .finish_non_exhaustive()
+    }
 }
 
 impl AnchorUpdater {
@@ -50,7 +58,7 @@ impl AnchorUpdater {
 
     /// Finds the next game after the anchor game and advances the anchor root if it is ready.
     pub async fn poll(
-        &mut self,
+        &self,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) {
@@ -69,10 +77,6 @@ impl AnchorUpdater {
 
         match verifier_client.status(game_address).await {
             Ok(GameStatus::DefenderWins) => {}
-            Ok(GameStatus::InProgress) => {
-                debug!(game = %game_address, "anchor update waiting for next game");
-                return;
-            }
             Ok(status) => {
                 debug!(
                     game = %game_address,
@@ -287,15 +291,6 @@ mod tests {
     const BLOCK_INTERVAL: u64 = 100;
     const INTERMEDIATE_BLOCK_INTERVAL: u64 = 100;
 
-    fn insert_l2_block(l2: &mut MockL2Provider, block: u64) -> B256 {
-        let storage_hash = B256::repeat_byte(block as u8);
-        let (header, account) = build_test_header_and_account(block, storage_hash);
-        let output_root =
-            OutputRoot::from_parts(header.state_root, storage_hash, header.hash_slow()).hash();
-        l2.insert_block(block, header, account);
-        output_root
-    }
-
     fn fixture(
         anchor_game: Address,
         game: Address,
@@ -309,7 +304,11 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
         let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        let storage_hash = B256::repeat_byte(BLOCK_INTERVAL as u8);
+        let (header, account) = build_test_header_and_account(BLOCK_INTERVAL, storage_hash);
+        let output_root =
+            OutputRoot::from_parts(header.state_root, storage_hash, header.hash_slow()).hash();
+        l2.insert_block(BLOCK_INTERVAL, header, account);
         let parent = if anchor_game == Address::ZERO { ASR_ADDRESS } else { anchor_game };
         let extra_data =
             game_lookup_key(0, parent, BLOCK_INTERVAL, INTERMEDIATE_BLOCK_INTERVAL, &[output_root])
@@ -337,7 +336,7 @@ mod tests {
     #[tokio::test]
     async fn poll_updates_next_defender_win() {
         let game = addr(1);
-        let (_, verifier, submitter, mut updater) =
+        let (_, verifier, submitter, updater) =
             fixture(Address::ZERO, game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
@@ -351,7 +350,7 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_in_progress_next_game() {
         let game = addr(1);
-        let (_, verifier, submitter, mut updater) =
+        let (_, verifier, submitter, updater) =
             fixture(Address::ZERO, game, GameStatus::InProgress);
 
         updater.poll(&verifier, &submitter).await;
@@ -362,7 +361,7 @@ mod tests {
     #[tokio::test]
     async fn poll_stops_at_challenger_wins_next_game() {
         let challenger_win = addr(10);
-        let (factory, verifier, submitter, mut updater) =
+        let (factory, verifier, submitter, updater) =
             fixture(Address::ZERO, challenger_win, GameStatus::ChallengerWins);
 
         updater.poll(&verifier, &submitter).await;
@@ -377,7 +376,7 @@ mod tests {
     async fn poll_starts_after_current_anchor_game() {
         let anchor_game = addr(10);
         let next_game = addr(11);
-        let (_, verifier, submitter, mut updater) =
+        let (_, verifier, submitter, updater) =
             fixture(anchor_game, next_game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
@@ -390,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_finalized_defender_win() {
         let game = addr(1);
-        let (_, verifier, submitter, mut updater) =
+        let (_, verifier, submitter, updater) =
             fixture(Address::ZERO, game, GameStatus::DefenderWins);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -13,25 +13,18 @@ use tracing::{debug, info, warn};
 use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
 
 /// Best-effort updater for the `AnchorStateRegistry`.
+#[derive(derive_more::Debug)]
 pub struct AnchorUpdater {
+    #[debug(skip)]
     factory_client: Arc<dyn DisputeGameFactoryClient>,
+    #[debug(skip)]
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
+    #[debug(skip)]
     output_validator: OutputValidator<dyn L2Provider>,
     anchor_state_registry_address: Address,
     game_type: u32,
     block_interval: u64,
     intermediate_block_interval: u64,
-}
-
-impl std::fmt::Debug for AnchorUpdater {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AnchorUpdater")
-            .field("anchor_state_registry_address", &self.anchor_state_registry_address)
-            .field("game_type", &self.game_type)
-            .field("block_interval", &self.block_interval)
-            .field("intermediate_block_interval", &self.intermediate_block_interval)
-            .finish_non_exhaustive()
-    }
 }
 
 impl AnchorUpdater {
@@ -295,12 +288,7 @@ mod tests {
         anchor_game: Address,
         game: Address,
         status: GameStatus,
-    ) -> (
-        Arc<MockDisputeGameFactory>,
-        MockAggregateVerifier,
-        MockBondTransactionSubmitter,
-        AnchorUpdater,
-    ) {
+    ) -> (MockAggregateVerifier, MockBondTransactionSubmitter, AnchorUpdater) {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
         let mut l2 = MockL2Provider::new();
@@ -330,14 +318,13 @@ mod tests {
             INTERMEDIATE_BLOCK_INTERVAL,
         );
 
-        (factory, verifier, submitter, updater)
+        (verifier, submitter, updater)
     }
 
     #[tokio::test]
     async fn poll_updates_next_defender_win() {
         let game = addr(1);
-        let (_, verifier, submitter, updater) =
-            fixture(Address::ZERO, game, GameStatus::DefenderWins);
+        let (verifier, submitter, updater) = fixture(Address::ZERO, game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -350,8 +337,7 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_in_progress_next_game() {
         let game = addr(1);
-        let (_, verifier, submitter, updater) =
-            fixture(Address::ZERO, game, GameStatus::InProgress);
+        let (verifier, submitter, updater) = fixture(Address::ZERO, game, GameStatus::InProgress);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -361,11 +347,9 @@ mod tests {
     #[tokio::test]
     async fn poll_stops_at_challenger_wins_next_game() {
         let challenger_win = addr(10);
-        let (factory, verifier, submitter, updater) =
+        let (verifier, submitter, updater) =
             fixture(Address::ZERO, challenger_win, GameStatus::ChallengerWins);
 
-        updater.poll(&verifier, &submitter).await;
-        factory.uuid_games.lock().unwrap().clear();
         updater.poll(&verifier, &submitter).await;
 
         assert!(submitter.recorded_calls().is_empty());
@@ -376,7 +360,7 @@ mod tests {
     async fn poll_starts_after_current_anchor_game() {
         let anchor_game = addr(10);
         let next_game = addr(11);
-        let (_, verifier, submitter, updater) =
+        let (verifier, submitter, updater) =
             fixture(anchor_game, next_game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
@@ -389,8 +373,7 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_finalized_defender_win() {
         let game = addr(1);
-        let (_, verifier, submitter, updater) =
-            fixture(Address::ZERO, game, GameStatus::DefenderWins);
+        let (verifier, submitter, updater) = fixture(Address::ZERO, game, GameStatus::DefenderWins);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;
         state.is_finalized = false;

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -4,12 +4,10 @@ use std::sync::Arc;
 
 use alloy_primitives::Address;
 use base_proof_contracts::{
-    AggregateVerifierClient, AnchorRoot, AnchorSnapshot, AnchorStateRegistryClient,
-    DisputeGameFactoryClient, GameStatus, encode_set_anchor_state_calldata, game_lookup_blocks,
-    game_lookup_key,
+    AggregateVerifierClient, AnchorRoot, AnchorStateRegistryClient, DisputeGameFactoryClient,
+    GameStatus, encode_set_anchor_state_calldata, game_lookup_blocks, game_lookup_key,
 };
 use base_proof_rpc::L2Provider;
-use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
 use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
@@ -22,8 +20,6 @@ pub struct AnchorUpdater {
     #[debug(skip)]
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
     output_validator: OutputValidator<dyn L2Provider>,
-    #[debug(skip)]
-    cached_next_game: Option<(AnchorSnapshot, Address)>,
     anchor_state_registry_address: Address,
     game_type: u32,
     block_interval: u64,
@@ -45,7 +41,6 @@ impl AnchorUpdater {
             factory_client,
             anchor_registry_client,
             output_validator: OutputValidator::new(l2_provider),
-            cached_next_game: None,
             anchor_state_registry_address,
             game_type,
             block_interval,
@@ -67,17 +62,9 @@ impl AnchorUpdater {
             }
         };
 
-        let game_address = match self.cached_next_game {
-            Some((cached_anchor, address)) if cached_anchor == anchor => address,
-            _ => {
-                self.cached_next_game = None;
-                let Some(address) = self.next_game(anchor.anchor_root, anchor.anchor_game).await
-                else {
-                    return;
-                };
-                self.cached_next_game = Some((anchor, address));
-                address
-            }
+        let Some(game_address) = self.next_game(anchor.anchor_root, anchor.anchor_game).await
+        else {
+            return;
         };
 
         match verifier_client.status(game_address).await {
@@ -92,7 +79,6 @@ impl AnchorUpdater {
                     status = %status,
                     "next game cannot update anchor"
                 );
-                self.cached_next_game = None;
                 return;
             }
             Err(e) => {
@@ -101,9 +87,7 @@ impl AnchorUpdater {
             }
         }
 
-        if Self::try_update(game_address, verifier_client, submitter).await {
-            self.cached_next_game = None;
-        }
+        Self::try_update(game_address, verifier_client, submitter).await;
     }
 
     async fn next_game(&self, anchor_root: AnchorRoot, anchor_game: Address) -> Option<Address> {
@@ -119,16 +103,9 @@ impl AnchorUpdater {
             }
         };
 
-        let mut roots =
-            stream::iter(blocks)
-                .map(|block| async move {
-                    (block, self.output_validator.compute_output_root(block).await)
-                })
-                .buffered(OutputValidator::<dyn L2Provider>::VALIDATION_CONCURRENCY);
-
         let mut intermediate_roots = Vec::new();
-        while let Some((block, result)) = roots.next().await {
-            let root = match result {
+        for block in blocks {
+            let root = match self.output_validator.compute_output_root(block).await {
                 Ok(root) => root,
                 Err(e) => {
                     debug!(block, error = %e, "anchor update waiting for output root");
@@ -185,12 +162,12 @@ impl AnchorUpdater {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) -> bool {
+    ) {
         let asr_address = match verifier_client.anchor_state_registry(game_address).await {
             Ok(address) => address,
             Err(e) => {
                 warn!(game = %game_address, error = %e, "failed to read anchor registry for game");
-                return false;
+                return;
             }
         };
 
@@ -198,11 +175,11 @@ impl AnchorUpdater {
             Ok(true) => {}
             Ok(false) => {
                 debug!(game = %game_address, asr = %asr_address, "anchor update waiting for finality");
-                return false;
+                return;
             }
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game finality for anchor update");
-                return false;
+                return;
             }
         }
 
@@ -210,7 +187,7 @@ impl AnchorUpdater {
             Ok(preflight) => preflight,
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read anchor preflight");
-                return false;
+                return;
             }
         };
 
@@ -226,7 +203,7 @@ impl AnchorUpdater {
             );
             ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
                 .increment(1);
-            return false;
+            return;
         }
 
         if preflight.paused || !preflight.respected {
@@ -237,14 +214,14 @@ impl AnchorUpdater {
                 respected = preflight.respected,
                 "anchor update waiting for registry eligibility"
             );
-            return false;
+            return;
         }
 
         let game_info = match verifier_client.game_info(game_address).await {
             Ok(info) => info,
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game info for anchor update");
-                return false;
+                return;
             }
         };
 
@@ -258,7 +235,7 @@ impl AnchorUpdater {
             );
             ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
                 .increment(1);
-            return false;
+            return;
         }
 
         match submitter
@@ -277,7 +254,6 @@ impl AnchorUpdater {
                 )
                 .increment(1);
                 ChallengerMetrics::anchor_l2_block_number().set(game_info.l2_block_number as f64);
-                true
             }
             Err(e) => {
                 warn!(
@@ -288,7 +264,6 @@ impl AnchorUpdater {
                 );
                 ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
-                false
             }
         }
     }
@@ -321,35 +296,6 @@ mod tests {
         output_root
     }
 
-    fn insert_next_game(
-        factory: &MockDisputeGameFactory,
-        parent: Address,
-        output_root: B256,
-        game: Address,
-    ) {
-        let extra_data =
-            game_lookup_key(0, parent, BLOCK_INTERVAL, INTERMEDIATE_BLOCK_INTERVAL, &[output_root])
-                .unwrap()
-                .extra_data;
-        factory.insert_uuid_game(GAME_TYPE, output_root, extra_data, game);
-    }
-
-    fn updater(
-        factory: Arc<MockDisputeGameFactory>,
-        anchor_registry: Arc<MockAnchorStateRegistry>,
-        l2: Arc<MockL2Provider>,
-    ) -> AnchorUpdater {
-        AnchorUpdater::new(
-            factory as Arc<dyn DisputeGameFactoryClient>,
-            anchor_registry as Arc<dyn AnchorStateRegistryClient>,
-            l2 as Arc<dyn L2Provider>,
-            ASR_ADDRESS,
-            GAME_TYPE,
-            BLOCK_INTERVAL,
-            INTERMEDIATE_BLOCK_INTERVAL,
-        )
-    }
-
     fn fixture(
         anchor_game: Address,
         game: Address,
@@ -365,14 +311,25 @@ mod tests {
         let mut l2 = MockL2Provider::new();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         let parent = if anchor_game == Address::ZERO { ASR_ADDRESS } else { anchor_game };
-        insert_next_game(&factory, parent, output_root, game);
+        let extra_data =
+            game_lookup_key(0, parent, BLOCK_INTERVAL, INTERMEDIATE_BLOCK_INTERVAL, &[output_root])
+                .unwrap()
+                .extra_data;
+        factory.insert_uuid_game(GAME_TYPE, output_root, extra_data, game);
 
         let mut state = mock_state(status, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter =
-            MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO), Ok(B256::ZERO)]);
-        let updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+        let submitter = MockBondTransactionSubmitter::success(B256::ZERO);
+        let updater = AnchorUpdater::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            anchor_registry as Arc<dyn AnchorStateRegistryClient>,
+            Arc::new(l2) as Arc<dyn L2Provider>,
+            ASR_ADDRESS,
+            GAME_TYPE,
+            BLOCK_INTERVAL,
+            INTERMEDIATE_BLOCK_INTERVAL,
+        );
 
         (factory, verifier, submitter, updater)
     }
@@ -400,41 +357,6 @@ mod tests {
         updater.poll(&verifier, &submitter).await;
 
         assert!(submitter.recorded_calls().is_empty());
-    }
-
-    #[tokio::test]
-    async fn poll_reuses_cached_next_game_while_anchor_is_unchanged() {
-        let game = addr(1);
-        let (factory, verifier, submitter, mut updater) =
-            fixture(Address::ZERO, game, GameStatus::InProgress);
-
-        updater.poll(&verifier, &submitter).await;
-        factory.uuid_games.lock().unwrap().clear();
-
-        let mut resolved_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        resolved_state.anchor_state_registry = ASR_ADDRESS;
-        verifier.update_game(game, resolved_state);
-
-        updater.poll(&verifier, &submitter).await;
-
-        let calls = submitter.recorded_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game);
-    }
-
-    #[tokio::test]
-    async fn poll_clears_cached_next_game_after_successful_update() {
-        let game = addr(1);
-        let (factory, verifier, submitter, mut updater) =
-            fixture(Address::ZERO, game, GameStatus::DefenderWins);
-
-        updater.poll(&verifier, &submitter).await;
-        factory.uuid_games.lock().unwrap().clear();
-        updater.poll(&verifier, &submitter).await;
-
-        let calls = submitter.recorded_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -8,6 +8,7 @@ use base_proof_contracts::{
     encode_set_anchor_state_calldata, game_lookup_blocks, game_lookup_key,
 };
 use base_proof_rpc::L2Provider;
+use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
 use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
@@ -105,9 +106,15 @@ impl AnchorUpdater {
             }
         };
 
+        let mut roots =
+            stream::iter(blocks)
+                .map(|block| async move {
+                    (block, self.output_validator.compute_output_root(block).await)
+                })
+                .buffered(OutputValidator::<dyn L2Provider>::VALIDATION_CONCURRENCY);
         let mut intermediate_roots = Vec::new();
-        for block in blocks {
-            let root = match self.output_validator.compute_output_root(block).await {
+        while let Some((block, result)) = roots.next().await {
+            let root = match result {
                 Ok(root) => root,
                 Err(e) => {
                     debug!(block, error = %e, "anchor update waiting for output root");
@@ -273,7 +280,7 @@ impl AnchorUpdater {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::B256;
     use base_protocol::OutputRoot;
@@ -324,6 +331,43 @@ mod tests {
         );
 
         (verifier, submitter, updater)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_game_computes_intermediate_roots_concurrently() {
+        let game = addr(1);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let blocks = [25, 50, 75, 100];
+        let mut roots = Vec::new();
+
+        for block in blocks {
+            let storage_hash = B256::repeat_byte(block as u8);
+            let (header, account) = build_test_header_and_account(block, storage_hash);
+            roots.push(
+                OutputRoot::from_parts(header.state_root, storage_hash, header.hash_slow()).hash(),
+            );
+            l2.insert_block(block, header, account);
+        }
+
+        let extra_data = game_lookup_key(0, ASR_ADDRESS, 100, 25, &roots).unwrap().extra_data;
+        factory.insert_uuid_game(GAME_TYPE, roots[3], extra_data, game);
+        l2.header_delay = Some(Duration::from_secs(1));
+
+        let updater = AnchorUpdater::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            anchor_registry as Arc<dyn AnchorStateRegistryClient>,
+            Arc::new(l2) as Arc<dyn L2Provider>,
+            ASR_ADDRESS,
+            GAME_TYPE,
+            100,
+            25,
+        );
+
+        let started = tokio::time::Instant::now();
+        assert_eq!(updater.next_game(0, Address::ZERO).await, Some(game));
+        assert!(started.elapsed() < Duration::from_secs(2));
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -1,11 +1,11 @@
 //! Anchor root update management.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use alloy_primitives::Address;
 use base_proof_contracts::{
-    AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameStatus,
-    encode_set_anchor_state_calldata, game_lookup_blocks, game_lookup_key,
+    AggregateVerifierClient, AnchorSnapshot, AnchorStateRegistryClient, DisputeGameFactoryClient,
+    GameStatus, encode_set_anchor_state_calldata, game_lookup_blocks, game_lookup_key,
 };
 use base_proof_rpc::L2Provider;
 use futures::stream::{self, StreamExt};
@@ -22,6 +22,8 @@ pub struct AnchorUpdater {
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
     #[debug(skip)]
     output_validator: OutputValidator<dyn L2Provider>,
+    #[debug(skip)]
+    cached_next_game: Mutex<Option<(AnchorSnapshot, Address)>>,
     anchor_state_registry_address: Address,
     game_type: u32,
     block_interval: u64,
@@ -43,6 +45,7 @@ impl AnchorUpdater {
             factory_client,
             anchor_registry_client,
             output_validator: OutputValidator::new(l2_provider),
+            cached_next_game: Mutex::new(None),
             anchor_state_registry_address,
             game_type,
             block_interval,
@@ -64,10 +67,17 @@ impl AnchorUpdater {
             }
         };
 
-        let Some(game_address) =
-            self.next_game(anchor.anchor_root.l2_block_number, anchor.anchor_game).await
-        else {
-            return;
+        let game_address = match self.cached_next_game(anchor) {
+            Some(address) => address,
+            None => {
+                let Some(address) =
+                    self.next_game(anchor.anchor_root.l2_block_number, anchor.anchor_game).await
+                else {
+                    return;
+                };
+                self.cache_next_game(anchor, address);
+                address
+            }
         };
 
         match verifier_client.status(game_address).await {
@@ -86,7 +96,28 @@ impl AnchorUpdater {
             }
         }
 
-        Self::try_update(game_address, verifier_client, submitter).await;
+        if Self::try_update(game_address, verifier_client, submitter).await {
+            self.clear_cached_next_game();
+        }
+    }
+
+    fn cached_next_game(&self, anchor: AnchorSnapshot) -> Option<Address> {
+        let mut cached = self.cached_next_game.lock().unwrap();
+        match *cached {
+            Some((cached_anchor, address)) if cached_anchor == anchor => Some(address),
+            _ => {
+                *cached = None;
+                None
+            }
+        }
+    }
+
+    fn cache_next_game(&self, anchor: AnchorSnapshot, address: Address) {
+        *self.cached_next_game.lock().unwrap() = Some((anchor, address));
+    }
+
+    fn clear_cached_next_game(&self) {
+        *self.cached_next_game.lock().unwrap() = None;
     }
 
     async fn next_game(
@@ -171,12 +202,12 @@ impl AnchorUpdater {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) {
+    ) -> bool {
         let asr_address = match verifier_client.anchor_state_registry(game_address).await {
             Ok(address) => address,
             Err(e) => {
                 warn!(game = %game_address, error = %e, "failed to read anchor registry for game");
-                return;
+                return false;
             }
         };
 
@@ -184,11 +215,11 @@ impl AnchorUpdater {
             Ok(true) => {}
             Ok(false) => {
                 debug!(game = %game_address, asr = %asr_address, "anchor update waiting for finality");
-                return;
+                return false;
             }
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game finality for anchor update");
-                return;
+                return false;
             }
         }
 
@@ -196,7 +227,7 @@ impl AnchorUpdater {
             Ok(preflight) => preflight,
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read anchor preflight");
-                return;
+                return false;
             }
         };
 
@@ -212,7 +243,7 @@ impl AnchorUpdater {
             );
             ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
                 .increment(1);
-            return;
+            return false;
         }
 
         if preflight.paused || !preflight.respected {
@@ -223,14 +254,14 @@ impl AnchorUpdater {
                 respected = preflight.respected,
                 "anchor update waiting for registry eligibility"
             );
-            return;
+            return false;
         }
 
         let game_info = match verifier_client.game_info(game_address).await {
             Ok(info) => info,
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game info for anchor update");
-                return;
+                return false;
             }
         };
 
@@ -244,7 +275,7 @@ impl AnchorUpdater {
             );
             ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
                 .increment(1);
-            return;
+            return false;
         }
 
         match submitter
@@ -263,6 +294,7 @@ impl AnchorUpdater {
                 )
                 .increment(1);
                 ChallengerMetrics::anchor_l2_block_number().set(game_info.l2_block_number as f64);
+                true
             }
             Err(e) => {
                 warn!(
@@ -273,6 +305,7 @@ impl AnchorUpdater {
                 );
                 ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
+                false
             }
         }
     }
@@ -300,7 +333,12 @@ mod tests {
         anchor_game: Address,
         game: Address,
         status: GameStatus,
-    ) -> (MockAggregateVerifier, MockBondTransactionSubmitter, AnchorUpdater) {
+    ) -> (
+        MockAggregateVerifier,
+        MockBondTransactionSubmitter,
+        AnchorUpdater,
+        Arc<MockDisputeGameFactory>,
+    ) {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
         let mut l2 = MockL2Provider::new();
@@ -330,7 +368,7 @@ mod tests {
             INTERMEDIATE_BLOCK_INTERVAL,
         );
 
-        (verifier, submitter, updater)
+        (verifier, submitter, updater, factory)
     }
 
     #[tokio::test(start_paused = true)]
@@ -373,7 +411,8 @@ mod tests {
     #[tokio::test]
     async fn poll_updates_next_defender_win() {
         let game = addr(1);
-        let (verifier, submitter, updater) = fixture(Address::ZERO, game, GameStatus::DefenderWins);
+        let (verifier, submitter, updater, _) =
+            fixture(Address::ZERO, game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -389,7 +428,7 @@ mod tests {
             [GameStatus::InProgress, GameStatus::ChallengerWins].into_iter().enumerate()
         {
             let game = addr(index as u64 + 1);
-            let (verifier, submitter, updater) = fixture(Address::ZERO, game, status);
+            let (verifier, submitter, updater, _) = fixture(Address::ZERO, game, status);
 
             updater.poll(&verifier, &submitter).await;
 
@@ -399,10 +438,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn poll_reuses_cached_next_game_while_anchor_is_unchanged() {
+        let game = addr(1);
+        let (verifier, submitter, updater, factory) =
+            fixture(Address::ZERO, game, GameStatus::InProgress);
+
+        updater.poll(&verifier, &submitter).await;
+        factory.uuid_games.lock().unwrap().clear();
+
+        let mut resolved_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        resolved_state.anchor_state_registry = ASR_ADDRESS;
+        verifier.update_game(game, resolved_state);
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, game);
+    }
+
+    #[tokio::test]
+    async fn poll_clears_cached_next_game_after_successful_update() {
+        let game = addr(1);
+        let (verifier, submitter, updater, factory) =
+            fixture(Address::ZERO, game, GameStatus::DefenderWins);
+
+        updater.poll(&verifier, &submitter).await;
+        factory.uuid_games.lock().unwrap().clear();
+        updater.poll(&verifier, &submitter).await;
+
+        assert_eq!(submitter.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
     async fn poll_starts_after_current_anchor_game() {
         let anchor_game = addr(10);
         let next_game = addr(11);
-        let (verifier, submitter, updater) =
+        let (verifier, submitter, updater, _) =
             fixture(anchor_game, next_game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
@@ -415,7 +487,8 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_finalized_defender_win() {
         let game = addr(1);
-        let (verifier, submitter, updater) = fixture(Address::ZERO, game, GameStatus::DefenderWins);
+        let (verifier, submitter, updater, _) =
+            fixture(Address::ZERO, game, GameStatus::DefenderWins);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;
         state.is_finalized = false;

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use alloy_primitives::Address;
 use base_proof_contracts::{
-    AggregateVerifierClient, AnchorRoot, AnchorStateRegistryClient, DisputeGameFactoryClient,
-    GameStatus, encode_set_anchor_state_calldata, game_lookup_blocks, game_lookup_key,
+    AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameStatus,
+    encode_set_anchor_state_calldata, game_lookup_blocks, game_lookup_key,
 };
 use base_proof_rpc::L2Provider;
 use tracing::{debug, info, warn};
@@ -63,7 +63,8 @@ impl AnchorUpdater {
             }
         };
 
-        let Some(game_address) = self.next_game(anchor.anchor_root, anchor.anchor_game).await
+        let Some(game_address) =
+            self.next_game(anchor.anchor_root.l2_block_number, anchor.anchor_game).await
         else {
             return;
         };
@@ -87,9 +88,13 @@ impl AnchorUpdater {
         Self::try_update(game_address, verifier_client, submitter).await;
     }
 
-    async fn next_game(&self, anchor_root: AnchorRoot, anchor_game: Address) -> Option<Address> {
+    async fn next_game(
+        &self,
+        anchor_l2_block_number: u64,
+        anchor_game: Address,
+    ) -> Option<Address> {
         let blocks = match game_lookup_blocks(
-            anchor_root.l2_block_number,
+            anchor_l2_block_number,
             self.block_interval,
             self.intermediate_block_interval,
         ) {
@@ -118,7 +123,7 @@ impl AnchorUpdater {
             anchor_game
         };
         let key = match game_lookup_key(
-            anchor_root.l2_block_number,
+            anchor_l2_block_number,
             parent,
             self.block_interval,
             self.intermediate_block_interval,
@@ -335,25 +340,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_waits_for_in_progress_next_game() {
-        let game = addr(1);
-        let (verifier, submitter, updater) = fixture(Address::ZERO, game, GameStatus::InProgress);
+    async fn poll_skips_non_defender_wins_next_game() {
+        for (index, status) in
+            [GameStatus::InProgress, GameStatus::ChallengerWins].into_iter().enumerate()
+        {
+            let game = addr(index as u64 + 1);
+            let (verifier, submitter, updater) = fixture(Address::ZERO, game, status);
 
-        updater.poll(&verifier, &submitter).await;
+            updater.poll(&verifier, &submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
-    }
-
-    #[tokio::test]
-    async fn poll_stops_at_challenger_wins_next_game() {
-        let challenger_win = addr(10);
-        let (verifier, submitter, updater) =
-            fixture(Address::ZERO, challenger_win, GameStatus::ChallengerWins);
-
-        updater.poll(&verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert_eq!(verifier.status_read_count(challenger_win), 1);
+            assert!(submitter.recorded_calls().is_empty());
+            assert_eq!(verifier.status_read_count(game), 1);
+        }
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -128,13 +128,14 @@ impl AnchorUpdater {
 
         let mut intermediate_roots = Vec::new();
         while let Some((block, result)) = roots.next().await {
-            match result {
-                Ok(root) => intermediate_roots.push(root),
+            let root = match result {
+                Ok(root) => root,
                 Err(e) => {
                     debug!(block, error = %e, "anchor update waiting for output root");
                     return None;
                 }
-            }
+            };
+            intermediate_roots.push(root);
         }
 
         let parent = if anchor_game == Address::ZERO {
@@ -260,8 +261,10 @@ impl AnchorUpdater {
             return false;
         }
 
-        let calldata = encode_set_anchor_state_calldata(game_address);
-        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
+        match submitter
+            .send_bond_tx(game_address, asr_address, encode_set_anchor_state_calldata(game_address))
+            .await
+        {
             Ok(tx_hash) => {
                 info!(
                     game = %game_address,
@@ -347,20 +350,38 @@ mod tests {
         )
     }
 
+    fn fixture(
+        anchor_game: Address,
+        game: Address,
+        status: GameStatus,
+    ) -> (
+        Arc<MockDisputeGameFactory>,
+        MockAggregateVerifier,
+        MockBondTransactionSubmitter,
+        AnchorUpdater,
+    ) {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        let parent = if anchor_game == Address::ZERO { ASR_ADDRESS } else { anchor_game };
+        insert_next_game(&factory, parent, output_root, game);
+
+        let mut state = mock_state(status, Address::ZERO, 100);
+        state.anchor_state_registry = ASR_ADDRESS;
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter =
+            MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO), Ok(B256::ZERO)]);
+        let updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+
+        (factory, verifier, submitter, updater)
+    }
+
     #[tokio::test]
     async fn poll_updates_next_defender_win() {
         let game = addr(1);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.anchor_state_registry = ASR_ADDRESS;
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO)]);
-        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+        let (_, verifier, submitter, mut updater) =
+            fixture(Address::ZERO, game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -373,16 +394,8 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_in_progress_next_game() {
         let game = addr(1);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
-        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+        let (_, verifier, submitter, mut updater) =
+            fixture(Address::ZERO, game, GameStatus::InProgress);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -392,22 +405,13 @@ mod tests {
     #[tokio::test]
     async fn poll_reuses_cached_next_game_while_anchor_is_unchanged() {
         let game = addr(1);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
-        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO)]);
-        let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+        let (factory, verifier, submitter, mut updater) =
+            fixture(Address::ZERO, game, GameStatus::InProgress);
 
         updater.poll(&verifier, &submitter).await;
         factory.uuid_games.lock().unwrap().clear();
 
-        let mut resolved_state = state;
-        resolved_state.status = GameStatus::DefenderWins;
+        let mut resolved_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         resolved_state.anchor_state_registry = ASR_ADDRESS;
         verifier.update_game(game, resolved_state);
 
@@ -421,18 +425,8 @@ mod tests {
     #[tokio::test]
     async fn poll_clears_cached_next_game_after_successful_update() {
         let game = addr(1);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.anchor_state_registry = ASR_ADDRESS;
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter =
-            MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO), Ok(B256::ZERO)]);
-        let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+        let (factory, verifier, submitter, mut updater) =
+            fixture(Address::ZERO, game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
         factory.uuid_games.lock().unwrap().clear();
@@ -446,18 +440,8 @@ mod tests {
     #[tokio::test]
     async fn poll_stops_at_challenger_wins_next_game() {
         let challenger_win = addr(10);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, ASR_ADDRESS, output_root, challenger_win);
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(
-            challenger_win,
-            mock_state(GameStatus::ChallengerWins, Address::ZERO, 100),
-        )]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+        let (factory, verifier, submitter, mut updater) =
+            fixture(Address::ZERO, challenger_win, GameStatus::ChallengerWins);
 
         updater.poll(&verifier, &submitter).await;
         factory.uuid_games.lock().unwrap().clear();
@@ -471,20 +455,8 @@ mod tests {
     async fn poll_starts_after_current_anchor_game() {
         let anchor_game = addr(10);
         let next_game = addr(11);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, anchor_game, output_root, next_game);
-        let mut next_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 200);
-        next_state.anchor_state_registry = ASR_ADDRESS;
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([
-            (anchor_game, mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
-            (next_game, next_state),
-        ]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO)]);
-        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+        let (_, verifier, submitter, mut updater) =
+            fixture(anchor_game, next_game, GameStatus::DefenderWins);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -496,18 +468,12 @@ mod tests {
     #[tokio::test]
     async fn poll_waits_for_finalized_defender_win() {
         let game = addr(1);
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
-        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
-        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
+        let (_, verifier, submitter, mut updater) =
+            fixture(Address::ZERO, game, GameStatus::DefenderWins);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;
         state.is_finalized = false;
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+        verifier.update_game(game, state);
 
         updater.poll(&verifier, &submitter).await;
 

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -15,26 +15,19 @@ use tracing::{debug, info, warn};
 use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
 
 /// Best-effort updater for the `AnchorStateRegistry`.
+#[derive(derive_more::Debug)]
 pub struct AnchorUpdater {
+    #[debug(skip)]
     factory_client: Arc<dyn DisputeGameFactoryClient>,
+    #[debug(skip)]
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
     output_validator: OutputValidator<dyn L2Provider>,
+    #[debug(skip)]
     cached_next_game: Option<(AnchorSnapshot, Address)>,
     anchor_state_registry_address: Address,
     game_type: u32,
     block_interval: u64,
     intermediate_block_interval: u64,
-}
-
-impl std::fmt::Debug for AnchorUpdater {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AnchorUpdater")
-            .field("anchor_state_registry_address", &self.anchor_state_registry_address)
-            .field("game_type", &self.game_type)
-            .field("block_interval", &self.block_interval)
-            .field("intermediate_block_interval", &self.intermediate_block_interval)
-            .finish_non_exhaustive()
-    }
 }
 
 impl AnchorUpdater {
@@ -126,7 +119,6 @@ impl AnchorUpdater {
             }
         };
 
-        let block_count = blocks.len();
         let mut roots =
             stream::iter(blocks)
                 .map(|block| async move {
@@ -134,7 +126,7 @@ impl AnchorUpdater {
                 })
                 .buffered(OutputValidator::<dyn L2Provider>::VALIDATION_CONCURRENCY);
 
-        let mut intermediate_roots = Vec::with_capacity(block_count);
+        let mut intermediate_roots = Vec::new();
         while let Some((block, result)) = roots.next().await {
             match result {
                 Ok(root) => intermediate_roots.push(root),
@@ -358,7 +350,6 @@ mod tests {
     #[tokio::test]
     async fn poll_updates_next_defender_win() {
         let game = addr(1);
-        let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
         let mut l2 = MockL2Provider::new();
@@ -368,7 +359,7 @@ mod tests {
         state.anchor_state_registry = ASR_ADDRESS;
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO)]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
@@ -401,7 +392,6 @@ mod tests {
     #[tokio::test]
     async fn poll_reuses_cached_next_game_while_anchor_is_unchanged() {
         let game = addr(1);
-        let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
         let mut l2 = MockL2Provider::new();
@@ -410,7 +400,7 @@ mod tests {
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO)]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
@@ -431,7 +421,6 @@ mod tests {
     #[tokio::test]
     async fn poll_clears_cached_next_game_after_successful_update() {
         let game = addr(1);
-        let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
         let mut l2 = MockL2Provider::new();
@@ -442,7 +431,7 @@ mod tests {
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
         let submitter =
-            MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash), Ok(tx_hash)]);
+            MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO), Ok(B256::ZERO)]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
@@ -482,7 +471,6 @@ mod tests {
     async fn poll_starts_after_current_anchor_game() {
         let anchor_game = addr(10);
         let next_game = addr(11);
-        let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
         let mut l2 = MockL2Provider::new();
@@ -495,7 +483,7 @@ mod tests {
             (anchor_game, mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
             (next_game, next_state),
         ]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(B256::ZERO)]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -716,6 +716,8 @@ pub struct MockL2Provider {
     pub proofs: HashMap<B256, EIP1186AccountProofResponse>,
     /// Block numbers that should return an error (simulating missing blocks).
     pub error_blocks: Vec<u64>,
+    /// Optional delay before returning block headers.
+    pub header_delay: Option<Duration>,
 }
 
 impl MockL2Provider {
@@ -766,6 +768,9 @@ impl L2Provider for MockL2Provider {
         };
         if self.error_blocks.contains(&block_number) {
             return Err(RpcError::BlockNotFound(format!("block {block_number} not available")));
+        }
+        if let Some(delay) = self.header_delay {
+            tokio::time::sleep(delay).await;
         }
         self.headers
             .get(&block_number)


### PR DESCRIPTION
### What changed? Why?

Simplifies `base-challenger` anchor updater state so tracked games are rescanned instead of caching status, registry, and L2 block metadata across polls.

This also uses the same tracking path for valid games and keeps in-progress games pending until `gameOver` before reading prover state or submitting anchor updates.

### Notes to reviewers

The diff mostly removes cached anchor metadata and the special `track_valid_game` path. `poll` now takes the tracked map while it processes entries and reinserts games that still need work, which avoids mutable borrow churn without changing retry or retention behavior.

### How has it been tested?

`cargo test -p base-challenger anchor`