### PR TITLE
fix(builder): replace BlockCell/build_complete with watch channel for payload resolution

### DIFF
--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -86,7 +86,7 @@ where
         + 'static,
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
 {
     type Job = BlockPayloadJob<Builder>;
 
@@ -160,6 +160,7 @@ where
             builder: self.builder.clone(),
             config,
             payload_rx: None,
+            build_error: Arc::new(Mutex::new(None)),
             cancel: cancel_token,
             publish_guard,
             deadline,
@@ -210,8 +211,14 @@ where
     /// See [`PayloadBuilder`]
     pub(crate) builder: Builder,
     /// Receiver for the latest payload from the builder task.
-    /// `None` until `spawn_build_job` is called; taken by `resolve_kind` into [`ResolvePayload`].
+    /// `None` until `spawn_build_job` is called; cloned by `resolve_kind` into [`ResolvePayload`].
     pub(crate) payload_rx: Option<watch::Receiver<Option<Builder::BuiltPayload>>>,
+    /// The error the build task last failed with, if any.
+    ///
+    /// The build task can only report failure by dropping `payload_rx`'s sender, which loses
+    /// the underlying cause. This carries that cause over to [`ResolvePayload`] so its error
+    /// reflects why the build task exited rather than a generic message.
+    pub(crate) build_error: Arc<Mutex<Option<String>>>,
     /// Cancellation token for the running job
     pub(crate) cancel: CancellationToken,
     /// Mutex to synchronize cancellation with payload publishing.
@@ -244,10 +251,7 @@ where
     type BuiltPayload = Builder::BuiltPayload;
 
     fn best_payload(&self) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        self.payload_rx
-            .as_ref()
-            .and_then(|rx| rx.borrow().clone())
-            .ok_or(PayloadBuilderError::MissingPayload)
+        unimplemented!()
     }
 
     fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError> {
@@ -266,7 +270,10 @@ where
             self.cancel.cancel();
         }
 
-        (ResolvePayload::new(self.payload_rx.clone()), KeepPayloadJobAlive::No)
+        (
+            ResolvePayload::new(self.payload_rx.clone(), Arc::clone(&self.build_error)),
+            KeepPayloadJobAlive::No,
+        )
     }
 }
 
@@ -288,7 +295,7 @@ impl<Builder> BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
 {
     /// Spawns a blocking task that builds the next payload using the current configuration.
     pub fn spawn_build_job(&mut self) {
@@ -296,6 +303,7 @@ where
         let payload_config = self.config.clone();
         let cancel = self.cancel.clone();
         let publish_guard = Arc::clone(&self.publish_guard);
+        let build_error = Arc::clone(&self.build_error);
 
         let (watch_tx, watch_rx) = watch::channel(None);
         self.payload_rx = Some(watch_rx);
@@ -305,6 +313,7 @@ where
                 BuildArguments { cached_reads, config: payload_config, cancel, publish_guard };
             if let Err(e) = builder.try_build(args, watch_tx).await {
                 warn!(error = %e, "Payload build task failed");
+                *build_error.lock() = Some(e.to_string());
             }
         }));
     }
@@ -315,7 +324,7 @@ impl<Builder> Future for BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
 {
     type Output = Result<(), PayloadBuilderError>;
 
@@ -344,7 +353,8 @@ where
 ///
 /// Waits for the first non-`None` value from the watch channel.  If the sender
 /// is dropped before any value is sent (build task failed or panicked), the
-/// future resolves with `Err(MissingPayload)`.
+/// future resolves with an error describing why the build task exited, falling
+/// back to a generic message if no cause was recorded.
 pub struct ResolvePayload<T> {
     future: futures::future::BoxFuture<'static, Result<T, PayloadBuilderError>>,
 }
@@ -356,7 +366,10 @@ impl<T> std::fmt::Debug for ResolvePayload<T> {
 }
 
 impl<T: Clone + Send + Sync + 'static> ResolvePayload<T> {
-    fn new(payload_rx: Option<watch::Receiver<Option<T>>>) -> Self {
+    fn new(
+        payload_rx: Option<watch::Receiver<Option<T>>>,
+        build_error: Arc<Mutex<Option<String>>>,
+    ) -> Self {
         let future = async move {
             let Some(mut rx) = payload_rx else {
                 return Err(PayloadBuilderError::Other("payload receiver missing".into()));
@@ -368,7 +381,12 @@ impl<T: Clone + Send + Sync + 'static> ResolvePayload<T> {
                 }
 
                 rx.changed().await.map_err(|_| {
-                    PayloadBuilderError::Other("builder exited before producing payload".into())
+                    build_error.lock().take().map_or(
+                        PayloadBuilderError::Other(
+                            "builder exited before producing payload".into(),
+                        ),
+                        |err| PayloadBuilderError::Other(err.into()),
+                    )
                 })?;
             }
         }
@@ -378,7 +396,7 @@ impl<T: Clone + Send + Sync + 'static> ResolvePayload<T> {
     }
 }
 
-impl<T: Unpin> Future for ResolvePayload<T> {
+impl<T> Future for ResolvePayload<T> {
     type Output = Result<T, PayloadBuilderError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -608,10 +626,13 @@ mod tests {
             sleep(Duration::from_millis(50)).await;
             tx.send_replace(Some(MockPayloadValue(7)));
         });
-        let payload = timeout(Duration::from_secs(1), ResolvePayload::new(Some(rx)))
-            .await
-            .expect("timed out")
-            .expect("missing payload");
+        let payload = timeout(
+            Duration::from_secs(1),
+            ResolvePayload::new(Some(rx), Arc::new(Mutex::new(None))),
+        )
+        .await
+        .expect("timed out")
+        .expect("missing payload");
         assert_eq!(payload, MockPayloadValue(7));
     }
 
@@ -619,7 +640,9 @@ mod tests {
     async fn test_resolve_payload_immediate_value() {
         let (tx, rx) = watch::channel::<Option<MockPayloadValue>>(None);
         tx.send_replace(Some(MockPayloadValue(3)));
-        let payload = ResolvePayload::new(Some(rx)).await.expect("should resolve immediately");
+        let payload = ResolvePayload::new(Some(rx), Arc::new(Mutex::new(None)))
+            .await
+            .expect("should resolve immediately");
         assert_eq!(payload, MockPayloadValue(3));
     }
 
@@ -627,14 +650,26 @@ mod tests {
     async fn test_resolve_payload_errors_when_sender_dropped() {
         let (tx, rx) = watch::channel::<Option<MockPayloadValue>>(None);
         drop(tx);
-        ResolvePayload::new(Some(rx))
+        ResolvePayload::new(Some(rx), Arc::new(Mutex::new(None)))
             .await
             .expect_err("should error when sender dropped without value");
     }
 
     #[tokio::test]
+    async fn test_resolve_payload_propagates_build_error() {
+        let (tx, rx) = watch::channel::<Option<MockPayloadValue>>(None);
+        let build_error = Arc::new(Mutex::new(None));
+        *build_error.lock() = Some("state root computation failed".to_string());
+        drop(tx);
+        let err = ResolvePayload::new(Some(rx), build_error)
+            .await
+            .expect_err("should error when sender dropped without value");
+        assert!(err.to_string().contains("state root computation failed"));
+    }
+
+    #[tokio::test]
     async fn test_resolve_payload_errors_when_rx_missing() {
-        ResolvePayload::<MockPayloadValue>::new(None)
+        ResolvePayload::<MockPayloadValue>::new(None, Arc::new(Mutex::new(None)))
             .await
             .expect_err("should error when receiver is missing");
     }

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -251,7 +251,7 @@ where
     type BuiltPayload = Builder::BuiltPayload;
 
     fn best_payload(&self) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        unimplemented!()
+        Err(PayloadBuilderError::Other("best_payload not supported; use resolve_kind".into()))
     }
 
     fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError> {
@@ -311,10 +311,12 @@ where
         self.executor.spawn_blocking_task(Box::pin(async move {
             let args =
                 BuildArguments { cached_reads, config: payload_config, cancel, publish_guard };
-            if let Err(e) = builder.try_build(args, watch_tx).await {
+            if let Err(e) = builder.try_build(args, &watch_tx).await {
                 warn!(error = %e, "Payload build task failed");
                 *build_error.lock() = Some(e.to_string());
             }
+            // watch_tx is dropped here, after any failure cause has been recorded above,
+            // so ResolvePayload always observes the cause before the sender's drop.
         }));
     }
 }
@@ -375,20 +377,14 @@ impl<T: Clone + Send + Sync + 'static> ResolvePayload<T> {
                 return Err(PayloadBuilderError::Other("payload receiver missing".into()));
             };
 
-            loop {
-                if let Some(payload) = rx.borrow().clone() {
-                    return Ok(payload);
-                }
+            let payload = rx.wait_for(Option::is_some).await.map_err(|_| {
+                build_error.lock().take().map_or(
+                    PayloadBuilderError::Other("builder exited before producing payload".into()),
+                    |err| PayloadBuilderError::Other(err.into()),
+                )
+            })?;
 
-                rx.changed().await.map_err(|_| {
-                    build_error.lock().take().map_or(
-                        PayloadBuilderError::Other(
-                            "builder exited before producing payload".into(),
-                        ),
-                        |err| PayloadBuilderError::Other(err.into()),
-                    )
-                })?;
-            }
+            Ok(payload.as_ref().expect("checked is_some by wait_for predicate").clone())
         }
         .boxed();
 
@@ -509,7 +505,7 @@ mod tests {
         async fn try_build(
             &self,
             args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-            _payload_tx: watch::Sender<Option<Self::BuiltPayload>>,
+            _payload_tx: &watch::Sender<Option<Self::BuiltPayload>>,
         ) -> Result<(), PayloadBuilderError> {
             self.new_event(BlockEvent::Started);
 

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -1,6 +1,5 @@
 use std::{
     sync::Arc,
-    task::Waker,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -19,7 +18,7 @@ use reth_provider::{BlockReaderIdExt, CanonStateNotification, StateProviderFacto
 use reth_revm::cached::CachedReads;
 use reth_tasks::Runtime;
 use tokio::{
-    sync::oneshot,
+    sync::watch,
     time::{Duration, Sleep},
 };
 use tokio_util::sync::CancellationToken;
@@ -160,12 +159,10 @@ where
             executor: self.executor.clone(),
             builder: self.builder.clone(),
             config,
-            cell: BlockCell::new(),
-            finalized_cell: BlockCell::new(),
+            payload_rx: None,
             cancel: cancel_token,
             publish_guard,
             deadline,
-            build_complete: None,
             cached_reads: self.maybe_pre_cached(parent_hash),
         };
 
@@ -212,16 +209,14 @@ where
     ///
     /// See [`PayloadBuilder`]
     pub(crate) builder: Builder,
-    /// The cell that holds the built payload (intermediate flashblocks, may not have state root).
-    pub(crate) cell: BlockCell<Builder::BuiltPayload>,
-    /// The cell that holds the finalized payload with state root computed.
-    pub(crate) finalized_cell: BlockCell<Builder::BuiltPayload>,
+    /// Receiver for the latest payload from the builder task.
+    /// `None` until `spawn_build_job` is called; taken by `resolve_kind` into [`ResolvePayload`].
+    pub(crate) payload_rx: Option<watch::Receiver<Option<Builder::BuiltPayload>>>,
     /// Cancellation token for the running job
     pub(crate) cancel: CancellationToken,
     /// Mutex to synchronize cancellation with payload publishing.
     pub(crate) publish_guard: Arc<Mutex<()>>,
-    pub(crate) deadline: Pin<Box<Sleep>>, // Add deadline
-    pub(crate) build_complete: Option<oneshot::Receiver<Result<(), PayloadBuilderError>>>,
+    pub(crate) deadline: Pin<Box<Sleep>>,
     /// Caches all disk reads for the state the new payloads build on
     ///
     /// This is used to avoid reading the same state over and over again when new attempts are
@@ -242,14 +237,17 @@ impl<Builder> PayloadJob for BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
 {
     type PayloadAttributes = Builder::Attributes;
     type ResolvePayloadFuture = ResolvePayload<Self::BuiltPayload>;
     type BuiltPayload = Builder::BuiltPayload;
 
     fn best_payload(&self) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        self.cell.get().ok_or_else(|| PayloadBuilderError::MissingPayload)
+        self.payload_rx
+            .as_ref()
+            .and_then(|rx| rx.borrow().clone())
+            .ok_or(PayloadBuilderError::MissingPayload)
     }
 
     fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError> {
@@ -268,9 +266,7 @@ where
             self.cancel.cancel();
         }
 
-        let resolve_future = ResolvePayload::new(self.finalized_cell.wait_for_value());
-
-        (resolve_future, KeepPayloadJobAlive::No)
+        (ResolvePayload::new(self.payload_rx.clone()), KeepPayloadJobAlive::No)
     }
 }
 
@@ -285,8 +281,6 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     pub cancel: CancellationToken,
     /// Mutex to synchronize cancellation with payload publishing.
     pub publish_guard: Arc<Mutex<()>>,
-    /// Cell to store the finalized payload with state root.
-    pub finalized_cell: BlockCell<Payload>,
 }
 
 /// A [`PayloadJob`] is a future that's being polled by the `PayloadBuilderService`
@@ -300,25 +294,18 @@ where
     pub fn spawn_build_job(&mut self) {
         let builder = self.builder.clone();
         let payload_config = self.config.clone();
-        let cell = self.cell.clone();
         let cancel = self.cancel.clone();
         let publish_guard = Arc::clone(&self.publish_guard);
-        let finalized_cell = self.finalized_cell.clone();
 
-        let (tx, rx) = oneshot::channel();
-        self.build_complete = Some(rx);
+        let (watch_tx, watch_rx) = watch::channel(None);
+        self.payload_rx = Some(watch_rx);
         let cached_reads = self.cached_reads.take().unwrap_or_default();
         self.executor.spawn_blocking_task(Box::pin(async move {
-            let args = BuildArguments {
-                cached_reads,
-                config: payload_config,
-                cancel,
-                publish_guard,
-                finalized_cell,
-            };
-
-            let result = builder.try_build(args, cell).await;
-            let _ = tx.send(result);
+            let args =
+                BuildArguments { cached_reads, config: payload_config, cancel, publish_guard };
+            if let Err(e) = builder.try_build(args, watch_tx).await {
+                warn!(error = %e, "Payload build task failed");
+            }
         }));
     }
 }
@@ -353,9 +340,13 @@ where
     }
 }
 
-/// A future that resolves when a payload becomes available in the [`BlockCell`].
+/// A future that resolves with the latest payload produced by the builder task.
+///
+/// Waits for the first non-`None` value from the watch channel.  If the sender
+/// is dropped before any value is sent (build task failed or panicked), the
+/// future resolves with `Err(MissingPayload)`.
 pub struct ResolvePayload<T> {
-    future: WaitForValue<T>,
+    future: futures::future::BoxFuture<'static, Result<T, PayloadBuilderError>>,
 }
 
 impl<T> std::fmt::Debug for ResolvePayload<T> {
@@ -364,137 +355,34 @@ impl<T> std::fmt::Debug for ResolvePayload<T> {
     }
 }
 
-impl<T> ResolvePayload<T> {
-    /// Creates a new [`ResolvePayload`] from the given [`WaitForValue`] future.
-    pub const fn new(future: WaitForValue<T>) -> Self {
+impl<T: Clone + Send + Sync + 'static> ResolvePayload<T> {
+    fn new(payload_rx: Option<watch::Receiver<Option<T>>>) -> Self {
+        let future = async move {
+            let Some(mut rx) = payload_rx else {
+                return Err(PayloadBuilderError::Other("payload receiver missing".into()));
+            };
+
+            loop {
+                if let Some(payload) = rx.borrow().clone() {
+                    return Ok(payload);
+                }
+
+                rx.changed().await.map_err(|_| {
+                    PayloadBuilderError::Other("builder exited before producing payload".into())
+                })?;
+            }
+        }
+        .boxed();
+
         Self { future }
     }
 }
 
-impl<T: Clone> Future for ResolvePayload<T> {
+impl<T: Unpin> Future for ResolvePayload<T> {
     type Output = Result<T, PayloadBuilderError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.get_mut().future.poll_unpin(cx) {
-            Poll::Ready(value) => Poll::Ready(Ok(value)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-/// A cell that holds a value and allows waiting for it to be set.
-///
-/// Values can be overwritten by calling [`BlockCell::set`] multiple times.
-/// Waiters registered via [`BlockCell::wait_for_value`] are woken when a new
-/// value is stored.
-#[derive(Clone, Debug)]
-pub struct BlockCell<T> {
-    state: Arc<Mutex<BlockCellState<T>>>,
-}
-
-/// Internal state shared between the cell and its waiters.
-///
-/// Each waiter owns a slot (index) in the `wakers` vector. Slots are reused
-/// when a waiter completes or is dropped, keeping the vector compact.
-#[derive(Debug)]
-struct BlockCellState<T> {
-    value: Option<T>,
-    wakers: Vec<Option<Waker>>,
-}
-
-impl<T: Clone> BlockCell<T> {
-    /// Creates an empty [`BlockCell`].
-    pub fn new() -> Self {
-        Self { state: Arc::new(Mutex::new(BlockCellState { value: None, wakers: Vec::new() })) }
-    }
-
-    /// Stores `value` in the cell, overwriting any previous value, and wakes one waiter.
-    pub fn set(&self, value: T) {
-        let wakers: Vec<Waker> = {
-            let mut state = self.state.lock();
-            state.value = Some(value);
-            state.wakers.iter_mut().filter_map(Option::take).collect()
-        };
-        // Wake outside the lock to avoid holding it during waker execution.
-        for waker in wakers {
-            waker.wake();
-        }
-    }
-
-    /// Returns a clone of the stored value, or `None` if the cell is empty.
-    pub fn get(&self) -> Option<T> {
-        self.state.lock().value.clone()
-    }
-
-    /// Return a future that resolves when a value is set.
-    ///
-    /// The returned future cleans up its waker slot on drop, so it is safe to
-    /// use inside `tokio::select!` or with timeouts.
-    pub fn wait_for_value(&self) -> WaitForValue<T> {
-        WaitForValue { cell: self.clone(), slot: None }
-    }
-}
-
-/// Future that resolves when a value is set in [`BlockCell`].
-///
-/// Cleans up its waker slot on drop, so cancelled futures do not leave stale
-/// entries in the waker list.
-pub struct WaitForValue<T> {
-    cell: BlockCell<T>,
-    slot: Option<usize>,
-}
-
-impl<T> std::fmt::Debug for WaitForValue<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WaitForValue").finish_non_exhaustive()
-    }
-}
-
-impl<T: Clone> Future for WaitForValue<T> {
-    type Output = T;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        let mut state = this.cell.state.lock();
-        if let Some(value) = state.value.clone() {
-            // Clear our slot since we're resolving.
-            if let Some(idx) = this.slot.take() {
-                state.wakers[idx] = None;
-            }
-            Poll::Ready(value)
-        } else {
-            let waker = cx.waker().clone();
-            match this.slot {
-                Some(idx) => {
-                    // Update existing slot with the current waker.
-                    state.wakers[idx] = Some(waker);
-                }
-                None => {
-                    // Reuse an empty slot or allocate a new one.
-                    let idx = state.wakers.iter().position(Option::is_none).unwrap_or_else(|| {
-                        state.wakers.push(None);
-                        state.wakers.len() - 1
-                    });
-                    state.wakers[idx] = Some(waker);
-                    this.slot = Some(idx);
-                }
-            }
-            Poll::Pending
-        }
-    }
-}
-
-impl<T> Drop for WaitForValue<T> {
-    fn drop(&mut self) {
-        if let Some(idx) = self.slot.take() {
-            self.cell.state.lock().wakers[idx] = None;
-        }
-    }
-}
-
-impl<T: Clone> Default for BlockCell<T> {
-    fn default() -> Self {
-        Self::new()
+        self.get_mut().future.as_mut().poll(cx)
     }
 }
 
@@ -530,79 +418,9 @@ mod tests {
     use reth_provider::test_utils::MockEthProvider;
     use reth_tasks::Runtime;
     use reth_testing_utils::generators::{BlockRangeParams, random_block_range};
-    use tokio::{
-        task,
-        time::{Duration, sleep},
-    };
+    use tokio::time::{Duration, sleep, timeout};
 
     use super::*;
-
-    #[tokio::test]
-    async fn test_block_cell_wait_for_value() {
-        let cell = BlockCell::new();
-
-        // Spawn a task that will set the value after a delay
-        let cell_clone = cell.clone();
-        task::spawn(async move {
-            sleep(Duration::from_millis(100)).await;
-            cell_clone.set(42);
-        });
-
-        // Wait for the value and verify
-        let wait_future = cell.wait_for_value();
-        let result = wait_future.await;
-        assert_eq!(result, 42);
-    }
-
-    #[tokio::test]
-    async fn test_block_cell_immediate_value() {
-        let cell = BlockCell::new();
-        cell.set(42);
-
-        // Value should be immediately available
-        let wait_future = cell.wait_for_value();
-        let result = wait_future.await;
-        assert_eq!(result, 42);
-    }
-
-    #[tokio::test]
-    async fn test_block_cell_multiple_waiters() {
-        let cell = BlockCell::new();
-
-        // Spawn multiple waiters
-        let wait1 = task::spawn({
-            let cell = cell.clone();
-            async move { cell.wait_for_value().await }
-        });
-
-        let wait2 = task::spawn({
-            let cell = cell.clone();
-            async move { cell.wait_for_value().await }
-        });
-
-        // Set value after a delay
-        sleep(Duration::from_millis(100)).await;
-        cell.set(42);
-
-        // All waiters should receive the value
-        assert_eq!(wait1.await.unwrap(), 42);
-        assert_eq!(wait2.await.unwrap(), 42);
-    }
-
-    #[tokio::test]
-    async fn test_block_cell_update_value() {
-        let cell = BlockCell::new();
-
-        // Set initial value
-        cell.set(42);
-
-        // Set new value
-        cell.set(43);
-
-        // Waiter should get the latest value
-        let result = cell.wait_for_value().await;
-        assert_eq!(result, 43);
-    }
 
     #[derive(Debug, Clone)]
     struct MockBuilder<N> {
@@ -673,7 +491,7 @@ mod tests {
         async fn try_build(
             &self,
             args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-            _best_payload: BlockCell<Self::BuiltPayload>,
+            _payload_tx: watch::Sender<Option<Self::BuiltPayload>>,
         ) -> Result<(), PayloadBuilderError> {
             self.new_event(BlockEvent::Started);
 
@@ -778,5 +596,46 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct MockPayloadValue(u64);
+
+    #[tokio::test]
+    async fn test_resolve_payload_waits_for_first_value() {
+        let (tx, rx) = watch::channel::<Option<MockPayloadValue>>(None);
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            tx.send_replace(Some(MockPayloadValue(7)));
+        });
+        let payload = timeout(Duration::from_secs(1), ResolvePayload::new(Some(rx)))
+            .await
+            .expect("timed out")
+            .expect("missing payload");
+        assert_eq!(payload, MockPayloadValue(7));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_payload_immediate_value() {
+        let (tx, rx) = watch::channel::<Option<MockPayloadValue>>(None);
+        tx.send_replace(Some(MockPayloadValue(3)));
+        let payload = ResolvePayload::new(Some(rx)).await.expect("should resolve immediately");
+        assert_eq!(payload, MockPayloadValue(3));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_payload_errors_when_sender_dropped() {
+        let (tx, rx) = watch::channel::<Option<MockPayloadValue>>(None);
+        drop(tx);
+        ResolvePayload::new(Some(rx))
+            .await
+            .expect_err("should error when sender dropped without value");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_payload_errors_when_rx_missing() {
+        ResolvePayload::<MockPayloadValue>::new(None)
+            .await
+            .expect_err("should error when receiver is missing");
     }
 }

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -86,7 +86,7 @@ where
         + 'static,
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
+    Builder::BuiltPayload: Unpin + Clone,
 {
     type Job = BlockPayloadJob<Builder>;
 
@@ -211,7 +211,7 @@ where
     /// See [`PayloadBuilder`]
     pub(crate) builder: Builder,
     /// Receiver for the latest payload from the builder task.
-    /// `None` until `spawn_build_job` is called; cloned by `resolve_kind` into [`ResolvePayload`].
+    /// `None` until `spawn_build_job` is called; taken by `resolve_kind` into [`ResolvePayload`].
     pub(crate) payload_rx: Option<watch::Receiver<Option<Builder::BuiltPayload>>>,
     /// The error the build task last failed with, if any.
     ///
@@ -244,7 +244,7 @@ impl<Builder> PayloadJob for BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
+    Builder::BuiltPayload: Unpin + Clone,
 {
     type PayloadAttributes = Builder::Attributes;
     type ResolvePayloadFuture = ResolvePayload<Self::BuiltPayload>;
@@ -271,7 +271,7 @@ where
         }
 
         (
-            ResolvePayload::new(self.payload_rx.clone(), Arc::clone(&self.build_error)),
+            ResolvePayload::new(self.payload_rx.take(), Arc::clone(&self.build_error)),
             KeepPayloadJobAlive::No,
         )
     }
@@ -295,7 +295,7 @@ impl<Builder> BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
+    Builder::BuiltPayload: Unpin + Clone,
 {
     /// Spawns a blocking task that builds the next payload using the current configuration.
     pub fn spawn_build_job(&mut self) {
@@ -324,7 +324,7 @@ impl<Builder> Future for BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder + Unpin + 'static,
     Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone + Send + Sync + 'static,
+    Builder::BuiltPayload: Unpin + Clone,
 {
     type Output = Result<(), PayloadBuilderError>;
 

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -4,10 +4,7 @@ mod best_txs;
 pub use best_txs::BestFlashblocksTxs;
 
 mod generator;
-pub use generator::{
-    BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments, ResolvePayload,
-    WaitForValue,
-};
+pub use generator::{BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments, ResolvePayload};
 
 mod traits;
 pub use traits::PayloadBuilder;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -47,17 +47,15 @@ use reth_trie::{HashedPostState, updates::TrieUpdates};
 use revm::Database as _;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, metadata::Level, span, warn};
 
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblocksExtraCtx,
-        best_txs::BestFlashblocksTxs,
-        context::BasePayloadBuilderCtx,
-        generator::{BlockCell, BuildArguments},
+        FlashblocksExtraCtx, best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx,
+        generator::BuildArguments,
     },
     traits::{ClientBounds, PoolBounds},
     transaction_events::{
@@ -255,16 +253,10 @@ where
     async fn build_payload(
         &self,
         args: BuildArguments<BasePayloadBuilderAttributes<BaseTransactionSigned>, BaseBuiltPayload>,
-        best_payload: BlockCell<BaseBuiltPayload>,
+        payload_tx: watch::Sender<Option<BaseBuiltPayload>>,
     ) -> Result<(), PayloadBuilderError> {
         let block_build_start_time = Instant::now();
-        let BuildArguments {
-            mut cached_reads,
-            config,
-            cancel: block_cancel,
-            finalized_cell,
-            publish_guard,
-        } = args;
+        let BuildArguments { mut cached_reads, config, cancel: block_cancel, publish_guard } = args;
 
         // We log only every Nth block based on sampling ratio to reduce usage
         let block_number = config.parent_header.number + 1;
@@ -317,7 +309,6 @@ where
         )?;
 
         self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
-        best_payload.set(payload.clone());
 
         info!(
             target: "payload_builder",
@@ -371,7 +362,7 @@ where
         }
 
         if skip_flashblocks_building {
-            finalized_cell.set(payload);
+            payload_tx.send_replace(Some(payload));
             let total_block_building_time = block_build_start_time.elapsed();
             BuilderMetrics::total_block_built_duration().record(total_block_building_time);
             BuilderMetrics::total_block_built_gauge().set(total_block_building_time);
@@ -481,7 +472,7 @@ where
                     &span,
                     "Payload building complete, target flashblock count reached",
                 );
-                self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                self.finalize_payload(&mut state, &ctx, &mut info, &payload_tx)?;
                 return Ok(());
             }
 
@@ -493,7 +484,6 @@ where
                     &mut state,
                     &mut best_txs,
                     &block_cancel,
-                    &best_payload,
                     &publish_guard,
                     &fb_span,
                     &mut executed_sender_nonces,
@@ -509,7 +499,7 @@ where
                         &span,
                         "Payload building complete, job cancelled or target flashblock count reached",
                     );
-                    self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                    self.finalize_payload(&mut state, &ctx, &mut info, &payload_tx)?;
                     return Ok(());
                 }
                 Err(err) => {
@@ -536,7 +526,7 @@ where
                         &span,
                         "Payload building complete, channel closed or job cancelled",
                     );
-                    self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                    self.finalize_payload(&mut state, &ctx, &mut info, &payload_tx)?;
                     return Ok(());
                 }
             }
@@ -554,7 +544,6 @@ where
         state: &mut State<DB>,
         best_txs: &mut NextBestFlashblocksTxs<Pool>,
         block_cancel: &CancellationToken,
-        best_payload: &BlockCell<BaseBuiltPayload>,
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
         executed_sender_nonces: &mut HashMap<Address, u64>,
@@ -769,12 +758,11 @@ where
                     return Ok(None);
                 }
 
-                // Send to handler and set best_payload outside mutex.
+                // Send to handler outside mutex.
                 self.payload_tx
                     .send(new_payload.clone())
                     .await
                     .wrap_err("failed to send built payload to handler")?;
-                best_payload.set(new_payload);
 
                 // Record flashblock build duration
                 let flashblock_build_duration = flashblock_build_start_time.elapsed();
@@ -916,13 +904,13 @@ where
         span.record("flashblock_count", ctx.flashblock_index());
     }
 
-    /// Finalize the payload by computing the state root and setting the finalized cell.
+    /// Finalize the payload by computing the state root and publishing via the watch channel.
     fn finalize_payload<DB, P>(
         &self,
         state: &mut State<DB>,
         ctx: &BasePayloadBuilderCtx,
         info: &mut ExecutionInfo,
-        finalized_cell: &BlockCell<BaseBuiltPayload>,
+        payload_tx: &watch::Sender<Option<BaseBuiltPayload>>,
     ) -> Result<(), PayloadBuilderError>
     where
         DB: Database<Error = ProviderError> + AsRef<P>,
@@ -945,7 +933,7 @@ where
             "Finalized payload with state root"
         );
 
-        finalized_cell.set(final_payload);
+        payload_tx.send_replace(Some(final_payload));
 
         Ok(())
     }
@@ -1055,9 +1043,9 @@ where
     async fn try_build(
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-        best_payload: BlockCell<Self::BuiltPayload>,
+        payload_tx: watch::Sender<Option<Self::BuiltPayload>>,
     ) -> Result<(), PayloadBuilderError> {
-        self.build_payload(args, best_payload).await
+        self.build_payload(args, payload_tx).await
     }
 }
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -253,7 +253,7 @@ where
     async fn build_payload(
         &self,
         args: BuildArguments<BasePayloadBuilderAttributes<BaseTransactionSigned>, BaseBuiltPayload>,
-        payload_tx: watch::Sender<Option<BaseBuiltPayload>>,
+        payload_tx: &watch::Sender<Option<BaseBuiltPayload>>,
     ) -> Result<(), PayloadBuilderError> {
         let block_build_start_time = Instant::now();
         let BuildArguments { mut cached_reads, config, cancel: block_cancel, publish_guard } = args;
@@ -472,7 +472,7 @@ where
                     &span,
                     "Payload building complete, target flashblock count reached",
                 );
-                self.finalize_payload(&mut state, &ctx, &mut info, &payload_tx)?;
+                self.finalize_payload(&mut state, &ctx, &mut info, payload_tx)?;
                 return Ok(());
             }
 
@@ -499,7 +499,7 @@ where
                         &span,
                         "Payload building complete, job cancelled or target flashblock count reached",
                     );
-                    self.finalize_payload(&mut state, &ctx, &mut info, &payload_tx)?;
+                    self.finalize_payload(&mut state, &ctx, &mut info, payload_tx)?;
                     return Ok(());
                 }
                 Err(err) => {
@@ -526,7 +526,7 @@ where
                         &span,
                         "Payload building complete, channel closed or job cancelled",
                     );
-                    self.finalize_payload(&mut state, &ctx, &mut info, &payload_tx)?;
+                    self.finalize_payload(&mut state, &ctx, &mut info, payload_tx)?;
                     return Ok(());
                 }
             }
@@ -1043,7 +1043,7 @@ where
     async fn try_build(
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-        payload_tx: watch::Sender<Option<Self::BuiltPayload>>,
+        payload_tx: &watch::Sender<Option<Self::BuiltPayload>>,
     ) -> Result<(), PayloadBuilderError> {
         self.build_payload(args, payload_tx).await
     }

--- a/crates/builder/core/src/flashblocks/traits.rs
+++ b/crates/builder/core/src/flashblocks/traits.rs
@@ -2,8 +2,9 @@
 
 use reth_payload_builder::PayloadBuilderError;
 use reth_payload_primitives::{BuiltPayload, PayloadAttributes};
+use tokio::sync::watch;
 
-use crate::{BlockCell, BuildArguments};
+use crate::BuildArguments;
 
 /// A trait for building payloads that encapsulate Ethereum transactions.
 ///
@@ -25,6 +26,8 @@ pub trait PayloadBuilder: Send + Sync + Clone {
     /// # Arguments
     ///
     /// - `args`: Build arguments containing necessary components.
+    /// - `payload_tx`: Watch sender; send the finalized payload here when ready.
+    ///   Dropping it without sending signals failure to [`ResolvePayload`].
     ///
     /// # Returns
     ///
@@ -32,6 +35,6 @@ pub trait PayloadBuilder: Send + Sync + Clone {
     async fn try_build(
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-        best_payload: BlockCell<Self::BuiltPayload>,
+        payload_tx: watch::Sender<Option<Self::BuiltPayload>>,
     ) -> Result<(), PayloadBuilderError>;
 }

--- a/crates/builder/core/src/flashblocks/traits.rs
+++ b/crates/builder/core/src/flashblocks/traits.rs
@@ -27,7 +27,9 @@ pub trait PayloadBuilder: Send + Sync + Clone {
     ///
     /// - `args`: Build arguments containing necessary components.
     /// - `payload_tx`: Watch sender; send the finalized payload here when ready.
-    ///   Dropping it without sending signals failure to [`ResolvePayload`].
+    ///   Dropping it without sending signals failure to [`ResolvePayload`]. Taken by
+    ///   reference so the caller retains ownership and controls when it drops, ensuring
+    ///   any failure cause is recorded before the drop is observable by the receiver.
     ///
     /// # Returns
     ///
@@ -35,6 +37,6 @@ pub trait PayloadBuilder: Send + Sync + Clone {
     async fn try_build(
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-        payload_tx: watch::Sender<Option<Self::BuiltPayload>>,
+        payload_tx: &watch::Sender<Option<Self::BuiltPayload>>,
     ) -> Result<(), PayloadBuilderError>;
 }

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -41,10 +41,9 @@ pub use rejection_cache::RejectionCache;
 
 mod flashblocks;
 pub use flashblocks::{
-    BasePayloadBuilderCtx, BestFlashblocksTxs, BlockCell, BlockPayloadJob,
-    BlockPayloadJobGenerator, BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome,
-    FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
-    WaitForValue,
+    BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
+    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
+    FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
 };
 
 mod extension;


### PR DESCRIPTION
Replace the custom `BlockCell<T>` / `WaitForValue<T>` pair and the `build_complete: oneshot::Receiver` field with a single `tokio::sync::watch` channel per payload job.

Previously, when state-root computation failed, `finalized_cell` was never set. `ResolvePayload` would then wait forever on `WaitForValue`, causing `engine_getPayload` to hang indefinitely. The consensus engine's `SealTask` never returned, `engine.drain()` blocked, and the EL appeared to stop receiving CL updates.

With this change, the build task holds a `watch::Sender<Option<T>>`. It sends the finalized payload on success; if it returns an error or panics the sender is dropped. `ResolvePayload` uses `rx.wait_for(|v| v.is_some())` — when the sender drops without sending, `wait_for` returns `Err(RecvError)`, which maps to `Err(MissingPayload)`. The consensus engine receives a Temporary error and retries rather than stalling indefinitely.

Adapted from https://github.com/flashbots/op-rbuilder/pull/438