### PR TITLE
feat(zk-backend): cluster groth16 aggregation

### DIFF
--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -138,6 +138,14 @@ struct WorkerArgs {
     #[arg(long, env = "RANGE_GAS_LIMIT", default_value_t = 1_000_000_000_000)]
     range_gas_limit: u64,
 
+    /// Cycle limit for aggregation proof requests.
+    #[arg(long, env = "AGGREGATION_CYCLE_LIMIT", default_value_t = 1_000_000_000_000)]
+    aggregation_cycle_limit: u64,
+
+    /// Gas limit for aggregation proof requests.
+    #[arg(long, env = "AGGREGATION_GAS_LIMIT", default_value_t = 1_000_000_000_000)]
+    aggregation_gas_limit: u64,
+
     /// Delay after an empty or failed discovery attempt, in milliseconds.
     #[arg(long, env = "JOB_DISCOVERY_POLL_INTERVAL_MS", default_value_t = 5_000)]
     job_discovery_poll_interval_ms: u64,
@@ -233,6 +241,8 @@ impl WorkerArgs {
                     )?,
                     range_cycle_limit: self.range_cycle_limit,
                     range_gas_limit: self.range_gas_limit,
+                    aggregation_cycle_limit: self.aggregation_cycle_limit,
+                    aggregation_gas_limit: self.aggregation_gas_limit,
                 }))
             }
             ZkBackendArg::Network => {

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -785,6 +785,7 @@ impl ClusterZkProver {
         }
 
         let range_session = ClusterSessionId::parse(range_backend_session_id)?;
+        let witness_start = std::time::Instant::now();
         let range_proof = self.download_cluster_proof(&range_session).await?;
         let stdin = self
             .provider
@@ -795,12 +796,14 @@ impl ClusterZkProver {
             )
             .await
             .map_err(|e| backend_error!("aggregation witness generation failed: {e}"))?;
+        let witness_gen_duration_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
 
         let session = self.create_cluster_request(proof_id, stdin, ProofMode::Groth16).await?;
         let backend_session_id = session.to_backend_session_id()?;
         info!(
             proof_id = %session.proof_id,
             proof_output_id = %session.proof_output_id,
+            witness_gen_duration_ms = witness_gen_duration_ms,
             cycle_limit = self.config.aggregation_cycle_limit,
             gas_limit = self.config.aggregation_gas_limit,
             "aggregation proof request submitted to SP1 cluster"

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -13,7 +13,10 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::{ClusterArtifactStore, ClusterProofConfig};
 use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, SessionType, ZkProofRequest, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{
+    ProofResult, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, ZkProofRequest,
+    ZkProofResult, ZkVm,
+};
 use serde::{Deserialize, Serialize};
 use sp1_cluster_common::{
     client::ClusterServiceClient,
@@ -23,7 +26,10 @@ use sp1_cluster_common::{
     },
 };
 use sp1_prover_types::{Artifact, ArtifactClient as _, ArtifactType};
-use sp1_sdk::{ProofFromNetwork, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{
+    HashableKey, ProofFromNetwork, SP1ProofWithPublicValues, SP1Stdin, SP1VerifyingKey,
+    network::proto::types::ProofMode,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -55,6 +61,10 @@ pub struct SuccinctClusterBackendConfig {
     pub range_cycle_limit: u64,
     /// Gas limit for range proof requests.
     pub range_gas_limit: u64,
+    /// Cycle limit for aggregation proof requests.
+    pub aggregation_cycle_limit: u64,
+    /// Gas limit for aggregation proof requests.
+    pub aggregation_gas_limit: u64,
 }
 
 /// Configuration for [`ClusterZkProver`].
@@ -68,21 +78,30 @@ pub struct ClusterZkProverConfig {
     pub default_sequence_window: u64,
     /// Cluster proof submission and artifact configuration.
     pub cluster: Arc<ClusterProofConfig>,
+    /// Range program verification key used by the aggregation program.
+    pub range_vk: Arc<SP1VerifyingKey>,
     /// Proof timeout.
     pub timeout: Duration,
     /// Cycle limit for range proof requests.
     pub range_cycle_limit: u64,
     /// Gas limit for range proof requests.
     pub range_gas_limit: u64,
+    /// Cycle limit for aggregation proof requests.
+    pub aggregation_cycle_limit: u64,
+    /// Gas limit for aggregation proof requests.
+    pub aggregation_gas_limit: u64,
 }
 
 impl std::fmt::Debug for ClusterZkProverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClusterZkProverConfig")
             .field("default_sequence_window", &self.default_sequence_window)
+            .field("range_vk", &self.range_vk.bytes32())
             .field("timeout", &self.timeout)
             .field("range_cycle_limit", &self.range_cycle_limit)
             .field("range_gas_limit", &self.range_gas_limit)
+            .field("aggregation_cycle_limit", &self.aggregation_cycle_limit)
+            .field("aggregation_gas_limit", &self.aggregation_gas_limit)
             .finish_non_exhaustive()
     }
 }
@@ -144,12 +163,33 @@ impl ClusterZkProver {
             timeout,
             range_cycle_limit,
             range_gas_limit,
+            aggregation_cycle_limit,
+            aggregation_gas_limit,
         } = config;
         let base_consensus_url = rpc.base_consensus_rpc.as_str().to_owned();
         let l1_node_url = rpc.l1_rpc.as_str().to_owned();
         let default_sequence_window = rpc.default_sequence_window;
 
         info!(backend = "cluster", "using Succinct SP1 cluster backend");
+        info!("computing range verification key");
+        let Some((range_vk, _aggregation_vk)) = SuccinctZkProverBuilder::complete_unless_cancelled(
+            cancel,
+            async {
+                base_proof_succinct_proof_utils::cluster_setup_vkeys().await.map_err(|error| {
+                    SuccinctZkProverBuildError::boxed_operation(
+                        "failed to compute proof verification keys",
+                        error.into_boxed_dyn_error(),
+                    )
+                })
+            },
+            "proof_verification_keys",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        info!("range verification key computed successfully");
+
         let Some(provider) = SuccinctZkProverBuilder::build_witness_provider(rpc, cancel).await?
         else {
             return Ok(None);
@@ -187,9 +227,12 @@ impl ClusterZkProver {
                 artifact_store_config,
                 service_client,
             }),
+            range_vk: range_vk.into(),
             timeout,
             range_cycle_limit,
             range_gas_limit,
+            aggregation_cycle_limit,
+            aggregation_gas_limit,
         };
 
         Ok(Some(Arc::new(Self::new(provider, prover_config))))
@@ -252,6 +295,16 @@ impl ClusterZkProver {
     /// Build the cluster proof id for a prover-service session attempt.
     pub fn proof_id_for_attempt(request_session_id: &str, attempt: u64) -> String {
         let base_proof_id = format!("prover_service_{request_session_id}");
+        if attempt == 0 {
+            return base_proof_id;
+        }
+
+        format!("{base_proof_id}_retry_{attempt}")
+    }
+
+    /// Build the deterministic cluster aggregation proof id for a prover-service session attempt.
+    pub fn aggregation_proof_id_for_attempt(request_session_id: &str, attempt: u64) -> String {
+        let base_proof_id = format!("prover_service_{request_session_id}_aggregation");
         if attempt == 0 {
             return base_proof_id;
         }
@@ -375,6 +428,58 @@ impl ClusterZkProver {
         })
     }
 
+    /// Validate that an existing cluster request is safe to resume after create raced.
+    pub fn validate_existing_cluster_request(
+        req: &ClusterProtoProofRequest,
+    ) -> Result<ProofRequestStatus, ZkProverError> {
+        let proof_status = Self::cluster_proof_status(req)?;
+        match proof_status {
+            ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
+                error!(
+                    proof_id = %req.id,
+                    proof_status = %proof_status.as_str_name(),
+                    "cluster proof created concurrently but already terminal"
+                );
+                return Err(backend_error!(
+                    "cluster proof {} created concurrently but already terminal: {}",
+                    req.id,
+                    proof_status.as_str_name()
+                ));
+            }
+            ProofRequestStatus::Unspecified => {
+                error!(
+                    proof_id = %req.id,
+                    "cluster proof created concurrently but has unspecified status"
+                );
+                return Err(backend_error!(
+                    "cluster proof {} created concurrently but has unspecified status",
+                    req.id
+                ));
+            }
+            ProofRequestStatus::Pending => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| backend_error!("invalid unix timestamp: {e}"))?
+                    .as_secs();
+                if req.deadline <= now {
+                    error!(
+                        proof_id = %req.id,
+                        deadline = req.deadline,
+                        now = now,
+                        "cluster proof created concurrently but deadline already elapsed"
+                    );
+                    return Err(backend_error!(
+                        "cluster proof {} created concurrently but deadline already elapsed",
+                        req.id
+                    ));
+                }
+            }
+            ProofRequestStatus::Completed => {}
+        }
+
+        Ok(proof_status)
+    }
+
     /// Convert a cluster proof request into a persisted session id.
     pub fn session_id_from_request(
         req: &ClusterProtoProofRequest,
@@ -386,18 +491,19 @@ impl ClusterZkProver {
         Ok(ClusterSessionId { proof_id: req.id.clone(), proof_output_id })
     }
 
-    /// Submit a compressed range proof to the cluster.
-    pub async fn submit_range_proof(
+    /// Find a usable cluster proof id, scanning candidates from `id_for_attempt` and skipping any
+    /// terminal or deadline-elapsed request. Returns `(id, None)` for a free id, or `(id,
+    /// Some(backend_session_id))` when a still-usable request can be reused directly.
+    pub async fn find_available_proof_id(
         &self,
-        request: &ZkProofRequest,
         request_session_id: &str,
-    ) -> Result<String, ZkProverError> {
-        let mut proof_id = None;
+        stage: &str,
+        id_for_attempt: impl Fn(&str, u64) -> String,
+    ) -> Result<(String, Option<String>), ZkProverError> {
         for attempt in 0..Self::MAX_SUBMIT_ATTEMPTS {
-            let candidate = Self::proof_id_for_attempt(request_session_id, attempt);
+            let candidate = id_for_attempt(request_session_id, attempt);
             let Some(existing) = self.get_cluster_request_once(&candidate).await? else {
-                proof_id = Some(candidate);
-                break;
+                return Ok((candidate, None));
             };
 
             let proof_status = Self::cluster_proof_status(&existing)?;
@@ -405,6 +511,7 @@ impl ClusterZkProver {
                 ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
                     info!(
                         proof_id = %candidate,
+                        stage = stage,
                         proof_status = %proof_status.as_str_name(),
                         "existing cluster request is terminal, trying next proof id"
                     );
@@ -417,6 +524,7 @@ impl ClusterZkProver {
                     if existing.deadline <= now {
                         info!(
                             proof_id = %candidate,
+                            stage = stage,
                             deadline = existing.deadline,
                             now = now,
                             "existing cluster request deadline elapsed, trying next proof id"
@@ -424,28 +532,43 @@ impl ClusterZkProver {
                         continue;
                     }
 
-                    info!(proof_id = %candidate, "cluster proof request already exists");
-                    return Self::session_id_from_request(&existing)?.to_backend_session_id();
+                    info!(proof_id = %candidate, stage = stage, "cluster request already exists");
+                    let backend_session_id =
+                        Self::session_id_from_request(&existing)?.to_backend_session_id()?;
+                    return Ok((candidate, Some(backend_session_id)));
                 }
                 ProofRequestStatus::Unspecified => {
                     return Err(backend_error!(
-                        "cluster proof {} has unspecified status",
-                        candidate
+                        "cluster {stage} proof {candidate} has unspecified status"
                     ));
                 }
                 ProofRequestStatus::Completed => {
-                    info!(proof_id = %candidate, "cluster proof request already exists");
-                    return Self::session_id_from_request(&existing)?.to_backend_session_id();
+                    info!(proof_id = %candidate, stage = stage, "cluster request already exists");
+                    let backend_session_id =
+                        Self::session_id_from_request(&existing)?.to_backend_session_id()?;
+                    return Ok((candidate, Some(backend_session_id)));
                 }
             }
         }
-        let proof_id = proof_id.ok_or_else(|| {
-            backend_error!(
-                "exhausted {} cluster submit attempts for request session id {}",
-                Self::MAX_SUBMIT_ATTEMPTS,
-                request_session_id
-            )
-        })?;
+
+        Err(backend_error!(
+            "exhausted {} cluster {stage} submit attempts for request session id {request_session_id}",
+            Self::MAX_SUBMIT_ATTEMPTS
+        ))
+    }
+
+    /// Submit a compressed range proof to the cluster.
+    pub async fn submit_range_proof(
+        &self,
+        request: &ZkProofRequest,
+        request_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        let (proof_id, existing_backend_session_id) = self
+            .find_available_proof_id(request_session_id, "range", Self::proof_id_for_attempt)
+            .await?;
+        if let Some(backend_session_id) = existing_backend_session_id {
+            return Ok(backend_session_id);
+        }
 
         let start_block = request.start_block_number;
         let end_block = start_block
@@ -504,7 +627,7 @@ impl ClusterZkProver {
             "witness generated, submitting range proof to SP1 cluster"
         );
 
-        let session = self.create_range_request(proof_id, stdin).await?;
+        let session = self.create_cluster_request(proof_id, stdin, ProofMode::Compressed).await?;
         let backend_session_id = session.to_backend_session_id()?;
         info!(
             proof_id = %session.proof_id,
@@ -515,74 +638,95 @@ impl ClusterZkProver {
         Ok(backend_session_id)
     }
 
-    /// Create the cluster request after uploading the range ELF and stdin artifacts.
-    pub async fn create_range_request(
+    /// Upload the stage artifacts and create the cluster proof request, dispatching on the
+    /// configured artifact store.
+    pub async fn create_cluster_request(
         &self,
         proof_id: String,
         stdin: SP1Stdin,
+        proof_mode: ProofMode,
     ) -> Result<ClusterSessionId, ZkProverError> {
         match &self.config.cluster.artifact_store {
             ClusterArtifactStore::Redis(client) => {
-                self.create_range_request_with_client(client.clone(), proof_id, stdin).await
+                self.create_cluster_request_with_client(client.clone(), proof_id, stdin, proof_mode)
+                    .await
             }
             ClusterArtifactStore::S3(client) => {
-                self.create_range_request_with_client(client.clone(), proof_id, stdin).await
+                self.create_cluster_request_with_client(client.clone(), proof_id, stdin, proof_mode)
+                    .await
             }
         }
     }
 
-    /// Upload artifacts with the provided client and create the cluster request.
-    pub async fn create_range_request_with_client<A>(
+    /// Upload the stage artifacts with the provided client and create the cluster request. The
+    /// `proof_mode` selects the stage: `Compressed` for the range proof, `Groth16` for aggregation.
+    pub async fn create_cluster_request_with_client<A>(
         &self,
         artifact_client: A,
         proof_id: String,
         stdin: SP1Stdin,
+        proof_mode: ProofMode,
     ) -> Result<ClusterSessionId, ZkProverError>
     where
         A: sp1_prover_types::ArtifactClient,
     {
+        let (elf, cycle_limit, gas_limit, stage) = match proof_mode {
+            ProofMode::Compressed => (
+                base_proof_succinct_elfs::RANGE_ELF_EMBEDDED,
+                self.config.range_cycle_limit,
+                self.config.range_gas_limit,
+                "range",
+            ),
+            ProofMode::Groth16 => (
+                base_proof_succinct_elfs::AGGREGATION_ELF,
+                self.config.aggregation_cycle_limit,
+                self.config.aggregation_gas_limit,
+                "aggregation",
+            ),
+            other => {
+                return Err(backend_error!(
+                    "unsupported cluster proof mode: {}",
+                    other.as_str_name()
+                ));
+            }
+        };
+
         let elf_id = artifact_client
             .create_artifact()
-            .map_err(|e| backend_error!("failed to create ELF artifact: {e}"))?;
+            .map_err(|e| backend_error!("failed to create {stage} ELF artifact: {e}"))?;
         artifact_client
-            .upload_with_type(
-                &elf_id,
-                ArtifactType::Program,
-                base_proof_succinct_elfs::RANGE_ELF_EMBEDDED.to_vec(),
-            )
+            .upload_with_type(&elf_id, ArtifactType::Program, elf.to_vec())
             .await
-            .map_err(|e| backend_error!("failed to upload range ELF: {e}"))?;
+            .map_err(|e| backend_error!("failed to upload {stage} ELF: {e}"))?;
 
         let stdin_id = artifact_client
             .create_artifact()
-            .map_err(|e| backend_error!("failed to create stdin artifact: {e}"))?;
+            .map_err(|e| backend_error!("failed to create {stage} stdin artifact: {e}"))?;
         artifact_client
             .upload_with_type(&stdin_id, ArtifactType::Stdin, stdin)
             .await
-            .map_err(|e| backend_error!("failed to upload stdin: {e}"))?;
+            .map_err(|e| backend_error!("failed to upload {stage} stdin: {e}"))?;
 
         let proof_output_id = artifact_client
             .create_artifact()
-            .map_err(|e| backend_error!("failed to create proof artifact: {e}"))?;
+            .map_err(|e| backend_error!("failed to create {stage} proof artifact: {e}"))?;
         let proof_output_id = proof_output_id.to_id();
         let deadline = SystemTime::now() + self.config.timeout;
         let deadline = deadline
             .duration_since(UNIX_EPOCH)
-            .map_err(|e| backend_error!("invalid cluster deadline: {e}"))?
+            .map_err(|e| backend_error!("invalid cluster {stage} deadline: {e}"))?
             .as_secs();
 
         let request = ProofRequestCreateRequest {
             proof_id: proof_id.clone(),
             program_artifact_id: elf_id.to_id(),
             stdin_artifact_id: stdin_id.to_id(),
-            options_artifact_id: Some(
-                (sp1_sdk::network::proto::types::ProofMode::Compressed as i32).to_string(),
-            ),
+            options_artifact_id: Some((proof_mode as i32).to_string()),
             proof_artifact_id: Some(proof_output_id.clone()),
             requester: vec![],
             deadline,
-            cycle_limit: self.config.range_cycle_limit,
-            gas_limit: self.config.range_gas_limit,
+            cycle_limit,
+            gas_limit,
             scheduled_by: None,
             stdin_private: false,
         };
@@ -591,54 +735,20 @@ impl ClusterZkProver {
             Ok(()) => Ok(ClusterSessionId { proof_id, proof_output_id }),
             Err(e) => {
                 if let Some(existing) = self.get_cluster_request(&proof_id).await? {
-                    let proof_status = Self::cluster_proof_status(&existing)?;
-                    match proof_status {
-                        ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
+                    let proof_status = Self::validate_existing_cluster_request(&existing)
+                        .inspect_err(|_| {
                             error!(
                                 proof_id = %proof_id,
-                                proof_status = %proof_status.as_str_name(),
+                                stage = stage,
                                 error = %e,
-                                "cluster proof create raced into terminal request"
+                                "cluster proof create raced into an unusable existing request"
                             );
-                            return Err(backend_error!(
-                                "cluster proof {proof_id} created concurrently but already terminal: {}",
-                                proof_status.as_str_name()
-                            ));
-                        }
-                        ProofRequestStatus::Unspecified => {
-                            error!(
-                                proof_id = %proof_id,
-                                proof_status = %proof_status.as_str_name(),
-                                error = %e,
-                                "cluster proof create raced into unspecified request"
-                            );
-                            return Err(backend_error!(
-                                "cluster proof {proof_id} created concurrently but has unspecified status"
-                            ));
-                        }
-                        ProofRequestStatus::Pending => {
-                            let now = SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .map_err(|e| backend_error!("invalid unix timestamp: {e}"))?
-                                .as_secs();
-                            if existing.deadline <= now {
-                                error!(
-                                    proof_id = %proof_id,
-                                    deadline = existing.deadline,
-                                    now = now,
-                                    error = %e,
-                                    "cluster proof create raced into expired pending request"
-                                );
-                                return Err(backend_error!(
-                                    "cluster proof {proof_id} created concurrently but deadline already elapsed"
-                                ));
-                            }
-                        }
-                        ProofRequestStatus::Completed => {}
-                    }
+                        })?;
 
                     info!(
                         proof_id = %proof_id,
+                        stage = stage,
+                        proof_status = %proof_status.as_str_name(),
                         error = %e,
                         "cluster proof create raced, using existing request"
                     );
@@ -647,12 +757,56 @@ impl ClusterZkProver {
 
                 error!(
                     proof_id = %proof_id,
+                    stage = stage,
                     error = %e,
                     "cluster proof create failed with no existing request"
                 );
-                Err(backend_error!("failed to create cluster proof: {e}"))
+                Err(backend_error!("failed to create cluster {stage} proof: {e}"))
             }
         }
+    }
+
+    /// Submit the Groth16 aggregation proof after the compressed range proof completes.
+    pub async fn submit_aggregation_proof(
+        &self,
+        request: &SnarkGroth16ProofRequest,
+        request_session_id: &str,
+        range_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        let (proof_id, existing_backend_session_id) = self
+            .find_available_proof_id(
+                request_session_id,
+                "aggregation",
+                Self::aggregation_proof_id_for_attempt,
+            )
+            .await?;
+        if let Some(backend_session_id) = existing_backend_session_id {
+            return Ok(backend_session_id);
+        }
+
+        let range_session = ClusterSessionId::parse(range_backend_session_id)?;
+        let range_proof = self.download_cluster_proof(&range_session).await?;
+        let stdin = self
+            .provider
+            .generate_aggregation_witness(
+                range_proof,
+                self.config.range_vk.as_ref(),
+                request.prover_address,
+            )
+            .await
+            .map_err(|e| backend_error!("aggregation witness generation failed: {e}"))?;
+
+        let session = self.create_cluster_request(proof_id, stdin, ProofMode::Groth16).await?;
+        let backend_session_id = session.to_backend_session_id()?;
+        info!(
+            proof_id = %session.proof_id,
+            proof_output_id = %session.proof_output_id,
+            cycle_limit = self.config.aggregation_cycle_limit,
+            gas_limit = self.config.aggregation_gas_limit,
+            "aggregation proof request submitted to SP1 cluster"
+        );
+
+        Ok(backend_session_id)
     }
 
     /// Download the proof output artifact.
@@ -677,6 +831,9 @@ impl ClusterZkProver {
 
 #[async_trait]
 impl ZkProver for ClusterZkProver {
+    /// Submit the initial range (STARK) proof for a request. The range proof-id namespace is keyed
+    /// on `request_session_id`, which the orchestrator maps to exactly one request kind; aggregation
+    /// runs later under a distinct `_aggregation` proof id (see `aggregation_proof_id_for_attempt`).
     async fn submit(
         &self,
         request: &ZkProofRequest,
@@ -735,9 +892,19 @@ impl ZkProver for ClusterZkProver {
         }
     }
 
+    async fn submit_next(
+        &self,
+        request: &SnarkGroth16ProofRequest,
+        request_session_id: &str,
+        completed_backend_session_id: &str,
+    ) -> Result<String, ZkProverError> {
+        self.submit_aggregation_proof(request, request_session_id, completed_backend_session_id)
+            .await
+    }
+
     async fn download(
         &self,
-        _session_type: SessionType,
+        session_type: SessionType,
         backend_session_id: &str,
     ) -> Result<ProofResult, ZkProverError> {
         let session = ClusterSessionId::parse(backend_session_id)?;
@@ -758,11 +925,11 @@ impl ZkProver for ClusterZkProver {
         let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
             .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
 
-        Ok(ProofResult::Compressed(ZkProofResult {
-            zk_vm: ZkVm::Sp1,
-            proof: proof.into(),
-            execution_stats: None,
-        }))
+        let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
+        match session_type {
+            SessionType::Snark => Ok(ProofResult::SnarkGroth16(SnarkGroth16ProofResult { proof })),
+            SessionType::Stark => Ok(ProofResult::Compressed(proof)),
+        }
     }
 }
 
@@ -790,5 +957,14 @@ mod tests {
 
         assert_eq!(first, "prover_service_session-1");
         assert_eq!(retry, "prover_service_session-1_retry_2");
+    }
+
+    #[test]
+    fn aggregation_proof_id_for_attempt_uses_stage_suffix() {
+        let first = ClusterZkProver::aggregation_proof_id_for_attempt("session-1", 0);
+        let retry = ClusterZkProver::aggregation_proof_id_for_attempt("session-1", 2);
+
+        assert_eq!(first, "prover_service_session-1_aggregation");
+        assert_eq!(retry, "prover_service_session-1_aggregation_retry_2");
     }
 }


### PR DESCRIPTION
## Summary

- Implement the SNARK aggregation stage for the SP1 cluster backend. `submit_next` downloads the completed range proof, builds the aggregation witness (`provider.rs` `generate_aggregation_witness`), and submits a Groth16 cluster request with dedicated `aggregation_cycle_limit` / `aggregation_gas_limit`.
- Use deterministic per-attempt proof ids (`aggregation_proof_id_for_attempt`) so crash-resume re-submission is idempotent and never orphans an in-flight aggregation request.
- Wire aggregation cycle/gas limits through the zk-host CLI.


Made with [Cursor](https://cursor.com)