### PR TITLE
fix(proof-host): log execute payload failures as errors

### DIFF
--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -24,7 +24,7 @@ use base_proof_preimage::{PreimageKey, PreimageKeyType};
 use base_protocol::{BlockInfo, OutputRoot};
 use futures::FutureExt;
 use tokio::sync::Semaphore;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     HostConfig, HostError, HostProviders, Metrics, Result, SharedKeyValueStore, store_ordered_trie,
@@ -376,7 +376,7 @@ impl PayloadWitnessPrefetcher {
         {
             Ok(response) => response,
             Err(err) => {
-                warn!(
+                error!(
                     target: HOST_SERVER_TARGET,
                     block_number,
                     ?parent_block_hash,
@@ -1173,7 +1173,7 @@ async fn handle_hint_inner(
             let hash: B256 = hint.data.as_ref().try_into()?;
 
             warn!(node_hash = %hash, "L2StateNode hint sent");
-            warn!("debug_executePayload failed to return a complete witness");
+            error!("debug_executePayload failed to return a complete witness");
 
             let preimage: Bytes = providers.l2.client().request("debug_dbGet", &[hash]).await?;
             let actual_hash = keccak256(preimage.as_ref());
@@ -1285,7 +1285,7 @@ async fn handle_hint_inner(
             {
                 Ok(response) => response,
                 Err(e) => {
-                    warn!(error = %e, "debug_executePayload failed");
+                    error!(error = %e, "debug_executePayload failed");
                     return Ok(());
                 }
             };

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -1172,8 +1172,7 @@ async fn handle_hint_inner(
 
             let hash: B256 = hint.data.as_ref().try_into()?;
 
-            warn!(node_hash = %hash, "L2StateNode hint sent");
-            error!("debug_executePayload failed to return a complete witness");
+            error!(node_hash = %hash, "debug_executePayload failed to return a complete witness");
 
             let preimage: Bytes = providers.l2.client().request("debug_dbGet", &[hash]).await?;
             let actual_hash = keccak256(preimage.as_ref());


### PR DESCRIPTION
### What changed? Why?

Updated nitro host payload witness handling so debug_executePayload RPC failures and incomplete witness fallback logs use error severity instead of warn. This makes failed witness collection visible at error level in host logs.

### Notes to reviewers

Only log severity changes; control flow is unchanged. Other best-effort prefetch warnings remain warnings.

### How has it been tested?

- cargo fmt --check
- cargo check -p base-proof-host