### PR TITLE
fix(ci): build load tester binary in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 jobs:
-  # Build base-reth-node, base-builder, and base-load-test together, cached by source hash
+  # Build base-reth-node, base-builder, and base-load-tester together, cached by source hash
   build-binaries:
     name: Build binaries
     runs-on: ubuntu-latest
@@ -66,11 +66,11 @@ jobs:
           cargo build --locked --bin base-builder --profile maxperf
           cp target/maxperf/base-builder ~/bin/base-builder
 
-      - name: Build base-load-test
+      - name: Build base-load-tester
         if: steps.cache-binaries.outputs.cache-hit != 'true'
         run: |
-          cargo build --locked -p base-load-tests --bin base-load-test --profile maxperf
-          cp target/maxperf/base-load-test ~/bin/base-load-test
+          cargo build --locked -p base-load-tester-bin --bin base-load-tester --profile maxperf
+          cp target/maxperf/base-load-tester ~/bin/base-load-test
 
       - name: Verify binaries exist
         run: |


### PR DESCRIPTION
## Summary

Updates the benchmark workflow to build the current load tester binary package.

The load tester now lives in `bin/load-tester` as package `base-load-tester-bin` with bin target `base-load-tester`, but the benchmark workflow still tries to build `base-load-tests --bin base-load-test`. The `base-load-tests` package is now a library package and no longer exposes that binary target.

This keeps the copied artifact name as `base-load-test` so the downstream benchmark runner invocation does not need to change.

## Why

The manual `Benchmark` workflow currently fails during the binary build stage before it can run the benchmark or upload benchmark artifacts.

## Changes

- Build `base-load-tester-bin --bin base-load-tester`
- Copy `target/maxperf/base-load-tester` to the existing expected artifact path: `~/bin/base-load-test`
- Update the workflow step/comment wording from `base-load-test` to `base-load-tester`

## Validation

- Checked Cargo metadata locally:
  - `base-load-tester-bin` exposes bin target `base-load-tester`
  - `base-load-tests` no longer exposes `base-load-test`
- Did not run the full benchmark workflow locally