### PR TITLE
chore(registrar): sort dependencies

### DIFF
--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -12,15 +12,15 @@ workspace = true
 
 [dependencies]
 # Alloy
-alloy-provider.workspace = true
 alloy-signer.workspace = true
+alloy-provider.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 
 # AWS
-aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-ec2.workspace = true
 aws-sdk-elasticloadbalancingv2.workspace = true
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
 
 # Crypto
 k256 = { workspace = true, features = ["ecdsa"] }


### PR DESCRIPTION
### What changed? Why?

Sorts the `base-tee-registrar` Alloy and AWS dependency entries in `Cargo.toml` to match the workspace waterfall ordering.

### Notes to reviewers

No dependency versions or features changed; this only reorders existing manifest entries.

### How has it been tested?

- `git diff --check`