### PR TITLE
fix(nitro-host): decouple proof generation heartbeats

### DIFF
--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -46,8 +46,8 @@ tokio-vsock.workspace = true
 [dev-dependencies]
 chrono.workspace = true
 alloy-genesis.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 base-common-genesis = { workspace = true, features = ["serde", "std"] }
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
 metrics = [ "base-proof-host/metrics" ]

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -46,8 +46,8 @@ tokio-vsock.workspace = true
 [dev-dependencies]
 chrono.workspace = true
 alloy-genesis.workspace = true
-tokio = { workspace = true, features = ["macros", "rt"] }
 base-common-genesis = { workspace = true, features = ["serde", "std"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
 metrics = [ "base-proof-host/metrics" ]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -258,7 +258,9 @@ where
         tokio::select! {
             biased;
             result = &mut heartbeat_failure => {
-                let source = result.ok().flatten().unwrap_or_else(Self::stopped_heartbeat_error);
+                let source = result
+                    .unwrap_or_else(|_| Some(Self::stopped_heartbeat_error()))
+                    .unwrap_or_else(Self::stopped_heartbeat_error);
                 match generate.await {
                     Ok(_) => {
                         info!(
@@ -286,19 +288,17 @@ where
                 })
             },
             result = &mut generate => {
-                if heartbeat_failure.is_finished() {
-                    let source = heartbeat_failure
-                        .await
-                        .ok()
-                        .flatten()
-                        .unwrap_or_else(Self::stopped_heartbeat_error);
+                heartbeat_cancel.cancel();
+                if let Some(source) = heartbeat_failure
+                    .await
+                    .unwrap_or_else(|_| Some(Self::stopped_heartbeat_error()))
+                {
                     return Err(ProofGeneratorError::Heartbeat {
                         session_id: request.session_id.clone(),
                         source,
                     });
                 }
 
-                heartbeat_cancel.cancel();
                 result.map_err(|source| ProofGeneratorError::Generate {
                     session_id: request.session_id.clone(),
                     source,

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -250,6 +250,7 @@ where
         Generate: Future<Output = Result<Output, NitroEnclavePoolError>>,
     {
         let heartbeat_cancel = CancellationToken::new();
+        let _heartbeat_cancel_guard = heartbeat_cancel.clone().drop_guard();
         let mut heartbeat_failure =
             self.spawn_heartbeat_until_failure(request.clone(), heartbeat_cancel.clone());
         tokio::pin!(generate);
@@ -682,6 +683,18 @@ mod tests {
         )
     }
 
+    async fn wait_for_heartbeats(client: &MockWorkerClient, count: usize) {
+        for _ in 0..50 {
+            if client.heartbeats().len() >= count {
+                return;
+            }
+
+            sleep(Duration::from_millis(1)).await;
+        }
+
+        panic!("expected at least {count} heartbeat(s)");
+    }
+
     #[test]
     fn request_requires_claim_metadata() {
         let job = proof_job(
@@ -757,6 +770,30 @@ mod tests {
             !client.heartbeats().is_empty(),
             "heartbeat task should run independently of the busy generation task"
         );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_stops_when_generation_future_is_aborted() {
+        let client = MockWorkerClient::default();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
+
+        let handle = tokio::spawn(async move {
+            generator
+                .with_heartbeat_while_generating(
+                    &request,
+                    std::future::pending::<Result<(), NitroEnclavePoolError>>(),
+                )
+                .await
+        });
+
+        wait_for_heartbeats(&client, 1).await;
+        handle.abort();
+        assert!(handle.await.expect_err("generation task should be aborted").is_cancelled());
+
+        let heartbeat_count = client.heartbeats().len();
+        sleep(Duration::from_millis(25)).await;
+        assert_eq!(client.heartbeats().len(), heartbeat_count);
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -109,19 +109,6 @@ pub struct ProofGeneratorTask {
     pub submit_handle: JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>>,
 }
 
-struct HeartbeatTask {
-    _cancel: DropGuard,
-    failure: oneshot::Receiver<ProverServiceClientError>,
-}
-
-impl HeartbeatTask {
-    fn stopped_error() -> ProverServiceClientError {
-        ProverServiceClientError::MissingResult(
-            "proof generator heartbeat thread stopped unexpectedly".to_owned(),
-        )
-    }
-}
-
 /// Orchestrates Nitro witness generation, enclave proving, and async proof submission.
 #[derive(Debug)]
 pub struct ProofGenerator<Client> {
@@ -266,34 +253,14 @@ where
     where
         Generate: Future<Output = Result<Output, NitroEnclavePoolError>>,
     {
-        let mut heartbeat = self.spawn_heartbeat_until_failure(request.clone());
+        let (_heartbeat_cancel, mut heartbeat_failure) =
+            self.spawn_heartbeat_until_failure(request.clone());
         tokio::pin!(generate);
 
         tokio::select! {
-            result = &mut generate => {
-                match heartbeat.failure.try_recv() {
-                    Ok(source) => {
-                        return Err(ProofGeneratorError::Heartbeat {
-                            session_id: request.session_id.clone(),
-                            source,
-                        });
-                    }
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Closed) => {
-                        return Err(ProofGeneratorError::Heartbeat {
-                            session_id: request.session_id.clone(),
-                            source: HeartbeatTask::stopped_error(),
-                        });
-                    }
-                }
-
-                result.map_err(|source| ProofGeneratorError::Generate {
-                    session_id: request.session_id.clone(),
-                    source,
-                })
-            }
-            source = &mut heartbeat.failure => {
-                let source = source.unwrap_or_else(|_| HeartbeatTask::stopped_error());
+            biased;
+            source = &mut heartbeat_failure => {
+                let source = source.unwrap_or_else(|_| Self::stopped_heartbeat_error());
                 match generate.await {
                     Ok(_) => {
                         info!(
@@ -320,10 +287,31 @@ where
                     source,
                 })
             },
+            result = &mut generate => {
+                match heartbeat_failure.try_recv() {
+                    Ok(source) => Err(ProofGeneratorError::Heartbeat {
+                        session_id: request.session_id.clone(),
+                        source,
+                    }),
+                    Err(TryRecvError::Closed) => Err(ProofGeneratorError::Heartbeat {
+                        session_id: request.session_id.clone(),
+                        source: Self::stopped_heartbeat_error(),
+                    }),
+                    Err(TryRecvError::Empty) => result.map_err(|source| {
+                        ProofGeneratorError::Generate {
+                            session_id: request.session_id.clone(),
+                            source,
+                        }
+                    }),
+                }
+            }
         }
     }
 
-    fn spawn_heartbeat_until_failure(&self, request: ProofGeneratorRequest) -> HeartbeatTask {
+    fn spawn_heartbeat_until_failure(
+        &self,
+        request: ProofGeneratorRequest,
+    ) -> (DropGuard, oneshot::Receiver<ProverServiceClientError>) {
         let submitter = self.submitter.clone();
         let heartbeat_config = self.heartbeat;
         let cancel = CancellationToken::new();
@@ -346,7 +334,13 @@ where
             }
         });
 
-        HeartbeatTask { _cancel: cancel.drop_guard(), failure }
+        (cancel.drop_guard(), failure)
+    }
+
+    fn stopped_heartbeat_error() -> ProverServiceClientError {
+        ProverServiceClientError::MissingResult(
+            "proof generator heartbeat thread stopped unexpectedly".to_owned(),
+        )
     }
 
     async fn heartbeat_until_failure(
@@ -753,30 +747,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn heartbeat_runs_while_generation_poll_blocks_runtime_thread() {
-        let client = MockWorkerClient::default();
-        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
-        let request = claimed_tee_request();
-
-        let err = generator
-            .with_heartbeat_while_generating(&request, async {
-                std::thread::sleep(Duration::from_millis(50));
-                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
-            })
-            .await
-            .unwrap_err();
-
-        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
-        assert!(
-            !client.heartbeats().is_empty(),
-            "heartbeat task should run independently of the busy generation task"
-        );
-    }
-
-    #[tokio::test]
     async fn heartbeat_failure_wins_after_generation_poll_blocks_runtime_thread() {
         let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
-        let generator = generator_with_heartbeat_interval(client, Duration::from_millis(5));
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
         let request = claimed_tee_request();
 
         let err = generator
@@ -788,18 +761,10 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
-    }
-
-    #[tokio::test]
-    async fn dropped_heartbeat_task_cancels_thread() {
-        let client = MockWorkerClient::default();
-        let generator =
-            generator_with_heartbeat_interval(client.clone(), Duration::from_millis(20));
-
-        drop(generator.spawn_heartbeat_until_failure(claimed_tee_request()));
-        sleep(Duration::from_millis(50)).await;
-
-        assert!(client.heartbeats().is_empty());
+        assert!(
+            !client.heartbeats().is_empty(),
+            "heartbeat task should run independently of the busy generation task"
+        );
     }
 
     #[tokio::test]
@@ -818,6 +783,7 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        sleep(Duration::from_millis(75)).await;
         assert!(client.heartbeats().is_empty());
     }
 

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -8,7 +8,11 @@ use base_prover_service_protocol::{
     HeartbeatRequest, ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
-use tokio::{sync::oneshot, task::JoinHandle, time::sleep};
+use tokio::{
+    sync::{oneshot, oneshot::error::TryRecvError},
+    task::JoinHandle,
+    time::sleep,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -113,6 +117,18 @@ struct HeartbeatTask {
 impl HeartbeatTask {
     fn cancel(&self) {
         self.cancel.cancel();
+    }
+
+    fn stopped_error() -> ProverServiceClientError {
+        ProverServiceClientError::MissingResult(
+            "proof generator heartbeat thread stopped unexpectedly".to_owned(),
+        )
+    }
+}
+
+impl Drop for HeartbeatTask {
+    fn drop(&mut self) {
+        self.cancel();
     }
 }
 
@@ -266,6 +282,23 @@ where
         tokio::select! {
             biased;
             result = &mut generate => {
+                match heartbeat.failure.try_recv() {
+                    Ok(source) => {
+                        heartbeat.cancel();
+                        return Err(ProofGeneratorError::Heartbeat {
+                            session_id: request.session_id.clone(),
+                            source,
+                        });
+                    }
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Closed) => {
+                        heartbeat.cancel();
+                        return Err(ProofGeneratorError::Heartbeat {
+                            session_id: request.session_id.clone(),
+                            source: HeartbeatTask::stopped_error(),
+                        });
+                    }
+                }
                 heartbeat.cancel();
 
                 result.map_err(|source| ProofGeneratorError::Generate {
@@ -274,7 +307,7 @@ where
                 })
             }
             source = &mut heartbeat.failure => {
-                let source = source.expect("proof generator heartbeat thread stopped unexpectedly");
+                let source = source.unwrap_or_else(|_| HeartbeatTask::stopped_error());
                 match generate.await {
                     Ok(_) => {
                         info!(
@@ -755,6 +788,35 @@ mod tests {
             !client.heartbeats().is_empty(),
             "heartbeat task should run independently of the busy generation task"
         );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_failure_wins_after_generation_poll_blocks_runtime_thread() {
+        let client = MockWorkerClient::with_heartbeat_failure(MockHeartbeatFailure::NonRetryable);
+        let generator = generator_with_heartbeat_interval(client, Duration::from_millis(5));
+        let request = claimed_tee_request();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                std::thread::sleep(Duration::from_millis(50));
+                Ok::<(), NitroEnclavePoolError>(())
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Heartbeat { .. }));
+    }
+
+    #[tokio::test]
+    async fn dropped_heartbeat_task_cancels_thread() {
+        let client = MockWorkerClient::default();
+        let generator =
+            generator_with_heartbeat_interval(client.clone(), Duration::from_millis(20));
+
+        drop(generator.spawn_heartbeat_until_failure(claimed_tee_request()));
+        sleep(Duration::from_millis(50)).await;
+
+        assert!(client.heartbeats().is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -8,12 +8,8 @@ use base_prover_service_protocol::{
     HeartbeatRequest, ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
-use tokio::{
-    sync::{oneshot, oneshot::error::TryRecvError},
-    task::JoinHandle,
-    time::sleep,
-};
-use tokio_util::sync::{CancellationToken, DropGuard};
+use tokio::{task::JoinHandle, time::sleep};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
@@ -253,14 +249,15 @@ where
     where
         Generate: Future<Output = Result<Output, NitroEnclavePoolError>>,
     {
-        let (_heartbeat_cancel, mut heartbeat_failure) =
-            self.spawn_heartbeat_until_failure(request.clone());
+        let heartbeat_cancel = CancellationToken::new();
+        let mut heartbeat_failure =
+            self.spawn_heartbeat_until_failure(request.clone(), heartbeat_cancel.clone());
         tokio::pin!(generate);
 
         tokio::select! {
             biased;
-            source = &mut heartbeat_failure => {
-                let source = source.unwrap_or_else(|_| Self::stopped_heartbeat_error());
+            result = &mut heartbeat_failure => {
+                let source = result.ok().flatten().unwrap_or_else(Self::stopped_heartbeat_error);
                 match generate.await {
                     Ok(_) => {
                         info!(
@@ -288,22 +285,23 @@ where
                 })
             },
             result = &mut generate => {
-                match heartbeat_failure.try_recv() {
-                    Ok(source) => Err(ProofGeneratorError::Heartbeat {
+                if heartbeat_failure.is_finished() {
+                    let source = heartbeat_failure
+                        .await
+                        .ok()
+                        .flatten()
+                        .unwrap_or_else(Self::stopped_heartbeat_error);
+                    return Err(ProofGeneratorError::Heartbeat {
                         session_id: request.session_id.clone(),
                         source,
-                    }),
-                    Err(TryRecvError::Closed) => Err(ProofGeneratorError::Heartbeat {
-                        session_id: request.session_id.clone(),
-                        source: Self::stopped_heartbeat_error(),
-                    }),
-                    Err(TryRecvError::Empty) => result.map_err(|source| {
-                        ProofGeneratorError::Generate {
-                            session_id: request.session_id.clone(),
-                            source,
-                        }
-                    }),
+                    });
                 }
+
+                heartbeat_cancel.cancel();
+                result.map_err(|source| ProofGeneratorError::Generate {
+                    session_id: request.session_id.clone(),
+                    source,
+                })
             }
         }
     }
@@ -311,30 +309,24 @@ where
     fn spawn_heartbeat_until_failure(
         &self,
         request: ProofGeneratorRequest,
-    ) -> (DropGuard, oneshot::Receiver<ProverServiceClientError>) {
+        cancel: CancellationToken,
+    ) -> JoinHandle<Option<ProverServiceClientError>> {
         let submitter = self.submitter.clone();
         let heartbeat_config = self.heartbeat;
-        let cancel = CancellationToken::new();
-        let heartbeat_cancel = cancel.clone();
-        let (failure_tx, failure) = oneshot::channel();
 
-        let _ = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("failed to build proof heartbeat runtime");
 
-            if let Some(error) = runtime.block_on(Self::heartbeat_until_failure(
+            runtime.block_on(Self::heartbeat_until_failure(
                 submitter,
                 heartbeat_config,
                 request,
-                heartbeat_cancel,
-            )) {
-                let _ = failure_tx.send(error);
-            }
-        });
-
-        (cancel.drop_guard(), failure)
+                cancel,
+            ))
+        })
     }
 
     fn stopped_heartbeat_error() -> ProverServiceClientError {

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -13,7 +13,7 @@ use tokio::{
     task::JoinHandle,
     time::sleep,
 };
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::{info, warn};
 
 use crate::{
@@ -110,7 +110,7 @@ pub struct ProofGeneratorTask {
 }
 
 struct HeartbeatTask {
-    cancel: CancellationToken,
+    _cancel: DropGuard,
     failure: oneshot::Receiver<ProverServiceClientError>,
 }
 
@@ -119,12 +119,6 @@ impl HeartbeatTask {
         ProverServiceClientError::MissingResult(
             "proof generator heartbeat thread stopped unexpectedly".to_owned(),
         )
-    }
-}
-
-impl Drop for HeartbeatTask {
-    fn drop(&mut self) {
-        self.cancel.cancel();
     }
 }
 
@@ -352,7 +346,7 @@ where
             }
         });
 
-        HeartbeatTask { cancel, failure }
+        HeartbeatTask { _cancel: cancel.drop_guard(), failure }
     }
 
     async fn heartbeat_until_failure(

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -350,6 +350,7 @@ where
     ) -> Option<ProverServiceClientError> {
         loop {
             tokio::select! {
+                biased;
                 () = cancel.cancelled() => return None,
                 () = sleep(heartbeat_config.normalized_interval()) => {}
             }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -280,7 +280,6 @@ where
             result = &mut generate => {
                 match heartbeat.failure.try_recv() {
                     Ok(source) => {
-                        heartbeat.cancel.cancel();
                         return Err(ProofGeneratorError::Heartbeat {
                             session_id: request.session_id.clone(),
                             source,
@@ -288,14 +287,12 @@ where
                     }
                     Err(TryRecvError::Empty) => {}
                     Err(TryRecvError::Closed) => {
-                        heartbeat.cancel.cancel();
                         return Err(ProofGeneratorError::Heartbeat {
                             session_id: request.session_id.clone(),
                             source: HeartbeatTask::stopped_error(),
                         });
                     }
                 }
-                heartbeat.cancel.cancel();
 
                 result.map_err(|source| ProofGeneratorError::Generate {
                     session_id: request.session_id.clone(),

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -1,6 +1,6 @@
 //! Proof generation orchestration for claimed Nitro worker jobs.
 
-use std::{future::Future, sync::Arc, thread, time::Duration};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use base_proof_primitives::ProofRequest as NitroProofRequest;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
@@ -276,7 +276,6 @@ where
         tokio::pin!(generate);
 
         tokio::select! {
-            biased;
             result = &mut generate => {
                 match heartbeat.failure.try_recv() {
                     Ok(source) => {
@@ -337,7 +336,7 @@ where
         let heartbeat_cancel = cancel.clone();
         let (failure_tx, failure) = oneshot::channel();
 
-        let _ = thread::spawn(move || {
+        let _ = tokio::task::spawn_blocking(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -115,10 +115,6 @@ struct HeartbeatTask {
 }
 
 impl HeartbeatTask {
-    fn cancel(&self) {
-        self.cancel.cancel();
-    }
-
     fn stopped_error() -> ProverServiceClientError {
         ProverServiceClientError::MissingResult(
             "proof generator heartbeat thread stopped unexpectedly".to_owned(),
@@ -128,7 +124,7 @@ impl HeartbeatTask {
 
 impl Drop for HeartbeatTask {
     fn drop(&mut self) {
-        self.cancel();
+        self.cancel.cancel();
     }
 }
 
@@ -284,7 +280,7 @@ where
             result = &mut generate => {
                 match heartbeat.failure.try_recv() {
                     Ok(source) => {
-                        heartbeat.cancel();
+                        heartbeat.cancel.cancel();
                         return Err(ProofGeneratorError::Heartbeat {
                             session_id: request.session_id.clone(),
                             source,
@@ -292,14 +288,14 @@ where
                     }
                     Err(TryRecvError::Empty) => {}
                     Err(TryRecvError::Closed) => {
-                        heartbeat.cancel();
+                        heartbeat.cancel.cancel();
                         return Err(ProofGeneratorError::Heartbeat {
                             session_id: request.session_id.clone(),
                             source: HeartbeatTask::stopped_error(),
                         });
                     }
                 }
-                heartbeat.cancel();
+                heartbeat.cancel.cancel();
 
                 result.map_err(|source| ProofGeneratorError::Generate {
                     session_id: request.session_id.clone(),
@@ -344,24 +340,21 @@ where
         let heartbeat_cancel = cancel.clone();
         let (failure_tx, failure) = oneshot::channel();
 
-        thread::Builder::new()
-            .name("nitro-proof-heartbeat".to_owned())
-            .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("failed to build proof heartbeat runtime");
+        let _ = thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build proof heartbeat runtime");
 
-                if let Some(error) = runtime.block_on(Self::heartbeat_until_failure(
-                    submitter,
-                    heartbeat_config,
-                    request,
-                    heartbeat_cancel,
-                )) {
-                    let _ = failure_tx.send(error);
-                }
-            })
-            .expect("failed to spawn proof heartbeat thread");
+            if let Some(error) = runtime.block_on(Self::heartbeat_until_failure(
+                submitter,
+                heartbeat_config,
+                request,
+                heartbeat_cancel,
+            )) {
+                let _ = failure_tx.send(error);
+            }
+        });
 
         HeartbeatTask { cancel, failure }
     }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -362,8 +362,9 @@ where
             };
 
             let result = tokio::select! {
-                () = cancel.cancelled() => return None,
+                biased;
                 result = submitter.heartbeat(heartbeat) => result,
+                () = cancel.cancelled() => return None,
             };
 
             match result {

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -1,6 +1,6 @@
 //! Proof generation orchestration for claimed Nitro worker jobs.
 
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{future::Future, sync::Arc, thread, time::Duration};
 
 use base_proof_primitives::ProofRequest as NitroProofRequest;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
@@ -8,7 +8,7 @@ use base_prover_service_protocol::{
     HeartbeatRequest, ProofJob, ProofRequestKind, TeeKind, WorkerSubmitProofResponse,
 };
 use thiserror::Error;
-use tokio::{task::JoinHandle, time::sleep};
+use tokio::{sync::oneshot, task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -103,6 +103,17 @@ pub struct ProofGeneratorTask {
     pub worker_id: String,
     /// Spawned proof submission task.
     pub submit_handle: JoinHandle<Result<WorkerSubmitProofResponse, ProofSubmitterError>>,
+}
+
+struct HeartbeatTask {
+    cancel: CancellationToken,
+    failure: oneshot::Receiver<ProverServiceClientError>,
+}
+
+impl HeartbeatTask {
+    fn cancel(&self) {
+        self.cancel.cancel();
+    }
 }
 
 /// Orchestrates Nitro witness generation, enclave proving, and async proof submission.
@@ -255,16 +266,15 @@ where
         tokio::select! {
             biased;
             result = &mut generate => {
-                heartbeat.abort();
-                let _ = heartbeat.await;
+                heartbeat.cancel();
 
                 result.map_err(|source| ProofGeneratorError::Generate {
                     session_id: request.session_id.clone(),
                     source,
                 })
             }
-            source = &mut heartbeat => {
-                let source = source.expect("proof generator heartbeat task panicked");
+            source = &mut heartbeat.failure => {
+                let source = source.expect("proof generator heartbeat thread stopped unexpectedly");
                 match generate.await {
                     Ok(_) => {
                         info!(
@@ -294,25 +304,46 @@ where
         }
     }
 
-    fn spawn_heartbeat_until_failure(
-        &self,
-        request: ProofGeneratorRequest,
-    ) -> JoinHandle<ProverServiceClientError> {
+    fn spawn_heartbeat_until_failure(&self, request: ProofGeneratorRequest) -> HeartbeatTask {
         let submitter = self.submitter.clone();
         let heartbeat_config = self.heartbeat;
+        let cancel = CancellationToken::new();
+        let heartbeat_cancel = cancel.clone();
+        let (failure_tx, failure) = oneshot::channel();
 
-        tokio::spawn(async move {
-            Self::heartbeat_until_failure(submitter, heartbeat_config, request).await
-        })
+        thread::Builder::new()
+            .name("nitro-proof-heartbeat".to_owned())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build proof heartbeat runtime");
+
+                if let Some(error) = runtime.block_on(Self::heartbeat_until_failure(
+                    submitter,
+                    heartbeat_config,
+                    request,
+                    heartbeat_cancel,
+                )) {
+                    let _ = failure_tx.send(error);
+                }
+            })
+            .expect("failed to spawn proof heartbeat thread");
+
+        HeartbeatTask { cancel, failure }
     }
 
     async fn heartbeat_until_failure(
         submitter: ProofSubmitter<Client>,
         heartbeat_config: ProofGeneratorHeartbeatConfig,
         request: ProofGeneratorRequest,
-    ) -> ProverServiceClientError {
+        cancel: CancellationToken,
+    ) -> Option<ProverServiceClientError> {
         loop {
-            sleep(heartbeat_config.normalized_interval()).await;
+            tokio::select! {
+                () = cancel.cancelled() => return None,
+                () = sleep(heartbeat_config.normalized_interval()) => {}
+            }
 
             let heartbeat = HeartbeatRequest {
                 session_id: request.session_id.clone(),
@@ -321,7 +352,12 @@ where
                 lock_duration_seconds: heartbeat_config.lock_duration_seconds,
             };
 
-            match submitter.heartbeat(heartbeat).await {
+            let result = tokio::select! {
+                () = cancel.cancelled() => return None,
+                result = submitter.heartbeat(heartbeat) => result,
+            };
+
+            match result {
                 Ok(response) => {
                     info!(
                         session_id = %request.session_id,
@@ -339,7 +375,7 @@ where
                         error = %error,
                         "proof job heartbeat failed"
                     );
-                    return error;
+                    return Some(error);
                 }
             }
         }
@@ -700,8 +736,8 @@ mod tests {
         }));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn heartbeat_runs_while_generation_poll_is_busy() {
+    #[tokio::test]
+    async fn heartbeat_runs_while_generation_poll_blocks_runtime_thread() {
         let client = MockWorkerClient::default();
         let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
         let request = claimed_tee_request();

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -10,7 +10,7 @@ use base_prover_service_protocol::{
 use thiserror::Error;
 use tokio::{task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::{
     NitroEnclavePool, NitroEnclavePoolError, ProofSubmitter, ProofSubmitterError,
@@ -249,17 +249,22 @@ where
     where
         Generate: Future<Output = Result<Output, NitroEnclavePoolError>>,
     {
-        let heartbeat = self.heartbeat_until_failure(request);
+        let mut heartbeat = self.spawn_heartbeat_until_failure(request.clone());
         tokio::pin!(generate);
-        tokio::pin!(heartbeat);
 
         tokio::select! {
             biased;
-            result = &mut generate => result.map_err(|source| ProofGeneratorError::Generate {
-                session_id: request.session_id.clone(),
-                source,
-            }),
+            result = &mut generate => {
+                heartbeat.abort();
+                let _ = heartbeat.await;
+
+                result.map_err(|source| ProofGeneratorError::Generate {
+                    session_id: request.session_id.clone(),
+                    source,
+                })
+            }
             source = &mut heartbeat => {
+                let source = source.expect("proof generator heartbeat task panicked");
                 match generate.await {
                     Ok(_) => {
                         info!(
@@ -289,23 +294,36 @@ where
         }
     }
 
-    async fn heartbeat_until_failure(
+    fn spawn_heartbeat_until_failure(
         &self,
-        request: &ProofGeneratorRequest,
+        request: ProofGeneratorRequest,
+    ) -> JoinHandle<ProverServiceClientError> {
+        let submitter = self.submitter.clone();
+        let heartbeat_config = self.heartbeat;
+
+        tokio::spawn(async move {
+            Self::heartbeat_until_failure(submitter, heartbeat_config, request).await
+        })
+    }
+
+    async fn heartbeat_until_failure(
+        submitter: ProofSubmitter<Client>,
+        heartbeat_config: ProofGeneratorHeartbeatConfig,
+        request: ProofGeneratorRequest,
     ) -> ProverServiceClientError {
         loop {
-            sleep(self.heartbeat.normalized_interval()).await;
+            sleep(heartbeat_config.normalized_interval()).await;
 
             let heartbeat = HeartbeatRequest {
                 session_id: request.session_id.clone(),
                 lock_id: request.lock_id.clone(),
                 worker_id: request.worker_id.clone(),
-                lock_duration_seconds: self.heartbeat.lock_duration_seconds,
+                lock_duration_seconds: heartbeat_config.lock_duration_seconds,
             };
 
-            match self.submitter.heartbeat(heartbeat).await {
+            match submitter.heartbeat(heartbeat).await {
                 Ok(response) => {
-                    debug!(
+                    info!(
                         session_id = %request.session_id,
                         lock_id = %request.lock_id,
                         worker_id = %request.worker_id,
@@ -680,6 +698,27 @@ mod tests {
                 && heartbeat.worker_id == TEST_WORKER_ID
                 && heartbeat.lock_duration_seconds == TEST_HEARTBEAT_LOCK_DURATION_SECONDS
         }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn heartbeat_runs_while_generation_poll_is_busy() {
+        let client = MockWorkerClient::default();
+        let generator = generator_with_heartbeat_interval(client.clone(), Duration::from_millis(5));
+        let request = claimed_tee_request();
+
+        let err = generator
+            .with_heartbeat_while_generating(&request, async {
+                std::thread::sleep(Duration::from_millis(50));
+                Err::<(), NitroEnclavePoolError>(NitroEnclavePoolError::Busy)
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ProofGeneratorError::Generate { .. }));
+        assert!(
+            !client.heartbeats().is_empty(),
+            "heartbeat task should run independently of the busy generation task"
+        );
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -259,7 +259,10 @@ where
             biased;
             result = &mut heartbeat_failure => {
                 let source = result
-                    .unwrap_or_else(|_| Some(Self::stopped_heartbeat_error()))
+                    .unwrap_or_else(|error| {
+                        warn!(error = %error, "proof heartbeat task stopped unexpectedly");
+                        Some(Self::stopped_heartbeat_error())
+                    })
                     .unwrap_or_else(Self::stopped_heartbeat_error);
                 match generate.await {
                     Ok(_) => {
@@ -291,7 +294,10 @@ where
                 heartbeat_cancel.cancel();
                 if let Some(source) = heartbeat_failure
                     .await
-                    .unwrap_or_else(|_| Some(Self::stopped_heartbeat_error()))
+                    .unwrap_or_else(|error| {
+                        warn!(error = %error, "proof heartbeat task stopped unexpectedly");
+                        Some(Self::stopped_heartbeat_error())
+                    })
                 {
                     return Err(ProofGeneratorError::Heartbeat {
                         session_id: request.session_id.clone(),


### PR DESCRIPTION
### What changed? Why?

Nitro host proof generation now runs prover-service heartbeats from `spawn_blocking` with a dedicated current-thread Tokio runtime while the enclave proof future is in progress. This keeps claimed job leases renewing even if proof generation blocks an async runtime worker thread, preventing another worker from reclaiming the same job after the server lock expires.

The heartbeat loop now observes cancellation while waiting between heartbeats and while an API call is pending. When generation finishes first, or when the generation future is aborted, the heartbeat worker stops instead of continuing in the background.

Accepted proof-job heartbeats are logged at info level to make lease extensions visible in deployed worker logs.

### Notes to reviewers

Heartbeat failure behavior is intentionally preserved: if the heartbeat fails before generation is accepted as complete, the generator waits for the in-flight proof future and then returns a heartbeat error, discarding any generated proof.

`spawn_blocking` is used because a regular spawned async task can still be starved when proof-generation polling monopolizes the async runtime worker thread.

The regression coverage now includes the blocked-runtime-thread case and verifies that heartbeat work stops when the generation future is aborted.

### How has it been tested?

- `cargo fmt -p base-proof-tee-nitro-host -- --check`
- `cargo test -p base-proof-tee-nitro-host proof_generator`
- `cargo check -p base-prover-nitro-host --features local,worker`
