### PR TITLE
feat(proof): configure MDBX proofs DB max read tx duration

### DIFF
--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use base_execution_trie::RocksdbProofsStorageOptions;
+use base_execution_trie::{MdbxProofsStorageOptions, RocksdbProofsStorageOptions};
 use base_upgrade_signal::{UpgradeSignalArgs, UpgradeSignalL1RpcArgs};
 use clap::{ArgAction, ValueEnum, builder::ArgPredicate};
 
@@ -90,6 +90,36 @@ impl ProofsHistoryDbBackend {
             _ => Ok(()),
         }
     }
+}
+
+/// Runtime tuning options for the `MDBX` proofs history backend.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::Args)]
+pub struct ProofsHistoryMdbxArgs {
+    /// Maximum duration a read transaction can stay open.
+    #[arg(
+        long = "proofs-history.mdbx.max-read-transaction-duration",
+        value_name = "PROOFS_HISTORY_MDBX_MAX_READ_TRANSACTION_DURATION",
+        value_parser = parse_positive_duration,
+        hide = true
+    )]
+    pub max_read_transaction_duration: Option<Duration>,
+}
+
+impl ProofsHistoryMdbxArgs {
+    /// Converts CLI arguments into storage options.
+    pub const fn storage_options(self) -> MdbxProofsStorageOptions {
+        MdbxProofsStorageOptions {
+            max_read_transaction_duration: self.max_read_transaction_duration,
+        }
+    }
+}
+
+fn parse_positive_duration(s: &str) -> Result<Duration, String> {
+    let d = humantime::parse_duration(s).map_err(|e| e.to_string())?;
+    if d.is_zero() {
+        return Err("duration must be greater than zero".to_owned());
+    }
+    Ok(d)
 }
 
 /// Runtime tuning options for the `RocksDB` proofs history backend.
@@ -358,6 +388,10 @@ pub struct RollupArgs {
     #[command(flatten)]
     pub proofs_history_rocksdb: ProofsHistoryRocksdbArgs,
 
+    /// Runtime tuning options for the `MDBX` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_mdbx: ProofsHistoryMdbxArgs,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
@@ -431,6 +465,7 @@ impl Default for RollupArgs {
             proofs_history_storage_path: None,
             proofs_history_db: ProofsHistoryDbBackend::default(),
             proofs_history_rocksdb: Default::default(),
+            proofs_history_mdbx: Default::default(),
             proofs_history_window: DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
@@ -615,6 +650,29 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_proofs_history_mdbx_tuning_options() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history.mdbx.max-read-transaction-duration",
+            "30s",
+        ])
+        .args;
+
+        let options = args.proofs_history_mdbx.storage_options();
+        assert_eq!(options.max_read_transaction_duration, Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn test_proofs_history_mdbx_rejects_zero_duration() {
+        let result = CommandParser::<RollupArgs>::try_parse_from([
+            "reth",
+            "--proofs-history.mdbx.max-read-transaction-duration",
+            "0s",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_proofs_history_db_rejects_ambiguous_storage_markers() {
         let dir = std::env::temp_dir().join(format!(
             "proofs-history-markers-{}-{}",
@@ -694,6 +752,7 @@ mod tests {
     #[test]
     fn test_proofs_history_rocksdb_tuning_options_hidden_from_help() {
         let help = CommandParser::<RollupArgs>::command().render_help().to_string();
+        assert!(!help.contains("proofs-history.mdbx.max-read-transaction-duration"));
         assert!(!help.contains("proofs-history.rocksdb.compression"));
         assert!(!help.contains("proofs-history.rocksdb.max-background-jobs"));
         assert!(!help.contains("proofs-history.rocksdb.rate-limit-mib-per-sec"));

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -57,6 +57,7 @@ pub async fn launch_node_with_proof_history(
         proofs_history_storage_path,
         proofs_history_db,
         proofs_history_rocksdb,
+        proofs_history_mdbx,
         proofs_history_window,
         proofs_history_prune_interval,
         proofs_history_verification_interval,
@@ -78,6 +79,7 @@ pub async fn launch_node_with_proof_history(
         proofs_history_storage_path: None,
         proofs_history_db: ProofsHistoryDbBackend::default(),
         proofs_history_rocksdb: Default::default(),
+        proofs_history_mdbx: Default::default(),
         proofs_history_window: DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS,
         proofs_history_prune_interval: Duration::from_secs(15),
         proofs_history_verification_interval: 0,
@@ -111,8 +113,11 @@ pub async fn launch_node_with_proof_history(
             }
             ProofsHistoryDbBackend::Mdbx => {
                 let mdbx = Arc::new(
-                    MdbxProofsStorage::new(&path)
-                        .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
+                    MdbxProofsStorage::new_with_options(
+                        &path,
+                        proofs_history_mdbx.storage_options(),
+                    )
+                    .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
                 );
                 node_builder = install_proofs_history(
                     node_builder,

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -41,6 +41,7 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         let proofs_history_enabled = args.proofs_history;
         let proofs_history_db = args.proofs_history_db;
         let proofs_history_rocksdb = args.proofs_history_rocksdb;
+        let proofs_history_mdbx = args.proofs_history_mdbx;
         let proofs_history_window = args.proofs_history_window;
         let proofs_history_prune_interval = args.proofs_history_prune_interval;
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
@@ -94,7 +95,8 @@ impl BaseNodeExtension for ProofsHistoryExtension {
                     );
                 }
                 ProofsHistoryDbBackend::Mdbx => {
-                    let mdbx = match MdbxProofsStorage::new(&path)
+                    let storage_options = proofs_history_mdbx.storage_options();
+                    let mdbx = match MdbxProofsStorage::new_with_options(&path, storage_options)
                         .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
                     {
                         Ok(mdbx) => mdbx,

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -7,7 +7,7 @@ mod models;
 pub use models::*;
 
 mod store;
-pub use store::MdbxProofsStorage;
+pub use store::{MdbxProofsStorage, MdbxProofsStorageOptions};
 
 mod rocksdb;
 pub use rocksdb::{

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::RangeBounds, path::Path};
+use std::{collections::BTreeMap, ops::RangeBounds, path::Path, time::Duration};
 
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256, map::HashMap};
@@ -9,7 +9,7 @@ use metrics::{Label, gauge};
 use reth_db::{
     Database, DatabaseEnv, DatabaseError,
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
-    mdbx::{DatabaseArguments, init_db_for},
+    mdbx::{DatabaseArguments, MaxReadTransactionDuration, init_db_for},
     table::{DupSort, Table},
     transaction::{DbTx, DbTxMut},
 };
@@ -48,6 +48,13 @@ pub struct MdbxProofsStorage {
     env: DatabaseEnv,
 }
 
+/// Options for opening [`MdbxProofsStorage`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MdbxProofsStorageOptions {
+    /// Maximum duration of a read transaction.
+    pub max_read_transaction_duration: Option<Duration>,
+}
+
 struct ProofWindowValue {
     earliest: NumHash,
     latest: NumHash,
@@ -75,7 +82,21 @@ struct HistoryDeleteBatch {
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
     pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
-        let env = init_db_for::<_, Tables>(path, DatabaseArguments::default())
+        Self::new_with_options(path, MdbxProofsStorageOptions::default())
+    }
+
+    /// Creates a new [`MdbxProofsStorage`] instance with the given path and options.
+    pub fn new_with_options(
+        path: &Path,
+        options: MdbxProofsStorageOptions,
+    ) -> Result<Self, BaseProofsStorageError> {
+        let mut args = DatabaseArguments::default();
+        if let Some(duration) = options.max_read_transaction_duration {
+            args = args.with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Set(
+                duration,
+            )));
+        }
+        let env = init_db_for::<_, Tables>(path, args)
             .map_err(|e| DatabaseError::Other(format!("Failed to open database: {e}")))?;
         Ok(Self { env })
     }
@@ -1306,6 +1327,17 @@ mod tests {
     };
 
     const B0: u64 = 0;
+
+    #[test]
+    fn new_with_options_accepts_custom_max_read_transaction_duration() {
+        let dir = TempDir::new().unwrap();
+        let options = MdbxProofsStorageOptions {
+            max_read_transaction_duration: Some(Duration::from_secs(30)),
+        };
+        let store = MdbxProofsStorage::new_with_options(dir.path(), options).expect("env");
+
+        let _tx = store.env.tx().expect("ro tx");
+    }
 
     #[test]
     fn store_hashed_accounts_writes_versioned_values() {

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -28,12 +28,12 @@ pub use in_memory::{
 
 pub mod db;
 pub use db::{
-    MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor,
-    ProofWindowValue, RocksDbHistoryTable, RocksDbLatestVersionResult, RocksdbAccountCursor,
-    RocksdbBatchSession, RocksdbHistoryDeleteBatch, RocksdbPreparedHistoryDeletes,
-    RocksdbPreparedPrune, RocksdbProofsStorage, RocksdbProofsStorageOptions, RocksdbPrunePlan,
-    RocksdbReadSnapshot, RocksdbReplacementState, RocksdbStorageCursor, RocksdbTrieCursor,
-    RocksdbVersionedCursor,
+    MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxProofsStorageOptions,
+    MdbxStorageCursor, MdbxTrieCursor, ProofWindowValue, RocksDbHistoryTable,
+    RocksDbLatestVersionResult, RocksdbAccountCursor, RocksdbBatchSession,
+    RocksdbHistoryDeleteBatch, RocksdbPreparedHistoryDeletes, RocksdbPreparedPrune,
+    RocksdbProofsStorage, RocksdbProofsStorageOptions, RocksdbPrunePlan, RocksdbReadSnapshot,
+    RocksdbReplacementState, RocksdbStorageCursor, RocksdbTrieCursor, RocksdbVersionedCursor,
 };
 
 pub mod metrics;


### PR DESCRIPTION
## Summary

The proofs DB (MDBX) was opened with `DatabaseArguments::default()`, which hard-codes the read transaction duration. This PR makes that limit operator-adjustable via a hidden CLI flag, following the same pattern as the existing RocksDB tuning flags.

## Changes

- **`base-execution-trie`**: Add `MdbxProofsStorageOptions { max_read_transaction_duration: Option<Duration> }` and `MdbxProofsStorage::new_with_options` that applies `MaxReadTransactionDuration::Set` when set, leaving `DatabaseArguments::default()` untouched otherwise. `new` delegates to `new_with_options(default)`.
- **`base-node-core`**: Add `ProofsHistoryMdbxArgs` (mirrors `ProofsHistoryRocksdbArgs`) with a single hidden flag:

  ```
  --proofs-history.mdbx.max-read-transaction-duration <DURATION>
  ```

  Accepts humantime durations (e.g. `30s`, `5m`). Flattened into `RollupArgs`, wired through `storage_options()`.
- **`base-proofs-extension`** + **`proof_history.rs`**: Pass `storage_options()` to `MdbxProofsStorage::new_with_options` in both the `ProofsHistoryExtension` and `launch_node_with_proof_history` paths.

## Tests

- `db::store::tests::new_with_options_accepts_custom_max_read_transaction_duration` — opens MDBX env with 30s timeout, verifies read transaction creation.
- `args::tests::test_parse_proofs_history_mdbx_tuning_options` — parses `--proofs-history.mdbx.max-read-transaction-duration 30s`, asserts `Duration::from_secs(30)`.
- Updated `args::tests::test_proofs_history_rocksdb_tuning_options_hidden_from_help` — asserts the new flag is also hidden from help output.