### PR TITLE
fix(evm): set inspect=false in EvmFactory:create_evm

### DIFF
--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -78,10 +78,8 @@ impl EvmFactory for BaseEvmFactory {
             .with_db(db)
             .with_block(input.block_env)
             .with_cfg(input.cfg_env)
-            .build_with_inspector_and_activation_admin_address(
-                NoOpInspector {},
-                self.activation_admin_address,
-            )
+            .build_base_with_activation_admin_address(self.activation_admin_address)
+            .with_inspector(NoOpInspector {})
     }
 
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
@@ -98,5 +96,32 @@ impl EvmFactory for BaseEvmFactory {
                 inspector,
                 self.activation_admin_address,
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::EvmEnv;
+    use revm::{context::{BlockEnv, CfgEnv}, database::EmptyDB, inspector::NoOpInspector};
+
+    use super::*;
+    use crate::BaseUpgrade;
+
+    fn default_env() -> EvmEnv<BaseSpecId> {
+        EvmEnv::new(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)), BlockEnv::default())
+    }
+
+    #[test]
+    fn create_evm_has_inspect_false() {
+        let factory = BaseEvmFactory::default();
+        let evm = factory.create_evm(EmptyDB::default(), default_env());
+        assert!(!evm.inspect);
+    }
+
+    #[test]
+    fn create_evm_with_inspector_has_inspect_true() {
+        let factory = BaseEvmFactory::default();
+        let evm = factory.create_evm_with_inspector(EmptyDB::default(), default_env(), NoOpInspector {});
+        assert!(evm.inspect);
     }
 }

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -102,7 +102,11 @@ impl EvmFactory for BaseEvmFactory {
 #[cfg(test)]
 mod tests {
     use alloy_evm::EvmEnv;
-    use revm::{context::{BlockEnv, CfgEnv}, database::EmptyDB, inspector::NoOpInspector};
+    use revm::{
+        context::{BlockEnv, CfgEnv},
+        database::EmptyDB,
+        inspector::NoOpInspector,
+    };
 
     use super::*;
     use crate::BaseUpgrade;
@@ -121,7 +125,8 @@ mod tests {
     #[test]
     fn create_evm_with_inspector_has_inspect_true() {
         let factory = BaseEvmFactory::default();
-        let evm = factory.create_evm_with_inspector(EmptyDB::default(), default_env(), NoOpInspector {});
+        let evm =
+            factory.create_evm_with_inspector(EmptyDB::default(), default_env(), NoOpInspector {});
         assert!(evm.inspect);
     }
 }


### PR DESCRIPTION
`create_evm` was calling `build_with_inspector_and_activation_admin_address` (inspect: true) despite not being the inspector code path. Switch to `build_base_with_activation_admin_address` + `.with_inspector(NoOpInspector)` so inspect is false and inspector callbacks are never invoked on uninstrumented execution.