### PR TITLE
feat(sidecrush): migrate from github.com/base/infra into base/base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,7 +1071,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1093,7 +1093,7 @@ dependencies = [
  "alloy-serde 2.0.5",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1375,7 +1375,7 @@ checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc 1.8.3",
  "alloy-transport 1.8.3",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
@@ -1396,7 +1396,7 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-tls",
  "hyper-util",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jsonwebtoken",
  "opentelemetry 0.31.0",
  "opentelemetry-http",
@@ -6229,6 +6229,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-sidecrush"
+version = "0.0.0"
+dependencies = [
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "anyhow",
+ "async-trait",
+ "cadence",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "base-sidecrush-bin"
+version = "0.0.0"
+dependencies = [
+ "base-sidecrush",
+ "cadence",
+ "clap",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "base-snapshotter"
 version = "0.0.0"
 dependencies = [
@@ -7419,6 +7444,15 @@ dependencies = [
  "libc",
  "once_cell",
  "serde",
+]
+
+[[package]]
+name = "cadence"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca08f6db9f0c963249cf23a27820f9d973d2acaad4d6bfaeb858b58ebd58a6a"
+dependencies = [
+ "crossbeam-channel",
 ]
 
 [[package]]
@@ -15379,7 +15413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -15399,7 +15433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -15420,7 +15454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15433,7 +15467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15446,7 +15480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -20833,18 +20867,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f0fad1b9f51cb6beb3aa84be925da5879d381a5c64aac7b50b6734d966439"
+checksum = "447a04cb85d3dabad2bb07034e9393419566a5f0bf9c34f746a04469782be963"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8372b2ed54e584140c8ffe9b11e101fcb27717d71ba9dca9de7f4a02e12cd5"
+checksum = "8c112cafd4c5c374d267a48c8976d12fca3b0f2cc2e44e6fb1343808310b4fc6"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -20853,9 +20887,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6e2a132f01b59001316abcc48696e983f8ae25b9f131c65ae895d28c4f0903"
+checksum = "1eaa537343a6b95b7c0d4e1f5355a4da7428ae5e2f65b62167295226a9a6f7a5"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -20864,9 +20898,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e20c8d55cda40285fe8e32d2f5fdae950e5d884a867e51cd6a4d36fe9fb8965"
+checksum = "129dff87e6accaf7238f605c536d76049c2bff1f6fa6d032ac56985c27c646be"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -20879,9 +20913,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f7aef8fe8b67e2523c5b3298766c409b4c5192bbda9a79057ef7c2044944b"
+checksum = "ee7b22007e82917494db0e87fbb277d6c1796106572333ed53019be629ad5cd3"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -20902,9 +20936,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bc7ea00417968bad0a0b2498d89405a94735a5105dad945b4c109ce9dd50bd"
+checksum = "6e5bb7b2f76cd38f1ecc42caeaee66841a9cb7cf802df1b5257874b5e773a3ec"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -20929,9 +20963,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e221a87b966e845fc20dde7cf2ae5402abb9f18ada41bbfb1585b84608e37a03"
+checksum = "ea991a652ea2e55f0523649f5c9efbfb32cf9fdcc2bf3b3580b4343a94379503"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -20944,9 +20978,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1896ae945a0288cbd53027c6aa94e239ca958f46c6f3740c35259620b9174900"
+checksum = "33b33f1eaadcd4159157758b0edcf1c14f470915f85c648e660e4740ff83e921"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -20957,9 +20991,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95de8c30f4af3373cae325895dbe346d40543f2c68cb4fde2b7ca2640a14a36d"
+checksum = "076e7f6d03a74a62024342eb5ef13719eae1adcfebb5232cfe8858ebc67f4d33"
 dependencies = [
  "p3-commit",
  "serde",
@@ -20968,9 +21002,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb47374580d144962efa45651d9b11cd6994219194a9af3499e7d3636b66e09b"
+checksum = "e2c742ca70828453dd3c154ad63816a987d27a7c454c19e9428b03fbdf4f118c"
 dependencies = [
  "p3-dft",
  "serde",
@@ -20982,18 +21016,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a2120404ebef7025707178ba8714d103f489880c4e45aa4d1779920eecb05c"
+checksum = "274f15a2a2508af5e1071ac890b672ad5b7727efba4bc1b33b33efd06045c02c"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be6ce4a857ba32b9ebff00e8c7da7ce4b821021c94ab7841df0fbf3b335de6e"
+checksum = "04717ab01c1202613436caf70948f3e7157bb4c35084817879787c98d62c87e9"
 dependencies = [
  "crossbeam",
  "futures",
@@ -21006,9 +21040,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358cb67fce3ee8d0eb0aca0f79125b8ba17905fa496d785c68c20303d5033067"
+checksum = "5aaf578d92dc05de1cd4fa7dc9ffeca918df20cda868326528ec0e81d9c153b1"
 dependencies = [
  "derive-where",
  "futures",
@@ -21040,18 +21074,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c390b1ca38b462d897c3d45550150b0681759ac729800fbb509e5c693b07cf5"
+checksum = "b9d2c1565483d5363ffa431b510778c5bef7c423ed21cee95440721de0372213"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6bdca3d0f1d43db8c6385cd7e711737b4ea3061692c91ae3f1c00e6cee1354"
+checksum = "8795ee9a92ecf0a604c0e3ed20e80bbc38772310c0622f94a2e1b66ca2455cb8"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -21064,27 +21098,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73bbd4fa3950410f9cd606cd5aa394c63c143f1ec67a2549247f439e7f60857"
+checksum = "50770150d6d5efc2ac3d20def5a6db2ca9d021defc74a414613174cfe40d96e1"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b14472c013bc6af12fa4dbce4914310ed828a8891368ce729c32681fc2e52b"
+checksum = "d9dc27cfc5036caca9642a71827c6b99b917fcd195285788d04f9b25f5df590e"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd51c818076fad68d93d5de84a0150c95296bbffedf8410ec37768b02c5c9e7"
+checksum = "9bb16c7104504683851c4aea91b9b4d28ac8fc643ecd21d798da894889c261df"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -21108,9 +21142,9 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec4cc9826228ed4f4e81baa3c8a16f3b3be535ae673009daebfeb06a57aab6d"
+checksum = "e46a58b8c6c7ab9fbb7dc55c68269b1d1d722beb23af8d6a1091c15877328145"
 dependencies = [
  "derive-where",
  "futures",
@@ -21129,27 +21163,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e885d53e76d1909e3e81f445c5dad58f1edb2516a5eecc5fa046bcecc0f79a4d"
+checksum = "25561d9ecf4bcf1aa2e800560ac557bff6dad943b9dc5cd0e8427fceca1e8c65"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790bdabbedf054cc63898653db2091778350d6cbe92cc4849b720197bf490b3f"
+checksum = "f6b24ad70b49f40d6acfe7b1ccf042db25820abe305a4c2232f15204f63f0227"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c105fd09e4511635da451a3a5ea67930de8bc2580e38f4e17fee7bfa863679a6"
+checksum = "9e7197d135a012724c2988e2c3a643a54eddbdaa0570b2540b55f39337b437cf"
 dependencies = [
  "derive-where",
  "futures",
@@ -21170,9 +21204,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21872dbcf1d74412a8694c1c7d591327f9fb135190b532b2bd142d8e6fcb149d"
+checksum = "4bcf5bf842f895678f170cc36ac7c4bc6521e7c119d24b2c0793f4bbcbe0d3d4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -21188,18 +21222,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60d8d1c8326e64946ad31ff87ea46ed33352c0cd83335616b807cdd7caf54df"
+checksum = "94e580d03bb5383aca1c12579a8a24b838afb12eb356439e740cba34904b6864"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8808c750ebf2fed123966b1ae2b2cdb68816b1c3720f34940f7d4bd0e642487"
+checksum = "4d4288b17090a89f1669437b7d4435b48da0e4a904669205c9b5d85afbf47176"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -21217,18 +21251,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fed277cde22eb01bee30960fa083d2a675e9753a941c83298cea5f4da90c63"
+checksum = "632cac9d74df33a49efd2ba559ab51171020d9a27c375abb29846f078fa50ad6"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae90758e6620773f2add87a35f1f383d5962c1bfb928ce341e6adf89e65e0bbc"
+checksum = "c772904088f4b52275b7faedfa70fdb14dba514c3c4165b8ddb6bbad3b0eb67b"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -21237,9 +21271,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a84e9e64017411723f6805bc56c56de41f16f3b47c6e0361608e3e24c4181a"
+checksum = "52f5c2e680078bfcfa0b782ce3512c06b8fcf8e3bc373c6c291e32395580e780"
 dependencies = [
  "derive-where",
  "futures",
@@ -21364,9 +21398,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c013676daf7ad3f1b1cfab1655a2e68f7607a6e460a5d51ed94c1b116b1b981"
+checksum = "b86f0b3b6f39976825b472e2967e212b4e36f6dc395c74076b25b2ed52c605dd"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -21449,9 +21483,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d42cb5ff5e1614cab6a504ba35ba2220b1b75ec707ff36290a98a87541dee2"
+checksum = "c4dcb59c94af4b470b005468d7c089208bc2ac834363193a8cdc2418e60a211a"
 dependencies = [
  "bincode 1.3.3",
  "bytemuck",
@@ -21493,9 +21527,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c6458a70a3ee7270edc07b088a27a6d976f3806a5176f862a44b459ea038b2"
+checksum = "170ac89e5233e23cff58ad32f7cbbeced26c3ce190207d6b1c7c1f699525b655"
 dependencies = [
  "base64 0.22.1",
  "bincode 1.3.3",
@@ -21515,9 +21549,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8e364bba7ffa8f0920a01380aa49339b402ec0fcda85e8f44f4ecf9fdb9d13"
+checksum = "704fef851e9f123f669ef04045fcff122453b0ca6942cd00b61d27c291c71a87"
 dependencies = [
  "bincode 1.3.3",
  "crash-handler",
@@ -21530,9 +21564,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f83a1a9147f47904ef93100a4a3628e8cf764845f59fa63ca4d823127a8118a"
+checksum = "20eaef541ed947056b37a7c16a149090a8c2a3e0d1e5f31fd1b0d688f1e9d96e"
 dependencies = [
  "bincode 1.3.3",
  "cfg-if",
@@ -21579,9 +21613,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a5b10d6fe1e0f893b1ae45301e6d61a0e89cf6b689659bf1f0151143a3c287"
+checksum = "93c3a16e1af983f60fb99176d340a401581677e63b7b1439ca034e83ca29476d"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -21600,9 +21634,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d019111b7cffb75a8ac223b917fa6b52ce86d54badff67080cc144b646876489"
+checksum = "3a34fe6b15dd14b498a3a4491c86ec2415bb70bac23571b18df1d15ac63c7bf8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -21611,9 +21645,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9797979904dd620bc4ede3cb5428c80b40a1208aa3af4bfa5c8168765b3005"
+checksum = "0a088f69335f9a594783d9ad3453be5f6f3abcc90b2387be57fb819acc3da203"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -21660,9 +21694,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8066e644f241c00b2410ebad85127d6b0f3ca81fcde2c064b0238a1564607f0"
+checksum = "65367f7b364358c1d7514a063177fa8131219a5cf24beb1be5547b0a043ff5ba"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -21677,9 +21711,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.0"
+version = "6.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5510c8971313bb6602642b0d8f6a4df95c6548be016fe598a670ac629ce558e6"
+checksum = "9281c105496b6b8d20b25f0be936242e5b747cc7711a68706ffbb3719d16145d"
 dependencies = [
  "bincode 1.3.3",
  "serde",
@@ -21688,9 +21722,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e37509eacbf8c2d0fe4af1b7faf7452158e6dae9f2d761667a8a5c59b5a863"
+checksum = "421b4590a89bf7c263f8a64844a4034ee8cb73c351498911ce0acd18da6b5ed2"
 dependencies = [
  "bincode 1.3.3",
  "blake3",
@@ -21800,9 +21834,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7476ca64175b28557bb07eb2f51b255b593efa57368d95ab9c54727ce8507b0e"
+checksum = "10edc1eeca25c63957a49516b4daccfe05e7564f75111a7a2d6642367c7bb5c6"
 dependencies = [
  "bincode 1.3.3",
  "itertools 0.14.0",
@@ -21840,9 +21874,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b44a83bf53f32effcd9d2ae3fe8d4bb77923166ba228a00dd14ee02d58a6b5"
+checksum = "44e968795d47837d58dfec2d650ae72b128722a37096faadff6ac20f5cc716c5"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -21861,9 +21895,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b09f1efb9fb06ea8d0527fc83ae1a7d9ed32a1bcd085dc76719dbfbf2d80f37"
+checksum = "28918f6630db8b7dfca815ac97fb0e4442319e52aa5edb813e6e368059e28e93"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -21885,9 +21919,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342e1ba459f495fa2301e6af33bb4f314bdb4ab19a2d30c7ce7d8c05e8709d0"
+checksum = "a0a020c7309bb3c62c34a1c9183106a7923e480b05b66c8a1d3419dc9b78d485"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -21910,9 +21944,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823880d30e7d9c0c10db6f5c8537c1b4bfadac90e8f44dc8e7da459e3f061f6c"
+checksum = "a1abf661a1ee1f0abb3737c14086a9e2127cbd88392c290ac1622455bd757d1f"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
@@ -21984,9 +22018,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a4fb8e2642046acb9ac642137c97fb466c17017579cece9040778306e54dc4"
+checksum = "b6dbb411abb1ea167f9b0b082c95f62ede26ab7ba72349770292a60dc0e9a673"
 dependencies = [
  "bincode 1.3.3",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ base-execution-eip8130-rpc-node = { path = "crates/execution/eip8130-rpc-node" }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }
+base-sidecrush = { path = "crates/infra/sidecrush" }
 audit-archiver-lib = { path = "crates/infra/audit" }
 base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
@@ -448,6 +449,7 @@ tracing-subscriber = "0.3.22"
 tracing = { version = "0.1.43", default-features = false }
 
 # Metrics
+cadence = "1.5"
 ordered-float = "5"
 metrics = { version = "0.24.3", default-features = false }
 metrics-util = { version = "0.20.1", default-features = false }

--- a/bin/sidecrush/Cargo.toml
+++ b/bin/sidecrush/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "base-sidecrush-bin"
+description = "Base Sidecrush Binary - block-production health-check sidecar"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "sidecrush"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+cadence = { workspace = true }
+tracing = { workspace = true }
+base-sidecrush = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "ansi", "json"] }

--- a/bin/sidecrush/src/main.rs
+++ b/bin/sidecrush/src/main.rs
@@ -1,0 +1,118 @@
+//! Block-production health-check sidecar binary. Long-lived process that polls an
+//! execution-layer HTTP RPC endpoint and emits four `StatsD` counters (`base.blocks.healthy`,
+//! `base.blocks.delayed`, `base.blocks.unhealthy`, `base.blocks.error`) to the local Datadog
+//! agent. All meaningful logic lives in the `base-sidecrush` library crate.
+
+use std::net::UdpSocket;
+
+use base_sidecrush::{
+    AlloyEthClient, BlockProductionHealthChecker, HealthcheckConfig, HealthcheckMetrics, Node,
+};
+use cadence::{StatsdClient, UdpMetricSink};
+use clap::{ArgAction, Parser};
+use tracing::Level;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Blockbuilding sidecar healthcheck service")]
+struct Args {
+    /// Ethereum node HTTP RPC URL
+    #[arg(long, env, default_value = "http://localhost:8545")]
+    node_url: String,
+
+    /// Poll interval in milliseconds
+    #[arg(long, env = "BBHC_SIDECAR_POLL_INTERVAL_MS", default_value_t = 1000u64)]
+    poll_interval_ms: u64,
+
+    /// Grace period in milliseconds before considering delayed
+    #[arg(long, env = "BBHC_SIDECAR_GRACE_PERIOD_MS", default_value_t = 2000u64)]
+    grace_period_ms: u64,
+
+    /// Threshold in milliseconds to consider unhealthy/stalled
+    #[arg(long, env = "BBHC_SIDECAR_UNHEALTHY_NODE_THRESHOLD_MS", default_value_t = 3000u64)]
+    unhealthy_node_threshold_ms: u64,
+
+    /// Log level
+    #[arg(long, env, default_value_t = Level::INFO)]
+    log_level: Level,
+
+    /// Log format (text|json)
+    #[arg(long, env, default_value = "json")]
+    log_format: String,
+
+    /// Treat node as a new instance on startup (suppresses initial errors until healthy).
+    /// Accepts `--new-instance=true|false` so it can be disabled explicitly.
+    #[arg(long, env, default_value_t = true, action = ArgAction::Set)]
+    new_instance: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    if args.log_format.to_lowercase() == "json" {
+        let _ = tracing_subscriber::fmt().json().with_max_level(args.log_level).try_init();
+    } else {
+        let _ = tracing_subscriber::fmt().with_max_level(args.log_level).try_init();
+    }
+
+    let statsd_host = std::env::var("DD_AGENT_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let statsd_addr = format!("{statsd_host}:8125");
+    tracing::info!(address = %statsd_addr, "connecting to StatsD agent");
+
+    let socket = UdpSocket::bind("0.0.0.0:0").expect("failed to bind UDP socket");
+    socket.set_nonblocking(true).expect("failed to set socket nonblocking");
+    let sink =
+        UdpMetricSink::from(statsd_addr.as_str(), socket).expect("failed to create StatsD sink");
+
+    let config_name =
+        std::env::var("CODEFLOW_CONFIG_NAME").unwrap_or_else(|_| "unknown".to_string());
+    let environment =
+        std::env::var("CODEFLOW_ENVIRONMENT").unwrap_or_else(|_| "unknown".to_string());
+    let project_name =
+        std::env::var("CODEFLOW_PROJECT_NAME").unwrap_or_else(|_| "unknown".to_string());
+    let service_name =
+        std::env::var("CODEFLOW_SERVICE_NAME").unwrap_or_else(|_| "unknown".to_string());
+
+    let statsd_client = StatsdClient::builder("base.blocks", sink)
+        .with_tag("configname", &config_name)
+        .with_tag("environment", &environment)
+        .with_tag("projectname", &project_name)
+        .with_tag("servicename", &service_name)
+        .build();
+
+    tracing::info!(
+        configname = %config_name,
+        environment = %environment,
+        projectname = %project_name,
+        servicename = %service_name,
+        "initialized StatsD client with tags"
+    );
+
+    let metrics = HealthcheckMetrics::new(statsd_client);
+
+    let node = Node::new(args.node_url.clone(), args.new_instance);
+    let client = AlloyEthClient::new_http(&args.node_url).expect("failed to create client");
+    let config = HealthcheckConfig::new(
+        args.poll_interval_ms,
+        args.grace_period_ms,
+        args.unhealthy_node_threshold_ms,
+    );
+
+    let mut checker: BlockProductionHealthChecker<_> =
+        BlockProductionHealthChecker::new(node, client, config, metrics);
+
+    let _status_handle = checker.spawn_status_emitter(2000);
+
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        let _ = shutdown_tx.send(());
+    });
+
+    tokio::select! {
+        _ = checker.poll_for_health_checks() => {},
+        _ = &mut shutdown_rx => {
+            tracing::info!("shutdown signal received, exiting");
+        }
+    }
+}

--- a/crates/infra/sidecrush/Cargo.toml
+++ b/crates/infra/sidecrush/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "base-sidecrush"
+description = "Block-production health-check sidecar library"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+cadence = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+alloy-provider = { workspace = true }
+alloy-rpc-types-eth = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["rt", "time", "macros"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/infra/sidecrush/README.md
+++ b/crates/infra/sidecrush/README.md
@@ -1,0 +1,30 @@
+# base-sidecrush
+
+Block-production health-check sidecar library.
+
+`base-sidecrush` polls an execution-layer node's HTTP RPC endpoint on a fixed
+interval, computes the age of the latest block relative to wall-clock time, and
+classifies the node into one of four health states:
+
+- **Healthy** — latest block age is within the configured grace period.
+- **Delayed** — block age is past the grace period but below the unhealthy
+  threshold.
+- **Unhealthy** — block age is at or above the unhealthy threshold; block
+  production is considered stalled.
+- **Error** — the RPC call failed or timed out (2 s per fetch).
+
+A separate 2 s heartbeat emits one `StatsD` counter increment per tick to
+Datadog under the `base.blocks` metric namespace, so alerting systems observe a
+continuous signal independent of poll cadence.
+
+## Types
+
+- [`BlockProductionHealthChecker`] — the async polling driver.
+- [`AlloyEthClient`] — an `EthClient` impl backed by the `alloy` HTTP provider.
+- [`HealthcheckMetrics`] — the `StatsD` counter wrapper.
+- [`Node`], [`HealthcheckConfig`], [`HeaderSummary`], [`HealthState`] — value
+  types describing the polling target, thresholds, block summaries, and current
+  state.
+
+Downstream deployment (Kubernetes manifests, image build) is defined by the
+`base-sidecrush-bin` binary crate in `bin/sidecrush/`.

--- a/crates/infra/sidecrush/src/healthcheck/alloy_client.rs
+++ b/crates/infra/sidecrush/src/healthcheck/alloy_client.rs
@@ -1,0 +1,43 @@
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_rpc_types_eth::BlockId;
+use async_trait::async_trait;
+
+use super::{EthClient, HeaderSummary};
+
+/// An [`EthClient`] backed by an [`alloy_provider::Provider`] HTTP transport.
+#[derive(Debug, Clone)]
+pub struct AlloyEthClient {
+    provider: RootProvider,
+}
+
+impl AlloyEthClient {
+    /// Construct a client that talks to an execution-layer node over HTTP JSON-RPC.
+    ///
+    /// The provider is built with `disable_recommended_fillers()` because sidecrush only issues
+    /// read-only `eth_getBlockByNumber` calls and never needs nonce/gas-price/chain-id fillers.
+    pub fn new_http(url: &str) -> anyhow::Result<Self> {
+        let provider =
+            ProviderBuilder::new().disable_recommended_fillers().connect_http(url.parse()?);
+        Ok(Self { provider })
+    }
+}
+
+#[async_trait]
+impl EthClient for AlloyEthClient {
+    async fn latest_header(
+        &self,
+    ) -> Result<HeaderSummary, Box<dyn std::error::Error + Send + Sync>> {
+        let block = self
+            .provider
+            .get_block(BlockId::latest())
+            .hashes()
+            .await?
+            .ok_or_else(|| "latest block not found".to_string())?;
+
+        let number: u64 = block.header.number;
+        let timestamp_unix_seconds: u64 = block.header.timestamp;
+        let transaction_count: usize = block.transactions.len();
+
+        Ok(HeaderSummary { number, timestamp_unix_seconds, transaction_count })
+    }
+}

--- a/crates/infra/sidecrush/src/healthcheck/mod.rs
+++ b/crates/infra/sidecrush/src/healthcheck/mod.rs
@@ -1,0 +1,391 @@
+//! Block-production health-check state machine and async polling driver.
+//!
+//! [`BlockProductionHealthChecker`] fetches the latest block header from an
+//! Ethereum HTTP RPC endpoint on a fixed interval, classifies it into a
+//! [`HealthState`], and stores the current state in an atomic that a decoupled
+//! 2 s heartbeat task (`spawn_status_emitter`) publishes to `StatsD`.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU8, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use tokio::time::{interval, timeout};
+use tracing::{debug, error, info};
+
+use crate::metrics::HealthcheckMetrics;
+
+mod alloy_client;
+pub use alloy_client::AlloyEthClient;
+
+/// The four terminal health states classified by [`BlockProductionHealthChecker`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthState {
+    /// Latest block age is within the grace period.
+    Healthy,
+    /// Latest block age is past the grace period but below the unhealthy threshold.
+    Delayed,
+    /// Latest block age is at or above the unhealthy threshold; block production is stalled.
+    Unhealthy,
+    /// The RPC call to fetch the latest block failed or timed out.
+    Error,
+}
+
+impl HealthState {
+    /// Numeric encoding used by the heartbeat emitter to pick which counter to increment.
+    pub const fn code(&self) -> u8 {
+        match self {
+            Self::Healthy => 0,
+            Self::Delayed => 1,
+            Self::Unhealthy => 2,
+            Self::Error => 3,
+        }
+    }
+}
+
+impl TryFrom<u8> for HealthState {
+    type Error = u8;
+
+    fn try_from(code: u8) -> Result<Self, u8> {
+        match code {
+            0 => Ok(Self::Healthy),
+            1 => Ok(Self::Delayed),
+            2 => Ok(Self::Unhealthy),
+            3 => Ok(Self::Error),
+            other => Err(other),
+        }
+    }
+}
+
+/// Timing thresholds that classify a [`HeaderSummary`] into a [`HealthState`].
+#[derive(Debug, Clone)]
+pub struct HealthcheckConfig {
+    /// Interval at which the RPC endpoint is polled.
+    pub poll_interval_ms: u64,
+    /// Block ages below this are [`HealthState::Healthy`].
+    pub grace_period_ms: u64,
+    /// Block ages at or above this are [`HealthState::Unhealthy`].
+    pub unhealthy_node_threshold_ms: u64,
+}
+
+impl HealthcheckConfig {
+    /// Construct a new config with explicit thresholds.
+    pub const fn new(
+        poll_interval_ms: u64,
+        grace_period_ms: u64,
+        unhealthy_node_threshold_ms: u64,
+    ) -> Self {
+        Self { poll_interval_ms, grace_period_ms, unhealthy_node_threshold_ms }
+    }
+}
+
+/// The RPC target of a health checker plus a bootstrap flag.
+#[derive(Debug, Clone)]
+pub struct Node {
+    /// HTTP RPC URL of the execution-layer node.
+    pub url: String,
+    /// When true, delayed/unhealthy classifications are suppressed until the first Healthy
+    /// observation so pod startup doesn't page.
+    pub is_new_instance: bool,
+}
+
+impl Node {
+    /// Construct a new `Node`.
+    pub fn new(url: impl Into<String>, is_new_instance: bool) -> Self {
+        Self { url: url.into(), is_new_instance }
+    }
+}
+
+/// The subset of a block header that [`BlockProductionHealthChecker`] needs.
+#[derive(Debug, Clone)]
+pub struct HeaderSummary {
+    /// Block number.
+    pub number: u64,
+    /// Block timestamp in Unix seconds.
+    pub timestamp_unix_seconds: u64,
+    /// Number of transactions in the block.
+    pub transaction_count: usize,
+}
+
+/// Minimal Ethereum client interface used by [`BlockProductionHealthChecker`].
+#[async_trait]
+pub trait EthClient: Send + Sync {
+    /// Fetch the latest block header summary.
+    async fn latest_header(
+        &self,
+    ) -> Result<HeaderSummary, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// Long-running poller that classifies block production into a [`HealthState`] and drives a
+/// `StatsD` emitter task.
+#[derive(Debug)]
+pub struct BlockProductionHealthChecker<C: EthClient> {
+    /// The node being monitored.
+    pub node: Node,
+    /// The Ethereum client used to fetch block headers.
+    pub client: C,
+    /// Timing thresholds.
+    pub config: HealthcheckConfig,
+    status_code: Arc<AtomicU8>,
+    metrics: HealthcheckMetrics,
+}
+
+impl<C: EthClient> BlockProductionHealthChecker<C> {
+    /// Construct a new checker starting in [`HealthState::Healthy`].
+    pub fn new(
+        node: Node,
+        client: C,
+        config: HealthcheckConfig,
+        metrics: HealthcheckMetrics,
+    ) -> Self {
+        // default to healthy until first classification
+        let initial_status: u8 = HealthState::Healthy.code();
+        Self { node, client, config, status_code: Arc::new(AtomicU8::new(initial_status)), metrics }
+    }
+
+    /// Spawn a background task that publishes the current [`HealthState`] to `StatsD` every
+    /// `period_ms` milliseconds, independent of poll cadence.
+    pub fn spawn_status_emitter(&self, period_ms: u64) -> tokio::task::JoinHandle<()> {
+        let status = Arc::clone(&self.status_code);
+        let metrics = self.metrics.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_millis(period_ms));
+            loop {
+                ticker.tick().await;
+                let code = status.load(Ordering::Relaxed);
+                let state = HealthState::try_from(code).unwrap_or(HealthState::Error);
+                match state {
+                    HealthState::Healthy => metrics.increment_status_healthy(),
+                    HealthState::Delayed => metrics.increment_status_delayed(),
+                    HealthState::Unhealthy => metrics.increment_status_unhealthy(),
+                    HealthState::Error => metrics.increment_status_error(),
+                }
+            }
+        })
+    }
+
+    /// Run a single health-check iteration: fetch latest header (2 s timeout), classify, store.
+    pub async fn run_health_check(&mut self) {
+        let url = &self.node.url;
+
+        debug!(sequencer = %url, "checking block production health");
+
+        // Enforce a 2s timeout on header fetch
+        let header_result = timeout(Duration::from_secs(2), self.client.latest_header()).await;
+
+        let latest = match header_result {
+            Ok(Ok(h)) => h,
+            Ok(Err(e)) => {
+                if self.node.is_new_instance {
+                    debug!(sequencer = %url, error = %e, "waiting for node to become healthy");
+                } else {
+                    error!(sequencer = %url, error = %e, "failed to fetch block");
+                }
+                self.status_code.store(HealthState::Error.code(), Ordering::Relaxed);
+                return;
+            }
+            Err(_elapsed) => {
+                if self.node.is_new_instance {
+                    debug!(sequencer = %url, "waiting for node to become healthy (timeout)");
+                } else {
+                    error!(sequencer = %url, "failed to fetch block (timeout)");
+                }
+                self.status_code.store(HealthState::Error.code(), Ordering::Relaxed);
+                return;
+            }
+        };
+
+        // Compute block age
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_secs();
+        let block_age_ms = now_secs.saturating_sub(latest.timestamp_unix_seconds) * 1000;
+
+        let unhealthy_ms = self.config.unhealthy_node_threshold_ms;
+        let grace_ms = self.config.grace_period_ms;
+
+        let state = if self.node.is_new_instance {
+            HealthState::Healthy
+        } else if block_age_ms >= unhealthy_ms {
+            HealthState::Unhealthy
+        } else if block_age_ms > grace_ms {
+            HealthState::Delayed
+        } else {
+            HealthState::Healthy
+        };
+        self.status_code.store(state.code(), Ordering::Relaxed);
+
+        if block_age_ms > grace_ms {
+            if self.node.is_new_instance {
+                // Suppress delayed/unhealthy while new instance catches up
+            } else if block_age_ms >= unhealthy_ms {
+                error!(
+                    block_number = latest.number,
+                    tx_count = latest.transaction_count,
+                    sequencer = %url,
+                    age_ms = block_age_ms,
+                    "block production unhealthy"
+                );
+            } else {
+                info!(
+                    block_number = latest.number,
+                    tx_count = latest.transaction_count,
+                    sequencer = %url,
+                    age_ms = block_age_ms,
+                    "delayed block production detected"
+                );
+            }
+        } else {
+            if self.node.is_new_instance {
+                self.node.is_new_instance = false;
+                info!(
+                    block_number = latest.number,
+                    tx_count = latest.transaction_count,
+                    sequencer = %url,
+                    "node becoming healthy"
+                );
+            }
+            debug!(
+                block_number = latest.number,
+                tx_count = latest.transaction_count,
+                sequencer = %url,
+                "block production healthy"
+            );
+        }
+    }
+
+    /// Run [`Self::run_health_check`] in a loop on the configured poll interval, forever.
+    pub async fn poll_for_health_checks(&mut self) {
+        let mut ticker = interval(Duration::from_millis(self.config.poll_interval_ms));
+        loop {
+            ticker.tick().await;
+            self.run_health_check().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::UdpSocket,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use cadence::{StatsdClient, UdpMetricSink};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct MockClient {
+        header: Arc<Mutex<HeaderSummary>>,
+    }
+
+    #[async_trait]
+    impl EthClient for MockClient {
+        async fn latest_header(
+            &self,
+        ) -> Result<HeaderSummary, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(self.header.lock().unwrap().clone())
+        }
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_secs()
+    }
+
+    fn mock_metrics() -> HealthcheckMetrics {
+        let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        socket.set_nonblocking(true).unwrap();
+        let sink = UdpMetricSink::from("127.0.0.1:8125", socket).unwrap();
+        let statsd_client = StatsdClient::from_sink("test", sink);
+        HealthcheckMetrics::new(statsd_client)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn healthy_new_block_emits_healthy() {
+        let cfg = HealthcheckConfig::new(1_000, 5_000, 15_000);
+        let start = now_secs();
+        let shared_header = Arc::new(Mutex::new(HeaderSummary {
+            number: 1,
+            timestamp_unix_seconds: start,
+            transaction_count: 5,
+        }));
+        let client = MockClient { header: Arc::clone(&shared_header) };
+        let node = Node::new("http://localhost:8545", false);
+        let metrics = mock_metrics();
+        let mut checker = BlockProductionHealthChecker::new(node, client, cfg, metrics);
+
+        checker.run_health_check().await;
+        assert_eq!(checker.status_code.load(Ordering::Relaxed), HealthState::Healthy.code());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delayed_new_block_emits_delayed() {
+        let grace_ms = 5_000u64;
+        let cfg = HealthcheckConfig::new(1_000, grace_ms, 15_000);
+        let start = now_secs();
+        let shared_header = Arc::new(Mutex::new(HeaderSummary {
+            number: 1,
+            timestamp_unix_seconds: start,
+            transaction_count: 5,
+        }));
+        let client = MockClient { header: Arc::clone(&shared_header) };
+        let node = Node::new("http://localhost:8545", false);
+        let metrics = mock_metrics();
+        let mut checker = BlockProductionHealthChecker::new(node, client, cfg, metrics);
+
+        // First healthy block
+        checker.run_health_check().await;
+        assert_eq!(checker.status_code.load(Ordering::Relaxed), HealthState::Healthy.code());
+
+        // Next block arrives but is delayed beyond grace
+        let delayed_ts = start.saturating_sub((grace_ms / 1000) + 1);
+        *shared_header.lock().unwrap() =
+            HeaderSummary { number: 2, timestamp_unix_seconds: delayed_ts, transaction_count: 5 };
+        checker.run_health_check().await;
+        assert_eq!(checker.status_code.load(Ordering::Relaxed), HealthState::Delayed.code());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn unhealthy_same_block_triggers_single_stall_emit() {
+        let unhealthy_ms = 15_000u64;
+        let cfg = HealthcheckConfig::new(1_000, 5_000, unhealthy_ms);
+        let start = now_secs();
+        let shared_header = Arc::new(Mutex::new(HeaderSummary {
+            number: 10,
+            timestamp_unix_seconds: start,
+            transaction_count: 5,
+        }));
+        let client = MockClient { header: Arc::clone(&shared_header) };
+        let node = Node::new("http://localhost:8545", false);
+        let metrics = mock_metrics();
+        let mut checker = BlockProductionHealthChecker::new(node, client, cfg, metrics);
+
+        // First observation (healthy)
+        checker.run_health_check().await;
+        assert_eq!(checker.status_code.load(Ordering::Relaxed), HealthState::Healthy.code());
+
+        // Same head, but now sufficiently old to be unhealthy -> emits stall once
+        let unhealthy_ts = start.saturating_sub((unhealthy_ms / 1000) + 1);
+        *shared_header.lock().unwrap() = HeaderSummary {
+            number: 10,
+            timestamp_unix_seconds: unhealthy_ts,
+            transaction_count: 5,
+        };
+        checker.run_health_check().await;
+        assert_eq!(checker.status_code.load(Ordering::Relaxed), HealthState::Unhealthy.code());
+
+        // Re-run again with same head: should not re-emit; flag remains set
+        checker.run_health_check().await;
+        assert_eq!(checker.status_code.load(Ordering::Relaxed), HealthState::Unhealthy.code());
+    }
+}

--- a/crates/infra/sidecrush/src/lib.rs
+++ b/crates/infra/sidecrush/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod healthcheck;
+pub use healthcheck::{
+    AlloyEthClient, BlockProductionHealthChecker, EthClient, HeaderSummary, HealthState,
+    HealthcheckConfig, Node,
+};
+
+mod metrics;
+pub use metrics::HealthcheckMetrics;

--- a/crates/infra/sidecrush/src/metrics.rs
+++ b/crates/infra/sidecrush/src/metrics.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use cadence::{CountedExt, StatsdClient};
+
+/// Metrics client wrapper for block building health checks.
+///
+/// Emits metrics every 2 seconds via status heartbeat (independent of poll frequency).
+#[derive(Clone, Debug)]
+pub struct HealthcheckMetrics {
+    client: Arc<StatsdClient>,
+}
+
+impl HealthcheckMetrics {
+    /// Wrap a pre-configured [`StatsdClient`] (with prefix, tags, and sink already set) in an
+    /// `Arc` so the emitter task can share it with the health-check poller.
+    pub fn new(client: StatsdClient) -> Self {
+        Self { client: Arc::new(client) }
+    }
+
+    /// Increment `status_healthy` counter (2s heartbeat).
+    pub fn increment_status_healthy(&self) {
+        let _ = self.client.incr("healthy");
+    }
+
+    /// Increment `status_delayed` counter (2s heartbeat).
+    pub fn increment_status_delayed(&self) {
+        let _ = self.client.incr("delayed");
+    }
+
+    /// Increment `status_unhealthy` counter (2s heartbeat).
+    pub fn increment_status_unhealthy(&self) {
+        let _ = self.client.incr("unhealthy");
+    }
+
+    /// Increment `status_error` counter (2s heartbeat).
+    pub fn increment_status_error(&self) {
+        let _ = self.client.incr("error");
+    }
+}

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -86,6 +86,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --profile $PROFILE --package base-batcher-bin --bin base-batcher && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-batcher /app/base-batcher
 
+FROM source AS sidecrush-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=sidecrush-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-sidecrush-bin --bin sidecrush && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/sidecrush /app/sidecrush
+
 FROM zk-builder-base AS zk-source
 COPY . .
 
@@ -128,6 +136,10 @@ ENTRYPOINT ["./audit-archiver"]
 FROM runtime-base AS batcher
 COPY --from=batcher-builder /app/base-batcher ./base-batcher
 ENTRYPOINT ["./base-batcher"]
+
+FROM runtime-base AS sidecrush
+COPY --from=sidecrush-builder /app/sidecrush ./sidecrush
+ENTRYPOINT ["./sidecrush"]
 
 FROM runtime-base AS zk-prover
 COPY --from=zk-prover-builder /app/base-prover-zk ./base-prover-zk

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -34,6 +34,7 @@ group "rust-services" {
     "ingress-rpc",
     "audit-archiver",
     "batcher",
+    "sidecrush",
     "zk-prover",
   ]
 }
@@ -98,6 +99,16 @@ target "batcher" {
   cache-from = [
     "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
     "type=registry,ref=${REGISTRY_IMAGE}:cache-batcher-${PLATFORM_PAIR}",
+  ]
+}
+
+target "sidecrush" {
+  inherits = ["_rust-service-common"]
+  target = "sidecrush"
+  tags = ["sidecrush:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-sidecrush-${PLATFORM_PAIR}",
   ]
 }
 


### PR DESCRIPTION
## Summary

Moves the `sidecrush` block-production health-check sidecar out of the now-archived [`github.com/base/infra`](https://github.com/base/infra) repo and into `base/base` as a standalone Rust binary published via the existing `rust-services` Docker pipeline.

`sidecrush` polls an execution-layer node's `eth_getBlockByNumber("latest")` on a configurable interval, computes the age of the latest block, and emits four StatsD counters under the `base.blocks` prefix to the local Datadog agent every 2 s:

- `base.blocks.healthy` — block age within grace period
- `base.blocks.delayed` — block age past grace but below unhealthy threshold
- `base.blocks.unhealthy` — block age at or above unhealthy threshold (stalled)
- `base.blocks.error` — RPC call failed or timed out

These metrics are actively consumed by 2 SLOs and 5 dashboards, so the migration preserves the same metric names, prefix, and tag schema.

## Changes

| File | Change |
|---|---|
| `crates/infra/sidecrush/` (new) | Library crate `base-sidecrush` — health-check state machine, alloy HTTP client, StatsD metrics wrapper |
| `bin/sidecrush/` (new) | Binary crate `base-sidecrush-bin` — CLI + tokio runtime + StatsD sink wiring; binary name `sidecrush` (preserved for backward compat) |
| `etc/docker/Dockerfile.rust-services` | New `sidecrush-builder` and `sidecrush` stages, matching the `batcher` shape |
| `etc/docker/docker-bake.hcl` | New `sidecrush` target added to the `rust-services` group |
| `Cargo.toml` | Add `cadence = "1.5"` (StatsD client) and `base-sidecrush = { path = "crates/infra/sidecrush" }` |

## Behavior parity

Identical to the infra version:

- **CLI flags:** `--node-url`, `--poll-interval-ms`, `--grace-period-ms`, `--unhealthy-node-threshold-ms`, `--log-level`, `--log-format`, `--new-instance`.
- **Env vars honored:** `NODE_URL`, `BBHC_SIDECAR_POLL_INTERVAL_MS`, `BBHC_SIDECAR_GRACE_PERIOD_MS`, `BBHC_SIDECAR_UNHEALTHY_NODE_THRESHOLD_MS`, `LOG_LEVEL`, `LOG_FORMAT`, `DD_AGENT_HOST`, `CODEFLOW_{CONFIG,ENVIRONMENT,PROJECT,SERVICE}_NAME`.
- **Metric names, prefix, tags:** unchanged.
- **Runtime image entrypoint:** unchanged (`./sidecrush`).

The one adjustment needed to fit `base/base`'s conventions was upgrading `alloy-*` from 1.5.2 → 2.0.5 to match the workspace; no source code changes were required for that upgrade — the `Provider::get_block` + `BlockId::latest()` surface is API-compatible.
