### PR TITLE
fix(sidecrush): handle SIGTERM so k8s pod shutdown exits promptly

### DIFF
--- a/bin/sidecrush/src/main.rs
+++ b/bin/sidecrush/src/main.rs
@@ -10,6 +10,8 @@ use base_sidecrush::{
 };
 use cadence::{StatsdClient, UdpMetricSink};
 use clap::{ArgAction, Parser};
+#[cfg(unix)]
+use tokio::signal::unix::{SignalKind, signal};
 use tracing::Level;
 
 #[derive(Parser, Debug)]
@@ -103,16 +105,32 @@ async fn main() {
 
     let _status_handle = checker.spawn_status_emitter(2000);
 
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    tokio::spawn(async move {
-        let _ = tokio::signal::ctrl_c().await;
-        let _ = shutdown_tx.send(());
-    });
-
     tokio::select! {
         _ = checker.poll_for_health_checks() => {},
-        _ = &mut shutdown_rx => {
-            tracing::info!("shutdown signal received, exiting");
+        received = shutdown_signal() => {
+            tracing::info!(signal = received, "shutdown signal received, exiting");
         }
     }
+}
+
+/// Wait for a graceful-shutdown signal.
+///
+/// On Unix this races `SIGTERM` (the default signal Kubernetes sends on pod shutdown) and
+/// `SIGINT` (Ctrl-C) so the container exits promptly instead of waiting for the `SIGKILL`
+/// that follows `terminationGracePeriodSeconds`. On non-Unix targets it falls back to
+/// Ctrl-C only.
+#[cfg(unix)]
+async fn shutdown_signal() -> &'static str {
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+    let mut sigint = signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
+    tokio::select! {
+        _ = sigterm.recv() => "SIGTERM",
+        _ = sigint.recv() => "SIGINT",
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() -> &'static str {
+    let _ = tokio::signal::ctrl_c().await;
+    "ctrl_c"
 }


### PR DESCRIPTION
## Summary

Sidecrush previously listened for `SIGINT` only (via `tokio::signal::ctrl_c()`), but Kubernetes sends **`SIGTERM`** to a pod's main container on shutdown. If the process doesn't handle it, K8s waits `terminationGracePeriodSeconds` (default 30 s) and then sends `SIGKILL`. So every sidecrush pod rollout was previously stuck waiting for that timeout on graceful termination, and the `"shutdown signal received, exiting"` log line never fired on the graceful-exit path — the pod was always force-killed instead.

## Fix

Replace the `ctrl_c`-only handler with a small `shutdown_signal()` helper that on Unix races `SIGTERM` and `SIGINT` via `tokio::signal::unix::signal`, returning which signal fired so the exit log line can identify it. Non-Unix targets keep `ctrl_c()` for local dev on Windows.

```rust
#[cfg(unix)]
async fn shutdown_signal() -> &'static str {
    let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
    let mut sigint  = signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
    tokio::select! {
        _ = sigterm.recv() => "SIGTERM",
        _ = sigint.recv()  => "SIGINT",
    }
}
```

Also drops the intermediate `oneshot` channel the old handler used — the top-level `select!` now awaits the signal future directly.

## Verification

- `RISC0_SKIP_BUILD_KERNELS=1 cargo check -p base-sidecrush-bin --all-targets` ✔
- `rustup run nightly cargo fmt --check` ✔
- `zepter format features` ✔
- `RISC0_SKIP_BUILD_KERNELS=1 cargo clippy -p base-sidecrush-bin --all-targets -- -D warnings` ✔

Manual verification (local run):

```bash
$ cargo run -p base-sidecrush-bin --bin sidecrush -- --node-url http://localhost:8545
{"timestamp":"...","level":"INFO","message":"connecting to StatsD agent",...}
# in another shell:
$ kill -TERM <pid>
# process exits with:
{"timestamp":"...","level":"INFO","message":"shutdown signal received, exiting","signal":"SIGTERM"}
```

## Impact

- Pod rollouts shorten by up to `terminationGracePeriodSeconds` per pod (typically 30 s → sub-second).
- No metric-name, tag-schema, or CLI changes. The four `base.blocks.*` counters, their tags, and every CLI flag are untouched.
- Non-Unix behavior is preserved (still handles Ctrl-C for local dev).

## Downstream

`protocols/base` currently pins sidecrush at `meyer9/sidecrush-pin` on this repo (SHA `eec0a4a67…`, taken from `main` immediately after [`#3864`](https://github.com/base/base/pull/3864) merged). Once this fix lands, someone with access can either:

- Fast-forward `meyer9/sidecrush-pin` to include this commit and re-cut the `protocols/base` sidecrush image, or
- Wait for the next base/base release that includes the fix, then bump `SIDECRUSH_COMMIT` on the `protocols/base` side (or fold into `BASE_*` if it's ready to consolidate).
