### PR TITLE
feat(prover-service): improve heartbeat observability

### DIFF
--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -6,7 +6,7 @@ pub use metrics::{
     PROOF_STATUS_SUCCEEDED, ProverMetrics, REQUESTS, RESPONSE_LATENCY_MS, RETRIED_REQUESTS,
     STUCK_REQUESTS, WITNESS_GENERATION_DURATION_MS, WORKER_JOBS_FAILED, api_proof_type_label,
     inc_proof_requests_completed, inc_requests, inc_retried_requests, inc_stuck_requests,
-    inc_worker_jobs_failed, proof_type_label, record_proof_request_duration,
+    inc_worker_jobs_failed, inc_worker_requests, proof_type_label, record_proof_request_duration,
     record_response_latency, record_terminal_proof_job, record_witness_generation_duration,
 };
 

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -10,7 +10,8 @@ use metrics::{counter, describe_counter, describe_histogram, histogram};
 // Metric name constants
 // ---------------------------------------------------------------------------
 
-/// Unified RPC request counter. Tags: method, success, `status_code`
+/// Unified RPC request counter. Tags: method, success, `status_code`.
+/// Worker-scoped RPCs also include `worker_id` and `prover_id`.
 pub const REQUESTS: &str = "prover_service.requests";
 /// RPC response latency in milliseconds. Tags: method, success
 pub const RESPONSE_LATENCY_MS: &str = "prover_service.response_latency_ms";
@@ -75,6 +76,18 @@ pub fn inc_requests(method: &str, success: bool, status_code: &str) {
         "method" => method.to_string(),
         "success" => success.to_string(),
         "status_code" => status_code.to_string(),
+    )
+    .increment(1);
+}
+
+/// Record a worker-scoped RPC request metric. Called once per RPC at handler completion.
+pub fn inc_worker_requests(method: &str, success: bool, status_code: &str, worker_id: &str) {
+    counter!(REQUESTS,
+        "method" => method.to_string(),
+        "success" => success.to_string(),
+        "status_code" => status_code.to_string(),
+        "worker_id" => worker_id.to_string(),
+        "prover_id" => worker_id.to_string(),
     )
     .increment(1);
 }
@@ -282,6 +295,51 @@ mod tests {
                 }
             }),
             Some(vec![0.0]),
+        );
+    }
+
+    #[test]
+    fn worker_request_records_worker_and_prover_labels() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            inc_worker_requests("Heartbeat", true, "OK", "worker-1");
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert_eq!(
+            snapshot.iter().find_map(|(ck, _, _, value)| {
+                if ck.kind() != MetricKind::Counter || ck.key().name() != REQUESTS {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "method" && label.value() == "Heartbeat")
+                {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "worker_id" && label.value() == "worker-1")
+                {
+                    return None;
+                }
+                if !ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "prover_id" && label.value() == "worker-1")
+                {
+                    return None;
+                }
+                match value {
+                    DebugValue::Counter(value) => Some(*value),
+                    _ => None,
+                }
+            }),
+            Some(1),
         );
     }
 

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -157,6 +157,21 @@ fn record_rpc_result<T>(method: &str, start: std::time::Instant, result: &RpcRes
     crate::metrics::record_response_latency(method, success, elapsed_ms);
 }
 
+fn record_worker_rpc_result<T>(
+    method: &str,
+    start: std::time::Instant,
+    result: &RpcResult<T>,
+    worker_id: &str,
+) {
+    let (success, status_code) = match result {
+        Ok(_) => (true, "OK"),
+        Err(error) => (false, rpc_status_code_str(error.code())),
+    };
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    crate::metrics::inc_worker_requests(method, success, status_code, worker_id);
+    crate::metrics::record_response_latency(method, success, elapsed_ms);
+}
+
 #[cfg(test)]
 mod tests {
     use super::WorkerApiConfig;

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -21,7 +21,7 @@ use crate::{
     metrics,
     server::{
         ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
-        not_found, record_rpc_result,
+        not_found, record_rpc_result, record_worker_rpc_result,
     },
 };
 
@@ -114,8 +114,9 @@ impl ProverServiceServer {
     /// Extends the lock on a worker-owned proof job.
     pub async fn heartbeat_impl(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
         let start = std::time::Instant::now();
+        let worker_id = request.worker_id.clone();
         let result = self.heartbeat_inner(request).await;
-        record_rpc_result("Heartbeat", start, &result);
+        record_worker_rpc_result("Heartbeat", start, &result, &worker_id);
 
         result
     }

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -14,14 +14,14 @@ use jsonrpsee::{
     core::{RpcResult, async_trait},
     types::ErrorObjectOwned,
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::{
     metrics,
     server::{
         ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
-        not_found, record_rpc_result, record_worker_rpc_result,
+        not_found, record_rpc_result, record_worker_rpc_result, rpc_status_code_str,
     },
 };
 
@@ -114,9 +114,38 @@ impl ProverServiceServer {
     /// Extends the lock on a worker-owned proof job.
     pub async fn heartbeat_impl(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
         let start = std::time::Instant::now();
+        let session_id = request.session_id.clone();
+        let lock_id = request.lock_id.clone();
         let worker_id = request.worker_id.clone();
+        let lock_duration_seconds = request.lock_duration_seconds;
         let result = self.heartbeat_inner(request).await;
         record_worker_rpc_result("Heartbeat", start, &result, &worker_id);
+
+        match &result {
+            Ok(response) => {
+                debug!(
+                    session_id = %session_id,
+                    lock_id = %lock_id,
+                    worker_id = %worker_id,
+                    lock_duration_seconds = lock_duration_seconds,
+                    status = ?response.job.status,
+                    lock_expires_at = ?response.job.lock_expires_at,
+                    "worker proof job heartbeat succeeded"
+                );
+            }
+            Err(error) => {
+                debug!(
+                    session_id = %session_id,
+                    lock_id = %lock_id,
+                    worker_id = %worker_id,
+                    lock_duration_seconds = lock_duration_seconds,
+                    status_code = %rpc_status_code_str(error.code()),
+                    error_code = error.code(),
+                    error_message = %error.message(),
+                    "worker proof job heartbeat failed"
+                );
+            }
+        }
 
         result
     }


### PR DESCRIPTION
## Summary
- Adds worker-scoped labels to prover-service worker RPC request metrics.
- Heartbeat requests on `prover_service.requests` now include `worker_id` and `prover_id`.
- `prover_id` is currently an alias of `worker_id` because the heartbeat request only carries `worker_id`.
- Adds prover-service-side `DEBUG` logs for heartbeat success and failure.
- Includes heartbeat request fields in logs so worker/session/lock issues can be debugged from service logs.
- Adds a unit test covering the new metric labels.

## Datadog Queries
Successful heartbeats for a worker:
```text
sum:prover_service.requests{method:heartbeat,success:true,status_code:ok,worker_id:<worker>}.as_count()
```

Same query using the prover alias label:
```text
sum:prover_service.requests{method:heartbeat,success:true,status_code:ok,prover_id:<worker>}.as_count()
```

Failed heartbeats for a worker:
```text
sum:prover_service.requests{method:heartbeat,success:false,worker_id:<worker>}.as_count()
```

All heartbeats grouped by worker:
```text
sum:prover_service.requests{method:heartbeat}.as_count() by {worker_id}
```

## Expected Debug Logs
Successful heartbeat message:
```text
worker proof job heartbeat succeeded
```

Successful heartbeat fields:
```text
session_id=<session_id>
lock_id=<lock_id>
worker_id=<worker_id>
lock_duration_seconds=<seconds>
status=<job_status>
lock_expires_at=<timestamp_or_none>
```

Failed heartbeat message:
```text
worker proof job heartbeat failed
```

Failed heartbeat fields:
```text
session_id=<session_id>
lock_id=<lock_id>
worker_id=<worker_id>
lock_duration_seconds=<seconds>
status_code=<rpc_status_code>
error_code=<numeric_rpc_error_code>
error_message=<rpc_error_message>
```

These logs are emitted at `DEBUG` level only.

## Test Plan
- `cargo fmt --package base-prover-service`
- `cargo test -p base-prover-service`