### PR TITLE
fix(consensus): avoid genesis fetch on pruned EL sync

### DIFF
--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -145,6 +145,7 @@ fn genesis_l2_block_info(cfg: &RollupConfig) -> L2BlockInfo {
         block_info: BlockInfo {
             hash: cfg.genesis.l2.hash,
             number: cfg.genesis.l2.number,
+            // Base chains start at L2 block 0, whose parent hash is zero.
             parent_hash: B256::ZERO,
             timestamp: cfg.genesis.l2_time,
         },

--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -140,7 +140,7 @@ impl L2ForkchoiceState {
     }
 }
 
-fn genesis_l2_block_info(cfg: &RollupConfig) -> L2BlockInfo {
+const fn genesis_l2_block_info(cfg: &RollupConfig) -> L2BlockInfo {
     L2BlockInfo {
         block_info: BlockInfo {
             hash: cfg.genesis.l2.hash,

--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -3,6 +3,7 @@
 use std::fmt::Display;
 
 use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_primitives::B256;
 use alloy_provider::Network;
 use alloy_rpc_types_eth::Block as RpcBlock;
 use alloy_transport::TransportResult;
@@ -69,40 +70,35 @@ impl L2ForkchoiceState {
         engine_client: &EngineClient_,
         checkpoint_reader: &CheckpointReader,
     ) -> Result<Self, SyncStartError> {
-        let finalized = {
-            let rpc_block =
-                match get_block_compat(engine_client, BlockNumberOrTag::Finalized.into()).await {
-                    Ok(Some(block)) => block,
-                    Ok(None) => engine_client
-                        .get_l2_block(cfg.genesis.l2.number.into())
-                        .full()
-                        .await?
-                        .ok_or(SyncStartError::BlockNotFound(cfg.genesis.l2.number.into()))?,
-                    Err(e) => return Err(e.into()),
-                };
-
-            let rpc_block_number = rpc_block.header.number;
-            match block_info_from_reth_or_checkpoint(
-                cfg,
-                ForkchoiceCheckpointLabel::Finalized,
-                rpc_block,
-                checkpoint_reader,
-            )
+        let finalized = match get_block_compat(engine_client, BlockNumberOrTag::Finalized.into())
             .await
-            {
-                Ok(info) => info,
-                Err(SyncStartError::FromBlock(FromBlockError::MissingL1InfoDeposit(hash))) => {
-                    warn!(
-                        target: "sync_start",
-                        block_hash = %hash,
-                        block_number = rpc_block_number,
-                        "finalized block body is pruned and no valid checkpoint exists, \
-                         recovering to earliest unpruned block"
-                    );
-                    find_earliest_unpruned_block(cfg, engine_client, rpc_block_number).await?
+        {
+            Ok(Some(rpc_block)) => {
+                let rpc_block_number = rpc_block.header.number;
+                match block_info_from_reth_or_checkpoint(
+                    cfg,
+                    ForkchoiceCheckpointLabel::Finalized,
+                    rpc_block,
+                    checkpoint_reader,
+                )
+                .await
+                {
+                    Ok(info) => info,
+                    Err(SyncStartError::FromBlock(FromBlockError::MissingL1InfoDeposit(hash))) => {
+                        warn!(
+                            target: "sync_start",
+                            block_hash = %hash,
+                            block_number = rpc_block_number,
+                            "finalized block body is pruned and no valid checkpoint exists, \
+                             recovering to earliest unpruned block"
+                        );
+                        find_earliest_unpruned_block(cfg, engine_client, rpc_block_number).await?
+                    }
+                    Err(e) => return Err(e),
                 }
-                Err(e) => return Err(e),
             }
+            Ok(None) => genesis_l2_block_info(cfg),
+            Err(e) => return Err(e.into()),
         };
         let safe = match get_block_compat(engine_client, BlockNumberOrTag::Safe.into()).await {
             Ok(Some(block)) => {
@@ -141,6 +137,19 @@ impl L2ForkchoiceState {
         };
 
         Ok(Self { un_safe, safe, finalized })
+    }
+}
+
+fn genesis_l2_block_info(cfg: &RollupConfig) -> L2BlockInfo {
+    L2BlockInfo {
+        block_info: BlockInfo {
+            hash: cfg.genesis.l2.hash,
+            number: cfg.genesis.l2.number,
+            parent_hash: B256::ZERO,
+            timestamp: cfg.genesis.l2_time,
+        },
+        l1_origin: cfg.genesis.l1,
+        seq_num: 0,
     }
 }
 

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -155,13 +155,20 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
 
 #[cfg(test)]
 mod tests {
-    use alloy_eips::BlockNumHash;
-    use alloy_primitives::{B256, b256};
+    use alloy_consensus::transaction::Recovered;
+    use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
+    use alloy_primitives::{Address, B256, Sealed, b256};
     use alloy_provider::Network;
-    use alloy_rpc_types_eth::Block;
+    use alloy_rpc_types_eth::{
+        Block as RpcBlock, BlockTransactions, Transaction as EthTransaction,
+    };
+    use base_common_consensus::{BaseTxEnvelope, TxDeposit};
     use base_common_genesis::ChainGenesis;
     use base_common_network::Base;
-    use base_protocol::L2BlockInfo;
+    use base_common_rpc_types::Transaction as BaseTransaction;
+    use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
+
+    use crate::test_utils::test_engine_client_builder;
 
     const BASE_SEPOLIA_GENESIS_HASH: B256 =
         b256!("0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4");
@@ -177,7 +184,7 @@ mod tests {
             l2: BlockNumHash { number: 0, hash: BASE_SEPOLIA_GENESIS_HASH },
             ..Default::default()
         };
-        let genesis_block: Block<<Base as Network>::TransactionResponse> =
+        let genesis_block: RpcBlock<<Base as Network>::TransactionResponse> =
             serde_json::from_str(BASE_SEPOLIA_GENESIS_RPC_RESPONSE).unwrap();
 
         let rpc_reported_hash = genesis_block.header.hash;
@@ -190,5 +197,78 @@ mod tests {
         let l2_block_info =
             L2BlockInfo::from_block_and_genesis(&consensus_block, &genesis).unwrap();
         assert_eq!(rpc_reported_hash, l2_block_info.block_info.hash);
+    }
+
+    fn l1_info_rpc_transaction(block_number: u64) -> BaseTransaction {
+        let envelope = BaseTxEnvelope::Deposit(Sealed::new_unchecked(
+            TxDeposit {
+                input: L1BlockInfoBedrock::default().encode_calldata(),
+                ..Default::default()
+            },
+            B256::ZERO,
+        ));
+        BaseTransaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: Recovered::new_unchecked(envelope, Address::ZERO),
+                block_hash: None,
+                block_number: Some(block_number),
+                block_timestamp: None,
+                effective_gas_price: Some(0),
+                transaction_index: Some(0),
+            },
+            deposit_nonce: None,
+            deposit_receipt_version: None,
+        }
+    }
+
+    fn l2_block_with_l1_info(number: u64, parent_hash: B256) -> RpcBlock<BaseTransaction> {
+        let mut block = RpcBlock::<BaseTransaction>::default();
+        block.header.inner.number = number;
+        block.header.inner.parent_hash = parent_hash;
+        block.header.inner.timestamp = number;
+        block.transactions = BlockTransactions::Full(vec![l1_info_rpc_transaction(number)]);
+        block
+    }
+
+    #[tokio::test]
+    async fn current_uses_config_genesis_when_finalized_label_is_unavailable() {
+        let mut rollup_config = base_common_genesis::RollupConfig::default();
+        rollup_config.genesis = ChainGenesis {
+            l1: BlockNumHash {
+                number: 10,
+                hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            },
+            l2: BlockNumHash {
+                number: 0,
+                hash: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+            },
+            l2_time: 20,
+            system_config: None,
+        };
+        let latest = l2_block_with_l1_info(1, rollup_config.genesis.l2.hash);
+        let latest_hash = latest.clone().into_consensus().hash_slow();
+        let client = test_engine_client_builder()
+            .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest)
+            .with_l1_block(BlockId::from(B256::ZERO), RpcBlock::<EthTransaction>::default())
+            .build();
+
+        let forkchoice = super::find_starting_forkchoice(&rollup_config, &client)
+            .await
+            .expect("forkchoice should not require fetching the pruned L2 genesis block");
+        let expected_genesis = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: rollup_config.genesis.l2.hash,
+                number: rollup_config.genesis.l2.number,
+                parent_hash: B256::ZERO,
+                timestamp: rollup_config.genesis.l2_time,
+            },
+            l1_origin: rollup_config.genesis.l1,
+            seq_num: 0,
+        };
+
+        assert_eq!(forkchoice.un_safe.block_info.number, 1);
+        assert_eq!(forkchoice.un_safe.block_info.hash, latest_hash);
+        assert_eq!(forkchoice.safe, expected_genesis);
+        assert_eq!(forkchoice.finalized, expected_genesis);
     }
 }

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -232,18 +232,20 @@ mod tests {
 
     #[tokio::test]
     async fn current_uses_config_genesis_when_finalized_label_is_unavailable() {
-        let mut rollup_config = base_common_genesis::RollupConfig::default();
-        rollup_config.genesis = ChainGenesis {
-            l1: BlockNumHash {
-                number: 10,
-                hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: BlockNumHash {
+                    number: 10,
+                    hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+                },
+                l2: BlockNumHash {
+                    number: 0,
+                    hash: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+                },
+                l2_time: 20,
+                system_config: None,
             },
-            l2: BlockNumHash {
-                number: 0,
-                hash: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
-            },
-            l2_time: 20,
-            system_config: None,
+            ..Default::default()
         };
         let latest = l2_block_with_l1_info(1, rollup_config.genesis.l2.hash);
         let latest_hash = latest.clone().into_consensus().hash_slow();

--- a/crates/infra/basectl/src/app/state.rs
+++ b/crates/infra/basectl/src/app/state.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Reverse,
     collections::VecDeque,
     time::{Duration, Instant},
 };
@@ -462,7 +463,7 @@ impl DaTracker {
 
         // Distribute the leftover (l2_delta - allocated) to entries with largest remainders
         let mut leftover = l2_delta - allocated;
-        remainders.sort_by(|a, b| b.1.cmp(&a.1));
+        remainders.sort_by_key(|&(_, frac)| Reverse(frac));
         for &(nth, _) in &remainders {
             if leftover == 0 {
                 break;

--- a/crates/infra/basectl/src/app/views/command_center.rs
+++ b/crates/infra/basectl/src/app/views/command_center.rs
@@ -497,7 +497,7 @@ fn render_config_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
         |sys| {
             let gas_limit = sys.gas_limit;
             let elasticity = sys.eip1559_elasticity.unwrap_or(0) as u64;
-            let gas_target = if elasticity > 0 { gas_limit / elasticity } else { 0 };
+            let gas_target = gas_limit.checked_div(elasticity).unwrap_or(0);
             let denominator = sys.eip1559_denominator.unwrap_or(0);
 
             let basefee_scalar =


### PR DESCRIPTION
### Description
On a pruned node that has EL sync'd from genesis fetching a block that doesn't exist returns null:

```
~ > n m cast rpc eth_getBlockByNumber finalized true
null
```

This causes the following to always return BlockNotFound when doing a fresh sync from genesis.
```
Ok(None) => engine_client
       .get_l2_block(cfg.genesis.l2.number.into())
       .full()
      .await?
      .ok_or(SyncStartError::BlockNotFound(cfg.genesis.l2.number.into()))?,
```

As the genesis block is static, we can just load this from config vs. fetching. This will allow safe/finalized head to reset to ~12 hours ago and sync to tip.