### PR TITLE
feat(eip8130): repin AA tx type to 0x79 and payer magic to 0x7A

### DIFF
--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -49,11 +49,11 @@ pub enum BaseReceiptEnvelope {
     /// [deposit]: https://specs.base.org/protocol/bridging/deposits
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(ReceiptWithBloom<DepositReceipt>),
-    /// Receipt envelope with type flag 123, containing an [EIP-8130] Account
+    /// Receipt envelope with type flag 121, containing an [EIP-8130] Account
     /// Abstraction receipt.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
-    #[cfg_attr(feature = "serde", serde(rename = "0x7b", alias = "0x7B"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x79"))]
     Eip8130(ReceiptWithBloom<Receipt<Log>>),
 }
 

--- a/crates/common/consensus/src/receipts/receipt.rs
+++ b/crates/common/consensus/src/receipts/receipt.rs
@@ -40,7 +40,7 @@ pub enum BaseReceipt<T = Log> {
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(DepositReceipt<T>),
     /// EIP-8130 Account Abstraction receipt
-    #[cfg_attr(feature = "serde", serde(rename = "0x7b", alias = "0x7B"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x79"))]
     Eip8130(Eip8130Receipt<T>),
 }
 

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, U256, address};
 ///
 /// Spec status (as of writing): EIP-8130 is in Draft. The transaction and payer
 /// type bytes below are pinned to the EIP-8130 constant-table values
-/// (`AA_TX_TYPE = 0x7B`, `AA_PAYER_TYPE = 0x7C`).
+/// (`AA_TX_TYPE = 0x79`, `AA_PAYER_TYPE = 0x7A`).
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug)]
@@ -21,18 +21,18 @@ pub struct Eip8130Constants;
 impl Eip8130Constants {
     /// [EIP-2718] transaction type byte for AA transactions (`EIP8130_TX_TYPE`).
     ///
-    /// Pinned to the EIP-8130 constant-table value `AA_TX_TYPE = 0x7B`.
+    /// Pinned to the EIP-8130 constant-table value `AA_TX_TYPE = 0x79`.
     ///
     /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
-    pub const EIP8130_TX_TYPE: u8 = 0x7B;
+    pub const EIP8130_TX_TYPE: u8 = 0x79;
 
     /// Magic prefix byte for payer signature domain separation (`EIP8130_PAYER_TYPE`).
     ///
     /// Used in the payer signature preimage:
     /// `keccak256(EIP8130_PAYER_TYPE || rlp([...fields through calls...]))`.
     ///
-    /// Pinned to the EIP-8130 constant-table value `AA_PAYER_TYPE = 0x7C`.
-    pub const EIP8130_PAYER_TYPE: u8 = 0x7C;
+    /// Pinned to the EIP-8130 constant-table value `AA_PAYER_TYPE = 0x7A`.
+    pub const EIP8130_PAYER_TYPE: u8 = 0x7A;
 
     /// Base intrinsic gas cost for any AA transaction (`EIP8130_BASE_COST`).
     pub const EIP8130_BASE_COST: u64 = 15_000;

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -788,7 +788,7 @@ mod tests {
         use crate::BaseTxEnvelope;
 
         let json = serde_json::json!({
-            "type": "0x7b",
+            "type": "0x79",
             "tx": {
                 "chainId": 1,
                 "sender": null,

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -52,10 +52,10 @@ pub enum BaseTxEnvelope {
     #[envelope(ty = 126)]
     #[serde(serialize_with = "crate::serde_deposit_tx_rpc")]
     Deposit(Sealed<TxDeposit>),
-    /// An [EIP-8130] Account Abstraction transaction tagged with type 0x7B.
+    /// An [EIP-8130] Account Abstraction transaction tagged with type 0x79.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
-    #[envelope(ty = 123, typed = TxEip8130)]
+    #[envelope(ty = 121, typed = TxEip8130)]
     Eip8130(Eip8130Signed),
 }
 

--- a/crates/common/consensus/src/transaction/pooled.rs
+++ b/crates/common/consensus/src/transaction/pooled.rs
@@ -35,10 +35,10 @@ pub enum BasePooledTransaction {
     /// A [`TxEip7702`] transaction tagged with type 4.
     #[envelope(ty = 4)]
     Eip7702(Signed<TxEip7702>),
-    /// An [EIP-8130] Account Abstraction transaction tagged with type 0x7B.
+    /// An [EIP-8130] Account Abstraction transaction tagged with type 0x79.
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
-    #[envelope(ty = 123, typed = TxEip8130)]
+    #[envelope(ty = 121, typed = TxEip8130)]
     Eip8130(Eip8130Signed),
 }
 

--- a/crates/common/consensus/src/transaction/tx_type.rs
+++ b/crates/common/consensus/src/transaction/tx_type.rs
@@ -12,14 +12,14 @@ pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
 /// Identifier for an [EIP-8130] Account Abstraction transaction.
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
-pub const EIP8130_TX_TYPE_ID: u8 = 123; // 0x7B
+pub const EIP8130_TX_TYPE_ID: u8 = 121; // 0x79
 
 /// Canonical user-facing rejection message for EIP-8130 transactions submitted before Cobalt.
 ///
 /// Used by `base-execution-rpc` when an EIP-8130 transaction is submitted before
 /// the Cobalt fork is active at the latest block timestamp.
 pub const EIP8130_REJECTION_MSG: &str = "EIP-8130 (account abstraction) transactions are gated behind Cobalt; \
-     eth_sendRawTransaction does not accept transaction type 0x7B before Cobalt";
+     eth_sendRawTransaction does not accept transaction type 0x79 before Cobalt";
 
 #[allow(clippy::derivable_impls)]
 impl Default for OpTxType {

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -2429,7 +2429,7 @@ mod tests {
     #[test]
     fn counterfactual_create_executes_and_is_included() {
         // End-to-end regression for the counterfactual smart-account CREATE bug
-        // (PR #3766): a `0x7b` create whose sender is the not-yet-existent CREATE2
+        // (PR #3766): a `0x79` create whose sender is the not-yet-existent CREATE2
         // address must authorize and be *included* through the full
         // `Eip8130Executor::execute` pipeline — not just the unit-level
         // `authorize_and_apply`. Before the fix this returned

--- a/crates/common/rpc-types/src/transaction.rs
+++ b/crates/common/rpc-types/src/transaction.rs
@@ -410,7 +410,7 @@ mod tests {
         };
         let rpc_tx = Transaction::from_transaction(recovered, tx_info);
 
-        assert_eq!(rpc_tx.ty(), 0x7B);
+        assert_eq!(rpc_tx.ty(), 0x79);
         assert_eq!(rpc_tx.deposit_nonce, None);
         assert_eq!(rpc_tx.deposit_receipt_version, None);
         assert_eq!(rpc_tx.inner.inner.signer(), Address::with_last_byte(0x11));
@@ -418,7 +418,7 @@ mod tests {
         let serialized = serde_json::to_string(&rpc_tx).expect("serialize eip-8130 rpc tx");
         let value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(value["type"], "0x7b", "tx type byte exposed in RPC response");
+        assert_eq!(value["type"], "0x79", "tx type byte exposed in RPC response");
         assert_eq!(value["from"], "0x0000000000000000000000000000000000000011");
         assert_eq!(value["blockNumber"], "0x64");
         assert_eq!(value["transactionIndex"], "0x0");

--- a/crates/execution/eip8130-rpc-node/tests/receipt.rs
+++ b/crates/execution/eip8130-rpc-node/tests/receipt.rs
@@ -1,4 +1,4 @@
-//! End-to-end inclusion test for an EIP-8130 (type `0x7b`) transaction: sign a
+//! End-to-end inclusion test for an EIP-8130 (type `0x79`) transaction: sign a
 //! minimal EOA-path transaction, mine it into a block, and assert that
 //! `eth_getTransactionReceipt` returns a successful receipt.
 
@@ -17,10 +17,10 @@ use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, TestHarness};
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis_cobalt};
 
 /// EIP-8130 transaction type byte.
-const EIP8130_TX_TYPE: u8 = 0x7b;
+const EIP8130_TX_TYPE: u8 = 0x79;
 
 /// Mines a minimal EOA-path EIP-8130 transaction and asserts its receipt is a
-/// successful type `0x7b` receipt.
+/// successful type `0x79` receipt.
 #[tokio::test]
 async fn eip8130_transaction_is_mined_and_has_a_receipt() -> eyre::Result<()> {
     let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis_cobalt()));
@@ -56,7 +56,7 @@ async fn eip8130_transaction_is_mined_and_has_a_receipt() -> eyre::Result<()> {
     let tx_hash = *signed.hash();
     let raw: Bytes = signed.encoded_2718().into();
 
-    assert_eq!(raw[0], EIP8130_TX_TYPE, "encoded transaction must carry the 0x7b type byte");
+    assert_eq!(raw[0], EIP8130_TX_TYPE, "encoded transaction must carry the 0x79 type byte");
 
     // The L1 block-info deposit must lead every block.
     harness.build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, raw]).await?;

--- a/crates/execution/rpc/src/error.rs
+++ b/crates/execution/rpc/src/error.rs
@@ -78,7 +78,7 @@ pub enum BaseInvalidTransactionError {
     /// An EIP-8130 (account-abstraction) transaction was submitted via
     /// `eth_sendRawTransaction` before the Cobalt fork was active.
     ///
-    /// The transaction type byte (`0x7B`) is recognised by the consensus layer for
+    /// The transaction type byte (`0x79`) is recognised by the consensus layer for
     /// decoding/serialization purposes, but RPC admission is rejected until the
     /// Cobalt fork is active. The txpool validator enforces the same fork gate for
     /// transactions arriving over devp2p.


### PR DESCRIPTION
## Summary
- Update the EIP-8130 account-abstraction transaction type byte from `0x7B` (123) to `0x79` (121).
- Update the EIP-8130 payer signature magic prefix byte from `0x7C` to `0x7A`.
- Propagate the new values across the canonical constants, `BaseTxEnvelope`/`BasePooledTransaction` type derives (`ty = 121`), receipt serde tags (`0x79`), and all doc/test references.

As per https://github.com/ethereum/EIPs/pull/11903 

## Details
- `Eip8130Constants::EIP8130_TX_TYPE` → `0x79`, `EIP8130_PAYER_TYPE` → `0x7A`.
- `EIP8130_TX_TYPE_ID` → `121` and rejection message updated.
- Receipt envelope/receipt serde renames updated to `0x79`.

## Test plan
- [x] `cargo check -p base-common-consensus`
- [x] `cargo test -p base-common-consensus --lib` (86 passed)
- [ ] CI on the full workspace