### PR TITLE
refactor(proof): always propose against finalized head, drop allow_non_finalized

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -51,10 +51,6 @@ pub struct ProposerArgs {
     #[arg(long = "dry-run", env = cli_env!("DRY_RUN"))]
     pub dry_run: bool,
 
-    /// Allow proposals based on non-finalized L1 data.
-    #[arg(long = "allow-non-finalized", env = cli_env!("ALLOW_NON_FINALIZED"))]
-    pub allow_non_finalized: bool,
-
     /// URL of the prover RPC endpoint.
     #[arg(long = "prover-rpc", env = cli_env!("PROVER_RPC"))]
     pub prover_rpc: Url,

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -15,8 +15,6 @@ use crate::cli::Cli;
 pub struct ProposerConfig {
     /// Dry-run mode: source proofs but do not submit transactions onchain.
     pub dry_run: bool,
-    /// Allow proposals based on non-finalized L1 data.
-    pub allow_non_finalized: bool,
     /// URL of the prover RPC endpoint.
     pub prover_rpc: Url,
     /// Prover RPC request timeout.
@@ -120,7 +118,6 @@ impl ProposerConfig {
 
         Ok(Self {
             dry_run: proposer.dry_run,
-            allow_non_finalized: proposer.allow_non_finalized,
             prover_rpc: proposer.prover_rpc,
             prover_timeout: proposer.prover_timeout,
             l1_eth_rpc: proposer.l1_eth_rpc,
@@ -194,7 +191,6 @@ mod tests {
     #[test]
     fn test_valid_config_maps_cli_fields() {
         let mut cli = minimal_cli();
-        cli.proposer.allow_non_finalized = true;
         cli.proposer.rpc_max_retries = 7;
         cli.proposer.recovery_scan_concurrency = 4.try_into().unwrap();
         cli.admin.admin_enabled = true;
@@ -202,7 +198,6 @@ mod tests {
         let config = ProposerConfig::from_cli(cli).unwrap();
 
         assert!(!config.dry_run);
-        assert!(config.allow_non_finalized);
         assert_eq!(config.game_type, 1);
         assert_eq!(config.retry.max_attempts, Some(7));
         assert_eq!(config.recovery_scan_concurrency, 4);

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -43,9 +43,6 @@ pub struct DriverConfig {
     pub intermediate_block_interval: u64,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
-    /// If true, use `safe_l2` (derived from L1 but L1 not yet finalized).
-    /// If false (default), use `finalized_l2` (derived from finalized L1).
-    pub allow_non_finalized: bool,
     /// Address of the proposer that submits proof transactions onchain.
     /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
     pub proposer_address: Address,
@@ -67,7 +64,6 @@ impl Default for DriverConfig {
             block_interval: 512,
             intermediate_block_interval: 512,
             game_type: 0,
-            allow_non_finalized: false,
             proposer_address: Address::ZERO,
             tee_image_hash: B256::ZERO,
             anchor_state_registry_address: Address::ZERO,
@@ -287,7 +283,6 @@ mod tests {
                 block_interval: config.block_interval,
                 intermediate_block_interval: config.intermediate_block_interval,
                 game_type: config.game_type,
-                allow_non_finalized: config.allow_non_finalized,
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
             },

--- a/crates/proof/proposer/src/metrics.rs
+++ b/crates/proof/proposer/src/metrics.rs
@@ -29,9 +29,15 @@ base_metrics::define_metrics! {
     #[label(name = "status", default = ["queued", "running", "succeeded", "failed"])]
     proof_status_received_total: counter,
 
-    #[describe("Latest safe (or finalized) L2 block number")]
+    // `safe_head` is kept as a deprecated alias for a zero-downtime metric rename;
+    // drop it once every Datadog monitor/dashboard uses `finalized_head`.
+    #[describe("Deprecated alias of finalized_head. Latest finalized L2 block number")]
     #[no_zero]
     safe_head: gauge,
+
+    #[describe("Latest finalized L2 block number")]
+    #[no_zero]
+    finalized_head: gauge,
 
     #[describe("Total number of L2 output proposals submitted")]
     l2_output_proposals_total: counter,

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -62,7 +62,7 @@ where
     /// Runs the proving pipeline until cancelled.
     ///
     /// Each session starts a dispatcher task and a collector task. The
-    /// dispatcher can run ahead up to the safe head, while the collector
+    /// dispatcher can run ahead up to the finalized head, while the collector
     /// submits ready proofs in order from an internal cursor. Outcomes that
     /// cannot safely advance that cursor restart both tasks from a fresh
     /// recovery walk.
@@ -121,10 +121,11 @@ where
             {
                 let _tick_timer = base_metrics::timed!(Metrics::tick_duration_seconds());
 
-                if let Some((recovered, safe_head)) =
+                if let Some((recovered, finalized_head)) =
                     self.proof_recovery.try_recover_and_plan(&mut cache).await
                 {
-                    Metrics::safe_head().set(safe_head as f64);
+                    Metrics::safe_head().set(finalized_head as f64);
+                    Metrics::finalized_head().set(finalized_head as f64);
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
                     // Dispatch failures retry from the in-memory cursor. A fresh recovery walk is
@@ -138,7 +139,7 @@ where
                     let current = cursor
                         .as_mut()
                         .expect("dispatcher cursor initialized from recovered state");
-                    self.proof_dispatcher.tick(current, safe_head).await;
+                    self.proof_dispatcher.tick(current, finalized_head).await;
 
                     dispatched_through.store(current.l2_block_number, Ordering::Relaxed);
                 }
@@ -157,10 +158,11 @@ where
             let restart = {
                 let _tick_timer = base_metrics::timed!(Metrics::collector_tick_duration_seconds());
 
-                if let Some((recovered, safe_head)) =
+                if let Some((recovered, finalized_head)) =
                     self.proof_recovery.try_recover_and_plan(&mut cache).await
                 {
-                    Metrics::safe_head().set(safe_head as f64);
+                    Metrics::safe_head().set(finalized_head as f64);
+                    Metrics::finalized_head().set(finalized_head as f64);
                     Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
 
                     if cursor_source != Some(recovered) || cursor.is_none() {
@@ -173,7 +175,7 @@ where
                     self.proof_collector
                         .tick(
                             current,
-                            safe_head,
+                            finalized_head,
                             dispatched_through.load(Ordering::Relaxed),
                             cancel,
                         )
@@ -300,7 +302,6 @@ mod tests {
                 block_interval: config.block_interval,
                 intermediate_block_interval: config.intermediate_block_interval,
                 game_type: config.game_type,
-                allow_non_finalized: config.allow_non_finalized,
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
             },

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -71,7 +71,7 @@ where
     pub async fn tick(
         &self,
         current: &mut RecoveredState,
-        safe_head: u64,
+        finalized_head: u64,
         dispatched_through: u64,
         cancel: &CancellationToken,
     ) -> bool {
@@ -90,12 +90,12 @@ where
                 return false;
             };
 
-            if target_block > safe_head {
+            if target_block > finalized_head {
                 debug!(
                     current_block = current.l2_block_number,
                     target_block,
-                    safe_head,
-                    "Safe head below collection target, waiting for L2 head to advance"
+                    finalized_head,
+                    "Finalized head below collection target, waiting for L2 head to advance"
                 );
                 return false;
             }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -255,25 +255,19 @@ mod tests {
         )
     }
 
-    fn sync_status_with_distinct_heads(
-        finalized_l2_number: u64,
-        safe_l2_number: u64,
-    ) -> SyncStatus {
-        let mut sync_status = test_sync_status(safe_l2_number, B256::repeat_byte(0x52));
+    fn sync_status_with_finalized_head(finalized_l2_number: u64) -> SyncStatus {
+        let mut sync_status = test_sync_status(finalized_l2_number, B256::repeat_byte(0x52));
         sync_status.finalized_l1 = test_l1_block_ref(10);
         sync_status.finalized_l1.hash = B256::repeat_byte(0xf1);
-        sync_status.safe_l1 = test_l1_block_ref(20);
-        sync_status.safe_l1.hash = B256::repeat_byte(0x5a);
         sync_status.finalized_l2 = test_l2_block_ref(finalized_l2_number, B256::repeat_byte(0xf2));
         sync_status.finalized_l2.l1origin.number = sync_status.finalized_l1.number;
-        sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number;
         sync_status
     }
 
     fn headers_for_sync_status(
         sync_status: &SyncStatus,
     ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
-        [sync_status.finalized_l1, sync_status.safe_l1]
+        [sync_status.finalized_l1]
             .into_iter()
             .map(|l1_head| (l1_head.hash, test_l1_header(l1_head.hash, l1_head.number)))
             .collect()
@@ -281,7 +275,7 @@ mod tests {
 
     #[test]
     fn select_l1_head_selects_finalized_head_or_rejects_target() {
-        let sync_status = sync_status_with_distinct_heads(300, 600);
+        let sync_status = sync_status_with_finalized_head(300);
 
         let finalized_l1 = ProofDispatcher::select_l1_head_for_target(200, &sync_status).unwrap();
         assert_eq!(finalized_l1.hash, B256::repeat_byte(0xf1));
@@ -293,7 +287,7 @@ mod tests {
 
     #[test]
     fn select_l1_head_rejects_l2_origin_beyond_finalized_l1_head() {
-        let mut sync_status = sync_status_with_distinct_heads(300, 600);
+        let mut sync_status = sync_status_with_finalized_head(300);
         sync_status.finalized_l2.l1origin.number = sync_status.finalized_l1.number + 1;
 
         let err = ProofDispatcher::select_l1_head_for_target(200, &sync_status)
@@ -304,7 +298,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_request_rejects_l1_rpc_header_mismatch() {
-        let sync_status = sync_status_with_distinct_heads(300, 600);
+        let sync_status = sync_status_with_finalized_head(300);
         let mut headers = headers_for_sync_status(&sync_status);
         headers.insert(
             sync_status.finalized_l1.hash,

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -264,15 +264,6 @@ mod tests {
         sync_status
     }
 
-    fn headers_for_sync_status(
-        sync_status: &SyncStatus,
-    ) -> HashMap<B256, alloy_rpc_types_eth::Header> {
-        [sync_status.finalized_l1]
-            .into_iter()
-            .map(|l1_head| (l1_head.hash, test_l1_header(l1_head.hash, l1_head.number)))
-            .collect()
-    }
-
     #[test]
     fn select_l1_head_selects_finalized_head_or_rejects_target() {
         let sync_status = sync_status_with_finalized_head(300);
@@ -299,11 +290,12 @@ mod tests {
     #[tokio::test]
     async fn build_request_rejects_l1_rpc_header_mismatch() {
         let sync_status = sync_status_with_finalized_head(300);
-        let mut headers = headers_for_sync_status(&sync_status);
-        headers.insert(
+        // Map the finalized L1 head hash to a header with a mismatched number to
+        // force the RPC-header mismatch path.
+        let headers = HashMap::from([(
             sync_status.finalized_l1.hash,
             test_l1_header(sync_status.finalized_l1.hash, sync_status.finalized_l1.number + 1),
-        );
+        )]);
         let dispatcher = ProofDispatcher::new(
             Arc::new(MockProofRequester::default()),
             Arc::new(MockL1 {

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -21,8 +21,6 @@ use crate::{
 /// Static parameters needed to build and dispatch proposer proof requests.
 #[derive(Debug, Clone, Copy)]
 pub struct ProofDispatcherConfig {
-    /// Whether requests may target safe, non-finalized L2 blocks.
-    pub allow_non_finalized: bool,
     /// Number of L2 blocks between proof targets.
     pub block_interval: u64,
     /// Address of the proposer that will submit the proof onchain.
@@ -36,7 +34,6 @@ pub struct ProofDispatcherConfig {
 impl From<&DriverConfig> for ProofDispatcherConfig {
     fn from(config: &DriverConfig) -> Self {
         Self {
-            allow_non_finalized: config.allow_non_finalized,
             block_interval: config.block_interval,
             proposer_address: config.proposer_address,
             intermediate_block_interval: config.intermediate_block_interval,
@@ -84,16 +81,12 @@ impl ProofDispatcher {
             self.l2_client.header_by_number(BlockNumberOrTag::Number(recovered.l2_block_number)),
         )
         .map_err(ProposerError::Rpc)?;
-        let (l1_head_source, l1_head) = Self::select_l1_head_for_target(
-            target_block,
-            &sync_status,
-            self.config.allow_non_finalized,
-        )?;
+        let l1_head = Self::select_l1_head_for_target(target_block, &sync_status)?;
         let l1_header =
             self.l1_client.header_by_hash(l1_head.hash).await.map_err(ProposerError::Rpc)?;
         if l1_header.hash != l1_head.hash || l1_header.number != l1_head.number {
             return Err(ProposerError::Internal(format!(
-                "selected {l1_head_source} L1 head {}:{} does not match L1 RPC header {}:{}",
+                "selected finalized L1 head {}:{} does not match L1 RPC header {}:{}",
                 l1_head.number, l1_head.hash, l1_header.number, l1_header.hash
             )));
         }
@@ -101,8 +94,6 @@ impl ProofDispatcher {
         info!(
             from_block = recovered.l2_block_number,
             to_block = target_block,
-            allow_non_finalized = self.config.allow_non_finalized,
-            l1_head_source = l1_head_source,
             l1_head_number = l1_header.number,
             l1_head_hash = %l1_header.hash,
             agreed_l2_head_hash = %agreed_l2_head.hash,
@@ -127,33 +118,24 @@ impl ProofDispatcher {
     fn select_l1_head_for_target(
         target_block: u64,
         sync_status: &SyncStatus,
-        allow_non_finalized: bool,
-    ) -> Result<(&'static str, L1BlockRef), ProposerError> {
-        let (l1_head_source, l1_head, l2_coverage) =
-            if target_block <= sync_status.finalized_l2.number {
-                ("finalized", sync_status.finalized_l1, sync_status.finalized_l2)
-            } else if !allow_non_finalized {
-                return Err(ProposerError::Internal(format!(
-                    "target block {target_block} is above rollup finalized head {}",
-                    sync_status.finalized_l2.number
-                )));
-            } else if target_block <= sync_status.safe_l2.number {
-                ("safe", sync_status.safe_l1, sync_status.safe_l2)
-            } else {
-                return Err(ProposerError::Internal(format!(
-                    "target block {target_block} is above rollup safe head {}",
-                    sync_status.safe_l2.number
-                )));
-            };
-
-        if l1_head.number < l2_coverage.l1origin.number {
+    ) -> Result<L1BlockRef, ProposerError> {
+        if target_block > sync_status.finalized_l2.number {
             return Err(ProposerError::Internal(format!(
-                "selected {l1_head_source} L1 head {} is below {l1_head_source} L2 origin {}",
-                l1_head.number, l2_coverage.l1origin.number
+                "target block {target_block} is above rollup finalized head {}",
+                sync_status.finalized_l2.number
             )));
         }
 
-        Ok((l1_head_source, l1_head))
+        let l1_head = sync_status.finalized_l1;
+        let l1_origin = sync_status.finalized_l2.l1origin.number;
+        if l1_head.number < l1_origin {
+            return Err(ProposerError::Internal(format!(
+                "selected finalized L1 head {} is below finalized L2 origin {l1_origin}",
+                l1_head.number
+            )));
+        }
+
+        Ok(l1_head)
     }
 
     async fn dispatch_request(&self, request: ProofRequest) -> Result<String, ProposerError> {
@@ -176,20 +158,20 @@ impl ProofDispatcher {
         }
     }
 
-    /// Dispatches every target from the current dispatcher cursor up to `safe_head`.
-    pub async fn tick(&self, current: &mut RecoveredState, safe_head: u64) {
+    /// Dispatches every target from the current dispatcher cursor up to `finalized_head`.
+    pub async fn tick(&self, current: &mut RecoveredState, finalized_head: u64) {
         loop {
             let Some(target_block) =
                 ProofTarget::next_block(current.l2_block_number, self.config.block_interval)
             else {
                 break;
             };
-            if target_block > safe_head {
+            if target_block > finalized_head {
                 debug!(
                     current_block = current.l2_block_number,
                     target_block,
-                    safe_head,
-                    "Safe head below dispatch target, waiting for L2 head to advance"
+                    finalized_head,
+                    "Finalized head below dispatch target, waiting for L2 head to advance"
                 );
                 break;
             }
@@ -298,36 +280,26 @@ mod tests {
     }
 
     #[test]
-    fn select_l1_head_selects_expected_head_or_rejects_target() {
+    fn select_l1_head_selects_finalized_head_or_rejects_target() {
         let sync_status = sync_status_with_distinct_heads(300, 600);
-        let (source, finalized_l1) =
-            ProofDispatcher::select_l1_head_for_target(200, &sync_status, true).unwrap();
-        assert_eq!(source, "finalized");
+
+        let finalized_l1 = ProofDispatcher::select_l1_head_for_target(200, &sync_status).unwrap();
         assert_eq!(finalized_l1.hash, B256::repeat_byte(0xf1));
         assert_eq!(finalized_l1.number, 10);
 
-        let (source, safe_l1) =
-            ProofDispatcher::select_l1_head_for_target(400, &sync_status, true).unwrap();
-        assert_eq!(source, "safe");
-        assert_eq!(safe_l1.hash, B256::repeat_byte(0x5a));
-        assert_eq!(safe_l1.number, 20);
-
-        let err = ProofDispatcher::select_l1_head_for_target(700, &sync_status, true).unwrap_err();
-        assert!(err.to_string().contains("above rollup safe head"));
-
-        let err = ProofDispatcher::select_l1_head_for_target(400, &sync_status, false).unwrap_err();
+        let err = ProofDispatcher::select_l1_head_for_target(400, &sync_status).unwrap_err();
         assert!(err.to_string().contains("above rollup finalized head"));
     }
 
     #[test]
-    fn select_l1_head_rejects_l2_coverage_beyond_selected_l1_head() {
+    fn select_l1_head_rejects_l2_origin_beyond_finalized_l1_head() {
         let mut sync_status = sync_status_with_distinct_heads(300, 600);
-        sync_status.safe_l2.l1origin.number = sync_status.safe_l1.number + 1;
+        sync_status.finalized_l2.l1origin.number = sync_status.finalized_l1.number + 1;
 
-        let err = ProofDispatcher::select_l1_head_for_target(400, &sync_status, true)
-            .expect_err("safe L1 must cover selected safe L2 origin");
+        let err = ProofDispatcher::select_l1_head_for_target(200, &sync_status)
+            .expect_err("finalized L1 must cover finalized L2 origin");
 
-        assert!(err.to_string().contains("below safe L2 origin"));
+        assert!(err.to_string().contains("below finalized L2 origin"));
     }
 
     #[tokio::test]
@@ -335,8 +307,8 @@ mod tests {
         let sync_status = sync_status_with_distinct_heads(300, 600);
         let mut headers = headers_for_sync_status(&sync_status);
         headers.insert(
-            sync_status.safe_l1.hash,
-            test_l1_header(sync_status.safe_l1.hash, sync_status.safe_l1.number + 1),
+            sync_status.finalized_l1.hash,
+            test_l1_header(sync_status.finalized_l1.hash, sync_status.finalized_l1.number + 1),
         );
         let dispatcher = ProofDispatcher::new(
             Arc::new(MockProofRequester::default()),
@@ -351,7 +323,6 @@ mod tests {
                 max_safe_block: None,
             }),
             ProofDispatcherConfig {
-                allow_non_finalized: true,
                 block_interval: 100,
                 proposer_address: Address::repeat_byte(0x04),
                 intermediate_block_interval: 300,
@@ -365,7 +336,7 @@ mod tests {
         };
 
         let err = dispatcher
-            .build_request(400, &recovered, B256::repeat_byte(0xaa))
+            .build_request(200, &recovered, B256::repeat_byte(0xaa))
             .await
             .expect_err("L1 RPC header must match rollup-selected L1 head");
 
@@ -400,7 +371,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tick_dispatches_all_targets_up_to_safe_head() {
+    async fn tick_dispatches_all_targets_up_to_finalized_head() {
         let requester = Arc::new(MockProofRequester::default());
         let dispatcher = dispatcher(Arc::clone(&requester));
         let mut current = RecoveredState {

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -104,7 +104,7 @@ impl ProofRecovery {
             }
         }
 
-        let state = match self.recover_latest_state(cache).await {
+        let state = match self.recover_latest_state(cache, finalized_head).await {
             Ok(s) => s,
             Err(e) => {
                 warn!(error = %e, "Failed to recover onchain state, retrying next tick");
@@ -116,10 +116,11 @@ impl ProofRecovery {
     }
 
     /// Recovers the latest onchain state using a deterministic forward walk
-    /// from the anchor root.
+    /// from the anchor root, bounded by `finalized_head`.
     pub async fn recover_latest_state(
         &self,
         cache: &mut Option<ProofRecoveryCache>,
+        finalized_head: u64,
     ) -> Result<RecoveredState, ProposerError> {
         let count = self
             .factory_client
@@ -138,15 +139,21 @@ impl ProofRecovery {
         let usable_cache =
             cache.as_ref().filter(|cached| anchor.l2_block_number <= cached.state.l2_block_number);
 
+        // Trust the cache only when no new games appeared AND finalized has not
+        // advanced far enough to admit the next already-existing game. The walk
+        // is bounded by finalized_head, so a rising finalized head can extend the
+        // cursor over games that already existed (game_count unchanged).
         if let Some(cached) = usable_cache
             && cached.game_count == count
+            && ProofTarget::next_block(cached.state.l2_block_number, self.config.block_interval)
+                .is_none_or(|next_block| next_block > finalized_head)
         {
             debug!(game_count = count, "No changes since last recovery, returning cached state");
             return Ok(cached.state);
         }
 
         let start = match usable_cache {
-            Some(cached) if count > cached.game_count => {
+            Some(cached) if count >= cached.game_count => {
                 debug!(
                     cached_block = cached.state.l2_block_number,
                     old_count = cached.game_count,
@@ -170,20 +177,30 @@ impl ProofRecovery {
             }
         };
 
-        let state = self.forward_walk(&start).await?;
+        let state = self.forward_walk(&start, finalized_head).await?;
 
         *cache = Some(ProofRecoveryCache { game_count: count, state });
         Ok(state)
     }
 
     /// Performs a deterministic forward walk to find the latest verified game
-    /// using UUID-based `games()` lookups.
-    async fn forward_walk(&self, start: &RecoveredState) -> Result<RecoveredState, ProposerError> {
+    /// using UUID-based `games()` lookups, stopping at `finalized_head` so the
+    /// recovered cursor never anchors on a non-finalized game.
+    async fn forward_walk(
+        &self,
+        start: &RecoveredState,
+        finalized_head: u64,
+    ) -> Result<RecoveredState, ProposerError> {
         let mut state = *start;
 
         while let Some(expected_block) =
             ProofTarget::next_block(state.l2_block_number, self.config.block_interval)
         {
+            if expected_block > finalized_head {
+                debug!(expected_block, finalized_head, "Reached finalized head, ending walk");
+                break;
+            }
+
             // Fetch all intermediate roots, including the canonical root for
             // `expected_block`, from the rollup node in one batch.
             let intermediate_blocks = ProposalIntervals::intermediate_block_numbers(
@@ -382,7 +399,7 @@ mod tests {
         recovery: &ProofRecovery,
     ) -> (RecoveredState, Option<ProofRecoveryCache>) {
         let mut cache: Option<ProofRecoveryCache> = None;
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let state = recovery.recover_latest_state(&mut cache, u64::MAX).await.unwrap();
         (state, cache)
     }
 
@@ -461,7 +478,7 @@ mod tests {
         let recovery = recovery(factory, output_roots);
 
         let mut cache: Option<ProofRecoveryCache> = None;
-        let result = recovery.recover_latest_state(&mut cache).await;
+        let result = recovery.recover_latest_state(&mut cache, u64::MAX).await;
 
         assert!(matches!(result, Err(ProposerError::Contract(_))));
     }
@@ -487,6 +504,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_recovery_walk_bounded_by_finalized_head() {
+        // Games exist on-chain for blocks 1..=4, but finalized only covers block 2.
+        let (factory, output_roots) = game_chain(4);
+        let recovery = recovery(factory, output_roots);
+
+        let mut cache: Option<ProofRecoveryCache> = None;
+        let state =
+            recovery.recover_latest_state(&mut cache, TEST_BLOCK_INTERVAL * 2).await.unwrap();
+        assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL * 2, "walk stops at finalized head");
+        assert_eq!(state.parent_address, proxy_addr(1), "cursor is the last finalized game");
+
+        // Finalized rises to cover every game. game_count is unchanged, yet the
+        // cursor must still advance over the games that already existed.
+        let state =
+            recovery.recover_latest_state(&mut cache, TEST_BLOCK_INTERVAL * 4).await.unwrap();
+        assert_eq!(
+            state.l2_block_number,
+            TEST_BLOCK_INTERVAL * 4,
+            "cursor advances when finalized rises, without any new game"
+        );
+        assert_eq!(state.parent_address, proxy_addr(3));
+    }
+
+    #[tokio::test]
     async fn test_recovery_cache_hit_equal_game_count() {
         let (factory, output_roots) = game_chain(1);
         let game_proxy = proxy_addr(0);
@@ -499,7 +540,9 @@ mod tests {
         assert_eq!(state1.l2_block_number, TEST_BLOCK_INTERVAL);
         assert_eq!(cache.as_ref().unwrap().game_count, 1);
 
-        let state2 = recovery.recover_latest_state(&mut cache).await.unwrap();
+        // finalized_head leaves no room past the cached tip, so the short-circuit
+        // returns the cached state without re-walking.
+        let state2 = recovery.recover_latest_state(&mut cache, TEST_BLOCK_INTERVAL).await.unwrap();
         assert_eq!(state2, state1);
     }
 
@@ -510,7 +553,7 @@ mod tests {
         let mut cache = cache(3, proxy_addr(2), B256::repeat_byte(0x03), TEST_BLOCK_INTERVAL * 3);
 
         let recovery = recovery(factory, output_roots);
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let state = recovery.recover_latest_state(&mut cache, u64::MAX).await.unwrap();
 
         assert_eq!(state.parent_address, proxy_addr(4), "should reach game 4 from cached tip");
         assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL * 5);
@@ -527,7 +570,7 @@ mod tests {
 
         let mut cache = cache(1, proxy_addr(0), B256::repeat_byte(0x01), TEST_BLOCK_INTERVAL);
 
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let state = recovery.recover_latest_state(&mut cache, u64::MAX).await.unwrap();
 
         assert_eq!(state.parent_address, proxy_addr(0), "should remain at game 0");
         assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL);
@@ -541,7 +584,7 @@ mod tests {
         let mut cache = cache(5, proxy_addr(99), B256::repeat_byte(0xDD), 5 * TEST_BLOCK_INTERVAL);
 
         let recovery = recovery(factory, output_roots);
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let state = recovery.recover_latest_state(&mut cache, u64::MAX).await.unwrap();
 
         assert_eq!(state.parent_address, proxy_addr(0), "reorg: should find the 1 remaining game");
         assert_eq!(state.l2_block_number, TEST_BLOCK_INTERVAL);
@@ -565,7 +608,7 @@ mod tests {
             TEST_BLOCK_INTERVAL,
             None,
         );
-        let state = recovery.recover_latest_state(&mut cache).await.unwrap();
+        let state = recovery.recover_latest_state(&mut cache, u64::MAX).await.unwrap();
 
         assert_eq!(state.parent_address, proxy_addr(0));
         assert_eq!(state.l2_block_number, anchor_block + TEST_BLOCK_INTERVAL);

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -24,8 +24,6 @@ pub struct ProofRecoveryConfig {
     pub intermediate_block_interval: u64,
     /// Dispute game type used for proposals.
     pub game_type: u32,
-    /// Whether recovery may use the safe head rather than finalized head.
-    pub allow_non_finalized: bool,
     /// Address used as the parent sentinel when the anchor has no game.
     pub anchor_state_registry_address: Address,
     /// Maximum number of concurrent rollup RPC calls during root fetching.
@@ -66,7 +64,7 @@ impl ProofRecovery {
         Self { config, rollup_client, anchor_registry, factory_client }
     }
 
-    /// Attempts to recover onchain state and fetch the safe head.
+    /// Attempts to recover onchain state and fetch the finalized head.
     ///
     /// Returns `None` if either step fails (logged as warnings), allowing the
     /// caller to fall through to the poll-tick sleep.
@@ -77,15 +75,11 @@ impl ProofRecovery {
         let sync_status = match self.rollup_client.sync_status().await {
             Ok(status) => status,
             Err(e) => {
-                warn!(error = %e, "Failed to fetch safe head, retrying next tick");
+                warn!(error = %e, "Failed to fetch sync status, retrying next tick");
                 return None;
             }
         };
-        let safe_head = if self.config.allow_non_finalized {
-            sync_status.safe_l2.number
-        } else {
-            sync_status.finalized_l2.number
-        };
+        let finalized_head = sync_status.finalized_l2.number;
 
         if let Some(cached) = cache.as_ref() {
             let Some(next_proposal_block) =
@@ -99,14 +93,14 @@ impl ProofRecovery {
                 return None;
             };
 
-            if safe_head < next_proposal_block {
+            if finalized_head < next_proposal_block {
                 debug!(
-                    safe_head,
+                    finalized_head,
                     cached_block = cached.state.l2_block_number,
                     next_proposal_block,
-                    "Safe head below next proposal target, skipping recovery"
+                    "Finalized head below next proposal target, skipping recovery"
                 );
-                return Some((cached.state, safe_head));
+                return Some((cached.state, finalized_head));
             }
         }
 
@@ -118,7 +112,7 @@ impl ProofRecovery {
             }
         };
 
-        Some((state, safe_head))
+        Some((state, finalized_head))
     }
 
     /// Recovers the latest onchain state using a deterministic forward walk
@@ -371,7 +365,6 @@ mod tests {
                 block_interval,
                 intermediate_block_interval,
                 game_type: TEST_GAME_TYPE,
-                allow_non_finalized: false,
                 anchor_state_registry_address: Address::ZERO,
                 scan_concurrency: 8,
             },

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -60,7 +60,6 @@ impl ProposerService {
         info!(version = env!("CARGO_PKG_VERSION"), "Proposer starting");
         info!(
             dry_run = config.dry_run,
-            allow_non_finalized = config.allow_non_finalized,
             anchor_state_registry = %config.anchor_state_registry_addr,
             dispute_game_factory = %config.dispute_game_factory_addr,
             game_type = config.game_type,
@@ -224,7 +223,6 @@ impl ProposerService {
             block_interval,
             intermediate_block_interval,
             game_type: config.game_type,
-            allow_non_finalized: config.allow_non_finalized,
             proposer_address: proposer_address.unwrap_or_default(),
             tee_image_hash: config.tee_image_hash,
             anchor_state_registry_address: config.anchor_state_registry_addr,
@@ -248,7 +246,6 @@ impl ProposerService {
                 block_interval: driver_config.block_interval,
                 intermediate_block_interval: driver_config.intermediate_block_interval,
                 game_type: driver_config.game_type,
-                allow_non_finalized: driver_config.allow_non_finalized,
                 anchor_state_registry_address: driver_config.anchor_state_registry_address,
                 scan_concurrency: driver_config.recovery_scan_concurrency,
             },


### PR DESCRIPTION
## Summary

Removes the `allow_non_finalized` flag from the proposer and always selects the finalized head for both L1 and L2.

## Changes

- Remove `allow_non_finalized` from CLI, `ProposerConfig`, `DriverConfig`, `ProofDispatcherConfig`, `ProofRecoveryConfig`, and all plumbing.
- `select_l1_head_for_target` uses `finalized_l1`/`finalized_l2` only; it errors if the target is above the finalized head, or if the finalized L1 head is below the finalized L2 origin.
- Recovery, dispatch, and collection use the finalized L2 head; the boundary value and related logs are renamed `safe_head` -> `finalized_head`.
- Metric: `safe_head` is kept as a deprecated alias and a new `finalized_head` gauge is added; both report the finalized head. `safe_head` is to be removed once monitors/dashboards are migrated.
- Simplify the dispatcher test helper to build finalized-only sync statuses.