### PR TITLE
feat(proof): configure MDBX proofs DB max read tx duration (backport to v1.1.2)

### DIFF
--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -4,6 +4,7 @@
 
 use std::{path::PathBuf, time::Duration};
 
+use base_execution_trie::MdbxProofsStorageOptions;
 use clap::{ValueEnum, builder::ArgPredicate};
 
 /// Transaction ordering strategy for the mempool.
@@ -23,6 +24,28 @@ pub enum TxpoolOrdering {
     /// Transactions are ordered by when they were received by the mempool,
     /// regardless of the fees they offer.
     Timestamp,
+}
+
+/// Runtime tuning options for the `MDBX` proofs history backend.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::Args)]
+pub struct ProofsHistoryMdbxArgs {
+    /// Maximum duration a read transaction can stay open.
+    #[arg(
+        long = "proofs-history.mdbx.max-read-transaction-duration",
+        value_name = "PROOFS_HISTORY_MDBX_MAX_READ_TRANSACTION_DURATION",
+        value_parser = humantime::parse_duration,
+        hide = true
+    )]
+    pub max_read_transaction_duration: Option<Duration>,
+}
+
+impl ProofsHistoryMdbxArgs {
+    /// Converts CLI arguments into storage options.
+    pub const fn storage_options(self) -> MdbxProofsStorageOptions {
+        MdbxProofsStorageOptions {
+            max_read_transaction_duration: self.max_read_transaction_duration,
+        }
+    }
 }
 
 /// Parameters for rollup configuration
@@ -89,6 +112,10 @@ pub struct RollupArgs {
     #[arg(long = "proofs-history.storage-path", value_name = "PROOFS_HISTORY_STORAGE_PATH")]
     pub proofs_history_storage_path: Option<PathBuf>,
 
+    /// Runtime tuning options for the `MDBX` proofs history backend.
+    #[command(flatten)]
+    pub proofs_history_mdbx: ProofsHistoryMdbxArgs,
+
     /// The window to span blocks for proofs history. Value is the number of blocks.
     /// Default is 1 month of blocks based on 2 seconds block time.
     /// 30 * 24 * 60 * 60 / 2 = `1_296_000`
@@ -108,7 +135,7 @@ pub struct RollupArgs {
     ///   but each run can take longer and block writes for longer.
     ///
     /// A shorter interval is preferred so that prune
-    /// runs stay small and don’t stall writes for too long.
+    /// runs stay small and don't stall writes for too long.
     ///
     /// CLI: `--proofs-history.prune-interval 10m`
     #[arg(
@@ -155,6 +182,7 @@ impl Default for RollupArgs {
             max_inflight_delegated_slots: 1,
             proofs_history: false,
             proofs_history_storage_path: None,
+            proofs_history_mdbx: Default::default(),
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
@@ -165,7 +193,7 @@ impl Default for RollupArgs {
 
 #[cfg(test)]
 mod tests {
-    use clap::{Args, Parser};
+    use clap::{Args, CommandFactory, Parser};
 
     use super::*;
 
@@ -295,5 +323,24 @@ mod tests {
         ])
         .args;
         assert!(!args.base_protocol);
+    }
+
+    #[test]
+    fn test_parse_proofs_history_mdbx_tuning_options() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--proofs-history.mdbx.max-read-transaction-duration",
+            "30s",
+        ])
+        .args;
+
+        let options = args.proofs_history_mdbx.storage_options();
+        assert_eq!(options.max_read_transaction_duration, Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn test_proofs_history_mdbx_hidden_from_help() {
+        let help = CommandParser::<RollupArgs>::command().render_help().to_string();
+        assert!(!help.contains("proofs-history.mdbx.max-read-transaction-duration"));
     }
 }

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -31,6 +31,7 @@ pub async fn launch_node_with_proof_history(
 ) -> eyre::Result<(), ErrReport> {
     let RollupArgs {
         proofs_history,
+        proofs_history_mdbx,
         proofs_history_window,
         proofs_history_prune_interval,
         proofs_history_verification_interval,
@@ -48,7 +49,7 @@ pub async fn launch_node_with_proof_history(
         info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
         let mdbx = Arc::new(
-            MdbxProofsStorage::new(&path)
+            MdbxProofsStorage::new_with_options(&path, proofs_history_mdbx.storage_options())
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
         );
         let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -39,6 +39,7 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         // TODO: if NodeHooks exposes the underlying Builder, we can call launch_node_with_proof_history
         let args = self.config;
         let proofs_history_enabled = args.proofs_history;
+        let proofs_history_mdbx = args.proofs_history_mdbx;
         let proofs_history_window = args.proofs_history_window;
         let proofs_history_prune_interval = args.proofs_history_prune_interval;
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
@@ -49,8 +50,11 @@ impl BaseNodeExtension for ProofsHistoryExtension {
                 .expect("Path must be provided if not using in-memory storage");
             info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
-            let mdbx = match MdbxProofsStorage::new(&path)
-                .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
+            let mdbx = match MdbxProofsStorage::new_with_options(
+                &path,
+                proofs_history_mdbx.storage_options(),
+            )
+            .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))
             {
                 Ok(mdbx) => mdbx,
                 Err(e) => {

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -9,7 +9,7 @@ mod models;
 pub use models::*;
 
 mod store;
-pub use store::MdbxProofsStorage;
+pub use store::{MdbxProofsStorage, MdbxProofsStorageOptions};
 
 mod cursor;
 pub use cursor::{

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::RangeBounds, path::Path};
+use std::{collections::BTreeMap, ops::RangeBounds, path::Path, time::Duration};
 
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256, map::HashMap};
@@ -9,7 +9,7 @@ use metrics::{Label, gauge};
 use reth_db::{
     Database, DatabaseEnv, DatabaseError,
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
-    mdbx::{DatabaseArguments, init_db_for},
+    mdbx::{DatabaseArguments, MaxReadTransactionDuration, init_db_for},
     table::{DupSort, Table},
     transaction::{DbTx, DbTxMut},
 };
@@ -48,6 +48,13 @@ pub struct MdbxProofsStorage {
     env: DatabaseEnv,
 }
 
+/// Options for opening [`MdbxProofsStorage`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MdbxProofsStorageOptions {
+    /// Maximum duration of a read transaction.
+    pub max_read_transaction_duration: Option<Duration>,
+}
+
 struct ProofWindowValue {
     earliest: NumHash,
     latest: NumHash,
@@ -75,7 +82,21 @@ struct HistoryDeleteBatch {
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
     pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
-        let env = init_db_for::<_, Tables>(path, DatabaseArguments::default())
+        Self::new_with_options(path, MdbxProofsStorageOptions::default())
+    }
+
+    /// Creates a new [`MdbxProofsStorage`] instance with the given path and options.
+    pub fn new_with_options(
+        path: &Path,
+        options: MdbxProofsStorageOptions,
+    ) -> Result<Self, BaseProofsStorageError> {
+        let mut args = DatabaseArguments::default();
+        if let Some(duration) = options.max_read_transaction_duration {
+            args = args.with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Set(
+                duration,
+            )));
+        }
+        let env = init_db_for::<_, Tables>(path, args)
             .map_err(|e| DatabaseError::Other(format!("Failed to open database: {e}")))?;
         Ok(Self { env })
     }
@@ -1112,7 +1133,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         account_nodes.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, account_nodes.into_iter(), true)?;
+            self.persist_history_batch(tx, 0, account_nodes, true)?;
             Ok(())
         })?
     }
@@ -1153,7 +1174,7 @@ impl BaseProofsInitialStateStore for MdbxProofsStorage {
         accounts.sort_by_key(|(key, _)| *key);
 
         self.env.update(|tx| {
-            self.persist_history_batch(tx, 0, accounts.into_iter(), true)?;
+            self.persist_history_batch(tx, 0, accounts, true)?;
             Ok(())
         })?
     }
@@ -1299,6 +1320,17 @@ mod tests {
     };
 
     const B0: u64 = 0;
+
+    #[test]
+    fn new_with_options_accepts_custom_max_read_transaction_duration() {
+        let dir = TempDir::new().unwrap();
+        let options = MdbxProofsStorageOptions {
+            max_read_transaction_duration: Some(Duration::from_secs(30)),
+        };
+        let store = MdbxProofsStorage::new_with_options(dir.path(), options).expect("env");
+
+        let _tx = store.env.tx().expect("ro tx");
+    }
 
     #[test]
     fn store_hashed_accounts_writes_versioned_values() {

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -28,7 +28,8 @@ pub use in_memory::{
 
 pub mod db;
 pub use db::{
-    MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCursor,
+    MdbxAccountCursor, MdbxBatchSession, MdbxProofsStorage, MdbxProofsStorageOptions,
+    MdbxStorageCursor, MdbxTrieCursor,
 };
 
 pub mod metrics;


### PR DESCRIPTION
Backport of #3858 to `releases/v1.1.2`.

Cherry-picks:
- `feat(trie): add MdbxProofsStorageOptions for adjustable read tx duration`
- `feat(proof): wire --proofs-history.mdbx.max-read-transaction-duration`

## Changes

Adds a hidden CLI flag `--proofs-history.mdbx.max-read-transaction-duration` that sets the MDBX `MaxReadTransactionDuration` for the proofs history database. When unset the Reth/MDBX default is preserved unchanged.

## Testing

- `cargo check -p base-execution-trie -p base-node-core -p base-proofs-extension` passes on `releases/v1.1.2`
- Focused tests for CLI parsing and MDBX options constructor pass