### PR TITLE
fix(builder): restore pruned txs when flashblock payload is abandoned

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -116,6 +116,15 @@ pub struct Args {
     #[arg(long = "builder.max-rejected-txs-per-block", default_value = "500")]
     pub max_rejected_txs_per_block: usize,
 
+    /// Whether to restore transactions pruned during flashblock building back into the pool when a
+    /// payload job is abandoned (superseded/expired) before being sealed.
+    #[arg(
+        long = "builder.flashblock-prune-rollback-enabled",
+        env = "BUILDER_FLASHBLOCK_PRUNE_ROLLBACK_ENABLED",
+        default_value = "false"
+    )]
+    pub flashblock_prune_rollback_enabled: bool,
+
     /// Buffer size for tx data store (LRU eviction when full)
     #[arg(long = "builder.tx-data-store-buffer-size", default_value = "10000")]
     pub tx_data_store_buffer_size: usize,
@@ -172,6 +181,7 @@ impl Default for Args {
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
+            flashblock_prune_rollback_enabled: false,
             tx_data_store_buffer_size: 10000,
             metering_store_ttl_secs: 30,
             rejection_cache_max_capacity: 100_000,
@@ -223,6 +233,7 @@ impl Args {
             audit_archiver_url: self.audit_archiver_url,
             rejected_tx_channel_size: self.rejected_tx_channel_size,
             max_rejected_txs_per_block: self.max_rejected_txs_per_block,
+            flashblock_prune_rollback_enabled: self.flashblock_prune_rollback_enabled,
         })
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -167,7 +167,7 @@ impl Default for BuilderConfig {
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
-            flashblock_prune_rollback_enabled: true,
+            flashblock_prune_rollback_enabled: false,
         }
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -95,6 +95,11 @@ pub struct BuilderConfig {
     /// Maximum number of rejected transactions accumulated per block before
     /// further rejections are dropped. Prevents unbounded `ExecutionInfo` growth.
     pub max_rejected_txs_per_block: usize,
+
+    /// Whether to restore transactions pruned during flashblock building back into the pool
+    /// when a payload job is abandoned (superseded by a new FCU or expired) before it is
+    /// sealed via `getPayload`.
+    pub flashblock_prune_rollback_enabled: bool,
 }
 
 impl BuilderConfig {
@@ -132,6 +137,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("audit_archiver_url", &self.audit_archiver_url)
             .field("rejected_tx_channel_size", &self.rejected_tx_channel_size)
             .field("max_rejected_txs_per_block", &self.max_rejected_txs_per_block)
+            .field("flashblock_prune_rollback_enabled", &self.flashblock_prune_rollback_enabled)
             .finish()
     }
 }
@@ -161,6 +167,7 @@ impl Default for BuilderConfig {
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
+            flashblock_prune_rollback_enabled: true,
         }
     }
 }
@@ -223,6 +230,13 @@ impl BuilderConfig {
         metering_wait_duration: Option<Duration>,
     ) -> Self {
         self.metering_wait_duration = metering_wait_duration;
+        self
+    }
+
+    /// Sets whether pruned flashblock transactions are restored on payload abandonment.
+    #[must_use]
+    pub const fn with_flashblock_prune_rollback_enabled(mut self, enabled: bool) -> Self {
+        self.flashblock_prune_rollback_enabled = enabled;
         self
     }
 }

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -247,6 +247,20 @@ where
     }
 }
 
+impl<Builder> Drop for BlockPayloadJob<Builder>
+where
+    Builder: PayloadBuilder,
+{
+    /// Cancel the job's token when the job is dropped without having been resolved, superseded, or
+    /// reaching its deadline (e.g. the `PayloadBuilderService` drops it during shutdown, or a panic
+    /// unwind). This wakes the task spawned by `settle_pruned_transactions` on the
+    /// `disposition_known == false` path, which would otherwise wait forever on
+    /// `cancel.cancelled().await`
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
 impl<Builder> PayloadJob for BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     task::Waker,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -163,6 +166,7 @@ where
             cell: BlockCell::new(),
             finalized_cell: BlockCell::new(),
             cancel: cancel_token,
+            resolved: Arc::new(AtomicBool::new(false)),
             publish_guard,
             deadline,
             build_complete: None,
@@ -218,6 +222,11 @@ where
     pub(crate) finalized_cell: BlockCell<Builder::BuiltPayload>,
     /// Cancellation token for the running job
     pub(crate) cancel: CancellationToken,
+    /// Set to `true` when this job is resolved via [`PayloadJob::resolve_kind`] (i.e. the payload
+    /// was retrieved via `getPayload` and is being sealed). Distinguishes a sealed job from one
+    /// that is abandoned (superseded by a new FCU or expired), which the build task uses to decide
+    /// whether to restore transactions pruned during flashblock building back into the pool.
+    pub(crate) resolved: Arc<AtomicBool>,
     /// Mutex to synchronize cancellation with payload publishing.
     pub(crate) publish_guard: Arc<Mutex<()>>,
     pub(crate) deadline: Pin<Box<Sleep>>, // Add deadline
@@ -265,6 +274,9 @@ where
         // Acquire mutex before cancelling to synchronize with payload publishing.
         {
             let _guard = self.publish_guard.lock();
+            // Mark resolved before cancelling so the build task observes it as sealed (and keeps
+            // its pruned transactions) rather than treating the cancellation as abandonment.
+            self.resolved.store(true, Ordering::Release);
             self.cancel.cancel();
         }
 
@@ -283,6 +295,9 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
     pub cancel: CancellationToken,
+    /// Set to `true` when the job is resolved via `getPayload`. Lets the build task distinguish a
+    /// sealed payload (keep pruned transactions) from an abandoned one (restore them to the pool).
+    pub resolved: Arc<AtomicBool>,
     /// Mutex to synchronize cancellation with payload publishing.
     pub publish_guard: Arc<Mutex<()>>,
     /// Cell to store the finalized payload with state root.
@@ -302,6 +317,7 @@ where
         let payload_config = self.config.clone();
         let cell = self.cell.clone();
         let cancel = self.cancel.clone();
+        let resolved = Arc::clone(&self.resolved);
         let publish_guard = Arc::clone(&self.publish_guard);
         let finalized_cell = self.finalized_cell.clone();
 
@@ -313,6 +329,7 @@ where
                 cached_reads,
                 config: payload_config,
                 cancel,
+                resolved,
                 publish_guard,
                 finalized_cell,
             };

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Div, Rem},
     sync::{
         Arc,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Instant,
 };
@@ -41,7 +41,7 @@ use reth_provider::{
 use reth_revm::{
     State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
 };
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{TransactionOrigin, TransactionPool, ValidPoolTransaction};
 use reth_trie::{HashedPostState, updates::TrieUpdates};
 use revm::Database as _;
 use serde::{Deserialize, Serialize};
@@ -73,6 +73,12 @@ type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
             >,
     >,
 >;
+
+/// Transactions pruned from the pool during flashblock building, retained (with their original
+/// [`TransactionOrigin`]) so they can be restored if the payload job is abandoned before it is
+/// sealed via `getPayload`.
+type PrunedTransactions<Pool> =
+    Vec<Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>;
 
 #[derive(Debug, Default)]
 struct LastEmittedFlashblockId {
@@ -255,6 +261,7 @@ where
             mut cached_reads,
             config,
             cancel: block_cancel,
+            resolved,
             finalized_cell,
             publish_guard,
         } = args;
@@ -460,6 +467,10 @@ where
         // Highest executed nonce per sender, updated incrementally per flashblock.
         let mut executed_sender_nonces: HashMap<Address, u64> = HashMap::default();
 
+        // Transactions pruned from the pool across this job's flashblocks. Restored to the pool if
+        // the job is abandoned (superseded/expired) before being sealed via `getPayload`.
+        let mut pruned_transactions: PrunedTransactions<Pool> = Vec::new();
+
         // Process flashblocks in a blocking loop
         loop {
             let flashblock_index = ctx.flashblock_index();
@@ -484,6 +495,14 @@ where
                     "Payload building complete, target flashblock count reached",
                 );
                 self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                // The block is complete but not yet retrieved; the spawned task waits to learn
+                // whether it is sealed via `getPayload` or abandoned before restoring.
+                self.settle_pruned_transactions(
+                    pruned_transactions,
+                    Arc::clone(&resolved),
+                    block_cancel.clone(),
+                    false,
+                );
                 return Ok(());
             }
 
@@ -499,6 +518,7 @@ where
                     &publish_guard,
                     &fb_span,
                     &mut executed_sender_nonces,
+                    &mut pruned_transactions,
                 )
                 .await
             {
@@ -512,6 +532,13 @@ where
                         "Payload building complete, job cancelled or target flashblock count reached",
                     );
                     self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                    // Cancellation already occurred; `resolved` distinguishes sealed from abandoned.
+                    self.settle_pruned_transactions(
+                        pruned_transactions,
+                        Arc::clone(&resolved),
+                        block_cancel.clone(),
+                        true,
+                    );
                     return Ok(());
                 }
                 Err(err) => {
@@ -521,6 +548,13 @@ where
                         ctx.flashblock_index(),
                         ctx.block_number(),
                         err
+                    );
+                    // The block failed to build and will not be sealed; restore pruned transactions.
+                    self.settle_pruned_transactions(
+                        pruned_transactions,
+                        Arc::clone(&resolved),
+                        block_cancel.clone(),
+                        true,
                     );
                     return Err(PayloadBuilderError::Other(err.into()));
                 }
@@ -539,6 +573,13 @@ where
                         "Payload building complete, channel closed or job cancelled",
                     );
                     self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                    // Cancellation already occurred; `resolved` distinguishes sealed from abandoned.
+                    self.settle_pruned_transactions(
+                        pruned_transactions,
+                        Arc::clone(&resolved),
+                        block_cancel.clone(),
+                        true,
+                    );
                     return Ok(());
                 }
             }
@@ -560,6 +601,7 @@ where
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
         executed_sender_nonces: &mut HashMap<Address, u64>,
+        pruned_transactions: &mut PrunedTransactions<Pool>,
     ) -> eyre::Result<Option<FlashblocksExtraCtx>> {
         let flashblock_index = ctx.flashblock_index();
         let target_gas_for_batch = ctx.extra.target_gas_for_batch;
@@ -653,7 +695,10 @@ where
             .collect::<Vec<_>>();
         best_txs.mark_committed(&new_transactions);
         self.config.metering_provider.remove(&new_transactions);
-        self.pool.prune_transactions(new_transactions);
+        let pruned = self.pool.prune_transactions(new_transactions);
+        if self.config.flashblock_prune_rollback_enabled {
+            pruned_transactions.extend(pruned);
+        }
 
         // Track executed nonces incrementally for the next flashblock's update_accounts call.
         debug_assert_eq!(
@@ -858,6 +903,57 @@ where
         span.record("flashblock_count", ctx.flashblock_index());
     }
 
+    /// Decide the fate of transactions pruned during flashblock building for a job that is ending.
+    ///
+    /// Flashblock building prunes committed transactions from the pool mined-style (see
+    /// [`Self::build_next_flashblock`]). If the payload is sealed via `getPayload` that removal is
+    /// correct, but if the job is abandoned (superseded by a new FCU or expired) before sealing,
+    /// reth has no recovery path for it — so the pruned transactions are reinserted here.
+    ///
+    /// `disposition_known` should be `false` only when the job has finished building but has not
+    /// yet been cancelled (target flashblock count reached): in that case the spawned task waits for
+    /// the job to be sealed or abandoned before deciding. `resolved` is set by `resolve_kind` when
+    /// the payload is retrieved, distinguishing a sealed payload (keep pruned) from an abandoned one
+    /// (restore).
+    fn settle_pruned_transactions(
+        &self,
+        pruned: PrunedTransactions<Pool>,
+        resolved: Arc<AtomicBool>,
+        block_cancel: CancellationToken,
+        disposition_known: bool,
+    ) {
+        if pruned.is_empty() {
+            return;
+        }
+
+        let pool = self.pool.clone();
+        tokio::spawn(async move {
+            // Wait until the job's fate is known: sealed via `getPayload` (sets `resolved`) or
+            // abandoned (cancelled without `resolved`).
+            if !disposition_known {
+                block_cancel.cancelled().await;
+            }
+
+            if resolved.load(Ordering::Acquire) {
+                // The payload was retrieved and is being sealed; the pruned transactions are
+                // legitimately part of it, so leave them out of the pool.
+                return;
+            }
+
+            // Abandoned before sealing: restore the pruned transactions. Any transaction that does
+            // end up canonical is re-pruned by the canonical-state notification, so an occasional
+            // redundant reinsert is self-correcting.
+            let attempted = pruned.len();
+            let succeeded = restore_pruned_transactions(&pool, &pruned).await;
+            info!(
+                target: "payload_builder",
+                attempted,
+                restored = succeeded,
+                "Restored pruned transactions after payload abandonment",
+            );
+        });
+    }
+
     /// Finalize the payload by computing the state root and setting the finalized cell.
     fn finalize_payload<DB, P>(
         &self,
@@ -981,6 +1077,25 @@ where
     let info = ctx.execute_sequencer_transactions(state)?;
 
     Ok(info)
+}
+
+/// Reinsert transactions that were pruned from the pool during flashblock building, preserving
+/// each transaction's original [`TransactionOrigin`] (unlike reth's canonical-reorg recovery,
+/// which downgrades everything to external). Returns the number successfully reinserted.
+///
+/// Reinsertion re-validates each transaction; any that is now stale (e.g. its nonce was already
+/// satisfied by a canonical block) is simply parked or rejected, so this is safe to call even when
+/// some of the pruned transactions did end up canonical.
+pub(crate) async fn restore_pruned_transactions<P: TransactionPool>(
+    pool: &P,
+    pruned: &[Arc<ValidPoolTransaction<P::Transaction>>],
+) -> usize {
+    if pruned.is_empty() {
+        return 0;
+    }
+    let restored: Vec<(TransactionOrigin, P::Transaction)> =
+        pruned.iter().map(|tx| (tx.origin, tx.transaction.clone())).collect();
+    pool.add_transactions_with_origins(restored).await.iter().filter(|r| r.is_ok()).count()
 }
 
 pub(crate) fn build_block<DB, P>(
@@ -1243,7 +1358,14 @@ mod tests {
     use reth_provider::noop::NoopProvider;
     use reth_revm::{State, database::StateProviderDatabase};
 
-    use super::{FlashblocksMetadata, build_block};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use reth_transaction_pool::{
+        PoolTransaction, TransactionOrigin, TransactionPool,
+        test_utils::{MockTransaction, testing_pool},
+    };
+
+    use super::{FlashblocksMetadata, build_block, restore_pruned_transactions};
     use crate::{ExecutionInfo, flashblocks::context::BasePayloadBuilderCtx};
 
     /// Creates a minimal [`BaseChainSpec`] with all L1 upgrades through Cancun
@@ -1510,5 +1632,83 @@ mod tests {
         let metadata: Metadata = serde_json::from_value(json).expect("v0.4.1 metadata must parse");
         assert_eq!(metadata.block_number, 123);
         assert_eq!(metadata.prev_flashblock_id, FlashblockId::default());
+    }
+
+    /// A transaction pruned during flashblock building (mined-style removal) is restored to the
+    /// pool by [`restore_pruned_transactions`], with its original [`TransactionOrigin`] preserved
+    /// per transaction. This is the abandonment recovery path: pruned, then the payload is
+    /// discarded before sealing, so the transactions must return to the pool.
+    #[tokio::test]
+    async fn restore_pruned_transactions_reinserts_preserving_per_tx_origin() {
+        let pool = testing_pool();
+
+        // A locally-submitted tx and an externally-gossiped tx from distinct senders.
+        let local = MockTransaction::eip1559();
+        let external = MockTransaction::eip1559();
+        let local_hash = *local.hash();
+        let external_hash = *external.hash();
+
+        pool.add_transaction(TransactionOrigin::Local, local).await.expect("add local");
+        pool.add_transaction(TransactionOrigin::External, external).await.expect("add external");
+        assert!(pool.contains(&local_hash) && pool.contains(&external_hash));
+
+        // Simulate flashblock commits pruning both mined-style.
+        let pruned = pool.prune_transactions(vec![local_hash, external_hash]);
+        assert_eq!(pruned.len(), 2, "prune returns the removed transactions");
+        assert!(
+            !pool.contains(&local_hash) && !pool.contains(&external_hash),
+            "prune removes transactions from the pool (canonical-inclusion semantics)"
+        );
+
+        // Abandonment: restore them.
+        let restored = restore_pruned_transactions(&pool, &pruned).await;
+        assert_eq!(restored, 2, "both pruned transactions are reinserted");
+
+        // Both are back, each with its original origin preserved.
+        assert_eq!(
+            pool.get(&local_hash).expect("local present").origin,
+            TransactionOrigin::Local,
+            "local origin must be preserved on restore"
+        );
+        assert_eq!(
+            pool.get(&external_hash).expect("external present").origin,
+            TransactionOrigin::External,
+            "external origin must be preserved on restore"
+        );
+    }
+
+    /// [`restore_pruned_transactions`] is a no-op for an empty journal.
+    #[tokio::test]
+    async fn restore_pruned_transactions_is_noop_when_empty() {
+        let pool = testing_pool();
+        assert_eq!(restore_pruned_transactions(&pool, &[]).await, 0);
+    }
+
+    /// Mirrors the decision in [`super::BasePayloadBuilder::settle_pruned_transactions`]: pruned
+    /// transactions are restored only when the payload was abandoned (`resolved == false`). A
+    /// payload sealed via `getPayload` (`resolved == true`) keeps its pruned transactions out of
+    /// the pool, matching canonical inclusion.
+    #[tokio::test]
+    async fn resolved_flag_gates_restoration() {
+        let pool = testing_pool();
+        let tx = MockTransaction::eip1559();
+        let hash = *tx.hash();
+        pool.add_transaction(TransactionOrigin::Local, tx).await.expect("add");
+        let pruned = pool.prune_transactions(vec![hash]);
+        assert!(!pool.contains(&hash));
+
+        // Sealed payload: do not restore.
+        let resolved = AtomicBool::new(true);
+        if !resolved.load(Ordering::Acquire) {
+            restore_pruned_transactions(&pool, &pruned).await;
+        }
+        assert!(!pool.contains(&hash), "a sealed payload must not restore pruned transactions");
+
+        // Abandoned payload: restore.
+        resolved.store(false, Ordering::Release);
+        if !resolved.load(Ordering::Acquire) {
+            restore_pruned_transactions(&pool, &pruned).await;
+        }
+        assert!(pool.contains(&hash), "an abandoned payload must restore pruned transactions");
     }
 }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1346,7 +1346,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use alloy_consensus::{Header, Receipt};
     use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
@@ -1357,9 +1360,6 @@ mod tests {
     use reth_primitives_traits::SealedHeader;
     use reth_provider::noop::NoopProvider;
     use reth_revm::{State, database::StateProviderDatabase};
-
-    use std::sync::atomic::{AtomicBool, Ordering};
-
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin, TransactionPool,
         test_utils::{MockTransaction, testing_pool},

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -497,7 +497,8 @@ where
                 self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
                 // The block is complete but not yet retrieved; the spawned task waits to learn
                 // whether it is sealed via `getPayload` or abandoned before restoring.
-                self.settle_pruned_transactions(
+                settle_pruned_transactions(
+                    self.pool.clone(),
                     pruned_transactions,
                     Arc::clone(&resolved),
                     block_cancel.clone(),
@@ -533,7 +534,8 @@ where
                     );
                     self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
                     // Cancellation already occurred; `resolved` distinguishes sealed from abandoned.
-                    self.settle_pruned_transactions(
+                    settle_pruned_transactions(
+                        self.pool.clone(),
                         pruned_transactions,
                         Arc::clone(&resolved),
                         block_cancel.clone(),
@@ -550,7 +552,8 @@ where
                         err
                     );
                     // The block failed to build and will not be sealed; restore pruned transactions.
-                    self.settle_pruned_transactions(
+                    settle_pruned_transactions(
+                        self.pool.clone(),
                         pruned_transactions,
                         Arc::clone(&resolved),
                         block_cancel.clone(),
@@ -574,7 +577,8 @@ where
                     );
                     self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
                     // Cancellation already occurred; `resolved` distinguishes sealed from abandoned.
-                    self.settle_pruned_transactions(
+                    settle_pruned_transactions(
+                        self.pool.clone(),
                         pruned_transactions,
                         Arc::clone(&resolved),
                         block_cancel.clone(),
@@ -903,57 +907,6 @@ where
         span.record("flashblock_count", ctx.flashblock_index());
     }
 
-    /// Decide the fate of transactions pruned during flashblock building for a job that is ending.
-    ///
-    /// Flashblock building prunes committed transactions from the pool mined-style (see
-    /// [`Self::build_next_flashblock`]). If the payload is sealed via `getPayload` that removal is
-    /// correct, but if the job is abandoned (superseded by a new FCU or expired) before sealing,
-    /// reth has no recovery path for it — so the pruned transactions are reinserted here.
-    ///
-    /// `disposition_known` should be `false` only when the job has finished building but has not
-    /// yet been cancelled (target flashblock count reached): in that case the spawned task waits for
-    /// the job to be sealed or abandoned before deciding. `resolved` is set by `resolve_kind` when
-    /// the payload is retrieved, distinguishing a sealed payload (keep pruned) from an abandoned one
-    /// (restore).
-    fn settle_pruned_transactions(
-        &self,
-        pruned: PrunedTransactions<Pool>,
-        resolved: Arc<AtomicBool>,
-        block_cancel: CancellationToken,
-        disposition_known: bool,
-    ) {
-        if pruned.is_empty() {
-            return;
-        }
-
-        let pool = self.pool.clone();
-        tokio::spawn(async move {
-            // Wait until the job's fate is known: sealed via `getPayload` (sets `resolved`) or
-            // abandoned (cancelled without `resolved`).
-            if !disposition_known {
-                block_cancel.cancelled().await;
-            }
-
-            if resolved.load(Ordering::Acquire) {
-                // The payload was retrieved and is being sealed; the pruned transactions are
-                // legitimately part of it, so leave them out of the pool.
-                return;
-            }
-
-            // Abandoned before sealing: restore the pruned transactions. Any transaction that does
-            // end up canonical is re-pruned by the canonical-state notification, so an occasional
-            // redundant reinsert is self-correcting.
-            let attempted = pruned.len();
-            let succeeded = restore_pruned_transactions(&pool, &pruned).await;
-            info!(
-                target: "payload_builder",
-                attempted,
-                restored = succeeded,
-                "Restored pruned transactions after payload abandonment",
-            );
-        });
-    }
-
     /// Finalize the payload by computing the state root and setting the finalized cell.
     fn finalize_payload<DB, P>(
         &self,
@@ -1077,6 +1030,61 @@ where
     let info = ctx.execute_sequencer_transactions(state)?;
 
     Ok(info)
+}
+
+/// Decide the fate of transactions pruned during flashblock building for a job that is ending, on a
+/// spawned task so the (blocking) build task can return immediately.
+///
+/// Returns the spawned task's [`JoinHandle`](tokio::task::JoinHandle) (or `None` when there is
+/// nothing to restore). Production callers drop it. The restore is intentionally fire-and-forget
+/// best-effort.
+pub(crate) fn settle_pruned_transactions<P: TransactionPool + 'static>(
+    pool: P,
+    pruned: PrunedTransactions<P>,
+    resolved: Arc<AtomicBool>,
+    block_cancel: CancellationToken,
+    disposition_known: bool,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if pruned.is_empty() {
+        return None;
+    }
+
+    Some(tokio::spawn(async move {
+        // Wait until the job's fate is known: sealed via `getPayload` (sets `resolved`) or
+        // abandoned (cancelled without `resolved`).
+        if !disposition_known {
+            block_cancel.cancelled().await;
+        }
+
+        if resolved.load(Ordering::Acquire) {
+            // The payload was retrieved and is being sealed; the pruned transactions are
+            // legitimately part of it, so leave them out of the pool.
+            return;
+        }
+
+        // Abandoned before sealing: restore the pruned transactions. Any transaction that does end
+        // up canonical is re-pruned by the canonical-state notification, so an occasional redundant
+        // reinsert is self-correcting.
+        let attempted = pruned.len();
+        let restored = restore_pruned_transactions(&pool, &pruned).await;
+        if restored < attempted {
+            // Best-effort: the canonical re-prune and peer gossip remain the backstops, but a
+            // partial failure shouldn't be silent.
+            warn!(
+                target: "payload_builder",
+                attempted,
+                restored,
+                "Failed to restore some pruned transactions after payload abandonment",
+            );
+        } else {
+            info!(
+                target: "payload_builder",
+                attempted,
+                restored,
+                "Restored pruned transactions after payload abandonment",
+            );
+        }
+    }))
 }
 
 /// Reinsert transactions that were pruned from the pool during flashblock building, preserving
@@ -1346,10 +1354,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    };
+    use std::sync::{Arc, atomic::AtomicBool};
 
     use alloy_consensus::{Header, Receipt};
     use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
@@ -1364,8 +1369,11 @@ mod tests {
         PoolTransaction, TransactionOrigin, TransactionPool,
         test_utils::{MockTransaction, testing_pool},
     };
+    use tokio_util::sync::CancellationToken;
 
-    use super::{FlashblocksMetadata, build_block, restore_pruned_transactions};
+    use super::{
+        FlashblocksMetadata, build_block, restore_pruned_transactions, settle_pruned_transactions,
+    };
     use crate::{ExecutionInfo, flashblocks::context::BasePayloadBuilderCtx};
 
     /// Creates a minimal [`BaseChainSpec`] with all L1 upgrades through Cancun
@@ -1684,12 +1692,44 @@ mod tests {
         assert_eq!(restore_pruned_transactions(&pool, &[]).await, 0);
     }
 
-    /// Mirrors the decision in [`super::BasePayloadBuilder::settle_pruned_transactions`]: pruned
-    /// transactions are restored only when the payload was abandoned (`resolved == false`). A
-    /// payload sealed via `getPayload` (`resolved == true`) keeps its pruned transactions out of
-    /// the pool, matching canonical inclusion.
+    /// `settle_pruned_transactions` on the target-flashblock-count path (`disposition_known =
+    /// false`): the spawned task must wait for the `CancellationToken` before acting, and once the
+    /// job is abandoned (cancelled without `resolved`) it restores the pruned transactions.
     #[tokio::test]
-    async fn resolved_flag_gates_restoration() {
+    async fn settle_restores_pruned_transactions_after_cancellation() {
+        let pool = testing_pool();
+        let tx = MockTransaction::eip1559();
+        let hash = *tx.hash();
+        pool.add_transaction(TransactionOrigin::Local, tx).await.expect("add");
+        let pruned = pool.prune_transactions(vec![hash]);
+        assert!(!pool.contains(&hash), "prune removes the tx");
+
+        let resolved = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = settle_pruned_transactions(
+            pool.clone(),
+            pruned,
+            Arc::clone(&resolved),
+            cancel.clone(),
+            false,
+        )
+        .expect("a restore task is spawned when there are pruned transactions");
+
+        // Give the task a chance to run: it must park on the (uncancelled) token, not restore.
+        tokio::task::yield_now().await;
+        assert!(!pool.contains(&hash), "must not restore before the job's fate is known");
+
+        // Abandon the job -> wakes the task, which restores the pruned transactions.
+        cancel.cancel();
+        handle.await.expect("settle task completes");
+        assert!(pool.contains(&hash), "an abandoned payload restores pruned transactions");
+    }
+
+    /// `settle_pruned_transactions` when the payload was sealed via `getPayload` (`resolved ==
+    /// true`): the task returns without restoring, so the pruned transactions stay out of the pool
+    /// (matching canonical inclusion).
+    #[tokio::test]
+    async fn settle_keeps_pruned_transactions_when_sealed() {
         let pool = testing_pool();
         let tx = MockTransaction::eip1559();
         let hash = *tx.hash();
@@ -1697,18 +1737,33 @@ mod tests {
         let pruned = pool.prune_transactions(vec![hash]);
         assert!(!pool.contains(&hash));
 
-        // Sealed payload: do not restore.
-        let resolved = AtomicBool::new(true);
-        if !resolved.load(Ordering::Acquire) {
-            restore_pruned_transactions(&pool, &pruned).await;
-        }
-        assert!(!pool.contains(&hash), "a sealed payload must not restore pruned transactions");
+        // disposition_known = true (cancellation already happened) and resolved = true (sealed).
+        let handle = settle_pruned_transactions(
+            pool.clone(),
+            pruned,
+            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
+            true,
+        )
+        .expect("task spawned");
+        handle.await.expect("settle task completes");
+        assert!(
+            !pool.contains(&hash),
+            "a sealed payload keeps pruned transactions out of the pool"
+        );
+    }
 
-        // Abandoned payload: restore.
-        resolved.store(false, Ordering::Release);
-        if !resolved.load(Ordering::Acquire) {
-            restore_pruned_transactions(&pool, &pruned).await;
-        }
-        assert!(pool.contains(&hash), "an abandoned payload must restore pruned transactions");
+    /// `settle_pruned_transactions` spawns nothing when there is nothing to restore.
+    #[tokio::test]
+    async fn settle_is_noop_when_nothing_pruned() {
+        let pool = testing_pool();
+        let handle = settle_pruned_transactions(
+            pool,
+            Vec::new(),
+            Arc::new(AtomicBool::new(false)),
+            CancellationToken::new(),
+            false,
+        );
+        assert!(handle.is_none(), "no task is spawned when there is nothing to restore");
     }
 }


### PR DESCRIPTION
## Summary

Flashblock payload building prunes committed transactions from the local txpool after each flashblock. If the in-progress payload is abandoned before it is sealed, those transactions are lost from this builder's pool.

This PR retains the transactions returned by `prune_transactions` and reinserts them into the pool when the payload job is abandoned, while leaving the sealed path untouched.

## Problem

- `crates/builder/core/src/flashblocks/payload.rs` discarded the return value of `pool.prune_transactions(...)`.
- The prune correctly removes committed txs so descendants are yielded in order across flashblock boundaries, but it is not reversible.
- reth's `maintain_transaction_pool` reinjects transactions only for canonical `Reorg { old, new }` (old-minus-new) and removes them on canonical commit. Neither path covers a speculative flashblock payload that never becomes canonical, so pruned txs can silently disappear from the local pool on cancellation/supersession.

## Solution

- Retain the `ValidPoolTransaction`s returned by `prune_transactions` in a per-job journal (gated on a new config flag).
- Add a per-job `resolved` flag set by `resolve_kind` (the `getPayload` path) before it cancels, so the build task can distinguish a **sealed** payload (keep pruned) from an **abandoned** one (restore).
- On the build task's terminal paths, hand the journal to a lightweight spawned task that waits for the job's disposition (if not already known), and reinserts the transactions via `add_transactions_with_origins` (when job is abandoned), **preserving each transaction's original origin** (unlike reth's reorg recovery, which downgrades to external).
- Reinsertion re-validates, so any tx that did end up canonical is re-pruned by the canonical-state notification. The reinsert is self-correcting.

### What is intentionally unchanged
- Per-flashblock pruning during an active build (nonce-chain ordering across flashblock boundaries).
- reth's canonical commit-prune and reorg old-minus-new recovery.
- On the sealed path (`resolved == true`) nothing is reinserted, so canonical inclusion still removes the transactions.

## Configuration

New `BuilderConfig::flashblock_prune_rollback_enabled` (default `false`).

## Testing

- `cargo test -p base-builder-core`, new unit tests (reth `testing_pool`):
  - abandoned payload → pruned txs restored, with per-tx origin preserved (`Local`/`External`);
  - resolved gate → sealed payload keeps txs out, abandoned payload restores;
  - empty-journal no-op.
- `cargo clippy -p base-builder-core --all-targets` clean.