### PR TITLE
refactor(challenger): clean up bond

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,7 +3631,6 @@ dependencies = [
  "base-runtime",
  "base-tx-manager",
  "clap",
- "derive_more 2.1.1",
  "eyre",
  "futures",
  "humantime",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -76,7 +76,6 @@ base-health = { workspace = true, features = ["axum-server"] }
 # Misc
 url.workspace = true
 humantime.workspace = true
-derive_more = { workspace = true, features = ["debug"] }
 
 # Test utilities (optional)
 serde_json = { workspace = true, optional = true }

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -9,10 +9,11 @@ use base_proof_contracts::{
     game_lookup_key,
 };
 use base_proof_rpc::L2Provider;
+use base_tx_manager::TxManager;
 use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
-use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
+use crate::{ChallengeSubmitter, ChallengerMetrics, OutputValidator};
 
 /// Best-effort updater for the `AnchorStateRegistry`.
 pub struct AnchorUpdater {
@@ -61,10 +62,10 @@ impl AnchorUpdater {
     }
 
     /// Finds the next game after the anchor game and advances the anchor root if it is ready.
-    pub async fn poll(
+    pub async fn poll<T: TxManager>(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<T>,
     ) {
         let anchor = match self.anchor_registry_client.anchor_snapshot().await {
             Ok(anchor) => anchor,
@@ -188,10 +189,10 @@ impl AnchorUpdater {
         }
     }
 
-    async fn try_update(
+    async fn try_update<T: TxManager>(
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<T>,
     ) -> bool {
         let asr_address = match verifier_client.anchor_state_registry(game_address).await {
             Ok(address) => address,
@@ -308,8 +309,8 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockAnchorStateRegistry, MockBondTransactionSubmitter,
-        MockDisputeGameFactory, MockL2Provider, addr, build_test_header_and_account, mock_state,
+        MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL2Provider,
+        SharedMockTxManager, addr, build_test_header_and_account, mock_state, receipt_with_status,
     };
 
     const ASR_ADDRESS: Address = Address::new([0xAA; 20]);
@@ -337,6 +338,17 @@ mod tests {
                 .unwrap()
                 .extra_data;
         factory.insert_uuid_game(GAME_TYPE, output_root, extra_data, game);
+    }
+
+    fn tx_success(tx_hash: B256) -> base_tx_manager::SendResponse {
+        Ok(receipt_with_status(true, tx_hash))
+    }
+
+    fn submitter(
+        responses: Vec<base_tx_manager::SendResponse>,
+    ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
+        let tx_manager = SharedMockTxManager::with_responses(responses);
+        (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
     }
 
     fn updater(
@@ -368,15 +380,15 @@ mod tests {
         state.anchor_state_registry = ASR_ADDRESS;
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game);
-        assert_eq!(calls[0].1, ASR_ADDRESS);
+        assert_eq!(calls[0].tx_data, encode_set_anchor_state_calldata(game));
+        assert_eq!(calls[0].to.unwrap(), ASR_ADDRESS);
     }
 
     #[tokio::test]
@@ -390,12 +402,12 @@ mod tests {
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
     }
 
     #[tokio::test]
@@ -410,7 +422,7 @@ mod tests {
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
@@ -423,9 +435,9 @@ mod tests {
 
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game);
+        assert_eq!(calls[0].tx_data, encode_set_anchor_state_calldata(game));
     }
 
     #[tokio::test]
@@ -441,17 +453,16 @@ mod tests {
         state.anchor_state_registry = ASR_ADDRESS;
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter =
-            MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash), Ok(tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash), tx_success(tx_hash)]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
         factory.uuid_games.lock().unwrap().clear();
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game);
+        assert_eq!(calls[0].tx_data, encode_set_anchor_state_calldata(game));
     }
 
     #[tokio::test]
@@ -467,14 +478,14 @@ mod tests {
             challenger_win,
             mock_state(GameStatus::ChallengerWins, Address::ZERO, 100),
         )]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
         factory.uuid_games.lock().unwrap().clear();
         updater.poll(&verifier, &submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
         assert_eq!(verifier.status_read_count(challenger_win), 1);
     }
 
@@ -495,14 +506,14 @@ mod tests {
             (anchor_game, mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
             (next_game, next_state),
         ]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, next_game);
+        assert_eq!(calls[0].tx_data, encode_set_anchor_state_calldata(next_game));
     }
 
     #[tokio::test]
@@ -518,11 +529,11 @@ mod tests {
         state.is_finalized = false;
 
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
     }
 }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -502,19 +502,16 @@ impl<C: Clock> BondManager<C> {
             return Ok(Some(phase));
         }
 
+        self.ensure_weth_delay(verifier_client, game_address).await;
+        let Some(delay) = self.weth_delay else {
+            debug!(game = %game_address, "WETH delay not yet known, waiting to submit unlock");
+            return Ok(Some(BondPhase::NeedsUnlock));
+        };
+
         match Self::send_claim_credit(game_address, "unlock", submitter).await {
-            Ok(_) => {
-                let Some(delay) = self.weth_delay else {
-                    debug!(
-                        game = %game_address,
-                        "unlock confirmed but WETH delay not yet known, will resolve on next poll"
-                    );
-                    return Ok(Some(BondPhase::NeedsUnlock));
-                };
-                Ok(Some(BondPhase::AwaitingDelay {
-                    ready_at: self.clock.now().saturating_add(delay),
-                }))
-            }
+            Ok(_) => Ok(Some(BondPhase::AwaitingDelay {
+                ready_at: self.clock.now().saturating_add(delay),
+            })),
             Err(e) => {
                 warn!(
                     game = %game_address,
@@ -661,7 +658,15 @@ impl<C: Clock> BondManager<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+    use std::{
+        collections::HashMap,
+        future::Future,
+        io::{ErrorKind, Read, Write},
+        net::TcpListener,
+        pin::Pin,
+        sync::Arc,
+        thread,
+    };
 
     use alloy_primitives::B256;
     use futures::stream::BoxStream;
@@ -742,6 +747,75 @@ mod tests {
     ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
         let tx_manager = SharedMockTxManager::with_responses(responses);
         (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
+    }
+
+    fn rpc_id(request: &str) -> &str {
+        let Some((_, tail)) = request.split_once("\"id\"") else {
+            return "0";
+        };
+        let Some((_, value)) = tail.split_once(':') else {
+            return "0";
+        };
+        value
+            .trim_start()
+            .split([',', '}'])
+            .next()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .unwrap_or("0")
+    }
+
+    fn content_length(request: &str) -> Option<usize> {
+        request.lines().find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length").then(|| value.trim().parse().ok())?
+        })
+    }
+
+    fn delayed_weth_rpc(delay: Duration) -> (url::Url, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
+        let handle = thread::spawn(move || {
+            let mut stream = (0..100)
+                .find_map(|_| match listener.accept() {
+                    Ok((stream, _)) => Some(stream),
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                        None
+                    }
+                    Err(e) => panic!("accept failed: {e}"),
+                })
+                .expect("timed out waiting for DelayedWETH delay request");
+            let mut request = Vec::new();
+            let mut buffer = [0; 1024];
+            loop {
+                let read = stream.read(&mut buffer).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                let text = String::from_utf8_lossy(&request);
+                let Some((headers, body)) = text.split_once("\r\n\r\n") else {
+                    continue;
+                };
+                if body.len() >= content_length(headers).unwrap_or(0) {
+                    break;
+                }
+            }
+
+            let request = String::from_utf8_lossy(&request);
+            let result = format!("0x{:064x}", delay.as_secs());
+            let body =
+                format!(r#"{{"jsonrpc":"2.0","id":{},"result":"{}"}}"#, rpc_id(&request), result);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (url, handle)
     }
 
     fn manager(
@@ -1073,6 +1147,40 @@ mod tests {
                     if ready_at == Duration::from_secs(560)
             ),
             "expected AwaitingDelay with monotonic deadline, got {result:?}",
+        );
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn try_unlock_loads_weth_delay_before_unlock() {
+        let claim_addr = claim_addr();
+        let game = addr(0);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
+        state.delayed_weth = addr(9);
+        let verifier = verifier(state);
+        let (rpc_url, handle) = delayed_weth_rpc(TEST_WETH_DELAY);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            rpc_url,
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            fixed_clock(500),
+        );
+        mgr.track_game(game, claim_addr);
+
+        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
+        let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
+        handle.join().unwrap();
+
+        assert!(
+            matches!(
+                result,
+                Some(BondPhase::AwaitingDelay { ready_at })
+                    if ready_at == Duration::from_secs(560)
+            ),
+            "expected AwaitingDelay from unlock time, got {result:?}",
         );
         assert_eq!(tx_manager.recorded_calls().len(), 1);
     }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -159,12 +159,9 @@ impl<C: Clock> BondManager<C> {
         };
         let game_address = game_at.proxy;
 
-        let (bond_recipient, zk_prover, resolved_at, bond_unlocked, bond_claimed) = match futures::try_join!(
+        let (bond_recipient, zk_prover) = match futures::try_join!(
             verifier_client.bond_recipient(game_address),
             verifier_client.zk_prover(game_address),
-            verifier_client.resolved_at(game_address),
-            verifier_client.bond_unlocked(game_address),
-            verifier_client.bond_claimed(game_address),
         ) {
             Ok(values) => values,
             Err(e) => {
@@ -177,13 +174,25 @@ impl<C: Clock> BondManager<C> {
             }
         };
 
-        if resolved_at == 0 {
-            if !self.claim_addresses.contains(&bond_recipient)
-                && !self.claim_addresses.contains(&zk_prover)
-            {
+        if !self.claim_addresses.contains(&bond_recipient)
+            && !self.claim_addresses.contains(&zk_prover)
+        {
+            return None;
+        }
+
+        let resolved_at = match verifier_client.resolved_at(game_address).await {
+            Ok(resolved_at) => resolved_at,
+            Err(e) => {
+                debug!(game = %game_address, error = %e, "failed to read bond state");
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_BOND_READ,
+                )
+                .increment(1);
                 return None;
             }
+        };
 
+        if resolved_at == 0 {
             let game_over = match verifier_client.game_over(game_address).await {
                 Ok(game_over) => game_over,
                 Err(e) => {
@@ -199,7 +208,38 @@ impl<C: Clock> BondManager<C> {
             return game_over.then_some(BondAction::Resolve(game_address));
         }
 
-        if !self.claim_addresses.contains(&bond_recipient) || bond_claimed {
+        let bond_recipient = match verifier_client.bond_recipient(game_address).await {
+            Ok(bond_recipient) => bond_recipient,
+            Err(e) => {
+                debug!(game = %game_address, error = %e, "failed to read bond state");
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_BOND_READ,
+                )
+                .increment(1);
+                return None;
+            }
+        };
+
+        if !self.claim_addresses.contains(&bond_recipient) {
+            return None;
+        }
+
+        let (bond_unlocked, bond_claimed) = match futures::try_join!(
+            verifier_client.bond_unlocked(game_address),
+            verifier_client.bond_claimed(game_address),
+        ) {
+            Ok(values) => values,
+            Err(e) => {
+                debug!(game = %game_address, error = %e, "failed to read bond state");
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_BOND_READ,
+                )
+                .increment(1);
+                return None;
+            }
+        };
+
+        if bond_claimed {
             return None;
         }
 
@@ -266,10 +306,11 @@ impl<C: Clock> BondManager<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
     ) -> eyre::Result<()> {
-        let delay = self.ensure_weth_delay(verifier_client, game_address).await?;
+        let (weth_client, delay) =
+            self.weth_client_and_delay(verifier_client, game_address).await?;
 
         let delay_started_at =
-            self.withdrawal_timestamp(verifier_client, game_address, bond_recipient).await?;
+            weth_client.withdrawal_timestamp(game_address, bond_recipient).await?;
         if delay_started_at == 0 {
             debug!(game = %game_address, recipient = %bond_recipient, "bond marked unlocked without DelayedWETH withdrawal state");
             return Ok(());
@@ -317,32 +358,22 @@ impl<C: Clock> BondManager<C> {
         result.map(|_| ())
     }
 
-    async fn ensure_weth_delay(
+    async fn weth_client_and_delay(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
-    ) -> eyre::Result<Duration> {
-        if let Some(delay) = self.weth_delay {
-            return Ok(delay);
-        }
-
+    ) -> eyre::Result<(DelayedWETHContractClient, Duration)> {
         let weth_address = verifier_client.delayed_weth(game_address).await?;
         let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
-        let delay = weth_client.delay().await?;
-        info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
-        self.weth_delay = Some(delay);
-        Ok(delay)
-    }
 
-    async fn withdrawal_timestamp(
-        &self,
-        verifier_client: &dyn AggregateVerifierClient,
-        game_address: Address,
-        bond_recipient: Address,
-    ) -> eyre::Result<u64> {
-        let weth_address = verifier_client.delayed_weth(game_address).await?;
-        let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
-        Ok(weth_client.withdrawal_timestamp(game_address, bond_recipient).await?)
+        let Some(delay) = self.weth_delay else {
+            let delay = weth_client.delay().await?;
+            info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
+            self.weth_delay = Some(delay);
+            return Ok((weth_client, delay));
+        };
+
+        Ok((weth_client, delay))
     }
 }
 
@@ -559,6 +590,7 @@ mod tests {
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
         handle.join().unwrap();
 
+        assert_eq!(verifier.delayed_weth_reads.lock().unwrap().len(), 1);
         assert!(tx_manager.recorded_calls().is_empty());
     }
 
@@ -576,6 +608,7 @@ mod tests {
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
         handle.join().unwrap();
 
+        assert_eq!(verifier.delayed_weth_reads.lock().unwrap().len(), 1);
         assert_eq!(tx_manager.recorded_calls().len(), 1);
     }
 }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -174,7 +174,7 @@ impl<C: Clock> BondManager<C> {
         };
 
         if !self.claim_addresses.contains(&bond_recipient)
-            && !self.claim_addresses.contains(&zk_prover)
+            && (zk_prover == Address::ZERO || !self.claim_addresses.contains(&zk_prover))
         {
             return None;
         }
@@ -556,6 +556,22 @@ mod tests {
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
 
         assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn scan_ignores_zero_zk_prover_match() {
+        let state = game_state(Address::repeat_byte(0xDD), Address::ZERO, 0, false);
+        let verifier = verifier(state);
+        let (submitter, tx_manager) = bond_submitter(vec![]);
+        let mut mgr = manager(
+            Address::ZERO,
+            "http://localhost:8545".parse().unwrap(),
+            fixed_clock(2_000_000_000),
+        );
+
+        mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
+
+        assert!(tx_manager.recorded_calls().is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -19,15 +19,6 @@ use tracing::{debug, info, warn};
 
 use crate::{ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics, GameScanner};
 
-/// Reason a game was removed from bond tracking.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RemovalReason {
-    /// Bond was successfully claimed.
-    Completed,
-    /// Bond is not claimable by the configured claim addresses.
-    NotClaimable,
-}
-
 /// Phase of the bond claim lifecycle for a single tracked game.
 #[derive(Debug, Clone)]
 pub enum BondPhase {
@@ -46,22 +37,6 @@ pub enum BondPhase {
         /// Whether `ready_at` was computed with the fallback WETH delay.
         using_default_delay: bool,
     },
-}
-
-/// A dispute game tracked for bond lifecycle management.
-#[derive(Debug, Clone)]
-pub struct TrackedGame {
-    /// Current lifecycle phase.
-    pub phase: BondPhase,
-    /// The address that will receive the bond.
-    pub bond_recipient: Address,
-}
-
-impl TrackedGame {
-    /// Creates a tracked game in the given phase.
-    pub const fn new(phase: BondPhase, bond_recipient: Address) -> Self {
-        Self { phase, bond_recipient }
-    }
 }
 
 /// Manages bond claiming for dispute games.
@@ -742,18 +717,6 @@ impl<C: Clock> BondManager<C> {
             Err(e) => warn!(error = %e, "failed to read DelayedWETH delay, will retry later"),
         }
     }
-}
-
-/// Trait for submitting dispute game maintenance transactions.
-#[async_trait::async_trait]
-pub trait BondTransactionSubmitter: Send + Sync {
-    /// Sends a transaction with the given calldata to `to`.
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: alloy_primitives::Bytes,
-    ) -> Result<alloy_primitives::B256, ChallengeSubmitError>;
 }
 
 #[cfg(test)]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1,32 +1,8 @@
-//! Bond lifecycle management.
-//!
-//! The [`BondManager`] tracks dispute games through a multi-phase credit
-//! claim lifecycle:
-//!
-//! 1. **[`NeedsResolve`](BondPhase::NeedsResolve)** — wait for the game's
-//!    dispute period to expire, then call `resolve()`.
-//! 2. **[`NeedsUnlock`](BondPhase::NeedsUnlock)** — call `claimCredit()`
-//!    to trigger `DelayedWETH.unlock()`.
-//! 3. **[`AwaitingDelay`](BondPhase::AwaitingDelay)** — wait for the
-//!    `DelayedWETH` delay to elapse.
-//! 4. **[`NeedsWithdraw`](BondPhase::NeedsWithdraw)** — call `claimCredit()`
-//!    again to complete the withdrawal.
-//!
-//! A comma-separated list of addresses is provided via the
-//! `BASE_CHALLENGER_BOND_CLAIM_ADDRESSES` env var. The manager tracks any
-//! game whose onchain `bondRecipient` matches one of those addresses,
-//! regardless of the game's resolution outcome (`CHALLENGER_WINS` or
-//! `DEFENDER_WINS`). This allows claiming bonds both for games won by the
-//! challenger and games proposed by addresses in the claim set.
-//!
-//! During startup recovery, `zkProver` is also checked against the claim
-//! addresses to recover pre-resolve challenged games, since `bondRecipient`
-//! is only updated to the challenger's address during `resolve()`. For
-//! already-resolved games matched solely via `zkProver`, the onchain
-//! `bondRecipient` is re-verified against the claim set before tracking.
+//! Bond lifecycle management for resolving, unlocking, and withdrawing
+//! dispute-game credits.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     sync::Arc,
     time::Duration,
 };
@@ -37,23 +13,15 @@ use base_proof_contracts::{
     DisputeGameFactoryClient, GameStatus, encode_claim_credit_calldata, encode_resolve_calldata,
 };
 use base_runtime::Clock;
+use base_tx_manager::TxManager;
 use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
-use crate::{ChallengerMetrics, GameScanner};
-
-/// Reason a game was removed from tracking after `BondManager::advance_game`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RemovalReason {
-    /// Bond was successfully claimed — the full lifecycle completed.
-    Completed,
-    /// Bond is not claimable by us (recipient changed after resolve).
-    NotClaimable,
-}
+use crate::{ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics, GameScanner};
 
 /// Phase of the bond claim lifecycle for a single tracked game.
-#[derive(Debug, Clone)]
-pub enum BondPhase {
+#[derive(Debug)]
+enum BondPhase {
     /// The game's dispute period is over; needs a `resolve()` call.
     NeedsResolve,
     /// The game has been resolved; needs the first `claimCredit()` call
@@ -62,82 +30,32 @@ pub enum BondPhase {
     /// The unlock has been submitted; waiting for the `DelayedWETH` delay
     /// to elapse before the second `claimCredit()` call.
     AwaitingDelay {
-        /// Monotonic timestamp at which the unlock occurred.
-        unlocked_at: Duration,
-        /// Unix timestamp used when recovering an already-unlocked bond.
-        unlocked_at_unix_secs: Option<u64>,
+        /// Monotonic timestamp at which withdrawal should be retried.
+        ready_at: Duration,
     },
-    /// The delay has elapsed; needs the second `claimCredit()` call to
-    /// complete the withdrawal.
-    NeedsWithdraw,
-    /// Bond fully claimed. The entry will be removed from tracking.
-    Completed,
 }
 
-/// A game being tracked for bond lifecycle management.
-#[derive(Debug, Clone)]
-pub struct TrackedGame {
-    /// Current lifecycle phase.
-    pub phase: BondPhase,
-    /// The address that will receive the bond.
-    pub bond_recipient: Address,
-}
-
-impl TrackedGame {
-    /// Creates a freshly-tracked game in the given phase.
-    pub const fn new(phase: BondPhase, bond_recipient: Address) -> Self {
-        Self { phase, bond_recipient }
-    }
-}
-
-/// Manages the bond claim lifecycle for dispute games.
-///
-/// After a successful `challenge()` submission, games are registered here.
-/// On each [`poll`](Self::poll) tick the manager checks each tracked game's
-/// onchain state and submits the next transaction in the lifecycle.
-///
-/// When bond claim addresses are configured, the manager also continuously
-/// discovers claimable games via [`discover_claimable_games`](Self::discover_claimable_games),
-/// scanning both newly created games and periodically rescanning the
-/// lookback window to catch games challenged or resolved by other actors.
-#[derive(derive_more::Debug)]
+/// Manages bond claiming for dispute games.
 pub struct BondManager<C: Clock> {
-    /// Games being tracked, keyed by proxy address.
-    tracked: HashMap<Address, TrackedGame>,
-    /// Addresses we are authorized to claim bonds on behalf of.
+    tracked: HashMap<Address, BondPhase>,
     claim_addresses: HashSet<Address>,
-    /// `DelayedWETH` withdrawal delay (read from contract at init or lazily
-    /// resolved on the first poll tick that has a tracked game).
     weth_delay: Option<Duration>,
-    /// L1 RPC URL used to instantiate the `DelayedWETH` contract client
-    /// when lazily resolving the withdrawal delay.
     l1_rpc_url: url::Url,
-    /// Injectable clock providing monotonic time. In production this is
-    /// backed by [`TokioRuntime`](base_runtime::TokioRuntime); tests can
-    /// substitute a deterministic clock.
-    #[debug(skip)]
     clock: C,
-    /// Factory client for querying game indices during bond discovery.
-    #[debug(skip)]
     factory_client: Arc<dyn DisputeGameFactoryClient>,
-    /// Highest game index scanned for bond discovery. Incremental scans
-    /// start from this index; periodic full rescans reset it backward.
     bond_scan_head: u64,
-    /// Monotonic timestamp of the last full rescan completion.
     last_full_scan: Duration,
-    /// Number of games to look back during periodic full rescans.
     lookback: u64,
-    /// How often a full rescan of the lookback window is performed to catch
-    /// state transitions (games challenged or resolved by other actors).
     discovery_interval: Duration,
 }
 
-impl<C: Clock> BondManager<C> {
-    /// Conservative fallback when the onchain `DelayedWETH` delay has not
-    /// been read yet. If the real delay is shorter the withdraw will simply
-    /// succeed earlier; if longer, the attempt reverts and is retried.
-    const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+impl<C: Clock> std::fmt::Debug for BondManager<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BondManager").finish_non_exhaustive()
+    }
+}
 
+impl<C: Clock> BondManager<C> {
     /// How long to wait before retrying a reverted withdraw attempt.
     const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
 
@@ -167,29 +85,6 @@ impl<C: Clock> BondManager<C> {
         }
     }
 
-    /// Returns `true` if bond claiming is enabled (at least one claim address configured).
-    pub fn is_enabled(&self) -> bool {
-        !self.claim_addresses.is_empty()
-    }
-
-    /// Sets the `DelayedWETH` withdrawal delay.
-    pub fn set_weth_delay(&mut self, delay: Duration) {
-        info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
-        self.weth_delay = Some(delay);
-    }
-
-    /// Returns the effective `DelayedWETH` withdrawal delay for a game, falling
-    /// back to `Self::DEFAULT_WETH_DELAY` when the onchain delay has not yet
-    /// been read. Both the `check_delay` and `submit_claim_credit`
-    /// retry-backoff paths must agree on this value, so the fallback is
-    /// centralized here.
-    pub fn effective_weth_delay(&self, game_address: Address) -> Duration {
-        self.weth_delay.unwrap_or_else(|| {
-            debug!(game = %game_address, "WETH delay not yet known, using default 7 days");
-            Self::DEFAULT_WETH_DELAY
-        })
-    }
-
     /// Returns the number of games currently being tracked.
     pub fn tracked_count(&self) -> usize {
         self.tracked.len()
@@ -209,50 +104,27 @@ impl<C: Clock> BondManager<C> {
             return false;
         }
 
-        if self.tracked.contains_key(&game_address) {
+        let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
             debug!(game = %game_address, "game already tracked for bond claiming");
             return false;
-        }
+        };
 
         info!(
             game = %game_address,
             recipient = %bond_recipient,
             "tracking game for bond claiming"
         );
-        self.tracked
-            .insert(game_address, TrackedGame::new(BondPhase::NeedsResolve, bond_recipient));
+        entry.insert(BondPhase::NeedsResolve);
         ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         true
     }
 
-    /// Returns `true` if the given game is being tracked.
-    pub fn is_tracking(&self, game_address: &Address) -> bool {
-        self.tracked.contains_key(game_address)
-    }
-
-    /// Updates the phase of a tracked game. No-op if the game is not tracked.
-    fn set_phase(&mut self, game_address: Address, phase: BondPhase) {
-        if let Some(game) = self.tracked.get_mut(&game_address) {
-            game.phase = phase;
-        }
-    }
-
-    /// Evaluates a single game for bond tracking eligibility.
-    ///
-    /// Fetches the game's `bondRecipient` and `zkProver`, matches them
-    /// against `claim_addresses`, determines the onchain lifecycle phase,
-    /// and returns the game address, matched address, and phase if the game
-    /// is eligible for tracking. Returns `None` when the game is not
-    /// relevant, already claimed, or an RPC error occurs.
     async fn evaluate_game_for_bonds(
+        &self,
         index: u64,
-        factory_client: &dyn DisputeGameFactoryClient,
         verifier_client: &dyn AggregateVerifierClient,
-        claim_addresses: &HashSet<Address>,
-        clock: &C,
-        weth_delay: Option<Duration>,
-    ) -> Option<(Address, Address, Option<BondPhase>)> {
-        let game_at = match factory_client.game_at_index(index).await {
+    ) -> Option<(Address, BondPhase)> {
+        let game_at = match self.factory_client.game_at_index(index).await {
             Ok(g) => g,
             Err(e) => {
                 warn!(index, error = %e, "failed to fetch game at index");
@@ -285,47 +157,40 @@ impl<C: Clock> BondManager<C> {
             }
         };
 
-        // Check both `bondRecipient` and `zkProver` against the claim
-        // addresses. Before `resolve()`, `bondRecipient` is the game
-        // creator while `zkProver` is the address that called
-        // `challenge()`. After `resolve()`, `bondRecipient` is updated
-        // to the `zkProver`. Checking both ensures we recover pre-resolve
-        // challenged games.
-        let matched_address = if claim_addresses.contains(&bond_recipient) {
-            bond_recipient
-        } else if zk_prover != Address::ZERO && claim_addresses.contains(&zk_prover) {
-            zk_prover
-        } else {
+        if !self.claim_addresses.contains(&bond_recipient)
+            && (zk_prover == Address::ZERO || !self.claim_addresses.contains(&zk_prover))
+        {
             return None;
+        }
+
+        let phase = match Self::determine_phase(
+            verifier_client,
+            game_address,
+            &self.clock,
+            self.weth_delay,
+        )
+        .await
+        {
+            Ok(Some(phase)) => phase,
+            Ok(None) => return None,
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    "failed to determine bond phase"
+                );
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_PHASE_READ,
+                )
+                .increment(1);
+                return None;
+            }
         };
 
-        let phase =
-            match Self::determine_phase(verifier_client, game_address, clock, weth_delay).await {
-                Ok(phase) => phase,
-                Err(e) => {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to determine bond phase"
-                    );
-                    ChallengerMetrics::bond_evaluation_errors_total(
-                        ChallengerMetrics::EVAL_ERROR_PHASE_READ,
-                    )
-                    .increment(1);
-                    return None;
-                }
-            };
-
-        // For already-resolved games, verify the current onchain
-        // `bondRecipient` is in our claim addresses. Games matched via
-        // `zkProver` may have a `bondRecipient` that is not in our
-        // claim set (e.g. a game where our challenge was nullified and
-        // the bond goes to the game creator). Pre-resolve games are
-        // kept — `bondRecipient` will be re-verified after resolve in
-        // `try_resolve`.
-        if let Some(ref p) = phase
-            && !matches!(p, BondPhase::NeedsResolve)
-            && !claim_addresses.contains(&bond_recipient)
+        // Pre-resolve games can match only by zkProver; resolved games must
+        // have already moved bondRecipient into our claim set.
+        if !matches!(phase, BondPhase::NeedsResolve)
+            && !self.claim_addresses.contains(&bond_recipient)
         {
             debug!(
                 game = %game_address,
@@ -336,56 +201,50 @@ impl<C: Clock> BondManager<C> {
             return None;
         }
 
-        Some((game_address, matched_address, phase))
+        Some((game_address, phase))
     }
 
-    /// Evaluates all games in `range` concurrently for bond tracking
-    /// eligibility, returning one entry per evaluated game.
-    async fn evaluate_bond_range(
+    async fn track_bond_range(
+        &mut self,
         range: std::ops::Range<u64>,
-        factory_client: &dyn DisputeGameFactoryClient,
         verifier_client: &dyn AggregateVerifierClient,
-        claim_addresses: &HashSet<Address>,
-        clock: &C,
-        weth_delay: Option<Duration>,
-    ) -> Vec<Option<(Address, Address, Option<BondPhase>)>> {
-        stream::iter(range)
-            .map(|i| async move {
-                Self::evaluate_game_for_bonds(
-                    i,
-                    factory_client,
-                    verifier_client,
-                    claim_addresses,
-                    clock,
-                    weth_delay,
-                )
+        scan_type: &'static str,
+    ) -> Vec<Address> {
+        let results: Vec<_> = {
+            let manager = &*self;
+            stream::iter(range)
+                .map(|i| manager.evaluate_game_for_bonds(i, verifier_client))
+                .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
+                .filter_map(std::future::ready)
+                .collect()
                 .await
-            })
-            .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
-            .collect()
-            .await
+        };
+        let mut tracked_games = Vec::new();
+
+        for (game_address, phase) in results {
+            let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
+                continue;
+            };
+
+            info!(
+                game = %game_address,
+                phase = ?phase,
+                scan_type,
+                "tracked claimable game"
+            );
+            entry.insert(phase);
+            tracked_games.push(game_address);
+        }
+
+        tracked_games
     }
 
-    /// Scans recent games at startup to recover bond tracking state after a
-    /// restart.
-    ///
-    /// Iterates the last `lookback` games from the factory concurrently and
-    /// checks if any have a `bondRecipient` or `zkProver` matching our claim
-    /// addresses. The `zkProver` check is necessary because before
-    /// `resolve()`, `bondRecipient` is the game creator — only after
-    /// resolution does it update to the challenger's address. Games that are
-    /// already fully claimed are skipped.
-    ///
-    /// Also reads the `DelayedWETH` delay from the first game found, if the
-    /// delay has not been set yet. Sets the bond discovery watermark to the
-    /// current `game_count` so that subsequent
-    /// [`discover_claimable_games`](Self::discover_claimable_games) calls
-    /// start scanning from where startup left off.
+    /// Scans recent games at startup to recover bond tracking state.
     pub async fn startup_scan(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
     ) -> eyre::Result<()> {
-        if !self.is_enabled() {
+        if self.claim_addresses.is_empty() {
             return Ok(());
         }
 
@@ -398,37 +257,7 @@ impl<C: Clock> BondManager<C> {
         let start_index = game_count.saturating_sub(self.lookback);
         info!(start = start_index, end = game_count, "scanning recent games for bond recovery");
 
-        self.ensure_weth_delay_from_index(verifier_client, start_index).await;
-
-        let results = Self::evaluate_bond_range(
-            start_index..game_count,
-            &*self.factory_client,
-            verifier_client,
-            &self.claim_addresses,
-            &self.clock,
-            self.weth_delay,
-        )
-        .await;
-
-        // Resolve the WETH delay from the first available game so the
-        // delay is bootstrapped as early as possible.
-        if let Some((game_address, _, _)) = results.iter().flatten().next() {
-            self.ensure_weth_delay(verifier_client, *game_address).await;
-        }
-
-        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
-            let Some(phase) = phase else {
-                continue;
-            };
-
-            info!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                phase = ?phase,
-                "recovered game for bond tracking"
-            );
-            self.tracked.insert(game_address, TrackedGame::new(phase, bond_recipient));
-        }
+        self.track_bond_range(start_index..game_count, verifier_client, "startup").await;
 
         self.bond_scan_head = game_count;
         self.last_full_scan = self.clock.now();
@@ -438,22 +267,12 @@ impl<C: Clock> BondManager<C> {
         Ok(())
     }
 
-    /// Discovers claimable games via two-tier scanning.
-    ///
-    /// **Incremental** (every call): scans from `bond_scan_head` to
-    /// `game_count`, catching newly created games. Typically zero to a
-    /// handful of games per tick, costing a single `game_count()` RPC
-    /// when idle.
-    ///
-    /// **Periodic full rescan** (every `discovery_interval`):
-    /// resets the watermark backward by `lookback` to re-evaluate games
-    /// whose state may have changed (e.g. challenged or resolved by
-    /// another actor since the last scan).
+    /// Discovers claimable games via incremental and periodic lookback scans.
     pub async fn discover_claimable_games(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
     ) -> eyre::Result<()> {
-        if !self.is_enabled() {
+        if self.claim_addresses.is_empty() {
             warn!("bond manager is disabled, skipping discovery scan");
             return Ok(());
         }
@@ -464,8 +283,6 @@ impl<C: Clock> BondManager<C> {
             return Ok(());
         }
 
-        // Periodic full rescan: reset watermark to re-evaluate the
-        // lookback window and catch state transitions on older games.
         let elapsed = self.clock.now().saturating_sub(self.last_full_scan);
         let is_full_rescan = elapsed >= self.discovery_interval;
         if is_full_rescan {
@@ -510,39 +327,9 @@ impl<C: Clock> BondManager<C> {
 
         ChallengerMetrics::bond_discovery_scans_total(scan_type).increment(1);
 
-        self.ensure_weth_delay_from_index(verifier_client, scan_start).await;
-
-        let results = Self::evaluate_bond_range(
-            scan_start..scan_end,
-            &*self.factory_client,
-            verifier_client,
-            &self.claim_addresses,
-            &self.clock,
-            self.weth_delay,
-        )
-        .await;
-
-        let mut discovered = 0;
-
-        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
-            if self.tracked.contains_key(&game_address) {
-                continue;
-            }
-
-            let Some(phase) = phase else {
-                continue;
-            };
-
-            info!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                phase = ?phase,
-                scan_type,
-                "discovered claimable game"
-            );
-            self.tracked.insert(game_address, TrackedGame::new(phase, bond_recipient));
-            discovered += 1;
-        }
+        let discovered =
+            self.track_bond_range(scan_start..scan_end, verifier_client, scan_type).await.len()
+                as u64;
 
         self.bond_scan_head = scan_end;
 
@@ -560,114 +347,94 @@ impl<C: Clock> BondManager<C> {
     }
 
     /// Polls all tracked games and advances each through the bond lifecycle.
-    ///
-    /// Called once per driver tick. Errors on individual games are logged and
-    /// do not abort processing of remaining games.
-    pub async fn poll(
+    pub async fn poll<T: TxManager>(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<T>,
     ) {
         if self.tracked.is_empty() {
             return;
         }
 
-        // Lazily resolve the DelayedWETH delay if not yet known.
-        if self.weth_delay.is_none()
-            && let Some(&game_address) = self.tracked.keys().next()
-        {
-            self.ensure_weth_delay(verifier_client, game_address).await;
-        }
+        let tracked = std::mem::take(&mut self.tracked);
+        let tracked_count = tracked.len();
 
-        let addresses: Vec<Address> = self.tracked.keys().copied().collect();
-        let mut removed = Vec::new();
-
-        for game_address in addresses {
-            match self.advance_game(game_address, verifier_client, submitter).await {
-                Ok(Some(reason)) => {
-                    removed.push((game_address, reason));
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to advance bond lifecycle"
-                    );
-                }
+        for (game_address, phase) in tracked {
+            if let Some(next_phase) =
+                self.advance_game(game_address, phase, verifier_client, submitter).await
+            {
+                self.tracked.insert(game_address, next_phase);
             }
         }
 
-        for (addr, reason) in &removed {
-            self.tracked.remove(addr);
-            match reason {
-                RemovalReason::Completed => {
-                    ChallengerMetrics::bonds_completed_total().increment(1);
-                }
-                RemovalReason::NotClaimable => {
-                    ChallengerMetrics::bonds_not_claimable_total().increment(1);
-                }
-            }
-        }
-
-        if !removed.is_empty() {
+        if self.tracked.len() != tracked_count {
             ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         }
     }
 
-    /// Advances a single game through the bond lifecycle state machine.
-    ///
-    /// Returns `Ok(Some(reason))` when the game should be removed from
-    /// tracking, or `Ok(None)` when it remains in its current or updated
-    /// phase.
-    async fn advance_game(
+    async fn advance_game<T: TxManager>(
         &mut self,
         game_address: Address,
+        phase: BondPhase,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
-        let game = match self.tracked.get(&game_address) {
-            Some(g) => g,
-            None => return Ok(None),
+        submitter: &ChallengeSubmitter<T>,
+    ) -> Option<BondPhase> {
+        let (result, retry_phase) = match phase {
+            BondPhase::NeedsResolve => (
+                self.try_resolve(game_address, verifier_client, submitter).await,
+                BondPhase::NeedsResolve,
+            ),
+            BondPhase::NeedsUnlock => (
+                self.try_unlock(game_address, verifier_client, submitter).await,
+                BondPhase::NeedsUnlock,
+            ),
+            BondPhase::AwaitingDelay { ready_at } => {
+                let now = self.clock.now();
+                if now < ready_at {
+                    let remaining = ready_at.saturating_sub(now);
+                    debug!(
+                        game = %game_address,
+                        remaining_secs = remaining.as_secs(),
+                        "waiting for DelayedWETH delay"
+                    );
+                    return Some(BondPhase::AwaitingDelay { ready_at });
+                }
+
+                info!(
+                    game = %game_address,
+                    ready_at_secs = ready_at.as_secs(),
+                    "DelayedWETH delay elapsed, submitting withdraw"
+                );
+                (
+                    self.try_withdraw(game_address, verifier_client, submitter).await,
+                    BondPhase::AwaitingDelay { ready_at: now },
+                )
+            }
         };
 
-        match &game.phase {
-            BondPhase::NeedsResolve => {
-                self.try_resolve(game_address, verifier_client, submitter).await
-            }
-            BondPhase::NeedsUnlock => {
-                self.try_unlock(game_address, verifier_client, submitter).await
-            }
-            BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs } => {
-                self.check_delay(game_address, *unlocked_at, *unlocked_at_unix_secs)
-            }
-            BondPhase::NeedsWithdraw => {
-                self.try_withdraw(game_address, verifier_client, submitter).await
-            }
-            BondPhase::Completed => Ok(Some(RemovalReason::Completed)),
-        }
+        result.unwrap_or_else(|e| {
+            warn!(
+                game = %game_address,
+                error = %e,
+                "failed to advance bond lifecycle"
+            );
+            Some(retry_phase)
+        })
     }
 
-    /// Attempts to resolve the game by calling `resolve()`.
-    ///
-    /// After resolution (either by us or by another actor), re-reads the
-    /// onchain `bondRecipient` to verify it is still in our claim
-    /// addresses. `resolve()` may update `bondRecipient` (e.g. to the
-    /// challenger's address on `CHALLENGER_WINS`), so games matched via
-    /// `zkProver` before resolution may no longer be claimable by us.
-    async fn try_resolve(
-        &mut self,
+    async fn try_resolve<T: TxManager>(
+        &self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<Option<BondPhase>> {
         let status = verifier_client.status(game_address).await?;
 
         if status == GameStatus::InProgress {
             let game_over = verifier_client.game_over(game_address).await?;
             if !game_over {
                 debug!(game = %game_address, "game dispute period not yet elapsed");
-                return Ok(None);
+                return Ok(Some(BondPhase::NeedsResolve));
             }
 
             let calldata = encode_resolve_calldata();
@@ -690,7 +457,7 @@ impl<C: Clock> BondManager<C> {
                     );
                     ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                         .increment(1);
-                    return Ok(None);
+                    return Ok(Some(BondPhase::NeedsResolve));
                 }
             }
         } else {
@@ -699,177 +466,125 @@ impl<C: Clock> BondManager<C> {
             info!(game = %game_address, status = ?status, "game already resolved");
         }
 
-        // Re-read the onchain bondRecipient — resolve may have changed it
-        // (e.g. to the challenger on CHALLENGER_WINS). If it is no longer
-        // in our claim set, stop tracking this game.
-        if !self.is_bond_claimable(verifier_client, game_address).await? {
-            return Ok(Some(RemovalReason::NotClaimable));
-        }
-
-        self.set_phase(game_address, BondPhase::NeedsUnlock);
-        Ok(None)
-    }
-
-    /// Checks whether the onchain `bondRecipient` for the given game is in
-    /// our claim addresses. Also updates the tracked game's
-    /// `bond_recipient` field to reflect the current onchain value (which
-    /// may differ from the pre-resolve value). Returns `false` if the
-    /// recipient is not in the claim set, signalling the caller to remove
-    /// the game from tracking.
-    async fn is_bond_claimable(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-        game_address: Address,
-    ) -> eyre::Result<bool> {
         let bond_recipient = verifier_client.bond_recipient(game_address).await?;
-
-        // Update the tracked entry so logging and debugging reflect the
-        // current onchain recipient, not the stale pre-resolve value.
-        if let Some(game) = self.tracked.get_mut(&game_address) {
-            game.bond_recipient = bond_recipient;
+        if !self.claim_addresses.contains(&bond_recipient) {
+            info!(
+                game = %game_address,
+                recipient = %bond_recipient,
+                "bond recipient not in claim addresses after resolve, removing from tracking"
+            );
+            ChallengerMetrics::bonds_not_claimable_total().increment(1);
+            return Ok(None);
         }
 
-        if self.claim_addresses.contains(&bond_recipient) {
-            return Ok(true);
-        }
-        info!(
-            game = %game_address,
-            recipient = %bond_recipient,
-            "bond recipient not in claim addresses after resolve, removing from tracking"
-        );
-        Ok(false)
+        Ok(Some(BondPhase::NeedsUnlock))
     }
 
-    /// Attempts the first `claimCredit()` call to trigger the unlock.
-    async fn try_unlock(
+    async fn try_unlock<T: TxManager>(
         &mut self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<Option<BondPhase>> {
         let (unlocked, resolved_at) = futures::try_join!(
             verifier_client.bond_unlocked(game_address),
             verifier_client.resolved_at(game_address),
         )?;
         if unlocked {
-            if self.delay_elapsed_since_unix(game_address, resolved_at) {
-                info!(
-                    game = %game_address,
-                    resolved_at,
-                    "bond already unlocked and delay elapsed, advancing to withdraw phase"
-                );
-                self.set_phase(game_address, BondPhase::NeedsWithdraw);
-                return Ok(None);
+            self.ensure_weth_delay(verifier_client, game_address).await;
+            let Some(delay) = self.weth_delay else {
+                debug!(game = %game_address, "WETH delay not yet known, waiting to advance unlock");
+                return Ok(Some(BondPhase::NeedsUnlock));
+            };
+
+            let phase = Self::unlocked_phase(&self.clock, resolved_at, delay);
+            info!(game = %game_address, resolved_at, phase = ?phase, "bond already unlocked");
+            return Ok(Some(phase));
+        }
+
+        match Self::send_claim_credit(game_address, "unlock", submitter).await {
+            Ok(_) => {
+                let Some(delay) = self.weth_delay else {
+                    debug!(
+                        game = %game_address,
+                        "unlock confirmed but WETH delay not yet known, will resolve on next poll"
+                    );
+                    return Ok(Some(BondPhase::NeedsUnlock));
+                };
+                Ok(Some(BondPhase::AwaitingDelay {
+                    ready_at: self.clock.now().saturating_add(delay),
+                }))
             }
-
-            let unlocked_at = Self::estimate_unlock_time(&self.clock, resolved_at);
-            info!(
-                game = %game_address,
-                resolved_at,
-                "bond already unlocked, advancing to delay phase"
-            );
-            self.set_phase(
-                game_address,
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: Some(resolved_at) },
-            );
-            return Ok(None);
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    step = "unlock",
+                    retry = "immediate",
+                    "claimCredit transaction failed, will retry"
+                );
+                Ok(Some(BondPhase::NeedsUnlock))
+            }
         }
-
-        self.submit_claim_credit(
-            game_address,
-            submitter,
-            "unlock",
-            BondPhase::AwaitingDelay { unlocked_at: self.clock.now(), unlocked_at_unix_secs: None },
-            None,
-        )
-        .await
     }
 
-    /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
-    fn check_delay(
-        &mut self,
-        game_address: Address,
-        unlocked_at: Duration,
-        unlocked_at_unix_secs: Option<u64>,
-    ) -> eyre::Result<Option<RemovalReason>> {
-        // Fall back to 7 days if the onchain delay has not been read yet.
-        // If the real delay is shorter, the withdraw attempt will simply
-        // succeed earlier than expected. If longer, the attempt will revert
-        // and be retried after a short backoff.
-        let delay = self.effective_weth_delay(game_address);
-
-        let elapsed = unlocked_at_unix_secs.map_or_else(
-            || self.clock.now().saturating_sub(unlocked_at),
-            |unix_secs| {
-                Duration::from_secs(self.clock.wall_clock_unix_secs().saturating_sub(unix_secs))
-            },
-        );
-
-        if elapsed >= delay {
-            info!(
-                game = %game_address,
-                elapsed_secs = elapsed.as_secs(),
-                "DelayedWETH delay elapsed, advancing to withdraw phase"
-            );
-            self.set_phase(game_address, BondPhase::NeedsWithdraw);
-        } else {
-            let remaining = delay.saturating_sub(elapsed);
-            debug!(
-                game = %game_address,
-                remaining_secs = remaining.as_secs(),
-                "waiting for DelayedWETH delay"
-            );
-        }
-        Ok(None)
-    }
-
-    /// Returns whether the effective WETH delay has elapsed since a Unix timestamp.
-    fn delay_elapsed_since_unix(&self, game_address: Address, unix_secs: u64) -> bool {
-        let delay = self.effective_weth_delay(game_address);
-        let elapsed =
-            Duration::from_secs(self.clock.wall_clock_unix_secs().saturating_sub(unix_secs));
-        elapsed >= delay
-    }
-
-    /// Attempts the second `claimCredit()` call to complete the withdrawal.
-    async fn try_withdraw(
-        &mut self,
+    async fn try_withdraw<T: TxManager>(
+        &self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<Option<BondPhase>> {
         let claimed = verifier_client.bond_claimed(game_address).await?;
         if claimed {
             info!(game = %game_address, "bond already claimed");
-            return Ok(Some(RemovalReason::Completed));
+            ChallengerMetrics::bonds_completed_total().increment(1);
+            return Ok(None);
         }
 
-        self.submit_claim_credit(
-            game_address,
-            submitter,
-            "withdraw",
-            BondPhase::Completed,
-            Some(Self::WITHDRAW_REVERT_RETRY_DELAY),
-        )
-        .await
+        match Self::send_claim_credit(game_address, "withdraw", submitter).await {
+            Ok(_) => {
+                ChallengerMetrics::bonds_completed_total().increment(1);
+                Ok(None)
+            }
+            Err(e) => {
+                let retry_delay = if matches!(&e, crate::ChallengeSubmitError::TxReverted { .. }) {
+                    Self::WITHDRAW_REVERT_RETRY_DELAY
+                } else {
+                    Duration::ZERO
+                };
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    step = "withdraw",
+                    retry_delay_secs = retry_delay.as_secs(),
+                    "claimCredit transaction failed, will retry"
+                );
+                Ok(Some(BondPhase::AwaitingDelay {
+                    ready_at: self.clock.now().saturating_add(retry_delay),
+                }))
+            }
+        }
     }
 
-    /// Submits a `claimCredit()` transaction and transitions to the given
-    /// phase on success. If `revert_retry_delay` is set, a reverted
-    /// transaction backs off by that duration before retrying. Returns
-    /// `Ok(Some(Completed))` when the success phase is [`BondPhase::Completed`].
-    async fn submit_claim_credit(
-        &mut self,
+    fn unlocked_phase(clock: &C, resolved_at: u64, delay: Duration) -> BondPhase {
+        let elapsed_since_resolve =
+            Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(resolved_at));
+        BondPhase::AwaitingDelay {
+            ready_at: clock.now().saturating_add(delay.saturating_sub(elapsed_since_resolve)),
+        }
+    }
+
+    async fn send_claim_credit<T: TxManager>(
         game_address: Address,
-        submitter: &dyn BondTransactionSubmitter,
-        step: &str,
-        success_phase: BondPhase,
-        revert_retry_delay: Option<Duration>,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        step: &'static str,
+        submitter: &ChallengeSubmitter<T>,
+    ) -> Result<(), ChallengeSubmitError> {
         let calldata = encode_claim_credit_calldata();
         ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
         info!(game = %game_address, step, "submitting claimCredit transaction");
-        match submitter.send_bond_tx(game_address, game_address, calldata).await {
+
+        let result = submitter.send_bond_tx(game_address, game_address, calldata).await;
+        match &result {
             Ok(tx_hash) => {
                 info!(
                     game = %game_address,
@@ -879,83 +594,15 @@ impl<C: Clock> BondManager<C> {
                 );
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
-                let completed = matches!(success_phase, BondPhase::Completed);
-                self.set_phase(game_address, success_phase);
-                Ok(completed.then_some(RemovalReason::Completed))
             }
-            Err(e) => {
+            Err(_) => {
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                    .increment(1);
-                if let Some(retry_delay) = revert_retry_delay
-                    && matches!(&e, crate::ChallengeSubmitError::TxReverted { .. })
-                {
-                    let delay = self.effective_weth_delay(game_address);
-                    let retry_delay = retry_delay.min(delay);
-                    let elapsed_before_retry = delay.saturating_sub(retry_delay);
-                    let unlocked_at = self.clock.now().saturating_sub(elapsed_before_retry);
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        step,
-                        retry = "after_backoff",
-                        retry_delay_secs = retry_delay.as_secs(),
-                        "claimCredit transaction failed, will retry after backoff"
-                    );
-                    self.set_phase(
-                        game_address,
-                        BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
-                    );
-                } else {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        step,
-                        retry = "immediate",
-                        "claimCredit transaction failed, will retry"
-                    );
-                }
-                Ok(None)
+                    .increment(1)
             }
         }
+        result.map(|_| ())
     }
 
-    /// Converts a Unix timestamp (seconds) to a monotonic [`Duration`]
-    /// relative to the given clock.
-    ///
-    /// Computes how long ago `unix_secs` occurred relative to `unix_now`
-    /// and subtracts that age from the current monotonic time. Used when
-    /// recovering onchain timestamps (e.g. `resolved_at`) into the
-    /// local monotonic time domain.
-    ///
-    /// `unix_now` is accepted as a parameter (callers obtain it via
-    /// [`Clock::wall_clock_unix_secs`]) so that the function is fully
-    /// deterministic and testable.
-    ///
-    /// If `unix_secs` is ahead of `unix_now` (e.g. L1 clock skew),
-    /// the age is treated as zero and `unlocked_at` equals the current
-    /// monotonic time — re-imposing the full delay. This is the safe
-    /// conservative fallback.
-    fn unix_to_monotonic(clock: &C, unix_secs: u64, unix_now: u64) -> Duration {
-        let age = Duration::from_secs(unix_now.saturating_sub(unix_secs));
-        clock.now().saturating_sub(age)
-    }
-
-    /// Estimates when the bond was unlocked using `resolved_at` as a
-    /// conservative lower bound. The unlock must have occurred after
-    /// resolve, so this may cause one early withdrawal attempt that
-    /// reverts, but is strictly better than resetting to "now" (which
-    /// would re-impose the full delay after every retry).
-    fn estimate_unlock_time(clock: &C, resolved_at: u64) -> Duration {
-        Self::unix_to_monotonic(clock, resolved_at, clock.wall_clock_unix_secs())
-    }
-
-    /// Determines the bond phase from onchain state.
-    ///
-    /// Returns `None` if the bond has already been fully claimed. Otherwise
-    /// returns the appropriate [`BondPhase`] based on the game's onchain
-    /// progression (resolved, unlocked, etc.). The caller is responsible
-    /// for verifying that the onchain `bondRecipient` is in the claim set
-    /// before acting on the returned phase.
     async fn determine_phase(
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
@@ -971,19 +618,11 @@ impl<C: Clock> BondManager<C> {
             return Ok(None);
         }
         if bond_unlocked {
-            if let Some(delay) = weth_delay {
-                let elapsed_since_resolve =
-                    Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(resolved_at));
-                if elapsed_since_resolve >= delay {
-                    return Ok(Some(BondPhase::NeedsWithdraw));
-                }
-            }
+            let Some(delay) = weth_delay else {
+                return Ok(Some(BondPhase::NeedsUnlock));
+            };
 
-            let unlocked_at = Self::estimate_unlock_time(clock, resolved_at);
-            return Ok(Some(BondPhase::AwaitingDelay {
-                unlocked_at,
-                unlocked_at_unix_secs: Some(resolved_at),
-            }));
+            return Ok(Some(Self::unlocked_phase(clock, resolved_at, delay)));
         }
 
         if resolved_at > 0 {
@@ -993,90 +632,50 @@ impl<C: Clock> BondManager<C> {
         Ok(Some(BondPhase::NeedsResolve))
     }
 
-    /// Resolves the `DelayedWETH` delay if not yet known, logging on failure.
     async fn ensure_weth_delay(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
     ) {
-        if self.weth_delay.is_none()
-            && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
-        {
-            warn!(error = %e, "failed to read DelayedWETH delay, will retry later");
-        }
-    }
-
-    /// Resolves the WETH delay using a game from the factory at the given index.
-    async fn ensure_weth_delay_from_index(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-        index: u64,
-    ) {
         if self.weth_delay.is_some() {
             return;
         }
 
-        match self.factory_client.game_at_index(index).await {
-            Ok(game_at) => self.ensure_weth_delay(verifier_client, game_at.proxy).await,
-            Err(e) => {
-                warn!(
-                    index,
-                    error = %e,
-                    "failed to fetch game for DelayedWETH delay resolution"
-                );
+        let result: eyre::Result<Duration> = async {
+            let weth_address = verifier_client.delayed_weth(game_address).await?;
+            let weth_client =
+                DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
+            Ok(weth_client.delay().await?)
+        }
+        .await;
+
+        match result {
+            Ok(delay) => {
+                info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
+                self.weth_delay = Some(delay);
             }
+            Err(e) => warn!(error = %e, "failed to read DelayedWETH delay, will retry later"),
         }
     }
-
-    /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
-    async fn resolve_weth_delay(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-        game_address: Address,
-    ) -> eyre::Result<()> {
-        let weth_address = verifier_client.delayed_weth(game_address).await?;
-        let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
-        let delay = weth_client.delay().await?;
-        self.set_weth_delay(delay);
-        Ok(())
-    }
-}
-
-/// Trait for submitting dispute game transactions (`resolve`, `claimCredit`, `setAnchorState`).
-///
-/// This abstracts the transaction submission layer so the [`BondManager`]
-/// can be tested with mock submitters.
-#[async_trait::async_trait]
-pub trait BondTransactionSubmitter: Send + Sync {
-    /// Sends a transaction with the given calldata to `to`. `game_address`
-    /// is the dispute game this transaction is associated with, used for
-    /// log/metric correlation.
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: alloy_primitives::Bytes,
-    ) -> Result<alloy_primitives::B256, crate::ChallengeSubmitError>;
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, future::Future, pin::Pin};
+    use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
     use alloy_primitives::B256;
     use futures::stream::BoxStream;
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory,
+        MockAggregateVerifier, MockDisputeGameFactory, SharedMockTxManager,
         TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
+        receipt_with_status,
     };
 
-    /// A deterministic clock that always returns fixed values.
-    ///
-    /// Used in unit tests that need precise control over the monotonic
-    /// time returned by [`Clock::now`] and the wall-clock Unix seconds
-    /// returned by [`Clock::wall_clock_unix_secs`].
+    const TEST_WETH_DELAY: Duration = Duration::from_secs(60);
+    const WITHDRAW_READY_MONOTONIC_SECS: u64 = 3_700;
+
     struct FixedClock {
         monotonic: Duration,
         wall_unix: u64,
@@ -1100,233 +699,140 @@ mod tests {
         }
     }
 
-    /// Creates a [`FixedClock`] with the given monotonic seconds and a
-    /// default wall-clock value of `2_000_000_000`.
     fn fixed_clock(secs: u64) -> FixedClock {
         FixedClock { monotonic: Duration::from_secs(secs), wall_unix: 2_000_000_000 }
     }
 
-    fn test_l1_rpc_url() -> url::Url {
-        "http://localhost:8545".parse().unwrap()
+    fn claim_addr() -> Address {
+        Address::repeat_byte(0xCC)
     }
 
-    fn make_manager(addresses: Vec<Address>) -> BondManager<FixedClock> {
-        let clock = fixed_clock(0);
+    fn game_state(
+        status: GameStatus,
+        bond_recipient: Address,
+        resolved_at: u64,
+        bond_unlocked: bool,
+    ) -> crate::test_utils::MockGameState {
+        let mut state = mock_state(status, Address::ZERO, 100);
+        state.bond_recipient = bond_recipient;
+        state.resolved_at = resolved_at;
+        state.bond_unlocked = bond_unlocked;
+        state
+    }
+
+    fn verifier(state: crate::test_utils::MockGameState) -> Arc<MockAggregateVerifier> {
+        Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])))
+    }
+
+    fn ready_phase() -> BondPhase {
+        BondPhase::AwaitingDelay { ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS) }
+    }
+
+    async fn advance(
+        mgr: &mut BondManager<FixedClock>,
+        phase: BondPhase,
+        verifier: &Arc<MockAggregateVerifier>,
+        submitter: &ChallengeSubmitter<SharedMockTxManager>,
+    ) -> BondPhase {
+        mgr.advance_game(addr(0), phase, &**verifier, submitter).await.unwrap()
+    }
+
+    fn bond_submitter(
+        responses: Vec<base_tx_manager::SendResponse>,
+    ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
+        let tx_manager = SharedMockTxManager::with_responses(responses);
+        (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
+    }
+
+    fn manager(
+        claim_addr: Address,
+        factory: Arc<dyn DisputeGameFactoryClient>,
+        lookback: u64,
+        clock: FixedClock,
+    ) -> BondManager<FixedClock> {
         let mut mgr = BondManager::new(
-            addresses,
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
+            vec![claim_addr],
+            "http://localhost:8545".parse().unwrap(),
+            factory,
+            lookback,
             TEST_DISCOVERY_INTERVAL,
             clock,
         );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        mgr.weth_delay = Some(TEST_WETH_DELAY);
         mgr
+    }
+
+    fn withdraw_ready_fixture(
+        responses: Vec<base_tx_manager::SendResponse>,
+    ) -> (
+        BondManager<FixedClock>,
+        Arc<MockAggregateVerifier>,
+        ChallengeSubmitter<SharedMockTxManager>,
+        SharedMockTxManager,
+    ) {
+        let claim_addr = claim_addr();
+        let wall_unix = 2_000_000_000;
+        let delay = Duration::from_secs(3_600);
+        let clock =
+            FixedClock { monotonic: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS), wall_unix };
+
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, clock);
+        mgr.weth_delay = Some(delay);
+
+        let state = game_state(GameStatus::DefenderWins, claim_addr, wall_unix - 3_600, true);
+        let verifier = verifier(state);
+        let (submitter, tx_manager) = bond_submitter(responses);
+
+        (mgr, verifier, submitter, tx_manager)
     }
 
     #[test]
     fn track_game_filters_by_claim_address() {
-        let addr = Address::repeat_byte(0x01);
+        let claim_addr = Address::repeat_byte(0x01);
         let other = Address::repeat_byte(0x02);
         let game = Address::repeat_byte(0xAA);
 
-        let mut mgr = make_manager(vec![addr]);
-        assert!(mgr.track_game(game, addr));
-        assert!(!mgr.track_game(game, addr)); // duplicate
-        assert!(!mgr.track_game(Address::repeat_byte(0xBB), other)); // not in set
-    }
-
-    #[test]
-    fn is_tracking_returns_correct_state() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let mut mgr = make_manager(vec![addr]);
-        assert!(!mgr.is_tracking(&game));
-        mgr.track_game(game, addr);
-        assert!(mgr.is_tracking(&game));
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(0));
+        assert!(mgr.track_game(game, claim_addr));
+        assert!(!mgr.track_game(game, claim_addr));
+        assert!(!mgr.track_game(Address::repeat_byte(0xBB), other));
     }
 
     #[tokio::test]
     async fn already_resolved_game_advances_to_unlock() {
         let claim_addr = Address::repeat_byte(0x01);
-        let game = addr(0);
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(0));
 
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let verifier = verifier(game_state(GameStatus::DefenderWins, claim_addr, 100, false));
+        let (submitter, tx_manager) = bond_submitter(vec![]);
 
-        let result = mgr.advance_game(game, &verifier, &submitter).await.unwrap();
+        let result = advance(&mut mgr, BondPhase::NeedsResolve, &verifier, &submitter).await;
 
-        assert!(result.is_none());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsUnlock));
-        assert!(submitter.recorded_calls().is_empty());
-    }
-
-    #[test]
-    fn check_delay_transitions_when_elapsed() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(
-            vec![addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // 100 seconds ago > 60 second delay
-        let unlocked_at = Duration::from_secs(900);
-        mgr.tracked.insert(
-            game,
-            TrackedGame::new(
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
-                addr,
-            ),
-        );
-
-        let result = mgr.check_delay(game, unlocked_at, None);
-        assert!(result.is_ok());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-    }
-
-    #[test]
-    fn check_delay_stays_when_not_elapsed() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(
-            vec![addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(3600));
-
-        // only 1 second ago < 3600 second delay
-        let unlocked_at = Duration::from_secs(999);
-        mgr.tracked.insert(
-            game,
-            TrackedGame::new(
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
-                addr,
-            ),
-        );
-
-        let result = mgr.check_delay(game, unlocked_at, None);
-        assert!(result.is_ok());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::AwaitingDelay { .. }));
-    }
-
-    #[test]
-    fn check_delay_uses_unix_timestamp_when_recovered() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let clock = FixedClock { monotonic: Duration::from_secs(10), wall_unix: 2_000 };
-        let mut mgr = BondManager::new(
-            vec![addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        let unlocked_at = Duration::ZERO;
-        mgr.tracked.insert(
-            game,
-            TrackedGame::new(
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: Some(1_900) },
-                addr,
-            ),
-        );
-
-        let result = mgr.check_delay(game, unlocked_at, Some(1_900));
-        assert!(result.is_ok());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
+        assert!(matches!(result, BondPhase::NeedsUnlock));
+        assert!(tx_manager.recorded_calls().is_empty());
     }
 
     #[tokio::test]
     async fn reverted_withdraw_backs_off_before_retrying() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let game = addr(0);
-        let wall_unix = 2_000_000_000;
-        let resolved_at = wall_unix - 3_600;
-        let monotonic_secs = 3_700;
-        let delay = Duration::from_secs(3_600);
-        let clock = FixedClock { monotonic: Duration::from_secs(monotonic_secs), wall_unix };
-        let stale_unlocked_at =
-            BondManager::<FixedClock>::estimate_unlock_time(&clock, resolved_at);
+        let (mut mgr, verifier, submitter, tx_manager) =
+            withdraw_ready_fixture(vec![Ok(receipt_with_status(false, B256::ZERO))]);
 
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(delay);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(
-            game,
-            BondPhase::AwaitingDelay {
-                unlocked_at: stale_unlocked_at,
-                unlocked_at_unix_secs: None,
-            },
-        );
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = resolved_at;
-        state.bond_unlocked = true;
-        state.bond_claimed = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Err(
-            crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO },
-        )]);
-
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-        assert!(submitter.recorded_calls().is_empty());
-
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert_eq!(submitter.recorded_calls().len(), 1);
-        let expected_unlocked_at = Duration::from_secs(monotonic_secs).saturating_sub(
-            delay.saturating_sub(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY),
-        );
+        let phase = advance(&mut mgr, ready_phase(), &verifier, &submitter).await;
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
+        let expected_ready_at = Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            .saturating_add(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY);
         assert!(
             matches!(
-                mgr.tracked.get(&game).unwrap().phase,
-                BondPhase::AwaitingDelay { unlocked_at, .. }
-                    if unlocked_at == expected_unlocked_at
+                phase,
+                BondPhase::AwaitingDelay { ready_at } if ready_at == expected_ready_at
             ),
-            "withdraw revert should back off without restarting the full delay"
-        );
-        assert_ne!(
-            expected_unlocked_at,
-            Duration::from_secs(monotonic_secs),
-            "withdraw revert must not model a fresh DelayedWETH unlock"
+            "withdraw revert should back off briefly"
         );
 
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
+        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
+        assert!(matches!(phase, BondPhase::AwaitingDelay { .. }));
         assert_eq!(
-            submitter.recorded_calls().len(),
+            tx_manager.recorded_calls().len(),
             1,
             "next poll should wait in AwaitingDelay instead of submitting again"
         );
@@ -1334,346 +840,148 @@ mod tests {
 
     #[tokio::test]
     async fn non_revert_withdraw_failure_does_not_back_off() {
-        // Regression guard for the `matches!(_, TxReverted { .. })` arm in
-        // `submit_claim_credit`: a non-revert error (e.g. a `TxManager`
-        // variant such as `NonceTooLow`) must leave the phase as
-        // `NeedsWithdraw` so the next poll resubmits immediately rather
-        // than waiting on the WETH-delay back-off window.
-        let claim_addr = Address::repeat_byte(0xCC);
-        let game = addr(0);
-        let wall_unix = 2_000_000_000;
-        let resolved_at = wall_unix - 3_600;
-        let monotonic_secs = 3_700;
-        let delay = Duration::from_secs(3_600);
-        let clock = FixedClock { monotonic: Duration::from_secs(monotonic_secs), wall_unix };
-        let stale_unlocked_at =
-            BondManager::<FixedClock>::estimate_unlock_time(&clock, resolved_at);
-
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(delay);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(
-            game,
-            BondPhase::AwaitingDelay {
-                unlocked_at: stale_unlocked_at,
-                unlocked_at_unix_secs: None,
-            },
-        );
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = resolved_at;
-        state.bond_unlocked = true;
-        state.bond_claimed = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        // Two non-revert failures so that both the first failed submission
-        // and the immediate retry have a response queued.
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![
-            Err(crate::ChallengeSubmitError::TxManager(
-                base_tx_manager::TxManagerError::NonceTooLow,
-            )),
-            Err(crate::ChallengeSubmitError::TxManager(
-                base_tx_manager::TxManagerError::NonceTooLow,
-            )),
+        let (mut mgr, verifier, submitter, tx_manager) = withdraw_ready_fixture(vec![
+            Err(base_tx_manager::TxManagerError::NonceTooLow),
+            Err(base_tx_manager::TxManagerError::NonceTooLow),
         ]);
 
-        // First poll: stale AwaitingDelay → check_delay transitions to
-        // NeedsWithdraw without submitting.
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-        assert!(submitter.recorded_calls().is_empty());
-
-        // Second poll: NeedsWithdraw → submit_claim_credit → non-revert
-        // failure. The phase must remain `NeedsWithdraw`; the back-off
-        // path is gated on `TxReverted` only.
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert_eq!(submitter.recorded_calls().len(), 1);
+        let phase = advance(&mut mgr, ready_phase(), &verifier, &submitter).await;
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
         assert!(
-            matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw),
-            "non-revert withdraw failure must not transition back to AwaitingDelay"
+            matches!(
+                phase,
+                BondPhase::AwaitingDelay { ready_at }
+                    if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            ),
+            "non-revert withdraw failure must retry immediately"
         );
 
-        // Third poll: still `NeedsWithdraw` → resubmits immediately,
-        // without waiting on a back-off window.
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
+        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
         assert_eq!(
-            submitter.recorded_calls().len(),
+            tx_manager.recorded_calls().len(),
             2,
             "non-revert failures must not introduce a back-off delay before retry"
         );
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-    }
-
-    #[test]
-    fn unix_to_monotonic_past_timestamp() {
-        // Clock at 500s monotonic, unix_now=2000, event at unix 1900
-        // → age = 100s → monotonic = 500 - 100 = 400s.
-        let clock = fixed_clock(500);
-        let result = BondManager::unix_to_monotonic(&clock, 1900, 2000);
-        assert_eq!(result, Duration::from_secs(400));
-    }
-
-    #[test]
-    fn unix_to_monotonic_future_timestamp_clamps() {
-        // If the onchain timestamp is ahead of local wall clock
-        // (clock skew), age saturates to 0 → monotonic = clock.now().
-        let clock = fixed_clock(500);
-        let result = BondManager::unix_to_monotonic(&clock, 2100, 2000);
-        assert_eq!(result, Duration::from_secs(500));
-    }
-
-    #[test]
-    fn unix_to_monotonic_same_timestamp() {
-        // Event happened "right now" → age = 0 → monotonic = clock.now().
-        let clock = fixed_clock(500);
-        let result = BondManager::unix_to_monotonic(&clock, 2000, 2000);
-        assert_eq!(result, Duration::from_secs(500));
-    }
-
-    #[test]
-    fn unix_to_monotonic_age_exceeds_monotonic() {
-        // If the event is older than the monotonic uptime, saturate to zero
-        // rather than underflowing.
-        let clock = fixed_clock(50);
-        let result = BondManager::unix_to_monotonic(&clock, 1000, 2000);
-        assert_eq!(result, Duration::ZERO);
-    }
-
-    #[test]
-    fn empty_claim_addresses_means_disabled() {
-        let clock = fixed_clock(0);
-        let mgr = BondManager::new(
-            vec![],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
+        assert!(
+            matches!(
+                phase,
+                BondPhase::AwaitingDelay { ready_at }
+                    if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            ),
+            "non-revert withdraw failure must stay ready for retry"
         );
-        assert!(!mgr.is_enabled());
     }
 
-    #[test]
-    fn non_empty_claim_addresses_means_enabled() {
-        let clock = fixed_clock(0);
-        let mgr = BondManager::new(
-            vec![Address::repeat_byte(0x01)],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        assert!(mgr.is_enabled());
-    }
-
-    // ---- discover_claimable_games tests ----
-
-    /// Builds a factory and verifier pair where each game has the given
-    /// `bond_recipient` and `zk_prover`. All games are `IN_PROGRESS` (status 0)
-    /// unless overridden.
     fn discovery_mocks(
         game_count: u64,
         bond_recipient: Address,
         zk_prover: Address,
     ) -> (Arc<dyn DisputeGameFactoryClient>, Arc<MockAggregateVerifier>) {
         let games: Vec<_> = (0..game_count).map(|i| factory_game(i, 0)).collect();
-        let mut verifier_games = HashMap::new();
-        for i in 0..game_count {
-            let mut state = mock_state(GameStatus::InProgress, zk_prover, 100 + i);
-            state.bond_recipient = bond_recipient;
-            verifier_games.insert(addr(i), state);
-        }
+        let verifier_games = (0..game_count)
+            .map(|i| {
+                let mut state = mock_state(GameStatus::InProgress, zk_prover, 100 + i);
+                state.bond_recipient = bond_recipient;
+                (addr(i), state)
+            })
+            .collect();
         let factory: Arc<dyn DisputeGameFactoryClient> =
             Arc::new(MockDisputeGameFactory::new(games));
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         (factory, verifier)
     }
 
-    #[tokio::test]
-    async fn discover_incremental_picks_up_new_games_by_recipient() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let (factory, verifier) = discovery_mocks(3, claim_addr, Address::ZERO);
+    async fn assert_discovery(
+        game_count: u64,
+        scan_head: u64,
+        lookback: u64,
+        ticks: usize,
+        expected_head: u64,
+        expected_tracked: usize,
+    ) {
+        let claim_addr = claim_addr();
+        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
+        let mut mgr = manager(claim_addr, factory, lookback, fixed_clock(0));
+        mgr.bond_scan_head = scan_head;
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        for _ in 0..ticks {
+            mgr.discover_claimable_games(&*verifier).await.unwrap();
+        }
 
-        // bond_scan_head defaults to 0, so the first call should scan all 3.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 3);
-        assert_eq!(mgr.bond_scan_head, 3);
+        assert_eq!(mgr.bond_scan_head, expected_head);
+        assert_eq!(mgr.tracked_count(), expected_tracked);
     }
 
     #[tokio::test]
-    async fn discover_incremental_picks_up_new_games_by_zk_prover() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let other_recipient = Address::repeat_byte(0xDD);
-        // bond_recipient is someone else, but zkProver matches our address.
-        // Status is InProgress, so the game should match via zkProver.
-        let (factory, verifier) = discovery_mocks(2, other_recipient, claim_addr);
+    async fn discover_filters_games() {
+        for (game_count, bond_recipient, zk_prover, expected_tracked) in [
+            (3_u64, claim_addr(), Address::ZERO, 3_usize),
+            (2, Address::repeat_byte(0xDD), claim_addr(), 2),
+            (3, Address::repeat_byte(0xDD), Address::ZERO, 0),
+        ] {
+            let claim_addr = claim_addr();
+            let (factory, verifier) = discovery_mocks(game_count, bond_recipient, zk_prover);
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+            let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
 
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 2);
+            mgr.discover_claimable_games(&*verifier).await.unwrap();
+            assert_eq!(mgr.tracked_count(), expected_tracked);
+            assert_eq!(mgr.bond_scan_head, game_count);
+        }
     }
 
     #[tokio::test]
     async fn discover_skips_already_tracked_games() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let (factory, verifier) = discovery_mocks(2, claim_addr, Address::ZERO);
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
 
-        // Pre-track game 0.
         mgr.track_game(addr(0), claim_addr);
         assert_eq!(mgr.tracked_count(), 1);
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
-        // Game 0 was already tracked, so only game 1 should be new.
         assert_eq!(mgr.tracked_count(), 2);
     }
 
     #[tokio::test]
     async fn discover_skips_already_claimed_games() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
 
         let games = vec![factory_game(0, 0)];
-        let mut verifier_games = HashMap::new();
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.bond_claimed = true; // already claimed
-        state.resolved_at = 500;
-        verifier_games.insert(addr(0), state);
+        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 500, false);
+        state.bond_claimed = true;
 
         let factory: Arc<dyn DisputeGameFactoryClient> =
             Arc::new(MockDisputeGameFactory::new(games));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let verifier = verifier(state);
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
         assert_eq!(mgr.tracked_count(), 0, "claimed game should not be tracked");
     }
 
     #[tokio::test]
-    async fn discover_advances_watermark() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let (factory, verifier) = discovery_mocks(5, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // Start from index 3 so only indices 3 and 4 are scanned.
-        mgr.bond_scan_head = 3;
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, 5);
-        assert_eq!(mgr.tracked_count(), 2, "only games 3 and 4 should be discovered");
-    }
-
-    #[tokio::test]
-    async fn discover_noop_when_watermark_equals_game_count() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let (factory, verifier) = discovery_mocks(5, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // Watermark already at game_count — nothing new to scan.
-        mgr.bond_scan_head = 5;
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0);
-        assert_eq!(mgr.bond_scan_head, 5);
+    async fn discover_updates_watermark() {
+        for (scan_head, expected_head, expected_tracked) in [(3_u64, 5_u64, 2_usize), (5, 5, 0)] {
+            assert_discovery(5, scan_head, 1000, 1, expected_head, expected_tracked).await;
+        }
     }
 
     #[tokio::test]
     async fn discover_full_rescan_resets_watermark() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let (factory, verifier) = discovery_mocks(10, claim_addr, Address::ZERO);
 
-        // Use a clock at 1000s so we can backdate last_full_scan.
         let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            5, // lookback = 5
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let mut mgr = manager(claim_addr, factory, 5, clock);
 
-        // Simulate that the previous scan already covered everything.
         mgr.bond_scan_head = 10;
 
-        // Force the full rescan by backdating `last_full_scan` past the
-        // discovery interval.
         mgr.last_full_scan = Duration::from_secs(1000).saturating_sub(TEST_DISCOVERY_INTERVAL);
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
-        // Full rescan should have reset watermark to 10 - 5 = 5
-        // and then scanned indices 5..10, discovering 5 new games.
         assert_eq!(mgr.bond_scan_head, 10);
         assert_eq!(mgr.tracked_count(), 5);
     }
@@ -1682,14 +990,13 @@ mod tests {
     async fn discover_disabled_when_no_claim_addresses() {
         let (_, verifier) = discovery_mocks(5, Address::repeat_byte(0xCC), Address::ZERO);
 
-        let clock = fixed_clock(0);
         let mut mgr = BondManager::new(
             vec![],
-            test_l1_rpc_url(),
+            "http://localhost:8545".parse().unwrap(),
             empty_factory(),
             1000,
             TEST_DISCOVERY_INTERVAL,
-            clock,
+            fixed_clock(0),
         );
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
@@ -1697,172 +1004,90 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_skips_unmatched_recipients() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let other = Address::repeat_byte(0xDD);
-        // Neither bondRecipient nor zkProver match our claim address.
-        let (factory, verifier) = discovery_mocks(3, other, Address::ZERO);
+    async fn determine_phase_returns_unlocked_phase() {
+        for (monotonic_secs, delay, expected_ready_at) in [
+            (500_u64, Duration::from_secs(120), Duration::from_secs(520)),
+            (10, Duration::from_secs(60), Duration::from_secs(10)),
+        ] {
+            let game = addr(0);
+            let verifier = verifier(game_state(
+                GameStatus::ChallengerWins,
+                Address::ZERO,
+                1_999_999_900,
+                true,
+            ));
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0);
-        // Watermark should still advance past the scanned range.
-        assert_eq!(mgr.bond_scan_head, 3);
-    }
-
-    #[tokio::test]
-    async fn determine_phase_returns_awaiting_delay_when_bond_unlocked() {
-        // resolved_at = 1_999_999_900 → age = 2_000_000_000 - 1_999_999_900 = 100s
-        // monotonic 500 - 100 = 400 → unlocked_at should be 400s.
-        let game = addr(0);
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.resolved_at = 1_999_999_900;
-        state.bond_unlocked = true;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(500);
-        let phase =
-            BondManager::determine_phase(&*verifier, game, &clock, None).await.unwrap().unwrap();
-        assert!(
-            matches!(phase, BondPhase::AwaitingDelay { unlocked_at, .. } if unlocked_at == Duration::from_secs(400)),
-            "expected AwaitingDelay {{ unlocked_at: 400s }}, got {phase:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn determine_phase_returns_needs_withdraw_when_delay_elapsed() {
-        let game = addr(0);
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.resolved_at = 1_999_999_900;
-        state.bond_unlocked = true;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(10);
-        let phase =
-            BondManager::determine_phase(&*verifier, game, &clock, Some(Duration::from_secs(60)))
+            let clock = fixed_clock(monotonic_secs);
+            let phase = BondManager::determine_phase(&*verifier, game, &clock, Some(delay))
                 .await
                 .unwrap()
                 .unwrap();
-        assert!(matches!(phase, BondPhase::NeedsWithdraw), "expected NeedsWithdraw, got {phase:?}",);
+            match (expected_ready_at, phase) {
+                (expected, BondPhase::AwaitingDelay { ready_at }) if ready_at == expected => {}
+                (_, phase) => panic!("unexpected phase: {phase:?}"),
+            }
+        }
     }
 
     #[tokio::test]
     async fn try_unlock_advances_to_withdraw_when_already_unlocked_and_delay_elapsed() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let game = addr(0);
-
-        // resolved_at = 1_999_999_800 -> age = 2_000_000_000 - 1_999_999_800 = 200s.
-        // With a 60s WETH delay, this should advance straight to withdrawal.
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = 1_999_999_800;
-        state.bond_unlocked = true;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(500);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let verifier =
+            verifier(game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_800, true));
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(500));
         mgr.track_game(game, claim_addr);
 
-        // MockBondTransactionSubmitter should NOT be called — the bond is
-        // already unlocked, so try_unlock must skip the transaction.
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = bond_submitter(vec![]);
         let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none(), "try_unlock should not remove the game");
-
-        let tracked = mgr.tracked.get(&game).expect("game should still be tracked");
         assert!(
-            matches!(tracked.phase, BondPhase::NeedsWithdraw),
-            "expected NeedsWithdraw, got {:?}",
-            tracked.phase,
+            matches!(
+                result,
+                Some(BondPhase::AwaitingDelay { ready_at })
+                    if ready_at == Duration::from_secs(500)
+            ),
+            "expected ready AwaitingDelay, got {result:?}",
         );
-        assert!(submitter.recorded_calls().is_empty(), "no transaction should have been submitted");
+        assert!(
+            tx_manager.recorded_calls().is_empty(),
+            "no transaction should have been submitted"
+        );
     }
 
     #[tokio::test]
     async fn try_unlock_uses_monotonic_timestamp_for_fresh_unlock() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let game = addr(0);
         let tx_hash = B256::repeat_byte(0xDD);
-
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = 1_999_999_900;
-        state.bond_unlocked = false;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(500);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let verifier =
+            verifier(game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_900, false));
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(500));
         mgr.track_game(game, claim_addr);
 
-        let submitter = MockBondTransactionSubmitter::success(tx_hash);
+        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
         let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none(), "try_unlock should not remove the game");
-
-        let tracked = mgr.tracked.get(&game).expect("game should still be tracked");
         assert!(
             matches!(
-                tracked.phase,
-                BondPhase::AwaitingDelay {
-                    unlocked_at,
-                    unlocked_at_unix_secs: None
-                } if unlocked_at == Duration::from_secs(500)
+                result,
+                Some(BondPhase::AwaitingDelay { ready_at })
+                    if ready_at == Duration::from_secs(560)
             ),
-            "expected AwaitingDelay with monotonic timestamp only, got {:?}",
-            tracked.phase,
+            "expected AwaitingDelay with monotonic deadline, got {result:?}",
         );
-        assert_eq!(submitter.recorded_calls().len(), 1);
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
     }
 
     #[tokio::test]
     async fn discover_handles_empty_factory() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
 
-        let clock = fixed_clock(0);
         let mut mgr = BondManager::new(
             vec![claim_addr],
-            test_l1_rpc_url(),
+            "http://localhost:8545".parse().unwrap(),
             empty_factory(),
             1000,
             TEST_DISCOVERY_INTERVAL,
-            clock,
+            fixed_clock(0),
         );
 
         let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
@@ -1871,87 +1096,14 @@ mod tests {
         assert_eq!(mgr.bond_scan_head, 0);
     }
 
-    // ---- lookback capping tests ----
-
     #[tokio::test]
-    async fn discover_caps_span_to_lookback() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let lookback = 500u64;
-        let game_count = 1200u64;
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // bond_scan_head starts at 0, game_count = 1200, span = 1200 > lookback.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-
-        assert_eq!(
-            mgr.bond_scan_head, lookback,
-            "watermark should advance by lookback, not to game_count"
-        );
-        // Only games 0..500 should be discovered.
-        assert_eq!(mgr.tracked_count(), lookback as usize);
-    }
-
-    #[tokio::test]
-    async fn discover_catches_up_over_multiple_ticks() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let lookback = 500u64;
-        let game_count = 800u64;
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // First tick: scans 0..500, watermark = 500.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, lookback);
-        assert_eq!(mgr.tracked_count(), lookback as usize);
-
-        // Second tick: scans 500..800 (span = 300 < lookback), watermark = 800.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, game_count);
-        assert_eq!(mgr.tracked_count(), game_count as usize);
-    }
-
-    #[tokio::test]
-    async fn discover_no_cap_when_span_within_lookback() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let lookback = 1000u64;
-        let game_count = 500u64;
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-
-        assert_eq!(mgr.bond_scan_head, game_count);
-        assert_eq!(mgr.tracked_count(), game_count as usize);
+    async fn discover_advances_by_lookback() {
+        for (lookback, game_count, ticks, expected_head, expected_tracked) in [
+            (500_u64, 1200_u64, 1_usize, 500_u64, 500_usize),
+            (500, 800, 2, 800, 800),
+            (1000, 500, 1, 500, 500),
+        ] {
+            assert_discovery(game_count, 0, lookback, ticks, expected_head, expected_tracked).await;
+        }
     }
 }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -364,11 +364,15 @@ impl<C: Clock> BondManager<C> {
             return;
         }
 
-        let tracked = std::mem::take(&mut self.tracked);
-        let tracked_count = tracked.len();
+        let addresses: Vec<_> = self.tracked.keys().copied().collect();
+        let tracked_count = self.tracked.len();
 
         let mut tried_weth_delay = false;
-        for (game_address, phase) in tracked {
+        for game_address in addresses {
+            let Some(phase) = self.tracked.remove(&game_address) else {
+                continue;
+            };
+
             if let Some(next_phase) = self
                 .advance_game(
                     game_address,

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -41,6 +41,8 @@ pub enum BondPhase {
     AwaitingDelay {
         /// Monotonic timestamp at which withdrawal should be retried.
         ready_at: Duration,
+        /// Wall-clock Unix timestamp when the DelayedWETH delay started.
+        delay_started_at: u64,
         /// Whether `ready_at` was computed with the fallback WETH delay.
         using_default_delay: bool,
     },
@@ -428,11 +430,11 @@ impl<C: Clock> BondManager<C> {
                 self.try_unlock(game_address, verifier_client, submitter, tried_weth_delay).await,
                 BondPhase::NeedsUnlock,
             ),
-            BondPhase::AwaitingDelay { mut ready_at, using_default_delay } => {
+            BondPhase::AwaitingDelay { mut ready_at, delay_started_at, using_default_delay } => {
                 if using_default_delay {
                     self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
                     if let Some(delay) = self.weth_delay {
-                        ready_at = Self::recompute_default_ready_at(ready_at, delay);
+                        ready_at = Self::delay_ready_at(&self.clock, delay_started_at, delay);
                     }
                 }
 
@@ -446,6 +448,7 @@ impl<C: Clock> BondManager<C> {
                     );
                     return Some(BondPhase::AwaitingDelay {
                         ready_at,
+                        delay_started_at,
                         using_default_delay: using_default_delay && self.weth_delay.is_none(),
                     });
                 }
@@ -460,11 +463,13 @@ impl<C: Clock> BondManager<C> {
                         game_address,
                         verifier_client,
                         submitter,
+                        delay_started_at,
                         using_default_delay,
                     )
                     .await,
                     BondPhase::AwaitingDelay {
                         ready_at: now,
+                        delay_started_at,
                         using_default_delay: using_default_delay && self.weth_delay.is_none(),
                     },
                 )
@@ -567,6 +572,7 @@ impl<C: Clock> BondManager<C> {
                 let delay = self.effective_weth_delay(game_address);
                 Ok(Some(BondPhase::AwaitingDelay {
                     ready_at: self.clock.now().saturating_add(delay),
+                    delay_started_at: self.clock.wall_clock_unix_secs(),
                     using_default_delay,
                 }))
             }
@@ -588,6 +594,7 @@ impl<C: Clock> BondManager<C> {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
+        delay_started_at: u64,
         using_default_delay: bool,
     ) -> eyre::Result<Option<BondPhase>> {
         let claimed = verifier_client.bond_claimed(game_address).await?;
@@ -617,6 +624,7 @@ impl<C: Clock> BondManager<C> {
                 );
                 Ok(Some(BondPhase::AwaitingDelay {
                     ready_at: self.clock.now().saturating_add(retry_delay),
+                    delay_started_at,
                     using_default_delay: using_default_delay && self.weth_delay.is_none(),
                 }))
             }
@@ -629,20 +637,17 @@ impl<C: Clock> BondManager<C> {
         delay: Duration,
         using_default_delay: bool,
     ) -> BondPhase {
-        let elapsed_since_resolve =
-            Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(resolved_at));
         BondPhase::AwaitingDelay {
-            ready_at: clock.now().saturating_add(delay.saturating_sub(elapsed_since_resolve)),
+            ready_at: Self::delay_ready_at(clock, resolved_at, delay),
+            delay_started_at: resolved_at,
             using_default_delay,
         }
     }
 
-    fn recompute_default_ready_at(ready_at: Duration, delay: Duration) -> Duration {
-        if delay >= Self::DEFAULT_WETH_DELAY {
-            ready_at.saturating_add(delay - Self::DEFAULT_WETH_DELAY)
-        } else {
-            ready_at.saturating_sub(Self::DEFAULT_WETH_DELAY - delay)
-        }
+    fn delay_ready_at(clock: &C, delay_started_at: u64, delay: Duration) -> Duration {
+        let elapsed =
+            Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(delay_started_at));
+        clock.now().saturating_add(delay.saturating_sub(elapsed))
     }
 
     fn effective_weth_delay(&self, game_address: Address) -> Duration {
@@ -827,6 +832,7 @@ mod tests {
     fn ready_phase() -> BondPhase {
         BondPhase::AwaitingDelay {
             ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
+            delay_started_at: 2_000_000_000,
             using_default_delay: false,
         }
     }
@@ -1418,6 +1424,7 @@ mod tests {
         );
 
         mgr.clock.monotonic = Duration::from_secs(561);
+        mgr.clock.wall_unix += 61;
         let mut tried_weth_delay = false;
         let result =
             mgr.advance_game(game, phase, &*verifier, &submitter, &mut tried_weth_delay).await;
@@ -1425,6 +1432,33 @@ mod tests {
 
         assert!(result.is_none(), "withdraw should complete after recovered delay");
         assert_eq!(tx_manager.recorded_calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn recovered_delay_uses_original_delay_start() {
+        let claim_addr = claim_addr();
+        let game = addr(0);
+        let actual_delay = Duration::from_secs(14 * 24 * 60 * 60);
+        let resolved_at = 2_000_000_000 - (30 * 24 * 60 * 60);
+        let verifier =
+            verifier(game_state(GameStatus::ChallengerWins, claim_addr, resolved_at, true));
+        let mut mgr =
+            manager(claim_addr, empty_factory(), 1000, fixed_clock(WITHDRAW_READY_MONOTONIC_SECS));
+        mgr.weth_delay = Some(actual_delay);
+        let (submitter, tx_manager) =
+            bond_submitter(vec![Ok(receipt_with_status(true, B256::ZERO))]);
+        let phase = BondPhase::AwaitingDelay {
+            ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
+            delay_started_at: resolved_at,
+            using_default_delay: true,
+        };
+        let mut tried_weth_delay = false;
+
+        let result =
+            mgr.advance_game(game, phase, &*verifier, &submitter, &mut tried_weth_delay).await;
+
+        assert!(result.is_none(), "old unlocked game should withdraw immediately");
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
     }
 
     #[tokio::test]
@@ -1448,6 +1482,8 @@ mod tests {
             bond_submitter(vec![Ok(receipt_with_status(false, B256::ZERO))]);
         let phase = BondPhase::AwaitingDelay {
             ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
+            delay_started_at: 2_000_000_000
+                - BondManager::<FixedClock>::DEFAULT_WETH_DELAY.as_secs(),
             using_default_delay: true,
         };
 

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -365,9 +365,17 @@ impl<C: Clock> BondManager<C> {
         let tracked = std::mem::take(&mut self.tracked);
         let tracked_count = tracked.len();
 
+        let mut tried_weth_delay = false;
         for (game_address, phase) in tracked {
-            if let Some(next_phase) =
-                self.advance_game(game_address, phase, verifier_client, submitter).await
+            if let Some(next_phase) = self
+                .advance_game(
+                    game_address,
+                    phase,
+                    verifier_client,
+                    submitter,
+                    &mut tried_weth_delay,
+                )
+                .await
             {
                 self.tracked.insert(game_address, next_phase);
             }
@@ -384,6 +392,7 @@ impl<C: Clock> BondManager<C> {
         phase: BondPhase,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
+        tried_weth_delay: &mut bool,
     ) -> Option<BondPhase> {
         let (result, retry_phase) = match phase {
             BondPhase::NeedsResolve => (
@@ -391,12 +400,12 @@ impl<C: Clock> BondManager<C> {
                 BondPhase::NeedsResolve,
             ),
             BondPhase::NeedsUnlock => (
-                self.try_unlock(game_address, verifier_client, submitter).await,
+                self.try_unlock(game_address, verifier_client, submitter, tried_weth_delay).await,
                 BondPhase::NeedsUnlock,
             ),
             BondPhase::AwaitingDelay { mut ready_at, using_default_delay } => {
                 if using_default_delay {
-                    self.ensure_weth_delay(verifier_client, game_address).await;
+                    self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
                     if let Some(delay) = self.weth_delay {
                         ready_at = Self::recompute_default_ready_at(ready_at, delay);
                     }
@@ -422,8 +431,17 @@ impl<C: Clock> BondManager<C> {
                     "DelayedWETH delay elapsed, submitting withdraw"
                 );
                 (
-                    self.try_withdraw(game_address, verifier_client, submitter).await,
-                    BondPhase::AwaitingDelay { ready_at: now, using_default_delay: false },
+                    self.try_withdraw(
+                        game_address,
+                        verifier_client,
+                        submitter,
+                        using_default_delay,
+                    )
+                    .await,
+                    BondPhase::AwaitingDelay {
+                        ready_at: now,
+                        using_default_delay: using_default_delay && self.weth_delay.is_none(),
+                    },
                 )
             }
         };
@@ -501,13 +519,14 @@ impl<C: Clock> BondManager<C> {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
+        tried_weth_delay: &mut bool,
     ) -> eyre::Result<Option<BondPhase>> {
         let (unlocked, resolved_at) = futures::try_join!(
             verifier_client.bond_unlocked(game_address),
             verifier_client.resolved_at(game_address),
         )?;
         if unlocked {
-            self.ensure_weth_delay(verifier_client, game_address).await;
+            self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
             let using_default_delay = self.weth_delay.is_none();
             let delay = self.effective_weth_delay(game_address);
             let phase = Self::unlocked_phase(&self.clock, resolved_at, delay, using_default_delay);
@@ -515,7 +534,7 @@ impl<C: Clock> BondManager<C> {
             return Ok(Some(phase));
         }
 
-        self.ensure_weth_delay(verifier_client, game_address).await;
+        self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
 
         match Self::send_claim_credit(game_address, "unlock", submitter).await {
             Ok(_) => {
@@ -544,6 +563,7 @@ impl<C: Clock> BondManager<C> {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
+        using_default_delay: bool,
     ) -> eyre::Result<Option<BondPhase>> {
         let claimed = verifier_client.bond_claimed(game_address).await?;
         if claimed {
@@ -572,7 +592,7 @@ impl<C: Clock> BondManager<C> {
                 );
                 Ok(Some(BondPhase::AwaitingDelay {
                     ready_at: self.clock.now().saturating_add(retry_delay),
-                    using_default_delay: false,
+                    using_default_delay: using_default_delay && self.weth_delay.is_none(),
                 }))
             }
         }
@@ -669,10 +689,12 @@ impl<C: Clock> BondManager<C> {
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
+        tried_weth_delay: &mut bool,
     ) {
-        if self.weth_delay.is_some() {
+        if self.weth_delay.is_some() || *tried_weth_delay {
             return;
         }
+        *tried_weth_delay = true;
 
         let result: eyre::Result<Duration> = async {
             let weth_address = verifier_client.delayed_weth(game_address).await?;
@@ -778,7 +800,10 @@ mod tests {
         verifier: &Arc<MockAggregateVerifier>,
         submitter: &ChallengeSubmitter<SharedMockTxManager>,
     ) -> BondPhase {
-        mgr.advance_game(addr(0), phase, &**verifier, submitter).await.unwrap()
+        let mut tried_weth_delay = false;
+        mgr.advance_game(addr(0), phase, &**verifier, submitter, &mut tried_weth_delay)
+            .await
+            .unwrap()
     }
 
     fn bond_submitter(
@@ -1173,7 +1198,9 @@ mod tests {
         mgr.track_game(game, claim_addr);
 
         let (submitter, tx_manager) = bond_submitter(vec![]);
-        let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
+        let mut tried_weth_delay = false;
+        let result =
+            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
         assert!(
             matches!(
                 result,
@@ -1199,7 +1226,9 @@ mod tests {
         mgr.track_game(game, claim_addr);
 
         let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
-        let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
+        let mut tried_weth_delay = false;
+        let result =
+            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
         assert!(
             matches!(
                 result,
@@ -1231,7 +1260,9 @@ mod tests {
         mgr.track_game(game, claim_addr);
 
         let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
-        let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
+        let mut tried_weth_delay = false;
+        let result =
+            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
         handle.join().unwrap();
 
         assert!(
@@ -1265,7 +1296,9 @@ mod tests {
         mgr.track_game(game, claim_addr);
 
         let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
-        let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
+        let mut tried_weth_delay = false;
+        let result =
+            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
         handle.join().unwrap();
 
         assert!(
@@ -1279,6 +1312,38 @@ mod tests {
             "expected fallback AwaitingDelay from unlock time, got {result:?}",
         );
         assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn poll_tries_weth_delay_once_per_tick() {
+        let claim_addr = claim_addr();
+        let tx_hash = B256::repeat_byte(0xDD);
+        let states = (0..2).map(|i| {
+            let mut state =
+                game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
+            state.delayed_weth = addr(9);
+            (addr(i), state)
+        });
+        let verifier = Arc::new(MockAggregateVerifier::new(states.collect()));
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            "http://127.0.0.1:0".parse().unwrap(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            fixed_clock(500),
+        );
+        mgr.tracked.insert(addr(0), BondPhase::NeedsUnlock);
+        mgr.tracked.insert(addr(1), BondPhase::NeedsUnlock);
+
+        let (submitter, tx_manager) = bond_submitter(vec![
+            Ok(receipt_with_status(true, tx_hash)),
+            Ok(receipt_with_status(true, tx_hash)),
+        ]);
+        mgr.poll(&*verifier, &submitter).await;
+
+        assert_eq!(verifier.delayed_weth_reads.lock().unwrap().len(), 1);
+        assert_eq!(tx_manager.recorded_calls().len(), 2);
     }
 
     #[tokio::test]
@@ -1304,18 +1369,67 @@ mod tests {
             Ok(receipt_with_status(true, tx_hash)),
             Ok(receipt_with_status(true, tx_hash)),
         ]);
-        let phase = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap().unwrap();
+        let mut tried_weth_delay = false;
+        let phase = mgr
+            .try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(
             matches!(&phase, BondPhase::AwaitingDelay { using_default_delay: true, .. }),
             "expected default-delay AwaitingDelay, got {phase:?}",
         );
 
         mgr.clock.monotonic = Duration::from_secs(561);
-        let result = mgr.advance_game(game, phase, &*verifier, &submitter).await;
+        let mut tried_weth_delay = false;
+        let result =
+            mgr.advance_game(game, phase, &*verifier, &submitter, &mut tried_weth_delay).await;
         handle.join().unwrap();
 
         assert!(result.is_none(), "withdraw should complete after recovered delay");
         assert_eq!(tx_manager.recorded_calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn reverted_default_withdraw_keeps_learning_weth_delay() {
+        let claim_addr = claim_addr();
+        let long_delay =
+            BondManager::<FixedClock>::DEFAULT_WETH_DELAY.saturating_add(Duration::from_secs(3600));
+        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, true);
+        state.delayed_weth = addr(9);
+        let verifier = verifier(state);
+        let (rpc_url, handle) = delayed_weth_rpc_sequence(vec![None, Some(long_delay)]);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            rpc_url,
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            fixed_clock(WITHDRAW_READY_MONOTONIC_SECS),
+        );
+        let (submitter, tx_manager) =
+            bond_submitter(vec![Ok(receipt_with_status(false, B256::ZERO))]);
+        let phase = BondPhase::AwaitingDelay {
+            ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
+            using_default_delay: true,
+        };
+
+        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
+        assert!(
+            matches!(&phase, BondPhase::AwaitingDelay { using_default_delay: true, .. }),
+            "reverted fallback withdraw should keep retrying delay lookup, got {phase:?}",
+        );
+
+        mgr.clock.monotonic = Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            .saturating_add(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY);
+        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
+        handle.join().unwrap();
+
+        assert!(
+            matches!(phase, BondPhase::AwaitingDelay { using_default_delay: false, .. }),
+            "recovered WETH delay should replace fallback state"
+        );
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -32,6 +32,8 @@ enum BondPhase {
     AwaitingDelay {
         /// Monotonic timestamp at which withdrawal should be retried.
         ready_at: Duration,
+        /// Whether `ready_at` was computed with the fallback WETH delay.
+        using_default_delay: bool,
     },
 }
 
@@ -392,7 +394,14 @@ impl<C: Clock> BondManager<C> {
                 self.try_unlock(game_address, verifier_client, submitter).await,
                 BondPhase::NeedsUnlock,
             ),
-            BondPhase::AwaitingDelay { ready_at } => {
+            BondPhase::AwaitingDelay { mut ready_at, using_default_delay } => {
+                if using_default_delay {
+                    self.ensure_weth_delay(verifier_client, game_address).await;
+                    if let Some(delay) = self.weth_delay {
+                        ready_at = Self::recompute_default_ready_at(ready_at, delay);
+                    }
+                }
+
                 let now = self.clock.now();
                 if now < ready_at {
                     let remaining = ready_at.saturating_sub(now);
@@ -401,7 +410,10 @@ impl<C: Clock> BondManager<C> {
                         remaining_secs = remaining.as_secs(),
                         "waiting for DelayedWETH delay"
                     );
-                    return Some(BondPhase::AwaitingDelay { ready_at });
+                    return Some(BondPhase::AwaitingDelay {
+                        ready_at,
+                        using_default_delay: using_default_delay && self.weth_delay.is_none(),
+                    });
                 }
 
                 info!(
@@ -411,7 +423,7 @@ impl<C: Clock> BondManager<C> {
                 );
                 (
                     self.try_withdraw(game_address, verifier_client, submitter).await,
-                    BondPhase::AwaitingDelay { ready_at: now },
+                    BondPhase::AwaitingDelay { ready_at: now, using_default_delay: false },
                 )
             }
         };
@@ -496,8 +508,9 @@ impl<C: Clock> BondManager<C> {
         )?;
         if unlocked {
             self.ensure_weth_delay(verifier_client, game_address).await;
+            let using_default_delay = self.weth_delay.is_none();
             let delay = self.effective_weth_delay(game_address);
-            let phase = Self::unlocked_phase(&self.clock, resolved_at, delay);
+            let phase = Self::unlocked_phase(&self.clock, resolved_at, delay, using_default_delay);
             info!(game = %game_address, resolved_at, phase = ?phase, "bond already unlocked");
             return Ok(Some(phase));
         }
@@ -506,9 +519,11 @@ impl<C: Clock> BondManager<C> {
 
         match Self::send_claim_credit(game_address, "unlock", submitter).await {
             Ok(_) => {
+                let using_default_delay = self.weth_delay.is_none();
                 let delay = self.effective_weth_delay(game_address);
                 Ok(Some(BondPhase::AwaitingDelay {
                     ready_at: self.clock.now().saturating_add(delay),
+                    using_default_delay,
                 }))
             }
             Err(e) => {
@@ -557,16 +572,31 @@ impl<C: Clock> BondManager<C> {
                 );
                 Ok(Some(BondPhase::AwaitingDelay {
                     ready_at: self.clock.now().saturating_add(retry_delay),
+                    using_default_delay: false,
                 }))
             }
         }
     }
 
-    fn unlocked_phase(clock: &C, resolved_at: u64, delay: Duration) -> BondPhase {
+    fn unlocked_phase(
+        clock: &C,
+        resolved_at: u64,
+        delay: Duration,
+        using_default_delay: bool,
+    ) -> BondPhase {
         let elapsed_since_resolve =
             Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(resolved_at));
         BondPhase::AwaitingDelay {
             ready_at: clock.now().saturating_add(delay.saturating_sub(elapsed_since_resolve)),
+            using_default_delay,
+        }
+    }
+
+    fn recompute_default_ready_at(ready_at: Duration, delay: Duration) -> Duration {
+        if delay >= Self::DEFAULT_WETH_DELAY {
+            ready_at.saturating_add(delay - Self::DEFAULT_WETH_DELAY)
+        } else {
+            ready_at.saturating_sub(Self::DEFAULT_WETH_DELAY - delay)
         }
     }
 
@@ -625,7 +655,7 @@ impl<C: Clock> BondManager<C> {
                 return Ok(Some(BondPhase::NeedsUnlock));
             };
 
-            return Ok(Some(Self::unlocked_phase(clock, resolved_at, delay)));
+            return Ok(Some(Self::unlocked_phase(clock, resolved_at, delay, false)));
         }
 
         if resolved_at > 0 {
@@ -736,7 +766,10 @@ mod tests {
     }
 
     fn ready_phase() -> BondPhase {
-        BondPhase::AwaitingDelay { ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS) }
+        BondPhase::AwaitingDelay {
+            ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
+            using_default_delay: false,
+        }
     }
 
     async fn advance(
@@ -779,58 +812,68 @@ mod tests {
     }
 
     fn delayed_weth_rpc(delay: Option<Duration>) -> (url::Url, thread::JoinHandle<()>) {
+        delayed_weth_rpc_sequence(vec![delay])
+    }
+
+    fn delayed_weth_rpc_sequence(
+        delays: Vec<Option<Duration>>,
+    ) -> (url::Url, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
         let handle = thread::spawn(move || {
-            let mut stream = (0..100)
-                .find_map(|_| match listener.accept() {
-                    Ok((stream, _)) => Some(stream),
-                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
-                        None
+            for delay in delays {
+                let mut stream = (0..100)
+                    .find_map(|_| match listener.accept() {
+                        Ok((stream, _)) => Some(stream),
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                            None
+                        }
+                        Err(e) => panic!("accept failed: {e}"),
+                    })
+                    .expect("timed out waiting for DelayedWETH delay request");
+                let mut request = Vec::new();
+                let mut buffer = [0; 1024];
+                loop {
+                    let read = stream.read(&mut buffer).unwrap();
+                    if read == 0 {
+                        break;
                     }
-                    Err(e) => panic!("accept failed: {e}"),
-                })
-                .expect("timed out waiting for DelayedWETH delay request");
-            let mut request = Vec::new();
-            let mut buffer = [0; 1024];
-            loop {
-                let read = stream.read(&mut buffer).unwrap();
-                if read == 0 {
-                    break;
+                    request.extend_from_slice(&buffer[..read]);
+                    let text = String::from_utf8_lossy(&request);
+                    let Some((headers, body)) = text.split_once("\r\n\r\n") else {
+                        continue;
+                    };
+                    if body.len() >= content_length(headers).unwrap_or(0) {
+                        break;
+                    }
                 }
-                request.extend_from_slice(&buffer[..read]);
-                let text = String::from_utf8_lossy(&request);
-                let Some((headers, body)) = text.split_once("\r\n\r\n") else {
-                    continue;
-                };
-                if body.len() >= content_length(headers).unwrap_or(0) {
-                    break;
-                }
-            }
 
-            let request = String::from_utf8_lossy(&request);
-            let body = match delay {
-                Some(delay) => {
-                    let result = format!("0x{:064x}", delay.as_secs());
-                    format!(
-                        r#"{{"jsonrpc":"2.0","id":{},"result":"{}"}}"#,
-                        rpc_id(&request),
-                        result
-                    )
-                }
-                None => format!(
-                    r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32000,"message":"boom"}}}}"#,
-                    rpc_id(&request)
-                ),
-            };
-            let response = format!(
-                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                body.len(),
-                body,
-            );
-            stream.write_all(response.as_bytes()).unwrap();
+                let request = String::from_utf8_lossy(&request);
+                let body = delay.map_or_else(
+                    || {
+                        format!(
+                            r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32000,"message":"boom"}}}}"#,
+                            rpc_id(&request)
+                        )
+                    },
+                    |delay| {
+                        let result = format!("0x{:064x}", delay.as_secs());
+                        format!(
+                            r#"{{"jsonrpc":"2.0","id":{},"result":"{}"}}"#,
+                            rpc_id(&request),
+                            result
+                        )
+                    },
+                );
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
         });
         (url, handle)
     }
@@ -915,7 +958,7 @@ mod tests {
         assert!(
             matches!(
                 phase,
-                BondPhase::AwaitingDelay { ready_at } if ready_at == expected_ready_at
+                BondPhase::AwaitingDelay { ready_at, .. } if ready_at == expected_ready_at
             ),
             "withdraw revert should back off briefly"
         );
@@ -941,7 +984,7 @@ mod tests {
         assert!(
             matches!(
                 phase,
-                BondPhase::AwaitingDelay { ready_at }
+                BondPhase::AwaitingDelay { ready_at, .. }
                     if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
             ),
             "non-revert withdraw failure must retry immediately"
@@ -956,7 +999,7 @@ mod tests {
         assert!(
             matches!(
                 phase,
-                BondPhase::AwaitingDelay { ready_at }
+                BondPhase::AwaitingDelay { ready_at, .. }
                     if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
             ),
             "non-revert withdraw failure must stay ready for retry"
@@ -1114,7 +1157,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             match (expected_ready_at, phase) {
-                (expected, BondPhase::AwaitingDelay { ready_at }) if ready_at == expected => {}
+                (expected, BondPhase::AwaitingDelay { ready_at, .. }) if ready_at == expected => {}
                 (_, phase) => panic!("unexpected phase: {phase:?}"),
             }
         }
@@ -1134,7 +1177,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Some(BondPhase::AwaitingDelay { ready_at })
+                Some(BondPhase::AwaitingDelay { ready_at, .. })
                     if ready_at == Duration::from_secs(500)
             ),
             "expected ready AwaitingDelay, got {result:?}",
@@ -1160,7 +1203,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Some(BondPhase::AwaitingDelay { ready_at })
+                Some(BondPhase::AwaitingDelay { ready_at, .. })
                     if ready_at == Duration::from_secs(560)
             ),
             "expected AwaitingDelay with monotonic deadline, got {result:?}",
@@ -1194,7 +1237,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Some(BondPhase::AwaitingDelay { ready_at })
+                Some(BondPhase::AwaitingDelay { ready_at, .. })
                     if ready_at == Duration::from_secs(560)
             ),
             "expected AwaitingDelay from unlock time, got {result:?}",
@@ -1228,7 +1271,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Some(BondPhase::AwaitingDelay { ready_at })
+                Some(BondPhase::AwaitingDelay { ready_at, .. })
                     if ready_at
                         == Duration::from_secs(500)
                             .saturating_add(BondManager::<FixedClock>::DEFAULT_WETH_DELAY)
@@ -1236,6 +1279,43 @@ mod tests {
             "expected fallback AwaitingDelay from unlock time, got {result:?}",
         );
         assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn awaiting_delay_recomputes_default_when_weth_delay_recovers() {
+        let claim_addr = claim_addr();
+        let game = addr(0);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
+        state.delayed_weth = addr(9);
+        let verifier = verifier(state);
+        let (rpc_url, handle) = delayed_weth_rpc_sequence(vec![None, Some(TEST_WETH_DELAY)]);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            rpc_url,
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            fixed_clock(500),
+        );
+        mgr.track_game(game, claim_addr);
+
+        let (submitter, tx_manager) = bond_submitter(vec![
+            Ok(receipt_with_status(true, tx_hash)),
+            Ok(receipt_with_status(true, tx_hash)),
+        ]);
+        let phase = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap().unwrap();
+        assert!(
+            matches!(&phase, BondPhase::AwaitingDelay { using_default_delay: true, .. }),
+            "expected default-delay AwaitingDelay, got {phase:?}",
+        );
+
+        mgr.clock.monotonic = Duration::from_secs(561);
+        let result = mgr.advance_game(game, phase, &*verifier, &submitter).await;
+        handle.join().unwrap();
+
+        assert!(result.is_none(), "withdraw should complete after recovered delay");
+        assert_eq!(tx_manager.recorded_calls().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -56,6 +56,10 @@ impl<C: Clock> std::fmt::Debug for BondManager<C> {
 }
 
 impl<C: Clock> BondManager<C> {
+    /// Conservative fallback when the onchain `DelayedWETH` delay has not
+    /// been read yet.
+    const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
     /// How long to wait before retrying a reverted withdraw attempt.
     const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
 
@@ -492,26 +496,21 @@ impl<C: Clock> BondManager<C> {
         )?;
         if unlocked {
             self.ensure_weth_delay(verifier_client, game_address).await;
-            let Some(delay) = self.weth_delay else {
-                debug!(game = %game_address, "WETH delay not yet known, waiting to advance unlock");
-                return Ok(Some(BondPhase::NeedsUnlock));
-            };
-
+            let delay = self.effective_weth_delay(game_address);
             let phase = Self::unlocked_phase(&self.clock, resolved_at, delay);
             info!(game = %game_address, resolved_at, phase = ?phase, "bond already unlocked");
             return Ok(Some(phase));
         }
 
         self.ensure_weth_delay(verifier_client, game_address).await;
-        let Some(delay) = self.weth_delay else {
-            debug!(game = %game_address, "WETH delay not yet known, waiting to submit unlock");
-            return Ok(Some(BondPhase::NeedsUnlock));
-        };
 
         match Self::send_claim_credit(game_address, "unlock", submitter).await {
-            Ok(_) => Ok(Some(BondPhase::AwaitingDelay {
-                ready_at: self.clock.now().saturating_add(delay),
-            })),
+            Ok(_) => {
+                let delay = self.effective_weth_delay(game_address);
+                Ok(Some(BondPhase::AwaitingDelay {
+                    ready_at: self.clock.now().saturating_add(delay),
+                }))
+            }
             Err(e) => {
                 warn!(
                     game = %game_address,
@@ -569,6 +568,13 @@ impl<C: Clock> BondManager<C> {
         BondPhase::AwaitingDelay {
             ready_at: clock.now().saturating_add(delay.saturating_sub(elapsed_since_resolve)),
         }
+    }
+
+    fn effective_weth_delay(&self, game_address: Address) -> Duration {
+        self.weth_delay.unwrap_or_else(|| {
+            debug!(game = %game_address, "WETH delay not yet known, using default delay");
+            Self::DEFAULT_WETH_DELAY
+        })
     }
 
     async fn send_claim_credit<T: TxManager>(
@@ -772,7 +778,7 @@ mod tests {
         })
     }
 
-    fn delayed_weth_rpc(delay: Duration) -> (url::Url, thread::JoinHandle<()>) {
+    fn delayed_weth_rpc(delay: Option<Duration>) -> (url::Url, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
@@ -805,9 +811,20 @@ mod tests {
             }
 
             let request = String::from_utf8_lossy(&request);
-            let result = format!("0x{:064x}", delay.as_secs());
-            let body =
-                format!(r#"{{"jsonrpc":"2.0","id":{},"result":"{}"}}"#, rpc_id(&request), result);
+            let body = match delay {
+                Some(delay) => {
+                    let result = format!("0x{:064x}", delay.as_secs());
+                    format!(
+                        r#"{{"jsonrpc":"2.0","id":{},"result":"{}"}}"#,
+                        rpc_id(&request),
+                        result
+                    )
+                }
+                None => format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32000,"message":"boom"}}}}"#,
+                    rpc_id(&request)
+                ),
+            };
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
                 body.len(),
@@ -1159,7 +1176,7 @@ mod tests {
         let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
         state.delayed_weth = addr(9);
         let verifier = verifier(state);
-        let (rpc_url, handle) = delayed_weth_rpc(TEST_WETH_DELAY);
+        let (rpc_url, handle) = delayed_weth_rpc(Some(TEST_WETH_DELAY));
         let mut mgr = BondManager::new(
             vec![claim_addr],
             rpc_url,
@@ -1181,6 +1198,42 @@ mod tests {
                     if ready_at == Duration::from_secs(560)
             ),
             "expected AwaitingDelay from unlock time, got {result:?}",
+        );
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn try_unlock_submits_with_default_when_weth_delay_unavailable() {
+        let claim_addr = claim_addr();
+        let game = addr(0);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
+        state.delayed_weth = addr(9);
+        let verifier = verifier(state);
+        let (rpc_url, handle) = delayed_weth_rpc(None);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            rpc_url,
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            fixed_clock(500),
+        );
+        mgr.track_game(game, claim_addr);
+
+        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
+        let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
+        handle.join().unwrap();
+
+        assert!(
+            matches!(
+                result,
+                Some(BondPhase::AwaitingDelay { ready_at })
+                    if ready_at
+                        == Duration::from_secs(500)
+                            .saturating_add(BondManager::<FixedClock>::DEFAULT_WETH_DELAY)
+            ),
+            "expected fallback AwaitingDelay from unlock time, got {result:?}",
         );
         assert_eq!(tx_manager.recorded_calls().len(), 1);
     }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -32,7 +32,7 @@ pub enum BondPhase {
     AwaitingDelay {
         /// Monotonic timestamp at which withdrawal should be retried.
         ready_at: Duration,
-        /// Wall-clock Unix timestamp when the DelayedWETH delay started.
+        /// Wall-clock Unix timestamp when the `DelayedWETH` delay started.
         delay_started_at: u64,
         /// Whether `ready_at` was computed with the fallback WETH delay.
         using_default_delay: bool,

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -19,9 +19,18 @@ use tracing::{debug, info, warn};
 
 use crate::{ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics, GameScanner};
 
+/// Reason a game was removed from bond tracking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemovalReason {
+    /// Bond was successfully claimed.
+    Completed,
+    /// Bond is not claimable by the configured claim addresses.
+    NotClaimable,
+}
+
 /// Phase of the bond claim lifecycle for a single tracked game.
-#[derive(Debug)]
-enum BondPhase {
+#[derive(Debug, Clone)]
+pub enum BondPhase {
     /// The game's dispute period is over; needs a `resolve()` call.
     NeedsResolve,
     /// The game has been resolved; needs the first `claimCredit()` call
@@ -35,6 +44,22 @@ enum BondPhase {
         /// Whether `ready_at` was computed with the fallback WETH delay.
         using_default_delay: bool,
     },
+}
+
+/// A dispute game tracked for bond lifecycle management.
+#[derive(Debug, Clone)]
+pub struct TrackedGame {
+    /// Current lifecycle phase.
+    pub phase: BondPhase,
+    /// The address that will receive the bond.
+    pub bond_recipient: Address,
+}
+
+impl TrackedGame {
+    /// Creates a tracked game in the given phase.
+    pub const fn new(phase: BondPhase, bond_recipient: Address) -> Self {
+        Self { phase, bond_recipient }
+    }
 }
 
 /// Manages bond claiming for dispute games.
@@ -712,6 +737,18 @@ impl<C: Clock> BondManager<C> {
             Err(e) => warn!(error = %e, "failed to read DelayedWETH delay, will retry later"),
         }
     }
+}
+
+/// Trait for submitting dispute game maintenance transactions.
+#[async_trait::async_trait]
+pub trait BondTransactionSubmitter: Send + Sync {
+    /// Sends a transaction with the given calldata to `to`.
+    async fn send_bond_tx(
+        &self,
+        game_address: Address,
+        to: Address,
+        calldata: alloy_primitives::Bytes,
+    ) -> Result<alloy_primitives::B256, ChallengeSubmitError>;
 }
 
 #[cfg(test)]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1,16 +1,11 @@
-//! Bond lifecycle management for resolving, unlocking, and withdrawing
-//! dispute-game credits.
+//! Stateless bond claiming for resolving, unlocking, and withdrawing dispute-game credits.
 
-use std::{
-    collections::{HashMap, HashSet, hash_map::Entry},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, DelayedWETHClient, DelayedWETHContractClient,
-    DisputeGameFactoryClient, GameStatus, encode_claim_credit_calldata, encode_resolve_calldata,
+    DisputeGameFactoryClient, encode_claim_credit_calldata, encode_resolve_calldata,
 };
 use base_runtime::Clock;
 use base_tx_manager::TxManager;
@@ -19,36 +14,31 @@ use tracing::{debug, info, warn};
 
 use crate::{ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics, GameScanner};
 
-/// Phase of the bond claim lifecycle for a single tracked game.
-#[derive(Debug, Clone)]
-pub enum BondPhase {
-    /// The game's dispute period is over; needs a `resolve()` call.
-    NeedsResolve,
-    /// The game has been resolved; needs the first `claimCredit()` call
-    /// to trigger `DelayedWETH.unlock()`.
-    NeedsUnlock,
-    /// The unlock has been submitted; waiting for the `DelayedWETH` delay
-    /// to elapse before the second `claimCredit()` call.
-    AwaitingDelay {
-        /// Monotonic timestamp at which withdrawal should be retried.
-        ready_at: Duration,
-        /// Wall-clock Unix timestamp when the `DelayedWETH` delay started.
-        delay_started_at: u64,
-        /// Whether `ready_at` was computed with the fallback WETH delay.
-        using_default_delay: bool,
-    },
+#[derive(Debug, Clone, Copy)]
+enum BondAction {
+    Resolve(Address),
+    Unlock(Address),
+    WithdrawIfReady { game_address: Address, bond_recipient: Address },
 }
 
-/// Manages bond claiming for dispute games.
+impl BondAction {
+    const fn game_address(self) -> Address {
+        match self {
+            Self::Resolve(game_address)
+            | Self::Unlock(game_address)
+            | Self::WithdrawIfReady { game_address, .. } => game_address,
+        }
+    }
+}
+
+/// Scans recent dispute games and claims any bonds that are ready onchain.
 pub struct BondManager<C: Clock> {
-    tracked: HashMap<Address, BondPhase>,
     claim_addresses: HashSet<Address>,
     weth_delay: Option<Duration>,
     l1_rpc_url: url::Url,
     clock: C,
     factory_client: Arc<dyn DisputeGameFactoryClient>,
-    bond_scan_head: u64,
-    last_full_scan: Duration,
+    last_scan: Option<Duration>,
     lookback: u64,
     discovery_interval: Duration,
 }
@@ -60,13 +50,6 @@ impl<C: Clock> std::fmt::Debug for BondManager<C> {
 }
 
 impl<C: Clock> BondManager<C> {
-    /// Conservative fallback when the onchain `DelayedWETH` delay has not
-    /// been read yet.
-    const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-
-    /// How long to wait before retrying a reverted withdraw attempt.
-    const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
-
     /// Creates a new bond manager for the given set of claim addresses.
     pub fn new(
         claim_addresses: Vec<Address>,
@@ -76,66 +59,97 @@ impl<C: Clock> BondManager<C> {
         discovery_interval: Duration,
         clock: C,
     ) -> Self {
-        let last_full_scan = clock.now();
         let set: HashSet<Address> = claim_addresses.into_iter().collect();
         info!(count = set.len(), "bond manager initialized with claim addresses");
         Self {
-            tracked: HashMap::new(),
             claim_addresses: set,
             weth_delay: None,
             l1_rpc_url,
             clock,
             factory_client,
-            bond_scan_head: 0,
-            last_full_scan,
+            last_scan: None,
             lookback,
             discovery_interval,
         }
     }
 
-    /// Returns the number of games currently being tracked.
-    pub fn tracked_count(&self) -> usize {
-        self.tracked.len()
-    }
-
-    /// Registers a game for bond tracking if its `bond_recipient` is in the
-    /// configured claim addresses.
-    ///
-    /// Returns `true` if the game was added to tracking.
-    pub fn track_game(&mut self, game_address: Address, bond_recipient: Address) -> bool {
-        if !self.claim_addresses.contains(&bond_recipient) {
-            debug!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                "skipping game — bond recipient not in claim addresses"
-            );
-            return false;
+    /// Scans the recent lookback window from scratch and advances ready bond claims.
+    pub async fn discover_claimable_games<T: TxManager>(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<()> {
+        if self.claim_addresses.is_empty() {
+            warn!("bond manager is disabled, skipping discovery scan");
+            return Ok(());
         }
 
-        let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
-            debug!(game = %game_address, "game already tracked for bond claiming");
-            return false;
-        };
+        let now = self.clock.now();
+        if !self.scan_due(now) {
+            return Ok(());
+        }
 
+        let game_count = self.factory_client.game_count().await?;
+        if game_count == 0 {
+            self.last_scan = Some(now);
+            debug!("no games found, skipping bond discovery scan");
+            return Ok(());
+        }
+
+        let start_index = game_count.saturating_sub(self.lookback);
         info!(
-            game = %game_address,
-            recipient = %bond_recipient,
-            "tracking game for bond claiming"
+            start = start_index,
+            end = game_count,
+            lookback = self.lookback,
+            "scanning recent games for claimable bonds"
         );
-        entry.insert(BondPhase::NeedsResolve);
-        ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
-        true
+
+        ChallengerMetrics::bond_discovery_scans_total("full").increment(1);
+        let actions = self.bond_actions(start_index..game_count, verifier_client).await;
+        let action_count = actions.len();
+
+        for action in actions {
+            self.process_action(action, verifier_client, submitter).await;
+        }
+
+        self.last_scan = Some(now);
+        ChallengerMetrics::bonds_tracked().set(0.0);
+
+        if action_count > 0 {
+            ChallengerMetrics::bond_discovery_games_found_total().increment(action_count as u64);
+            info!(actions = action_count, "bond discovery complete");
+        }
+
+        Ok(())
+    }
+
+    fn scan_due(&self, now: Duration) -> bool {
+        self.last_scan
+            .is_none_or(|last_scan| now.saturating_sub(last_scan) >= self.discovery_interval)
+    }
+
+    async fn bond_actions(
+        &self,
+        range: std::ops::Range<u64>,
+        verifier_client: &dyn AggregateVerifierClient,
+    ) -> Vec<BondAction> {
+        stream::iter(range)
+            .map(|i| self.evaluate_game_for_bonds(i, verifier_client))
+            .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
+            .filter_map(std::future::ready)
+            .collect()
+            .await
     }
 
     async fn evaluate_game_for_bonds(
         &self,
         index: u64,
         verifier_client: &dyn AggregateVerifierClient,
-    ) -> Option<(Address, BondPhase)> {
+    ) -> Option<BondAction> {
         let game_at = match self.factory_client.game_at_index(index).await {
-            Ok(g) => g,
+            Ok(game_at) => game_at,
             Err(e) => {
-                warn!(index, error = %e, "failed to fetch game at index");
+                warn!(index = index, error = %e, "failed to fetch game at index");
                 ChallengerMetrics::bond_evaluation_errors_total(
                     ChallengerMetrics::EVAL_ERROR_GAME_FETCH,
                 )
@@ -143,20 +157,18 @@ impl<C: Clock> BondManager<C> {
                 return None;
             }
         };
-
         let game_address = game_at.proxy;
 
-        let (bond_recipient, zk_prover) = match futures::try_join!(
+        let (bond_recipient, zk_prover, resolved_at, bond_unlocked, bond_claimed) = match futures::try_join!(
             verifier_client.bond_recipient(game_address),
             verifier_client.zk_prover(game_address),
+            verifier_client.resolved_at(game_address),
+            verifier_client.bond_unlocked(game_address),
+            verifier_client.bond_claimed(game_address),
         ) {
-            Ok(pair) => pair,
+            Ok(values) => values,
             Err(e) => {
-                debug!(
-                    game = %game_address,
-                    error = %e,
-                    "failed to read bondRecipient/zkProver"
-                );
+                debug!(game = %game_address, error = %e, "failed to read bond state");
                 ChallengerMetrics::bond_evaluation_errors_total(
                     ChallengerMetrics::EVAL_ERROR_BOND_READ,
                 )
@@ -165,475 +177,120 @@ impl<C: Clock> BondManager<C> {
             }
         };
 
-        if !self.claim_addresses.contains(&bond_recipient)
-            && (zk_prover == Address::ZERO || !self.claim_addresses.contains(&zk_prover))
-        {
-            return None;
-        }
-
-        let phase = match Self::determine_phase(
-            verifier_client,
-            game_address,
-            &self.clock,
-            self.weth_delay,
-        )
-        .await
-        {
-            Ok(Some(phase)) => phase,
-            Ok(None) => return None,
-            Err(e) => {
-                warn!(
-                    game = %game_address,
-                    error = %e,
-                    "failed to determine bond phase"
-                );
-                ChallengerMetrics::bond_evaluation_errors_total(
-                    ChallengerMetrics::EVAL_ERROR_PHASE_READ,
-                )
-                .increment(1);
+        if resolved_at == 0 {
+            if !self.claim_addresses.contains(&bond_recipient)
+                && !self.claim_addresses.contains(&zk_prover)
+            {
                 return None;
             }
-        };
 
-        // Pre-resolve games can match only by zkProver; resolved games must
-        // have already moved bondRecipient into our claim set.
-        if !matches!(phase, BondPhase::NeedsResolve)
-            && !self.claim_addresses.contains(&bond_recipient)
-        {
-            debug!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                "onchain bondRecipient not in claim addresses \
-                 for resolved game, skipping"
-            );
+            let game_over = match verifier_client.game_over(game_address).await {
+                Ok(game_over) => game_over,
+                Err(e) => {
+                    warn!(game = %game_address, error = %e, "failed to read gameOver");
+                    ChallengerMetrics::bond_evaluation_errors_total(
+                        ChallengerMetrics::EVAL_ERROR_PHASE_READ,
+                    )
+                    .increment(1);
+                    return None;
+                }
+            };
+
+            return game_over.then_some(BondAction::Resolve(game_address));
+        }
+
+        if !self.claim_addresses.contains(&bond_recipient) || bond_claimed {
             return None;
         }
 
-        Some((game_address, phase))
+        if bond_unlocked {
+            Some(BondAction::WithdrawIfReady { game_address, bond_recipient })
+        } else {
+            Some(BondAction::Unlock(game_address))
+        }
     }
 
-    async fn track_bond_range(
+    async fn process_action<T: TxManager>(
         &mut self,
-        range: std::ops::Range<u64>,
-        verifier_client: &dyn AggregateVerifierClient,
-        scan_type: &'static str,
-    ) -> Vec<Address> {
-        let results: Vec<_> = {
-            let manager = &*self;
-            stream::iter(range)
-                .map(|i| manager.evaluate_game_for_bonds(i, verifier_client))
-                .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
-                .filter_map(std::future::ready)
-                .collect()
-                .await
-        };
-        let mut tracked_games = Vec::new();
-
-        for (game_address, phase) in results {
-            let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
-                continue;
-            };
-
-            info!(
-                game = %game_address,
-                phase = ?phase,
-                scan_type,
-                "tracked claimable game"
-            );
-            entry.insert(phase);
-            tracked_games.push(game_address);
-        }
-
-        tracked_games
-    }
-
-    /// Scans recent games at startup to recover bond tracking state.
-    pub async fn startup_scan(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-    ) -> eyre::Result<()> {
-        if self.claim_addresses.is_empty() {
-            return Ok(());
-        }
-
-        let game_count = self.factory_client.game_count().await?;
-        if game_count == 0 {
-            info!("no games in factory, skipping bond startup scan");
-            return Ok(());
-        }
-
-        let start_index = game_count.saturating_sub(self.lookback);
-        info!(start = start_index, end = game_count, "scanning recent games for bond recovery");
-
-        self.track_bond_range(start_index..game_count, verifier_client, "startup").await;
-
-        self.bond_scan_head = game_count;
-        self.last_full_scan = self.clock.now();
-
-        ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
-        info!(count = self.tracked.len(), "bond startup scan complete");
-        Ok(())
-    }
-
-    /// Discovers claimable games via incremental and periodic lookback scans.
-    pub async fn discover_claimable_games(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-    ) -> eyre::Result<()> {
-        if self.claim_addresses.is_empty() {
-            warn!("bond manager is disabled, skipping discovery scan");
-            return Ok(());
-        }
-
-        let game_count = self.factory_client.game_count().await?;
-        if game_count == 0 {
-            debug!("no games found, skipping bond discovery scan");
-            return Ok(());
-        }
-
-        let elapsed = self.clock.now().saturating_sub(self.last_full_scan);
-        let is_full_rescan = elapsed >= self.discovery_interval;
-        if is_full_rescan {
-            let new_head = game_count.saturating_sub(self.lookback);
-            debug!(
-                new_head,
-                game_count,
-                lookback = self.lookback,
-                "performing periodic full bond rescan"
-            );
-            self.bond_scan_head = new_head;
-        }
-
-        let scan_start = self.bond_scan_head;
-        if scan_start >= game_count {
-            return Ok(());
-        }
-
-        let scan_end = game_count.min(scan_start.saturating_add(self.lookback));
-        if scan_end < game_count {
-            let behind = game_count - scan_end;
-            warn!(
-                scan_start,
-                scan_end,
-                game_count,
-                max = self.lookback,
-                behind,
-                "bond scan span exceeds lookback cap, scanning partial range"
-            );
-        }
-
-        let scan_type = if is_full_rescan { "full" } else { "incremental" };
-        debug!(
-            scan_type,
-            scan_start,
-            scan_end,
-            effective_span = scan_end - scan_start,
-            game_count,
-            tracked = self.tracked.len(),
-            "bond discovery scan"
-        );
-
-        ChallengerMetrics::bond_discovery_scans_total(scan_type).increment(1);
-
-        let discovered =
-            self.track_bond_range(scan_start..scan_end, verifier_client, scan_type).await.len()
-                as u64;
-
-        self.bond_scan_head = scan_end;
-
-        if is_full_rescan {
-            self.last_full_scan = self.clock.now();
-        }
-
-        if discovered > 0 {
-            ChallengerMetrics::bond_discovery_games_found_total().increment(discovered);
-            ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
-            info!(discovered, tracked = self.tracked.len(), scan_type, "bond discovery complete");
-        }
-
-        Ok(())
-    }
-
-    /// Polls all tracked games and advances each through the bond lifecycle.
-    pub async fn poll<T: TxManager>(
-        &mut self,
+        action: BondAction,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
     ) {
-        if self.tracked.is_empty() {
-            return;
-        }
-
-        let addresses: Vec<_> = self.tracked.keys().copied().collect();
-        let tracked_count = self.tracked.len();
-
-        let mut tried_weth_delay = false;
-        for game_address in addresses {
-            let Some(phase) = self.tracked.remove(&game_address) else {
-                continue;
-            };
-
-            if let Some(next_phase) = self
-                .advance_game(
-                    game_address,
-                    phase,
-                    verifier_client,
-                    submitter,
-                    &mut tried_weth_delay,
-                )
-                .await
-            {
-                self.tracked.insert(game_address, next_phase);
+        let game_address = action.game_address();
+        let result = match action {
+            BondAction::Resolve(game_address) => {
+                self.try_resolve(game_address, submitter).await.map_err(|e| eyre::eyre!(e))
             }
-        }
-
-        if self.tracked.len() != tracked_count {
-            ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
-        }
-    }
-
-    async fn advance_game<T: TxManager>(
-        &mut self,
-        game_address: Address,
-        phase: BondPhase,
-        verifier_client: &dyn AggregateVerifierClient,
-        submitter: &ChallengeSubmitter<T>,
-        tried_weth_delay: &mut bool,
-    ) -> Option<BondPhase> {
-        let (result, retry_phase) = match phase {
-            BondPhase::NeedsResolve => (
-                self.try_resolve(game_address, verifier_client, submitter).await,
-                BondPhase::NeedsResolve,
-            ),
-            BondPhase::NeedsUnlock => (
-                self.try_unlock(game_address, verifier_client, submitter, tried_weth_delay).await,
-                BondPhase::NeedsUnlock,
-            ),
-            BondPhase::AwaitingDelay { mut ready_at, delay_started_at, using_default_delay } => {
-                if using_default_delay {
-                    self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
-                    if let Some(delay) = self.weth_delay {
-                        ready_at = Self::delay_ready_at(&self.clock, delay_started_at, delay);
-                    }
-                }
-
-                let now = self.clock.now();
-                if now < ready_at {
-                    let remaining = ready_at.saturating_sub(now);
-                    debug!(
-                        game = %game_address,
-                        remaining_secs = remaining.as_secs(),
-                        "waiting for DelayedWETH delay"
-                    );
-                    return Some(BondPhase::AwaitingDelay {
-                        ready_at,
-                        delay_started_at,
-                        using_default_delay: using_default_delay && self.weth_delay.is_none(),
-                    });
-                }
-
-                info!(
-                    game = %game_address,
-                    ready_at_secs = ready_at.as_secs(),
-                    "DelayedWETH delay elapsed, submitting withdraw"
-                );
-                (
-                    self.try_withdraw(
-                        game_address,
-                        verifier_client,
-                        submitter,
-                        delay_started_at,
-                        using_default_delay,
-                    )
-                    .await,
-                    BondPhase::AwaitingDelay {
-                        ready_at: now,
-                        delay_started_at,
-                        using_default_delay: using_default_delay && self.weth_delay.is_none(),
-                    },
-                )
+            BondAction::Unlock(game_address) => {
+                Self::send_claim_credit(game_address, "unlock", submitter)
+                    .await
+                    .map_err(|e| eyre::eyre!(e))
+            }
+            BondAction::WithdrawIfReady { game_address, bond_recipient } => {
+                self.try_withdraw_if_ready(game_address, bond_recipient, verifier_client, submitter)
+                    .await
             }
         };
 
-        result.unwrap_or_else(|e| {
-            warn!(
-                game = %game_address,
-                error = %e,
-                "failed to advance bond lifecycle"
-            );
-            Some(retry_phase)
-        })
+        if let Err(e) = result {
+            warn!(game = %game_address, error = %e, "failed to advance bond claim");
+        }
     }
 
     async fn try_resolve<T: TxManager>(
         &self,
         game_address: Address,
-        verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
-    ) -> eyre::Result<Option<BondPhase>> {
-        let status = verifier_client.status(game_address).await?;
-
-        if status == GameStatus::InProgress {
-            let game_over = verifier_client.game_over(game_address).await?;
-            if !game_over {
-                debug!(game = %game_address, "game dispute period not yet elapsed");
-                return Ok(Some(BondPhase::NeedsResolve));
+    ) -> Result<(), ChallengeSubmitError> {
+        let calldata = encode_resolve_calldata();
+        info!(game = %game_address, "submitting resolve transaction");
+        match submitter.send_bond_tx(game_address, game_address, calldata).await {
+            Ok(tx_hash) => {
+                info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
+                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+                Ok(())
             }
-
-            let calldata = encode_resolve_calldata();
-            info!(game = %game_address, "submitting resolve transaction");
-            match submitter.send_bond_tx(game_address, game_address, calldata).await {
-                Ok(tx_hash) => {
-                    info!(
-                        game = %game_address,
-                        tx_hash = %tx_hash,
-                        "resolve transaction confirmed"
-                    );
-                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
-                        .increment(1);
-                }
-                Err(e) => {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        "resolve transaction failed, will retry"
-                    );
-                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                        .increment(1);
-                    return Ok(Some(BondPhase::NeedsResolve));
-                }
+            Err(e) => {
+                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+                Err(e)
             }
-        } else {
-            ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
-                .increment(1);
-            info!(game = %game_address, status = ?status, "game already resolved");
         }
-
-        let bond_recipient = verifier_client.bond_recipient(game_address).await?;
-        if !self.claim_addresses.contains(&bond_recipient) {
-            info!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                "bond recipient not in claim addresses after resolve, removing from tracking"
-            );
-            ChallengerMetrics::bonds_not_claimable_total().increment(1);
-            return Ok(None);
-        }
-
-        Ok(Some(BondPhase::NeedsUnlock))
     }
 
-    async fn try_unlock<T: TxManager>(
+    async fn try_withdraw_if_ready<T: TxManager>(
         &mut self,
         game_address: Address,
+        bond_recipient: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
-        tried_weth_delay: &mut bool,
-    ) -> eyre::Result<Option<BondPhase>> {
-        let (unlocked, resolved_at) = futures::try_join!(
-            verifier_client.bond_unlocked(game_address),
-            verifier_client.resolved_at(game_address),
-        )?;
-        if unlocked {
-            self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
-            let using_default_delay = self.weth_delay.is_none();
-            let delay = self.effective_weth_delay(game_address);
-            let phase = Self::unlocked_phase(&self.clock, resolved_at, delay, using_default_delay);
-            info!(game = %game_address, resolved_at, phase = ?phase, "bond already unlocked");
-            return Ok(Some(phase));
+    ) -> eyre::Result<()> {
+        let delay = self.ensure_weth_delay(verifier_client, game_address).await?;
+
+        let delay_started_at =
+            self.withdrawal_timestamp(verifier_client, game_address, bond_recipient).await?;
+        if delay_started_at == 0 {
+            debug!(game = %game_address, recipient = %bond_recipient, "bond marked unlocked without DelayedWETH withdrawal state");
+            return Ok(());
         }
 
-        self.ensure_weth_delay(verifier_client, game_address, tried_weth_delay).await;
-
-        match Self::send_claim_credit(game_address, "unlock", submitter).await {
-            Ok(_) => {
-                let using_default_delay = self.weth_delay.is_none();
-                let delay = self.effective_weth_delay(game_address);
-                Ok(Some(BondPhase::AwaitingDelay {
-                    ready_at: self.clock.now().saturating_add(delay),
-                    delay_started_at: self.clock.wall_clock_unix_secs(),
-                    using_default_delay,
-                }))
-            }
-            Err(e) => {
-                warn!(
-                    game = %game_address,
-                    error = %e,
-                    step = "unlock",
-                    retry = "immediate",
-                    "claimCredit transaction failed, will retry"
-                );
-                Ok(Some(BondPhase::NeedsUnlock))
-            }
-        }
-    }
-
-    async fn try_withdraw<T: TxManager>(
-        &self,
-        game_address: Address,
-        verifier_client: &dyn AggregateVerifierClient,
-        submitter: &ChallengeSubmitter<T>,
-        delay_started_at: u64,
-        using_default_delay: bool,
-    ) -> eyre::Result<Option<BondPhase>> {
-        let claimed = verifier_client.bond_claimed(game_address).await?;
-        if claimed {
-            info!(game = %game_address, "bond already claimed");
-            ChallengerMetrics::bonds_completed_total().increment(1);
-            return Ok(None);
+        let ready_at = delay_started_at.saturating_add(delay.as_secs());
+        let now = self.clock.wall_clock_unix_secs();
+        if now < ready_at {
+            debug!(
+                game = %game_address,
+                ready_at = ready_at,
+                now = now,
+                remaining_secs = ready_at - now,
+                "waiting for DelayedWETH delay"
+            );
+            return Ok(());
         }
 
-        match Self::send_claim_credit(game_address, "withdraw", submitter).await {
-            Ok(_) => {
-                ChallengerMetrics::bonds_completed_total().increment(1);
-                Ok(None)
-            }
-            Err(e) => {
-                let retry_delay = if matches!(&e, crate::ChallengeSubmitError::TxReverted { .. }) {
-                    Self::WITHDRAW_REVERT_RETRY_DELAY
-                } else {
-                    Duration::ZERO
-                };
-                warn!(
-                    game = %game_address,
-                    error = %e,
-                    step = "withdraw",
-                    retry_delay_secs = retry_delay.as_secs(),
-                    "claimCredit transaction failed, will retry"
-                );
-                Ok(Some(BondPhase::AwaitingDelay {
-                    ready_at: self.clock.now().saturating_add(retry_delay),
-                    delay_started_at,
-                    using_default_delay: using_default_delay && self.weth_delay.is_none(),
-                }))
-            }
-        }
-    }
-
-    fn unlocked_phase(
-        clock: &C,
-        resolved_at: u64,
-        delay: Duration,
-        using_default_delay: bool,
-    ) -> BondPhase {
-        BondPhase::AwaitingDelay {
-            ready_at: Self::delay_ready_at(clock, resolved_at, delay),
-            delay_started_at: resolved_at,
-            using_default_delay,
-        }
-    }
-
-    fn delay_ready_at(clock: &C, delay_started_at: u64, delay: Duration) -> Duration {
-        let elapsed =
-            Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(delay_started_at));
-        clock.now().saturating_add(delay.saturating_sub(elapsed))
-    }
-
-    fn effective_weth_delay(&self, game_address: Address) -> Duration {
-        self.weth_delay.unwrap_or_else(|| {
-            debug!(game = %game_address, "WETH delay not yet known, using default delay");
-            Self::DEFAULT_WETH_DELAY
-        })
+        Self::send_claim_credit(game_address, "withdraw", submitter).await?;
+        ChallengerMetrics::bonds_completed_total().increment(1);
+        Ok(())
     }
 
     async fn send_claim_credit<T: TxManager>(
@@ -648,12 +305,7 @@ impl<C: Clock> BondManager<C> {
         let result = submitter.send_bond_tx(game_address, game_address, calldata).await;
         match &result {
             Ok(tx_hash) => {
-                info!(
-                    game = %game_address,
-                    tx_hash = %tx_hash,
-                    step,
-                    "claimCredit transaction confirmed"
-                );
+                info!(game = %game_address, tx_hash = %tx_hash, step, "claimCredit transaction confirmed");
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
             }
@@ -665,61 +317,32 @@ impl<C: Clock> BondManager<C> {
         result.map(|_| ())
     }
 
-    async fn determine_phase(
-        verifier_client: &dyn AggregateVerifierClient,
-        game_address: Address,
-        clock: &C,
-        weth_delay: Option<Duration>,
-    ) -> eyre::Result<Option<BondPhase>> {
-        let (bond_claimed, resolved_at, bond_unlocked) = futures::try_join!(
-            verifier_client.bond_claimed(game_address),
-            verifier_client.resolved_at(game_address),
-            verifier_client.bond_unlocked(game_address),
-        )?;
-        if bond_claimed {
-            return Ok(None);
-        }
-        if bond_unlocked {
-            let Some(delay) = weth_delay else {
-                return Ok(Some(BondPhase::NeedsUnlock));
-            };
-
-            return Ok(Some(Self::unlocked_phase(clock, resolved_at, delay, false)));
-        }
-
-        if resolved_at > 0 {
-            return Ok(Some(BondPhase::NeedsUnlock));
-        }
-
-        Ok(Some(BondPhase::NeedsResolve))
-    }
-
     async fn ensure_weth_delay(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
-        tried_weth_delay: &mut bool,
-    ) {
-        if self.weth_delay.is_some() || *tried_weth_delay {
-            return;
+    ) -> eyre::Result<Duration> {
+        if let Some(delay) = self.weth_delay {
+            return Ok(delay);
         }
-        *tried_weth_delay = true;
 
-        let result: eyre::Result<Duration> = async {
-            let weth_address = verifier_client.delayed_weth(game_address).await?;
-            let weth_client =
-                DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
-            Ok(weth_client.delay().await?)
-        }
-        .await;
+        let weth_address = verifier_client.delayed_weth(game_address).await?;
+        let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
+        let delay = weth_client.delay().await?;
+        info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
+        self.weth_delay = Some(delay);
+        Ok(delay)
+    }
 
-        match result {
-            Ok(delay) => {
-                info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
-                self.weth_delay = Some(delay);
-            }
-            Err(e) => warn!(error = %e, "failed to read DelayedWETH delay, will retry later"),
-        }
+    async fn withdrawal_timestamp(
+        &self,
+        verifier_client: &dyn AggregateVerifierClient,
+        game_address: Address,
+        bond_recipient: Address,
+    ) -> eyre::Result<u64> {
+        let weth_address = verifier_client.delayed_weth(game_address).await?;
+        let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
+        Ok(weth_client.withdrawal_timestamp(game_address, bond_recipient).await?)
     }
 }
 
@@ -741,12 +364,8 @@ mod tests {
     use super::*;
     use crate::test_utils::{
         MockAggregateVerifier, MockDisputeGameFactory, SharedMockTxManager,
-        TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
-        receipt_with_status,
+        TEST_DISCOVERY_INTERVAL, addr, factory_game, mock_state, receipt_with_status,
     };
-
-    const TEST_WETH_DELAY: Duration = Duration::from_secs(60);
-    const WITHDRAW_READY_MONOTONIC_SECS: u64 = 3_700;
 
     struct FixedClock {
         monotonic: Duration,
@@ -771,24 +390,26 @@ mod tests {
         }
     }
 
-    fn fixed_clock(secs: u64) -> FixedClock {
-        FixedClock { monotonic: Duration::from_secs(secs), wall_unix: 2_000_000_000 }
-    }
-
     fn claim_addr() -> Address {
         Address::repeat_byte(0xCC)
     }
 
+    fn fixed_clock(wall_unix: u64) -> FixedClock {
+        FixedClock { monotonic: Duration::from_secs(wall_unix), wall_unix }
+    }
+
     fn game_state(
-        status: GameStatus,
         bond_recipient: Address,
+        zk_prover: Address,
         resolved_at: u64,
         bond_unlocked: bool,
     ) -> crate::test_utils::MockGameState {
-        let mut state = mock_state(status, Address::ZERO, 100);
+        let mut state = mock_state(base_proof_contracts::GameStatus::InProgress, zk_prover, 100);
         state.bond_recipient = bond_recipient;
         state.resolved_at = resolved_at;
         state.bond_unlocked = bond_unlocked;
+        state.game_over = true;
+        state.delayed_weth = addr(9);
         state
     }
 
@@ -796,24 +417,13 @@ mod tests {
         Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])))
     }
 
-    fn ready_phase() -> BondPhase {
-        BondPhase::AwaitingDelay {
-            ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
-            delay_started_at: 2_000_000_000,
-            using_default_delay: false,
-        }
-    }
-
-    async fn advance(
-        mgr: &mut BondManager<FixedClock>,
-        phase: BondPhase,
-        verifier: &Arc<MockAggregateVerifier>,
-        submitter: &ChallengeSubmitter<SharedMockTxManager>,
-    ) -> BondPhase {
-        let mut tried_weth_delay = false;
-        mgr.advance_game(addr(0), phase, &**verifier, submitter, &mut tried_weth_delay)
-            .await
-            .unwrap()
+    fn manager(
+        claim_addr: Address,
+        rpc_url: url::Url,
+        clock: FixedClock,
+    ) -> BondManager<FixedClock> {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 0)]));
+        BondManager::new(vec![claim_addr], rpc_url, factory, 1000, TEST_DISCOVERY_INTERVAL, clock)
     }
 
     fn bond_submitter(
@@ -846,18 +456,16 @@ mod tests {
         })
     }
 
-    fn delayed_weth_rpc(delay: Option<Duration>) -> (url::Url, thread::JoinHandle<()>) {
-        delayed_weth_rpc_sequence(vec![delay])
+    fn u256(value: u64) -> String {
+        format!("{value:064x}")
     }
 
-    fn delayed_weth_rpc_sequence(
-        delays: Vec<Option<Duration>>,
-    ) -> (url::Url, thread::JoinHandle<()>) {
+    fn delayed_weth_rpc(results: Vec<String>) -> (url::Url, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap()).parse().unwrap();
         let handle = thread::spawn(move || {
-            for delay in delays {
+            for result in results {
                 let mut stream = (0..100)
                     .find_map(|_| match listener.accept() {
                         Ok((stream, _)) => Some(stream),
@@ -867,7 +475,7 @@ mod tests {
                         }
                         Err(e) => panic!("accept failed: {e}"),
                     })
-                    .expect("timed out waiting for DelayedWETH delay request");
+                    .expect("timed out waiting for DelayedWETH request");
                 let mut request = Vec::new();
                 let mut buffer = [0; 1024];
                 loop {
@@ -886,21 +494,10 @@ mod tests {
                 }
 
                 let request = String::from_utf8_lossy(&request);
-                let body = delay.map_or_else(
-                    || {
-                        format!(
-                            r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32000,"message":"boom"}}}}"#,
-                            rpc_id(&request)
-                        )
-                    },
-                    |delay| {
-                        let result = format!("0x{:064x}", delay.as_secs());
-                        format!(
-                            r#"{{"jsonrpc":"2.0","id":{},"result":"{}"}}"#,
-                            rpc_id(&request),
-                            result
-                        )
-                    },
+                let body = format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":"0x{}"}}"#,
+                    rpc_id(&request),
+                    result
                 );
                 let response = format!(
                     "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -913,592 +510,72 @@ mod tests {
         (url, handle)
     }
 
-    fn manager(
-        claim_addr: Address,
-        factory: Arc<dyn DisputeGameFactoryClient>,
-        lookback: u64,
-        clock: FixedClock,
-    ) -> BondManager<FixedClock> {
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            "http://localhost:8545".parse().unwrap(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.weth_delay = Some(TEST_WETH_DELAY);
-        mgr
-    }
-
-    fn withdraw_ready_fixture(
-        responses: Vec<base_tx_manager::SendResponse>,
-    ) -> (
-        BondManager<FixedClock>,
-        Arc<MockAggregateVerifier>,
-        ChallengeSubmitter<SharedMockTxManager>,
-        SharedMockTxManager,
-    ) {
+    #[tokio::test]
+    async fn scan_resolves_unresolved_challenge_bond() {
         let claim_addr = claim_addr();
-        let wall_unix = 2_000_000_000;
-        let delay = Duration::from_secs(3_600);
-        let clock =
-            FixedClock { monotonic: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS), wall_unix };
-
-        let mut mgr = manager(claim_addr, empty_factory(), 1000, clock);
-        mgr.weth_delay = Some(delay);
-
-        let state = game_state(GameStatus::DefenderWins, claim_addr, wall_unix - 3_600, true);
+        let state = game_state(Address::repeat_byte(0xDD), claim_addr, 0, false);
         let verifier = verifier(state);
-        let (submitter, tx_manager) = bond_submitter(responses);
+        let (submitter, tx_manager) =
+            bond_submitter(vec![Ok(receipt_with_status(true, B256::ZERO))]);
+        let mut mgr = manager(
+            claim_addr,
+            "http://localhost:8545".parse().unwrap(),
+            fixed_clock(2_000_000_000),
+        );
 
-        (mgr, verifier, submitter, tx_manager)
-    }
+        mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
 
-    #[test]
-    fn track_game_filters_by_claim_address() {
-        let claim_addr = Address::repeat_byte(0x01);
-        let other = Address::repeat_byte(0x02);
-        let game = Address::repeat_byte(0xAA);
-
-        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(0));
-        assert!(mgr.track_game(game, claim_addr));
-        assert!(!mgr.track_game(game, claim_addr));
-        assert!(!mgr.track_game(Address::repeat_byte(0xBB), other));
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
     }
 
     #[tokio::test]
-    async fn already_resolved_game_advances_to_unlock() {
-        let claim_addr = Address::repeat_byte(0x01);
-        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(0));
+    async fn scan_unlocks_resolved_claimable_bond() {
+        let claim_addr = claim_addr();
+        let state = game_state(claim_addr, Address::ZERO, 2_000_000_000, false);
+        let verifier = verifier(state);
+        let (submitter, tx_manager) =
+            bond_submitter(vec![Ok(receipt_with_status(true, B256::ZERO))]);
+        let mut mgr = manager(
+            claim_addr,
+            "http://localhost:8545".parse().unwrap(),
+            fixed_clock(2_000_000_000),
+        );
 
-        let verifier = verifier(game_state(GameStatus::DefenderWins, claim_addr, 100, false));
+        mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
+
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn scan_waits_for_delayed_weth_timestamp() {
+        let claim_addr = claim_addr();
+        let state = game_state(claim_addr, Address::ZERO, 2_000_000_000, true);
+        let verifier = verifier(state);
+        let (rpc_url, handle) =
+            delayed_weth_rpc(vec![u256(60), format!("{}{}", u256(1), u256(100))]);
         let (submitter, tx_manager) = bond_submitter(vec![]);
+        let mut mgr = manager(claim_addr, rpc_url, fixed_clock(150));
 
-        let result = advance(&mut mgr, BondPhase::NeedsResolve, &verifier, &submitter).await;
+        mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
+        handle.join().unwrap();
 
-        assert!(matches!(result, BondPhase::NeedsUnlock));
         assert!(tx_manager.recorded_calls().is_empty());
     }
 
     #[tokio::test]
-    async fn reverted_withdraw_backs_off_before_retrying() {
-        let (mut mgr, verifier, submitter, tx_manager) =
-            withdraw_ready_fixture(vec![Ok(receipt_with_status(false, B256::ZERO))]);
-
-        let phase = advance(&mut mgr, ready_phase(), &verifier, &submitter).await;
-        assert_eq!(tx_manager.recorded_calls().len(), 1);
-        let expected_ready_at = Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
-            .saturating_add(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY);
-        assert!(
-            matches!(
-                phase,
-                BondPhase::AwaitingDelay { ready_at, .. } if ready_at == expected_ready_at
-            ),
-            "withdraw revert should back off briefly"
-        );
-
-        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
-        assert!(matches!(phase, BondPhase::AwaitingDelay { .. }));
-        assert_eq!(
-            tx_manager.recorded_calls().len(),
-            1,
-            "next poll should wait in AwaitingDelay instead of submitting again"
-        );
-    }
-
-    #[tokio::test]
-    async fn non_revert_withdraw_failure_does_not_back_off() {
-        let (mut mgr, verifier, submitter, tx_manager) = withdraw_ready_fixture(vec![
-            Err(base_tx_manager::TxManagerError::NonceTooLow),
-            Err(base_tx_manager::TxManagerError::NonceTooLow),
-        ]);
-
-        let phase = advance(&mut mgr, ready_phase(), &verifier, &submitter).await;
-        assert_eq!(tx_manager.recorded_calls().len(), 1);
-        assert!(
-            matches!(
-                phase,
-                BondPhase::AwaitingDelay { ready_at, .. }
-                    if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
-            ),
-            "non-revert withdraw failure must retry immediately"
-        );
-
-        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
-        assert_eq!(
-            tx_manager.recorded_calls().len(),
-            2,
-            "non-revert failures must not introduce a back-off delay before retry"
-        );
-        assert!(
-            matches!(
-                phase,
-                BondPhase::AwaitingDelay { ready_at, .. }
-                    if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
-            ),
-            "non-revert withdraw failure must stay ready for retry"
-        );
-    }
-
-    fn discovery_mocks(
-        game_count: u64,
-        bond_recipient: Address,
-        zk_prover: Address,
-    ) -> (Arc<dyn DisputeGameFactoryClient>, Arc<MockAggregateVerifier>) {
-        let games: Vec<_> = (0..game_count).map(|i| factory_game(i, 0)).collect();
-        let verifier_games = (0..game_count)
-            .map(|i| {
-                let mut state = mock_state(GameStatus::InProgress, zk_prover, 100 + i);
-                state.bond_recipient = bond_recipient;
-                (addr(i), state)
-            })
-            .collect();
-        let factory: Arc<dyn DisputeGameFactoryClient> =
-            Arc::new(MockDisputeGameFactory::new(games));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        (factory, verifier)
-    }
-
-    async fn assert_discovery(
-        game_count: u64,
-        scan_head: u64,
-        lookback: u64,
-        ticks: usize,
-        expected_head: u64,
-        expected_tracked: usize,
-    ) {
+    async fn scan_withdraws_after_delayed_weth_timestamp() {
         let claim_addr = claim_addr();
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-        let mut mgr = manager(claim_addr, factory, lookback, fixed_clock(0));
-        mgr.bond_scan_head = scan_head;
-
-        for _ in 0..ticks {
-            mgr.discover_claimable_games(&*verifier).await.unwrap();
-        }
-
-        assert_eq!(mgr.bond_scan_head, expected_head);
-        assert_eq!(mgr.tracked_count(), expected_tracked);
-    }
-
-    #[tokio::test]
-    async fn discover_filters_games() {
-        for (game_count, bond_recipient, zk_prover, expected_tracked) in [
-            (3_u64, claim_addr(), Address::ZERO, 3_usize),
-            (2, Address::repeat_byte(0xDD), claim_addr(), 2),
-            (3, Address::repeat_byte(0xDD), Address::ZERO, 0),
-        ] {
-            let claim_addr = claim_addr();
-            let (factory, verifier) = discovery_mocks(game_count, bond_recipient, zk_prover);
-
-            let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
-
-            mgr.discover_claimable_games(&*verifier).await.unwrap();
-            assert_eq!(mgr.tracked_count(), expected_tracked);
-            assert_eq!(mgr.bond_scan_head, game_count);
-        }
-    }
-
-    #[tokio::test]
-    async fn discover_skips_already_tracked_games() {
-        let claim_addr = claim_addr();
-        let (factory, verifier) = discovery_mocks(2, claim_addr, Address::ZERO);
-
-        let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
-
-        mgr.track_game(addr(0), claim_addr);
-        assert_eq!(mgr.tracked_count(), 1);
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 2);
-    }
-
-    #[tokio::test]
-    async fn discover_skips_already_claimed_games() {
-        let claim_addr = claim_addr();
-
-        let games = vec![factory_game(0, 0)];
-        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 500, false);
-        state.bond_claimed = true;
-
-        let factory: Arc<dyn DisputeGameFactoryClient> =
-            Arc::new(MockDisputeGameFactory::new(games));
+        let state = game_state(claim_addr, Address::ZERO, 2_000_000_000, true);
         let verifier = verifier(state);
-
-        let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0, "claimed game should not be tracked");
-    }
-
-    #[tokio::test]
-    async fn discover_updates_watermark() {
-        for (scan_head, expected_head, expected_tracked) in [(3_u64, 5_u64, 2_usize), (5, 5, 0)] {
-            assert_discovery(5, scan_head, 1000, 1, expected_head, expected_tracked).await;
-        }
-    }
-
-    #[tokio::test]
-    async fn discover_full_rescan_resets_watermark() {
-        let claim_addr = claim_addr();
-        let (factory, verifier) = discovery_mocks(10, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(1000);
-        let mut mgr = manager(claim_addr, factory, 5, clock);
-
-        mgr.bond_scan_head = 10;
-
-        mgr.last_full_scan = Duration::from_secs(1000).saturating_sub(TEST_DISCOVERY_INTERVAL);
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, 10);
-        assert_eq!(mgr.tracked_count(), 5);
-    }
-
-    #[tokio::test]
-    async fn discover_disabled_when_no_claim_addresses() {
-        let (_, verifier) = discovery_mocks(5, Address::repeat_byte(0xCC), Address::ZERO);
-
-        let mut mgr = BondManager::new(
-            vec![],
-            "http://localhost:8545".parse().unwrap(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(0),
-        );
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0);
-    }
-
-    #[tokio::test]
-    async fn determine_phase_returns_unlocked_phase() {
-        for (monotonic_secs, delay, expected_ready_at) in [
-            (500_u64, Duration::from_secs(120), Duration::from_secs(520)),
-            (10, Duration::from_secs(60), Duration::from_secs(10)),
-        ] {
-            let game = addr(0);
-            let verifier = verifier(game_state(
-                GameStatus::ChallengerWins,
-                Address::ZERO,
-                1_999_999_900,
-                true,
-            ));
-
-            let clock = fixed_clock(monotonic_secs);
-            let phase = BondManager::determine_phase(&*verifier, game, &clock, Some(delay))
-                .await
-                .unwrap()
-                .unwrap();
-            match (expected_ready_at, phase) {
-                (expected, BondPhase::AwaitingDelay { ready_at, .. }) if ready_at == expected => {}
-                (_, phase) => panic!("unexpected phase: {phase:?}"),
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn try_unlock_advances_to_withdraw_when_already_unlocked_and_delay_elapsed() {
-        let claim_addr = claim_addr();
-        let game = addr(0);
-        let verifier =
-            verifier(game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_800, true));
-        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(500));
-        mgr.track_game(game, claim_addr);
-
-        let (submitter, tx_manager) = bond_submitter(vec![]);
-        let mut tried_weth_delay = false;
-        let result =
-            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
-        assert!(
-            matches!(
-                result,
-                Some(BondPhase::AwaitingDelay { ready_at, .. })
-                    if ready_at == Duration::from_secs(500)
-            ),
-            "expected ready AwaitingDelay, got {result:?}",
-        );
-        assert!(
-            tx_manager.recorded_calls().is_empty(),
-            "no transaction should have been submitted"
-        );
-    }
-
-    #[tokio::test]
-    async fn try_unlock_uses_monotonic_timestamp_for_fresh_unlock() {
-        let claim_addr = claim_addr();
-        let game = addr(0);
-        let tx_hash = B256::repeat_byte(0xDD);
-        let verifier =
-            verifier(game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_900, false));
-        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(500));
-        mgr.track_game(game, claim_addr);
-
-        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
-        let mut tried_weth_delay = false;
-        let result =
-            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
-        assert!(
-            matches!(
-                result,
-                Some(BondPhase::AwaitingDelay { ready_at, .. })
-                    if ready_at == Duration::from_secs(560)
-            ),
-            "expected AwaitingDelay with monotonic deadline, got {result:?}",
-        );
-        assert_eq!(tx_manager.recorded_calls().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn try_unlock_loads_weth_delay_before_unlock() {
-        let claim_addr = claim_addr();
-        let game = addr(0);
-        let tx_hash = B256::repeat_byte(0xDD);
-        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
-        state.delayed_weth = addr(9);
-        let verifier = verifier(state);
-        let (rpc_url, handle) = delayed_weth_rpc(Some(TEST_WETH_DELAY));
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            rpc_url,
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(500),
-        );
-        mgr.track_game(game, claim_addr);
-
-        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
-        let mut tried_weth_delay = false;
-        let result =
-            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
-        handle.join().unwrap();
-
-        assert!(
-            matches!(
-                result,
-                Some(BondPhase::AwaitingDelay { ready_at, .. })
-                    if ready_at == Duration::from_secs(560)
-            ),
-            "expected AwaitingDelay from unlock time, got {result:?}",
-        );
-        assert_eq!(tx_manager.recorded_calls().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn try_unlock_submits_with_default_when_weth_delay_unavailable() {
-        let claim_addr = claim_addr();
-        let game = addr(0);
-        let tx_hash = B256::repeat_byte(0xDD);
-        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
-        state.delayed_weth = addr(9);
-        let verifier = verifier(state);
-        let (rpc_url, handle) = delayed_weth_rpc(None);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            rpc_url,
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(500),
-        );
-        mgr.track_game(game, claim_addr);
-
-        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
-        let mut tried_weth_delay = false;
-        let result =
-            mgr.try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay).await.unwrap();
-        handle.join().unwrap();
-
-        assert!(
-            matches!(
-                result,
-                Some(BondPhase::AwaitingDelay { ready_at, .. })
-                    if ready_at
-                        == Duration::from_secs(500)
-                            .saturating_add(BondManager::<FixedClock>::DEFAULT_WETH_DELAY)
-            ),
-            "expected fallback AwaitingDelay from unlock time, got {result:?}",
-        );
-        assert_eq!(tx_manager.recorded_calls().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn poll_tries_weth_delay_once_per_tick() {
-        let claim_addr = claim_addr();
-        let tx_hash = B256::repeat_byte(0xDD);
-        let states = (0..2).map(|i| {
-            let mut state =
-                game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
-            state.delayed_weth = addr(9);
-            (addr(i), state)
-        });
-        let verifier = Arc::new(MockAggregateVerifier::new(states.collect()));
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            "http://127.0.0.1:0".parse().unwrap(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(500),
-        );
-        mgr.tracked.insert(addr(0), BondPhase::NeedsUnlock);
-        mgr.tracked.insert(addr(1), BondPhase::NeedsUnlock);
-
-        let (submitter, tx_manager) = bond_submitter(vec![
-            Ok(receipt_with_status(true, tx_hash)),
-            Ok(receipt_with_status(true, tx_hash)),
-        ]);
-        mgr.poll(&*verifier, &submitter).await;
-
-        assert_eq!(verifier.delayed_weth_reads.lock().unwrap().len(), 1);
-        assert_eq!(tx_manager.recorded_calls().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn awaiting_delay_recomputes_default_when_weth_delay_recovers() {
-        let claim_addr = claim_addr();
-        let game = addr(0);
-        let tx_hash = B256::repeat_byte(0xDD);
-        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, false);
-        state.delayed_weth = addr(9);
-        let verifier = verifier(state);
-        let (rpc_url, handle) = delayed_weth_rpc_sequence(vec![None, Some(TEST_WETH_DELAY)]);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            rpc_url,
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(500),
-        );
-        mgr.track_game(game, claim_addr);
-
-        let (submitter, tx_manager) = bond_submitter(vec![
-            Ok(receipt_with_status(true, tx_hash)),
-            Ok(receipt_with_status(true, tx_hash)),
-        ]);
-        let mut tried_weth_delay = false;
-        let phase = mgr
-            .try_unlock(game, &*verifier, &submitter, &mut tried_weth_delay)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(
-            matches!(&phase, BondPhase::AwaitingDelay { using_default_delay: true, .. }),
-            "expected default-delay AwaitingDelay, got {phase:?}",
-        );
-
-        mgr.clock.monotonic = Duration::from_secs(561);
-        mgr.clock.wall_unix += 61;
-        let mut tried_weth_delay = false;
-        let result =
-            mgr.advance_game(game, phase, &*verifier, &submitter, &mut tried_weth_delay).await;
-        handle.join().unwrap();
-
-        assert!(result.is_none(), "withdraw should complete after recovered delay");
-        assert_eq!(tx_manager.recorded_calls().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn recovered_delay_uses_original_delay_start() {
-        let claim_addr = claim_addr();
-        let game = addr(0);
-        let actual_delay = Duration::from_secs(14 * 24 * 60 * 60);
-        let resolved_at = 2_000_000_000 - (30 * 24 * 60 * 60);
-        let verifier =
-            verifier(game_state(GameStatus::ChallengerWins, claim_addr, resolved_at, true));
-        let mut mgr =
-            manager(claim_addr, empty_factory(), 1000, fixed_clock(WITHDRAW_READY_MONOTONIC_SECS));
-        mgr.weth_delay = Some(actual_delay);
+        let (rpc_url, handle) =
+            delayed_weth_rpc(vec![u256(60), format!("{}{}", u256(1), u256(100))]);
         let (submitter, tx_manager) =
             bond_submitter(vec![Ok(receipt_with_status(true, B256::ZERO))]);
-        let phase = BondPhase::AwaitingDelay {
-            ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
-            delay_started_at: resolved_at,
-            using_default_delay: true,
-        };
-        let mut tried_weth_delay = false;
+        let mut mgr = manager(claim_addr, rpc_url, fixed_clock(160));
 
-        let result =
-            mgr.advance_game(game, phase, &*verifier, &submitter, &mut tried_weth_delay).await;
-
-        assert!(result.is_none(), "old unlocked game should withdraw immediately");
-        assert_eq!(tx_manager.recorded_calls().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn reverted_default_withdraw_keeps_learning_weth_delay() {
-        let claim_addr = claim_addr();
-        let long_delay =
-            BondManager::<FixedClock>::DEFAULT_WETH_DELAY.saturating_add(Duration::from_secs(3600));
-        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_000, true);
-        state.delayed_weth = addr(9);
-        let verifier = verifier(state);
-        let (rpc_url, handle) = delayed_weth_rpc_sequence(vec![None, Some(long_delay)]);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            rpc_url,
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(WITHDRAW_READY_MONOTONIC_SECS),
-        );
-        let (submitter, tx_manager) =
-            bond_submitter(vec![Ok(receipt_with_status(false, B256::ZERO))]);
-        let phase = BondPhase::AwaitingDelay {
-            ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS),
-            delay_started_at: 2_000_000_000
-                - BondManager::<FixedClock>::DEFAULT_WETH_DELAY.as_secs(),
-            using_default_delay: true,
-        };
-
-        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
-        assert!(
-            matches!(&phase, BondPhase::AwaitingDelay { using_default_delay: true, .. }),
-            "reverted fallback withdraw should keep retrying delay lookup, got {phase:?}",
-        );
-
-        mgr.clock.monotonic = Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
-            .saturating_add(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY);
-        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
+        mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
         handle.join().unwrap();
 
-        assert!(
-            matches!(phase, BondPhase::AwaitingDelay { using_default_delay: false, .. }),
-            "recovered WETH delay should replace fallback state"
-        );
         assert_eq!(tx_manager.recorded_calls().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn discover_handles_empty_factory() {
-        let claim_addr = claim_addr();
-
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            "http://localhost:8545".parse().unwrap(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            fixed_clock(0),
-        );
-
-        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0);
-        assert_eq!(mgr.bond_scan_head, 0);
-    }
-
-    #[tokio::test]
-    async fn discover_advances_by_lookback() {
-        for (lookback, game_count, ticks, expected_head, expected_tracked) in [
-            (500_u64, 1200_u64, 1_usize, 500_u64, 500_usize),
-            (500, 800, 2, 800, 800),
-            (1000, 500, 1, 500, 500),
-        ] {
-            assert_discovery(game_count, 0, lookback, ticks, expected_head, expected_tracked).await;
-        }
     }
 }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -80,7 +80,7 @@ impl<C: Clock> BondManager<C> {
         submitter: &ChallengeSubmitter<T>,
     ) -> eyre::Result<()> {
         if self.claim_addresses.is_empty() {
-            warn!("bond manager is disabled, skipping discovery scan");
+            debug!("bond manager is disabled, skipping discovery scan");
             return Ok(());
         }
 
@@ -113,7 +113,6 @@ impl<C: Clock> BondManager<C> {
         }
 
         self.last_scan = Some(now);
-        ChallengerMetrics::bonds_tracked().set(0.0);
 
         if action_count > 0 {
             ChallengerMetrics::bond_discovery_games_found_total().increment(action_count as u64);
@@ -323,7 +322,7 @@ impl<C: Clock> BondManager<C> {
                 game = %game_address,
                 ready_at = ready_at,
                 now = now,
-                remaining_secs = ready_at - now,
+                remaining_secs = ready_at.saturating_sub(now),
                 "waiting for DelayedWETH delay"
             );
             return Ok(());

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -124,7 +124,7 @@ pub struct ChallengerArgs {
     #[command(flatten)]
     pub tx_manager: TxManagerCli,
 
-    /// Number of recent factory games scanned by bond discovery.
+    /// Number of recent factory games scanned by each bond discovery pass.
     #[arg(
         long = "bond-discovery-lookback-games",
         env = cli_env!("BOND_DISCOVERY_LOOKBACK_GAMES"),
@@ -132,8 +132,7 @@ pub struct ChallengerArgs {
     )]
     pub bond_discovery_lookback_games: u64,
 
-    /// How often a full rescan of the bond lookback window is performed to
-    /// catch state transitions (games challenged or resolved by other actors).
+    /// How often the bond lookback window is scanned from scratch.
     #[arg(
         long = "bond-discovery-interval",
         env = cli_env!("BOND_DISCOVERY_INTERVAL"),

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -209,13 +209,11 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     /// Executes a single scan-validate-prove-submit cycle.
     ///
     /// First polls any in-flight proof sessions that are not in the current
-    /// scan batch, then discovers claimable bonds, advances bond lifecycle
-    /// claims, polls anchor updates, and finally scans for new candidates and
-    /// processes them.
+    /// scan batch, then scans recent games for claimable bonds, polls anchor
+    /// updates, and finally scans for new candidates and processes them.
     pub async fn step(&mut self) -> eyre::Result<()> {
         self.poll_pending_proofs().await;
         self.discover_claimable_bonds().await;
-        self.poll_bond_claims().await;
         self.anchor_updater.poll(&*self.verifier_client, &self.submitter).await;
 
         let candidates = self.scanner.scan().await?;
@@ -230,26 +228,15 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         Ok(())
     }
 
-    /// Discovers new claimable games via incremental and periodic full
-    /// rescanning. Runs before [`poll_bond_claims`](Self::poll_bond_claims)
-    /// so that newly discovered games are immediately eligible for
-    /// advancement in the same tick.
+    /// Scans recent games from scratch and advances ready bond claims.
     async fn discover_claimable_bonds(&mut self) {
         let Some(ref mut bond_manager) = self.bond_manager else {
             return;
         };
 
-        match bond_manager.discover_claimable_games(&*self.verifier_client).await {
+        match bond_manager.discover_claimable_games(&*self.verifier_client, &self.submitter).await {
             Ok(_) => {}
             Err(e) => warn!(error = %e, "bond discovery scan failed"),
-        }
-    }
-
-    /// Polls the bond manager to advance tracked games through the bond
-    /// lifecycle (resolve → unlock → delay → withdraw).
-    async fn poll_bond_claims(&mut self) {
-        if let Some(ref mut bond_manager) = self.bond_manager {
-            bond_manager.poll(&*self.verifier_client, &self.submitter).await;
         }
     }
 
@@ -824,20 +811,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         match result {
             Ok(_) => {
                 self.pending_proofs.remove(&game_address);
-
-                if intent == DisputeIntent::Challenge
-                    && let Some(ref mut bond_manager) = self.bond_manager
-                {
-                    let sender = self.submitter.sender_address();
-                    if !bond_manager.track_game(game_address, sender) {
-                        warn!(
-                            game = %game_address,
-                            sender = %sender,
-                            "bond will not be tracked — sender address is not \
-                             in --bond-claim-addresses; bond may go unclaimed"
-                        );
-                    }
-                }
             }
             Err(e) => {
                 let known_revert = match &e {

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -93,7 +93,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt
         f.debug_struct("DriverComponents")
             .field("scanner", &self.scanner)
             .field("tee", &self.tee.as_ref().map(|_| ".."))
-            .field("bond_manager", &self.bond_manager)
+            .field("bond_manager", &self.bond_manager.as_ref().map(|_| ".."))
             .finish_non_exhaustive()
     }
 }

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -51,7 +51,7 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, RemovalReason, TrackedGame};
+pub use bond::BondManager;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -51,7 +51,7 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::{BondManager, BondPhase};
+pub use bond::BondManager;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -51,7 +51,7 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, RemovalReason, TrackedGame};
+pub use bond::{BondManager, BondPhase};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -51,7 +51,7 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::BondManager;
+pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, RemovalReason, TrackedGame};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -101,7 +101,7 @@ base_metrics::define_metrics! {
     #[describe("Latency in seconds for bond transaction confirmation")]
     bond_tx_latency_seconds: histogram,
 
-    #[describe("Number of games currently tracked for bond claiming")]
+    #[describe("Legacy gauge: stateless bond claiming keeps no per-game state")]
     bonds_tracked: gauge,
 
     #[describe("Total number of bonds successfully claimed")]
@@ -111,7 +111,7 @@ base_metrics::define_metrics! {
     bonds_not_claimable_total: counter,
 
     #[describe("Total bond discovery scans performed")]
-    #[label(name = "scan_type", default = ["full", "incremental"])]
+    #[label(name = "scan_type", default = ["full"])]
     bond_discovery_scans_total: counter,
 
     #[describe("Total claimable games found by bond discovery")]

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -101,14 +101,8 @@ base_metrics::define_metrics! {
     #[describe("Latency in seconds for bond transaction confirmation")]
     bond_tx_latency_seconds: histogram,
 
-    #[describe("Legacy gauge: stateless bond claiming keeps no per-game state")]
-    bonds_tracked: gauge,
-
     #[describe("Total number of bonds successfully claimed")]
     bonds_completed_total: counter,
-
-    #[describe("Total number of bonds dropped because recipient changed after resolve")]
-    bonds_not_claimable_total: counter,
 
     #[describe("Total bond discovery scans performed")]
     #[label(name = "scan_type", default = ["full"])]

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -196,28 +196,14 @@ impl ChallengerService {
         );
 
         let bond_manager = if !config.bond_claim_addresses.is_empty() {
-            let mut bm = BondManager::new(
+            Some(BondManager::new(
                 config.bond_claim_addresses,
                 l1_rpc_url,
                 Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
                 config.bond_discovery_lookback_games,
                 config.bond_discovery_interval,
                 TokioRuntime::new(),
-            );
-            info!("starting bond recovery scan");
-            match bm.startup_scan(&*verifier_client).await {
-                Ok(_) => {}
-                Err(e) => {
-                    // On failure `bond_scan_head` stays at 0, so
-                    // `discover_claimable_games` will progressively scan the
-                    // factory over multiple ticks (capped at `lookback` games
-                    // per tick). This is intentional: progressive catch-up
-                    // is preferable to disabling bond claiming entirely.
-                    warn!(error = %e, "bond startup scan failed, continuing without recovery");
-                }
-            }
-            info!(tracked = bm.tracked_count(), "bond manager ready");
-            Some(bm)
+            ))
         } else {
             info!("bond claiming disabled (no --bond-claim-addresses)");
             None

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -15,7 +15,7 @@ use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::{debug, info};
 
-use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
+use crate::{ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
 /// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
@@ -113,11 +113,8 @@ impl<T: TxManager> ChallengeSubmitter<T> {
 
         Ok(tx_hash)
     }
-}
-
-#[async_trait::async_trait]
-impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
-    async fn send_bond_tx(
+    /// Sends a bond or anchor maintenance transaction.
+    pub async fn send_bond_tx(
         &self,
         game_address: Address,
         to: Address,

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -156,7 +156,7 @@ impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
         to: Address,
         calldata: Bytes,
     ) -> Result<B256, ChallengeSubmitError> {
-        ChallengeSubmitter::send_bond_tx(self, game_address, to, calldata).await
+        Self::send_bond_tx(self, game_address, to, calldata).await
     }
 }
 

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -15,7 +15,7 @@ use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::{debug, info};
 
-use crate::{ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
+use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
 /// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
@@ -145,6 +145,18 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         }
 
         Ok(tx_hash)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
+    async fn send_bond_tx(
+        &self,
+        game_address: Address,
+        to: Address,
+        calldata: Bytes,
+    ) -> Result<B256, ChallengeSubmitError> {
+        ChallengeSubmitter::send_bond_tx(self, game_address, to, calldata).await
     }
 }
 

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -15,7 +15,7 @@ use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::{debug, info};
 
-use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
+use crate::{ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
 /// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
@@ -145,18 +145,6 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         }
 
         Ok(tx_hash)
-    }
-}
-
-#[async_trait::async_trait]
-impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: Bytes,
-    ) -> Result<B256, ChallengeSubmitError> {
-        Self::send_bond_tx(self, game_address, to, calldata).await
     }
 }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -270,6 +270,8 @@ pub struct MockAggregateVerifier {
     pub game_over_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `anchor_state_registry`, used by tests that assert cached reads.
     pub anchor_state_registry_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `delayed_weth`, used by tests that assert cached reads.
+    pub delayed_weth_reads: Mutex<Vec<Address>>,
 }
 
 impl MockAggregateVerifier {
@@ -284,6 +286,7 @@ impl MockAggregateVerifier {
             countered_index_reads: Mutex::new(Vec::new()),
             game_over_reads: Mutex::new(Vec::new()),
             anchor_state_registry_reads: Mutex::new(Vec::new()),
+            delayed_weth_reads: Mutex::new(Vec::new()),
         }
     }
 
@@ -440,6 +443,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn delayed_weth(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.delayed_weth_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.delayed_weth)
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -256,11 +256,6 @@ pub struct MockAggregateVerifier {
     /// Per-address game state lookup, wrapped in a `Mutex` for interior
     /// mutability in multi-step tests.
     pub games: Mutex<HashMap<Address, MockGameState>>,
-    /// Per-address count of status calls that should fail before reading state.
-    pub status_failures: Mutex<HashMap<Address, u64>>,
-    /// Addresses passed to `bond_recipient`, used by tests that assert polling
-    /// avoids redundant lifecycle reads.
-    pub bond_recipient_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `game_info`, used by tests that assert cached reads.
     pub game_info_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `status`, used by tests that assert cached reads.
@@ -279,11 +274,9 @@ pub struct MockAggregateVerifier {
 
 impl MockAggregateVerifier {
     /// Creates a new mock verifier from a pre-built game state map.
-    pub fn new(games: HashMap<Address, MockGameState>) -> Self {
+    pub const fn new(games: HashMap<Address, MockGameState>) -> Self {
         Self {
             games: Mutex::new(games),
-            status_failures: Mutex::new(HashMap::new()),
-            bond_recipient_reads: Mutex::new(Vec::new()),
             game_info_reads: Mutex::new(Vec::new()),
             status_reads: Mutex::new(Vec::new()),
             zk_prover_reads: Mutex::new(Vec::new()),
@@ -300,23 +293,6 @@ impl MockAggregateVerifier {
     /// state changes (e.g. marking a game as resolved after proof submission).
     pub fn update_game(&self, address: Address, state: MockGameState) {
         self.games.lock().unwrap().insert(address, state);
-    }
-
-    /// Causes the next `count` status reads for a game to fail.
-    pub fn fail_status_reads(&self, address: Address, count: u64) {
-        if count > 0 {
-            self.status_failures.lock().unwrap().insert(address, count);
-        }
-    }
-
-    /// Returns how many times `bond_recipient` was read for a game.
-    pub fn bond_recipient_read_count(&self, game_address: Address) -> usize {
-        self.bond_recipient_reads
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|&&read_address| read_address == game_address)
-            .count()
     }
 
     /// Returns how many times `game_info` was read for a game.
@@ -372,16 +348,6 @@ impl AggregateVerifierClient for MockAggregateVerifier {
 
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
         self.status_reads.lock().unwrap().push(game_address);
-        let mut failures = self.status_failures.lock().unwrap();
-        if let Some(remaining) = failures.get_mut(&game_address) {
-            *remaining -= 1;
-            if *remaining == 0 {
-                failures.remove(&game_address);
-            }
-            return Err(ContractError::Validation(format!(
-                "simulated status error for game {game_address}"
-            )));
-        }
         self.get(game_address, |s| s.status)
     }
 
@@ -450,7 +416,6 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn bond_recipient(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.bond_recipient_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.bond_recipient)
     }
 
@@ -938,22 +903,49 @@ impl L1HeadProvider for MockL1HeadProvider {
 pub struct MockTxManager {
     /// Queue of responses returned by [`send`](TxManager::send).
     pub responses: Mutex<VecDeque<SendResponse>>,
+    /// Transaction candidates submitted through [`send`](TxManager::send).
+    pub calls: Mutex<Vec<TxCandidate>>,
 }
 
 impl MockTxManager {
     /// Creates a new mock with a single pre-configured response.
     pub fn new(response: SendResponse) -> Self {
-        Self { responses: Mutex::new(VecDeque::from([response])) }
+        Self { responses: Mutex::new(VecDeque::from([response])), calls: Mutex::new(Vec::new()) }
     }
 
     /// Creates a new mock with multiple responses returned in order.
     pub fn with_responses(responses: Vec<SendResponse>) -> Self {
-        Self { responses: Mutex::new(VecDeque::from(responses)) }
+        Self { responses: Mutex::new(VecDeque::from(responses)), calls: Mutex::new(Vec::new()) }
+    }
+
+    /// Returns the recorded transaction candidates.
+    pub fn recorded_calls(&self) -> Vec<TxCandidate> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+/// Cloneable handle around [`MockTxManager`] for tests that need to inspect
+/// calls after moving a tx manager into another type.
+#[derive(Debug, Clone)]
+pub struct SharedMockTxManager {
+    inner: Arc<MockTxManager>,
+}
+
+impl SharedMockTxManager {
+    /// Creates a shared mock with multiple responses returned in order.
+    pub fn with_responses(responses: Vec<SendResponse>) -> Self {
+        Self { inner: Arc::new(MockTxManager::with_responses(responses)) }
+    }
+
+    /// Returns the recorded transaction candidates.
+    pub fn recorded_calls(&self) -> Vec<TxCandidate> {
+        self.inner.recorded_calls()
     }
 }
 
 impl TxManager for MockTxManager {
-    async fn send(&self, _candidate: TxCandidate) -> SendResponse {
+    async fn send(&self, candidate: TxCandidate) -> SendResponse {
+        self.calls.lock().unwrap().push(candidate);
         self.responses.lock().unwrap().pop_front().expect("MockTxManager has no more responses")
     }
 
@@ -963,6 +955,20 @@ impl TxManager for MockTxManager {
 
     fn sender_address(&self) -> Address {
         Address::ZERO
+    }
+}
+
+impl TxManager for SharedMockTxManager {
+    async fn send(&self, candidate: TxCandidate) -> SendResponse {
+        self.inner.send(candidate).await
+    }
+
+    async fn send_async(&self, candidate: TxCandidate) -> SendHandle {
+        self.inner.send_async(candidate).await
+    }
+
+    fn sender_address(&self) -> Address {
+        self.inner.sender_address()
     }
 }
 
@@ -1042,51 +1048,6 @@ pub fn build_test_header_and_account_for_address(
         storage_proof: vec![],
     };
     (header, account_result)
-}
-
-/// Mock bond transaction submitter for testing the [`BondManager`](crate::BondManager).
-///
-/// Records all submitted transactions and returns pre-configured responses.
-#[derive(Debug)]
-pub struct MockBondTransactionSubmitter {
-    /// Queue of results returned by [`send_bond_tx`](crate::BondTransactionSubmitter::send_bond_tx).
-    pub responses: Mutex<VecDeque<Result<B256, crate::ChallengeSubmitError>>>,
-    /// Recorded `(game_address, to, calldata)` tuples for each submitted transaction.
-    pub calls: Mutex<Vec<(Address, Address, Bytes)>>,
-}
-
-impl MockBondTransactionSubmitter {
-    /// Creates a mock that returns a single successful transaction hash.
-    pub fn success(tx_hash: B256) -> Self {
-        Self { responses: Mutex::new(VecDeque::from([Ok(tx_hash)])), calls: Mutex::new(Vec::new()) }
-    }
-
-    /// Creates a mock with multiple responses returned in order.
-    pub fn with_responses(responses: Vec<Result<B256, crate::ChallengeSubmitError>>) -> Self {
-        Self { responses: Mutex::new(VecDeque::from(responses)), calls: Mutex::new(Vec::new()) }
-    }
-
-    /// Returns the recorded calls as `(game_address, to, calldata)` tuples.
-    pub fn recorded_calls(&self) -> Vec<(Address, Address, Bytes)> {
-        self.calls.lock().unwrap().clone()
-    }
-}
-
-#[async_trait]
-impl crate::BondTransactionSubmitter for MockBondTransactionSubmitter {
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: Bytes,
-    ) -> Result<B256, crate::ChallengeSubmitError> {
-        self.calls.lock().unwrap().push((game_address, to, calldata));
-        self.responses
-            .lock()
-            .unwrap()
-            .pop_front()
-            .expect("MockBondTransactionSubmitter has no more responses")
-    }
 }
 
 #[cfg(test)]

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -12,11 +12,11 @@ use base_challenger::{
     DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
     PendingProofs, ProofKind, ProofPhase, ProofUpdate, TeeConfig,
     test_utils::{
-        DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
-        MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager,
-        MockZkProofProvider, MockZkProofState, TEST_DISCOVERY_INTERVAL, addr,
-        build_test_header_and_account, empty_factory, factory_game, mock_anchor_registry,
-        mock_state, mock_state_with_tee, receipt_with_status,
+        DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockDisputeGameFactory,
+        MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager, MockZkProofProvider,
+        MockZkProofState, TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account,
+        empty_factory, factory_game, mock_anchor_registry, mock_state, mock_state_with_tee,
+        receipt_with_status,
     },
 };
 use base_proof_contracts::{
@@ -1430,241 +1430,18 @@ async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Bond lifecycle integration tests
+// Bond tracking integration test
 // ──────────────────────────────────────────────────────────────────────────
 
-const fn bond_test_state(claim_addr: Address) -> MockGameState {
-    let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-    state.bond_recipient = claim_addr;
-    state
-}
-
-fn bond_test_verifier(claim_addr: Address) -> Arc<MockAggregateVerifier> {
-    single_game_verifier(bond_test_state(claim_addr))
-}
-
 fn default_bond_manager(claim_addr: Address) -> BondManager<TokioRuntime> {
-    let mut mgr = BondManager::new(
+    BondManager::new(
         vec![claim_addr],
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
         TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
-    mgr
-}
-
-#[tokio::test]
-async fn test_bond_manager_full_lifecycle() {
-    // Verify the full bond lifecycle: NeedsResolve → NeedsUnlock →
-    // AwaitingDelay → NeedsWithdraw → Completed.
-    //
-    // The mock verifier uses a static game state, so we set
-    // ChallengerWins to represent a game that has already been
-    // resolved onchain. The manager detects this and advances directly
-    // to NeedsUnlock without submitting a resolve transaction.
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-    let tx_hash = DEFAULT_TX_HASH;
-    let verifier = bond_test_verifier(claim_addr);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Ok(tx_hash), // claimCredit (unlock) tx
-        Ok(tx_hash), // claimCredit (withdraw) tx
-    ]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-
-    assert!(mgr.track_game(game_addr, claim_addr));
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 1: NeedsResolve → already resolved (ChallengerWins) → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
-
-    // Poll 2: NeedsUnlock → claimCredit (unlock) tx → AwaitingDelay.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked during delay");
-
-    // Poll 3: AwaitingDelay (delay=0s, already elapsed) → NeedsWithdraw.
-    // check_delay transitions to NeedsWithdraw, but advance_game returns
-    // Ok(false), so the game is still tracked. Need one more poll.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after delay");
-
-    // Poll 4: NeedsWithdraw → claimCredit (withdraw) tx → Completed → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0, "game should be removed after completion");
-
-    // Verify 2 transactions were submitted (unlock + withdraw, no resolve).
-    let calls = submitter.recorded_calls();
-    assert_eq!(calls.len(), 2, "expected 2 bond transactions (unlock, withdraw)");
-    for (game, target, _) in &calls {
-        assert_eq!(*game, game_addr, "all transactions should reference the game address");
-        assert_eq!(*target, game_addr, "all transactions should target the game address");
-    }
-}
-
-#[tokio::test]
-async fn test_bond_manager_skips_already_unlocked_game() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-    let tx_hash = DEFAULT_TX_HASH;
-
-    let mut state = bond_test_state(claim_addr);
-    state.bond_unlocked = true;
-    state.resolved_at = 1_000_000;
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Ok(tx_hash), // withdraw
-    ]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-
-    // Poll 1: NeedsResolve → status != 0 → NeedsUnlock (no tx).
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 2: NeedsUnlock -> bond_unlocked=true and delay=0 -> NeedsWithdraw (no tx).
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 3: NeedsWithdraw -> submit withdraw -> Completed -> removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0);
-
-    assert_eq!(submitter.recorded_calls().len(), 1);
-}
-
-#[tokio::test]
-async fn test_bond_manager_skips_already_claimed_game() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-
-    let mut state = bond_test_state(claim_addr);
-    state.bond_unlocked = true;
-    state.bond_claimed = true;
-    state.resolved_at = 1_000_000;
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-
-    // Polls 1-3: NeedsResolve → NeedsUnlock → AwaitingDelay → NeedsWithdraw (no txs).
-    for _ in 0..3 {
-        mgr.poll(&*verifier, &submitter).await;
-    }
-
-    // Poll 4: NeedsWithdraw → bond_claimed=true → Completed → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0);
-
-    assert!(
-        submitter.recorded_calls().is_empty(),
-        "no transactions should be submitted for already-claimed bond"
-    );
-}
-
-#[tokio::test]
-async fn test_bond_manager_tx_failure_retries() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-    let tx_hash = DEFAULT_TX_HASH;
-    let verifier = bond_test_verifier(claim_addr);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Err(base_tx_manager::TxManagerError::NonceTooLow.into()),
-        Ok(tx_hash), // retry succeeds
-    ]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-
-    // Poll 1: NeedsResolve → already resolved (ChallengerWins) → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
-
-    // Poll 2: NeedsUnlock → claimCredit tx fails → stays NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after tx failure");
-
-    // Poll 3: NeedsUnlock → retry → claimCredit tx succeeds → AwaitingDelay.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after unlock");
-
-    assert_eq!(submitter.recorded_calls().len(), 2, "expected 2 claimCredit attempts");
-}
-
-#[tokio::test]
-async fn test_bond_manager_ignores_non_claim_addresses() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let other_addr = Address::repeat_byte(0xDD);
-    let game_addr = addr(0);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    assert!(!mgr.track_game(game_addr, other_addr));
-    assert_eq!(mgr.tracked_count(), 0);
-}
-
-#[tokio::test]
-async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
-    // DEFENDER_WINS but bondRecipient is ours → keep and advance to NeedsUnlock.
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-
-    let mut state = bond_test_state(claim_addr);
-    state.status = GameStatus::DefenderWins;
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 1: NeedsResolve → resolved, bondRecipient in claim set → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(
-        mgr.tracked_count(),
-        1,
-        "game should be kept when bondRecipient is in claim addresses"
-    );
-}
-
-#[tokio::test]
-async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
-    // bondRecipient not in claim set → removed from tracking.
-    let claim_addr = ZK_PROVER_ADDR;
-    let other_addr = Address::repeat_byte(0xDD);
-    let game_addr = addr(0);
-
-    let mut state = bond_test_state(claim_addr);
-    state.status = GameStatus::DefenderWins;
-    state.bond_recipient = other_addr; // bond goes to someone else
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 1: NeedsResolve → resolved, bondRecipient not in claim set → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(
-        mgr.tracked_count(),
-        0,
-        "game should be removed when bondRecipient is not in claim addresses"
-    );
-
-    let calls = submitter.recorded_calls();
-    assert!(calls.is_empty(), "bond manager should not submit anchor update txs");
+    )
 }
 
 #[tokio::test]
@@ -1676,11 +1453,8 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
 
     let tx_manager = default_tx_manager();
 
-    let mut bond_manager = default_bond_manager(sender_addr);
-    bond_manager.set_weth_delay(Duration::from_secs(3600));
-
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
-    driver.bond_manager = Some(bond_manager);
+    driver.bond_manager = Some(default_bond_manager(sender_addr));
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -1693,8 +1467,9 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
     driver.step().await.unwrap();
 
     let bond_mgr = driver.bond_manager.as_ref().expect("bond_manager should be Some");
-    assert!(
-        bond_mgr.is_tracking(&addr(0)),
+    assert_eq!(
+        bond_mgr.tracked_count(),
+        1,
         "game should be tracked by bond manager after successful challenge"
     );
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -14,9 +14,8 @@ use base_challenger::{
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockDisputeGameFactory,
         MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager, MockZkProofProvider,
-        MockZkProofState, TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account,
-        empty_factory, factory_game, mock_anchor_registry, mock_state, mock_state_with_tee,
-        receipt_with_status,
+        MockZkProofState, addr, build_test_header_and_account, factory_game, mock_anchor_registry,
+        mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
 use base_proof_contracts::{
@@ -1426,51 +1425,6 @@ async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
         entry.intent,
         DisputeIntent::Nullify,
         "dual-proof TEE fallback must use Nullify intent, not Challenge"
-    );
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// Bond tracking integration test
-// ──────────────────────────────────────────────────────────────────────────
-
-fn default_bond_manager(claim_addr: Address) -> BondManager<TokioRuntime> {
-    BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    )
-}
-
-#[tokio::test]
-async fn test_driver_tracks_bond_after_successful_challenge() {
-    let (l2, factory, verifier) = invalid_game_mocks();
-    let sender_addr = Address::ZERO; // MockTxManager returns ZERO as sender_address
-
-    let zk = succeeded_zk_prover("bond-track", vec![0xDE, 0xAD]);
-
-    let tx_manager = default_tx_manager();
-
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
-    driver.bond_manager = Some(default_bond_manager(sender_addr));
-
-    // Step 1: proof initiated, not yet polled.
-    driver.step().await.unwrap();
-    assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
-        "proof should be pending after initiation"
-    );
-
-    // Step 2: proof polled → Succeeded → challenge tx submitted → bond tracked.
-    driver.step().await.unwrap();
-
-    let bond_mgr = driver.bond_manager.as_ref().expect("bond_manager should be Some");
-    assert_eq!(
-        bond_mgr.tracked_count(),
-        1,
-        "game should be tracked by bond manager after successful challenge"
     );
 }
 

--- a/crates/proof/contracts/src/delayed_weth.rs
+++ b/crates/proof/contracts/src/delayed_weth.rs
@@ -19,6 +19,9 @@ alloy_sol_types::sol! {
     interface IDelayedWETH {
         /// Returns the withdrawal delay in seconds.
         function delay() external view returns (uint256);
+
+        /// Returns the unlocked withdrawal request for an owner/sub-account pair.
+        function withdrawals(address owner, address guy) external view returns (uint256 amount, uint256 timestamp);
     }
 }
 
@@ -27,6 +30,13 @@ alloy_sol_types::sol! {
 pub trait DelayedWETHClient: Send + Sync {
     /// Returns the withdrawal delay enforced between `unlock()` and `withdraw()`.
     async fn delay(&self) -> Result<Duration, ContractError>;
+
+    /// Returns the timestamp at which `owner` unlocked withdrawals for `guy`.
+    async fn withdrawal_timestamp(
+        &self,
+        owner: Address,
+        guy: Address,
+    ) -> Result<u64, ContractError>;
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -53,5 +63,19 @@ impl DelayedWETHClient for DelayedWETHContractClient {
             delay_u256.try_into().map_err(|_| ContractError::validation("delay overflows u64"))?;
 
         Ok(Duration::from_secs(delay_secs))
+    }
+
+    async fn withdrawal_timestamp(
+        &self,
+        owner: Address,
+        guy: Address,
+    ) -> Result<u64, ContractError> {
+        let withdrawal =
+            contract_call!(self.contract.withdrawals(owner, guy).call(), "withdrawals failed")?;
+
+        withdrawal
+            .timestamp
+            .try_into()
+            .map_err(|_| ContractError::validation("withdrawal timestamp overflows u64"))
     }
 }


### PR DESCRIPTION
### What changed? Why?

Refactors `base-challenger` bond claiming from a tracked lifecycle state machine into a stateless recent-game scanner. Each discovery pass scans the configured lookback window from scratch, reads the current onchain state, and immediately submits the next ready maintenance transaction: `resolve()`, `claimCredit()` to unlock, or `claimCredit()` to withdraw.

Claimable game detection still matches configured claim addresses against `bondRecipient` and nonzero `zkProver` so unresolved challenges can be recovered. Before acting on resolved games, the scanner re-reads `bondRecipient` and skips games whose current recipient is not in the claim set.

Withdraw readiness now uses the actual `DelayedWETH.withdrawals(game, recipient).timestamp` plus the onchain `delay()` instead of estimating unlock time locally. The `DelayedWETH` client exposes the withdrawals lookup, and the bond manager caches the delay after the first successful read.

The driver no longer runs a startup recovery scan, maintains an in-memory tracked-bond map, or registers a bond after a successful challenge submission. Bond claiming is recovered entirely by the periodic lookback scan. Anchor and bond maintenance transactions now use `ChallengeSubmitter<T>` directly through `send_bond_tx`, which removes the separate `BondTransactionSubmitter` test trait and the `derive_more` dependency.

### Notes to reviewers

Most of the functional change is in `crates/proof/challenge/src/bond.rs`. The important behavior change is that progress is derived from onchain state every scan rather than from local phases, so restarts and missed ticks are handled by rescanning the lookback window.

`crates/proof/contracts/src/delayed_weth.rs` adds the `withdrawals(owner, guy)` binding used to decide whether a withdraw is ready. Metrics for tracked in-memory bonds and not-claimable removals were dropped because those states no longer exist.

Tests were updated to assert the scanner submits resolve/unlock/withdraw actions through the real `ChallengeSubmitter` path and waits on the `DelayedWETH` withdrawal timestamp before withdrawing.

### How has it been tested?

- `cargo test -p base-challenger`
- `cargo clippy -p base-challenger --all-targets`
