### PR TITLE
feat(snapshotter): only sync when EL is near tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6257,6 +6257,8 @@ dependencies = [
 name = "base-snapshotter"
 version = "0.0.0"
 dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-provider 2.0.5",
  "anyhow",
  "async-trait",
  "aws-config",
@@ -6275,6 +6277,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tracing",
+ "url",
  "zstd",
 ]
 

--- a/bin/snapshotter/main.rs
+++ b/bin/snapshotter/main.rs
@@ -5,7 +5,8 @@ use aws_config::BehaviorVersion;
 use aws_credential_types::Credentials;
 use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder};
 use base_snapshotter::{
-    DockerContainerManager, S3ConfigType, SnapshotUploader, Snapshotter, SnapshotterConfig,
+    DockerContainerManager, RpcTipChecker, S3ConfigType, SnapshotUploader, Snapshotter,
+    SnapshotterConfig,
 };
 use clap::Parser;
 use tracing::{info, warn};
@@ -28,6 +29,7 @@ async fn main() -> Result<()> {
     }
 
     let container_manager = DockerContainerManager::new(&config.docker_socket)?;
+    let tip_checker = RpcTipChecker::new(config.el_rpc_url.clone());
     let storage_client = create_s3_client(&config).await?;
     let uploader = SnapshotUploader::new(
         storage_client,
@@ -36,7 +38,7 @@ async fn main() -> Result<()> {
         config.public_base_url.clone(),
     );
 
-    let snapshotter = Snapshotter::new(container_manager, uploader, config);
+    let snapshotter = Snapshotter::new(container_manager, tip_checker, uploader, config);
     snapshotter.run().await
 }
 

--- a/crates/infra/snapshotter/Cargo.toml
+++ b/crates/infra/snapshotter/Cargo.toml
@@ -12,16 +12,19 @@ workspace = true
 
 [dependencies]
 tar = { workspace = true }
+url = { workspace = true }
 zstd = { workspace = true }
 anyhow = { workspace = true }
 blake3 = { workspace = true }
 rayon = { workspace = true }
 bollard = { workspace = true }
 futures = { workspace = true }
-reth-cli-commands = { workspace = true }
 tracing = { workspace = true }
+alloy-eips = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
+reth-cli-commands = { workspace = true }
+alloy-provider = { workspace = true, features = ["reqwest"] }
 tokio = { workspace = true, features = ["rt", "fs"] }
 clap = { workspace = true, features = ["derive", "env"] }
 aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }

--- a/crates/infra/snapshotter/README.md
+++ b/crates/infra/snapshotter/README.md
@@ -27,13 +27,16 @@ base-snapshotter = { workspace = true }
 ```
 
 ```rust,ignore
-use base_snapshotter::{DockerContainerManager, Snapshotter, SnapshotUploader, SnapshotterConfig};
+use base_snapshotter::{
+    DockerContainerManager, RpcTipChecker, Snapshotter, SnapshotUploader, SnapshotterConfig,
+};
 
 let config = SnapshotterConfig::parse();
 let container_manager = DockerContainerManager::new(&config.docker_socket)?;
+let tip_checker = RpcTipChecker::new(config.el_rpc_url.clone());
 
 // ... create s3_client and uploader ...
-let snapshotter = Snapshotter::new(container_manager, uploader, config);
+let snapshotter = Snapshotter::new(container_manager, tip_checker, uploader, config);
 snapshotter.run().await?;
 ```
 

--- a/crates/infra/snapshotter/README.md
+++ b/crates/infra/snapshotter/README.md
@@ -5,9 +5,14 @@ Sidecar for generating and uploading reth node snapshots to S3-compatible storag
 ## Overview
 
 Runs alongside a Base execution layer node (base-node-reth) and orchestrates periodic snapshot
-creation. `Snapshotter` coordinates the full lifecycle: stopping the EL container via the Docker
-socket, generating a snapshot manifest and chunk archives using reth's `SnapshotManifestCommand`,
-uploading all artifacts to an S3-compatible store (e.g. Cloudflare R2), then restarting the EL.
+creation. `Snapshotter` coordinates the full lifecycle: verifying the EL is at chain tip (its
+latest block is within a configurable freshness window, default 10s), stopping the EL container
+via the Docker socket, generating a snapshot manifest and chunk archives using reth's
+`SnapshotManifestCommand`, uploading all artifacts to an S3-compatible store (e.g. Cloudflare R2),
+then restarting the EL.
+
+If the EL is not at tip when a run begins, the snapshot is skipped and the container is left
+running untouched.
 
 The Docker socket (`/var/run/docker.sock`) is volume-mounted into the sidecar container, giving
 it control over sibling containers on the host.

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -3,6 +3,11 @@
 use std::{num::NonZeroUsize, path::PathBuf};
 
 use clap::{Parser, ValueEnum};
+use url::Url;
+
+/// Default tip threshold in seconds: how fresh the latest block must be for the
+/// EL to be considered "at tip".
+pub const DEFAULT_TIP_THRESHOLD_SECS: u64 = 10;
 
 /// How the S3/R2 client is configured.
 #[derive(Debug, Clone, ValueEnum)]
@@ -23,6 +28,22 @@ pub struct SnapshotterConfig {
     /// Docker container name of the execution layer node to stop/start.
     #[arg(long)]
     pub container_name: String,
+
+    /// HTTP JSON-RPC URL of the execution layer node.
+    ///
+    /// Used to verify the EL is at tip (latest block is recent) before pausing
+    /// the container for a snapshot.
+    #[arg(long, env = "SNAPSHOTTER_EL_RPC_URL")]
+    pub el_rpc_url: Url,
+
+    /// Maximum age (in seconds) of the latest block for the EL to be considered
+    /// "at tip".
+    ///
+    /// If the latest block's timestamp is older than this many seconds relative
+    /// to the current wall-clock time, the snapshot run is skipped and the EL
+    /// container is left untouched.
+    #[arg(long, env = "SNAPSHOTTER_TIP_THRESHOLD_SECS", default_value_t = DEFAULT_TIP_THRESHOLD_SECS)]
+    pub tip_threshold_secs: u64,
 
     /// Source datadir containing the reth node data (static files + DB).
     #[arg(long, short = 'd')]

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -8,13 +8,16 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod config;
-pub use config::{S3ConfigType, SnapshotterConfig};
+pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
 
 mod progress;
 pub use progress::{ArchiveProgress, UploadProgress};
 
 mod container;
 pub use container::{ContainerManager, DockerContainerManager};
+
+mod tip;
+pub use tip::TipChecker;
 
 mod snapshot;
 pub use snapshot::{

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -17,7 +17,7 @@ mod container;
 pub use container::{ContainerManager, DockerContainerManager};
 
 mod tip;
-pub use tip::TipChecker;
+pub use tip::{RpcTipChecker, TipChecker};
 
 mod snapshot;
 pub use snapshot::{

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -2,16 +2,17 @@
 
 use std::{
     path::PathBuf,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, bail};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
     snapshot::{SnapshotGenerator, SnapshotManifest},
+    tip::TipChecker,
     upload::SnapshotUploader,
 };
 
@@ -43,6 +44,7 @@ impl<C: ContainerManager> Snapshotter<C> {
 
     /// Executes the full snapshot lifecycle.
     ///
+    /// 0. Verifies the EL is at chain tip; skips the run if it is not
     /// 1. Stops the EL container
     /// 2. Verifies the container is stopped
     /// 3. Generates snapshot archives
@@ -50,6 +52,20 @@ impl<C: ContainerManager> Snapshotter<C> {
     /// 5. Clears reth's persisted peer list (best effort)
     /// 6. Restarts the EL container (always, even on failure)
     pub async fn run(&self) -> Result<()> {
+        // Only snapshot when the EL is caught up to tip. Snapshotting a lagging
+        // node would publish stale data and pause a node that is still syncing.
+        let threshold = Duration::from_secs(self.config.tip_threshold_secs);
+        let at_tip = TipChecker::is_at_tip(&self.config.el_rpc_url, threshold)
+            .await
+            .context("failed to check EL tip status")?;
+        if !at_tip {
+            warn!(
+                threshold_secs = self.config.tip_threshold_secs,
+                "EL is not at tip; skipping snapshot run and leaving container running"
+            );
+            return Ok(());
+        }
+
         let stop_result = self.container_manager.stop(&self.config.container_name).await;
 
         let result = match stop_result {

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -20,26 +20,29 @@ use crate::{
 ///
 /// The EL container is always restarted, even if snapshot generation or upload
 /// fails. This prevents leaving the node in a stopped state on errors.
-pub struct Snapshotter<C: ContainerManager> {
+pub struct Snapshotter<C: ContainerManager, T: TipChecker> {
     container_manager: C,
+    tip_checker: T,
     uploader: SnapshotUploader,
     config: SnapshotterConfig,
 }
 
-impl<C: ContainerManager> std::fmt::Debug for Snapshotter<C> {
+impl<C: ContainerManager, T: TipChecker> std::fmt::Debug for Snapshotter<C, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Snapshotter").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
-impl<C: ContainerManager> Snapshotter<C> {
-    /// Creates a new snapshotter with the given container manager and uploader.
+impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
+    /// Creates a new snapshotter with the given container manager, tip checker,
+    /// and uploader.
     pub const fn new(
         container_manager: C,
+        tip_checker: T,
         uploader: SnapshotUploader,
         config: SnapshotterConfig,
     ) -> Self {
-        Self { container_manager, uploader, config }
+        Self { container_manager, tip_checker, uploader, config }
     }
 
     /// Executes the full snapshot lifecycle.
@@ -54,10 +57,17 @@ impl<C: ContainerManager> Snapshotter<C> {
     pub async fn run(&self) -> Result<()> {
         // Only snapshot when the EL is caught up to tip. Snapshotting a lagging
         // node would publish stale data and pause a node that is still syncing.
+        //
+        // This is a best-effort PRE-check, not a guarantee of freshness at
+        // snapshot time. There is an inherent TOCTOU gap: after this check
+        // passes, time elapses while we stop the container, generate archives,
+        // and upload — so a node that was "barely at tip" (e.g. 9s old with a
+        // 10s threshold) may be stale by the time data is actually captured.
+        // This is acceptable for the default 10s threshold on a 2s block-time
+        // chain, but callers tightening the threshold should keep this in mind.
         let threshold = Duration::from_secs(self.config.tip_threshold_secs);
-        let at_tip = TipChecker::is_at_tip(&self.config.el_rpc_url, threshold)
-            .await
-            .context("failed to check EL tip status")?;
+        let at_tip =
+            self.tip_checker.is_at_tip(threshold).await.context("failed to check EL tip status")?;
         if !at_tip {
             warn!(
                 threshold_secs = self.config.tip_threshold_secs,

--- a/crates/infra/snapshotter/src/tip.rs
+++ b/crates/infra/snapshotter/src/tip.rs
@@ -5,27 +5,46 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{Provider, ProviderBuilder};
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use tracing::info;
 use url::Url;
 
-/// Checks whether an execution layer node is at chain tip by inspecting the
-/// timestamp of its latest block.
-#[derive(Debug)]
-pub struct TipChecker;
-
-impl TipChecker {
+/// Checks whether an execution layer node is at chain tip.
+///
+/// Abstracted behind a trait (like [`crate::ContainerManager`]) so the
+/// orchestrator can be exercised in tests without a live RPC endpoint.
+#[async_trait]
+pub trait TipChecker: Send + Sync {
     /// Returns `true` if the EL's latest block is within `threshold` of the
     /// current wall-clock time.
-    ///
-    /// Fetches the `latest` block via `eth_getBlockByNumber` and compares its
-    /// timestamp against `SystemTime::now()`. A block in the future (clock skew)
-    /// is always considered at tip.
-    pub async fn is_at_tip(rpc_url: &Url, threshold: Duration) -> Result<bool> {
+    async fn is_at_tip(&self, threshold: Duration) -> Result<bool>;
+}
+
+/// [`TipChecker`] backed by an execution layer JSON-RPC endpoint.
+///
+/// Determines tip status by fetching the `latest` block via
+/// `eth_getBlockByNumber` and comparing its timestamp against the current
+/// wall-clock time.
+#[derive(Debug, Clone)]
+pub struct RpcTipChecker {
+    rpc_url: Url,
+}
+
+impl RpcTipChecker {
+    /// Creates a new tip checker targeting the given EL RPC URL.
+    pub const fn new(rpc_url: Url) -> Self {
+        Self { rpc_url }
+    }
+}
+
+#[async_trait]
+impl TipChecker for RpcTipChecker {
+    async fn is_at_tip(&self, threshold: Duration) -> Result<bool> {
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
-            .connect(rpc_url.as_str())
+            .connect(self.rpc_url.as_str())
             .await
-            .with_context(|| format!("connecting to EL RPC at {rpc_url}"))?;
+            .with_context(|| format!("connecting to EL RPC at {}", self.rpc_url))?;
 
         let block = provider
             .get_block_by_number(BlockNumberOrTag::Latest)

--- a/crates/infra/snapshotter/src/tip.rs
+++ b/crates/infra/snapshotter/src/tip.rs
@@ -1,0 +1,59 @@
+//! Verifies the execution layer is caught up to chain tip before pausing.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_provider::{Provider, ProviderBuilder};
+use anyhow::{Context, Result};
+use tracing::info;
+use url::Url;
+
+/// Checks whether an execution layer node is at chain tip by inspecting the
+/// timestamp of its latest block.
+#[derive(Debug)]
+pub struct TipChecker;
+
+impl TipChecker {
+    /// Returns `true` if the EL's latest block is within `threshold` of the
+    /// current wall-clock time.
+    ///
+    /// Fetches the `latest` block via `eth_getBlockByNumber` and compares its
+    /// timestamp against `SystemTime::now()`. A block in the future (clock skew)
+    /// is always considered at tip.
+    pub async fn is_at_tip(rpc_url: &Url, threshold: Duration) -> Result<bool> {
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect(rpc_url.as_str())
+            .await
+            .with_context(|| format!("connecting to EL RPC at {rpc_url}"))?;
+
+        let block = provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await
+            .context("fetching latest block")?
+            .context("latest block not found")?;
+
+        let block_timestamp = block.header.timestamp;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock is before UNIX epoch")?
+            .as_secs();
+
+        // Saturating: a block timestamp in the future (clock skew) yields an age
+        // of 0, which is always within threshold.
+        let age = now.saturating_sub(block_timestamp);
+        let at_tip = age <= threshold.as_secs();
+
+        info!(
+            block = block.header.number,
+            block_timestamp,
+            now,
+            age_secs = age,
+            threshold_secs = threshold.as_secs(),
+            at_tip,
+            "checked EL tip status"
+        );
+
+        Ok(at_tip)
+    }
+}

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use base_snapshotter::{
     ChunkedArchive, ComponentManifest, ContainerManager, DockerContainerManager,
-    OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotUploader,
+    OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotUploader, TipChecker,
 };
 use bollard::{
     Docker,
@@ -67,6 +67,50 @@ impl ContainerManager for MockContainerManager {
 
     async fn is_running(&self, _container_name: &str) -> Result<bool> {
         Ok(self.running.load(Ordering::Relaxed))
+    }
+}
+
+/// Mock tip checker that returns a fixed at-tip status without any RPC calls.
+struct MockTipChecker {
+    at_tip: bool,
+}
+
+impl MockTipChecker {
+    const fn new(at_tip: bool) -> Self {
+        Self { at_tip }
+    }
+}
+
+#[async_trait]
+impl TipChecker for MockTipChecker {
+    async fn is_at_tip(&self, _threshold: std::time::Duration) -> Result<bool> {
+        Ok(self.at_tip)
+    }
+}
+
+/// Builds a `SnapshotterConfig` for orchestrator tests. `source_datadir` is set
+/// to a nonexistent path so `generate_and_upload` fails deterministically.
+fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig {
+    base_snapshotter::SnapshotterConfig {
+        container_name: "fake-el".to_string(),
+        el_rpc_url: "http://127.0.0.1:8545".parse().expect("valid test URL"),
+        tip_threshold_secs: base_snapshotter::DEFAULT_TIP_THRESHOLD_SECS,
+        source_datadir: tmp.join("nonexistent-datadir"),
+        output_dir: tmp.join("output"),
+        bucket: bucket.to_string(),
+        prefix: "test".to_string(),
+        chain_id: 8453,
+        block: Some(100),
+        blocks_per_file: Some(500_000),
+        snapshot_threads: None,
+        retain_runs: NonZeroUsize::new(3).expect("retain runs should be non-zero"),
+        docker_socket: "/var/run/docker.sock".to_string(),
+        s3_config_type: base_snapshotter::S3ConfigType::Aws,
+        s3_endpoint: None,
+        s3_region: "us-east-1".to_string(),
+        s3_access_key_id: None,
+        s3_secret_access_key: None,
+        public_base_url: None,
     }
 }
 
@@ -790,34 +834,83 @@ async fn orchestrator_always_restarts_on_failure() -> Result<()> {
     );
 
     let tmp = tempfile::tempdir()?;
+    let config = test_config(&harness.bucket_name, tmp.path());
 
-    let config = base_snapshotter::SnapshotterConfig {
-        container_name: "fake-el".to_string(),
-        source_datadir: tmp.path().join("nonexistent-datadir"),
-        output_dir: tmp.path().join("output"),
-        bucket: harness.bucket_name.clone(),
-        prefix: "test".to_string(),
-        chain_id: 8453,
-        block: Some(100),
-        blocks_per_file: Some(500_000),
-        snapshot_threads: None,
-        retain_runs: NonZeroUsize::new(3).expect("retain runs should be non-zero"),
-        docker_socket: "/var/run/docker.sock".to_string(),
-        s3_config_type: base_snapshotter::S3ConfigType::Aws,
-        s3_endpoint: None,
-        s3_region: "us-east-1".to_string(),
-        s3_access_key_id: None,
-        s3_secret_access_key: None,
-        public_base_url: None,
-    };
-
-    let snapshotter =
-        base_snapshotter::Snapshotter::new(std::sync::Arc::clone(&manager), uploader, config);
+    let snapshotter = base_snapshotter::Snapshotter::new(
+        std::sync::Arc::clone(&manager),
+        MockTipChecker::new(true),
+        uploader,
+        config,
+    );
 
     let result = snapshotter.run().await;
     assert!(result.is_err(), "should fail because source_datadir doesn't exist");
     assert!(manager.was_stopped(), "container should have been stopped");
     assert!(manager.was_started(), "container should always be restarted even on failure");
+
+    Ok(())
+}
+
+/// When the EL is not at tip, the run must be skipped entirely: the container is
+/// neither stopped nor started, and `run` returns `Ok`.
+#[tokio::test]
+#[serial]
+async fn orchestrator_skips_when_not_at_tip() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let manager = std::sync::Arc::new(MockContainerManager::new());
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "test".to_string(),
+        None,
+    );
+
+    let tmp = tempfile::tempdir()?;
+    let config = test_config(&harness.bucket_name, tmp.path());
+
+    let snapshotter = base_snapshotter::Snapshotter::new(
+        std::sync::Arc::clone(&manager),
+        MockTipChecker::new(false),
+        uploader,
+        config,
+    );
+
+    let result = snapshotter.run().await;
+    assert!(result.is_ok(), "run should return Ok when skipping a not-at-tip node");
+    assert!(!manager.was_stopped(), "container must not be stopped when EL is not at tip");
+    assert!(!manager.was_started(), "container must not be started when EL is not at tip");
+
+    Ok(())
+}
+
+/// When the EL is at tip, the run proceeds to stop the container (and, here,
+/// fails downstream on the nonexistent datadir but still restarts).
+#[tokio::test]
+#[serial]
+async fn orchestrator_proceeds_when_at_tip() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let manager = std::sync::Arc::new(MockContainerManager::new());
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "test".to_string(),
+        None,
+    );
+
+    let tmp = tempfile::tempdir()?;
+    let config = test_config(&harness.bucket_name, tmp.path());
+
+    let snapshotter = base_snapshotter::Snapshotter::new(
+        std::sync::Arc::clone(&manager),
+        MockTipChecker::new(true),
+        uploader,
+        config,
+    );
+
+    let result = snapshotter.run().await;
+    assert!(result.is_err(), "should fail downstream because source_datadir doesn't exist");
+    assert!(manager.was_stopped(), "container should have been stopped when EL is at tip");
+    assert!(manager.was_started(), "container should always be restarted");
 
     Ok(())
 }


### PR DESCRIPTION
- requires passing `el_rpc_url` for the local endpoint (i.e., `http://localhost:18545/`)
- checks if local latest block timestamp is within a configurable time threshold (i.e., default to 10s ago)