### PR TITLE
fix(consensus): reconcile existing safe block before build fallback

### DIFF
--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -31,11 +31,12 @@ use crate::{
 ///  Because tasks are executed one at a time, they are considered to be atomic operations over the
 /// [`EngineState`], and are given exclusive access to the engine state during execution.
 ///
-/// Tasks within the queue are also considered fallible. If they fail with a temporary error,
-/// they are not popped from the queue, the error is returned, and they are retried on the
-/// next call to [`Engine::drain`]. Tasks that fail with a [`EngineTaskErrorSeverity::Flush`]
-/// error are popped from the queue before the error is returned, so that the derivation
-/// pipeline can be flushed without the offending task being retried in-place.
+/// Tasks within the queue are also considered fallible. If they fail with a temporary or
+/// deferred error, they are not popped from the queue, the error is returned, and they are
+/// retried on the next call to [`Engine::drain`]. Tasks that fail with a
+/// [`EngineTaskErrorSeverity::Flush`] error are popped from the queue before the error is
+/// returned, so that the derivation pipeline can be flushed without the offending task being
+/// retried in-place.
 #[derive(Debug)]
 pub struct Engine<EngineClient_: EngineClient> {
     /// The state of the engine.
@@ -106,6 +107,9 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
                 match severity {
                     EngineTaskErrorSeverity::Temporary => {
                         trace!(target: "engine", error = %err, "Temporary engine error");
+                    }
+                    EngineTaskErrorSeverity::Deferred => {
+                        trace!(target: "engine", error = %err, "Deferred engine error");
                     }
                     EngineTaskErrorSeverity::Critical => {
                         error!(target: "engine", error = %err, "Critical engine error");
@@ -481,6 +485,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         {
             match err.severity() {
                 EngineTaskErrorSeverity::Temporary
+                | EngineTaskErrorSeverity::Deferred
                 | EngineTaskErrorSeverity::Flush
                 | EngineTaskErrorSeverity::Reset => {
                     warn!(target: "engine", ?err, "Forkchoice update failed during reset. Trying again...");

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
@@ -16,6 +16,9 @@ pub enum ConsolidateTaskError {
     /// Failed to fetch the unsafe L2 block.
     #[error("Failed to fetch the unsafe L2 block")]
     FailedToFetchUnsafeL2Block,
+    /// Failed to fetch the derived L2 block before build fallback.
+    #[error("Failed to fetch the derived L2 block")]
+    FailedToFetchDerivedL2Block,
     /// The build task failed.
     #[error(transparent)]
     BuildTaskFailed(#[from] BuildTaskError),
@@ -43,9 +46,9 @@ impl EngineTaskError for ConsolidateTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::MissingUnsafeL2Block(_) => EngineTaskErrorSeverity::Reset,
-            Self::FailedToFetchUnsafeL2Block | Self::ForkchoiceUpdateDidNotApply => {
-                EngineTaskErrorSeverity::Temporary
-            }
+            Self::FailedToFetchUnsafeL2Block
+            | Self::FailedToFetchDerivedL2Block
+            | Self::ForkchoiceUpdateDidNotApply => EngineTaskErrorSeverity::Temporary,
             Self::BuildTaskFailed(inner) => inner.severity(),
             Self::SealTaskFailed(inner) => inner.severity(),
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
@@ -25,9 +25,9 @@ pub enum ConsolidateTaskError {
     /// The consolidation forkchoice update call to the engine api failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
-    /// The forkchoice update completed without advancing to the safe head.
-    #[error("Forkchoice update did not advance to the safe head")]
-    ForkchoiceUpdateDidNotAdvance,
+    /// The forkchoice update completed without applying the requested heads.
+    #[error("Forkchoice update did not apply the requested heads")]
+    ForkchoiceUpdateDidNotApply,
 }
 
 impl From<BuildAndSealError> for ConsolidateTaskError {
@@ -43,7 +43,7 @@ impl EngineTaskError for ConsolidateTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::MissingUnsafeL2Block(_) => EngineTaskErrorSeverity::Reset,
-            Self::FailedToFetchUnsafeL2Block | Self::ForkchoiceUpdateDidNotAdvance => {
+            Self::FailedToFetchUnsafeL2Block | Self::ForkchoiceUpdateDidNotApply => {
                 EngineTaskErrorSeverity::Temporary
             }
             Self::BuildTaskFailed(inner) => inner.severity(),

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
@@ -43,11 +43,12 @@ impl EngineTaskError for ConsolidateTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::MissingUnsafeL2Block(_) => EngineTaskErrorSeverity::Reset,
-            Self::FailedToFetchUnsafeL2Block => EngineTaskErrorSeverity::Temporary,
+            Self::FailedToFetchUnsafeL2Block | Self::ForkchoiceUpdateDidNotAdvance => {
+                EngineTaskErrorSeverity::Temporary
+            }
             Self::BuildTaskFailed(inner) => inner.severity(),
             Self::SealTaskFailed(inner) => inner.severity(),
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
-            Self::ForkchoiceUpdateDidNotAdvance => EngineTaskErrorSeverity::Temporary,
         }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
@@ -25,6 +25,9 @@ pub enum ConsolidateTaskError {
     /// The consolidation forkchoice update call to the engine api failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
+    /// The forkchoice update completed without advancing to the safe head.
+    #[error("Forkchoice update did not advance to the safe head")]
+    ForkchoiceUpdateDidNotAdvance,
 }
 
 impl From<BuildAndSealError> for ConsolidateTaskError {
@@ -44,6 +47,7 @@ impl EngineTaskError for ConsolidateTaskError {
             Self::BuildTaskFailed(inner) => inner.severity(),
             Self::SealTaskFailed(inner) => inner.severity(),
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
+            Self::ForkchoiceUpdateDidNotAdvance => EngineTaskErrorSeverity::Temporary,
         }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/error.rs
@@ -46,9 +46,10 @@ impl EngineTaskError for ConsolidateTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::MissingUnsafeL2Block(_) => EngineTaskErrorSeverity::Reset,
-            Self::FailedToFetchUnsafeL2Block
-            | Self::FailedToFetchDerivedL2Block
-            | Self::ForkchoiceUpdateDidNotApply => EngineTaskErrorSeverity::Temporary,
+            Self::FailedToFetchUnsafeL2Block | Self::FailedToFetchDerivedL2Block => {
+                EngineTaskErrorSeverity::Temporary
+            }
+            Self::ForkchoiceUpdateDidNotApply => EngineTaskErrorSeverity::Deferred,
             Self::BuildTaskFailed(inner) => inner.severity(),
             Self::SealTaskFailed(inner) => inner.severity(),
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -150,7 +150,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                 safe_head = %state.sync_state.safe_head(),
                 "Apply safe head did not advance engine state"
             );
-            return Err(ConsolidateTaskError::ForkchoiceUpdateDidNotAdvance);
+            return Err(ConsolidateTaskError::ForkchoiceUpdateDidNotApply);
         }
 
         let fcu_duration = fcu_start.elapsed();
@@ -378,27 +378,17 @@ impl<EngineClient_: EngineClient> EngineTaskExt for ConsolidateTask<EngineClient
     //   injected safe head is ahead of the EngineActor's unsafe head, we reconcile the unsafe chain
     //   up to the safe head instead of consolidating.
     async fn execute(&self, state: &mut EngineState) -> Result<(), ConsolidateTaskError> {
-        match &self.input {
-            ConsolidateInput::Attributes { .. }
-                if state.sync_state.safe_head().block_info.number
-                    < state.sync_state.unsafe_head().block_info.number =>
-            {
-                self.consolidate(state).await
-            }
-            ConsolidateInput::Attributes { .. } => {
-                if self.reconcile_existing_derived_block(state).await? {
-                    Ok(())
-                } else {
-                    self.reconcile_unsafe_to_safe(state).await
-                }
-            }
-            ConsolidateInput::BlockInfo(safe_block_info)
-                if safe_block_info.block_info.number
-                    < state.sync_state.unsafe_head().block_info.number =>
-            {
-                self.consolidate(state).await
-            }
-            ConsolidateInput::BlockInfo { .. } => self.reconcile_unsafe_to_safe(state).await,
+        let safe_head_number = match &self.input {
+            ConsolidateInput::Attributes { .. } => state.sync_state.safe_head().block_info.number,
+            ConsolidateInput::BlockInfo(safe_block_info) => safe_block_info.block_info.number,
+        };
+
+        if safe_head_number < state.sync_state.unsafe_head().block_info.number {
+            self.consolidate(state).await
+        } else if self.reconcile_existing_derived_block(state).await? {
+            Ok(())
+        } else {
+            self.reconcile_unsafe_to_safe(state).await
         }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -216,6 +216,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
         };
         let block_fetch_duration = fetch_start.elapsed();
         let block_hash = block.header.hash;
+        let block = block.map_header(|header| header.into_inner());
 
         if !self.input.is_consistent_with_block(&self.cfg, &block) {
             debug!(

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -211,7 +211,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                     error = ?err,
                     "Failed to fetch derived L2 block before build fallback"
                 );
-                return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block);
+                return Err(ConsolidateTaskError::FailedToFetchDerivedL2Block);
             }
         };
         let block_fetch_duration = fetch_start.elapsed();

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -204,8 +204,13 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                 );
                 return Ok(false);
             }
-            Err(_) => {
-                warn!(target: "engine", block_num, "Failed to fetch derived L2 block before build fallback");
+            Err(err) => {
+                warn!(
+                    target: "engine",
+                    block_num,
+                    error = ?err,
+                    "Failed to fetch derived L2 block before build fallback"
+                );
                 return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block);
             }
         };

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -138,6 +138,21 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
             e
         })?;
 
+        if state.sync_state.unsafe_head() != *safe_l2
+            || state.sync_state.local_safe_head() != *safe_l2
+            || state.sync_state.safe_head() != *safe_l2
+        {
+            warn!(
+                target: "engine",
+                safe_l2 = %safe_l2,
+                unsafe_head = %state.sync_state.unsafe_head(),
+                local_safe_head = %state.sync_state.local_safe_head(),
+                safe_head = %state.sync_state.safe_head(),
+                "Apply safe head did not advance engine state"
+            );
+            return Err(ConsolidateTaskError::ForkchoiceUpdateDidNotAdvance);
+        }
+
         let fcu_duration = fcu_start.elapsed();
 
         info!(
@@ -164,6 +179,71 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                 self.reconcile_to_safe_head(state, safe_l2).await
             }
         }
+    }
+
+    /// If safe derivation is about to build on the current safe head, first check whether the EL
+    /// already has the derived block. This covers the case where an earlier unsafe FCU returned
+    /// `SYNCING`, reth later backfilled the block, but consensus never advanced its unsafe head.
+    async fn reconcile_existing_derived_block(
+        &self,
+        state: &mut EngineState,
+    ) -> Result<bool, ConsolidateTaskError> {
+        let ConsolidateInput::Attributes(attributes) = &self.input else {
+            return Ok(false);
+        };
+
+        let block_num = attributes.block_number();
+        let fetch_start = Instant::now();
+        let block = match self.client.l2_block_by_label(block_num.into()).await {
+            Ok(Some(block)) => block,
+            Ok(None) => {
+                debug!(
+                    target: "engine",
+                    block_num,
+                    "Derived block not found in EL; proceeding to build fallback"
+                );
+                return Ok(false);
+            }
+            Err(_) => {
+                warn!(target: "engine", block_num, "Failed to fetch derived L2 block before build fallback");
+                return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block);
+            }
+        };
+        let block_fetch_duration = fetch_start.elapsed();
+        let block_hash = block.header.hash;
+
+        if !self.input.is_consistent_with_block(&self.cfg, &block) {
+            debug!(
+                target: "engine",
+                input = ?self.input,
+                block_hash = %block_hash,
+                "Derived block does not match attributes; proceeding to build fallback",
+            );
+            return Ok(false);
+        }
+
+        let block_info = match L2BlockInfo::from_block_and_genesis(
+            &block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
+            &self.cfg.genesis,
+        ) {
+            Ok(block_info) => block_info,
+            Err(e) => {
+                warn!(target: "engine", error = ?e, "Failed to construct L2BlockInfo from derived block; proceeding to build fallback");
+                return Ok(false);
+            }
+        };
+
+        self.reconcile_to_safe_head(state, &block_info).await?;
+
+        info!(
+            target: "engine",
+            hash = %block_info.block_info.hash,
+            number = block_info.block_info.number,
+            ?block_fetch_duration,
+            "Reconciled existing derived block before build fallback"
+        );
+
+        Ok(true)
     }
 
     /// Attempts consolidation on the engine state.
@@ -293,14 +373,27 @@ impl<EngineClient_: EngineClient> EngineTaskExt for ConsolidateTask<EngineClient
     //   injected safe head is ahead of the EngineActor's unsafe head, we reconcile the unsafe chain
     //   up to the safe head instead of consolidating.
     async fn execute(&self, state: &mut EngineState) -> Result<(), ConsolidateTaskError> {
-        let safe_head_number = match &self.input {
-            ConsolidateInput::Attributes { .. } => state.sync_state.safe_head().block_info.number,
-            ConsolidateInput::BlockInfo(safe_block_info) => safe_block_info.block_info.number,
-        };
-        if safe_head_number < state.sync_state.unsafe_head().block_info.number {
-            self.consolidate(state).await
-        } else {
-            self.reconcile_unsafe_to_safe(state).await
+        match &self.input {
+            ConsolidateInput::Attributes { .. }
+                if state.sync_state.safe_head().block_info.number
+                    < state.sync_state.unsafe_head().block_info.number =>
+            {
+                self.consolidate(state).await
+            }
+            ConsolidateInput::Attributes { .. } => {
+                if self.reconcile_existing_derived_block(state).await? {
+                    Ok(())
+                } else {
+                    self.reconcile_unsafe_to_safe(state).await
+                }
+            }
+            ConsolidateInput::BlockInfo(safe_block_info)
+                if safe_block_info.block_info.number
+                    < state.sync_state.unsafe_head().block_info.number =>
+            {
+                self.consolidate(state).await
+            }
+            ConsolidateInput::BlockInfo { .. } => self.reconcile_unsafe_to_safe(state).await,
         }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
@@ -328,11 +328,11 @@ async fn consolidate_syncing_yields_until_a_later_drain() {
 
     let err = timeout(Duration::from_secs(1), engine.drain())
         .await
-        .expect("a temporary consolidation failure must yield to the engine processor")
+        .expect("a deferred consolidation failure must yield to the engine processor")
         .expect_err("SYNCING must keep the consolidation task pending");
 
-    assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
-    assert_eq!(*queue_rx.borrow(), 1, "temporary task must remain queued");
+    assert_eq!(err.severity(), EngineTaskErrorSeverity::Deferred);
+    assert_eq!(*queue_rx.borrow(), 1, "deferred task must remain queued");
     assert_eq!(engine.state().sync_state.unsafe_head(), pinned_head);
 
     client.set_fork_choice_updated_v3_response(valid_fcu()).await;

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
@@ -4,16 +4,17 @@ use std::sync::Arc;
 
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::{BlockNumberOrTag, Encodable2718};
-use alloy_primitives::{Address, FixedBytes, b256};
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, b256};
 use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum};
 use alloy_rpc_types_eth::{Block as RpcBlock, BlockTransactions};
 use base_common_consensus::{BaseTxEnvelope, TxDeposit};
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types::Transaction as BaseTransaction;
-use base_protocol::L1BlockInfoBedrock;
+use base_protocol::{AttributesWithParent, BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
 
 use crate::{
-    AttributesMatch, AttributesMismatch, ConsolidateTask, EngineTaskExt,
+    AttributesMatch, AttributesMismatch, ConsolidateTask, EngineTaskExt, SynchronizeTask,
+    state::EngineSyncStateUpdate,
     task_queue::tasks::consolidate::task::ConsolidateInput,
     test_utils::{TestAttributesBuilder, TestEngineStateBuilder, test_engine_client_builder},
 };
@@ -23,6 +24,12 @@ fn l1_info_deposit_tx() -> BaseTxEnvelope {
         input: L1BlockInfoBedrock::default().encode_calldata(),
         ..Default::default()
     })
+}
+
+fn encoded_l1_info_deposit_tx() -> Bytes {
+    let mut tx = Vec::new();
+    l1_info_deposit_tx().encode_2718(&mut tx);
+    tx.into()
 }
 
 fn rpc_transaction(tx: BaseTxEnvelope, block_number: u64) -> BaseTransaction {
@@ -37,6 +44,68 @@ fn rpc_transaction(tx: BaseTxEnvelope, block_number: u64) -> BaseTransaction {
         },
         deposit_nonce: None,
         deposit_receipt_version: None,
+    }
+}
+
+fn l2_block_info(number: u64, hash: B256, parent_hash: B256, timestamp: u64) -> L2BlockInfo {
+    L2BlockInfo {
+        block_info: BlockInfo { number, hash, parent_hash, timestamp },
+        l1_origin: Default::default(),
+        seq_num: 0,
+    }
+}
+
+fn matching_rpc_block(
+    block_info: L2BlockInfo,
+    attributes: &AttributesWithParent,
+) -> RpcBlock<BaseTransaction> {
+    let mut block = RpcBlock::<BaseTransaction>::default();
+    block.header.hash = block_info.block_info.hash;
+    block.header.inner.number = block_info.block_info.number;
+    block.header.inner.parent_hash = attributes.parent.block_info.hash;
+    block.header.inner.timestamp = attributes.attributes().payload_attributes.timestamp;
+    block.header.inner.mix_hash = attributes.attributes().payload_attributes.prev_randao;
+    block.header.inner.gas_limit = attributes.attributes().gas_limit.unwrap_or_default();
+    block.header.inner.parent_beacon_block_root =
+        attributes.attributes().payload_attributes.parent_beacon_block_root;
+    block.header.inner.beneficiary =
+        attributes.attributes().payload_attributes.suggested_fee_recipient;
+    block.transactions = BlockTransactions::Full(vec![rpc_transaction(
+        l1_info_deposit_tx(),
+        block_info.block_info.number,
+    )]);
+    block
+}
+
+fn block_info_from_rpc_block(block: RpcBlock<BaseTransaction>, cfg: &RollupConfig) -> L2BlockInfo {
+    L2BlockInfo::from_block_and_genesis(
+        &block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
+        &cfg.genesis,
+    )
+    .expect("test block must decode as L2BlockInfo")
+}
+
+fn syncing_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus {
+            status: PayloadStatusEnum::Syncing,
+            latest_valid_hash: None,
+        },
+        payload_id: None,
+    }
+}
+
+fn valid_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus { status: PayloadStatusEnum::Valid, latest_valid_hash: None },
+        payload_id: None,
+    }
+}
+
+fn valid_build_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus { status: PayloadStatusEnum::Valid, latest_valid_hash: None },
+        payload_id: Some(PayloadId::new([9u8; 8])),
     }
 }
 
@@ -118,6 +187,180 @@ async fn consolidate_does_not_crash_when_safe_behind_unsafe_and_attributes_misma
             "must not fail with UnsafeHeadChangedSinceBuild: {err}"
         );
     }
+}
+
+#[tokio::test]
+async fn consolidate_reconciles_unadvanced_unsafe_before_non_span_safe_attributes() {
+    let cfg = Arc::new(RollupConfig::default());
+    let pinned_head = l2_block_info(
+        10,
+        b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        b256!("9999999999999999999999999999999999999999999999999999999999999999"),
+        20,
+    );
+    let pending_unsafe = l2_block_info(
+        40,
+        b256!("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+        b256!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+        80,
+    );
+    let safe_child = l2_block_info(
+        11,
+        b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        pinned_head.block_info.hash,
+        22,
+    );
+    let attributes = TestAttributesBuilder::new()
+        .with_parent(pinned_head)
+        .with_timestamp(safe_child.block_info.timestamp)
+        .with_transactions(vec![encoded_l1_info_deposit_tx()])
+        .with_is_last_in_span(false)
+        .build();
+
+    let client = Arc::new(
+        test_engine_client_builder()
+            .with_fork_choice_updated_v2_response(valid_build_fcu())
+            .with_fork_choice_updated_v3_response(syncing_fcu())
+            .build(),
+    );
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(pinned_head)
+        .with_safe_head(pinned_head)
+        .with_finalized_head(pinned_head)
+        .with_el_sync_finished(true)
+        .build();
+
+    // A live unsafe target was accepted by newPayload, but its bare FCU returned SYNCING while
+    // reth backfilled. Consensus therefore remains pinned at the old unsafe head.
+    SynchronizeTask::new(
+        Arc::clone(&client),
+        Arc::clone(&cfg),
+        EngineSyncStateUpdate { unsafe_head: Some(pending_unsafe), ..Default::default() },
+    )
+    .execute(&mut state)
+    .await
+    .expect("SYNCING unsafe FCU should be non-fatal");
+    assert_eq!(state.sync_state.unsafe_head(), pinned_head);
+
+    // EL sync has now caught up enough to serve the next safe block that derivation is about to
+    // confirm.
+    client.set_fork_choice_updated_v3_response(valid_fcu()).await;
+    let safe_child_block = matching_rpc_block(safe_child, &attributes);
+    let expected_safe_child = block_info_from_rpc_block(safe_child_block.clone(), &cfg);
+    client
+        .set_l2_block_by_label(
+            BlockNumberOrTag::Number(safe_child.block_info.number),
+            safe_child_block,
+        )
+        .await;
+
+    ConsolidateTask::new(Arc::clone(&client), Arc::clone(&cfg), ConsolidateInput::from(attributes))
+        .execute(&mut state)
+        .await
+        .expect("safe derivation should reconcile the available unsafe block instead of building");
+
+    assert!(
+        state.sync_state.unsafe_head().block_info.number >= expected_safe_child.block_info.number,
+        "unsafe head must advance before safe derivation advances"
+    );
+    assert_eq!(state.sync_state.local_safe_head(), expected_safe_child);
+    assert_eq!(state.sync_state.safe_head(), expected_safe_child);
+
+    let storage = client.storage();
+    let requests = storage.read().await;
+    assert!(
+        requests
+            .fork_choice_updated_v2_requests
+            .iter()
+            .chain(requests.fork_choice_updated_v3_requests.iter())
+            .all(|(_, has_attrs)| !has_attrs),
+        "safe reconciliation must not start a stale FCU-with-attributes build"
+    );
+}
+
+#[tokio::test]
+async fn consolidate_reconciles_unadvanced_unsafe_before_last_span_safe_attributes() {
+    let cfg = Arc::new(RollupConfig::default());
+    let pinned_head = l2_block_info(
+        10,
+        b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        b256!("9999999999999999999999999999999999999999999999999999999999999999"),
+        20,
+    );
+    let pending_unsafe = l2_block_info(
+        40,
+        b256!("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+        b256!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+        80,
+    );
+    let safe_child = l2_block_info(
+        11,
+        b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        pinned_head.block_info.hash,
+        22,
+    );
+    let attributes = TestAttributesBuilder::new()
+        .with_parent(pinned_head)
+        .with_timestamp(safe_child.block_info.timestamp)
+        .with_transactions(vec![encoded_l1_info_deposit_tx()])
+        .with_is_last_in_span(true)
+        .build();
+
+    let client = Arc::new(
+        test_engine_client_builder()
+            .with_fork_choice_updated_v2_response(valid_build_fcu())
+            .with_fork_choice_updated_v3_response(syncing_fcu())
+            .build(),
+    );
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(pinned_head)
+        .with_safe_head(pinned_head)
+        .with_finalized_head(pinned_head)
+        .with_el_sync_finished(true)
+        .build();
+
+    SynchronizeTask::new(
+        Arc::clone(&client),
+        Arc::clone(&cfg),
+        EngineSyncStateUpdate { unsafe_head: Some(pending_unsafe), ..Default::default() },
+    )
+    .execute(&mut state)
+    .await
+    .expect("SYNCING unsafe FCU should be non-fatal");
+    assert_eq!(state.sync_state.unsafe_head(), pinned_head);
+
+    client.set_fork_choice_updated_v3_response(valid_fcu()).await;
+    let safe_child_block = matching_rpc_block(safe_child, &attributes);
+    let expected_safe_child = block_info_from_rpc_block(safe_child_block.clone(), &cfg);
+    client
+        .set_l2_block_by_label(
+            BlockNumberOrTag::Number(safe_child.block_info.number),
+            safe_child_block,
+        )
+        .await;
+
+    ConsolidateTask::new(Arc::clone(&client), Arc::clone(&cfg), ConsolidateInput::from(attributes))
+        .execute(&mut state)
+        .await
+        .expect("span-ending safe derivation should use a bare FCU after unsafe reconciliation");
+
+    assert!(
+        state.sync_state.unsafe_head().block_info.number >= expected_safe_child.block_info.number,
+        "unsafe head must advance before safe derivation advances"
+    );
+    assert_eq!(state.sync_state.local_safe_head(), expected_safe_child);
+    assert_eq!(state.sync_state.safe_head(), expected_safe_child);
+
+    let storage = client.storage();
+    let requests = storage.read().await;
+    assert!(
+        requests
+            .fork_choice_updated_v2_requests
+            .iter()
+            .chain(requests.fork_choice_updated_v3_requests.iter())
+            .all(|(_, has_attrs)| !has_attrs),
+        "span-ending safe reconciliation must not start a stale FCU-with-attributes build"
+    );
 }
 
 #[tokio::test]

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
@@ -1,6 +1,6 @@
 //! Tests for `ConsolidateTask::execute`
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::{BlockNumberOrTag, Encodable2718};
@@ -11,9 +11,11 @@ use base_common_consensus::{BaseTxEnvelope, TxDeposit};
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types::Transaction as BaseTransaction;
 use base_protocol::{AttributesWithParent, BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
+use tokio::{sync::watch, time::timeout};
 
 use crate::{
-    AttributesMatch, AttributesMismatch, ConsolidateTask, EngineTaskExt, SynchronizeTask,
+    AttributesMatch, AttributesMismatch, ConsolidateTask, Engine, EngineTask, EngineTaskError,
+    EngineTaskErrorSeverity, EngineTaskExt, SynchronizeTask,
     state::EngineSyncStateUpdate,
     task_queue::tasks::consolidate::task::ConsolidateInput,
     test_utils::{TestAttributesBuilder, TestEngineStateBuilder, test_engine_client_builder},
@@ -276,6 +278,70 @@ async fn consolidate_reconciles_unadvanced_unsafe_before_non_span_safe_attribute
             .all(|(_, has_attrs)| !has_attrs),
         "safe reconciliation must not start a stale FCU-with-attributes build"
     );
+}
+
+#[tokio::test]
+async fn consolidate_syncing_yields_until_a_later_drain() {
+    let cfg = Arc::new(RollupConfig::default());
+    let pinned_head = l2_block_info(
+        10,
+        b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        b256!("9999999999999999999999999999999999999999999999999999999999999999"),
+        20,
+    );
+    let safe_child = l2_block_info(
+        11,
+        b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        pinned_head.block_info.hash,
+        22,
+    );
+    let attributes = TestAttributesBuilder::new()
+        .with_parent(pinned_head)
+        .with_timestamp(safe_child.block_info.timestamp)
+        .with_transactions(vec![encoded_l1_info_deposit_tx()])
+        .build();
+    let safe_child_block = matching_rpc_block(safe_child, &attributes);
+    let expected_safe_child = block_info_from_rpc_block(safe_child_block.clone(), &cfg);
+    let client = Arc::new(
+        test_engine_client_builder()
+            .with_l2_block_by_label(
+                BlockNumberOrTag::Number(safe_child.block_info.number),
+                safe_child_block,
+            )
+            .with_fork_choice_updated_v3_response(syncing_fcu())
+            .build(),
+    );
+    let initial_state = TestEngineStateBuilder::new()
+        .with_unsafe_head(pinned_head)
+        .with_safe_head(pinned_head)
+        .with_finalized_head(pinned_head)
+        .with_el_sync_finished(true)
+        .build();
+    let (state_tx, _) = watch::channel(initial_state);
+    let (queue_tx, queue_rx) = watch::channel(0usize);
+    let mut engine = Engine::new(initial_state, state_tx, queue_tx);
+    engine.enqueue(EngineTask::Consolidate(Box::new(ConsolidateTask::new(
+        Arc::clone(&client),
+        Arc::clone(&cfg),
+        ConsolidateInput::from(attributes),
+    ))));
+
+    let err = timeout(Duration::from_secs(1), engine.drain())
+        .await
+        .expect("a temporary consolidation failure must yield to the engine processor")
+        .expect_err("SYNCING must keep the consolidation task pending");
+
+    assert_eq!(err.severity(), EngineTaskErrorSeverity::Temporary);
+    assert_eq!(*queue_rx.borrow(), 1, "temporary task must remain queued");
+    assert_eq!(engine.state().sync_state.unsafe_head(), pinned_head);
+
+    client.set_fork_choice_updated_v3_response(valid_fcu()).await;
+    engine.drain().await.expect("a later drain should retry the pending consolidation");
+
+    assert_eq!(*queue_rx.borrow(), 0);
+    assert_eq!(engine.state().sync_state.unsafe_head(), expected_safe_child);
+    assert_eq!(engine.state().sync_state.local_safe_head(), expected_safe_child);
+    assert_eq!(engine.state().sync_state.safe_head(), expected_safe_child);
 }
 
 #[tokio::test]

--- a/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
@@ -34,9 +34,9 @@ pub enum InsertTaskError {
     /// The forkchoice update call to consolidate the block into the engine state failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
-    /// The forkchoice update completed without advancing the unsafe head to the inserted payload.
-    #[error("Forkchoice update did not advance to the inserted payload")]
-    ForkchoiceUpdateDidNotAdvance,
+    /// The forkchoice update completed without applying the inserted payload.
+    #[error("Forkchoice update did not apply the inserted payload")]
+    ForkchoiceUpdateDidNotApply,
 }
 
 impl EngineTaskError for InsertTaskError {
@@ -47,7 +47,7 @@ impl EngineTaskError for InsertTaskError {
             | Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
             Self::InsertFailed(_)
             | Self::UnexpectedPayloadStatus(_)
-            | Self::ForkchoiceUpdateDidNotAdvance => EngineTaskErrorSeverity::Temporary,
+            | Self::ForkchoiceUpdateDidNotApply => EngineTaskErrorSeverity::Temporary,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
         }
     }

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -322,7 +322,7 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         if (self.result_tx.is_some() || self.payload_policy.is_authoritative())
             && state.sync_state.unsafe_head() != new_block_ref
         {
-            return Err(InsertTaskError::ForkchoiceUpdateDidNotAdvance);
+            return Err(InsertTaskError::ForkchoiceUpdateDidNotApply);
         }
 
         if self.payload_policy.is_authoritative() {

--- a/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
@@ -78,7 +78,7 @@ impl SealTaskError {
                 | InsertTaskError::L2BlockInfoConstruction(_) => true,
                 InsertTaskError::InsertFailed(_)
                 | InsertTaskError::UnexpectedPayloadStatus(_)
-                | InsertTaskError::ForkchoiceUpdateDidNotAdvance => false,
+                | InsertTaskError::ForkchoiceUpdateDidNotApply => false,
             },
             Self::GetPayloadFailed(_)
             | Self::HoloceneInvalidFlush

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -21,9 +21,13 @@ use crate::{
 /// This is used to determine how to handle the error when draining the engine task queue.
 #[derive(Debug, PartialEq, Eq, Display, Clone, Copy)]
 pub enum EngineTaskErrorSeverity {
-    /// The error is temporary and the task is retried.
+    /// The error is temporary and the task is retried in-place.
     #[display("temporary")]
     Temporary,
+    /// The error should be handed back to the next engine drain cycle rather than retried
+    /// in-place (avoids hot-looping while the EL catches up).
+    #[display("deferred")]
+    Deferred,
     /// The error is critical and is propagated to the engine actor.
     #[display("critical")]
     Critical,
@@ -82,6 +86,7 @@ impl EngineTaskErrorSeverity {
     pub const fn as_label(self) -> &'static str {
         match self {
             Self::Temporary => "temporary",
+            Self::Deferred => "deferred",
             Self::Critical => "critical",
             Self::Reset => "reset",
             Self::Flush => "flush",
@@ -197,18 +202,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
             Metrics::engine_task_failure(self.task_metrics_label(), severity.as_label())
                 .increment(1);
 
-            if matches!(
-                &e,
-                EngineTaskErrors::Consolidate(ConsolidateTaskError::ForkchoiceUpdateDidNotApply)
-            ) {
-                trace!(
-                    target: "engine",
-                    error = %e,
-                    "Deferring consolidation retry to the next engine drain"
-                );
-                return Err(e);
-            }
-
             match severity {
                 EngineTaskErrorSeverity::Temporary => {
                     trace!(target: "engine", error = %e, "Temporary engine error");
@@ -217,6 +210,14 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
                     yield_now().await;
 
                     continue;
+                }
+                EngineTaskErrorSeverity::Deferred => {
+                    trace!(
+                        target: "engine",
+                        error = %e,
+                        "Deferring engine task retry to the next engine drain"
+                    );
+                    return Err(e);
                 }
                 EngineTaskErrorSeverity::Critical => {
                     error!(target: "engine", error = %e, "Critical engine error");

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -199,7 +199,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
 
             if matches!(
                 &e,
-                EngineTaskErrors::Consolidate(ConsolidateTaskError::ForkchoiceUpdateDidNotAdvance)
+                EngineTaskErrors::Consolidate(ConsolidateTaskError::ForkchoiceUpdateDidNotApply)
             ) {
                 trace!(
                     target: "engine",

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -197,6 +197,18 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
             Metrics::engine_task_failure(self.task_metrics_label(), severity.as_label())
                 .increment(1);
 
+            if matches!(
+                &e,
+                EngineTaskErrors::Consolidate(ConsolidateTaskError::ForkchoiceUpdateDidNotAdvance)
+            ) {
+                trace!(
+                    target: "engine",
+                    error = %e,
+                    "Deferring consolidation retry to the next engine drain"
+                );
+                return Err(e);
+            }
+
             match severity {
                 EngineTaskErrorSeverity::Temporary => {
                     trace!(target: "engine", error = %e, "Temporary engine error");

--- a/crates/consensus/engine/src/test_utils/attributes.rs
+++ b/crates/consensus/engine/src/test_utils/attributes.rs
@@ -78,6 +78,13 @@ impl TestAttributesBuilder {
         self
     }
 
+    /// Sets whether these attributes are the last block in the current span.
+    #[allow(dead_code)]
+    pub const fn with_is_last_in_span(mut self, is_last_in_span: bool) -> Self {
+        self.is_last_in_span = is_last_in_span;
+        self
+    }
+
     /// Builds the `AttributesWithParent`
     pub fn build(self) -> AttributesWithParent {
         let attributes = BasePayloadAttributes {

--- a/crates/consensus/engine/src/test_utils/attributes.rs
+++ b/crates/consensus/engine/src/test_utils/attributes.rs
@@ -79,7 +79,6 @@ impl TestAttributesBuilder {
     }
 
     /// Sets whether these attributes are the last block in the current span.
-    #[allow(dead_code)]
     pub const fn with_is_last_in_span(mut self, is_last_in_span: bool) -> Self {
         self.is_last_in_span = is_last_in_span;
         self

--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -70,8 +70,12 @@ pub struct MockEngineStorage {
     // Version-specific fork_choice_updated responses
     /// Storage for `fork_choice_updated_v2` responses.
     pub fork_choice_updated_v2_response: Option<ForkchoiceUpdated>,
+    /// Storage for `fork_choice_updated_v2` requests and whether they included payload attributes.
+    pub fork_choice_updated_v2_requests: Vec<(ForkchoiceState, bool)>,
     /// Storage for `fork_choice_updated_v3` responses.
     pub fork_choice_updated_v3_response: Option<ForkchoiceUpdated>,
+    /// Storage for `fork_choice_updated_v3` requests and whether they included payload attributes.
+    pub fork_choice_updated_v3_requests: Vec<(ForkchoiceState, bool)>,
 
     // Version-specific fork_choice_updated error overrides
     /// Error to return for `fork_choice_updated_v2` instead of a response.
@@ -602,10 +606,13 @@ impl BaseEngineApi for MockEngineClient {
 
     async fn fork_choice_updated_v2(
         &self,
-        _fork_choice_state: ForkchoiceState,
-        _payload_attributes: Option<BasePayloadAttributes>,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<BasePayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage
+            .fork_choice_updated_v2_requests
+            .push((fork_choice_state, payload_attributes.is_some()));
         if let Some(error) = storage.fork_choice_updated_v2_error.clone() {
             return Err(TransportError::ErrorResp(error));
         }
@@ -619,10 +626,13 @@ impl BaseEngineApi for MockEngineClient {
 
     async fn fork_choice_updated_v3(
         &self,
-        _fork_choice_state: ForkchoiceState,
-        _payload_attributes: Option<BasePayloadAttributes>,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<BasePayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage
+            .fork_choice_updated_v3_requests
+            .push((fork_choice_state, payload_attributes.is_some()));
         if let Some(error) = storage.fork_choice_updated_v3_error.clone() {
             return Err(TransportError::ErrorResp(error));
         }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -353,6 +353,10 @@ where
                 trace!(target: "engine", %error, "Temporary engine task error");
                 Ok(ResetOutcome::NotReset)
             }
+            EngineTaskErrorSeverity::Deferred => {
+                trace!(target: "engine", %error, "Deferred engine task error");
+                Ok(ResetOutcome::NotReset)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- check for an already-imported L2 block matching the derived safe attributes before falling back to an FCU-with-attributes build
- when the block exists and matches the derived attributes, adopt it through the follow-safe path so unsafe/local-safe/safe advance together
- treat follow-safe FCUs that return without applying the requested head state as temporary errors so the consolidate task is retried instead of silently popped
- add regression coverage for the case where an earlier unsafe FCU returned `SYNCING`, EL later backfilled the block, and safe derivation resumes while consensus unsafe is still pinned

## Motivation

A July 7 HA sequencer replacement exposed the following recovery sequence:

1. The replacement pod started with a local chain view roughly 215 blocks behind the live chain. Base Consensus admitted a far-ahead external unsafe payload because the gap was within the bounded forwarding window.
2. Reth accepted the payload, returned `SYNCING`, and staged execution-layer backfill for the missing range. Consensus correctly left its logical unsafe head at the old local block while EL sync was incomplete.
3. Reth completed backfill, but consensus did not reconcile the pending unsafe target. It continued to reason from `safe == unsafe == N` even though the EL now contained the next block.
4. Safe derivation produced attributes for `N+1`. Because consensus still saw `safe == unsafe`, `ConsolidateTask` took the attributes build fallback and sent an FCU asking the EL to build `N+1` on the old parent `N`.
5. Reth performed an expensive historical state-root calculation for the already-imported block, fell back to database reads after a cache miss, and eventually failed with an MDBX read-transaction timeout. Safe-head confirmation then remained stuck.

The first three steps—pod recovery, bounded unsafe-payload admission, and Reth backfill—were expected. The missing post-backfill reconciliation is the leading explanation for why safe derivation took the stale build path. The state-root timeout was the visible failure caused by asking the EL to build on the old head, not the initial trigger.

This PR avoids that stale build by checking for an existing L2 block matching the derived attributes before requesting a new payload. When found, consensus adopts it through a bare follow-safe FCU, advancing all relevant heads consistently. If that FCU returns without applying the requested state, the task yields back to the engine drain so EL sync can progress and the next drain can retry.

## Testing

- `cargo +nightly fmt`
- `git diff --check`
- `cargo test -p base-consensus-engine`

## QA

- Added deterministic mock-engine regression coverage for an already-imported block matching both span-ending and non-span derived attributes. The tests verify that reconciliation uses the follow-safe bare FCU, advances unsafe/local-safe/safe together, and avoids an FCU-with-attributes build request.
- Added a `SYNCING` regression test that verifies a non-applying follow-safe FCU yields back to the engine drain and succeeds on a later retry instead of monopolizing the task queue.
- Exercised control and candidate builds in an isolated split CL/EL devnet with clean, pinned source and image inputs. The exact production stale-head/backfill timing was not reproducibly induced there, so the devnet result is inconclusive for that specific scenario; the deterministic tests provide the primary correctness evidence.

## Change Management

type=routine
risk=low
impact=sev5