### PR TITLE
feat(devnet): add execution, consensus, builder, basectl, snapshotter docker targets

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,7 @@ jobs:
   warm-devnet-cache:
     strategy:
       matrix:
-        target: [base, batcher]
+        target: [base, execution, consensus, batcher]
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,7 @@ jobs:
   warm-devnet-cache:
     strategy:
       matrix:
-        target: [base, execution, consensus, batcher]
+        target: [base, execution, consensus, builder, batcher]
 
     runs-on: ubuntu-24.04
 

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -62,6 +62,30 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --profile $PROFILE --package base-consensus --bin base-consensus && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-consensus /app/base-consensus
 
+FROM source AS builder-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=builder-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-builder /app/base-builder
+
+FROM source AS basectl-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=basectl-target,sharing=locked \
+    cargo build --profile $PROFILE --package basectl --bin basectl && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/basectl /app/basectl
+
+FROM source AS snapshotter-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=snapshotter-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-snapshotter-bin --bin snapshotter && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/snapshotter /app/snapshotter
+
 FROM source AS proposer-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
@@ -131,6 +155,18 @@ ENTRYPOINT ["./base-reth-node"]
 FROM runtime-base AS consensus
 COPY --from=consensus-builder /app/base-consensus ./base-consensus
 ENTRYPOINT ["./base-consensus"]
+
+FROM runtime-base AS builder
+COPY --from=builder-builder /app/base-builder ./base-builder
+ENTRYPOINT ["./base-builder"]
+
+FROM runtime-base AS basectl
+COPY --from=basectl-builder /app/basectl ./basectl
+ENTRYPOINT ["./basectl"]
+
+FROM runtime-base AS snapshotter
+COPY --from=snapshotter-builder /app/snapshotter ./snapshotter
+ENTRYPOINT ["./snapshotter"]
 
 FROM runtime-base AS proposer
 COPY --from=proposer-builder /app/base-proposer ./base-proposer

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -46,6 +46,22 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --profile $PROFILE --package base --bin base && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base /app/base
 
+FROM source AS execution-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=execution-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-reth-node /app/base-reth-node
+
+FROM source AS consensus-builder
+ARG PROFILE=release
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=consensus-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-consensus --bin base-consensus && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-consensus /app/base-consensus
+
 FROM source AS proposer-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
@@ -107,6 +123,14 @@ WORKDIR /app
 FROM runtime-base AS base
 COPY --from=base-builder /app/base ./base
 ENTRYPOINT ["./base"]
+
+FROM runtime-base AS execution
+COPY --from=execution-builder /app/base-reth-node ./base-reth-node
+ENTRYPOINT ["./base-reth-node"]
+
+FROM runtime-base AS consensus
+COPY --from=consensus-builder /app/base-consensus ./base-consensus
+ENTRYPOINT ["./base-consensus"]
 
 FROM runtime-base AS proposer
 COPY --from=proposer-builder /app/base-proposer ./base-proposer

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -29,6 +29,8 @@ group "default" {
 group "rust-services" {
   targets = [
     "base",
+    "execution",
+    "consensus",
     "proposer",
     "websocket-proxy",
     "ingress-rpc",
@@ -65,6 +67,26 @@ target "base" {
   inherits = ["_rust-service-common"]
   target = "base"
   tags = ["base:local"]
+}
+
+target "execution" {
+  inherits = ["_rust-service-common"]
+  target = "execution"
+  tags = ["base-reth-node:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-execution-${PLATFORM_PAIR}",
+  ]
+}
+
+target "consensus" {
+  inherits = ["_rust-service-common"]
+  target = "consensus"
+  tags = ["base-consensus:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-consensus-${PLATFORM_PAIR}",
+  ]
 }
 
 target "proposer" {

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -75,7 +75,7 @@ target "base" {
 target "execution" {
   inherits = ["_rust-service-common"]
   target = "execution"
-  tags = ["base-reth-node:local"]
+  tags = ["base-execution:local"]
   cache-from = [
     "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
     "type=registry,ref=${REGISTRY_IMAGE}:cache-execution-${PLATFORM_PAIR}",
@@ -105,7 +105,7 @@ target "builder" {
 target "basectl" {
   inherits = ["_rust-service-common"]
   target = "basectl"
-  tags = ["basectl:local"]
+  tags = ["base-basectl:local"]
 }
 
 target "snapshotter" {

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -31,6 +31,9 @@ group "rust-services" {
     "base",
     "execution",
     "consensus",
+    "builder",
+    "basectl",
+    "snapshotter",
     "proposer",
     "websocket-proxy",
     "ingress-rpc",
@@ -87,6 +90,28 @@ target "consensus" {
     "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
     "type=registry,ref=${REGISTRY_IMAGE}:cache-consensus-${PLATFORM_PAIR}",
   ]
+}
+
+target "builder" {
+  inherits = ["_rust-service-common"]
+  target = "builder"
+  tags = ["base-builder:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-builder-${PLATFORM_PAIR}",
+  ]
+}
+
+target "basectl" {
+  inherits = ["_rust-service-common"]
+  target = "basectl"
+  tags = ["basectl:local"]
+}
+
+target "snapshotter" {
+  inherits = ["_rust-service-common"]
+  target = "snapshotter"
+  tags = ["base-snapshotter:local"]
 }
 
 target "proposer" {


### PR DESCRIPTION
## Motivation

Commit 0e87b22 (#3686) unified the docker devnet binary and removed the individual `client`, `builder`, and `consensus` targets from `docker-bake.hcl`. That's the right long-term default for devnet, but there are still workflows (release/audit tooling, one-off benchmarks, running a single service in isolation) that need to build individual binaries as their own docker images.

This PR adds five single-binary targets back to the bake:

| Target | Package | Binary | Image tag |
|---|---|---|---|
| `execution` | `base-reth-node` | `base-reth-node` | `base-execution:local` |
| `consensus` | `base-consensus` | `base-consensus` | `base-consensus:local` |
| `builder` | `base-builder-bin` | `base-builder` | `base-builder:local` |
| `basectl` | `basectl` | `basectl` | `base-basectl:local` |
| `snapshotter` | `base-snapshotter-bin` | `snapshotter` | `base-snapshotter:local` |

All tags use the `base-` prefix for consistency with the existing rust-services set (`base-consensus`, `base-builder`, `base-batcher`, `base-proposer`, `base-prover-zk`).

The unified `base` target is kept as the default and remains the only image built/published by CI (`build-and-push`). The new targets are opt-in via `docker buildx bake execution` etc.

## Changes

**`etc/docker/Dockerfile.rust-services`**
- 5 new `*-builder` stages (one per target), each `cargo build`-ing the matching package under its own cache mount (`id=execution-target` etc) so parallel bakes don't step on each other.
- 5 new runtime stages copying the binary and setting `ENTRYPOINT`.

**`etc/docker/docker-bake.hcl`**
- 5 new targets inheriting `_rust-service-common` (rust + platform + cache-to args).
- Added to `group "rust-services"` so `bake rust-services` still means "all rust images".
- `cache-from` mirrors the `batcher` pattern for the three big builds (execution, consensus, builder): shared cache plus a per-target cache tag. basectl/snapshotter only use the shared cache (small builds, not worth a dedicated cache tag).
- `group "devnet"` and `group "ingress"` are intentionally **not** modified — the unified `base` binary is still the correct entry point for devnet.

**`.github/workflows/docker.yml`**
- `warm-devnet-cache` matrix: `[base, batcher]` → `[base, execution, consensus, builder, batcher]`. basectl/snapshotter omitted (small, weren't cached pre-unification either).

## Local build verification

Ran `PLATFORM_PAIR=linux-amd64 PROFILE=dev BASE_SUCCINCT_ELF_REQUIRE=0 docker buildx bake <target> --load` for each new target on a warm cache and verified `--help` output.

| Target | Build time | Image size | `--help` output |
|---|---:|---:|---|
| execution | 2m36s | 246 MB | `Base Reth Binary / Usage: base-reth-node [OPTIONS] <COMMAND>` |
| consensus | 2m02s | 177 MB | `CLI argument types for Base consensus clients / Usage: base-consensus [OPTIONS] <COMMAND>` |
| builder | 2m38s | 243 MB | `Base Builder Binary / Usage: base-builder [OPTIONS] <COMMAND>` |
| basectl | 0m45s | 76 MB | `Base infrastructure control CLI / Usage: basectl [OPTIONS] [COMMAND]` |
| snapshotter | 1m35s | 153 MB | `Snapshot and upload reth node data to S3-compatible storage / Usage: snapshotter [OPTIONS] ...` |

All five binaries execute successfully inside their runtime images.

Bake config also validated with `docker buildx bake execution consensus builder basectl snapshotter --print` — resolves cleanly, targets inherit correctly, tags are as expected.

## Notes for reviewers

- **Not re-adding a bundled image.** The pre-unification `client` target co-located base-reth-node + base-consensus + basectl + snapshotter in one image. This PR keeps them separate — cleaner boundaries and lets you pull only what you need. Happy to bundle them back if that's preferred for tooling that expects the old layout.
- **`build-release.yml` untouched.** Release still ships only the unified `base` image. If we want to publish the new targets, that's a follow-up (needs a decision on registry naming).
- **Groups `devnet` / `ingress` untouched.** The unified `base` image covers the roles those groups used to compose. Ping me if any of them should be reverted to the split layout.

## Test build reproduction

```bash
PLATFORM_PAIR=linux-amd64 PROFILE=dev BASE_SUCCINCT_ELF_REQUIRE=0 \
  docker buildx bake -f etc/docker/docker-bake.hcl \
    execution consensus builder basectl snapshotter --load

docker run --rm --entrypoint /app/base-reth-node   base-execution:local     --help
docker run --rm --entrypoint /app/base-consensus   base-consensus:local     --help
docker run --rm --entrypoint /app/base-builder     base-builder:local       --help
docker run --rm --entrypoint /app/basectl          base-basectl:local       --help
docker run --rm --entrypoint /app/snapshotter      base-snapshotter:local   --help
```
