### PR TITLE
chore(prover-service): debug log worker heartbeats

### DIFF
--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -14,14 +14,14 @@ use jsonrpsee::{
     core::{RpcResult, async_trait},
     types::ErrorObjectOwned,
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::{
     metrics,
     server::{
         ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
-        not_found, record_rpc_result, record_worker_rpc_result,
+        not_found, record_rpc_result, record_worker_rpc_result, rpc_status_code_str,
     },
 };
 
@@ -114,9 +114,38 @@ impl ProverServiceServer {
     /// Extends the lock on a worker-owned proof job.
     pub async fn heartbeat_impl(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
         let start = std::time::Instant::now();
+        let session_id = request.session_id.clone();
+        let lock_id = request.lock_id.clone();
         let worker_id = request.worker_id.clone();
+        let lock_duration_seconds = request.lock_duration_seconds;
         let result = self.heartbeat_inner(request).await;
         record_worker_rpc_result("Heartbeat", start, &result, &worker_id);
+
+        match &result {
+            Ok(response) => {
+                debug!(
+                    session_id = %session_id,
+                    lock_id = %lock_id,
+                    worker_id = %worker_id,
+                    lock_duration_seconds = lock_duration_seconds,
+                    status = ?response.job.status,
+                    lock_expires_at = ?response.job.lock_expires_at,
+                    "worker proof job heartbeat succeeded"
+                );
+            }
+            Err(error) => {
+                debug!(
+                    session_id = %session_id,
+                    lock_id = %lock_id,
+                    worker_id = %worker_id,
+                    lock_duration_seconds = lock_duration_seconds,
+                    status_code = %rpc_status_code_str(error.code()),
+                    error_code = error.code(),
+                    error_message = %error.message(),
+                    "worker proof job heartbeat failed"
+                );
+            }
+        }
 
         result
     }


### PR DESCRIPTION
## Summary
- Adds prover-service-side `DEBUG` logs for worker heartbeat RPCs.
- Logs one event for successful heartbeats and one event for failed heartbeats.
- Includes the heartbeat request parameters in both paths so worker/session issues can be debugged from service logs.

## Expected Debug Logs
Successful heartbeat message:
```text
worker proof job heartbeat succeeded
```

Successful heartbeat fields:
```text
session_id=<session_id>
lock_id=<lock_id>
worker_id=<worker_id>
lock_duration_seconds=<seconds>
status=<job_status>
lock_expires_at=<timestamp_or_none>
```

Failed heartbeat message:
```text
worker proof job heartbeat failed
```

Failed heartbeat fields:
```text
session_id=<session_id>
lock_id=<lock_id>
worker_id=<worker_id>
lock_duration_seconds=<seconds>
status_code=<rpc_status_code>
error_code=<numeric_rpc_error_code>
error_message=<rpc_error_message>
```

These are emitted at `DEBUG` level only.

## Test Plan
- `cargo fmt --package base-prover-service`
- `cargo test -p base-prover-service`