### PR TITLE
refactor(challenger): clean up cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,7 +3631,6 @@ dependencies = [
  "base-runtime",
  "base-tx-manager",
  "clap",
- "derive_more 2.1.1",
  "eyre",
  "futures",
  "humantime",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -76,7 +76,6 @@ base-health = { workspace = true, features = ["axum-server"] }
 # Misc
 url.workspace = true
 humantime.workspace = true
-derive_more = { workspace = true, features = ["debug"] }
 
 # Test utilities (optional)
 serde_json = { workspace = true, optional = true }

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -1,9 +1,6 @@
 //! Anchor root update management.
 
-use std::{
-    collections::{HashMap, hash_map::Entry},
-    time::Duration,
-};
+use std::{collections::HashMap, time::Duration};
 
 use alloy_primitives::Address;
 use base_proof_contracts::{
@@ -29,21 +26,13 @@ pub struct AnchorUpdater<C: Clock> {
     retention: Duration,
 }
 
-/// Cached state for a tracked anchor update.
+/// State for a tracked anchor update.
 #[derive(Debug, Default)]
 pub struct TrackedAnchorUpdate {
     /// Monotonic timestamp when retryable failures began.
     pub retry_started_at: Option<Duration>,
-    /// Cached terminal game status.
-    pub status: Option<GameStatus>,
-    /// Cached `AnchorStateRegistry` address for the game.
-    pub asr_address: Option<Address>,
-    /// Cached immutable game L2 block number.
-    pub l2_block_number: Option<u64>,
     /// Whether this updater already submitted `resolve()` for the game.
     pub resolve_submitted: bool,
-    /// Whether prover reads should wait until the dispute period has elapsed.
-    pub defer_prover_reads_until_game_over: bool,
 }
 
 impl<C: Clock> AnchorUpdater<C> {
@@ -55,35 +44,14 @@ impl<C: Clock> AnchorUpdater<C> {
 
     /// Registers a game for anchor root advancement.
     pub fn track_game(&mut self, game_address: Address) {
-        self.track_game_with_options(game_address, false);
-    }
-
-    /// Registers a valid in-progress game for anchor root advancement.
-    pub fn track_valid_game(&mut self, game_address: Address) {
-        self.track_game_with_options(game_address, true);
-    }
-
-    fn track_game_with_options(
-        &mut self,
-        game_address: Address,
-        defer_prover_reads_until_game_over: bool,
-    ) {
-        let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
+        if self.tracked.contains_key(&game_address) {
             debug!(game = %game_address, "game already tracked for anchor update");
             return;
-        };
+        }
 
         info!(game = %game_address, "tracking game for anchor update");
-        entry.insert(TrackedAnchorUpdate {
-            defer_prover_reads_until_game_over,
-            ..TrackedAnchorUpdate::default()
-        });
+        self.tracked.insert(game_address, TrackedAnchorUpdate::default());
         ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
-    }
-
-    /// Returns `true` if the given game is being tracked.
-    pub fn is_tracking(&self, game_address: &Address) -> bool {
-        self.tracked.contains_key(game_address)
     }
 
     /// Polls all tracked games and advances eligible anchor roots.
@@ -96,54 +64,42 @@ impl<C: Clock> AnchorUpdater<C> {
             return;
         }
 
-        let addresses: Vec<Address> = self.tracked.keys().copied().collect();
-
-        for game_address in addresses {
-            let Some(game) = self.tracked.get_mut(&game_address) else {
-                continue;
-            };
-
-            let outcome = Self::try_update(game_address, game, verifier_client, submitter).await;
+        for (game_address, mut game) in std::mem::take(&mut self.tracked) {
+            let outcome =
+                Self::try_update(game_address, &mut game, verifier_client, submitter).await;
             let should_remove = match outcome {
                 AnchorUpdateOutcome::Complete => true,
                 AnchorUpdateOutcome::Pending => {
                     game.retry_started_at = None;
                     false
                 }
-                AnchorUpdateOutcome::Retry => {
-                    Self::handle_retry(&self.clock, self.retention, game_address, game)
-                }
+                AnchorUpdateOutcome::Retry => self.handle_retry(game_address, &mut game),
             };
 
-            if should_remove {
-                self.tracked.remove(&game_address);
+            if !should_remove {
+                self.tracked.insert(game_address, game);
             }
         }
 
         ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
     }
 
-    fn handle_retry(
-        clock: &C,
-        retention: Duration,
-        game_address: Address,
-        game: &mut TrackedAnchorUpdate,
-    ) -> bool {
-        let now = clock.now();
+    fn handle_retry(&self, game_address: Address, game: &mut TrackedAnchorUpdate) -> bool {
+        let now = self.clock.now();
         let Some(retry_started_at) = game.retry_started_at else {
             game.retry_started_at = Some(now);
             return false;
         };
 
         let elapsed = now.saturating_sub(retry_started_at);
-        if elapsed < retention {
+        if elapsed < self.retention {
             return false;
         }
 
         warn!(
             game = %game_address,
             retained_secs = elapsed.as_secs(),
-            retention_secs = retention.as_secs(),
+            retention_secs = self.retention.as_secs(),
             "dropping anchor update after retention timeout"
         );
         true
@@ -155,24 +111,15 @@ impl<C: Clock> AnchorUpdater<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> AnchorUpdateOutcome {
-        let status = if let Some(status) = game.status {
-            status
-        } else {
-            match verifier_client.status(game_address).await {
-                Ok(s) => {
-                    if s != GameStatus::InProgress {
-                        game.status = Some(s);
-                    }
-                    s
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read status for anchor update, will retry"
-                    );
-                    return AnchorUpdateOutcome::Retry;
-                }
+        let status = match verifier_client.status(game_address).await {
+            Ok(status) => status,
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    error = %e,
+                    "failed to read status for anchor update, will retry"
+                );
+                return AnchorUpdateOutcome::Retry;
             }
         };
 
@@ -182,26 +129,20 @@ impl<C: Clock> AnchorUpdater<C> {
                 return AnchorUpdateOutcome::Pending;
             }
 
-            let mut game_over = None;
-            if game.defer_prover_reads_until_game_over {
-                let is_game_over = match verifier_client.game_over(game_address).await {
-                    Ok(game_over) => game_over,
-                    Err(e) => {
-                        debug!(
-                            game = %game_address,
-                            error = %e,
-                            "failed to read gameOver for anchor update, will retry"
-                        );
-                        return AnchorUpdateOutcome::Retry;
-                    }
-                };
-
-                if !is_game_over {
-                    return AnchorUpdateOutcome::Pending;
+            let game_over = match verifier_client.game_over(game_address).await {
+                Ok(game_over) => game_over,
+                Err(e) => {
+                    debug!(
+                        game = %game_address,
+                        error = %e,
+                        "failed to read gameOver for anchor update, will retry"
+                    );
+                    return AnchorUpdateOutcome::Retry;
                 }
+            };
 
-                game.defer_prover_reads_until_game_over = false;
-                game_over = Some(is_game_over);
+            if !game_over {
+                return AnchorUpdateOutcome::Pending;
             }
 
             let (zk_prover, tee_prover, countered_index) = match tokio::try_join!(
@@ -238,28 +179,11 @@ impl<C: Clock> AnchorUpdater<C> {
                 return AnchorUpdateOutcome::Pending;
             }
 
-            let game_over = match game_over {
-                Some(game_over) => game_over,
-                None => match verifier_client.game_over(game_address).await {
-                    Ok(game_over) => game_over,
-                    Err(e) => {
-                        debug!(
-                            game = %game_address,
-                            error = %e,
-                            "failed to read gameOver for anchor update, will retry"
-                        );
-                        return AnchorUpdateOutcome::Retry;
-                    }
-                },
-            };
-
-            if !game_over {
-                return AnchorUpdateOutcome::Pending;
-            }
-
-            let calldata = encode_resolve_calldata();
             info!(game = %game_address, "submitting resolve transaction for anchor update");
-            match submitter.send_bond_tx(game_address, game_address, calldata).await {
+            match submitter
+                .send_bond_tx(game_address, game_address, encode_resolve_calldata())
+                .await
+            {
                 Ok(tx_hash) => {
                     info!(
                         game = %game_address,
@@ -290,22 +214,15 @@ impl<C: Clock> AnchorUpdater<C> {
             return AnchorUpdateOutcome::Complete;
         }
 
-        let asr_address = if let Some(asr_address) = game.asr_address {
-            asr_address
-        } else {
-            match verifier_client.anchor_state_registry(game_address).await {
-                Ok(addr) => {
-                    game.asr_address = Some(addr);
-                    addr
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read anchorStateRegistry for anchor update"
-                    );
-                    return AnchorUpdateOutcome::Retry;
-                }
+        let asr_address = match verifier_client.anchor_state_registry(game_address).await {
+            Ok(addr) => addr,
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    error = %e,
+                    "failed to read anchorStateRegistry for anchor update"
+                );
+                return AnchorUpdateOutcome::Retry;
             }
         };
 
@@ -375,23 +292,16 @@ impl<C: Clock> AnchorUpdater<C> {
             return AnchorUpdateOutcome::Retry;
         }
 
-        let game_l2_block_number = if let Some(l2_block_number) = game.l2_block_number {
-            l2_block_number
-        } else {
-            match verifier_client.game_info(game_address).await {
-                Ok(info) => {
-                    game.l2_block_number = Some(info.l2_block_number);
-                    info.l2_block_number
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        asr = %asr_address,
-                        error = %e,
-                        "failed to read game info for anchor preflight, will retry"
-                    );
-                    return AnchorUpdateOutcome::Retry;
-                }
+        let game_l2_block_number = match verifier_client.game_info(game_address).await {
+            Ok(info) => info.l2_block_number,
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    error = %e,
+                    "failed to read game info for anchor preflight, will retry"
+                );
+                return AnchorUpdateOutcome::Retry;
             }
         };
 
@@ -408,8 +318,10 @@ impl<C: Clock> AnchorUpdater<C> {
             return AnchorUpdateOutcome::Complete;
         }
 
-        let calldata = encode_set_anchor_state_calldata(game_address);
-        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
+        match submitter
+            .send_bond_tx(game_address, asr_address, encode_set_anchor_state_calldata(game_address))
+            .await
+        {
             Ok(tx_hash) => {
                 info!(
                     game = %game_address,
@@ -449,10 +361,29 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, addr, mock_state, mock_state_with_tee,
+        MockAggregateVerifier, MockBondTransactionSubmitter, MockGameState, addr, mock_state,
+        mock_state_with_tee,
     };
 
     const DEFAULT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+
+    fn verifier(game: Address, state: MockGameState) -> MockAggregateVerifier {
+        MockAggregateVerifier::new(HashMap::from([(game, state)]))
+    }
+
+    async fn assert_pending(
+        updater: &mut AnchorUpdater<TokioRuntime>,
+        verifier: &MockAggregateVerifier,
+        submitter: &MockBondTransactionSubmitter,
+        game: Address,
+    ) {
+        updater.poll(verifier, submitter).await;
+        updater.poll(verifier, submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(updater.tracked.contains_key(&game));
+        assert_eq!(updater.tracked[&game].retry_started_at, None);
+    }
 
     #[tokio::test]
     async fn poll_updates_anchor_for_defender_wins() {
@@ -462,7 +393,7 @@ mod tests {
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = asr;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
@@ -484,18 +415,13 @@ mod tests {
         state.anchor_state_registry = asr;
         state.is_finalized = false;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        updater.poll(&verifier, &submitter).await;
-        updater.poll(&verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(updater.tracked.contains_key(&game));
-        assert_eq!(updater.tracked[&game].retry_started_at, None);
+        assert_pending(&mut updater, &verifier, &submitter, game).await;
     }
 
     #[tokio::test]
@@ -507,18 +433,13 @@ mod tests {
         state.anchor_state_registry = asr;
         state.is_paused = true;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
+        let verifier = verifier(game, state.clone());
         let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        updater.poll(&verifier, &submitter).await;
-        updater.poll(&verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(updater.tracked.contains_key(&game));
-        assert_eq!(updater.tracked[&game].retry_started_at, None);
+        assert_pending(&mut updater, &verifier, &submitter, game).await;
 
         state.is_paused = false;
         verifier.update_game(game, state);
@@ -527,29 +448,6 @@ mod tests {
 
         assert_eq!(submitter.recorded_calls().len(), 1);
         assert!(updater.tracked.is_empty());
-    }
-
-    #[tokio::test]
-    async fn poll_caches_anchor_metadata_while_waiting_for_finality() {
-        let game = addr(0);
-        let asr = Address::repeat_byte(0xAA);
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
-        updater.track_game(game);
-
-        updater.poll(&verifier, &submitter).await;
-        updater.poll(&verifier, &submitter).await;
-
-        assert!(updater.tracked.contains_key(&game));
-        assert_eq!(verifier.status_read_count(game), 1);
-        assert_eq!(verifier.anchor_state_registry_read_count(game), 1);
-        assert_eq!(verifier.game_info_read_count(game), 0);
     }
 
     #[tokio::test]
@@ -562,7 +460,7 @@ mod tests {
         state.anchor_state_registry = asr;
         state.game_over = true;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
+        let verifier = verifier(game, state.clone());
         let submitter = MockBondTransactionSubmitter::with_responses(vec![
             Ok(resolve_tx_hash),
             Ok(anchor_tx_hash),
@@ -597,7 +495,7 @@ mod tests {
         let mut state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
         state.game_over = true;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(resolve_tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
@@ -615,29 +513,24 @@ mod tests {
     async fn poll_keeps_pre_game_over_game_pending() {
         let game = addr(0);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        updater.poll(&verifier, &submitter).await;
-        updater.poll(&verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(updater.tracked.contains_key(&game));
-        assert_eq!(updater.tracked[&game].retry_started_at, None);
+        assert_pending(&mut updater, &verifier, &submitter, game).await;
     }
 
     #[tokio::test]
     async fn poll_does_not_read_prover_state_before_game_over() {
         let game = addr(0);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
-        updater.track_valid_game(game);
+        updater.track_game(game);
 
         updater.poll(&verifier, &submitter).await;
 
@@ -658,25 +551,20 @@ mod tests {
         state.countered_index = 1;
         state.game_over = true;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        updater.poll(&verifier, &submitter).await;
-        updater.poll(&verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(updater.tracked.contains_key(&game));
-        assert_eq!(updater.tracked[&game].retry_started_at, None);
+        assert_pending(&mut updater, &verifier, &submitter, game).await;
     }
 
     #[tokio::test]
     async fn poll_skips_non_defender_wins() {
         let game = addr(0);
         let state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
@@ -689,34 +577,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_caches_game_l2_block_across_retries() {
-        let game = addr(0);
-        let asr = Address::repeat_byte(0xAA);
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.anchor_state_registry = asr;
-
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![
-            Err(crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO }),
-            Err(crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO }),
-        ]);
-
-        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
-        updater.track_game(game);
-
-        updater.poll(&verifier, &submitter).await;
-        updater.poll(&verifier, &submitter).await;
-
-        assert_eq!(submitter.recorded_calls().len(), 2);
-        assert_eq!(verifier.game_info_read_count(game), 1);
-        assert!(updater.tracked.contains_key(&game));
-    }
-
-    #[tokio::test]
     async fn poll_drops_fully_nullified_game() {
         let game = addr(0);
-        let state = mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100);
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let mut state =
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100);
+        state.game_over = true;
+        let verifier = verifier(game, state);
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -156,9 +156,10 @@ impl<C: Clock> AnchorUpdater<C> {
         };
 
         if status == GameStatus::InProgress {
-            let (zk_prover, tee_prover) = match tokio::try_join!(
+            let (zk_prover, tee_prover, countered_index) = match tokio::try_join!(
                 verifier_client.zk_prover(game_address),
                 verifier_client.tee_prover(game_address),
+                verifier_client.countered_index(game_address),
             ) {
                 Ok(provers) => provers,
                 Err(e) => {
@@ -178,6 +179,15 @@ impl<C: Clock> AnchorUpdater<C> {
                 )
                 .increment(1);
                 return AnchorUpdateOutcome::Complete;
+            }
+
+            if countered_index > 0 {
+                debug!(
+                    game = %game_address,
+                    countered_index,
+                    "anchor update waiting for active challenge"
+                );
+                return AnchorUpdateOutcome::Pending;
             }
 
             let game_over = match verifier_client.game_over(game_address).await {
@@ -501,6 +511,29 @@ mod tests {
     async fn poll_keeps_pre_game_over_game_pending() {
         let game = addr(0);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(updater.tracked.contains_key(&game));
+        assert_eq!(updater.tracked[&game].retry_started_at, None);
+    }
+
+    #[tokio::test]
+    async fn poll_waits_for_active_challenge() {
+        let game = addr(0);
+        let tee = Address::repeat_byte(0xEE);
+        let zk = Address::repeat_byte(0xCC);
+        let mut state = mock_state_with_tee(GameStatus::InProgress, zk, tee, 100);
+        state.countered_index = 1;
+        state.game_over = true;
+
         let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -311,7 +311,7 @@ impl<C: Clock> AnchorUpdater<C> {
                 asr = %asr_address,
                 "anchor update not ready because registry is paused"
             );
-            return AnchorUpdateOutcome::Retry;
+            return AnchorUpdateOutcome::Pending;
         }
 
         if !preflight.respected {
@@ -444,6 +444,37 @@ mod tests {
         assert!(submitter.recorded_calls().is_empty());
         assert!(updater.tracked.contains_key(&game));
         assert_eq!(updater.tracked[&game].retry_started_at, None);
+    }
+
+    #[tokio::test]
+    async fn poll_keeps_paused_registry_pending_until_unpaused() {
+        let game = addr(0);
+        let asr = Address::repeat_byte(0xAA);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = asr;
+        state.is_paused = true;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(updater.tracked.contains_key(&game));
+        assert_eq!(updater.tracked[&game].retry_started_at, None);
+
+        state.is_paused = false;
+        verifier.update_game(game, state);
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert_eq!(submitter.recorded_calls().len(), 1);
+        assert!(updater.tracked.is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -10,9 +10,10 @@ use base_proof_contracts::{
     AggregateVerifierClient, GameStatus, encode_resolve_calldata, encode_set_anchor_state_calldata,
 };
 use base_runtime::Clock;
+use base_tx_manager::TxManager;
 use tracing::{debug, info, warn};
 
-use crate::{BondTransactionSubmitter, ChallengerMetrics};
+use crate::{ChallengeSubmitter, ChallengerMetrics};
 
 #[derive(Debug, Clone, Copy)]
 enum AnchorUpdateOutcome {
@@ -63,10 +64,10 @@ impl<C: Clock> AnchorUpdater<C> {
     }
 
     /// Polls all tracked games and advances eligible anchor roots.
-    pub async fn poll(
+    pub async fn poll<T: TxManager>(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<T>,
     ) {
         if self.tracked.is_empty() {
             return;
@@ -113,11 +114,11 @@ impl<C: Clock> AnchorUpdater<C> {
         true
     }
 
-    async fn try_update(
+    async fn try_update<T: TxManager>(
         game_address: Address,
         game: &mut TrackedAnchorUpdate,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<T>,
     ) -> AnchorUpdateOutcome {
         let status = match verifier_client.status(game_address).await {
             Ok(status) => status,
@@ -369,8 +370,8 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, MockGameState, addr, mock_state,
-        mock_state_with_tee,
+        MockAggregateVerifier, MockGameState, SharedMockTxManager, addr, mock_state,
+        mock_state_with_tee, receipt_with_status,
     };
 
     const DEFAULT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
@@ -379,16 +380,28 @@ mod tests {
         MockAggregateVerifier::new(HashMap::from([(game, state)]))
     }
 
+    fn tx_success(tx_hash: B256) -> base_tx_manager::SendResponse {
+        Ok(receipt_with_status(true, tx_hash))
+    }
+
+    fn submitter(
+        responses: Vec<base_tx_manager::SendResponse>,
+    ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
+        let tx_manager = SharedMockTxManager::with_responses(responses);
+        (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
+    }
+
     async fn assert_pending(
         updater: &mut AnchorUpdater<TokioRuntime>,
         verifier: &MockAggregateVerifier,
-        submitter: &MockBondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<SharedMockTxManager>,
+        tx_manager: &SharedMockTxManager,
         game: Address,
     ) {
         updater.poll(verifier, submitter).await;
         updater.poll(verifier, submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
         assert!(updater.tracked.contains_key(&game));
         assert_eq!(updater.tracked[&game].retry_started_at, None);
     }
@@ -402,16 +415,16 @@ mod tests {
         state.anchor_state_registry = asr;
 
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
         updater.track_game(game);
 
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].1, asr);
+        assert_eq!(calls[0].to, Some(asr));
         assert!(updater.tracked.is_empty());
     }
 
@@ -424,12 +437,12 @@ mod tests {
         state.is_finalized = false;
 
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        assert_pending(&mut updater, &verifier, &submitter, game).await;
+        assert_pending(&mut updater, &verifier, &submitter, &tx_manager, game).await;
     }
 
     #[tokio::test]
@@ -442,19 +455,19 @@ mod tests {
         state.is_paused = true;
 
         let verifier = verifier(game, state.clone());
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        assert_pending(&mut updater, &verifier, &submitter, game).await;
+        assert_pending(&mut updater, &verifier, &submitter, &tx_manager, game).await;
 
         state.is_paused = false;
         verifier.update_game(game, state);
 
         updater.poll(&verifier, &submitter).await;
 
-        assert_eq!(submitter.recorded_calls().len(), 1);
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
         assert!(updater.tracked.is_empty());
     }
 
@@ -469,20 +482,18 @@ mod tests {
         state.game_over = true;
 
         let verifier = verifier(game, state.clone());
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![
-            Ok(resolve_tx_hash),
-            Ok(anchor_tx_hash),
-        ]);
+        let (submitter, tx_manager) =
+            submitter(vec![tx_success(resolve_tx_hash), tx_success(anchor_tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
         updater.track_game(game);
 
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].1, game);
-        assert_eq!(calls[0].2, encode_resolve_calldata());
+        assert_eq!(calls[0].to, Some(game));
+        assert_eq!(calls[0].tx_data, encode_resolve_calldata());
         assert!(updater.tracked.contains_key(&game));
 
         state.status = GameStatus::DefenderWins;
@@ -490,9 +501,9 @@ mod tests {
 
         updater.poll(&verifier, &submitter).await;
 
-        let calls = submitter.recorded_calls();
+        let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[1].1, asr);
+        assert_eq!(calls[1].to, Some(asr));
         assert!(updater.tracked.is_empty());
     }
 
@@ -504,7 +515,7 @@ mod tests {
         state.game_over = true;
 
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(resolve_tx_hash)]);
+        let (submitter, tx_manager) = submitter(vec![tx_success(resolve_tx_hash)]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
         updater.track_game(game);
@@ -512,7 +523,7 @@ mod tests {
         updater.poll(&verifier, &submitter).await;
         updater.poll(&verifier, &submitter).await;
 
-        assert_eq!(submitter.recorded_calls().len(), 1);
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
         assert!(updater.tracked.contains_key(&game));
         assert!(updater.tracked[&game].resolve_submitted);
     }
@@ -522,12 +533,12 @@ mod tests {
         let game = addr(0);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        assert_pending(&mut updater, &verifier, &submitter, game).await;
+        assert_pending(&mut updater, &verifier, &submitter, &tx_manager, game).await;
     }
 
     #[tokio::test]
@@ -535,7 +546,7 @@ mod tests {
         let game = addr(0);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
         updater.track_game(game);
@@ -546,7 +557,7 @@ mod tests {
         assert!(verifier.zk_prover_reads.lock().unwrap().is_empty());
         assert!(verifier.tee_prover_reads.lock().unwrap().is_empty());
         assert!(verifier.countered_index_reads.lock().unwrap().is_empty());
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
         assert!(updater.tracked.contains_key(&game));
     }
 
@@ -560,12 +571,12 @@ mod tests {
         state.game_over = true;
 
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);
 
-        assert_pending(&mut updater, &verifier, &submitter, game).await;
+        assert_pending(&mut updater, &verifier, &submitter, &tx_manager, game).await;
     }
 
     #[tokio::test]
@@ -573,14 +584,14 @@ mod tests {
         let game = addr(0);
         let state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
         updater.track_game(game);
 
         updater.poll(&verifier, &submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
         assert!(!updater.tracked.contains_key(&game));
     }
 
@@ -591,14 +602,14 @@ mod tests {
             mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100);
         state.game_over = true;
         let verifier = verifier(game, state);
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
         updater.track_game(game);
 
         updater.poll(&verifier, &submitter).await;
 
-        assert!(submitter.recorded_calls().is_empty());
+        assert!(tx_manager.recorded_calls().is_empty());
         assert!(!updater.tracked.contains_key(&game));
     }
 
@@ -606,7 +617,7 @@ mod tests {
     async fn poll_drops_after_retention_when_status_read_keeps_failing() {
         let game = addr(0);
         let verifier = MockAggregateVerifier::new(HashMap::new());
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, _tx_manager) = submitter(vec![]);
 
         let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
         updater.track_game(game);

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -1,6 +1,9 @@
 //! Anchor root update management.
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    time::Duration,
+};
 
 use alloy_primitives::Address;
 use base_proof_contracts::{
@@ -44,14 +47,19 @@ impl<C: Clock> AnchorUpdater<C> {
 
     /// Registers a game for anchor root advancement.
     pub fn track_game(&mut self, game_address: Address) {
-        if self.tracked.contains_key(&game_address) {
+        let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
             debug!(game = %game_address, "game already tracked for anchor update");
             return;
-        }
+        };
 
         info!(game = %game_address, "tracking game for anchor update");
-        self.tracked.insert(game_address, TrackedAnchorUpdate::default());
+        entry.insert(TrackedAnchorUpdate::default());
         ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
+    }
+
+    /// Returns `true` if the given game is being tracked.
+    pub fn is_tracking(&self, game_address: &Address) -> bool {
+        self.tracked.contains_key(game_address)
     }
 
     /// Polls all tracked games and advances eligible anchor roots.

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -1,0 +1,481 @@
+//! Anchor root update management.
+
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    time::Duration,
+};
+
+use alloy_primitives::Address;
+use base_proof_contracts::{
+    AggregateVerifierClient, GameStatus, encode_resolve_calldata, encode_set_anchor_state_calldata,
+};
+use base_runtime::Clock;
+use tracing::{debug, info, warn};
+
+use crate::{BondTransactionSubmitter, ChallengerMetrics};
+
+#[derive(Debug, Clone, Copy)]
+enum AnchorUpdateOutcome {
+    Pending,
+    Retry,
+    Complete,
+}
+
+/// Best-effort updater for the `AnchorStateRegistry`.
+#[derive(Debug)]
+pub struct AnchorUpdater<C: Clock> {
+    tracked: HashMap<Address, Option<Duration>>,
+    clock: C,
+    retention: Duration,
+}
+
+impl<C: Clock> AnchorUpdater<C> {
+    /// Creates an anchor updater.
+    pub fn new(clock: C, retention: Duration) -> Self {
+        info!(retention_secs = retention.as_secs(), "anchor update retention configured");
+        Self { tracked: HashMap::new(), clock, retention }
+    }
+
+    /// Registers a game for anchor root advancement.
+    pub fn track_game(&mut self, game_address: Address) {
+        let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
+            debug!(game = %game_address, "game already tracked for anchor update");
+            return;
+        };
+
+        info!(game = %game_address, "tracking game for anchor update");
+        entry.insert(None);
+        ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
+    }
+
+    /// Returns `true` if the given game is being tracked.
+    pub fn is_tracking(&self, game_address: &Address) -> bool {
+        self.tracked.contains_key(game_address)
+    }
+
+    /// Polls all tracked games and advances eligible anchor roots.
+    pub async fn poll(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) {
+        if self.tracked.is_empty() {
+            return;
+        }
+
+        let addresses: Vec<Address> = self.tracked.keys().copied().collect();
+
+        for game_address in addresses {
+            let should_remove =
+                match Self::try_update(game_address, verifier_client, submitter).await {
+                    AnchorUpdateOutcome::Complete => true,
+                    AnchorUpdateOutcome::Pending => {
+                        if let Some(game) = self.tracked.get_mut(&game_address) {
+                            *game = None;
+                        }
+                        false
+                    }
+                    AnchorUpdateOutcome::Retry => self.handle_retry(game_address),
+                };
+
+            if should_remove {
+                self.tracked.remove(&game_address);
+            }
+        }
+
+        ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
+    }
+
+    fn handle_retry(&mut self, game_address: Address) -> bool {
+        let now = self.clock.now();
+        let Some(game) = self.tracked.get_mut(&game_address) else {
+            return false;
+        };
+
+        let Some(retry_started_at) = *game else {
+            *game = Some(now);
+            return false;
+        };
+
+        let elapsed = now.saturating_sub(retry_started_at);
+        if elapsed < self.retention {
+            return false;
+        }
+
+        warn!(
+            game = %game_address,
+            retained_secs = elapsed.as_secs(),
+            retention_secs = self.retention.as_secs(),
+            "dropping anchor update after retention timeout"
+        );
+        true
+    }
+
+    async fn try_update(
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) -> AnchorUpdateOutcome {
+        let status = match verifier_client.status(game_address).await {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(game = %game_address, error = %e, "failed to read status for anchor update");
+                return AnchorUpdateOutcome::Pending;
+            }
+        };
+
+        if status == GameStatus::InProgress {
+            let (zk_prover, tee_prover) = match tokio::try_join!(
+                verifier_client.zk_prover(game_address),
+                verifier_client.tee_prover(game_address),
+            ) {
+                Ok(provers) => provers,
+                Err(e) => {
+                    debug!(
+                        game = %game_address,
+                        error = %e,
+                        "failed to read provers for anchor update"
+                    );
+                    return AnchorUpdateOutcome::Pending;
+                }
+            };
+
+            if tee_prover == Address::ZERO && zk_prover == Address::ZERO {
+                debug!(game = %game_address, "skipping fully nullified anchor update");
+                ChallengerMetrics::anchor_update_tx_outcome_total(
+                    ChallengerMetrics::STATUS_SKIPPED,
+                )
+                .increment(1);
+                return AnchorUpdateOutcome::Complete;
+            }
+
+            let game_over = match verifier_client.game_over(game_address).await {
+                Ok(game_over) => game_over,
+                Err(e) => {
+                    debug!(
+                        game = %game_address,
+                        error = %e,
+                        "failed to read gameOver for anchor update"
+                    );
+                    return AnchorUpdateOutcome::Pending;
+                }
+            };
+
+            if !game_over {
+                return AnchorUpdateOutcome::Pending;
+            }
+
+            let calldata = encode_resolve_calldata();
+            info!(game = %game_address, "submitting resolve transaction for anchor update");
+            match submitter.send_bond_tx(game_address, game_address, calldata).await {
+                Ok(tx_hash) => {
+                    info!(
+                        game = %game_address,
+                        tx_hash = %tx_hash,
+                        "resolve transaction confirmed for anchor update"
+                    );
+                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                        .increment(1);
+                    return AnchorUpdateOutcome::Pending;
+                }
+                Err(e) => {
+                    warn!(
+                        game = %game_address,
+                        error = %e,
+                        "resolve transaction failed for anchor update, will retry"
+                    );
+                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                        .increment(1);
+                    return AnchorUpdateOutcome::Retry;
+                }
+            }
+        }
+
+        if status != GameStatus::DefenderWins {
+            ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
+                .increment(1);
+            return AnchorUpdateOutcome::Complete;
+        }
+
+        let asr_address = match verifier_client.anchor_state_registry(game_address).await {
+            Ok(addr) => addr,
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    error = %e,
+                    "failed to read anchorStateRegistry for anchor update"
+                );
+                return AnchorUpdateOutcome::Retry;
+            }
+        };
+
+        match verifier_client.is_game_finalized(asr_address, game_address).await {
+            Ok(true) => {}
+            Ok(false) => {
+                debug!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    "anchor update not ready because game is not finalized"
+                );
+                return AnchorUpdateOutcome::Pending;
+            }
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    error = %e,
+                    "failed to read isGameFinalized, will retry"
+                );
+                return AnchorUpdateOutcome::Retry;
+            }
+        }
+
+        let preflight = match verifier_client.anchor_preflight(asr_address, game_address).await {
+            Ok(p) => p,
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    error = %e,
+                    "failed to read anchor preflight state, will retry"
+                );
+                return AnchorUpdateOutcome::Retry;
+            }
+        };
+
+        if preflight.permanently_ineligible() {
+            info!(
+                game = %game_address,
+                asr = %asr_address,
+                blacklisted = preflight.blacklisted,
+                retired = preflight.retired,
+                respected = preflight.respected,
+                "skipping permanently ineligible anchor update"
+            );
+            ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
+                .increment(1);
+            return AnchorUpdateOutcome::Complete;
+        }
+
+        if preflight.paused {
+            debug!(
+                game = %game_address,
+                asr = %asr_address,
+                "anchor update not ready because registry is paused"
+            );
+            return AnchorUpdateOutcome::Retry;
+        }
+
+        if !preflight.respected {
+            debug!(
+                game = %game_address,
+                asr = %asr_address,
+                "anchor update not ready because game is not currently respected"
+            );
+            return AnchorUpdateOutcome::Retry;
+        }
+
+        let game_l2_block_number = match verifier_client.game_info(game_address).await {
+            Ok(info) => info.l2_block_number,
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    error = %e,
+                    "failed to read game info for anchor preflight, will retry"
+                );
+                return AnchorUpdateOutcome::Retry;
+            }
+        };
+
+        if game_l2_block_number <= preflight.anchor_root.l2_block_number {
+            info!(
+                game = %game_address,
+                asr = %asr_address,
+                game_l2_block = game_l2_block_number,
+                anchor_l2_block = preflight.anchor_root.l2_block_number,
+                "skipping stale anchor update"
+            );
+            ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
+                .increment(1);
+            return AnchorUpdateOutcome::Complete;
+        }
+
+        let calldata = encode_set_anchor_state_calldata(game_address);
+        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    tx_hash = %tx_hash,
+                    "anchor state registry updated"
+                );
+                ChallengerMetrics::anchor_update_tx_outcome_total(
+                    ChallengerMetrics::STATUS_SUCCESS,
+                )
+                .increment(1);
+                // Prometheus gauges are f64; this is telemetry, not protocol state.
+                ChallengerMetrics::anchor_l2_block_number().set(game_l2_block_number as f64);
+                AnchorUpdateOutcome::Complete
+            }
+            Err(e) => {
+                debug!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    error = %e,
+                    "anchor update failed, will retry"
+                );
+                ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+                AnchorUpdateOutcome::Retry
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, time::Duration};
+
+    use alloy_primitives::B256;
+    use base_runtime::TokioRuntime;
+
+    use super::*;
+    use crate::test_utils::{
+        MockAggregateVerifier, MockBondTransactionSubmitter, addr, mock_state, mock_state_with_tee,
+    };
+
+    const DEFAULT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+
+    #[tokio::test]
+    async fn poll_updates_anchor_for_defender_wins() {
+        let game = addr(0);
+        let asr = Address::repeat_byte(0xAA);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = asr;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, asr);
+        assert!(updater.tracked.is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_keeps_unfinalized_game_pending() {
+        let game = addr(0);
+        let asr = Address::repeat_byte(0xAA);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = asr;
+        state.is_finalized = false;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(updater.tracked.contains_key(&game));
+        assert_eq!(updater.tracked[&game], None);
+    }
+
+    #[tokio::test]
+    async fn poll_resolves_game_before_anchor_update() {
+        let game = addr(0);
+        let asr = Address::repeat_byte(0xAA);
+        let resolve_tx_hash = B256::repeat_byte(0xCC);
+        let anchor_tx_hash = B256::repeat_byte(0xDD);
+        let mut state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        state.anchor_state_registry = asr;
+        state.game_over = true;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![
+            Ok(resolve_tx_hash),
+            Ok(anchor_tx_hash),
+        ]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, game);
+        assert_eq!(calls[0].2, encode_resolve_calldata());
+        assert!(updater.tracked.contains_key(&game));
+
+        state.status = GameStatus::DefenderWins;
+        verifier.update_game(game, state);
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].1, asr);
+        assert!(updater.tracked.is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_keeps_pre_game_over_game_pending() {
+        let game = addr(0);
+        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(updater.tracked.contains_key(&game));
+        assert_eq!(updater.tracked[&game], None);
+    }
+
+    #[tokio::test]
+    async fn poll_skips_non_defender_wins() {
+        let game = addr(0);
+        let state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(!updater.tracked.contains_key(&game));
+    }
+
+    #[tokio::test]
+    async fn poll_drops_fully_nullified_game() {
+        let game = addr(0);
+        let state = mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100);
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(!updater.tracked.contains_key(&game));
+    }
+}

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -24,9 +24,22 @@ enum AnchorUpdateOutcome {
 /// Best-effort updater for the `AnchorStateRegistry`.
 #[derive(Debug)]
 pub struct AnchorUpdater<C: Clock> {
-    tracked: HashMap<Address, Option<Duration>>,
+    tracked: HashMap<Address, TrackedAnchorUpdate>,
     clock: C,
     retention: Duration,
+}
+
+/// Cached state for a tracked anchor update.
+#[derive(Debug, Default)]
+pub struct TrackedAnchorUpdate {
+    /// Monotonic timestamp when retryable failures began.
+    pub retry_started_at: Option<Duration>,
+    /// Cached terminal game status.
+    pub status: Option<GameStatus>,
+    /// Cached `AnchorStateRegistry` address for the game.
+    pub asr_address: Option<Address>,
+    /// Cached immutable game L2 block number.
+    pub l2_block_number: Option<u64>,
 }
 
 impl<C: Clock> AnchorUpdater<C> {
@@ -44,7 +57,7 @@ impl<C: Clock> AnchorUpdater<C> {
         };
 
         info!(game = %game_address, "tracking game for anchor update");
-        entry.insert(None);
+        entry.insert(TrackedAnchorUpdate::default());
         ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
     }
 
@@ -66,17 +79,21 @@ impl<C: Clock> AnchorUpdater<C> {
         let addresses: Vec<Address> = self.tracked.keys().copied().collect();
 
         for game_address in addresses {
-            let should_remove =
-                match Self::try_update(game_address, verifier_client, submitter).await {
-                    AnchorUpdateOutcome::Complete => true,
-                    AnchorUpdateOutcome::Pending => {
-                        if let Some(game) = self.tracked.get_mut(&game_address) {
-                            *game = None;
-                        }
-                        false
+            let Some(game) = self.tracked.get_mut(&game_address) else {
+                continue;
+            };
+
+            let outcome = Self::try_update(game_address, game, verifier_client, submitter).await;
+            let should_remove = match outcome {
+                AnchorUpdateOutcome::Complete => true,
+                AnchorUpdateOutcome::Pending => {
+                    if let Some(game) = self.tracked.get_mut(&game_address) {
+                        game.retry_started_at = None;
                     }
-                    AnchorUpdateOutcome::Retry => self.handle_retry(game_address),
-                };
+                    false
+                }
+                AnchorUpdateOutcome::Retry => self.handle_retry(game_address),
+            };
 
             if should_remove {
                 self.tracked.remove(&game_address);
@@ -92,8 +109,8 @@ impl<C: Clock> AnchorUpdater<C> {
             return false;
         };
 
-        let Some(retry_started_at) = *game else {
-            *game = Some(now);
+        let Some(retry_started_at) = game.retry_started_at else {
+            game.retry_started_at = Some(now);
             return false;
         };
 
@@ -113,14 +130,28 @@ impl<C: Clock> AnchorUpdater<C> {
 
     async fn try_update(
         game_address: Address,
+        game: &mut TrackedAnchorUpdate,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> AnchorUpdateOutcome {
-        let status = match verifier_client.status(game_address).await {
-            Ok(s) => s,
-            Err(e) => {
-                debug!(game = %game_address, error = %e, "failed to read status for anchor update");
-                return AnchorUpdateOutcome::Pending;
+        let status = if let Some(status) = game.status {
+            status
+        } else {
+            match verifier_client.status(game_address).await {
+                Ok(s) => {
+                    if s != GameStatus::InProgress {
+                        game.status = Some(s);
+                    }
+                    s
+                }
+                Err(e) => {
+                    debug!(
+                        game = %game_address,
+                        error = %e,
+                        "failed to read status for anchor update, will retry"
+                    );
+                    return AnchorUpdateOutcome::Retry;
+                }
             }
         };
 
@@ -134,9 +165,9 @@ impl<C: Clock> AnchorUpdater<C> {
                     debug!(
                         game = %game_address,
                         error = %e,
-                        "failed to read provers for anchor update"
+                        "failed to read provers for anchor update, will retry"
                     );
-                    return AnchorUpdateOutcome::Pending;
+                    return AnchorUpdateOutcome::Retry;
                 }
             };
 
@@ -155,9 +186,9 @@ impl<C: Clock> AnchorUpdater<C> {
                     debug!(
                         game = %game_address,
                         error = %e,
-                        "failed to read gameOver for anchor update"
+                        "failed to read gameOver for anchor update, will retry"
                     );
-                    return AnchorUpdateOutcome::Pending;
+                    return AnchorUpdateOutcome::Retry;
                 }
             };
 
@@ -197,15 +228,22 @@ impl<C: Clock> AnchorUpdater<C> {
             return AnchorUpdateOutcome::Complete;
         }
 
-        let asr_address = match verifier_client.anchor_state_registry(game_address).await {
-            Ok(addr) => addr,
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    error = %e,
-                    "failed to read anchorStateRegistry for anchor update"
-                );
-                return AnchorUpdateOutcome::Retry;
+        let asr_address = if let Some(asr_address) = game.asr_address {
+            asr_address
+        } else {
+            match verifier_client.anchor_state_registry(game_address).await {
+                Ok(addr) => {
+                    game.asr_address = Some(addr);
+                    addr
+                }
+                Err(e) => {
+                    debug!(
+                        game = %game_address,
+                        error = %e,
+                        "failed to read anchorStateRegistry for anchor update"
+                    );
+                    return AnchorUpdateOutcome::Retry;
+                }
             }
         };
 
@@ -275,16 +313,23 @@ impl<C: Clock> AnchorUpdater<C> {
             return AnchorUpdateOutcome::Retry;
         }
 
-        let game_l2_block_number = match verifier_client.game_info(game_address).await {
-            Ok(info) => info.l2_block_number,
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "failed to read game info for anchor preflight, will retry"
-                );
-                return AnchorUpdateOutcome::Retry;
+        let game_l2_block_number = if let Some(l2_block_number) = game.l2_block_number {
+            l2_block_number
+        } else {
+            match verifier_client.game_info(game_address).await {
+                Ok(info) => {
+                    game.l2_block_number = Some(info.l2_block_number);
+                    info.l2_block_number
+                }
+                Err(e) => {
+                    debug!(
+                        game = %game_address,
+                        asr = %asr_address,
+                        error = %e,
+                        "failed to read game info for anchor preflight, will retry"
+                    );
+                    return AnchorUpdateOutcome::Retry;
+                }
             }
         };
 
@@ -388,7 +433,30 @@ mod tests {
 
         assert!(submitter.recorded_calls().is_empty());
         assert!(updater.tracked.contains_key(&game));
-        assert_eq!(updater.tracked[&game], None);
+        assert_eq!(updater.tracked[&game].retry_started_at, None);
+    }
+
+    #[tokio::test]
+    async fn poll_caches_anchor_metadata_while_waiting_for_finality() {
+        let game = addr(0);
+        let asr = Address::repeat_byte(0xAA);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = asr;
+        state.is_finalized = false;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(updater.tracked.contains_key(&game));
+        assert_eq!(verifier.status_read_count(game), 1);
+        assert_eq!(verifier.anchor_state_registry_read_count(game), 1);
+        assert_eq!(verifier.game_info_read_count(game), 0);
     }
 
     #[tokio::test]
@@ -444,7 +512,7 @@ mod tests {
 
         assert!(submitter.recorded_calls().is_empty());
         assert!(updater.tracked.contains_key(&game));
-        assert_eq!(updater.tracked[&game], None);
+        assert_eq!(updater.tracked[&game].retry_started_at, None);
     }
 
     #[tokio::test]
@@ -464,6 +532,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn poll_caches_game_l2_block_across_retries() {
+        let game = addr(0);
+        let asr = Address::repeat_byte(0xAA);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = asr;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![
+            Err(crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO }),
+            Err(crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO }),
+        ]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert_eq!(submitter.recorded_calls().len(), 2);
+        assert_eq!(verifier.game_info_read_count(game), 1);
+        assert!(updater.tracked.contains_key(&game));
+    }
+
+    #[tokio::test]
     async fn poll_drops_fully_nullified_game() {
         let game = addr(0);
         let state = mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100);
@@ -476,6 +568,22 @@ mod tests {
         updater.poll(&verifier, &submitter).await;
 
         assert!(submitter.recorded_calls().is_empty());
+        assert!(!updater.tracked.contains_key(&game));
+    }
+
+    #[tokio::test]
+    async fn poll_drops_after_retention_when_status_read_keeps_failing() {
+        let game = addr(0);
+        let verifier = MockAggregateVerifier::new(HashMap::new());
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), Duration::ZERO);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        assert!(updater.tracked.contains_key(&game));
+
+        updater.poll(&verifier, &submitter).await;
         assert!(!updater.tracked.contains_key(&game));
     }
 }

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -42,6 +42,8 @@ pub struct TrackedAnchorUpdate {
     pub l2_block_number: Option<u64>,
     /// Whether this updater already submitted `resolve()` for the game.
     pub resolve_submitted: bool,
+    /// Whether prover reads should wait until the dispute period has elapsed.
+    pub defer_prover_reads_until_game_over: bool,
 }
 
 impl<C: Clock> AnchorUpdater<C> {
@@ -53,13 +55,29 @@ impl<C: Clock> AnchorUpdater<C> {
 
     /// Registers a game for anchor root advancement.
     pub fn track_game(&mut self, game_address: Address) {
+        self.track_game_with_options(game_address, false);
+    }
+
+    /// Registers a valid in-progress game for anchor root advancement.
+    pub fn track_valid_game(&mut self, game_address: Address) {
+        self.track_game_with_options(game_address, true);
+    }
+
+    fn track_game_with_options(
+        &mut self,
+        game_address: Address,
+        defer_prover_reads_until_game_over: bool,
+    ) {
         let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
             debug!(game = %game_address, "game already tracked for anchor update");
             return;
         };
 
         info!(game = %game_address, "tracking game for anchor update");
-        entry.insert(TrackedAnchorUpdate::default());
+        entry.insert(TrackedAnchorUpdate {
+            defer_prover_reads_until_game_over,
+            ..TrackedAnchorUpdate::default()
+        });
         ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
     }
 
@@ -89,12 +107,12 @@ impl<C: Clock> AnchorUpdater<C> {
             let should_remove = match outcome {
                 AnchorUpdateOutcome::Complete => true,
                 AnchorUpdateOutcome::Pending => {
-                    if let Some(game) = self.tracked.get_mut(&game_address) {
-                        game.retry_started_at = None;
-                    }
+                    game.retry_started_at = None;
                     false
                 }
-                AnchorUpdateOutcome::Retry => self.handle_retry(game_address),
+                AnchorUpdateOutcome::Retry => {
+                    Self::handle_retry(&self.clock, self.retention, game_address, game)
+                }
             };
 
             if should_remove {
@@ -105,26 +123,27 @@ impl<C: Clock> AnchorUpdater<C> {
         ChallengerMetrics::anchor_update_tracked_games().set(self.tracked.len() as f64);
     }
 
-    fn handle_retry(&mut self, game_address: Address) -> bool {
-        let now = self.clock.now();
-        let Some(game) = self.tracked.get_mut(&game_address) else {
-            return false;
-        };
-
+    fn handle_retry(
+        clock: &C,
+        retention: Duration,
+        game_address: Address,
+        game: &mut TrackedAnchorUpdate,
+    ) -> bool {
+        let now = clock.now();
         let Some(retry_started_at) = game.retry_started_at else {
             game.retry_started_at = Some(now);
             return false;
         };
 
         let elapsed = now.saturating_sub(retry_started_at);
-        if elapsed < self.retention {
+        if elapsed < retention {
             return false;
         }
 
         warn!(
             game = %game_address,
             retained_secs = elapsed.as_secs(),
-            retention_secs = self.retention.as_secs(),
+            retention_secs = retention.as_secs(),
             "dropping anchor update after retention timeout"
         );
         true
@@ -163,6 +182,28 @@ impl<C: Clock> AnchorUpdater<C> {
                 return AnchorUpdateOutcome::Pending;
             }
 
+            let mut game_over = None;
+            if game.defer_prover_reads_until_game_over {
+                let is_game_over = match verifier_client.game_over(game_address).await {
+                    Ok(game_over) => game_over,
+                    Err(e) => {
+                        debug!(
+                            game = %game_address,
+                            error = %e,
+                            "failed to read gameOver for anchor update, will retry"
+                        );
+                        return AnchorUpdateOutcome::Retry;
+                    }
+                };
+
+                if !is_game_over {
+                    return AnchorUpdateOutcome::Pending;
+                }
+
+                game.defer_prover_reads_until_game_over = false;
+                game_over = Some(is_game_over);
+            }
+
             let (zk_prover, tee_prover, countered_index) = match tokio::try_join!(
                 verifier_client.zk_prover(game_address),
                 verifier_client.tee_prover(game_address),
@@ -197,16 +238,19 @@ impl<C: Clock> AnchorUpdater<C> {
                 return AnchorUpdateOutcome::Pending;
             }
 
-            let game_over = match verifier_client.game_over(game_address).await {
-                Ok(game_over) => game_over,
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read gameOver for anchor update, will retry"
-                    );
-                    return AnchorUpdateOutcome::Retry;
-                }
+            let game_over = match game_over {
+                Some(game_over) => game_over,
+                None => match verifier_client.game_over(game_address).await {
+                    Ok(game_over) => game_over,
+                    Err(e) => {
+                        debug!(
+                            game = %game_address,
+                            error = %e,
+                            "failed to read gameOver for anchor update, will retry"
+                        );
+                        return AnchorUpdateOutcome::Retry;
+                    }
+                },
             };
 
             if !game_over {
@@ -583,6 +627,26 @@ mod tests {
         assert!(submitter.recorded_calls().is_empty());
         assert!(updater.tracked.contains_key(&game));
         assert_eq!(updater.tracked[&game].retry_started_at, None);
+    }
+
+    #[tokio::test]
+    async fn poll_does_not_read_prover_state_before_game_over() {
+        let game = addr(0);
+        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_valid_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert_eq!(verifier.game_over_reads.lock().unwrap().as_slice(), &[game]);
+        assert!(verifier.zk_prover_reads.lock().unwrap().is_empty());
+        assert!(verifier.tee_prover_reads.lock().unwrap().is_empty());
+        assert!(verifier.countered_index_reads.lock().unwrap().is_empty());
+        assert!(submitter.recorded_calls().is_empty());
+        assert!(updater.tracked.contains_key(&game));
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -40,6 +40,8 @@ pub struct TrackedAnchorUpdate {
     pub asr_address: Option<Address>,
     /// Cached immutable game L2 block number.
     pub l2_block_number: Option<u64>,
+    /// Whether this updater already submitted `resolve()` for the game.
+    pub resolve_submitted: bool,
 }
 
 impl<C: Clock> AnchorUpdater<C> {
@@ -156,6 +158,11 @@ impl<C: Clock> AnchorUpdater<C> {
         };
 
         if status == GameStatus::InProgress {
+            if game.resolve_submitted {
+                debug!(game = %game_address, "waiting for submitted resolve transaction to be reflected");
+                return AnchorUpdateOutcome::Pending;
+            }
+
             let (zk_prover, tee_prover, countered_index) = match tokio::try_join!(
                 verifier_client.zk_prover(game_address),
                 verifier_client.tee_prover(game_address),
@@ -217,6 +224,7 @@ impl<C: Clock> AnchorUpdater<C> {
                     );
                     ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                         .increment(1);
+                    game.resolve_submitted = true;
                     return AnchorUpdateOutcome::Pending;
                 }
                 Err(e) => {
@@ -536,6 +544,27 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[1].1, asr);
         assert!(updater.tracked.is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_does_not_resubmit_resolve_while_status_lags() {
+        let game = addr(0);
+        let resolve_tx_hash = B256::repeat_byte(0xCC);
+        let mut state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        state.game_over = true;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(resolve_tx_hash)]);
+
+        let mut updater = AnchorUpdater::new(TokioRuntime::new(), DEFAULT_RETENTION);
+        updater.track_game(game);
+
+        updater.poll(&verifier, &submitter).await;
+        updater.poll(&verifier, &submitter).await;
+
+        assert_eq!(submitter.recorded_calls().len(), 1);
+        assert!(updater.tracked.contains_key(&game));
+        assert!(updater.tracked[&game].resolve_submitted);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -424,7 +424,7 @@ impl<C: Clock> BondManager<C> {
     }
 
     async fn try_resolve<T: TxManager>(
-        &mut self,
+        &self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
@@ -530,7 +530,7 @@ impl<C: Clock> BondManager<C> {
     }
 
     async fn try_withdraw<T: TxManager>(
-        &mut self,
+        &self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1,32 +1,8 @@
-//! Bond lifecycle management.
-//!
-//! The [`BondManager`] tracks dispute games through a multi-phase credit
-//! claim lifecycle:
-//!
-//! 1. **[`NeedsResolve`](BondPhase::NeedsResolve)** — wait for the game's
-//!    dispute period to expire, then call `resolve()`.
-//! 2. **[`NeedsUnlock`](BondPhase::NeedsUnlock)** — call `claimCredit()`
-//!    to trigger `DelayedWETH.unlock()`.
-//! 3. **[`AwaitingDelay`](BondPhase::AwaitingDelay)** — wait for the
-//!    `DelayedWETH` delay to elapse.
-//! 4. **[`NeedsWithdraw`](BondPhase::NeedsWithdraw)** — call `claimCredit()`
-//!    again to complete the withdrawal.
-//!
-//! A comma-separated list of addresses is provided via the
-//! `BASE_CHALLENGER_BOND_CLAIM_ADDRESSES` env var. The manager tracks any
-//! game whose onchain `bondRecipient` matches one of those addresses,
-//! regardless of the game's resolution outcome (`CHALLENGER_WINS` or
-//! `DEFENDER_WINS`). This allows claiming bonds both for games won by the
-//! challenger and games proposed by addresses in the claim set.
-//!
-//! During startup recovery, `zkProver` is also checked against the claim
-//! addresses to recover pre-resolve challenged games, since `bondRecipient`
-//! is only updated to the challenger's address during `resolve()`. For
-//! already-resolved games matched solely via `zkProver`, the onchain
-//! `bondRecipient` is re-verified against the claim set before tracking.
+//! Bond lifecycle management for resolving, unlocking, and withdrawing
+//! dispute-game credits.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     sync::Arc,
     time::Duration,
 };
@@ -37,23 +13,15 @@ use base_proof_contracts::{
     DisputeGameFactoryClient, GameStatus, encode_claim_credit_calldata, encode_resolve_calldata,
 };
 use base_runtime::Clock;
+use base_tx_manager::TxManager;
 use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
-use crate::{ChallengerMetrics, GameScanner};
-
-/// Reason a game was removed from tracking after `BondManager::advance_game`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RemovalReason {
-    /// Bond was successfully claimed — the full lifecycle completed.
-    Completed,
-    /// Bond is not claimable by us (recipient changed after resolve).
-    NotClaimable,
-}
+use crate::{ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics, GameScanner};
 
 /// Phase of the bond claim lifecycle for a single tracked game.
-#[derive(Debug, Clone)]
-pub enum BondPhase {
+#[derive(Debug)]
+enum BondPhase {
     /// The game's dispute period is over; needs a `resolve()` call.
     NeedsResolve,
     /// The game has been resolved; needs the first `claimCredit()` call
@@ -62,82 +30,32 @@ pub enum BondPhase {
     /// The unlock has been submitted; waiting for the `DelayedWETH` delay
     /// to elapse before the second `claimCredit()` call.
     AwaitingDelay {
-        /// Monotonic timestamp at which the unlock occurred.
-        unlocked_at: Duration,
-        /// Unix timestamp used when recovering an already-unlocked bond.
-        unlocked_at_unix_secs: Option<u64>,
+        /// Monotonic timestamp at which withdrawal should be retried.
+        ready_at: Duration,
     },
-    /// The delay has elapsed; needs the second `claimCredit()` call to
-    /// complete the withdrawal.
-    NeedsWithdraw,
-    /// Bond fully claimed. The entry will be removed from tracking.
-    Completed,
 }
 
-/// A game being tracked for bond lifecycle management.
-#[derive(Debug, Clone)]
-pub struct TrackedGame {
-    /// Current lifecycle phase.
-    pub phase: BondPhase,
-    /// The address that will receive the bond.
-    pub bond_recipient: Address,
-}
-
-impl TrackedGame {
-    /// Creates a freshly-tracked game in the given phase.
-    pub const fn new(phase: BondPhase, bond_recipient: Address) -> Self {
-        Self { phase, bond_recipient }
-    }
-}
-
-/// Manages the bond claim lifecycle for dispute games.
-///
-/// After a successful `challenge()` submission, games are registered here.
-/// On each [`poll`](Self::poll) tick the manager checks each tracked game's
-/// onchain state and submits the next transaction in the lifecycle.
-///
-/// When bond claim addresses are configured, the manager also continuously
-/// discovers claimable games via [`discover_claimable_games`](Self::discover_claimable_games),
-/// scanning both newly created games and periodically rescanning the
-/// lookback window to catch games challenged or resolved by other actors.
-#[derive(derive_more::Debug)]
+/// Manages bond claiming for dispute games.
 pub struct BondManager<C: Clock> {
-    /// Games being tracked, keyed by proxy address.
-    tracked: HashMap<Address, TrackedGame>,
-    /// Addresses we are authorized to claim bonds on behalf of.
+    tracked: HashMap<Address, BondPhase>,
     claim_addresses: HashSet<Address>,
-    /// `DelayedWETH` withdrawal delay (read from contract at init or lazily
-    /// resolved on the first poll tick that has a tracked game).
     weth_delay: Option<Duration>,
-    /// L1 RPC URL used to instantiate the `DelayedWETH` contract client
-    /// when lazily resolving the withdrawal delay.
     l1_rpc_url: url::Url,
-    /// Injectable clock providing monotonic time. In production this is
-    /// backed by [`TokioRuntime`](base_runtime::TokioRuntime); tests can
-    /// substitute a deterministic clock.
-    #[debug(skip)]
     clock: C,
-    /// Factory client for querying game indices during bond discovery.
-    #[debug(skip)]
     factory_client: Arc<dyn DisputeGameFactoryClient>,
-    /// Highest game index scanned for bond discovery. Incremental scans
-    /// start from this index; periodic full rescans reset it backward.
     bond_scan_head: u64,
-    /// Monotonic timestamp of the last full rescan completion.
     last_full_scan: Duration,
-    /// Number of games to look back during periodic full rescans.
     lookback: u64,
-    /// How often a full rescan of the lookback window is performed to catch
-    /// state transitions (games challenged or resolved by other actors).
     discovery_interval: Duration,
 }
 
-impl<C: Clock> BondManager<C> {
-    /// Conservative fallback when the onchain `DelayedWETH` delay has not
-    /// been read yet. If the real delay is shorter the withdraw will simply
-    /// succeed earlier; if longer, the attempt reverts and is retried.
-    const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+impl<C: Clock> std::fmt::Debug for BondManager<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BondManager").finish_non_exhaustive()
+    }
+}
 
+impl<C: Clock> BondManager<C> {
     /// How long to wait before retrying a reverted withdraw attempt.
     const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
 
@@ -167,29 +85,6 @@ impl<C: Clock> BondManager<C> {
         }
     }
 
-    /// Returns `true` if bond claiming is enabled (at least one claim address configured).
-    pub fn is_enabled(&self) -> bool {
-        !self.claim_addresses.is_empty()
-    }
-
-    /// Sets the `DelayedWETH` withdrawal delay.
-    pub fn set_weth_delay(&mut self, delay: Duration) {
-        info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
-        self.weth_delay = Some(delay);
-    }
-
-    /// Returns the effective `DelayedWETH` withdrawal delay for a game, falling
-    /// back to `Self::DEFAULT_WETH_DELAY` when the onchain delay has not yet
-    /// been read. Both the `check_delay` and `submit_claim_credit`
-    /// retry-backoff paths must agree on this value, so the fallback is
-    /// centralized here.
-    pub fn effective_weth_delay(&self, game_address: Address) -> Duration {
-        self.weth_delay.unwrap_or_else(|| {
-            debug!(game = %game_address, "WETH delay not yet known, using default 7 days");
-            Self::DEFAULT_WETH_DELAY
-        })
-    }
-
     /// Returns the number of games currently being tracked.
     pub fn tracked_count(&self) -> usize {
         self.tracked.len()
@@ -209,50 +104,27 @@ impl<C: Clock> BondManager<C> {
             return false;
         }
 
-        if self.tracked.contains_key(&game_address) {
+        let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
             debug!(game = %game_address, "game already tracked for bond claiming");
             return false;
-        }
+        };
 
         info!(
             game = %game_address,
             recipient = %bond_recipient,
             "tracking game for bond claiming"
         );
-        self.tracked
-            .insert(game_address, TrackedGame::new(BondPhase::NeedsResolve, bond_recipient));
+        entry.insert(BondPhase::NeedsResolve);
         ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         true
     }
 
-    /// Returns `true` if the given game is being tracked.
-    pub fn is_tracking(&self, game_address: &Address) -> bool {
-        self.tracked.contains_key(game_address)
-    }
-
-    /// Updates the phase of a tracked game. No-op if the game is not tracked.
-    fn set_phase(&mut self, game_address: Address, phase: BondPhase) {
-        if let Some(game) = self.tracked.get_mut(&game_address) {
-            game.phase = phase;
-        }
-    }
-
-    /// Evaluates a single game for bond tracking eligibility.
-    ///
-    /// Fetches the game's `bondRecipient` and `zkProver`, matches them
-    /// against `claim_addresses`, determines the onchain lifecycle phase,
-    /// and returns the game address, matched address, and phase if the game
-    /// is eligible for tracking. Returns `None` when the game is not
-    /// relevant, already claimed, or an RPC error occurs.
     async fn evaluate_game_for_bonds(
+        &self,
         index: u64,
-        factory_client: &dyn DisputeGameFactoryClient,
         verifier_client: &dyn AggregateVerifierClient,
-        claim_addresses: &HashSet<Address>,
-        clock: &C,
-        weth_delay: Option<Duration>,
-    ) -> Option<(Address, Address, Option<BondPhase>)> {
-        let game_at = match factory_client.game_at_index(index).await {
+    ) -> Option<(Address, BondPhase)> {
+        let game_at = match self.factory_client.game_at_index(index).await {
             Ok(g) => g,
             Err(e) => {
                 warn!(index, error = %e, "failed to fetch game at index");
@@ -285,47 +157,40 @@ impl<C: Clock> BondManager<C> {
             }
         };
 
-        // Check both `bondRecipient` and `zkProver` against the claim
-        // addresses. Before `resolve()`, `bondRecipient` is the game
-        // creator while `zkProver` is the address that called
-        // `challenge()`. After `resolve()`, `bondRecipient` is updated
-        // to the `zkProver`. Checking both ensures we recover pre-resolve
-        // challenged games.
-        let matched_address = if claim_addresses.contains(&bond_recipient) {
-            bond_recipient
-        } else if zk_prover != Address::ZERO && claim_addresses.contains(&zk_prover) {
-            zk_prover
-        } else {
+        if !self.claim_addresses.contains(&bond_recipient)
+            && (zk_prover == Address::ZERO || !self.claim_addresses.contains(&zk_prover))
+        {
             return None;
+        }
+
+        let phase = match Self::determine_phase(
+            verifier_client,
+            game_address,
+            &self.clock,
+            self.weth_delay,
+        )
+        .await
+        {
+            Ok(Some(phase)) => phase,
+            Ok(None) => return None,
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    "failed to determine bond phase"
+                );
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_PHASE_READ,
+                )
+                .increment(1);
+                return None;
+            }
         };
 
-        let phase =
-            match Self::determine_phase(verifier_client, game_address, clock, weth_delay).await {
-                Ok(phase) => phase,
-                Err(e) => {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to determine bond phase"
-                    );
-                    ChallengerMetrics::bond_evaluation_errors_total(
-                        ChallengerMetrics::EVAL_ERROR_PHASE_READ,
-                    )
-                    .increment(1);
-                    return None;
-                }
-            };
-
-        // For already-resolved games, verify the current onchain
-        // `bondRecipient` is in our claim addresses. Games matched via
-        // `zkProver` may have a `bondRecipient` that is not in our
-        // claim set (e.g. a game where our challenge was nullified and
-        // the bond goes to the game creator). Pre-resolve games are
-        // kept — `bondRecipient` will be re-verified after resolve in
-        // `try_resolve`.
-        if let Some(ref p) = phase
-            && !matches!(p, BondPhase::NeedsResolve)
-            && !claim_addresses.contains(&bond_recipient)
+        // Pre-resolve games can match only by zkProver; resolved games must
+        // have already moved bondRecipient into our claim set.
+        if !matches!(phase, BondPhase::NeedsResolve)
+            && !self.claim_addresses.contains(&bond_recipient)
         {
             debug!(
                 game = %game_address,
@@ -336,56 +201,50 @@ impl<C: Clock> BondManager<C> {
             return None;
         }
 
-        Some((game_address, matched_address, phase))
+        Some((game_address, phase))
     }
 
-    /// Evaluates all games in `range` concurrently for bond tracking
-    /// eligibility, returning one entry per evaluated game.
-    async fn evaluate_bond_range(
+    async fn track_bond_range(
+        &mut self,
         range: std::ops::Range<u64>,
-        factory_client: &dyn DisputeGameFactoryClient,
         verifier_client: &dyn AggregateVerifierClient,
-        claim_addresses: &HashSet<Address>,
-        clock: &C,
-        weth_delay: Option<Duration>,
-    ) -> Vec<Option<(Address, Address, Option<BondPhase>)>> {
-        stream::iter(range)
-            .map(|i| async move {
-                Self::evaluate_game_for_bonds(
-                    i,
-                    factory_client,
-                    verifier_client,
-                    claim_addresses,
-                    clock,
-                    weth_delay,
-                )
+        scan_type: &'static str,
+    ) -> Vec<Address> {
+        let results: Vec<_> = {
+            let manager = &*self;
+            stream::iter(range)
+                .map(|i| manager.evaluate_game_for_bonds(i, verifier_client))
+                .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
+                .filter_map(std::future::ready)
+                .collect()
                 .await
-            })
-            .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
-            .collect()
-            .await
+        };
+        let mut tracked_games = Vec::new();
+
+        for (game_address, phase) in results {
+            let Entry::Vacant(entry) = self.tracked.entry(game_address) else {
+                continue;
+            };
+
+            info!(
+                game = %game_address,
+                phase = ?phase,
+                scan_type,
+                "tracked claimable game"
+            );
+            entry.insert(phase);
+            tracked_games.push(game_address);
+        }
+
+        tracked_games
     }
 
-    /// Scans recent games at startup to recover bond tracking state after a
-    /// restart.
-    ///
-    /// Iterates the last `lookback` games from the factory concurrently and
-    /// checks if any have a `bondRecipient` or `zkProver` matching our claim
-    /// addresses. The `zkProver` check is necessary because before
-    /// `resolve()`, `bondRecipient` is the game creator — only after
-    /// resolution does it update to the challenger's address. Games that are
-    /// already fully claimed are skipped.
-    ///
-    /// Also reads the `DelayedWETH` delay from the first game found, if the
-    /// delay has not been set yet. Sets the bond discovery watermark to the
-    /// current `game_count` so that subsequent
-    /// [`discover_claimable_games`](Self::discover_claimable_games) calls
-    /// start scanning from where startup left off.
+    /// Scans recent games at startup to recover bond tracking state.
     pub async fn startup_scan(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
     ) -> eyre::Result<Vec<Address>> {
-        if !self.is_enabled() {
+        if self.claim_addresses.is_empty() {
             return Ok(Vec::new());
         }
 
@@ -398,39 +257,8 @@ impl<C: Clock> BondManager<C> {
         let start_index = game_count.saturating_sub(self.lookback);
         info!(start = start_index, end = game_count, "scanning recent games for bond recovery");
 
-        self.ensure_weth_delay_from_index(verifier_client, start_index).await;
-
-        let results = Self::evaluate_bond_range(
-            start_index..game_count,
-            &*self.factory_client,
-            verifier_client,
-            &self.claim_addresses,
-            &self.clock,
-            self.weth_delay,
-        )
-        .await;
-
-        // Resolve the WETH delay from the first available game so the
-        // delay is bootstrapped as early as possible.
-        if let Some((game_address, _, _)) = results.iter().flatten().next() {
-            self.ensure_weth_delay(verifier_client, *game_address).await;
-        }
-
-        let mut recovered_games = Vec::new();
-        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
-            let Some(phase) = phase else {
-                continue;
-            };
-
-            info!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                phase = ?phase,
-                "recovered game for bond tracking"
-            );
-            self.tracked.insert(game_address, TrackedGame::new(phase, bond_recipient));
-            recovered_games.push(game_address);
-        }
+        let recovered_games =
+            self.track_bond_range(start_index..game_count, verifier_client, "startup").await;
 
         self.bond_scan_head = game_count;
         self.last_full_scan = self.clock.now();
@@ -440,22 +268,12 @@ impl<C: Clock> BondManager<C> {
         Ok(recovered_games)
     }
 
-    /// Discovers claimable games via two-tier scanning.
-    ///
-    /// **Incremental** (every call): scans from `bond_scan_head` to
-    /// `game_count`, catching newly created games. Typically zero to a
-    /// handful of games per tick, costing a single `game_count()` RPC
-    /// when idle.
-    ///
-    /// **Periodic full rescan** (every `discovery_interval`):
-    /// resets the watermark backward by `lookback` to re-evaluate games
-    /// whose state may have changed (e.g. challenged or resolved by
-    /// another actor since the last scan).
+    /// Discovers claimable games via incremental and periodic lookback scans.
     pub async fn discover_claimable_games(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
     ) -> eyre::Result<Vec<Address>> {
-        if !self.is_enabled() {
+        if self.claim_addresses.is_empty() {
             warn!("bond manager is disabled, skipping discovery scan");
             return Ok(Vec::new());
         }
@@ -466,8 +284,6 @@ impl<C: Clock> BondManager<C> {
             return Ok(Vec::new());
         }
 
-        // Periodic full rescan: reset watermark to re-evaluate the
-        // lookback window and catch state transitions on older games.
         let elapsed = self.clock.now().saturating_sub(self.last_full_scan);
         let is_full_rescan = elapsed >= self.discovery_interval;
         if is_full_rescan {
@@ -512,39 +328,8 @@ impl<C: Clock> BondManager<C> {
 
         ChallengerMetrics::bond_discovery_scans_total(scan_type).increment(1);
 
-        self.ensure_weth_delay_from_index(verifier_client, scan_start).await;
-
-        let results = Self::evaluate_bond_range(
-            scan_start..scan_end,
-            &*self.factory_client,
-            verifier_client,
-            &self.claim_addresses,
-            &self.clock,
-            self.weth_delay,
-        )
-        .await;
-
-        let mut discovered_games = Vec::new();
-
-        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
-            if self.tracked.contains_key(&game_address) {
-                continue;
-            }
-
-            let Some(phase) = phase else {
-                continue;
-            };
-
-            info!(
-                game = %game_address,
-                recipient = %bond_recipient,
-                phase = ?phase,
-                scan_type,
-                "discovered claimable game"
-            );
-            self.tracked.insert(game_address, TrackedGame::new(phase, bond_recipient));
-            discovered_games.push(game_address);
-        }
+        let discovered_games =
+            self.track_bond_range(scan_start..scan_end, verifier_client, scan_type).await;
 
         self.bond_scan_head = scan_end;
 
@@ -563,114 +348,94 @@ impl<C: Clock> BondManager<C> {
     }
 
     /// Polls all tracked games and advances each through the bond lifecycle.
-    ///
-    /// Called once per driver tick. Errors on individual games are logged and
-    /// do not abort processing of remaining games.
-    pub async fn poll(
+    pub async fn poll<T: TxManager>(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
+        submitter: &ChallengeSubmitter<T>,
     ) {
         if self.tracked.is_empty() {
             return;
         }
 
-        // Lazily resolve the DelayedWETH delay if not yet known.
-        if self.weth_delay.is_none()
-            && let Some(&game_address) = self.tracked.keys().next()
-        {
-            self.ensure_weth_delay(verifier_client, game_address).await;
-        }
+        let tracked = std::mem::take(&mut self.tracked);
+        let tracked_count = tracked.len();
 
-        let addresses: Vec<Address> = self.tracked.keys().copied().collect();
-        let mut removed = Vec::new();
-
-        for game_address in addresses {
-            match self.advance_game(game_address, verifier_client, submitter).await {
-                Ok(Some(reason)) => {
-                    removed.push((game_address, reason));
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to advance bond lifecycle"
-                    );
-                }
+        for (game_address, phase) in tracked {
+            if let Some(next_phase) =
+                self.advance_game(game_address, phase, verifier_client, submitter).await
+            {
+                self.tracked.insert(game_address, next_phase);
             }
         }
 
-        for (addr, reason) in &removed {
-            self.tracked.remove(addr);
-            match reason {
-                RemovalReason::Completed => {
-                    ChallengerMetrics::bonds_completed_total().increment(1);
-                }
-                RemovalReason::NotClaimable => {
-                    ChallengerMetrics::bonds_not_claimable_total().increment(1);
-                }
-            }
-        }
-
-        if !removed.is_empty() {
+        if self.tracked.len() != tracked_count {
             ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         }
     }
 
-    /// Advances a single game through the bond lifecycle state machine.
-    ///
-    /// Returns `Ok(Some(reason))` when the game should be removed from
-    /// tracking, or `Ok(None)` when it remains in its current or updated
-    /// phase.
-    async fn advance_game(
+    async fn advance_game<T: TxManager>(
         &mut self,
         game_address: Address,
+        phase: BondPhase,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
-        let game = match self.tracked.get(&game_address) {
-            Some(g) => g,
-            None => return Ok(None),
+        submitter: &ChallengeSubmitter<T>,
+    ) -> Option<BondPhase> {
+        let (result, retry_phase) = match phase {
+            BondPhase::NeedsResolve => (
+                self.try_resolve(game_address, verifier_client, submitter).await,
+                BondPhase::NeedsResolve,
+            ),
+            BondPhase::NeedsUnlock => (
+                self.try_unlock(game_address, verifier_client, submitter).await,
+                BondPhase::NeedsUnlock,
+            ),
+            BondPhase::AwaitingDelay { ready_at } => {
+                let now = self.clock.now();
+                if now < ready_at {
+                    let remaining = ready_at.saturating_sub(now);
+                    debug!(
+                        game = %game_address,
+                        remaining_secs = remaining.as_secs(),
+                        "waiting for DelayedWETH delay"
+                    );
+                    return Some(BondPhase::AwaitingDelay { ready_at });
+                }
+
+                info!(
+                    game = %game_address,
+                    ready_at_secs = ready_at.as_secs(),
+                    "DelayedWETH delay elapsed, submitting withdraw"
+                );
+                (
+                    self.try_withdraw(game_address, verifier_client, submitter).await,
+                    BondPhase::AwaitingDelay { ready_at: now },
+                )
+            }
         };
 
-        match &game.phase {
-            BondPhase::NeedsResolve => {
-                self.try_resolve(game_address, verifier_client, submitter).await
-            }
-            BondPhase::NeedsUnlock => {
-                self.try_unlock(game_address, verifier_client, submitter).await
-            }
-            BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs } => {
-                self.check_delay(game_address, *unlocked_at, *unlocked_at_unix_secs)
-            }
-            BondPhase::NeedsWithdraw => {
-                self.try_withdraw(game_address, verifier_client, submitter).await
-            }
-            BondPhase::Completed => Ok(Some(RemovalReason::Completed)),
-        }
+        result.unwrap_or_else(|e| {
+            warn!(
+                game = %game_address,
+                error = %e,
+                "failed to advance bond lifecycle"
+            );
+            Some(retry_phase)
+        })
     }
 
-    /// Attempts to resolve the game by calling `resolve()`.
-    ///
-    /// After resolution (either by us or by another actor), re-reads the
-    /// onchain `bondRecipient` to verify it is still in our claim
-    /// addresses. `resolve()` may update `bondRecipient` (e.g. to the
-    /// challenger's address on `CHALLENGER_WINS`), so games matched via
-    /// `zkProver` before resolution may no longer be claimable by us.
-    async fn try_resolve(
+    async fn try_resolve<T: TxManager>(
         &mut self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<Option<BondPhase>> {
         let status = verifier_client.status(game_address).await?;
 
         if status == GameStatus::InProgress {
             let game_over = verifier_client.game_over(game_address).await?;
             if !game_over {
                 debug!(game = %game_address, "game dispute period not yet elapsed");
-                return Ok(None);
+                return Ok(Some(BondPhase::NeedsResolve));
             }
 
             let calldata = encode_resolve_calldata();
@@ -693,7 +458,7 @@ impl<C: Clock> BondManager<C> {
                     );
                     ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                         .increment(1);
-                    return Ok(None);
+                    return Ok(Some(BondPhase::NeedsResolve));
                 }
             }
         } else {
@@ -702,177 +467,121 @@ impl<C: Clock> BondManager<C> {
             info!(game = %game_address, status = ?status, "game already resolved");
         }
 
-        // Re-read the onchain bondRecipient — resolve may have changed it
-        // (e.g. to the challenger on CHALLENGER_WINS). If it is no longer
-        // in our claim set, stop tracking this game.
-        if !self.is_bond_claimable(verifier_client, game_address).await? {
-            return Ok(Some(RemovalReason::NotClaimable));
-        }
-
-        self.set_phase(game_address, BondPhase::NeedsUnlock);
-        Ok(None)
-    }
-
-    /// Checks whether the onchain `bondRecipient` for the given game is in
-    /// our claim addresses. Also updates the tracked game's
-    /// `bond_recipient` field to reflect the current onchain value (which
-    /// may differ from the pre-resolve value). Returns `false` if the
-    /// recipient is not in the claim set, signalling the caller to remove
-    /// the game from tracking.
-    async fn is_bond_claimable(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-        game_address: Address,
-    ) -> eyre::Result<bool> {
         let bond_recipient = verifier_client.bond_recipient(game_address).await?;
-
-        // Update the tracked entry so logging and debugging reflect the
-        // current onchain recipient, not the stale pre-resolve value.
-        if let Some(game) = self.tracked.get_mut(&game_address) {
-            game.bond_recipient = bond_recipient;
+        if !self.claim_addresses.contains(&bond_recipient) {
+            info!(
+                game = %game_address,
+                recipient = %bond_recipient,
+                "bond recipient not in claim addresses after resolve, removing from tracking"
+            );
+            ChallengerMetrics::bonds_not_claimable_total().increment(1);
+            return Ok(None);
         }
 
-        if self.claim_addresses.contains(&bond_recipient) {
-            return Ok(true);
-        }
-        info!(
-            game = %game_address,
-            recipient = %bond_recipient,
-            "bond recipient not in claim addresses after resolve, removing from tracking"
-        );
-        Ok(false)
+        Ok(Some(BondPhase::NeedsUnlock))
     }
 
-    /// Attempts the first `claimCredit()` call to trigger the unlock.
-    async fn try_unlock(
+    async fn try_unlock<T: TxManager>(
         &mut self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<Option<BondPhase>> {
         let (unlocked, resolved_at) = futures::try_join!(
             verifier_client.bond_unlocked(game_address),
             verifier_client.resolved_at(game_address),
         )?;
         if unlocked {
-            if self.delay_elapsed_since_unix(game_address, resolved_at) {
-                info!(
-                    game = %game_address,
-                    resolved_at,
-                    "bond already unlocked and delay elapsed, advancing to withdraw phase"
-                );
-                self.set_phase(game_address, BondPhase::NeedsWithdraw);
-                return Ok(None);
+            self.ensure_weth_delay(verifier_client, game_address).await;
+            let Some(delay) = self.weth_delay else {
+                debug!(game = %game_address, "WETH delay not yet known, waiting to advance unlock");
+                return Ok(Some(BondPhase::NeedsUnlock));
+            };
+
+            let phase = Self::unlocked_phase(&self.clock, resolved_at, delay);
+            info!(game = %game_address, resolved_at, phase = ?phase, "bond already unlocked");
+            return Ok(Some(phase));
+        }
+
+        match Self::send_claim_credit(game_address, "unlock", submitter).await {
+            Ok(_) => {
+                let Some(delay) = self.weth_delay else {
+                    return Ok(Some(BondPhase::NeedsUnlock));
+                };
+                Ok(Some(BondPhase::AwaitingDelay {
+                    ready_at: self.clock.now().saturating_add(delay),
+                }))
             }
-
-            let unlocked_at = Self::estimate_unlock_time(&self.clock, resolved_at);
-            info!(
-                game = %game_address,
-                resolved_at,
-                "bond already unlocked, advancing to delay phase"
-            );
-            self.set_phase(
-                game_address,
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: Some(resolved_at) },
-            );
-            return Ok(None);
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    step = "unlock",
+                    retry = "immediate",
+                    "claimCredit transaction failed, will retry"
+                );
+                Ok(Some(BondPhase::NeedsUnlock))
+            }
         }
-
-        self.submit_claim_credit(
-            game_address,
-            submitter,
-            "unlock",
-            BondPhase::AwaitingDelay { unlocked_at: self.clock.now(), unlocked_at_unix_secs: None },
-            None,
-        )
-        .await
     }
 
-    /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
-    fn check_delay(
-        &mut self,
-        game_address: Address,
-        unlocked_at: Duration,
-        unlocked_at_unix_secs: Option<u64>,
-    ) -> eyre::Result<Option<RemovalReason>> {
-        // Fall back to 7 days if the onchain delay has not been read yet.
-        // If the real delay is shorter, the withdraw attempt will simply
-        // succeed earlier than expected. If longer, the attempt will revert
-        // and be retried after a short backoff.
-        let delay = self.effective_weth_delay(game_address);
-
-        let elapsed = unlocked_at_unix_secs.map_or_else(
-            || self.clock.now().saturating_sub(unlocked_at),
-            |unix_secs| {
-                Duration::from_secs(self.clock.wall_clock_unix_secs().saturating_sub(unix_secs))
-            },
-        );
-
-        if elapsed >= delay {
-            info!(
-                game = %game_address,
-                elapsed_secs = elapsed.as_secs(),
-                "DelayedWETH delay elapsed, advancing to withdraw phase"
-            );
-            self.set_phase(game_address, BondPhase::NeedsWithdraw);
-        } else {
-            let remaining = delay.saturating_sub(elapsed);
-            debug!(
-                game = %game_address,
-                remaining_secs = remaining.as_secs(),
-                "waiting for DelayedWETH delay"
-            );
-        }
-        Ok(None)
-    }
-
-    /// Returns whether the effective WETH delay has elapsed since a Unix timestamp.
-    fn delay_elapsed_since_unix(&self, game_address: Address, unix_secs: u64) -> bool {
-        let delay = self.effective_weth_delay(game_address);
-        let elapsed =
-            Duration::from_secs(self.clock.wall_clock_unix_secs().saturating_sub(unix_secs));
-        elapsed >= delay
-    }
-
-    /// Attempts the second `claimCredit()` call to complete the withdrawal.
-    async fn try_withdraw(
+    async fn try_withdraw<T: TxManager>(
         &mut self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<Option<BondPhase>> {
         let claimed = verifier_client.bond_claimed(game_address).await?;
         if claimed {
             info!(game = %game_address, "bond already claimed");
-            return Ok(Some(RemovalReason::Completed));
+            ChallengerMetrics::bonds_completed_total().increment(1);
+            return Ok(None);
         }
 
-        self.submit_claim_credit(
-            game_address,
-            submitter,
-            "withdraw",
-            BondPhase::Completed,
-            Some(Self::WITHDRAW_REVERT_RETRY_DELAY),
-        )
-        .await
+        match Self::send_claim_credit(game_address, "withdraw", submitter).await {
+            Ok(_) => {
+                ChallengerMetrics::bonds_completed_total().increment(1);
+                Ok(None)
+            }
+            Err(e) => {
+                let retry_delay = if matches!(&e, crate::ChallengeSubmitError::TxReverted { .. }) {
+                    Self::WITHDRAW_REVERT_RETRY_DELAY
+                } else {
+                    Duration::ZERO
+                };
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    step = "withdraw",
+                    retry_delay_secs = retry_delay.as_secs(),
+                    "claimCredit transaction failed, will retry"
+                );
+                Ok(Some(BondPhase::AwaitingDelay {
+                    ready_at: self.clock.now().saturating_add(retry_delay),
+                }))
+            }
+        }
     }
 
-    /// Submits a `claimCredit()` transaction and transitions to the given
-    /// phase on success. If `revert_retry_delay` is set, a reverted
-    /// transaction backs off by that duration before retrying. Returns
-    /// `Ok(Some(Completed))` when the success phase is [`BondPhase::Completed`].
-    async fn submit_claim_credit(
-        &mut self,
+    fn unlocked_phase(clock: &C, resolved_at: u64, delay: Duration) -> BondPhase {
+        let elapsed_since_resolve =
+            Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(resolved_at));
+        BondPhase::AwaitingDelay {
+            ready_at: clock.now().saturating_add(delay.saturating_sub(elapsed_since_resolve)),
+        }
+    }
+
+    async fn send_claim_credit<T: TxManager>(
         game_address: Address,
-        submitter: &dyn BondTransactionSubmitter,
-        step: &str,
-        success_phase: BondPhase,
-        revert_retry_delay: Option<Duration>,
-    ) -> eyre::Result<Option<RemovalReason>> {
+        step: &'static str,
+        submitter: &ChallengeSubmitter<T>,
+    ) -> Result<(), ChallengeSubmitError> {
         let calldata = encode_claim_credit_calldata();
         ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
         info!(game = %game_address, step, "submitting claimCredit transaction");
-        match submitter.send_bond_tx(game_address, game_address, calldata).await {
+
+        let result = submitter.send_bond_tx(game_address, game_address, calldata).await;
+        match &result {
             Ok(tx_hash) => {
                 info!(
                     game = %game_address,
@@ -882,83 +591,15 @@ impl<C: Clock> BondManager<C> {
                 );
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
-                let completed = matches!(success_phase, BondPhase::Completed);
-                self.set_phase(game_address, success_phase);
-                Ok(completed.then_some(RemovalReason::Completed))
             }
-            Err(e) => {
+            Err(_) => {
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                    .increment(1);
-                if let Some(retry_delay) = revert_retry_delay
-                    && matches!(&e, crate::ChallengeSubmitError::TxReverted { .. })
-                {
-                    let delay = self.effective_weth_delay(game_address);
-                    let retry_delay = retry_delay.min(delay);
-                    let elapsed_before_retry = delay.saturating_sub(retry_delay);
-                    let unlocked_at = self.clock.now().saturating_sub(elapsed_before_retry);
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        step,
-                        retry = "after_backoff",
-                        retry_delay_secs = retry_delay.as_secs(),
-                        "claimCredit transaction failed, will retry after backoff"
-                    );
-                    self.set_phase(
-                        game_address,
-                        BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
-                    );
-                } else {
-                    warn!(
-                        game = %game_address,
-                        error = %e,
-                        step,
-                        retry = "immediate",
-                        "claimCredit transaction failed, will retry"
-                    );
-                }
-                Ok(None)
+                    .increment(1)
             }
         }
+        result.map(|_| ())
     }
 
-    /// Converts a Unix timestamp (seconds) to a monotonic [`Duration`]
-    /// relative to the given clock.
-    ///
-    /// Computes how long ago `unix_secs` occurred relative to `unix_now`
-    /// and subtracts that age from the current monotonic time. Used when
-    /// recovering onchain timestamps (e.g. `resolved_at`) into the
-    /// local monotonic time domain.
-    ///
-    /// `unix_now` is accepted as a parameter (callers obtain it via
-    /// [`Clock::wall_clock_unix_secs`]) so that the function is fully
-    /// deterministic and testable.
-    ///
-    /// If `unix_secs` is ahead of `unix_now` (e.g. L1 clock skew),
-    /// the age is treated as zero and `unlocked_at` equals the current
-    /// monotonic time — re-imposing the full delay. This is the safe
-    /// conservative fallback.
-    fn unix_to_monotonic(clock: &C, unix_secs: u64, unix_now: u64) -> Duration {
-        let age = Duration::from_secs(unix_now.saturating_sub(unix_secs));
-        clock.now().saturating_sub(age)
-    }
-
-    /// Estimates when the bond was unlocked using `resolved_at` as a
-    /// conservative lower bound. The unlock must have occurred after
-    /// resolve, so this may cause one early withdrawal attempt that
-    /// reverts, but is strictly better than resetting to "now" (which
-    /// would re-impose the full delay after every retry).
-    fn estimate_unlock_time(clock: &C, resolved_at: u64) -> Duration {
-        Self::unix_to_monotonic(clock, resolved_at, clock.wall_clock_unix_secs())
-    }
-
-    /// Determines the bond phase from onchain state.
-    ///
-    /// Returns `None` if the bond has already been fully claimed. Otherwise
-    /// returns the appropriate [`BondPhase`] based on the game's onchain
-    /// progression (resolved, unlocked, etc.). The caller is responsible
-    /// for verifying that the onchain `bondRecipient` is in the claim set
-    /// before acting on the returned phase.
     async fn determine_phase(
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
@@ -974,19 +615,11 @@ impl<C: Clock> BondManager<C> {
             return Ok(None);
         }
         if bond_unlocked {
-            if let Some(delay) = weth_delay {
-                let elapsed_since_resolve =
-                    Duration::from_secs(clock.wall_clock_unix_secs().saturating_sub(resolved_at));
-                if elapsed_since_resolve >= delay {
-                    return Ok(Some(BondPhase::NeedsWithdraw));
-                }
-            }
+            let Some(delay) = weth_delay else {
+                return Ok(Some(BondPhase::NeedsUnlock));
+            };
 
-            let unlocked_at = Self::estimate_unlock_time(clock, resolved_at);
-            return Ok(Some(BondPhase::AwaitingDelay {
-                unlocked_at,
-                unlocked_at_unix_secs: Some(resolved_at),
-            }));
+            return Ok(Some(Self::unlocked_phase(clock, resolved_at, delay)));
         }
 
         if resolved_at > 0 {
@@ -996,90 +629,49 @@ impl<C: Clock> BondManager<C> {
         Ok(Some(BondPhase::NeedsResolve))
     }
 
-    /// Resolves the `DelayedWETH` delay if not yet known, logging on failure.
     async fn ensure_weth_delay(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
     ) {
-        if self.weth_delay.is_none()
-            && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
-        {
-            warn!(error = %e, "failed to read DelayedWETH delay, will retry later");
-        }
-    }
-
-    /// Resolves the WETH delay using a game from the factory at the given index.
-    async fn ensure_weth_delay_from_index(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-        index: u64,
-    ) {
         if self.weth_delay.is_some() {
             return;
         }
 
-        match self.factory_client.game_at_index(index).await {
-            Ok(game_at) => self.ensure_weth_delay(verifier_client, game_at.proxy).await,
-            Err(e) => {
-                warn!(
-                    index,
-                    error = %e,
-                    "failed to fetch game for DelayedWETH delay resolution"
-                );
+        let result: eyre::Result<Duration> = async {
+            let weth_address = verifier_client.delayed_weth(game_address).await?;
+            let weth_client =
+                DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
+            Ok(weth_client.delay().await?)
+        }
+        .await;
+
+        match result {
+            Ok(delay) => {
+                info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
+                self.weth_delay = Some(delay);
             }
+            Err(e) => warn!(error = %e, "failed to read DelayedWETH delay, will retry later"),
         }
     }
-
-    /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
-    async fn resolve_weth_delay(
-        &mut self,
-        verifier_client: &dyn AggregateVerifierClient,
-        game_address: Address,
-    ) -> eyre::Result<()> {
-        let weth_address = verifier_client.delayed_weth(game_address).await?;
-        let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
-        let delay = weth_client.delay().await?;
-        self.set_weth_delay(delay);
-        Ok(())
-    }
-}
-
-/// Trait for submitting bond lifecycle transactions (`resolve`, `claimCredit`).
-///
-/// This abstracts the transaction submission layer so the [`BondManager`]
-/// can be tested with mock submitters.
-#[async_trait::async_trait]
-pub trait BondTransactionSubmitter: Send + Sync {
-    /// Sends a transaction with the given calldata to `to`. `game_address`
-    /// is the dispute game this transaction is associated with, used for
-    /// log/metric correlation.
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: alloy_primitives::Bytes,
-    ) -> Result<alloy_primitives::B256, crate::ChallengeSubmitError>;
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, future::Future, pin::Pin};
-
-    use alloy_primitives::B256;
-    use futures::stream::BoxStream;
+    use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory,
+        MockAggregateVerifier, MockDisputeGameFactory, SharedMockTxManager,
         TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
+        receipt_with_status,
     };
+    use alloy_primitives::B256;
+    use futures::stream::BoxStream;
 
-    /// A deterministic clock that always returns fixed values.
-    ///
-    /// Used in unit tests that need precise control over the monotonic
-    /// time returned by [`Clock::now`] and the wall-clock Unix seconds
-    /// returned by [`Clock::wall_clock_unix_secs`].
+    const TEST_WETH_DELAY: Duration = Duration::from_secs(60);
+    const WITHDRAW_READY_MONOTONIC_SECS: u64 = 3_700;
+
     struct FixedClock {
         monotonic: Duration,
         wall_unix: u64,
@@ -1103,233 +695,140 @@ mod tests {
         }
     }
 
-    /// Creates a [`FixedClock`] with the given monotonic seconds and a
-    /// default wall-clock value of `2_000_000_000`.
     fn fixed_clock(secs: u64) -> FixedClock {
         FixedClock { monotonic: Duration::from_secs(secs), wall_unix: 2_000_000_000 }
     }
 
-    fn test_l1_rpc_url() -> url::Url {
-        "http://localhost:8545".parse().unwrap()
+    fn claim_addr() -> Address {
+        Address::repeat_byte(0xCC)
     }
 
-    fn make_manager(addresses: Vec<Address>) -> BondManager<FixedClock> {
-        let clock = fixed_clock(0);
+    fn game_state(
+        status: GameStatus,
+        bond_recipient: Address,
+        resolved_at: u64,
+        bond_unlocked: bool,
+    ) -> crate::test_utils::MockGameState {
+        let mut state = mock_state(status, Address::ZERO, 100);
+        state.bond_recipient = bond_recipient;
+        state.resolved_at = resolved_at;
+        state.bond_unlocked = bond_unlocked;
+        state
+    }
+
+    fn verifier(state: crate::test_utils::MockGameState) -> Arc<MockAggregateVerifier> {
+        Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])))
+    }
+
+    fn ready_phase() -> BondPhase {
+        BondPhase::AwaitingDelay { ready_at: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS) }
+    }
+
+    async fn advance(
+        mgr: &mut BondManager<FixedClock>,
+        phase: BondPhase,
+        verifier: &Arc<MockAggregateVerifier>,
+        submitter: &ChallengeSubmitter<SharedMockTxManager>,
+    ) -> BondPhase {
+        mgr.advance_game(addr(0), phase, &**verifier, submitter).await.unwrap()
+    }
+
+    fn bond_submitter(
+        responses: Vec<base_tx_manager::SendResponse>,
+    ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
+        let tx_manager = SharedMockTxManager::with_responses(responses);
+        (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
+    }
+
+    fn manager(
+        claim_addr: Address,
+        factory: Arc<dyn DisputeGameFactoryClient>,
+        lookback: u64,
+        clock: FixedClock,
+    ) -> BondManager<FixedClock> {
         let mut mgr = BondManager::new(
-            addresses,
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
+            vec![claim_addr],
+            "http://localhost:8545".parse().unwrap(),
+            factory,
+            lookback,
             TEST_DISCOVERY_INTERVAL,
             clock,
         );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        mgr.weth_delay = Some(TEST_WETH_DELAY);
         mgr
+    }
+
+    fn withdraw_ready_fixture(
+        responses: Vec<base_tx_manager::SendResponse>,
+    ) -> (
+        BondManager<FixedClock>,
+        Arc<MockAggregateVerifier>,
+        ChallengeSubmitter<SharedMockTxManager>,
+        SharedMockTxManager,
+    ) {
+        let claim_addr = claim_addr();
+        let wall_unix = 2_000_000_000;
+        let delay = Duration::from_secs(3_600);
+        let clock =
+            FixedClock { monotonic: Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS), wall_unix };
+
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, clock);
+        mgr.weth_delay = Some(delay);
+
+        let state = game_state(GameStatus::DefenderWins, claim_addr, wall_unix - 3_600, true);
+        let verifier = verifier(state);
+        let (submitter, tx_manager) = bond_submitter(responses);
+
+        (mgr, verifier, submitter, tx_manager)
     }
 
     #[test]
     fn track_game_filters_by_claim_address() {
-        let addr = Address::repeat_byte(0x01);
+        let claim_addr = Address::repeat_byte(0x01);
         let other = Address::repeat_byte(0x02);
         let game = Address::repeat_byte(0xAA);
 
-        let mut mgr = make_manager(vec![addr]);
-        assert!(mgr.track_game(game, addr));
-        assert!(!mgr.track_game(game, addr)); // duplicate
-        assert!(!mgr.track_game(Address::repeat_byte(0xBB), other)); // not in set
-    }
-
-    #[test]
-    fn is_tracking_returns_correct_state() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let mut mgr = make_manager(vec![addr]);
-        assert!(!mgr.is_tracking(&game));
-        mgr.track_game(game, addr);
-        assert!(mgr.is_tracking(&game));
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(0));
+        assert!(mgr.track_game(game, claim_addr));
+        assert!(!mgr.track_game(game, claim_addr));
+        assert!(!mgr.track_game(Address::repeat_byte(0xBB), other));
     }
 
     #[tokio::test]
     async fn already_resolved_game_advances_to_unlock() {
         let claim_addr = Address::repeat_byte(0x01);
-        let game = addr(0);
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(0));
 
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let verifier = verifier(game_state(GameStatus::DefenderWins, claim_addr, 100, false));
+        let (submitter, tx_manager) = bond_submitter(vec![]);
 
-        let result = mgr.advance_game(game, &verifier, &submitter).await.unwrap();
+        let result = advance(&mut mgr, BondPhase::NeedsResolve, &verifier, &submitter).await;
 
-        assert!(result.is_none());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsUnlock));
-        assert!(submitter.recorded_calls().is_empty());
-    }
-
-    #[test]
-    fn check_delay_transitions_when_elapsed() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(
-            vec![addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // 100 seconds ago > 60 second delay
-        let unlocked_at = Duration::from_secs(900);
-        mgr.tracked.insert(
-            game,
-            TrackedGame::new(
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
-                addr,
-            ),
-        );
-
-        let result = mgr.check_delay(game, unlocked_at, None);
-        assert!(result.is_ok());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-    }
-
-    #[test]
-    fn check_delay_stays_when_not_elapsed() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(
-            vec![addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(3600));
-
-        // only 1 second ago < 3600 second delay
-        let unlocked_at = Duration::from_secs(999);
-        mgr.tracked.insert(
-            game,
-            TrackedGame::new(
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: None },
-                addr,
-            ),
-        );
-
-        let result = mgr.check_delay(game, unlocked_at, None);
-        assert!(result.is_ok());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::AwaitingDelay { .. }));
-    }
-
-    #[test]
-    fn check_delay_uses_unix_timestamp_when_recovered() {
-        let addr = Address::repeat_byte(0x01);
-        let game = Address::repeat_byte(0xAA);
-
-        let clock = FixedClock { monotonic: Duration::from_secs(10), wall_unix: 2_000 };
-        let mut mgr = BondManager::new(
-            vec![addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        let unlocked_at = Duration::ZERO;
-        mgr.tracked.insert(
-            game,
-            TrackedGame::new(
-                BondPhase::AwaitingDelay { unlocked_at, unlocked_at_unix_secs: Some(1_900) },
-                addr,
-            ),
-        );
-
-        let result = mgr.check_delay(game, unlocked_at, Some(1_900));
-        assert!(result.is_ok());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
+        assert!(matches!(result, BondPhase::NeedsUnlock));
+        assert!(tx_manager.recorded_calls().is_empty());
     }
 
     #[tokio::test]
     async fn reverted_withdraw_backs_off_before_retrying() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let game = addr(0);
-        let wall_unix = 2_000_000_000;
-        let resolved_at = wall_unix - 3_600;
-        let monotonic_secs = 3_700;
-        let delay = Duration::from_secs(3_600);
-        let clock = FixedClock { monotonic: Duration::from_secs(monotonic_secs), wall_unix };
-        let stale_unlocked_at =
-            BondManager::<FixedClock>::estimate_unlock_time(&clock, resolved_at);
+        let (mut mgr, verifier, submitter, tx_manager) =
+            withdraw_ready_fixture(vec![Ok(receipt_with_status(false, B256::ZERO))]);
 
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(delay);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(
-            game,
-            BondPhase::AwaitingDelay {
-                unlocked_at: stale_unlocked_at,
-                unlocked_at_unix_secs: None,
-            },
-        );
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = resolved_at;
-        state.bond_unlocked = true;
-        state.bond_claimed = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Err(
-            crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO },
-        )]);
-
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-        assert!(submitter.recorded_calls().is_empty());
-
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert_eq!(submitter.recorded_calls().len(), 1);
-        let expected_unlocked_at = Duration::from_secs(monotonic_secs).saturating_sub(
-            delay.saturating_sub(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY),
-        );
+        let phase = advance(&mut mgr, ready_phase(), &verifier, &submitter).await;
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
+        let expected_ready_at = Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            .saturating_add(BondManager::<FixedClock>::WITHDRAW_REVERT_RETRY_DELAY);
         assert!(
             matches!(
-                mgr.tracked.get(&game).unwrap().phase,
-                BondPhase::AwaitingDelay { unlocked_at, .. }
-                    if unlocked_at == expected_unlocked_at
+                phase,
+                BondPhase::AwaitingDelay { ready_at } if ready_at == expected_ready_at
             ),
-            "withdraw revert should back off without restarting the full delay"
-        );
-        assert_ne!(
-            expected_unlocked_at,
-            Duration::from_secs(monotonic_secs),
-            "withdraw revert must not model a fresh DelayedWETH unlock"
+            "withdraw revert should back off briefly"
         );
 
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
+        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
+        assert!(matches!(phase, BondPhase::AwaitingDelay { .. }));
         assert_eq!(
-            submitter.recorded_calls().len(),
+            tx_manager.recorded_calls().len(),
             1,
             "next poll should wait in AwaitingDelay instead of submitting again"
         );
@@ -1337,346 +836,148 @@ mod tests {
 
     #[tokio::test]
     async fn non_revert_withdraw_failure_does_not_back_off() {
-        // Regression guard for the `matches!(_, TxReverted { .. })` arm in
-        // `submit_claim_credit`: a non-revert error (e.g. a `TxManager`
-        // variant such as `NonceTooLow`) must leave the phase as
-        // `NeedsWithdraw` so the next poll resubmits immediately rather
-        // than waiting on the WETH-delay back-off window.
-        let claim_addr = Address::repeat_byte(0xCC);
-        let game = addr(0);
-        let wall_unix = 2_000_000_000;
-        let resolved_at = wall_unix - 3_600;
-        let monotonic_secs = 3_700;
-        let delay = Duration::from_secs(3_600);
-        let clock = FixedClock { monotonic: Duration::from_secs(monotonic_secs), wall_unix };
-        let stale_unlocked_at =
-            BondManager::<FixedClock>::estimate_unlock_time(&clock, resolved_at);
-
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(delay);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(
-            game,
-            BondPhase::AwaitingDelay {
-                unlocked_at: stale_unlocked_at,
-                unlocked_at_unix_secs: None,
-            },
-        );
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = resolved_at;
-        state.bond_unlocked = true;
-        state.bond_claimed = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        // Two non-revert failures so that both the first failed submission
-        // and the immediate retry have a response queued.
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![
-            Err(crate::ChallengeSubmitError::TxManager(
-                base_tx_manager::TxManagerError::NonceTooLow,
-            )),
-            Err(crate::ChallengeSubmitError::TxManager(
-                base_tx_manager::TxManagerError::NonceTooLow,
-            )),
+        let (mut mgr, verifier, submitter, tx_manager) = withdraw_ready_fixture(vec![
+            Err(base_tx_manager::TxManagerError::NonceTooLow),
+            Err(base_tx_manager::TxManagerError::NonceTooLow),
         ]);
 
-        // First poll: stale AwaitingDelay → check_delay transitions to
-        // NeedsWithdraw without submitting.
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-        assert!(submitter.recorded_calls().is_empty());
-
-        // Second poll: NeedsWithdraw → submit_claim_credit → non-revert
-        // failure. The phase must remain `NeedsWithdraw`; the back-off
-        // path is gated on `TxReverted` only.
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
-        assert_eq!(submitter.recorded_calls().len(), 1);
+        let phase = advance(&mut mgr, ready_phase(), &verifier, &submitter).await;
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
         assert!(
-            matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw),
-            "non-revert withdraw failure must not transition back to AwaitingDelay"
+            matches!(
+                phase,
+                BondPhase::AwaitingDelay { ready_at }
+                    if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            ),
+            "non-revert withdraw failure must retry immediately"
         );
 
-        // Third poll: still `NeedsWithdraw` → resubmits immediately,
-        // without waiting on a back-off window.
-        let result = mgr.advance_game(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none());
+        let phase = advance(&mut mgr, phase, &verifier, &submitter).await;
         assert_eq!(
-            submitter.recorded_calls().len(),
+            tx_manager.recorded_calls().len(),
             2,
             "non-revert failures must not introduce a back-off delay before retry"
         );
-        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
-    }
-
-    #[test]
-    fn unix_to_monotonic_past_timestamp() {
-        // Clock at 500s monotonic, unix_now=2000, event at unix 1900
-        // → age = 100s → monotonic = 500 - 100 = 400s.
-        let clock = fixed_clock(500);
-        let result = BondManager::unix_to_monotonic(&clock, 1900, 2000);
-        assert_eq!(result, Duration::from_secs(400));
-    }
-
-    #[test]
-    fn unix_to_monotonic_future_timestamp_clamps() {
-        // If the onchain timestamp is ahead of local wall clock
-        // (clock skew), age saturates to 0 → monotonic = clock.now().
-        let clock = fixed_clock(500);
-        let result = BondManager::unix_to_monotonic(&clock, 2100, 2000);
-        assert_eq!(result, Duration::from_secs(500));
-    }
-
-    #[test]
-    fn unix_to_monotonic_same_timestamp() {
-        // Event happened "right now" → age = 0 → monotonic = clock.now().
-        let clock = fixed_clock(500);
-        let result = BondManager::unix_to_monotonic(&clock, 2000, 2000);
-        assert_eq!(result, Duration::from_secs(500));
-    }
-
-    #[test]
-    fn unix_to_monotonic_age_exceeds_monotonic() {
-        // If the event is older than the monotonic uptime, saturate to zero
-        // rather than underflowing.
-        let clock = fixed_clock(50);
-        let result = BondManager::unix_to_monotonic(&clock, 1000, 2000);
-        assert_eq!(result, Duration::ZERO);
-    }
-
-    #[test]
-    fn empty_claim_addresses_means_disabled() {
-        let clock = fixed_clock(0);
-        let mgr = BondManager::new(
-            vec![],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
+        assert!(
+            matches!(
+                phase,
+                BondPhase::AwaitingDelay { ready_at }
+                    if ready_at == Duration::from_secs(WITHDRAW_READY_MONOTONIC_SECS)
+            ),
+            "non-revert withdraw failure must stay ready for retry"
         );
-        assert!(!mgr.is_enabled());
     }
 
-    #[test]
-    fn non_empty_claim_addresses_means_enabled() {
-        let clock = fixed_clock(0);
-        let mgr = BondManager::new(
-            vec![Address::repeat_byte(0x01)],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        assert!(mgr.is_enabled());
-    }
-
-    // ---- discover_claimable_games tests ----
-
-    /// Builds a factory and verifier pair where each game has the given
-    /// `bond_recipient` and `zk_prover`. All games are `IN_PROGRESS` (status 0)
-    /// unless overridden.
     fn discovery_mocks(
         game_count: u64,
         bond_recipient: Address,
         zk_prover: Address,
     ) -> (Arc<dyn DisputeGameFactoryClient>, Arc<MockAggregateVerifier>) {
         let games: Vec<_> = (0..game_count).map(|i| factory_game(i, 0)).collect();
-        let mut verifier_games = HashMap::new();
-        for i in 0..game_count {
-            let mut state = mock_state(GameStatus::InProgress, zk_prover, 100 + i);
-            state.bond_recipient = bond_recipient;
-            verifier_games.insert(addr(i), state);
-        }
+        let verifier_games = (0..game_count)
+            .map(|i| {
+                let mut state = mock_state(GameStatus::InProgress, zk_prover, 100 + i);
+                state.bond_recipient = bond_recipient;
+                (addr(i), state)
+            })
+            .collect();
         let factory: Arc<dyn DisputeGameFactoryClient> =
             Arc::new(MockDisputeGameFactory::new(games));
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         (factory, verifier)
     }
 
-    #[tokio::test]
-    async fn discover_incremental_picks_up_new_games_by_recipient() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let (factory, verifier) = discovery_mocks(3, claim_addr, Address::ZERO);
+    async fn assert_discovery(
+        game_count: u64,
+        scan_head: u64,
+        lookback: u64,
+        ticks: usize,
+        expected_head: u64,
+        expected_tracked: usize,
+    ) {
+        let claim_addr = claim_addr();
+        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
+        let mut mgr = manager(claim_addr, factory, lookback, fixed_clock(0));
+        mgr.bond_scan_head = scan_head;
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        for _ in 0..ticks {
+            mgr.discover_claimable_games(&*verifier).await.unwrap();
+        }
 
-        // bond_scan_head defaults to 0, so the first call should scan all 3.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 3);
-        assert_eq!(mgr.bond_scan_head, 3);
+        assert_eq!(mgr.bond_scan_head, expected_head);
+        assert_eq!(mgr.tracked_count(), expected_tracked);
     }
 
     #[tokio::test]
-    async fn discover_incremental_picks_up_new_games_by_zk_prover() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let other_recipient = Address::repeat_byte(0xDD);
-        // bond_recipient is someone else, but zkProver matches our address.
-        // Status is InProgress, so the game should match via zkProver.
-        let (factory, verifier) = discovery_mocks(2, other_recipient, claim_addr);
+    async fn discover_filters_games() {
+        for (game_count, bond_recipient, zk_prover, expected_tracked) in [
+            (3_u64, claim_addr(), Address::ZERO, 3_usize),
+            (2, Address::repeat_byte(0xDD), claim_addr(), 2),
+            (3, Address::repeat_byte(0xDD), Address::ZERO, 0),
+        ] {
+            let claim_addr = claim_addr();
+            let (factory, verifier) = discovery_mocks(game_count, bond_recipient, zk_prover);
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+            let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
 
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 2);
+            mgr.discover_claimable_games(&*verifier).await.unwrap();
+            assert_eq!(mgr.tracked_count(), expected_tracked);
+            assert_eq!(mgr.bond_scan_head, game_count);
+        }
     }
 
     #[tokio::test]
     async fn discover_skips_already_tracked_games() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let (factory, verifier) = discovery_mocks(2, claim_addr, Address::ZERO);
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
 
-        // Pre-track game 0.
         mgr.track_game(addr(0), claim_addr);
         assert_eq!(mgr.tracked_count(), 1);
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
-        // Game 0 was already tracked, so only game 1 should be new.
         assert_eq!(mgr.tracked_count(), 2);
     }
 
     #[tokio::test]
     async fn discover_skips_already_claimed_games() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
 
         let games = vec![factory_game(0, 0)];
-        let mut verifier_games = HashMap::new();
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.bond_claimed = true; // already claimed
-        state.resolved_at = 500;
-        verifier_games.insert(addr(0), state);
+        let mut state = game_state(GameStatus::ChallengerWins, claim_addr, 500, false);
+        state.bond_claimed = true;
 
         let factory: Arc<dyn DisputeGameFactoryClient> =
             Arc::new(MockDisputeGameFactory::new(games));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let verifier = verifier(state);
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let mut mgr = manager(claim_addr, factory, 1000, fixed_clock(0));
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
         assert_eq!(mgr.tracked_count(), 0, "claimed game should not be tracked");
     }
 
     #[tokio::test]
-    async fn discover_advances_watermark() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let (factory, verifier) = discovery_mocks(5, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // Start from index 3 so only indices 3 and 4 are scanned.
-        mgr.bond_scan_head = 3;
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, 5);
-        assert_eq!(mgr.tracked_count(), 2, "only games 3 and 4 should be discovered");
-    }
-
-    #[tokio::test]
-    async fn discover_noop_when_watermark_equals_game_count() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let (factory, verifier) = discovery_mocks(5, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // Watermark already at game_count — nothing new to scan.
-        mgr.bond_scan_head = 5;
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0);
-        assert_eq!(mgr.bond_scan_head, 5);
+    async fn discover_updates_watermark() {
+        for (scan_head, expected_head, expected_tracked) in [(3_u64, 5_u64, 2_usize), (5, 5, 0)] {
+            assert_discovery(5, scan_head, 1000, 1, expected_head, expected_tracked).await;
+        }
     }
 
     #[tokio::test]
     async fn discover_full_rescan_resets_watermark() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let (factory, verifier) = discovery_mocks(10, claim_addr, Address::ZERO);
 
-        // Use a clock at 1000s so we can backdate last_full_scan.
         let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            5, // lookback = 5
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let mut mgr = manager(claim_addr, factory, 5, clock);
 
-        // Simulate that the previous scan already covered everything.
         mgr.bond_scan_head = 10;
 
-        // Force the full rescan by backdating `last_full_scan` past the
-        // discovery interval.
         mgr.last_full_scan = Duration::from_secs(1000).saturating_sub(TEST_DISCOVERY_INTERVAL);
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
-        // Full rescan should have reset watermark to 10 - 5 = 5
-        // and then scanned indices 5..10, discovering 5 new games.
         assert_eq!(mgr.bond_scan_head, 10);
         assert_eq!(mgr.tracked_count(), 5);
     }
@@ -1685,14 +986,13 @@ mod tests {
     async fn discover_disabled_when_no_claim_addresses() {
         let (_, verifier) = discovery_mocks(5, Address::repeat_byte(0xCC), Address::ZERO);
 
-        let clock = fixed_clock(0);
         let mut mgr = BondManager::new(
             vec![],
-            test_l1_rpc_url(),
+            "http://localhost:8545".parse().unwrap(),
             empty_factory(),
             1000,
             TEST_DISCOVERY_INTERVAL,
-            clock,
+            fixed_clock(0),
         );
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
@@ -1700,172 +1000,92 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_skips_unmatched_recipients() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let other = Address::repeat_byte(0xDD);
-        // Neither bondRecipient nor zkProver match our claim address.
-        let (factory, verifier) = discovery_mocks(3, other, Address::ZERO);
+    async fn determine_phase_returns_unlocked_phase() {
+        for (monotonic_secs, delay, expected_ready_at) in [
+            (500_u64, Duration::from_secs(120), Duration::from_secs(520)),
+            (10, Duration::from_secs(60), Duration::from_secs(10)),
+        ] {
+            let game = addr(0);
+            let verifier = verifier(game_state(
+                GameStatus::ChallengerWins,
+                Address::ZERO,
+                1_999_999_900,
+                true,
+            ));
 
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.tracked_count(), 0);
-        // Watermark should still advance past the scanned range.
-        assert_eq!(mgr.bond_scan_head, 3);
-    }
-
-    #[tokio::test]
-    async fn determine_phase_returns_awaiting_delay_when_bond_unlocked() {
-        // resolved_at = 1_999_999_900 → age = 2_000_000_000 - 1_999_999_900 = 100s
-        // monotonic 500 - 100 = 400 → unlocked_at should be 400s.
-        let game = addr(0);
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.resolved_at = 1_999_999_900;
-        state.bond_unlocked = true;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(500);
-        let phase =
-            BondManager::determine_phase(&*verifier, game, &clock, None).await.unwrap().unwrap();
-        assert!(
-            matches!(phase, BondPhase::AwaitingDelay { unlocked_at, .. } if unlocked_at == Duration::from_secs(400)),
-            "expected AwaitingDelay {{ unlocked_at: 400s }}, got {phase:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn determine_phase_returns_needs_withdraw_when_delay_elapsed() {
-        let game = addr(0);
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.resolved_at = 1_999_999_900;
-        state.bond_unlocked = true;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(10);
-        let phase =
-            BondManager::determine_phase(&*verifier, game, &clock, Some(Duration::from_secs(60)))
+            let clock = fixed_clock(monotonic_secs);
+            let phase = BondManager::determine_phase(&*verifier, game, &clock, Some(delay))
                 .await
                 .unwrap()
                 .unwrap();
-        assert!(matches!(phase, BondPhase::NeedsWithdraw), "expected NeedsWithdraw, got {phase:?}",);
+            match (expected_ready_at, phase) {
+                (expected, BondPhase::AwaitingDelay { ready_at }) if ready_at == expected => {}
+                (_, phase) => panic!("unexpected phase: {phase:?}"),
+            }
+        }
     }
 
     #[tokio::test]
     async fn try_unlock_advances_to_withdraw_when_already_unlocked_and_delay_elapsed() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let game = addr(0);
-
-        // resolved_at = 1_999_999_800 -> age = 2_000_000_000 - 1_999_999_800 = 200s.
-        // With a 60s WETH delay, this should advance straight to withdrawal.
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = 1_999_999_800;
-        state.bond_unlocked = true;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(500);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let verifier =
+            verifier(game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_800, true));
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(500));
         mgr.track_game(game, claim_addr);
 
-        // MockBondTransactionSubmitter should NOT be called — the bond is
-        // already unlocked, so try_unlock must skip the transaction.
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let (submitter, tx_manager) = bond_submitter(vec![]);
         let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none(), "try_unlock should not remove the game");
-
-        let tracked = mgr.tracked.get(&game).expect("game should still be tracked");
         assert!(
-            matches!(tracked.phase, BondPhase::NeedsWithdraw),
-            "expected NeedsWithdraw, got {:?}",
-            tracked.phase,
+            matches!(
+                result,
+                Some(BondPhase::AwaitingDelay { ready_at })
+                    if ready_at == Duration::from_secs(500)
+            ),
+            "expected ready AwaitingDelay, got {:?}",
+            result,
         );
-        assert!(submitter.recorded_calls().is_empty(), "no transaction should have been submitted");
+        assert!(
+            tx_manager.recorded_calls().is_empty(),
+            "no transaction should have been submitted"
+        );
     }
 
     #[tokio::test]
     async fn try_unlock_uses_monotonic_timestamp_for_fresh_unlock() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
         let game = addr(0);
         let tx_hash = B256::repeat_byte(0xDD);
-
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.resolved_at = 1_999_999_900;
-        state.bond_unlocked = false;
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let clock = fixed_clock(500);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            empty_factory(),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
+        let verifier =
+            verifier(game_state(GameStatus::ChallengerWins, claim_addr, 1_999_999_900, false));
+        let mut mgr = manager(claim_addr, empty_factory(), 1000, fixed_clock(500));
         mgr.track_game(game, claim_addr);
 
-        let submitter = MockBondTransactionSubmitter::success(tx_hash);
+        let (submitter, tx_manager) = bond_submitter(vec![Ok(receipt_with_status(true, tx_hash))]);
         let result = mgr.try_unlock(game, &*verifier, &submitter).await.unwrap();
-        assert!(result.is_none(), "try_unlock should not remove the game");
-
-        let tracked = mgr.tracked.get(&game).expect("game should still be tracked");
         assert!(
             matches!(
-                tracked.phase,
-                BondPhase::AwaitingDelay {
-                    unlocked_at,
-                    unlocked_at_unix_secs: None
-                } if unlocked_at == Duration::from_secs(500)
+                result,
+                Some(BondPhase::AwaitingDelay { ready_at })
+                    if ready_at == Duration::from_secs(560)
             ),
-            "expected AwaitingDelay with monotonic timestamp only, got {:?}",
-            tracked.phase,
+            "expected AwaitingDelay with monotonic deadline, got {:?}",
+            result,
         );
-        assert_eq!(submitter.recorded_calls().len(), 1);
+        assert_eq!(tx_manager.recorded_calls().len(), 1);
     }
 
     #[tokio::test]
     async fn discover_handles_empty_factory() {
-        let claim_addr = Address::repeat_byte(0xCC);
+        let claim_addr = claim_addr();
 
-        let clock = fixed_clock(0);
         let mut mgr = BondManager::new(
             vec![claim_addr],
-            test_l1_rpc_url(),
+            "http://localhost:8545".parse().unwrap(),
             empty_factory(),
             1000,
             TEST_DISCOVERY_INTERVAL,
-            clock,
+            fixed_clock(0),
         );
 
         let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
@@ -1874,87 +1094,14 @@ mod tests {
         assert_eq!(mgr.bond_scan_head, 0);
     }
 
-    // ---- lookback capping tests ----
-
     #[tokio::test]
-    async fn discover_caps_span_to_lookback() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let lookback = 500u64;
-        let game_count = 1200u64;
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // bond_scan_head starts at 0, game_count = 1200, span = 1200 > lookback.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-
-        assert_eq!(
-            mgr.bond_scan_head, lookback,
-            "watermark should advance by lookback, not to game_count"
-        );
-        // Only games 0..500 should be discovered.
-        assert_eq!(mgr.tracked_count(), lookback as usize);
-    }
-
-    #[tokio::test]
-    async fn discover_catches_up_over_multiple_ticks() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let lookback = 500u64;
-        let game_count = 800u64;
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        // First tick: scans 0..500, watermark = 500.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, lookback);
-        assert_eq!(mgr.tracked_count(), lookback as usize);
-
-        // Second tick: scans 500..800 (span = 300 < lookback), watermark = 800.
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-        assert_eq!(mgr.bond_scan_head, game_count);
-        assert_eq!(mgr.tracked_count(), game_count as usize);
-    }
-
-    #[tokio::test]
-    async fn discover_no_cap_when_span_within_lookback() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let lookback = 1000u64;
-        let game_count = 500u64;
-        let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
-
-        let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(
-            vec![claim_addr],
-            test_l1_rpc_url(),
-            factory,
-            lookback,
-            TEST_DISCOVERY_INTERVAL,
-            clock,
-        );
-        mgr.set_weth_delay(Duration::from_secs(60));
-
-        mgr.discover_claimable_games(&*verifier).await.unwrap();
-
-        assert_eq!(mgr.bond_scan_head, game_count);
-        assert_eq!(mgr.tracked_count(), game_count as usize);
+    async fn discover_advances_by_lookback() {
+        for (lookback, game_count, ticks, expected_head, expected_tracked) in [
+            (500_u64, 1200_u64, 1_usize, 500_u64, 500_usize),
+            (500, 800, 2, 800, 800),
+            (1000, 500, 1, 500, 500),
+        ] {
+            assert_discovery(game_count, 0, lookback, ticks, expected_head, expected_tracked).await;
+        }
     }
 }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1064,7 +1064,7 @@ pub trait BondTransactionSubmitter: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use std::{future::Future, pin::Pin};
+    use std::{collections::HashMap, future::Future, pin::Pin};
 
     use alloy_primitives::B256;
     use futures::stream::BoxStream;
@@ -1148,6 +1148,25 @@ mod tests {
         assert!(!mgr.is_tracking(&game));
         mgr.track_game(game, addr);
         assert!(mgr.is_tracking(&game));
+    }
+
+    #[tokio::test]
+    async fn already_resolved_game_advances_to_unlock() {
+        let claim_addr = Address::repeat_byte(0x01);
+        let game = addr(0);
+        let mut mgr = make_manager(vec![claim_addr]);
+        mgr.track_game(game, claim_addr);
+
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.bond_recipient = claim_addr;
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let result = mgr.advance_game(game, &verifier, &submitter).await.unwrap();
+
+        assert!(result.is_none());
+        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsUnlock));
+        assert!(submitter.recorded_calls().is_empty());
     }
 
     #[test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -35,7 +35,6 @@ use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, DelayedWETHClient, DelayedWETHContractClient,
     DisputeGameFactoryClient, GameStatus, encode_claim_credit_calldata, encode_resolve_calldata,
-    encode_set_anchor_state_calldata,
 };
 use base_runtime::Clock;
 use futures::stream::{self, StreamExt};
@@ -82,42 +81,12 @@ pub struct TrackedGame {
     pub phase: BondPhase,
     /// The address that will receive the bond.
     pub bond_recipient: Address,
-    /// Whether the anchor state update has been completed (or skipped)
-    /// for this game. Set to `true` after a successful
-    /// `setAnchorState()` call or when the game is not eligible
-    /// (e.g. `CHALLENGER_WINS`).
-    pub anchor_update_complete: bool,
-    /// Cached on-chain game status. Populated on the first successful
-    /// `status()` RPC read; subsequent ticks reuse the cached value
-    /// because the status is immutable after resolution.
-    pub cached_status: Option<GameStatus>,
-    /// Cached `AnchorStateRegistry` address for this game. Read from the
-    /// game contract on first use and reused thereafter (immutable per game).
-    pub cached_asr_address: Option<Address>,
-    /// Cached L2 block number for this game. Read from immutable game info
-    /// once the game is finalized and reused for retries.
-    pub cached_l2_block_number: Option<u64>,
-    /// Monotonic timestamp for games whose bond lifecycle is complete but
-    /// which remain tracked until the anchor update completes.
-    pub anchor_update_retained_since: Option<Duration>,
-    /// Removal reason to use once a retained game is finally evicted.
-    pub anchor_update_retention_reason: Option<RemovalReason>,
 }
 
 impl TrackedGame {
-    /// Creates a freshly-tracked game in the given phase. All caches and
-    /// retention timestamps start unset.
+    /// Creates a freshly-tracked game in the given phase.
     pub const fn new(phase: BondPhase, bond_recipient: Address) -> Self {
-        Self {
-            phase,
-            bond_recipient,
-            anchor_update_complete: false,
-            cached_status: None,
-            cached_asr_address: None,
-            cached_l2_block_number: None,
-            anchor_update_retained_since: None,
-            anchor_update_retention_reason: None,
-        }
+        Self { phase, bond_recipient }
     }
 }
 
@@ -161,9 +130,6 @@ pub struct BondManager<C: Clock> {
     /// How often a full rescan of the lookback window is performed to catch
     /// state transitions (games challenged or resolved by other actors).
     discovery_interval: Duration,
-    /// Maximum time to retain a completed bond game while waiting for its
-    /// anchor update to complete.
-    anchor_update_retention: Duration,
 }
 
 impl<C: Clock> BondManager<C> {
@@ -171,10 +137,6 @@ impl<C: Clock> BondManager<C> {
     /// been read yet. If the real delay is shorter the withdraw will simply
     /// succeed earlier; if longer, the attempt reverts and is retried.
     const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-
-    /// Default maximum time to keep a completed bond game tracked while
-    /// waiting for its best-effort anchor update to finish.
-    const DEFAULT_ANCHOR_UPDATE_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 
     /// How long to wait before retrying a reverted withdraw attempt.
     const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
@@ -202,7 +164,6 @@ impl<C: Clock> BondManager<C> {
             last_full_scan,
             lookback,
             discovery_interval,
-            anchor_update_retention: Self::DEFAULT_ANCHOR_UPDATE_RETENTION,
         }
     }
 
@@ -227,13 +188,6 @@ impl<C: Clock> BondManager<C> {
             debug!(game = %game_address, "WETH delay not yet known, using default 7 days");
             Self::DEFAULT_WETH_DELAY
         })
-    }
-
-    /// Sets the maximum time a completed bond game remains tracked while
-    /// waiting for its anchor update to complete.
-    pub fn set_anchor_update_retention(&mut self, retention: Duration) {
-        info!(retention_secs = retention.as_secs(), "anchor update retention configured");
-        self.anchor_update_retention = retention;
     }
 
     /// Returns the number of games currently being tracked.
@@ -430,15 +384,15 @@ impl<C: Clock> BondManager<C> {
     pub async fn startup_scan(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Vec<Address>> {
         if !self.is_enabled() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let game_count = self.factory_client.game_count().await?;
         if game_count == 0 {
             info!("no games in factory, skipping bond startup scan");
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let start_index = game_count.saturating_sub(self.lookback);
@@ -462,6 +416,7 @@ impl<C: Clock> BondManager<C> {
             self.ensure_weth_delay(verifier_client, *game_address).await;
         }
 
+        let mut recovered_games = Vec::new();
         for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
             let Some(phase) = phase else {
                 continue;
@@ -474,6 +429,7 @@ impl<C: Clock> BondManager<C> {
                 "recovered game for bond tracking"
             );
             self.tracked.insert(game_address, TrackedGame::new(phase, bond_recipient));
+            recovered_games.push(game_address);
         }
 
         self.bond_scan_head = game_count;
@@ -481,7 +437,7 @@ impl<C: Clock> BondManager<C> {
 
         ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         info!(count = self.tracked.len(), "bond startup scan complete");
-        Ok(())
+        Ok(recovered_games)
     }
 
     /// Discovers claimable games via two-tier scanning.
@@ -498,16 +454,16 @@ impl<C: Clock> BondManager<C> {
     pub async fn discover_claimable_games(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Vec<Address>> {
         if !self.is_enabled() {
             warn!("bond manager is disabled, skipping discovery scan");
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let game_count = self.factory_client.game_count().await?;
         if game_count == 0 {
             debug!("no games found, skipping bond discovery scan");
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         // Periodic full rescan: reset watermark to re-evaluate the
@@ -527,7 +483,7 @@ impl<C: Clock> BondManager<C> {
 
         let scan_start = self.bond_scan_head;
         if scan_start >= game_count {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let scan_end = game_count.min(scan_start.saturating_add(self.lookback));
@@ -568,7 +524,7 @@ impl<C: Clock> BondManager<C> {
         )
         .await;
 
-        let mut discovered = 0u64;
+        let mut discovered_games = Vec::new();
 
         for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
             if self.tracked.contains_key(&game_address) {
@@ -587,7 +543,7 @@ impl<C: Clock> BondManager<C> {
                 "discovered claimable game"
             );
             self.tracked.insert(game_address, TrackedGame::new(phase, bond_recipient));
-            discovered += 1;
+            discovered_games.push(game_address);
         }
 
         self.bond_scan_head = scan_end;
@@ -596,13 +552,14 @@ impl<C: Clock> BondManager<C> {
             self.last_full_scan = self.clock.now();
         }
 
-        if discovered > 0 {
+        if !discovered_games.is_empty() {
+            let discovered = discovered_games.len() as u64;
             ChallengerMetrics::bond_discovery_games_found_total().increment(discovered);
             ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
             info!(discovered, tracked = self.tracked.len(), scan_type, "bond discovery complete");
         }
 
-        Ok(())
+        Ok(discovered_games)
     }
 
     /// Polls all tracked games and advances each through the bond lifecycle.
@@ -629,26 +586,11 @@ impl<C: Clock> BondManager<C> {
         let mut removed = Vec::new();
 
         for game_address in addresses {
-            if let Some(reason) =
-                self.tracked.get(&game_address).and_then(|g| g.anchor_update_retention_reason)
-            {
-                self.try_anchor_update(game_address, verifier_client, submitter).await;
-                if self.handle_lifecycle_completion(game_address, reason) {
-                    removed.push((game_address, reason));
-                }
-                continue;
-            }
-
             match self.advance_game(game_address, verifier_client, submitter).await {
                 Ok(Some(reason)) => {
-                    self.try_anchor_update(game_address, verifier_client, submitter).await;
-                    if self.handle_lifecycle_completion(game_address, reason) {
-                        removed.push((game_address, reason));
-                    }
+                    removed.push((game_address, reason));
                 }
-                Ok(None) => {
-                    self.try_anchor_update(game_address, verifier_client, submitter).await;
-                }
+                Ok(None) => {}
                 Err(e) => {
                     warn!(
                         game = %game_address,
@@ -674,57 +616,6 @@ impl<C: Clock> BondManager<C> {
         if !removed.is_empty() {
             ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         }
-        let retained =
-            self.tracked.values().filter(|g| g.anchor_update_retained_since.is_some()).count();
-        ChallengerMetrics::anchor_update_retained_games().set(retained as f64);
-    }
-
-    /// Decides whether a game whose bond lifecycle has finished should be
-    /// removed now or retained until [`try_anchor_update`] succeeds.
-    ///
-    /// Returns `true` if the caller should remove the game from tracking.
-    fn handle_lifecycle_completion(
-        &mut self,
-        game_address: Address,
-        reason: RemovalReason,
-    ) -> bool {
-        let now = self.clock.now();
-        let Some(game) = self.tracked.get_mut(&game_address) else {
-            return true;
-        };
-        if game.anchor_update_complete {
-            return true;
-        }
-        if let Some(retained_since) = game.anchor_update_retained_since {
-            game.anchor_update_retention_reason = Some(reason);
-            let retained_duration = now.saturating_sub(retained_since);
-            if retained_duration >= self.anchor_update_retention {
-                warn!(
-                    game = %game_address,
-                    reason = ?reason,
-                    retained_secs = retained_duration.as_secs(),
-                    retention_secs = self.anchor_update_retention.as_secs(),
-                    "evicting game after anchor update retention timeout"
-                );
-                return true;
-            }
-            debug!(
-                game = %game_address,
-                reason = ?reason,
-                retained_secs = retained_duration.as_secs(),
-                "keeping game tracked until anchor update completes"
-            );
-            return false;
-        }
-        game.anchor_update_retained_since = Some(now);
-        game.anchor_update_retention_reason = Some(reason);
-        warn!(
-            game = %game_address,
-            reason = ?reason,
-            "retaining completed bond game until anchor update completes"
-        );
-        ChallengerMetrics::anchor_update_retained_games_total().increment(1);
-        false
     }
 
     /// Advances a single game through the bond lifecycle state machine.
@@ -793,23 +684,6 @@ impl<C: Clock> BondManager<C> {
                     );
                     ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                         .increment(1);
-                    // Re-read and cache the now-immutable status so that
-                    // try_anchor_update (called later this tick) can use
-                    // it without a redundant RPC call.
-                    match verifier_client.status(game_address).await {
-                        Ok(resolved_status) => {
-                            if let Some(g) = self.tracked.get_mut(&game_address) {
-                                g.cached_status = Some(resolved_status);
-                            }
-                        }
-                        Err(e) => {
-                            debug!(
-                                game = %game_address,
-                                error = %e,
-                                "failed to cache status after resolve, will re-read later"
-                            );
-                        }
-                    }
                 }
                 Err(e) => {
                     warn!(
@@ -826,12 +700,6 @@ impl<C: Clock> BondManager<C> {
             ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
                 .increment(1);
             info!(game = %game_address, status = ?status, "game already resolved");
-            // Status is immutable after resolution — cache it so that
-            // try_anchor_update (called later this tick) can skip the
-            // redundant RPC round-trip.
-            if let Some(g) = self.tracked.get_mut(&game_address) {
-                g.cached_status = Some(status);
-            }
         }
 
         // Re-read the onchain bondRecipient — resolve may have changed it
@@ -1059,7 +927,7 @@ impl<C: Clock> BondManager<C> {
     ///
     /// Computes how long ago `unix_secs` occurred relative to `unix_now`
     /// and subtracts that age from the current monotonic time. Used when
-    /// recovering on-chain timestamps (e.g. `resolved_at`) into the
+    /// recovering onchain timestamps (e.g. `resolved_at`) into the
     /// local monotonic time domain.
     ///
     /// `unix_now` is accepted as a parameter (callers obtain it via
@@ -1163,235 +1031,6 @@ impl<C: Clock> BondManager<C> {
         }
     }
 
-    /// Marks the anchor update as complete for a tracked game. No-op if the
-    /// game is no longer tracked.
-    fn mark_anchor_update_complete(&mut self, game_address: Address) {
-        if let Some(game) = self.tracked.get_mut(&game_address) {
-            game.anchor_update_complete = true;
-        }
-    }
-
-    /// Marks an anchor update as permanently skipped: the game cannot become
-    /// a valid anchor and we increment the SKIPPED outcome metric.
-    fn skip_anchor_update_permanently(&mut self, game_address: Address) {
-        self.mark_anchor_update_complete(game_address);
-        ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
-            .increment(1);
-    }
-
-    /// Best-effort attempt to update the `AnchorStateRegistry` for a
-    /// resolved game.
-    ///
-    /// Skips updates for games that are permanently ineligible (blacklisted,
-    /// retired, or already stale relative to the current anchor) so the tx
-    /// submitter is not spammed each poll tick. Transient ineligibility
-    /// (airgap delay not elapsed, not yet finalized, or currently
-    /// unrespected) is left to retry on the next tick — the on-chain
-    /// `setAnchorState()` call is permissionless and self-validating.
-    async fn try_anchor_update(
-        &mut self,
-        game_address: Address,
-        verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) {
-        let game = match self.tracked.get(&game_address) {
-            Some(g) => g,
-            None => return,
-        };
-
-        if game.anchor_update_complete
-            || (game.cached_status.is_none() && matches!(game.phase, BondPhase::NeedsResolve))
-        {
-            return;
-        }
-
-        // Only DEFENDER_WINS games can update the anchor state.
-        // The status is immutable after resolution, so we cache it
-        // after the first successful RPC read to avoid redundant calls.
-        let status = if let Some(cached) = game.cached_status {
-            cached
-        } else {
-            match verifier_client.status(game_address).await {
-                Ok(s) => {
-                    if let Some(g) = self.tracked.get_mut(&game_address) {
-                        g.cached_status = Some(s);
-                    }
-                    s
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read status for anchor update"
-                    );
-                    return;
-                }
-            }
-        };
-
-        if status != GameStatus::DefenderWins {
-            self.skip_anchor_update_permanently(game_address);
-            return;
-        }
-
-        // Resolve the ASR address from the game contract (cached after first read).
-        let asr_address = if let Some(cached) =
-            self.tracked.get(&game_address).and_then(|g| g.cached_asr_address)
-        {
-            cached
-        } else {
-            match verifier_client.anchor_state_registry(game_address).await {
-                Ok(addr) => {
-                    if let Some(g) = self.tracked.get_mut(&game_address) {
-                        g.cached_asr_address = Some(addr);
-                    }
-                    addr
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read anchorStateRegistry for anchor update"
-                    );
-                    return;
-                }
-            }
-        };
-
-        // Keep the cheap finality read before the heavier preflight batch. With
-        // a nonzero ASR airgap, blacklisted/retired games may retry this single
-        // read until finality, but moving preflight earlier would add several
-        // reads for every ordinary not-yet-finalized game.
-        match verifier_client.is_game_finalized(asr_address, game_address).await {
-            Ok(true) => {}
-            Ok(false) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    "anchor state update not ready because game is not finalized"
-                );
-                return;
-            }
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "failed to read isGameFinalized, will retry"
-                );
-                return;
-            }
-        }
-
-        let preflight = match verifier_client.anchor_preflight(asr_address, game_address).await {
-            Ok(p) => p,
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "failed to read anchor preflight state, will retry"
-                );
-                return;
-            }
-        };
-
-        if preflight.permanently_ineligible() {
-            info!(
-                game = %game_address,
-                asr = %asr_address,
-                blacklisted = preflight.blacklisted,
-                retired = preflight.retired,
-                respected = preflight.respected,
-                "skipping permanently ineligible anchor update"
-            );
-            self.skip_anchor_update_permanently(game_address);
-            return;
-        }
-
-        if preflight.paused {
-            debug!(
-                game = %game_address,
-                asr = %asr_address,
-                "anchor state update not ready because registry is paused"
-            );
-            return;
-        }
-
-        if !preflight.respected {
-            debug!(
-                game = %game_address,
-                asr = %asr_address,
-                "anchor state update not ready because game is not currently respected"
-            );
-            return;
-        }
-
-        let game_l2_block_number = if let Some(cached) =
-            self.tracked.get(&game_address).and_then(|g| g.cached_l2_block_number)
-        {
-            cached
-        } else {
-            match verifier_client.game_info(game_address).await {
-                Ok(info) => {
-                    if let Some(g) = self.tracked.get_mut(&game_address) {
-                        g.cached_l2_block_number = Some(info.l2_block_number);
-                    }
-                    info.l2_block_number
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        asr = %asr_address,
-                        error = %e,
-                        "failed to read game info for anchor preflight, will retry"
-                    );
-                    return;
-                }
-            }
-        };
-
-        if game_l2_block_number <= preflight.anchor_root.l2_block_number {
-            info!(
-                game = %game_address,
-                asr = %asr_address,
-                game_l2_block = game_l2_block_number,
-                anchor_l2_block = preflight.anchor_root.l2_block_number,
-                "skipping stale anchor state update"
-            );
-            self.skip_anchor_update_permanently(game_address);
-            return;
-        }
-
-        let calldata = encode_set_anchor_state_calldata(game_address);
-        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
-            Ok(tx_hash) => {
-                info!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    tx_hash = %tx_hash,
-                    "anchor state registry updated"
-                );
-                self.mark_anchor_update_complete(game_address);
-                ChallengerMetrics::anchor_update_tx_outcome_total(
-                    ChallengerMetrics::STATUS_SUCCESS,
-                )
-                .increment(1);
-                ChallengerMetrics::anchor_l2_block_number().set(game_l2_block_number as f64);
-            }
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "anchor state update failed, will retry"
-                );
-                ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                    .increment(1);
-            }
-        }
-    }
-
     /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
     async fn resolve_weth_delay(
         &mut self,
@@ -1406,8 +1045,7 @@ impl<C: Clock> BondManager<C> {
     }
 }
 
-/// Trait for submitting bond lifecycle transactions (resolve, claimCredit,
-/// setAnchorState).
+/// Trait for submitting bond lifecycle transactions (`resolve`, `claimCredit`).
 ///
 /// This abstracts the transaction submission layer so the [`BondManager`]
 /// can be tested with mock submitters.
@@ -1433,7 +1071,7 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory, MockGameState,
+        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory,
         TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
     };
 
@@ -1771,7 +1409,7 @@ mod tests {
 
     #[test]
     fn unix_to_monotonic_future_timestamp_clamps() {
-        // If the on-chain timestamp is ahead of local wall clock
+        // If the onchain timestamp is ahead of local wall clock
         // (clock skew), age saturates to 0 → monotonic = clock.now().
         let clock = fixed_clock(500);
         let result = BondManager::unix_to_monotonic(&clock, 2100, 2000);
@@ -2299,276 +1937,5 @@ mod tests {
 
         assert_eq!(mgr.bond_scan_head, game_count);
         assert_eq!(mgr.tracked_count(), game_count as usize);
-    }
-
-    // ---- anchor state update tests ----
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_needs_resolve_phase() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        // Game is still in NeedsResolve — should not attempt anchor update.
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(!mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_challenger_wins() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        // ChallengerWins — not eligible for anchor update.
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        // No tx submitted, but marked complete (won't retry).
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_sends_tx_for_defender_wins() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        // DefenderWins — eligible for anchor update.
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let tx_hash = B256::repeat_byte(0xDD);
-        let submitter = MockBondTransactionSubmitter::success(tx_hash);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        let calls = submitter.recorded_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game, "tx should carry game address as context");
-        assert_eq!(calls[0].1, asr, "tx should be sent to ASR address");
-        assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_retries_on_failure() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(
-            game,
-            BondPhase::AwaitingDelay {
-                unlocked_at: Duration::from_secs(0),
-                unlocked_at_unix_secs: None,
-            },
-        );
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        // First attempt fails (e.g. airgap not elapsed → tx reverted).
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Err(
-            crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO },
-        )]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        // Should NOT be marked complete — will retry next tick.
-        assert!(!mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_not_retried_after_success() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        // First call succeeds.
-        let tx_hash = B256::repeat_byte(0xDD);
-        let submitter = MockBondTransactionSubmitter::success(tx_hash);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-        assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
-
-        // Second call should be a no-op (no submitter response needed).
-        let submitter2 = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter2).await;
-        assert!(submitter2.recorded_calls().is_empty());
-    }
-
-    async fn run_anchor_update_skip_case(
-        mutate: impl FnOnce(&mut MockGameState),
-        expect_complete: bool,
-    ) {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        mutate(&mut state);
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty(), "no tx expected");
-        assert_eq!(
-            mgr.tracked.get(&game).unwrap().anchor_update_complete,
-            expect_complete,
-            "anchor_update_complete mismatch"
-        );
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_blacklisted_game() {
-        run_anchor_update_skip_case(|s| s.is_blacklisted = true, true).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_retired_game() {
-        run_anchor_update_skip_case(|s| s.is_retired = true, true).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_retries_for_unrespected_game() {
-        run_anchor_update_skip_case(|s| s.is_respected = false, false).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_retries_when_registry_paused() {
-        run_anchor_update_skip_case(|s| s.is_paused = true, false).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_stale_game() {
-        run_anchor_update_skip_case(|s| s.anchor_root.l2_block_number = 200, true).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_waits_for_finalization() {
-        run_anchor_update_skip_case(|s| s.is_finalized = false, false).await;
-    }
-
-    #[tokio::test]
-    async fn poll_keeps_game_until_anchor_update_completes() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::Completed);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.poll(&*verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty(), "no tx should be sent before finalization");
-        assert!(mgr.is_tracking(&game), "game should stay tracked until anchor update completes");
-    }
-
-    #[tokio::test]
-    async fn poll_evicts_game_after_anchor_update_retention_timeout() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.set_anchor_update_retention(Duration::from_secs(10));
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::Completed);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(mgr.is_tracking(&game), "game should be retained before timeout");
-
-        mgr.clock.monotonic = Duration::from_secs(10);
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(!mgr.is_tracking(&game), "game should be evicted at retention timeout");
-    }
-
-    #[tokio::test]
-    async fn poll_skips_bond_lifecycle_for_retained_not_claimable_game() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let other_recipient = Address::repeat_byte(0xDD);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = other_recipient;
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(mgr.is_tracking(&game), "game should be retained for anchor update");
-        assert_eq!(verifier.bond_recipient_read_count(game), 1);
-
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(mgr.is_tracking(&game), "game should remain retained before finalization");
-        assert_eq!(
-            verifier.bond_recipient_read_count(game),
-            1,
-            "retained game should not re-run the bond lifecycle"
-        );
     }
 }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -506,6 +506,10 @@ impl<C: Clock> BondManager<C> {
         match Self::send_claim_credit(game_address, "unlock", submitter).await {
             Ok(_) => {
                 let Some(delay) = self.weth_delay else {
+                    debug!(
+                        game = %game_address,
+                        "unlock confirmed but WETH delay not yet known, will resolve on next poll"
+                    );
                     return Ok(Some(BondPhase::NeedsUnlock));
                 };
                 Ok(Some(BondPhase::AwaitingDelay {
@@ -660,14 +664,15 @@ impl<C: Clock> BondManager<C> {
 mod tests {
     use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
+    use alloy_primitives::B256;
+    use futures::stream::BoxStream;
+
     use super::*;
     use crate::test_utils::{
         MockAggregateVerifier, MockDisputeGameFactory, SharedMockTxManager,
         TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
         receipt_with_status,
     };
-    use alloy_primitives::B256;
-    use futures::stream::BoxStream;
 
     const TEST_WETH_DELAY: Duration = Duration::from_secs(60);
     const WITHDRAW_READY_MONOTONIC_SECS: u64 = 3_700;
@@ -1042,8 +1047,7 @@ mod tests {
                 Some(BondPhase::AwaitingDelay { ready_at })
                     if ready_at == Duration::from_secs(500)
             ),
-            "expected ready AwaitingDelay, got {:?}",
-            result,
+            "expected ready AwaitingDelay, got {result:?}",
         );
         assert!(
             tx_manager.recorded_calls().is_empty(),
@@ -1069,8 +1073,7 @@ mod tests {
                 Some(BondPhase::AwaitingDelay { ready_at })
                     if ready_at == Duration::from_secs(560)
             ),
-            "expected AwaitingDelay with monotonic deadline, got {:?}",
-            result,
+            "expected AwaitingDelay with monotonic deadline, got {result:?}",
         );
         assert_eq!(tx_manager.recorded_calls().len(), 1);
     }

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -1,13 +1,10 @@
 //! CLI argument definitions for the challenger.
-//!
-//! All flags use the `BASE_CHALLENGER_` environment-variable prefix
-//! (e.g. `BASE_CHALLENGER_L1_ETH_RPC`). The default metrics port is **7300**.
 
 use std::time::Duration;
 
 use alloy_primitives::Address;
 use base_cli_utils::CliStyles;
-use clap::Parser;
+use clap::{Args, Parser};
 use url::Url;
 
 base_cli_utils::define_cli_env!("BASE_CHALLENGER");
@@ -41,28 +38,28 @@ pub struct Cli {
 }
 
 /// Core challenger configuration arguments.
-#[derive(Debug, Parser)]
+#[derive(Debug, Args)]
 #[command(next_help_heading = "Challenger")]
 pub struct ChallengerArgs {
     /// URL of the L1 Ethereum RPC endpoint.
-    #[arg(long = "l1-eth-rpc", env = cli_env!("L1_ETH_RPC"))]
+    #[arg(long, env = cli_env!("L1_ETH_RPC"))]
     pub l1_eth_rpc: Url,
 
     /// URL of the L2 Ethereum RPC endpoint.
-    #[arg(long = "l2-eth-rpc", env = cli_env!("L2_ETH_RPC"))]
+    #[arg(long, env = cli_env!("L2_ETH_RPC"))]
     pub l2_eth_rpc: Url,
 
     /// Address of the `DisputeGameFactory` contract on L1.
-    #[arg(long = "dispute-game-factory-addr", env = cli_env!("DISPUTE_GAME_FACTORY_ADDR"))]
+    #[arg(long, env = cli_env!("DISPUTE_GAME_FACTORY_ADDR"))]
     pub dispute_game_factory_addr: Address,
 
     /// Address of the `AnchorStateRegistry` contract on L1.
-    #[arg(long = "anchor-state-registry-addr", env = cli_env!("ANCHOR_STATE_REGISTRY_ADDR"))]
+    #[arg(long, env = cli_env!("ANCHOR_STATE_REGISTRY_ADDR"))]
     pub anchor_state_registry_addr: Address,
 
     /// Polling interval for new dispute games (e.g., "12s", "1m").
     #[arg(
-        long = "poll-interval",
+        long,
         env = cli_env!("POLL_INTERVAL"),
         default_value = "12s",
         value_parser = humantime::parse_duration
@@ -70,23 +67,13 @@ pub struct ChallengerArgs {
     pub poll_interval: Duration,
 
     /// URL of the ZK RPC endpoint.
-    #[arg(long = "zk-rpc-url", env = cli_env!("ZK_RPC_URL"))]
+    #[arg(long, env = cli_env!("ZK_RPC_URL"))]
     pub zk_rpc_url: Url,
-
-    /// Timeout for establishing the initial gRPC connection to the ZK proof
-    /// service (e.g., "10s", "1m").
-    #[arg(
-        long = "zk-connect-timeout",
-        env = cli_env!("ZK_CONNECT_TIMEOUT"),
-        default_value = "10s",
-        value_parser = humantime::parse_duration
-    )]
-    pub zk_connect_timeout: Duration,
 
     /// Timeout for individual gRPC requests to the ZK proof service
     /// (e.g., "30s", "1m").
     #[arg(
-        long = "zk-request-timeout",
+        long,
         env = cli_env!("ZK_REQUEST_TIMEOUT"),
         default_value = "30s",
         value_parser = humantime::parse_duration
@@ -96,7 +83,7 @@ pub struct ChallengerArgs {
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed and
     /// retrying (e.g., "30m", "2h"). Should be set above the typical proof generation time.
     #[arg(
-        long = "max-proof-duration",
+        long,
         env = cli_env!("MAX_PROOF_DURATION"),
         default_value = "4h",
         value_parser = humantime::parse_duration
@@ -105,11 +92,7 @@ pub struct ChallengerArgs {
 
     /// Retryable TEE submission failures to tolerate before falling back to ZK.
     /// Set to 0 to fall back immediately on the first retryable TEE tx error.
-    #[arg(
-        long = "tee-submit-retry-limit",
-        env = cli_env!("TEE_SUBMIT_RETRY_LIMIT"),
-        default_value = "3"
-    )]
+    #[arg(long, env = cli_env!("TEE_SUBMIT_RETRY_LIMIT"), default_value_t = 3)]
     pub tee_submit_retry_limit: u32,
 
     /// Signer configuration (local private key or remote sidecar).
@@ -121,17 +104,13 @@ pub struct ChallengerArgs {
     pub tx_manager: TxManagerCli,
 
     /// Number of recent factory games scanned by bond discovery.
-    #[arg(
-        long = "bond-discovery-lookback-games",
-        env = cli_env!("BOND_DISCOVERY_LOOKBACK_GAMES"),
-        default_value = "1000"
-    )]
+    #[arg(long, env = cli_env!("BOND_DISCOVERY_LOOKBACK_GAMES"), default_value_t = 1000)]
     pub bond_discovery_lookback_games: u64,
 
     /// How often a full rescan of the bond lookback window is performed to
     /// catch state transitions (games challenged or resolved by other actors).
     #[arg(
-        long = "bond-discovery-interval",
+        long,
         env = cli_env!("BOND_DISCOVERY_INTERVAL"),
         default_value = "300s",
         value_parser = humantime::parse_duration
@@ -140,7 +119,7 @@ pub struct ChallengerArgs {
 
     /// Maximum time to retry an eligible anchor state update after it starts failing.
     #[arg(
-        long = "anchor-update-retention",
+        long,
         env = cli_env!("ANCHOR_UPDATE_RETENTION"),
         default_value = "24h",
         value_parser = humantime::parse_duration
@@ -154,7 +133,7 @@ pub struct ChallengerArgs {
     /// these addresses. Requires two `claimCredit()` calls per game with
     /// a `DelayedWETH` delay in between.
     #[arg(
-        long = "bond-claim-addresses",
+        long,
         env = cli_env!("BOND_CLAIM_ADDRESSES"),
         value_delimiter = ','
     )]

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -138,8 +138,7 @@ pub struct ChallengerArgs {
     )]
     pub bond_discovery_interval: Duration,
 
-    /// Maximum time to keep a completed bond game tracked while waiting for
-    /// its anchor update to complete.
+    /// Maximum time to retry an eligible anchor state update after it starts failing.
     #[arg(
         long = "anchor-update-retention",
         env = cli_env!("ANCHOR_UPDATE_RETENTION"),

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -111,8 +111,7 @@ pub struct ChallengerConfig {
     pub bond_discovery_lookback_games: u64,
     /// How often a full rescan of the bond lookback window is performed.
     pub bond_discovery_interval: Duration,
-    /// Maximum time to keep a completed bond game tracked while waiting for
-    /// its anchor update to complete.
+    /// Maximum time to retry an eligible anchor state update after it starts failing.
     pub anchor_update_retention: Duration,
     /// Addresses to claim bonds on behalf of.
     pub bond_claim_addresses: Vec<Address>,

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -95,8 +95,6 @@ pub struct ChallengerConfig {
     pub poll_interval: Duration,
     /// URL of the ZK RPC endpoint.
     pub zk_rpc_url: Validated<Url>,
-    /// Timeout for establishing the initial gRPC connection to the ZK proof service.
-    pub zk_connect_timeout: Duration,
     /// Timeout for individual gRPC requests to the ZK proof service.
     pub zk_request_timeout: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
@@ -179,7 +177,6 @@ impl ChallengerConfig {
         }
 
         require_nonzero_duration(cli.challenger.poll_interval, "poll-interval")?;
-        require_nonzero_duration(cli.challenger.zk_connect_timeout, "zk-connect-timeout")?;
         require_nonzero_duration(cli.challenger.zk_request_timeout, "zk-request-timeout")?;
         require_nonzero_duration(cli.challenger.max_proof_duration, "max-proof-duration")?;
 
@@ -219,7 +216,6 @@ impl ChallengerConfig {
             anchor_state_registry_addr: cli.challenger.anchor_state_registry_addr,
             poll_interval: cli.challenger.poll_interval,
             zk_rpc_url,
-            zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
             max_proof_duration: cli.challenger.max_proof_duration,
             tee_submit_retry_limit: cli.challenger.tee_submit_retry_limit,
@@ -290,7 +286,6 @@ mod tests {
         let cli = cli_from_args(&SIGNER_ARGS);
         let config = ChallengerConfig::from_cli(cli).unwrap();
         assert_eq!(config.poll_interval, Duration::from_secs(12));
-        assert_eq!(config.zk_connect_timeout, Duration::from_secs(10));
         assert_eq!(config.zk_request_timeout, Duration::from_secs(30));
         assert_eq!(config.tee_submit_retry_limit, 3);
         assert_eq!(
@@ -325,7 +320,6 @@ mod tests {
 
     #[rstest]
     #[case::poll_interval("--poll-interval", "0s", "poll-interval")]
-    #[case::zk_connect_timeout("--zk-connect-timeout", "0s", "zk-connect-timeout")]
     #[case::zk_request_timeout("--zk-request-timeout", "0s", "zk-request-timeout")]
     #[case::bond_discovery_lookback_games(
         "--bond-discovery-lookback-games",

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -35,10 +35,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    BondManager, CandidateGame, ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics,
-    DisputeIntent, GameCategory, GameScanner, IntermediateValidationParams, L1HeadProvider,
-    OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate,
-    ValidatorError,
+    AnchorUpdater, BondManager, CandidateGame, ChallengeSubmitError, ChallengeSubmitter,
+    ChallengerMetrics, DisputeIntent, GameCategory, GameScanner, IntermediateValidationParams,
+    L1HeadProvider, OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase,
+    ProofUpdate, ValidatorError,
 };
 
 /// Configuration for the challenger [`Driver`].
@@ -82,6 +82,8 @@ pub struct DriverComponents<
     pub verifier_client: Arc<dyn AggregateVerifierClient>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
     pub bond_manager: Option<BondManager<C>>,
+    /// Best-effort anchor state updater.
+    pub anchor_updater: AnchorUpdater<C>,
 }
 
 impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt::Debug
@@ -121,6 +123,8 @@ where
     ignored_games: HashSet<Address>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
     pub bond_manager: Option<BondManager<C>>,
+    /// Best-effort anchor state updater.
+    pub anchor_updater: AnchorUpdater<C>,
     /// Interval between polling cycles.
     pub poll_interval: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
@@ -159,6 +163,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             pending_proofs: PendingProofs::new(),
             ignored_games: HashSet::new(),
             bond_manager: components.bond_manager,
+            anchor_updater: components.anchor_updater,
             poll_interval: config.poll_interval,
             max_proof_duration: config.max_proof_duration,
             tee_submit_retry_limit: config.tee_submit_retry_limit,
@@ -202,6 +207,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         self.poll_pending_proofs().await;
         self.discover_claimable_bonds().await;
         self.poll_bond_claims().await;
+        self.anchor_updater.poll(&*self.verifier_client, &self.submitter).await;
 
         let candidates = self.scanner.scan().await?;
 
@@ -220,10 +226,17 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     /// so that newly discovered games are immediately eligible for
     /// advancement in the same tick.
     async fn discover_claimable_bonds(&mut self) {
-        if let Some(ref mut bond_manager) = self.bond_manager
-            && let Err(e) = bond_manager.discover_claimable_games(&*self.verifier_client).await
-        {
-            warn!(error = %e, "bond discovery scan failed");
+        let Some(ref mut bond_manager) = self.bond_manager else {
+            return;
+        };
+
+        match bond_manager.discover_claimable_games(&*self.verifier_client).await {
+            Ok(games) => {
+                for game_address in games {
+                    self.anchor_updater.track_game(game_address);
+                }
+            }
+            Err(e) => warn!(error = %e, "bond discovery scan failed"),
         }
     }
 
@@ -319,7 +332,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                     }
 
                     // Persistent configuration errors: these indicate a
-                    // mismatch between the cached interval and on-chain
+                    // mismatch between the cached interval and onchain
                     // state (e.g. after a governance `setImplementation`
                     // that changed `INTERMEDIATE_BLOCK_INTERVAL`).
                     // Propagate so the caller logs the error at game level
@@ -365,6 +378,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
         if result.is_valid {
             debug!(game = %game_address, "game output roots are valid");
+            self.anchor_updater.track_game(game_address);
             return Ok(());
         }
 
@@ -496,7 +510,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
     /// Attempts TEE-first proof sourcing with ZK fallback.
     ///
-    /// The `intent` determines the on-chain action for the ZK fallback path.
+    /// The `intent` determines the onchain action for the ZK fallback path.
     /// TEE proofs always use `nullify()` regardless of `intent`.
     ///
     /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
@@ -604,7 +618,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             .ok_or_else(|| eyre::eyre!("claimed_l2_block_number overflow"))?;
 
         // Use the game's stored L1 head (from CWIA) so the enclave signs a
-        // journal whose `l1OriginHash` matches what the on-chain `nullify()`
+        // journal whose `l1OriginHash` matches what the onchain `nullify()`
         // will use for verification. Look up its block number concurrently
         // with the agreed L2 state computation.
         let l1_head = candidate.l1_head;
@@ -808,18 +822,21 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                 self.pending_proofs.remove(&game_address);
 
                 // After a successful challenge(), register the game for bond
-                // tracking so the BondManager can resolve and claim the bond.
-                if intent == DisputeIntent::Challenge
-                    && let Some(ref mut bond_manager) = self.bond_manager
-                {
-                    let sender = self.submitter.sender_address();
-                    if !bond_manager.track_game(game_address, sender) {
-                        warn!(
-                            game = %game_address,
-                            sender = %sender,
-                            "bond will not be tracked — sender address is not \
-                             in --bond-claim-addresses; bond may go unclaimed"
-                        );
+                // tracking so the BondManager can resolve and claim the bond,
+                // and let the anchor updater advance it once resolved.
+                if intent == DisputeIntent::Challenge {
+                    self.anchor_updater.track_game(game_address);
+
+                    if let Some(ref mut bond_manager) = self.bond_manager {
+                        let sender = self.submitter.sender_address();
+                        if !bond_manager.track_game(game_address, sender) {
+                            warn!(
+                                game = %game_address,
+                                sender = %sender,
+                                "bond will not be tracked — sender address is not \
+                                 in --bond-claim-addresses; bond may go unclaimed"
+                            );
+                        }
                     }
                 }
             }
@@ -1110,6 +1127,10 @@ mod tests {
             tee: None,
             verifier_client: verifier,
             bond_manager: None,
+            anchor_updater: AnchorUpdater::new(
+                TokioRuntime::new(),
+                Duration::from_secs(24 * 60 * 60),
+            ),
         };
         let driver = Driver::new(
             DriverConfig {

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -821,17 +821,17 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             Ok(_) => {
                 self.pending_proofs.remove(&game_address);
 
-                if intent == DisputeIntent::Challenge {
-                    if let Some(ref mut bond_manager) = self.bond_manager {
-                        let sender = self.submitter.sender_address();
-                        if !bond_manager.track_game(game_address, sender) {
-                            warn!(
-                                game = %game_address,
-                                sender = %sender,
-                                "bond will not be tracked — sender address is not \
-                                 in --bond-claim-addresses; bond may go unclaimed"
-                            );
-                        }
+                if intent == DisputeIntent::Challenge
+                    && let Some(ref mut bond_manager) = self.bond_manager
+                {
+                    let sender = self.submitter.sender_address();
+                    if !bond_manager.track_game(game_address, sender) {
+                        warn!(
+                            game = %game_address,
+                            sender = %sender,
+                            "bond will not be tracked — sender address is not \
+                             in --bond-claim-addresses; bond may go unclaimed"
+                        );
                     }
                 }
             }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -1263,6 +1263,7 @@ mod tests {
         driver.poll_or_submit(addr(0)).await.unwrap();
 
         assert!(!driver.pending_proofs.contains_key(&addr(0)));
+        assert!(!driver.anchor_updater.is_tracking(&addr(0)));
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -379,7 +379,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
         if result.is_valid {
             debug!(game = %game_address, "game output roots are valid");
-            self.anchor_updater.track_game(game_address);
+            self.anchor_updater.track_valid_game(game_address);
             return Ok(());
         }
 

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -379,7 +379,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
         if result.is_valid {
             debug!(game = %game_address, "game output roots are valid");
-            self.anchor_updater.track_valid_game(game_address);
+            self.anchor_updater.track_game(game_address);
             return Ok(());
         }
 
@@ -1263,7 +1263,6 @@ mod tests {
         driver.poll_or_submit(addr(0)).await.unwrap();
 
         assert!(!driver.pending_proofs.contains_key(&addr(0)));
-        assert!(!driver.anchor_updater.is_tracking(&addr(0)));
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -821,12 +821,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             Ok(_) => {
                 self.pending_proofs.remove(&game_address);
 
-                // After a successful challenge(), register the game for bond
-                // tracking so the BondManager can resolve and claim the bond,
-                // and let the anchor updater advance it once resolved.
                 if intent == DisputeIntent::Challenge {
-                    self.anchor_updater.track_game(game_address);
-
                     if let Some(ref mut bond_manager) = self.bond_manager {
                         let sender = self.submitter.sender_address();
                         if !bond_manager.track_game(game_address, sender) {
@@ -1255,6 +1250,19 @@ mod tests {
         driver.poll_or_submit(addr(0)).await.unwrap();
 
         assert!(!driver.pending_proofs.contains_key(&addr(0)));
+    }
+
+    #[tokio::test]
+    async fn challenge_success_does_not_track_anchor_update() {
+        let tx_hash = B256::repeat_byte(0x44);
+        let (mut driver, _proof_requester) =
+            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, tx_hash))));
+        insert_ready_proof(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert!(!driver.pending_proofs.contains_key(&addr(0)));
+        assert!(!driver.anchor_updater.is_tracking(&addr(0)));
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -93,7 +93,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt
         f.debug_struct("DriverComponents")
             .field("scanner", &self.scanner)
             .field("tee", &self.tee.as_ref().map(|_| ".."))
-            .field("bond_manager", &self.bond_manager)
+            .field("bond_manager", &self.bond_manager.as_ref().map(|_| ".."))
             .finish_non_exhaustive()
     }
 }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -202,7 +202,8 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     ///
     /// First polls any in-flight proof sessions that are not in the current
     /// scan batch, then discovers claimable bonds, advances bond lifecycle
-    /// claims, and finally scans for new candidates and processes them.
+    /// claims, polls anchor updates, and finally scans for new candidates and
+    /// processes them.
     pub async fn step(&mut self) -> eyre::Result<()> {
         self.poll_pending_proofs().await;
         self.discover_claimable_bonds().await;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -9,6 +9,9 @@
 mod cli;
 pub use cli::{ChallengerArgs, Cli, HealthArgs, LogArgs, MetricsArgs, SignerCli, TxManagerCli};
 
+mod anchor;
+pub use anchor::AnchorUpdater;
+
 mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};
 

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -51,7 +51,7 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, RemovalReason, TrackedGame};
+pub use bond::BondManager;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -10,7 +10,7 @@ mod cli;
 pub use cli::{ChallengerArgs, Cli, HealthArgs, LogArgs, MetricsArgs, SignerCli, TxManagerCli};
 
 mod anchor;
-pub use anchor::AnchorUpdater;
+pub use anchor::{AnchorUpdater, TrackedAnchorUpdate};
 
 mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -125,15 +125,8 @@ base_metrics::define_metrics! {
     #[label(name = "status", default = ["success", "error", "skipped"])]
     anchor_update_tx_outcome_total: counter,
 
-    #[describe(
-        "Number of otherwise-removable games currently retained while awaiting anchor state update"
-    )]
-    anchor_update_retained_games: gauge,
-
-    #[describe(
-        "Total games retained past bond lifecycle completion while awaiting anchor state update"
-    )]
-    anchor_update_retained_games_total: counter,
+    #[describe("Number of games currently tracked for anchor state updates")]
+    anchor_update_tracked_games: gauge,
 
     #[describe(
         "L2 block number of the most recent anchor state successfully advanced by this challenger. \
@@ -158,7 +151,7 @@ impl ChallengerMetrics {
     pub const STATUS_ERROR: &str = "error";
 
     /// Label value when a resolve was skipped because the game was already
-    /// resolved on-chain (e.g. by another actor).
+    /// resolved onchain (e.g. by another actor).
     pub const STATUS_ALREADY_RESOLVED: &str = "already_resolved";
 
     /// Label value when an anchor update was skipped (game not eligible).

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -453,7 +453,7 @@ impl GameScanner {
             factory_read_errors,
             status_read_errors,
             scan_start,
-            scan_head = game_count - 1,
+            scan_head = game_count.saturating_sub(1),
             "anchor recovery scan complete"
         );
         Ok(candidates)

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -404,7 +404,7 @@ impl GameScanner {
         }
 
         let scan_start = self.scan_start_index(game_count).await;
-        let candidates: Vec<Address> = stream::iter(scan_start..game_count)
+        let candidates: Vec<(Address, bool)> = stream::iter(scan_start..game_count)
             .map(|index| async move {
                 let game = match self.factory_client.game_at_index(index).await {
                     Ok(game) => game,
@@ -415,7 +415,7 @@ impl GameScanner {
                 };
 
                 match self.verifier_client.status(game.proxy).await {
-                    Ok(GameStatus::DefenderWins) => Some(game.proxy),
+                    Ok(GameStatus::DefenderWins) => Some((game.proxy, false)),
                     Ok(status) => {
                         debug!(
                             index,
@@ -432,7 +432,7 @@ impl GameScanner {
                             error = %e,
                             "failed to read game status during anchor recovery, tracking for retry"
                         );
-                        Some(game.proxy)
+                        Some((game.proxy, true))
                     }
                 }
             })
@@ -440,9 +440,13 @@ impl GameScanner {
             .filter_map(|candidate| async move { candidate })
             .collect()
             .await;
+        let status_read_errors = candidates.iter().filter(|(_, is_error)| *is_error).count();
+        let candidates: Vec<Address> =
+            candidates.into_iter().map(|(candidate, _)| candidate).collect();
 
         info!(
             recovered = candidates.len(),
+            status_read_errors,
             scan_start,
             scan_head = game_count - 1,
             "anchor recovery scan complete"

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -392,6 +392,64 @@ impl GameScanner {
         scan_start
     }
 
+    /// Scans post-anchor games for already-resolved defender wins that may
+    /// still need `setAnchorState()`.
+    pub async fn recover_anchor_candidates(&self) -> Result<Vec<Address>> {
+        let _scan_guard = self.scan_lock.lock().await;
+        let game_count = self.factory_client.game_count().await?;
+
+        if game_count == 0 {
+            debug!("factory has no games");
+            return Ok(vec![]);
+        }
+
+        let scan_start = self.scan_start_index(game_count).await;
+        let candidates: Vec<Address> = stream::iter(scan_start..game_count)
+            .map(|index| async move {
+                let game = match self.factory_client.game_at_index(index).await {
+                    Ok(game) => game,
+                    Err(e) => {
+                        warn!(index, error = %e, "failed to fetch game during anchor recovery");
+                        return None;
+                    }
+                };
+
+                match self.verifier_client.status(game.proxy).await {
+                    Ok(GameStatus::DefenderWins) => Some(game.proxy),
+                    Ok(status) => {
+                        debug!(
+                            index,
+                            game = %game.proxy,
+                            status = %status,
+                            "game is not an anchor recovery candidate"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        warn!(
+                            index,
+                            game = %game.proxy,
+                            error = %e,
+                            "failed to read game status during anchor recovery, tracking for retry"
+                        );
+                        Some(game.proxy)
+                    }
+                }
+            })
+            .buffer_unordered(Self::SCAN_CONCURRENCY)
+            .filter_map(|candidate| async move { candidate })
+            .collect()
+            .await;
+
+        info!(
+            recovered = candidates.len(),
+            scan_start,
+            scan_head = game_count - 1,
+            "anchor recovery scan complete"
+        );
+        Ok(candidates)
+    }
+
     /// Finds `target` in the half-open factory index range `[start, end)`,
     /// searching backward in batches and returning the match closest to `end`.
     ///
@@ -612,5 +670,55 @@ impl GameScanner {
         cache.insert(cache_key, interval);
 
         Ok(interval)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use super::*;
+    use crate::test_utils::{
+        MockAggregateVerifier, MockDisputeGameFactory, addr, factory_game, mock_anchor_registry,
+        mock_state,
+    };
+
+    #[tokio::test]
+    async fn recover_anchor_candidates_finds_resolved_defender_wins_after_anchor() {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![
+            factory_game(0, 1),
+            factory_game(1, 1),
+            factory_game(2, 1),
+            factory_game(3, 1),
+        ]));
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::from([
+            (addr(0), mock_state(GameStatus::DefenderWins, Address::ZERO, 50)),
+            (addr(1), mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
+            (addr(2), mock_state(GameStatus::DefenderWins, Address::ZERO, 200)),
+            (addr(3), mock_state(GameStatus::InProgress, Address::ZERO, 300)),
+        ])));
+        let scanner = GameScanner::new(factory, verifier, mock_anchor_registry(addr(1)));
+
+        let recovered = scanner.recover_anchor_candidates().await.unwrap();
+
+        assert_eq!(recovered, vec![addr(2)]);
+    }
+
+    #[tokio::test]
+    async fn recover_anchor_candidates_tracks_status_errors_for_retry() {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![
+            factory_game(0, 1),
+            factory_game(1, 1),
+            factory_game(2, 1),
+        ]));
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::from([
+            (addr(0), mock_state(GameStatus::DefenderWins, Address::ZERO, 50)),
+            (addr(1), mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
+        ])));
+        let scanner = GameScanner::new(factory, verifier, mock_anchor_registry(addr(1)));
+
+        let recovered = scanner.recover_anchor_candidates().await.unwrap();
+
+        assert_eq!(recovered, vec![addr(2)]);
     }
 }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -404,47 +404,49 @@ impl GameScanner {
         }
 
         let scan_start = self.scan_start_index(game_count).await;
-        let results: Vec<(Option<Address>, bool, bool)> = stream::iter(scan_start..game_count)
-            .map(|index| async move {
-                let game = match self.factory_client.game_at_index(index).await {
-                    Ok(game) => game,
-                    Err(e) => {
-                        warn!(index, error = %e, "failed to fetch game during anchor recovery");
-                        return (None, true, false);
-                    }
-                };
+        let mut results: Vec<(u64, Option<Address>, bool, bool)> =
+            stream::iter(scan_start..game_count)
+                .map(|index| async move {
+                    let game = match self.factory_client.game_at_index(index).await {
+                        Ok(game) => game,
+                        Err(e) => {
+                            warn!(index, error = %e, "failed to fetch game during anchor recovery");
+                            return (index, None, true, false);
+                        }
+                    };
 
-                match self.verifier_client.status(game.proxy).await {
-                    Ok(GameStatus::DefenderWins) => (Some(game.proxy), false, false),
-                    Ok(status) => {
-                        debug!(
-                            index,
-                            game = %game.proxy,
-                            status = %status,
-                            "game is not an anchor recovery candidate"
-                        );
-                        (None, false, false)
+                    match self.verifier_client.status(game.proxy).await {
+                        Ok(GameStatus::DefenderWins) => (index, Some(game.proxy), false, false),
+                        Ok(status) => {
+                            debug!(
+                                index,
+                                game = %game.proxy,
+                                status = %status,
+                                "game is not an anchor recovery candidate"
+                            );
+                            (index, None, false, false)
+                        }
+                        Err(e) => {
+                            warn!(
+                                index,
+                                game = %game.proxy,
+                                error = %e,
+                                "failed to read game status during anchor recovery"
+                            );
+                            (index, None, false, true)
+                        }
                     }
-                    Err(e) => {
-                        warn!(
-                            index,
-                            game = %game.proxy,
-                            error = %e,
-                            "failed to read game status during anchor recovery"
-                        );
-                        (None, false, true)
-                    }
-                }
-            })
-            .buffer_unordered(Self::SCAN_CONCURRENCY)
-            .collect()
-            .await;
+                })
+                .buffer_unordered(Self::SCAN_CONCURRENCY)
+                .collect()
+                .await;
+        results.sort_unstable_by_key(|(index, _, _, _)| *index);
         let factory_read_errors =
-            results.iter().filter(|(_, factory_read_failed, _)| *factory_read_failed).count();
+            results.iter().filter(|(_, _, factory_read_failed, _)| *factory_read_failed).count();
         let status_read_errors =
-            results.iter().filter(|(_, _, status_read_failed)| *status_read_failed).count();
+            results.iter().filter(|(_, _, _, status_read_failed)| *status_read_failed).count();
         let candidates: Vec<Address> =
-            results.into_iter().filter_map(|(candidate, _, _)| candidate).collect();
+            results.into_iter().filter_map(|(_, candidate, _, _)| candidate).collect();
 
         info!(
             recovered = candidates.len(),
@@ -697,18 +699,20 @@ mod tests {
             factory_game(1, 1),
             factory_game(2, 1),
             factory_game(3, 1),
+            factory_game(4, 1),
         ]));
         let verifier = Arc::new(MockAggregateVerifier::new(HashMap::from([
             (addr(0), mock_state(GameStatus::DefenderWins, Address::ZERO, 50)),
             (addr(1), mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
             (addr(2), mock_state(GameStatus::DefenderWins, Address::ZERO, 200)),
-            (addr(3), mock_state(GameStatus::InProgress, Address::ZERO, 300)),
+            (addr(3), mock_state(GameStatus::DefenderWins, Address::ZERO, 300)),
+            (addr(4), mock_state(GameStatus::InProgress, Address::ZERO, 400)),
         ])));
         let scanner = GameScanner::new(factory, verifier, mock_anchor_registry(addr(1)));
 
         let recovered = scanner.recover_anchor_candidates().await.unwrap();
 
-        assert_eq!(recovered, vec![addr(2)]);
+        assert_eq!(recovered, vec![addr(2), addr(3)]);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -404,18 +404,18 @@ impl GameScanner {
         }
 
         let scan_start = self.scan_start_index(game_count).await;
-        let results: Vec<(Option<Address>, bool)> = stream::iter(scan_start..game_count)
+        let results: Vec<(Option<Address>, bool, bool)> = stream::iter(scan_start..game_count)
             .map(|index| async move {
                 let game = match self.factory_client.game_at_index(index).await {
                     Ok(game) => game,
                     Err(e) => {
                         warn!(index, error = %e, "failed to fetch game during anchor recovery");
-                        return (None, false);
+                        return (None, true, false);
                     }
                 };
 
                 match self.verifier_client.status(game.proxy).await {
-                    Ok(GameStatus::DefenderWins) => (Some(game.proxy), false),
+                    Ok(GameStatus::DefenderWins) => (Some(game.proxy), false, false),
                     Ok(status) => {
                         debug!(
                             index,
@@ -423,7 +423,7 @@ impl GameScanner {
                             status = %status,
                             "game is not an anchor recovery candidate"
                         );
-                        (None, false)
+                        (None, false, false)
                     }
                     Err(e) => {
                         warn!(
@@ -432,19 +432,23 @@ impl GameScanner {
                             error = %e,
                             "failed to read game status during anchor recovery"
                         );
-                        (None, true)
+                        (None, false, true)
                     }
                 }
             })
             .buffer_unordered(Self::SCAN_CONCURRENCY)
             .collect()
             .await;
-        let status_read_errors = results.iter().filter(|(_, is_error)| *is_error).count();
+        let factory_read_errors =
+            results.iter().filter(|(_, factory_read_failed, _)| *factory_read_failed).count();
+        let status_read_errors =
+            results.iter().filter(|(_, _, status_read_failed)| *status_read_failed).count();
         let candidates: Vec<Address> =
-            results.into_iter().filter_map(|(candidate, _)| candidate).collect();
+            results.into_iter().filter_map(|(candidate, _, _)| candidate).collect();
 
         info!(
             recovered = candidates.len(),
+            factory_read_errors,
             status_read_errors,
             scan_start,
             scan_head = game_count - 1,

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -404,18 +404,18 @@ impl GameScanner {
         }
 
         let scan_start = self.scan_start_index(game_count).await;
-        let candidates: Vec<(Address, bool)> = stream::iter(scan_start..game_count)
+        let results: Vec<(Option<Address>, bool)> = stream::iter(scan_start..game_count)
             .map(|index| async move {
                 let game = match self.factory_client.game_at_index(index).await {
                     Ok(game) => game,
                     Err(e) => {
                         warn!(index, error = %e, "failed to fetch game during anchor recovery");
-                        return None;
+                        return (None, false);
                     }
                 };
 
                 match self.verifier_client.status(game.proxy).await {
-                    Ok(GameStatus::DefenderWins) => Some((game.proxy, false)),
+                    Ok(GameStatus::DefenderWins) => (Some(game.proxy), false),
                     Ok(status) => {
                         debug!(
                             index,
@@ -423,26 +423,25 @@ impl GameScanner {
                             status = %status,
                             "game is not an anchor recovery candidate"
                         );
-                        None
+                        (None, false)
                     }
                     Err(e) => {
                         warn!(
                             index,
                             game = %game.proxy,
                             error = %e,
-                            "failed to read game status during anchor recovery, tracking for retry"
+                            "failed to read game status during anchor recovery"
                         );
-                        Some((game.proxy, true))
+                        (None, true)
                     }
                 }
             })
             .buffer_unordered(Self::SCAN_CONCURRENCY)
-            .filter_map(|candidate| async move { candidate })
             .collect()
             .await;
-        let status_read_errors = candidates.iter().filter(|(_, is_error)| *is_error).count();
+        let status_read_errors = results.iter().filter(|(_, is_error)| *is_error).count();
         let candidates: Vec<Address> =
-            candidates.into_iter().map(|(candidate, _)| candidate).collect();
+            results.into_iter().filter_map(|(candidate, _)| candidate).collect();
 
         info!(
             recovered = candidates.len(),
@@ -709,7 +708,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recover_anchor_candidates_tracks_status_errors_for_retry() {
+    async fn recover_anchor_candidates_skips_status_errors() {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![
             factory_game(0, 1),
             factory_game(1, 1),
@@ -723,6 +722,6 @@ mod tests {
 
         let recovered = scanner.recover_anchor_candidates().await.unwrap();
 
-        assert_eq!(recovered, vec![addr(2)]);
+        assert!(recovered.is_empty());
     }
 }

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -22,8 +22,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
-    BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver, DriverComponents,
-    DriverConfig, GameScanner, OutputValidator,
+    AnchorUpdater, BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver,
+    DriverComponents, DriverConfig, GameScanner, OutputValidator,
 };
 
 /// Top-level challenger service.
@@ -147,7 +147,26 @@ impl ChallengerService {
             .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
         let tee = Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) });
 
-        // ── 7. Bond manager (optional) ─────────────────────────────────────
+        // ── 7. Scanner, anchor updater, and bond manager ──────────────────
+        let scanner = GameScanner::new(
+            Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&verifier_client),
+            anchor_registry_client,
+        );
+
+        let mut anchor_updater =
+            AnchorUpdater::new(TokioRuntime::new(), config.anchor_update_retention);
+
+        info!("starting anchor recovery scan");
+        match scanner.recover_anchor_candidates().await {
+            Ok(games) => {
+                for game_address in games {
+                    anchor_updater.track_game(game_address);
+                }
+            }
+            Err(e) => warn!(error = %e, "anchor recovery scan failed, continuing without recovery"),
+        }
+
         let bond_manager = if !config.bond_claim_addresses.is_empty() {
             let mut bm = BondManager::new(
                 config.bond_claim_addresses,
@@ -157,15 +176,21 @@ impl ChallengerService {
                 config.bond_discovery_interval,
                 TokioRuntime::new(),
             );
-            bm.set_anchor_update_retention(config.anchor_update_retention);
             info!("starting bond recovery scan");
-            if let Err(e) = bm.startup_scan(&*verifier_client).await {
-                // On failure `bond_scan_head` stays at 0, so
-                // `discover_claimable_games` will progressively scan the
-                // factory over multiple ticks (capped at `lookback` games
-                // per tick). This is intentional: progressive catch-up
-                // is preferable to disabling bond claiming entirely.
-                warn!(error = %e, "bond startup scan failed, continuing without recovery");
+            match bm.startup_scan(&*verifier_client).await {
+                Ok(games) => {
+                    for game_address in games {
+                        anchor_updater.track_game(game_address);
+                    }
+                }
+                Err(e) => {
+                    // On failure `bond_scan_head` stays at 0, so
+                    // `discover_claimable_games` will progressively scan the
+                    // factory over multiple ticks (capped at `lookback` games
+                    // per tick). This is intentional: progressive catch-up
+                    // is preferable to disabling bond claiming entirely.
+                    warn!(error = %e, "bond startup scan failed, continuing without recovery");
+                }
             }
             info!(tracked = bm.tracked_count(), "bond manager ready");
             Some(bm)
@@ -174,10 +199,7 @@ impl ChallengerService {
             None
         };
 
-        // ── 7b. Assemble scanner, validator, and driver ─────────────────────
-        let scanner =
-            GameScanner::new(factory_client, Arc::clone(&verifier_client), anchor_registry_client);
-
+        // ── 7b. Assemble validator and driver ──────────────────────────────
         let validator = OutputValidator::new(l2_client);
 
         // ── 8. Start health HTTP server ──────────────────────────────────────
@@ -206,6 +228,7 @@ impl ChallengerService {
                 tee,
                 verifier_client,
                 bond_manager,
+                anchor_updater,
             },
         );
 

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -15,7 +15,7 @@ use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::{debug, info};
 
-use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
+use crate::{ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
 /// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
@@ -113,11 +113,8 @@ impl<T: TxManager> ChallengeSubmitter<T> {
 
         Ok(tx_hash)
     }
-}
-
-#[async_trait::async_trait]
-impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
-    async fn send_bond_tx(
+    /// Sends a bond or anchor maintenance transaction.
+    pub async fn send_bond_tx(
         &self,
         game_address: Address,
         to: Address,

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -244,6 +244,14 @@ pub struct MockAggregateVerifier {
     pub game_info_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `status`, used by tests that assert cached reads.
     pub status_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `zk_prover`, used by tests that assert cheap pending polls.
+    pub zk_prover_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `tee_prover`, used by tests that assert cheap pending polls.
+    pub tee_prover_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `countered_index`, used by tests that assert cheap pending polls.
+    pub countered_index_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `game_over`, used by tests that assert cheap pending polls.
+    pub game_over_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `anchor_state_registry`, used by tests that assert cached reads.
     pub anchor_state_registry_reads: Mutex<Vec<Address>>,
 }
@@ -256,6 +264,10 @@ impl MockAggregateVerifier {
             bond_recipient_reads: Mutex::new(Vec::new()),
             game_info_reads: Mutex::new(Vec::new()),
             status_reads: Mutex::new(Vec::new()),
+            zk_prover_reads: Mutex::new(Vec::new()),
+            tee_prover_reads: Mutex::new(Vec::new()),
+            countered_index_reads: Mutex::new(Vec::new()),
+            game_over_reads: Mutex::new(Vec::new()),
             anchor_state_registry_reads: Mutex::new(Vec::new()),
         }
     }
@@ -335,10 +347,12 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.zk_prover_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.zk_prover)
     }
 
     async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.tee_prover_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.tee_prover)
     }
 
@@ -383,10 +397,12 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.countered_index_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.countered_index)
     }
 
     async fn game_over(&self, game_address: Address) -> Result<bool, ContractError> {
+        self.game_over_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_over)
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -240,12 +240,24 @@ pub struct MockAggregateVerifier {
     /// Addresses passed to `bond_recipient`, used by tests that assert polling
     /// avoids redundant lifecycle reads.
     pub bond_recipient_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `game_info`, used by tests that assert cached reads.
+    pub game_info_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `status`, used by tests that assert cached reads.
+    pub status_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `anchor_state_registry`, used by tests that assert cached reads.
+    pub anchor_state_registry_reads: Mutex<Vec<Address>>,
 }
 
 impl MockAggregateVerifier {
     /// Creates a new mock verifier from a pre-built game state map.
     pub const fn new(games: HashMap<Address, MockGameState>) -> Self {
-        Self { games: Mutex::new(games), bond_recipient_reads: Mutex::new(Vec::new()) }
+        Self {
+            games: Mutex::new(games),
+            bond_recipient_reads: Mutex::new(Vec::new()),
+            game_info_reads: Mutex::new(Vec::new()),
+            status_reads: Mutex::new(Vec::new()),
+            anchor_state_registry_reads: Mutex::new(Vec::new()),
+        }
     }
 
     /// Updates the state for a specific game address.
@@ -259,6 +271,36 @@ impl MockAggregateVerifier {
     /// Returns how many times `bond_recipient` was read for a game.
     pub fn bond_recipient_read_count(&self, game_address: Address) -> usize {
         self.bond_recipient_reads
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&read_address| read_address == game_address)
+            .count()
+    }
+
+    /// Returns how many times `game_info` was read for a game.
+    pub fn game_info_read_count(&self, game_address: Address) -> usize {
+        self.game_info_reads
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&read_address| read_address == game_address)
+            .count()
+    }
+
+    /// Returns how many times `status` was read for a game.
+    pub fn status_read_count(&self, game_address: Address) -> usize {
+        self.status_reads
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&read_address| read_address == game_address)
+            .count()
+    }
+
+    /// Returns how many times `anchor_state_registry` was read for a game.
+    pub fn anchor_state_registry_read_count(&self, game_address: Address) -> usize {
+        self.anchor_state_registry_reads
             .lock()
             .unwrap()
             .iter()
@@ -283,10 +325,12 @@ impl MockAggregateVerifier {
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError> {
+        self.game_info_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_info)
     }
 
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
+        self.status_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.status)
     }
 
@@ -380,6 +424,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn anchor_state_registry(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.anchor_state_registry_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.anchor_state_registry)
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -237,9 +237,6 @@ pub struct MockAggregateVerifier {
     /// Per-address game state lookup, wrapped in a `Mutex` for interior
     /// mutability in multi-step tests.
     pub games: Mutex<HashMap<Address, MockGameState>>,
-    /// Addresses passed to `bond_recipient`, used by tests that assert polling
-    /// avoids redundant lifecycle reads.
-    pub bond_recipient_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `game_info`, used by tests that assert cached reads.
     pub game_info_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `status`, used by tests that assert cached reads.
@@ -261,7 +258,6 @@ impl MockAggregateVerifier {
     pub const fn new(games: HashMap<Address, MockGameState>) -> Self {
         Self {
             games: Mutex::new(games),
-            bond_recipient_reads: Mutex::new(Vec::new()),
             game_info_reads: Mutex::new(Vec::new()),
             status_reads: Mutex::new(Vec::new()),
             zk_prover_reads: Mutex::new(Vec::new()),
@@ -278,16 +274,6 @@ impl MockAggregateVerifier {
     /// state changes (e.g. marking a game as resolved after proof submission).
     pub fn update_game(&self, address: Address, state: MockGameState) {
         self.games.lock().unwrap().insert(address, state);
-    }
-
-    /// Returns how many times `bond_recipient` was read for a game.
-    pub fn bond_recipient_read_count(&self, game_address: Address) -> usize {
-        self.bond_recipient_reads
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|&&read_address| read_address == game_address)
-            .count()
     }
 
     /// Returns how many times `game_info` was read for a game.
@@ -411,7 +397,6 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn bond_recipient(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.bond_recipient_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.bond_recipient)
     }
 
@@ -899,22 +884,49 @@ impl L1HeadProvider for MockL1HeadProvider {
 pub struct MockTxManager {
     /// Queue of responses returned by [`send`](TxManager::send).
     pub responses: Mutex<VecDeque<SendResponse>>,
+    /// Transaction candidates submitted through [`send`](TxManager::send).
+    pub calls: Mutex<Vec<TxCandidate>>,
 }
 
 impl MockTxManager {
     /// Creates a new mock with a single pre-configured response.
     pub fn new(response: SendResponse) -> Self {
-        Self { responses: Mutex::new(VecDeque::from([response])) }
+        Self { responses: Mutex::new(VecDeque::from([response])), calls: Mutex::new(Vec::new()) }
     }
 
     /// Creates a new mock with multiple responses returned in order.
     pub fn with_responses(responses: Vec<SendResponse>) -> Self {
-        Self { responses: Mutex::new(VecDeque::from(responses)) }
+        Self { responses: Mutex::new(VecDeque::from(responses)), calls: Mutex::new(Vec::new()) }
+    }
+
+    /// Returns the recorded transaction candidates.
+    pub fn recorded_calls(&self) -> Vec<TxCandidate> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+/// Cloneable handle around [`MockTxManager`] for tests that need to inspect
+/// calls after moving a tx manager into another type.
+#[derive(Debug, Clone)]
+pub struct SharedMockTxManager {
+    inner: Arc<MockTxManager>,
+}
+
+impl SharedMockTxManager {
+    /// Creates a shared mock with multiple responses returned in order.
+    pub fn with_responses(responses: Vec<SendResponse>) -> Self {
+        Self { inner: Arc::new(MockTxManager::with_responses(responses)) }
+    }
+
+    /// Returns the recorded transaction candidates.
+    pub fn recorded_calls(&self) -> Vec<TxCandidate> {
+        self.inner.recorded_calls()
     }
 }
 
 impl TxManager for MockTxManager {
-    async fn send(&self, _candidate: TxCandidate) -> SendResponse {
+    async fn send(&self, candidate: TxCandidate) -> SendResponse {
+        self.calls.lock().unwrap().push(candidate);
         self.responses.lock().unwrap().pop_front().expect("MockTxManager has no more responses")
     }
 
@@ -924,6 +936,20 @@ impl TxManager for MockTxManager {
 
     fn sender_address(&self) -> Address {
         Address::ZERO
+    }
+}
+
+impl TxManager for SharedMockTxManager {
+    async fn send(&self, candidate: TxCandidate) -> SendResponse {
+        self.inner.send(candidate).await
+    }
+
+    async fn send_async(&self, candidate: TxCandidate) -> SendHandle {
+        self.inner.send_async(candidate).await
+    }
+
+    fn sender_address(&self) -> Address {
+        self.inner.sender_address()
     }
 }
 
@@ -1003,51 +1029,6 @@ pub fn build_test_header_and_account_for_address(
         storage_proof: vec![],
     };
     (header, account_result)
-}
-
-/// Mock bond transaction submitter for testing the [`BondManager`](crate::BondManager).
-///
-/// Records all submitted transactions and returns pre-configured responses.
-#[derive(Debug)]
-pub struct MockBondTransactionSubmitter {
-    /// Queue of results returned by [`send_bond_tx`](crate::BondTransactionSubmitter::send_bond_tx).
-    pub responses: Mutex<VecDeque<Result<B256, crate::ChallengeSubmitError>>>,
-    /// Recorded `(game_address, to, calldata)` tuples for each submitted transaction.
-    pub calls: Mutex<Vec<(Address, Address, Bytes)>>,
-}
-
-impl MockBondTransactionSubmitter {
-    /// Creates a mock that returns a single successful transaction hash.
-    pub fn success(tx_hash: B256) -> Self {
-        Self { responses: Mutex::new(VecDeque::from([Ok(tx_hash)])), calls: Mutex::new(Vec::new()) }
-    }
-
-    /// Creates a mock with multiple responses returned in order.
-    pub fn with_responses(responses: Vec<Result<B256, crate::ChallengeSubmitError>>) -> Self {
-        Self { responses: Mutex::new(VecDeque::from(responses)), calls: Mutex::new(Vec::new()) }
-    }
-
-    /// Returns the recorded calls as `(game_address, to, calldata)` tuples.
-    pub fn recorded_calls(&self) -> Vec<(Address, Address, Bytes)> {
-        self.calls.lock().unwrap().clone()
-    }
-}
-
-#[async_trait]
-impl crate::BondTransactionSubmitter for MockBondTransactionSubmitter {
-    async fn send_bond_tx(
-        &self,
-        game_address: Address,
-        to: Address,
-        calldata: Bytes,
-    ) -> Result<B256, crate::ChallengeSubmitError> {
-        self.calls.lock().unwrap().push((game_address, to, calldata));
-        self.responses
-            .lock()
-            .unwrap()
-            .pop_front()
-            .expect("MockBondTransactionSubmitter has no more responses")
-    }
 }
 
 #[cfg(test)]

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,9 +8,9 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
-    BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
+    AnchorUpdater, BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
     DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofPhase, ProofUpdate, TeeConfig,
+    PendingProofs, ProofKind, ProofPhase, ProofUpdate, TeeConfig,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
         MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager,
@@ -101,6 +101,10 @@ fn test_driver_with_tee(
             tee,
             verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
             bond_manager: None,
+            anchor_updater: AnchorUpdater::new(
+                TokioRuntime::new(),
+                Duration::from_secs(24 * 60 * 60),
+            ),
         },
     )
 }
@@ -293,7 +297,7 @@ async fn test_step_invalid_game_proof_succeeded() {
         "proof should be pending after initiation"
     );
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -404,6 +408,10 @@ async fn test_step_scan_error_propagated() {
             tee: None,
             verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
             bond_manager: None::<BondManager<TokioRuntime>>,
+            anchor_updater: AnchorUpdater::new(
+                TokioRuntime::new(),
+                Duration::from_secs(24 * 60 * 60),
+            ),
         },
     );
 
@@ -435,7 +443,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     // Simulate the proof completing before the next poll.
     zk.state.lock().unwrap().proof_status = ProofStatus::Succeeded;
 
-    // Simulate the on-chain effect: game is resolved after challenge tx.
+    // Simulate the onchain effect: game is resolved after challenge tx.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -478,7 +486,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     let entry = driver.pending_proofs.get(&addr(0)).expect("proof should be preserved");
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -586,7 +594,7 @@ async fn test_step_proof_retry_succeeds() {
     // Simulate proof succeeding on the retry session.
     zk.state.lock().unwrap().proof_status = ProofStatus::Succeeded;
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -704,7 +712,7 @@ async fn test_step_proof_exceeds_max_retries() {
         assert_eq!(entry.retry_count, i + 1);
     }
 
-    // Simulate the on-chain effect: mark the game as resolved so the
+    // Simulate the onchain effect: mark the game as resolved so the
     // stateless scanner does not re-discover it after the entry is dropped.
     verifier.update_game(
         addr(0),
@@ -789,7 +797,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         "ZK proof should be pending after TEE fallback"
     );
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -865,7 +873,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
 
 #[tokio::test]
 async fn test_step_tee_contract_revert_falls_back_to_zk() {
-    // TEE proof succeeds but the on-chain nullify() call reverts.
+    // TEE proof succeeds but the onchain nullify() call reverts.
     // Contract-level failures are proof-specific enough to fall back to ZK.
     let (l2, factory, root_15, root_20) = base_game_mocks();
 
@@ -1063,6 +1071,40 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
 }
 
 #[tokio::test]
+async fn test_successful_nullify_does_not_track_anchor_update() {
+    let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+    let l2 = default_l2();
+    let verifier = single_game_verifier(mock_state_with_tee(
+        GameStatus::InProgress,
+        ZK_PROVER_ADDR,
+        DEFAULT_TEE_PROVER,
+        20,
+    ));
+
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.pending_proofs.insert(
+        addr(0),
+        PendingProof {
+            phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from_static(&[0x00, 0xAA]) },
+            kind: ProofKind::Tee { zk_fallback_request: None, zk_fallback_intent: None },
+            invalid_index: 1,
+            expected_root: BOGUS_ROOT,
+            retry_count: 0,
+            tee_submit_retry_count: 0,
+            intent: DisputeIntent::Nullify,
+        },
+    );
+
+    driver.step().await.unwrap();
+
+    assert!(!driver.pending_proofs.contains_key(&addr(0)));
+    assert!(
+        !driver.anchor_updater.is_tracking(&addr(0)),
+        "nullify results should be rescanned before anchor update tracking"
+    );
+}
+
+#[tokio::test]
 async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
     // A pending proof with DisputeIntent::Challenge should be dropped
     // when zkProver is non-zero (game already challenged).
@@ -1094,10 +1136,10 @@ async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
 /// root is at 0-based index 1 (block 20).
 ///
 /// Layout: starting=10, `l2_block=20`, interval=5, checkpoints at 15 and 20.
-/// `correct_root_at_20` controls whether the on-chain root at index 1
+/// `correct_root_at_20` controls whether the onchain root at index 1
 /// (block 20) matches the L2-computed root:
-/// - `true`: on-chain root is correct → ZK challenge was fraudulent → nullify.
-/// - `false`: on-chain root is bogus → ZK challenge was legitimate → skip.
+/// - `true`: onchain root is correct → ZK challenge was fraudulent → nullify.
+/// - `false`: onchain root is bogus → ZK challenge was legitimate → skip.
 fn fraudulent_zk_challenge_mocks(
     correct_root_at_20: bool,
 ) -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
@@ -1117,7 +1159,7 @@ fn fraudulent_zk_challenge_mocks(
 
 #[tokio::test]
 async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
-    // The on-chain root at the challenged index is wrong, meaning the ZK
+    // The onchain root at the challenged index is wrong, meaning the ZK
     // challenge was legitimate. The driver should skip without initiating
     // a proof.
     let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(false);
@@ -1133,7 +1175,7 @@ async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
 
 #[tokio::test]
 async fn test_step_fraudulent_zk_challenge_nullifies() {
-    // The on-chain root at the challenged index is correct, meaning the
+    // The onchain root at the challenged index is correct, meaning the
     // ZK challenge was fraudulent. The driver should initiate a ZK proof
     // with DisputeIntent::Nullify.
     let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(true);
@@ -1411,7 +1453,7 @@ async fn test_bond_manager_full_lifecycle() {
     //
     // The mock verifier uses a static game state, so we set
     // ChallengerWins to represent a game that has already been
-    // resolved on-chain. The manager detects this and advances directly
+    // resolved onchain. The manager detects this and advances directly
     // to NeedsUnlock without submitting a resolve transaction.
     let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
@@ -1570,9 +1612,7 @@ async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
     state.status = GameStatus::DefenderWins;
     let verifier = single_game_verifier(state);
 
-    // One response for the anchor state update that is attempted after
-    // advance_game (DEFENDER_WINS triggers a setAnchorState call).
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(DEFAULT_TX_HASH)]);
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
     let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
@@ -1599,10 +1639,7 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
     state.bond_recipient = other_addr; // bond goes to someone else
     let verifier = single_game_verifier(state);
 
-    // One response for the anchor state update — even though the bond is
-    // not claimable, anchor updates are a public good and are still
-    // attempted for DEFENDER_WINS games before removal.
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(DEFAULT_TX_HASH)]);
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
     let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
@@ -1616,9 +1653,8 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
         "game should be removed when bondRecipient is not in claim addresses"
     );
 
-    // The only transaction submitted should be the anchor state update.
     let calls = submitter.recorded_calls();
-    assert_eq!(calls.len(), 1, "only the anchor update tx should be submitted");
+    assert!(calls.is_empty(), "bond manager should not submit anchor update txs");
 }
 
 #[tokio::test]
@@ -1681,7 +1717,7 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
 
     // The mock verifier's `read_intermediate_block_interval` returns 5,
     // so the scanner caches interval=5. With span=10, the validator
-    // expects 10/5 = 2 intermediate roots, but only 1 is on-chain.
+    // expects 10/5 = 2 intermediate roots, but only 1 is onchain.
     let l2 = default_l2();
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -1074,12 +1074,10 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
 async fn test_successful_nullify_does_not_track_anchor_update() {
     let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
     let l2 = default_l2();
-    let verifier = single_game_verifier(mock_state_with_tee(
-        GameStatus::InProgress,
-        ZK_PROVER_ADDR,
-        DEFAULT_TEE_PROVER,
-        20,
-    ));
+    let mut game_state =
+        mock_state_with_tee(GameStatus::InProgress, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20);
+    game_state.game_over = true;
+    let verifier = single_game_verifier(game_state);
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.pending_proofs.insert(
@@ -1098,10 +1096,7 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
     driver.step().await.unwrap();
 
     assert!(!driver.pending_proofs.contains_key(&addr(0)));
-    assert!(
-        !driver.anchor_updater.is_tracking(&addr(0)),
-        "nullify results should be rescanned before anchor update tracking"
-    );
+    driver.step().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -12,11 +12,11 @@ use base_challenger::{
     DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
     PendingProofs, ProofKind, ProofPhase, ProofUpdate, TeeConfig,
     test_utils::{
-        DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
-        MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager,
-        MockZkProofProvider, MockZkProofState, TEST_DISCOVERY_INTERVAL, addr,
-        build_test_header_and_account, empty_factory, factory_game, mock_anchor_registry,
-        mock_state, mock_state_with_tee, receipt_with_status,
+        DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockDisputeGameFactory,
+        MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager, MockZkProofProvider,
+        MockZkProofState, TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account,
+        empty_factory, factory_game, mock_anchor_registry, mock_state, mock_state_with_tee,
+        receipt_with_status,
     },
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex, GameStatus};
@@ -1418,241 +1418,18 @@ async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Bond lifecycle integration tests
+// Bond tracking integration test
 // ──────────────────────────────────────────────────────────────────────────
 
-const fn bond_test_state(claim_addr: Address) -> MockGameState {
-    let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-    state.bond_recipient = claim_addr;
-    state
-}
-
-fn bond_test_verifier(claim_addr: Address) -> Arc<MockAggregateVerifier> {
-    single_game_verifier(bond_test_state(claim_addr))
-}
-
 fn default_bond_manager(claim_addr: Address) -> BondManager<TokioRuntime> {
-    let mut mgr = BondManager::new(
+    BondManager::new(
         vec![claim_addr],
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
         TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
-    mgr
-}
-
-#[tokio::test]
-async fn test_bond_manager_full_lifecycle() {
-    // Verify the full bond lifecycle: NeedsResolve → NeedsUnlock →
-    // AwaitingDelay → NeedsWithdraw → Completed.
-    //
-    // The mock verifier uses a static game state, so we set
-    // ChallengerWins to represent a game that has already been
-    // resolved onchain. The manager detects this and advances directly
-    // to NeedsUnlock without submitting a resolve transaction.
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-    let tx_hash = DEFAULT_TX_HASH;
-    let verifier = bond_test_verifier(claim_addr);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Ok(tx_hash), // claimCredit (unlock) tx
-        Ok(tx_hash), // claimCredit (withdraw) tx
-    ]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-
-    assert!(mgr.track_game(game_addr, claim_addr));
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 1: NeedsResolve → already resolved (ChallengerWins) → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
-
-    // Poll 2: NeedsUnlock → claimCredit (unlock) tx → AwaitingDelay.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked during delay");
-
-    // Poll 3: AwaitingDelay (delay=0s, already elapsed) → NeedsWithdraw.
-    // check_delay transitions to NeedsWithdraw, but advance_game returns
-    // Ok(false), so the game is still tracked. Need one more poll.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after delay");
-
-    // Poll 4: NeedsWithdraw → claimCredit (withdraw) tx → Completed → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0, "game should be removed after completion");
-
-    // Verify 2 transactions were submitted (unlock + withdraw, no resolve).
-    let calls = submitter.recorded_calls();
-    assert_eq!(calls.len(), 2, "expected 2 bond transactions (unlock, withdraw)");
-    for (game, target, _) in &calls {
-        assert_eq!(*game, game_addr, "all transactions should reference the game address");
-        assert_eq!(*target, game_addr, "all transactions should target the game address");
-    }
-}
-
-#[tokio::test]
-async fn test_bond_manager_skips_already_unlocked_game() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-    let tx_hash = DEFAULT_TX_HASH;
-
-    let mut state = bond_test_state(claim_addr);
-    state.bond_unlocked = true;
-    state.resolved_at = 1_000_000;
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Ok(tx_hash), // withdraw
-    ]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-
-    // Poll 1: NeedsResolve → status != 0 → NeedsUnlock (no tx).
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 2: NeedsUnlock -> bond_unlocked=true and delay=0 -> NeedsWithdraw (no tx).
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 3: NeedsWithdraw -> submit withdraw -> Completed -> removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0);
-
-    assert_eq!(submitter.recorded_calls().len(), 1);
-}
-
-#[tokio::test]
-async fn test_bond_manager_skips_already_claimed_game() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-
-    let mut state = bond_test_state(claim_addr);
-    state.bond_unlocked = true;
-    state.bond_claimed = true;
-    state.resolved_at = 1_000_000;
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-
-    // Polls 1-3: NeedsResolve → NeedsUnlock → AwaitingDelay → NeedsWithdraw (no txs).
-    for _ in 0..3 {
-        mgr.poll(&*verifier, &submitter).await;
-    }
-
-    // Poll 4: NeedsWithdraw → bond_claimed=true → Completed → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0);
-
-    assert!(
-        submitter.recorded_calls().is_empty(),
-        "no transactions should be submitted for already-claimed bond"
-    );
-}
-
-#[tokio::test]
-async fn test_bond_manager_tx_failure_retries() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-    let tx_hash = DEFAULT_TX_HASH;
-    let verifier = bond_test_verifier(claim_addr);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Err(base_tx_manager::TxManagerError::NonceTooLow.into()),
-        Ok(tx_hash), // retry succeeds
-    ]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-
-    // Poll 1: NeedsResolve → already resolved (ChallengerWins) → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
-
-    // Poll 2: NeedsUnlock → claimCredit tx fails → stays NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after tx failure");
-
-    // Poll 3: NeedsUnlock → retry → claimCredit tx succeeds → AwaitingDelay.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after unlock");
-
-    assert_eq!(submitter.recorded_calls().len(), 2, "expected 2 claimCredit attempts");
-}
-
-#[tokio::test]
-async fn test_bond_manager_ignores_non_claim_addresses() {
-    let claim_addr = ZK_PROVER_ADDR;
-    let other_addr = Address::repeat_byte(0xDD);
-    let game_addr = addr(0);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    assert!(!mgr.track_game(game_addr, other_addr));
-    assert_eq!(mgr.tracked_count(), 0);
-}
-
-#[tokio::test]
-async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
-    // DEFENDER_WINS but bondRecipient is ours → keep and advance to NeedsUnlock.
-    let claim_addr = ZK_PROVER_ADDR;
-    let game_addr = addr(0);
-
-    let mut state = bond_test_state(claim_addr);
-    state.status = GameStatus::DefenderWins;
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 1: NeedsResolve → resolved, bondRecipient in claim set → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(
-        mgr.tracked_count(),
-        1,
-        "game should be kept when bondRecipient is in claim addresses"
-    );
-}
-
-#[tokio::test]
-async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
-    // bondRecipient not in claim set → removed from tracking.
-    let claim_addr = ZK_PROVER_ADDR;
-    let other_addr = Address::repeat_byte(0xDD);
-    let game_addr = addr(0);
-
-    let mut state = bond_test_state(claim_addr);
-    state.status = GameStatus::DefenderWins;
-    state.bond_recipient = other_addr; // bond goes to someone else
-    let verifier = single_game_verifier(state);
-
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-    let mut mgr = default_bond_manager(claim_addr);
-    mgr.track_game(game_addr, claim_addr);
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 1: NeedsResolve → resolved, bondRecipient not in claim set → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(
-        mgr.tracked_count(),
-        0,
-        "game should be removed when bondRecipient is not in claim addresses"
-    );
-
-    let calls = submitter.recorded_calls();
-    assert!(calls.is_empty(), "bond manager should not submit anchor update txs");
+    )
 }
 
 #[tokio::test]
@@ -1664,11 +1441,8 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
 
     let tx_manager = default_tx_manager();
 
-    let mut bond_manager = default_bond_manager(sender_addr);
-    bond_manager.set_weth_delay(Duration::from_secs(3600));
-
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
-    driver.bond_manager = Some(bond_manager);
+    driver.bond_manager = Some(default_bond_manager(sender_addr));
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -1681,8 +1455,9 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
     driver.step().await.unwrap();
 
     let bond_mgr = driver.bond_manager.as_ref().expect("bond_manager should be Some");
-    assert!(
-        bond_mgr.is_tracking(&addr(0)),
+    assert_eq!(
+        bond_mgr.tracked_count(),
+        1,
         "game should be tracked by bond manager after successful challenge"
     );
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -1096,7 +1096,10 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
     driver.step().await.unwrap();
 
     assert!(!driver.pending_proofs.contains_key(&addr(0)));
-    driver.step().await.unwrap();
+    assert!(
+        !driver.anchor_updater.is_tracking(&addr(0)),
+        "nullify results should be rescanned before anchor update tracking"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
### What changed? Why?

- Refactored challenger post-game handling into separate anchor and bond managers. `AnchorUpdater` tracks eligible games, resolves game-over unchallenged games, and advances the `AnchorStateRegistry` only after finality and preflight checks. It recovers resolved defender-win games at startup and retries transient failures for the configured retention period.
- Refined bond discovery and claiming: claimable games are scanned incrementally with periodic full rescans, recovered at startup, and advanced through resolve, unlock, delay, and withdraw phases. Reverted withdrawals receive a short retry backoff.
- Simplified challenger CLI configuration by relying on Clap-derived long flag names, using typed numeric defaults, and removing the unused `--zk-connect-timeout` setting.

### Notes to reviewers

- Anchor processing now runs independently of bond claiming, including when no `--bond-claim-addresses` are configured.
- Existing long flag names remain unchanged. The only removed interface is `--zk-connect-timeout` / `BASE_CHALLENGER_ZK_CONNECT_TIMEOUT`; `--zk-request-timeout` remains the timeout for individual ZK proof-service requests.

### How has it been tested?

- `cargo test -p base-challenger`