### PR TITLE
Improve snapshotter progress and upload resiliency

### DIFF
--- a/crates/infra/snapshotter/Cargo.toml
+++ b/crates/infra/snapshotter/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = { workspace = true }
 serde_json = { workspace = true }
 reth-cli-commands = { workspace = true }
 alloy-provider = { workspace = true, features = ["reqwest"] }
-tokio = { workspace = true, features = ["rt", "fs"] }
+tokio = { workspace = true, features = ["rt", "fs", "time"] }
 clap = { workspace = true, features = ["derive", "env"] }
 aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
 

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -55,6 +55,11 @@ pub struct SnapshotterConfig {
     #[arg(long, short = 'o')]
     pub output_dir: PathBuf,
 
+    /// Upload an already-generated `run-<timestamp>` directory from `output_dir`
+    /// instead of stopping the EL and regenerating snapshot artifacts.
+    #[arg(long)]
+    pub upload_existing_run_timestamp: Option<u64>,
+
     /// S3-compatible bucket name.
     #[arg(long)]
     pub bucket: String,

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -11,7 +11,10 @@ mod config;
 pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
 
 mod progress;
-pub use progress::{ArchiveProgress, UploadProgress};
+pub use progress::{
+    ArchiveProgress, ComponentProgressLogger, ComponentProgressReporter, ComponentProgressState,
+    UploadProgress,
+};
 
 mod container;
 pub use container::{ContainerManager, DockerContainerManager};

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -25,7 +25,7 @@ pub use tip::{RpcTipChecker, TipChecker};
 mod snapshot;
 pub use snapshot::{
     ChunkFilename, ChunkedArchive, ComponentManifest, OutputFileChecksum, SingleArchive,
-    SnapshotGenerator, SnapshotManifest, SnapshotManifestExt, collect_output_files,
+    SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
 };
 
 mod upload;

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -12,8 +12,8 @@ pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
 
 mod progress;
 pub use progress::{
-    ArchiveProgress, ComponentProgressLogger, ComponentProgressReporter, ComponentProgressState,
-    UploadProgress,
+    ActiveArchiveState, ArchiveProgress, ComponentProgressLogger, ComponentProgressReporter,
+    ComponentProgressState, UploadProgress,
 };
 
 mod container;
@@ -25,7 +25,7 @@ pub use tip::{RpcTipChecker, TipChecker};
 mod snapshot;
 pub use snapshot::{
     ChunkFilename, ChunkedArchive, ComponentManifest, OutputFileChecksum, SingleArchive,
-    SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+    SnapshotGenerator, SnapshotManifest, SnapshotManifestExt, collect_output_files,
 };
 
 mod upload;

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -12,7 +12,10 @@ use tracing::{error, info, warn};
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
-    snapshot::{OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt},
+    snapshot::{
+        OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+        collect_output_files,
+    },
     tip::TipChecker,
     upload::SnapshotUploader,
 };
@@ -293,17 +296,4 @@ fn existing_run_output_dir(base: &Path, timestamp: u64) -> Result<PathBuf> {
         bail!("existing run path is not a directory: {}", run_dir.display());
     }
     Ok(run_dir)
-}
-
-/// Collects all files in a run output directory (non-recursive).
-fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
-        .with_context(|| format!("failed to read output dir {}", dir.display()))?
-        .map(|entry| entry.map(|entry| entry.path()))
-        .collect::<std::io::Result<Vec<_>>>()?
-        .into_iter()
-        .filter(|path| path.is_file())
-        .collect();
-    files.sort();
-    Ok(files)
 }

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -12,10 +12,7 @@ use tracing::{error, info, warn};
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
-    snapshot::{
-        OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
-        collect_output_files,
-    },
+    snapshot::{OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt},
     tip::TipChecker,
     upload::SnapshotUploader,
 };
@@ -213,7 +210,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             "uploading existing snapshot run"
         );
 
-        let files = collect_output_files(&run_output_dir)?;
+        let files = SnapshotGenerator::collect_output_files(&run_output_dir)?;
         let remote_manifest = self.uploader.fetch_previous_manifest().await?;
         info!(
             has_remote_manifest = remote_manifest.is_some(),

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -55,7 +55,15 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
     /// 4. Uploads to S3/R2
     /// 5. Clears reth's persisted peer list (best effort)
     /// 6. Restarts the EL container (always, even on failure)
+    ///
+    /// When `upload_existing_run_timestamp` is set, the snapshotter skips the
+    /// container lifecycle entirely and uploads the existing `run-<timestamp>`
+    /// directory from `output_dir`.
     pub async fn run(&self) -> Result<()> {
+        if let Some(run_timestamp) = self.config.upload_existing_run_timestamp {
+            return self.upload_existing_run(run_timestamp).await;
+        }
+
         // Only snapshot when the EL is caught up to tip. Snapshotting a lagging
         // node would publish stale data and pause a node that is still syncing.
         //
@@ -181,20 +189,63 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             bail!("snapshot generation produced no files");
         }
 
+        self.upload_run_directory(&run_output_dir, run_timestamp, files, remote_manifest.as_ref())
+            .await?;
+
+        info!(output_dir = %run_output_dir.display(), "cleaning up local artifacts");
+        if let Err(e) = tokio::fs::remove_dir_all(&run_output_dir).await {
+            error!(error = %e, "failed to clean up output directory");
+        }
+
+        Ok(())
+    }
+
+    /// Uploads an existing `run-<timestamp>` directory without regenerating artifacts
+    /// or touching the EL container lifecycle.
+    async fn upload_existing_run(&self, run_timestamp: u64) -> Result<()> {
+        let run_output_dir = existing_run_output_dir(&self.config.output_dir, run_timestamp)?;
+        info!(
+            run_timestamp,
+            output_dir = %run_output_dir.display(),
+            "uploading existing snapshot run"
+        );
+
+        let files = collect_output_files(&run_output_dir)?;
+        let remote_manifest = self.uploader.fetch_previous_manifest().await?;
+        info!(
+            has_remote_manifest = remote_manifest.is_some(),
+            "fetched previous manifest for blake3 diff"
+        );
+        self.upload_run_directory(&run_output_dir, run_timestamp, files, remote_manifest.as_ref())
+            .await
+    }
+
+    /// Uploads one prepared run directory after generation or from upload-only mode.
+    async fn upload_run_directory(
+        &self,
+        run_output_dir: &Path,
+        run_timestamp: u64,
+        files: Vec<PathBuf>,
+        remote_manifest: Option<&SnapshotManifest>,
+    ) -> Result<()> {
+        if files.is_empty() {
+            bail!("snapshot run directory produced no files")
+        }
+
         let manifest_bytes = tokio::fs::read(run_output_dir.join("manifest.json"))
             .await
-            .context("failed to read freshly generated manifest.json")?;
-        let local_manifest: SnapshotManifest = serde_json::from_slice(&manifest_bytes)
-            .context("failed to parse freshly generated manifest.json")?;
+            .context("failed to read run manifest.json")?;
+        let local_manifest: SnapshotManifest =
+            serde_json::from_slice(&manifest_bytes).context("failed to parse run manifest.json")?;
 
         self.uploader
             .upload(
-                &run_output_dir,
+                run_output_dir,
                 &files,
                 run_timestamp,
                 self.config.retain_runs.get(),
                 &local_manifest,
-                remote_manifest.as_ref(),
+                remote_manifest,
             )
             .await
             .with_context(|| {
@@ -204,12 +255,6 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
                     run_output_dir.display()
                 )
             })?;
-
-        info!(output_dir = %run_output_dir.display(), "cleaning up local artifacts");
-        if let Err(e) = tokio::fs::remove_dir_all(&run_output_dir).await {
-            error!(error = %e, "failed to clean up output directory");
-        }
-
         Ok(())
     }
 
@@ -237,4 +282,28 @@ fn create_run_output_dir(base: &std::path::Path, timestamp: u64) -> Result<PathB
     std::fs::create_dir_all(&run_dir)
         .with_context(|| format!("failed to create run dir {}", run_dir.display()))?;
     Ok(run_dir)
+}
+
+/// Resolves an existing `run-<timestamp>` directory for upload-only mode.
+fn existing_run_output_dir(base: &Path, timestamp: u64) -> Result<PathBuf> {
+    let run_dir = base.join(format!("run-{timestamp}"));
+    let metadata = std::fs::metadata(&run_dir)
+        .with_context(|| format!("failed to stat existing run dir {}", run_dir.display()))?;
+    if !metadata.is_dir() {
+        bail!("existing run path is not a directory: {}", run_dir.display());
+    }
+    Ok(run_dir)
+}
+
+/// Collects all files in a run output directory (non-recursive).
+fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read output dir {}", dir.display()))?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()?
+        .into_iter()
+        .filter(|path| path.is_file())
+        .collect();
+    files.sort();
+    Ok(files)
 }

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -1,6 +1,7 @@
 //! Orchestrates the full snapshot lifecycle with a restart safety guard.
 
 use std::{
+    collections::HashMap,
     path::PathBuf,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -11,7 +12,7 @@ use tracing::{error, info, warn};
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
-    snapshot::{SnapshotGenerator, SnapshotManifest},
+    snapshot::{OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt},
     tip::TipChecker,
     upload::SnapshotUploader,
 };
@@ -139,21 +140,37 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             "fetched previous manifest for blake3 diff"
         );
 
+        let previous_chunk_output_files: HashMap<String, Vec<OutputFileChecksum>> = remote_manifest
+            .as_ref()
+            .map(|manifest| {
+                remote_static_files
+                    .keys()
+                    .filter_map(|filename| {
+                        manifest
+                            .chunk_output_files_for_file(filename)
+                            .map(|output_files| (filename.clone(), output_files))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let source_datadir = self.config.source_datadir.clone();
         let output_dir_for_gen = run_output_dir.clone();
         let chain_id = self.config.chain_id;
         let block = self.config.block;
         let blocks_per_file = self.config.blocks_per_file;
         let remote_for_gen = remote_static_files;
+        let previous_chunk_output_files_for_gen = previous_chunk_output_files;
 
         let files = tokio::task::spawn_blocking(move || {
-            SnapshotGenerator::generate_manifest(
+            SnapshotGenerator::generate_manifest_with_previous_chunk_output_files(
                 &source_datadir,
                 &output_dir_for_gen,
                 chain_id,
                 block,
                 blocks_per_file,
                 &remote_for_gen,
+                &previous_chunk_output_files_for_gen,
             )
         })
         .await
@@ -180,7 +197,13 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
                 remote_manifest.as_ref(),
             )
             .await
-            .context("snapshot upload failed")?;
+            .with_context(|| {
+                format!(
+                    "snapshot upload failed for run_timestamp={} output_dir={}",
+                    run_timestamp,
+                    run_output_dir.display()
+                )
+            })?;
 
         info!(output_dir = %run_output_dir.display(), "cleaning up local artifacts");
         if let Err(e) = tokio::fs::remove_dir_all(&run_output_dir).await {

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -50,7 +50,8 @@ fn progress_bar(done: u64, total: u64) -> String {
     let filled = if total == 0 {
         UPLOAD_PROGRESS_BAR_WIDTH
     } else {
-        ((done.min(total) as usize) * UPLOAD_PROGRESS_BAR_WIDTH) / (total as usize)
+        (((done.min(total) as u128) * (UPLOAD_PROGRESS_BAR_WIDTH as u128)) / (total as u128))
+            as usize
     };
     format!(
         "{}{}",

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashMap,
+    io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
@@ -13,7 +14,6 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 /// Interval between periodic progress logs during long-running snapshot operations
@@ -22,9 +22,59 @@ pub(crate) const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 
 const UPLOAD_STALL_WARNING_AFTER: Duration = Duration::from_secs(5 * 60);
 const MAX_STALLED_UPLOADS_IN_LOG: usize = 5;
+const INTERACTIVE_UPLOAD_RENDER_INTERVAL: Duration = Duration::from_millis(250);
+const INTERACTIVE_UPLOAD_ROWS: usize = 10;
+const UPLOAD_PROGRESS_BAR_WIDTH: usize = 24;
 
 const fn percent(done: u64, total: u64) -> u64 {
     if total == 0 { 100 } else { done.saturating_mul(100) / total }
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+    let mut value = bytes as f64;
+    let mut unit = UNITS[0];
+    for next_unit in UNITS.iter().skip(1) {
+        if value < 1024.0 {
+            break;
+        }
+        value /= 1024.0;
+        unit = next_unit;
+    }
+
+    if unit == "B" { format!("{bytes} B") } else { format!("{value:.1} {unit}") }
+}
+
+fn progress_bar(done: u64, total: u64) -> String {
+    let filled = if total == 0 {
+        UPLOAD_PROGRESS_BAR_WIDTH
+    } else {
+        ((done.min(total) as usize) * UPLOAD_PROGRESS_BAR_WIDTH) / (total as usize)
+    };
+    format!(
+        "{}{}",
+        "#".repeat(filled),
+        "-".repeat(UPLOAD_PROGRESS_BAR_WIDTH.saturating_sub(filled))
+    )
+}
+
+fn truncate_for_display(value: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() <= max_chars {
+        return value.to_string();
+    }
+    if max_chars <= 3 {
+        return "...".chars().take(max_chars).collect();
+    }
+
+    let front = (max_chars - 3) / 2;
+    let back = max_chars - 3 - front;
+    format!(
+        "{}...{}",
+        chars[..front].iter().collect::<String>(),
+        chars[chars.len() - back..].iter().collect::<String>()
+    )
 }
 
 /// Cumulative compression progress shared across every file in a single archive,
@@ -70,14 +120,81 @@ pub struct ComponentProgressReporter {
 }
 
 impl ComponentProgressReporter {
+    /// Registers an active archive within the component and returns a reporter
+    /// that streams byte progress into that archive's row.
+    pub(crate) fn start_archive(
+        &self,
+        archive_name: impl Into<String>,
+        total_bytes: u64,
+    ) -> ArchiveProgressReporter {
+        let archive_name = archive_name.into();
+        let now = Instant::now();
+        if let Ok(mut active_archives) = self.state.active_archives.lock() {
+            active_archives.insert(
+                archive_name.clone(),
+                ActiveArchiveState { total_bytes, bytes_done: 0, started: now },
+            );
+        }
+        ArchiveProgressReporter { component: self.clone(), archive_name }
+    }
+
     /// Adds `n` compressed source bytes to the component-wide total.
     pub fn record(&self, n: u64) {
         self.state.bytes_done.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Adds `n` source bytes to one active archive and the component total.
+    pub(crate) fn record_archive_bytes(&self, archive_name: &str, n: u64) {
+        self.record(n);
+        if let Ok(mut active_archives) = self.state.active_archives.lock()
+            && let Some(state) = active_archives.get_mut(archive_name)
+        {
+            state.bytes_done = state.bytes_done.saturating_add(n).min(state.total_bytes);
+        }
+    }
+
     /// Marks one archive within the component as fully packaged.
-    pub fn archive_completed(&self) {
+    pub(crate) fn archive_completed(&self, archive_name: &str) {
+        if let Ok(mut active_archives) = self.state.active_archives.lock()
+            && let Some(state) = active_archives.remove(archive_name)
+        {
+            let remaining = state.total_bytes.saturating_sub(state.bytes_done);
+            if remaining > 0 {
+                self.record(remaining);
+            }
+        }
         self.state.archives_done.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Removes a failed archive from the active set without counting it complete.
+    pub(crate) fn archive_failed(&self, archive_name: &str) {
+        if let Ok(mut active_archives) = self.state.active_archives.lock() {
+            active_archives.remove(archive_name);
+        }
+    }
+}
+
+/// Per-archive reporter backed by a shared component progress state.
+#[derive(Clone, Debug)]
+pub(crate) struct ArchiveProgressReporter {
+    component: ComponentProgressReporter,
+    archive_name: String,
+}
+
+impl ArchiveProgressReporter {
+    /// Adds `n` source bytes to this archive and the parent component total.
+    pub(crate) fn record(&self, n: u64) {
+        self.component.record_archive_bytes(&self.archive_name, n);
+    }
+
+    /// Marks this archive as fully packaged and removes it from the active set.
+    pub(crate) fn finish(&self) {
+        self.component.archive_completed(&self.archive_name);
+    }
+
+    /// Removes this archive from the active set after a failure.
+    pub(crate) fn fail(&self) {
+        self.component.archive_failed(&self.archive_name);
     }
 }
 
@@ -107,23 +224,63 @@ impl ComponentProgressLogger {
             started: Instant::now(),
             bytes_done: AtomicU64::new(0),
             archives_done: AtomicU64::new(0),
+            active_archives: Mutex::new(HashMap::new()),
+            interactive: io::stdout().is_terminal(),
         });
         let reporter = ComponentProgressReporter { state: Arc::clone(&state) };
         let (stop_tx, stop_rx) = mpsc::channel();
         let join_handle = std::thread::spawn(move || {
-            while stop_rx.recv_timeout(PROGRESS_LOG_INTERVAL).is_err() {
+            let mut rendered_lines = 0usize;
+            let tick = if state.interactive {
+                INTERACTIVE_UPLOAD_RENDER_INTERVAL
+            } else {
+                PROGRESS_LOG_INTERVAL
+            };
+            while stop_rx.recv_timeout(tick).is_err() {
                 let bytes_done = state.bytes_done.load(Ordering::Relaxed);
                 let archives_done = state.archives_done.load(Ordering::Relaxed);
-                info!(
-                    component = %state.component_name,
-                    bytes_done,
-                    total_bytes = state.total_bytes,
-                    percent = percent(bytes_done, state.total_bytes),
-                    archives_done,
-                    total_archives = state.total_archives,
-                    elapsed_secs = state.started.elapsed().as_secs(),
-                    "compressing component"
-                );
+                let active_archives = state.active_archives.lock().ok().map(|active| {
+                    let now = Instant::now();
+                    let mut items: Vec<ArchiveSnapshot> = active
+                        .iter()
+                        .map(|(archive_name, archive)| ArchiveSnapshot {
+                            archive_name: archive_name.clone(),
+                            total_bytes: archive.total_bytes,
+                            bytes_done: archive.bytes_done,
+                            age_secs: now.duration_since(archive.started).as_secs(),
+                        })
+                        .collect();
+                    items.sort_unstable_by(|a, b| a.archive_name.cmp(&b.archive_name));
+                    items
+                });
+
+                if state.interactive {
+                    rendered_lines = render_interactive_component(
+                        &state.component_name,
+                        &active_archives.unwrap_or_default(),
+                        bytes_done,
+                        state.total_bytes,
+                        archives_done,
+                        state.total_archives,
+                        state.started.elapsed().as_secs(),
+                        rendered_lines,
+                    );
+                } else {
+                    info!(
+                        component = %state.component_name,
+                        bytes_done,
+                        total_bytes = state.total_bytes,
+                        percent = percent(bytes_done, state.total_bytes),
+                        archives_done,
+                        total_archives = state.total_archives,
+                        active_archives = active_archives.as_ref().map_or(0, Vec::len),
+                        elapsed_secs = state.started.elapsed().as_secs(),
+                        "compressing component"
+                    );
+                }
+            }
+            if state.interactive {
+                clear_interactive_uploads(rendered_lines);
             }
         });
         Self { stop_tx: Some(stop_tx), join_handle: Some(join_handle), reporter }
@@ -155,6 +312,23 @@ pub struct ComponentProgressState {
     started: Instant,
     bytes_done: AtomicU64,
     archives_done: AtomicU64,
+    active_archives: Mutex<HashMap<String, ActiveArchiveState>>,
+    interactive: bool,
+}
+
+#[derive(Debug)]
+struct ActiveArchiveState {
+    total_bytes: u64,
+    bytes_done: u64,
+    started: Instant,
+}
+
+#[derive(Clone, Debug)]
+struct ArchiveSnapshot {
+    archive_name: String,
+    total_bytes: u64,
+    bytes_done: u64,
+    age_secs: u64,
 }
 
 /// Cumulative upload progress shared across concurrent artifact uploads. A spawned
@@ -165,7 +339,8 @@ pub struct UploadProgress {
     files_completed: Arc<AtomicU64>,
     total_bytes: u64,
     total_files: usize,
-    active_uploads: Arc<Mutex<HashMap<String, Instant>>>,
+    active_uploads: Arc<Mutex<HashMap<String, UploadFileState>>>,
+    interactive: bool,
 }
 
 impl UploadProgress {
@@ -196,6 +371,7 @@ impl UploadProgress {
             total_bytes,
             total_files,
             active_uploads: Arc::new(Mutex::new(HashMap::new())),
+            interactive: io::stdout().is_terminal(),
         })
     }
 
@@ -204,48 +380,105 @@ impl UploadProgress {
         self.uploaded.fetch_add(n, Ordering::Relaxed);
     }
 
-    /// Marks one whole artifact as fully uploaded.
-    pub(crate) fn file_completed(&self) {
+    /// Adds `n` uploaded bytes to the cumulative total and the named active file.
+    pub(crate) fn add_for_file(&self, key: &str, n: u64) {
+        self.add(n);
+        if let Ok(mut active_uploads) = self.active_uploads.lock()
+            && let Some(state) = active_uploads.get_mut(key)
+        {
+            state.uploaded_bytes = state.uploaded_bytes.saturating_add(n).min(state.total_bytes);
+            state.last_update = Instant::now();
+            state.stage = UploadStage::Uploading;
+        }
+    }
+
+    /// Registers an in-flight file upload so interactive rendering can show progress.
+    pub(crate) fn start_file(&self, key: impl Into<String>, total_bytes: u64, stage: UploadStage) {
+        let key = key.into();
+        if let Ok(mut active_uploads) = self.active_uploads.lock() {
+            let now = Instant::now();
+            active_uploads.insert(
+                key,
+                UploadFileState {
+                    total_bytes,
+                    uploaded_bytes: 0,
+                    stage,
+                    started: now,
+                    last_update: now,
+                },
+            );
+        }
+    }
+
+    /// Updates the current stage for one active file upload.
+    pub(crate) fn set_stage(&self, key: &str, stage: UploadStage) {
+        if let Ok(mut active_uploads) = self.active_uploads.lock()
+            && let Some(state) = active_uploads.get_mut(key)
+        {
+            state.stage = stage;
+            state.last_update = Instant::now();
+        }
+    }
+
+    /// Removes a failed file upload from the active set.
+    pub(crate) fn fail_file(&self, key: &str) {
+        if let Ok(mut active_uploads) = self.active_uploads.lock() {
+            active_uploads.remove(key);
+        }
+    }
+
+    /// Marks one whole artifact as fully uploaded and removes it from the active set.
+    pub(crate) fn finish_file(&self, key: &str) {
+        if let Ok(mut active_uploads) = self.active_uploads.lock()
+            && let Some(state) = active_uploads.remove(key)
+        {
+            let remaining = state.total_bytes.saturating_sub(state.uploaded_bytes);
+            if remaining > 0 {
+                self.add(remaining);
+            }
+        }
         self.files_completed.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Registers an in-flight upload operation and removes it automatically when dropped.
-    pub(crate) fn start_item(&self, label: impl Into<String>) -> UploadActivityGuard {
-        let label = label.into();
-        if let Ok(mut active_uploads) = self.active_uploads.lock() {
-            active_uploads.insert(label.clone(), Instant::now());
-        }
-        UploadActivityGuard { label, active_uploads: Arc::clone(&self.active_uploads) }
-    }
-
-    /// Spawns a background task that logs upload progress once per interval until
-    /// aborted via the returned handle.
-    pub fn spawn_logger(&self) -> JoinHandle<()> {
+    /// Spawns a background logger or interactive renderer, depending on whether
+    /// stdout is a terminal.
+    pub(crate) fn spawn_logger(&self) -> UploadProgressLogger {
         let uploaded = Arc::clone(&self.uploaded);
         let files_completed = Arc::clone(&self.files_completed);
         let total_bytes = self.total_bytes;
         let total_files = self.total_files;
         let active_uploads = Arc::clone(&self.active_uploads);
-        tokio::spawn(async move {
+        let interactive = self.interactive;
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let join_handle = std::thread::spawn(move || {
             let started = Instant::now();
-            let mut ticker = tokio::time::interval(PROGRESS_LOG_INTERVAL);
             let mut last_done = 0u64;
             let mut stalled_since: Option<Instant> = None;
             let mut last_stall_warning: Option<Instant> = None;
-            ticker.tick().await;
-            loop {
-                ticker.tick().await;
+            let mut rendered_lines = 0usize;
+            let tick = if interactive {
+                INTERACTIVE_UPLOAD_RENDER_INTERVAL
+            } else {
+                PROGRESS_LOG_INTERVAL
+            };
+
+            while stop_rx.recv_timeout(tick).is_err() {
                 let done = uploaded.load(Ordering::Relaxed);
                 let files_done = files_completed.load(Ordering::Relaxed);
                 let active_snapshot = active_uploads.lock().ok().map(|active| {
                     let now = Instant::now();
-                    let mut items: Vec<(String, u64)> = active
+                    let mut items: Vec<UploadFileSnapshot> = active
                         .iter()
-                        .map(|(label, started)| {
-                            (label.clone(), now.duration_since(*started).as_secs())
+                        .map(|(key, state)| UploadFileSnapshot {
+                            key: key.clone(),
+                            total_bytes: state.total_bytes,
+                            uploaded_bytes: state.uploaded_bytes,
+                            stage: state.stage,
+                            age_secs: now.duration_since(state.started).as_secs(),
+                            idle_secs: now.duration_since(state.last_update).as_secs(),
                         })
                         .collect();
-                    items.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+                    items.sort_unstable_by(|a, b| a.key.cmp(&b.key));
                     items
                 });
                 let active_count = active_snapshot.as_ref().map_or(0, Vec::len);
@@ -262,7 +495,16 @@ impl UploadProgress {
                             .into_iter()
                             .flatten()
                             .take(MAX_STALLED_UPLOADS_IN_LOG)
-                            .map(|(label, age_secs)| format!("{label} ({age_secs}s)"))
+                            .map(|state| {
+                                format!(
+                                    "{} [{}] {} / {} (idle {}s)",
+                                    state.key,
+                                    state.stage.label(),
+                                    human_bytes(state.uploaded_bytes),
+                                    human_bytes(state.total_bytes),
+                                    state.idle_secs
+                                )
+                            })
                             .collect();
                         warn!(
                             bytes_uploaded = done,
@@ -281,32 +523,223 @@ impl UploadProgress {
                     last_stall_warning = None;
                 }
 
-                info!(
-                    bytes_uploaded = done,
-                    total_bytes,
-                    percent = percent(done, total_bytes),
-                    files_uploaded = files_done,
-                    total_files,
-                    active_uploads = active_count,
-                    elapsed_secs = started.elapsed().as_secs(),
-                    "uploading snapshot artifacts (progress)"
-                );
+                if interactive {
+                    rendered_lines = render_interactive_uploads(
+                        &active_snapshot.unwrap_or_default(),
+                        done,
+                        total_bytes,
+                        files_done,
+                        total_files,
+                        started.elapsed().as_secs(),
+                        rendered_lines,
+                    );
+                } else {
+                    info!(
+                        bytes_uploaded = done,
+                        total_bytes,
+                        percent = percent(done, total_bytes),
+                        files_uploaded = files_done,
+                        total_files,
+                        active_uploads = active_count,
+                        elapsed_secs = started.elapsed().as_secs(),
+                        "uploading snapshot artifacts (progress)"
+                    );
+                }
                 last_done = done;
             }
-        })
+            if interactive {
+                clear_interactive_uploads(rendered_lines);
+            }
+        });
+
+        UploadProgressLogger { stop_tx: Some(stop_tx), join_handle: Some(join_handle) }
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct UploadActivityGuard {
-    label: String,
-    active_uploads: Arc<Mutex<HashMap<String, Instant>>>,
+pub(crate) struct UploadProgressLogger {
+    stop_tx: Option<mpsc::Sender<()>>,
+    join_handle: Option<StdJoinHandle<()>>,
 }
 
-impl Drop for UploadActivityGuard {
-    fn drop(&mut self) {
-        if let Ok(mut active_uploads) = self.active_uploads.lock() {
-            active_uploads.remove(&self.label);
+impl UploadProgressLogger {
+    /// Stops the background upload logger and clears any interactive rendering.
+    pub(crate) fn stop(mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(join_handle) = self.join_handle.take() {
+            let _ = join_handle.join();
         }
     }
+}
+
+impl Drop for UploadProgressLogger {
+    fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(join_handle) = self.join_handle.take() {
+            let _ = join_handle.join();
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum UploadStage {
+    CreatingMultipart,
+    Uploading,
+    CompletingMultipart,
+}
+
+impl UploadStage {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::CreatingMultipart => "create",
+            Self::Uploading => "upload",
+            Self::CompletingMultipart => "complete",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct UploadFileState {
+    total_bytes: u64,
+    uploaded_bytes: u64,
+    stage: UploadStage,
+    started: Instant,
+    last_update: Instant,
+}
+
+#[derive(Clone, Debug)]
+struct UploadFileSnapshot {
+    key: String,
+    total_bytes: u64,
+    uploaded_bytes: u64,
+    stage: UploadStage,
+    age_secs: u64,
+    idle_secs: u64,
+}
+
+fn render_interactive_uploads(
+    active: &[UploadFileSnapshot],
+    done: u64,
+    total_bytes: u64,
+    files_done: u64,
+    total_files: usize,
+    elapsed_secs: u64,
+    previously_rendered_lines: usize,
+) -> usize {
+    const TOTAL_LINES: usize = INTERACTIVE_UPLOAD_ROWS + 1;
+
+    let mut stdout = io::stdout().lock();
+    let lines_to_move_up = previously_rendered_lines.saturating_sub(1);
+    if lines_to_move_up > 0 {
+        let _ = write!(stdout, "\x1b[{}F", lines_to_move_up);
+    }
+
+    let hidden_count = active.len().saturating_sub(INTERACTIVE_UPLOAD_ROWS);
+    for row in 0..INTERACTIVE_UPLOAD_ROWS {
+        let _ = write!(stdout, "\x1b[2K");
+        if let Some(file) = active.get(row) {
+            let name = file.key.rsplit('/').next().unwrap_or(&file.key);
+            let line = format!(
+                "{:<36} [{}] [{}] {:>10} / {:<10} {:>4}% {:>5}s",
+                truncate_for_display(name, 36),
+                file.stage.label(),
+                progress_bar(file.uploaded_bytes, file.total_bytes),
+                human_bytes(file.uploaded_bytes),
+                human_bytes(file.total_bytes),
+                percent(file.uploaded_bytes, file.total_bytes),
+                file.age_secs
+            );
+            let _ = write!(stdout, "{line}");
+        }
+        let _ = writeln!(stdout);
+    }
+
+    let status = format!(
+        "files {files_done}/{total_files} | active {}{} | total {} / {} ({}%) | elapsed {}s",
+        active.len(),
+        if hidden_count > 0 { format!(" (+{hidden_count} hidden)") } else { String::new() },
+        human_bytes(done),
+        human_bytes(total_bytes),
+        percent(done, total_bytes),
+        elapsed_secs
+    );
+    let _ = write!(stdout, "\x1b[2K{status}");
+    let _ = stdout.flush();
+
+    TOTAL_LINES
+}
+
+fn clear_interactive_uploads(rendered_lines: usize) {
+    if rendered_lines == 0 {
+        return;
+    }
+
+    let mut stdout = io::stdout().lock();
+    let lines_to_move_up = rendered_lines.saturating_sub(1);
+    if lines_to_move_up > 0 {
+        let _ = write!(stdout, "\x1b[{}F", lines_to_move_up);
+    }
+    for line in 0..rendered_lines {
+        let _ = write!(stdout, "\x1b[2K");
+        if line + 1 < rendered_lines {
+            let _ = writeln!(stdout);
+        }
+    }
+    let _ = write!(stdout, "\r");
+    let _ = stdout.flush();
+}
+
+fn render_interactive_component(
+    component_name: &str,
+    active: &[ArchiveSnapshot],
+    done: u64,
+    total_bytes: u64,
+    archives_done: u64,
+    total_archives: usize,
+    elapsed_secs: u64,
+    previously_rendered_lines: usize,
+) -> usize {
+    const TOTAL_LINES: usize = INTERACTIVE_UPLOAD_ROWS + 1;
+
+    let mut stdout = io::stdout().lock();
+    let lines_to_move_up = previously_rendered_lines.saturating_sub(1);
+    if lines_to_move_up > 0 {
+        let _ = write!(stdout, "\x1b[{}F", lines_to_move_up);
+    }
+
+    let hidden_count = active.len().saturating_sub(INTERACTIVE_UPLOAD_ROWS);
+    for row in 0..INTERACTIVE_UPLOAD_ROWS {
+        let _ = write!(stdout, "\x1b[2K");
+        if let Some(archive) = active.get(row) {
+            let line = format!(
+                "{:<36} [{}] {:>10} / {:<10} {:>4}% {:>5}s",
+                truncate_for_display(&archive.archive_name, 36),
+                progress_bar(archive.bytes_done, archive.total_bytes),
+                human_bytes(archive.bytes_done),
+                human_bytes(archive.total_bytes),
+                percent(archive.bytes_done, archive.total_bytes),
+                archive.age_secs
+            );
+            let _ = write!(stdout, "{line}");
+        }
+        let _ = writeln!(stdout);
+    }
+
+    let status = format!(
+        "component {component_name} | archives {archives_done}/{total_archives} | active {}{} | total {} / {} ({}%) | elapsed {}s",
+        active.len(),
+        if hidden_count > 0 { format!(" (+{hidden_count} hidden)") } else { String::new() },
+        human_bytes(done),
+        human_bytes(total_bytes),
+        percent(done, total_bytes),
+        elapsed_secs
+    );
+    let _ = write!(stdout, "\x1b[2K{status}");
+    let _ = stdout.flush();
+
+    TOTAL_LINES
 }

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -1,21 +1,27 @@
 //! Shared progress-reporting helpers used across snapshot generation and upload.
 
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
+        mpsc,
     },
+    thread::JoinHandle as StdJoinHandle,
     time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
 use tokio::task::JoinHandle;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Interval between periodic progress logs during long-running snapshot operations
 /// (archive compression and artifact upload).
 pub(crate) const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
+
+const UPLOAD_STALL_WARNING_AFTER: Duration = Duration::from_secs(5 * 60);
+const MAX_STALLED_UPLOADS_IN_LOG: usize = 5;
 
 const fn percent(done: u64, total: u64) -> u64 {
     if total == 0 { 100 } else { done.saturating_mul(100) / total }
@@ -56,12 +62,110 @@ impl ArchiveProgress {
     }
 }
 
+/// Shared compression progress for a whole chunked snapshot component such as
+/// `transactions`, aggregating bytes across every archive compressed in parallel.
+#[derive(Clone, Debug)]
+pub struct ComponentProgressReporter {
+    state: Arc<ComponentProgressState>,
+}
+
+impl ComponentProgressReporter {
+    /// Adds `n` compressed source bytes to the component-wide total.
+    pub fn record(&self, n: u64) {
+        self.state.bytes_done.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Marks one archive within the component as fully packaged.
+    pub fn archive_completed(&self) {
+        self.state.archives_done.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Owns a background logger that periodically reports one progress line for an
+/// entire chunked component while its archives are being compressed.
+pub struct ComponentProgressLogger {
+    stop_tx: Option<mpsc::Sender<()>>,
+    join_handle: Option<StdJoinHandle<()>>,
+    reporter: ComponentProgressReporter,
+}
+
+impl std::fmt::Debug for ComponentProgressLogger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComponentProgressLogger")
+            .field("reporter", &self.reporter)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ComponentProgressLogger {
+    /// Starts a periodic logger for one chunked component.
+    pub fn new(component_name: String, total_bytes: u64, total_archives: usize) -> Self {
+        let state = Arc::new(ComponentProgressState {
+            component_name,
+            total_bytes,
+            total_archives,
+            started: Instant::now(),
+            bytes_done: AtomicU64::new(0),
+            archives_done: AtomicU64::new(0),
+        });
+        let reporter = ComponentProgressReporter { state: Arc::clone(&state) };
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let join_handle = std::thread::spawn(move || {
+            while stop_rx.recv_timeout(PROGRESS_LOG_INTERVAL).is_err() {
+                let bytes_done = state.bytes_done.load(Ordering::Relaxed);
+                let archives_done = state.archives_done.load(Ordering::Relaxed);
+                info!(
+                    component = %state.component_name,
+                    bytes_done,
+                    total_bytes = state.total_bytes,
+                    percent = percent(bytes_done, state.total_bytes),
+                    archives_done,
+                    total_archives = state.total_archives,
+                    elapsed_secs = state.started.elapsed().as_secs(),
+                    "compressing component"
+                );
+            }
+        });
+        Self { stop_tx: Some(stop_tx), join_handle: Some(join_handle), reporter }
+    }
+
+    /// Returns a cloneable reporter that worker threads can update concurrently.
+    pub fn reporter(&self) -> ComponentProgressReporter {
+        self.reporter.clone()
+    }
+}
+
+impl Drop for ComponentProgressLogger {
+    fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(join_handle) = self.join_handle.take() {
+            let _ = join_handle.join();
+        }
+    }
+}
+
+/// Shared immutable metadata and atomics backing one component-wide compression logger.
+#[derive(Debug)]
+pub struct ComponentProgressState {
+    component_name: String,
+    total_bytes: u64,
+    total_archives: usize,
+    started: Instant,
+    bytes_done: AtomicU64,
+    archives_done: AtomicU64,
+}
+
 /// Cumulative upload progress shared across concurrent artifact uploads. A spawned
 /// ticker reads the atomic byte counter and logs throughput once per interval.
 #[derive(Debug)]
 pub struct UploadProgress {
     uploaded: Arc<AtomicU64>,
+    files_completed: Arc<AtomicU64>,
     total_bytes: u64,
+    total_files: usize,
+    active_uploads: Arc<Mutex<HashMap<String, Instant>>>,
 }
 
 impl UploadProgress {
@@ -74,6 +178,7 @@ impl UploadProgress {
         manifest_path: &Path,
     ) -> Result<Self> {
         let mut total_bytes = 0u64;
+        let total_files = static_uploads.len() + run_uploads.len() + 1;
         let files = static_uploads
             .iter()
             .map(PathBuf::as_path)
@@ -85,7 +190,13 @@ impl UploadProgress {
                 .with_context(|| format!("failed to stat {} for upload total", file.display()))?;
             total_bytes += meta.len();
         }
-        Ok(Self { uploaded: Arc::new(AtomicU64::new(0)), total_bytes })
+        Ok(Self {
+            uploaded: Arc::new(AtomicU64::new(0)),
+            files_completed: Arc::new(AtomicU64::new(0)),
+            total_bytes,
+            total_files,
+            active_uploads: Arc::new(Mutex::new(HashMap::new())),
+        })
     }
 
     /// Adds `n` successfully-uploaded bytes to the cumulative counter.
@@ -93,26 +204,109 @@ impl UploadProgress {
         self.uploaded.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Marks one whole artifact as fully uploaded.
+    pub(crate) fn file_completed(&self) {
+        self.files_completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Registers an in-flight upload operation and removes it automatically when dropped.
+    pub(crate) fn start_item(&self, label: impl Into<String>) -> UploadActivityGuard {
+        let label = label.into();
+        if let Ok(mut active_uploads) = self.active_uploads.lock() {
+            active_uploads.insert(label.clone(), Instant::now());
+        }
+        UploadActivityGuard { label, active_uploads: Arc::clone(&self.active_uploads) }
+    }
+
     /// Spawns a background task that logs upload progress once per interval until
     /// aborted via the returned handle.
     pub fn spawn_logger(&self) -> JoinHandle<()> {
         let uploaded = Arc::clone(&self.uploaded);
+        let files_completed = Arc::clone(&self.files_completed);
         let total_bytes = self.total_bytes;
+        let total_files = self.total_files;
+        let active_uploads = Arc::clone(&self.active_uploads);
         tokio::spawn(async move {
             let started = Instant::now();
             let mut ticker = tokio::time::interval(PROGRESS_LOG_INTERVAL);
+            let mut last_done = 0u64;
+            let mut stalled_since: Option<Instant> = None;
+            let mut last_stall_warning: Option<Instant> = None;
             ticker.tick().await;
             loop {
                 ticker.tick().await;
                 let done = uploaded.load(Ordering::Relaxed);
+                let files_done = files_completed.load(Ordering::Relaxed);
+                let active_snapshot = active_uploads.lock().ok().map(|active| {
+                    let now = Instant::now();
+                    let mut items: Vec<(String, u64)> = active
+                        .iter()
+                        .map(|(label, started)| {
+                            (label.clone(), now.duration_since(*started).as_secs())
+                        })
+                        .collect();
+                    items.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+                    items
+                });
+                let active_count = active_snapshot.as_ref().map_or(0, Vec::len);
+
+                if done == last_done && active_count > 0 {
+                    let stalled_at = stalled_since.get_or_insert_with(Instant::now);
+                    let should_warn = stalled_at.elapsed() >= UPLOAD_STALL_WARNING_AFTER
+                        && last_stall_warning.is_none_or(|last_warning| {
+                            last_warning.elapsed() >= UPLOAD_STALL_WARNING_AFTER
+                        });
+                    if should_warn {
+                        let stalled_uploads: Vec<String> = active_snapshot
+                            .as_ref()
+                            .into_iter()
+                            .flatten()
+                            .take(MAX_STALLED_UPLOADS_IN_LOG)
+                            .map(|(label, age_secs)| format!("{label} ({age_secs}s)"))
+                            .collect();
+                        warn!(
+                            bytes_uploaded = done,
+                            total_bytes,
+                            files_uploaded = files_done,
+                            total_files,
+                            stalled_secs = stalled_at.elapsed().as_secs(),
+                            active_uploads = active_count,
+                            stalled_uploads = ?stalled_uploads,
+                            "upload progress is stalled"
+                        );
+                        last_stall_warning = Some(Instant::now());
+                    }
+                } else {
+                    stalled_since = None;
+                    last_stall_warning = None;
+                }
+
                 info!(
                     bytes_uploaded = done,
                     total_bytes,
                     percent = percent(done, total_bytes),
+                    files_uploaded = files_done,
+                    total_files,
+                    active_uploads = active_count,
                     elapsed_secs = started.elapsed().as_secs(),
                     "uploading snapshot artifacts (progress)"
                 );
+                last_done = done;
             }
         })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct UploadActivityGuard {
+    label: String,
+    active_uploads: Arc<Mutex<HashMap<String, Instant>>>,
+}
+
+impl Drop for UploadActivityGuard {
+    fn drop(&mut self) {
+        if let Ok(mut active_uploads) = self.active_uploads.lock() {
+            active_uploads.remove(&self.label);
+        }
     }
 }

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -258,12 +258,14 @@ impl ComponentProgressLogger {
                     rendered_lines = render_interactive_component(
                         &state.component_name,
                         &active_archives.unwrap_or_default(),
-                        bytes_done,
-                        state.total_bytes,
-                        archives_done,
-                        state.total_archives,
-                        state.started.elapsed().as_secs(),
-                        rendered_lines,
+                        InteractiveSummary {
+                            done: bytes_done,
+                            total_bytes: state.total_bytes,
+                            completed: archives_done,
+                            total_items: state.total_archives,
+                            elapsed_secs: state.started.elapsed().as_secs(),
+                            previously_rendered_lines: rendered_lines,
+                        },
                     );
                 } else {
                     info!(
@@ -341,6 +343,15 @@ struct ArchiveSnapshot {
     total_bytes: u64,
     bytes_done: u64,
     age_secs: u64,
+}
+
+struct InteractiveSummary {
+    done: u64,
+    total_bytes: u64,
+    completed: u64,
+    total_items: usize,
+    elapsed_secs: u64,
+    previously_rendered_lines: usize,
 }
 
 /// Cumulative upload progress shared across concurrent artifact uploads. A spawned
@@ -647,7 +658,7 @@ fn render_interactive_uploads(
     let mut stdout = io::stdout().lock();
     let lines_to_move_up = previously_rendered_lines.saturating_sub(1);
     if lines_to_move_up > 0 {
-        let _ = write!(stdout, "\x1b[{}F", lines_to_move_up);
+        let _ = write!(stdout, "\x1b[{lines_to_move_up}F");
     }
 
     let hidden_count = active.len().saturating_sub(INTERACTIVE_UPLOAD_ROWS);
@@ -693,7 +704,7 @@ fn clear_interactive_uploads(rendered_lines: usize) {
     let mut stdout = io::stdout().lock();
     let lines_to_move_up = rendered_lines.saturating_sub(1);
     if lines_to_move_up > 0 {
-        let _ = write!(stdout, "\x1b[{}F", lines_to_move_up);
+        let _ = write!(stdout, "\x1b[{lines_to_move_up}F");
     }
     for line in 0..rendered_lines {
         let _ = write!(stdout, "\x1b[2K");
@@ -708,19 +719,14 @@ fn clear_interactive_uploads(rendered_lines: usize) {
 fn render_interactive_component(
     component_name: &str,
     active: &[ArchiveSnapshot],
-    done: u64,
-    total_bytes: u64,
-    archives_done: u64,
-    total_archives: usize,
-    elapsed_secs: u64,
-    previously_rendered_lines: usize,
+    summary: InteractiveSummary,
 ) -> usize {
     const TOTAL_LINES: usize = INTERACTIVE_UPLOAD_ROWS + 1;
 
     let mut stdout = io::stdout().lock();
-    let lines_to_move_up = previously_rendered_lines.saturating_sub(1);
+    let lines_to_move_up = summary.previously_rendered_lines.saturating_sub(1);
     if lines_to_move_up > 0 {
-        let _ = write!(stdout, "\x1b[{}F", lines_to_move_up);
+        let _ = write!(stdout, "\x1b[{lines_to_move_up}F");
     }
 
     let hidden_count = active.len().saturating_sub(INTERACTIVE_UPLOAD_ROWS);
@@ -742,13 +748,15 @@ fn render_interactive_component(
     }
 
     let status = format!(
-        "component {component_name} | archives {archives_done}/{total_archives} | active {}{} | total {} / {} ({}%) | elapsed {}s",
+        "component {component_name} | archives {}/{} | active {}{} | total {} / {} ({}%) | elapsed {}s",
+        summary.completed,
+        summary.total_items,
         active.len(),
         if hidden_count > 0 { format!(" (+{hidden_count} hidden)") } else { String::new() },
-        human_bytes(done),
-        human_bytes(total_bytes),
-        percent(done, total_bytes),
-        elapsed_secs
+        human_bytes(summary.done),
+        human_bytes(summary.total_bytes),
+        percent(summary.done, summary.total_bytes),
+        summary.elapsed_secs
     );
     let _ = write!(stdout, "\x1b[2K{status}");
     let _ = stdout.flush();

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -306,21 +306,33 @@ impl Drop for ComponentProgressLogger {
 /// Shared immutable metadata and atomics backing one component-wide compression logger.
 #[derive(Debug)]
 pub struct ComponentProgressState {
-    component_name: String,
-    total_bytes: u64,
-    total_archives: usize,
-    started: Instant,
-    bytes_done: AtomicU64,
-    archives_done: AtomicU64,
-    active_archives: Mutex<HashMap<String, ActiveArchiveState>>,
-    interactive: bool,
+    /// Snapshot component name such as `headers` or `receipts`.
+    pub component_name: String,
+    /// Total uncompressed source bytes scheduled for this component.
+    pub total_bytes: u64,
+    /// Number of archives that will be produced for this component.
+    pub total_archives: usize,
+    /// Monotonic timestamp when component compression started.
+    pub started: Instant,
+    /// Aggregate uncompressed source bytes processed across all archives.
+    pub bytes_done: AtomicU64,
+    /// Number of archives that have fully completed compression.
+    pub archives_done: AtomicU64,
+    /// Currently active archive rows for the live component renderer.
+    pub active_archives: Mutex<HashMap<String, ActiveArchiveState>>,
+    /// Whether the component logger is rendering interactively to a TTY.
+    pub interactive: bool,
 }
 
+/// Live progress state for one in-flight archive within a component.
 #[derive(Debug)]
-struct ActiveArchiveState {
-    total_bytes: u64,
-    bytes_done: u64,
-    started: Instant,
+pub struct ActiveArchiveState {
+    /// Total uncompressed source bytes for this archive.
+    pub total_bytes: u64,
+    /// Uncompressed source bytes processed so far for this archive.
+    pub bytes_done: u64,
+    /// Monotonic timestamp when this archive started compression.
+    pub started: Instant,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -21,7 +21,7 @@ pub use reth_cli_commands::download::manifest::{
 };
 use tracing::info;
 
-use crate::progress::ArchiveProgress;
+use crate::progress::{ComponentProgressLogger, ComponentProgressReporter};
 
 /// Default blocks per static file segment.
 const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
@@ -117,6 +117,31 @@ impl SnapshotGenerator {
         blocks_per_file: Option<u64>,
         remote_static_files: &HashMap<String, u64>,
     ) -> Result<Vec<PathBuf>> {
+        Self::generate_manifest_with_previous_chunk_output_files(
+            source_datadir,
+            output_dir,
+            chain_id,
+            block,
+            blocks_per_file,
+            remote_static_files,
+            &HashMap::new(),
+        )
+    }
+
+    /// Generates snapshot archives while reusing prior per-file chunk metadata when available.
+    ///
+    /// This avoids a long serial pre-pass over finalized chunks: when `previous_chunk_output_files`
+    /// contains a skipped archive's `OutputFileChecksum` entries, the generator can copy those
+    /// manifest rows directly instead of re-hashing local files that will not be re-uploaded.
+    pub fn generate_manifest_with_previous_chunk_output_files(
+        source_datadir: &Path,
+        output_dir: &Path,
+        chain_id: u64,
+        block: Option<u64>,
+        blocks_per_file: Option<u64>,
+        remote_static_files: &HashMap<String, u64>,
+        previous_chunk_output_files: &HashMap<String, Vec<OutputFileChecksum>>,
+    ) -> Result<Vec<PathBuf>> {
         std::fs::create_dir_all(output_dir)
             .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
 
@@ -157,6 +182,7 @@ impl SnapshotGenerator {
 
         for &(key, segment_name) in CHUNKED_COMPONENTS {
             let mut planned = Vec::new();
+            let mut planned_hash_only = Vec::new();
             let mut found_any = false;
             let mut chunk_sizes = vec![0u64; num_chunks as usize];
             let mut chunk_decompressed = vec![0u64; num_chunks as usize];
@@ -176,10 +202,6 @@ impl SnapshotGenerator {
                 }
                 found_any = true;
 
-                let output_files = chunk_output_files_for_source_files(&source_files)?;
-                chunk_decompressed[i as usize] = output_files.iter().map(|f| f.size).sum();
-                chunk_output_files[i as usize] = output_files;
-
                 if skip_ranges.contains(&(start, end)) {
                     let archive_name = ChunkFilename::format(key, start, end);
                     chunk_sizes[i as usize] =
@@ -188,6 +210,17 @@ impl SnapshotGenerator {
                                 "missing remote size for skipped archive {archive_name}"
                             )
                         })?;
+
+                    if let Some(output_files) = previous_chunk_output_files.get(&archive_name) {
+                        chunk_decompressed[i as usize] = output_files.iter().map(|f| f.size).sum();
+                        chunk_output_files[i as usize] = output_files.clone();
+                    } else {
+                        planned_hash_only.push(PlannedChunk {
+                            chunk_idx: i,
+                            archive_path: output_dir.join(&archive_name),
+                            source_files,
+                        });
+                    }
                     continue;
                 }
 
@@ -201,14 +234,47 @@ impl SnapshotGenerator {
             if !found_any {
                 info!(component = key, "no static files found, skipping component");
             } else {
+                let hashed_only: Vec<PackagedChunk> = planned_hash_only
+                    .into_par_iter()
+                    .map(|p| {
+                        let output_files = chunk_output_files_for_source_files(&p.source_files)?;
+                        Ok(PackagedChunk { chunk_idx: p.chunk_idx, size: 0, output_files })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                for p in hashed_only {
+                    let idx = p.chunk_idx as usize;
+                    chunk_decompressed[idx] = p.output_files.iter().map(|f| f.size).sum();
+                    chunk_output_files[idx] = p.output_files;
+                }
+
+                let progress_logger = if planned.is_empty() {
+                    None
+                } else {
+                    Some(ComponentProgressLogger::new(
+                        key.to_string(),
+                        planned_chunks_total_bytes(&planned)?,
+                        planned.len(),
+                    ))
+                };
+                let progress_reporter =
+                    progress_logger.as_ref().map(ComponentProgressLogger::reporter);
                 let packaged: Vec<PackagedChunk> = planned
                     .into_par_iter()
                     .map(|p| {
-                        let output_files = write_chunk_archive(&p.archive_path, &p.source_files)?;
+                        let output_files = write_chunk_archive(
+                            &p.archive_path,
+                            &p.source_files,
+                            progress_reporter.clone(),
+                        )?;
+                        if let Some(progress_reporter) = progress_reporter.as_ref() {
+                            progress_reporter.archive_completed();
+                        }
                         let size = std::fs::metadata(&p.archive_path)?.len();
                         Ok(PackagedChunk { chunk_idx: p.chunk_idx, size, output_files })
                     })
                     .collect::<Result<Vec<_>>>()?;
+                drop(progress_logger);
 
                 for p in packaged {
                     let idx = p.chunk_idx as usize;
@@ -528,12 +594,16 @@ fn package_single_component(
         bail!("cannot package empty archive: {archive_name}");
     }
     let archive_path = output_dir.join(archive_name);
-    let output_files = write_archive_from_planned_files(&archive_path, files)?;
+    let output_files = write_archive_from_planned_files(&archive_path, files, None)?;
     let size = std::fs::metadata(&archive_path)?.len();
     Ok((size, output_files))
 }
 
-fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<OutputFileChecksum>> {
+fn write_chunk_archive(
+    path: &Path,
+    source_files: &[PathBuf],
+    progress: Option<ComponentProgressReporter>,
+) -> Result<Vec<OutputFileChecksum>> {
     let planned: Vec<PlannedFile> = source_files
         .iter()
         .map(|p| {
@@ -546,7 +616,7 @@ fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<Outp
         })
         .collect::<Result<Vec<_>>>()?;
 
-    write_archive_from_planned_files(path, &planned)
+    write_archive_from_planned_files(path, &planned, progress)
 }
 
 fn chunk_output_files_for_source_files(
@@ -570,13 +640,15 @@ fn chunk_output_files_for_source_files(
 fn write_archive_from_planned_files(
     path: &Path,
     files: &[PlannedFile],
+    progress: Option<ComponentProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let file = std::fs::File::create(path)?;
     let mut encoder = zstd::Encoder::new(file, 0)?;
     encoder.include_checksum(true)?;
     let mut builder = tar::Builder::new(encoder);
 
-    let output_files = compute_output_files_and_archive(files, Some((&mut builder, path)))?;
+    let output_files =
+        compute_output_files_and_archive(files, Some((&mut builder, path)), progress)?;
 
     let encoder = builder.into_inner()?;
     encoder.finish()?;
@@ -587,27 +659,20 @@ fn write_archive_from_planned_files(
 fn compute_output_files_for_planned_files(
     files: &[PlannedFile],
 ) -> Result<Vec<OutputFileChecksum>> {
-    compute_output_files_and_archive(files, None)
+    compute_output_files_and_archive(files, None, None)
 }
 
 fn compute_output_files_and_archive(
     files: &[PlannedFile],
     mut archive: Option<(&mut tar::Builder<zstd::Encoder<'_, std::fs::File>>, &Path)>,
+    progress: Option<ComponentProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
-    let archive_name = archive
-        .as_ref()
-        .and_then(|(_, path)| path.file_name().map(|n| n.to_string_lossy().to_string()));
-    let total_bytes: u64 = files
-        .iter()
-        .try_fold(0u64, |acc, f| std::fs::metadata(&f.source_path).map(|m| acc + m.len()))?;
-    let mut progress = archive_name.map(|name| ArchiveProgress::new(name, total_bytes));
-
     let mut output_files = Vec::with_capacity(files.len());
     for planned in files {
         let expected_size = std::fs::metadata(&planned.source_path)?.len();
 
         let source_file = std::fs::File::open(&planned.source_path)?;
-        let mut reader = HashingReader::new(source_file, progress.as_mut());
+        let mut reader = HashingReader::new(source_file, progress.clone());
 
         if let Some((builder, archive_path)) = archive.as_mut() {
             let mut header = tar::Header::new_gnu();
@@ -645,15 +710,15 @@ fn compute_output_files_and_archive(
     Ok(output_files)
 }
 
-struct HashingReader<'a, R> {
+struct HashingReader<R> {
     inner: R,
     hasher: blake3::Hasher,
     bytes_read: u64,
-    progress: Option<&'a mut ArchiveProgress>,
+    progress: Option<ComponentProgressReporter>,
 }
 
-impl<'a, R: Read> HashingReader<'a, R> {
-    fn new(inner: R, progress: Option<&'a mut ArchiveProgress>) -> Self {
+impl<R: Read> HashingReader<R> {
+    fn new(inner: R, progress: Option<ComponentProgressReporter>) -> Self {
         Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0, progress }
     }
 
@@ -662,18 +727,27 @@ impl<'a, R: Read> HashingReader<'a, R> {
     }
 }
 
-impl<R: Read> Read for HashingReader<'_, R> {
+impl<R: Read> Read for HashingReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let n = self.inner.read(buf)?;
         if n > 0 {
             self.bytes_read += n as u64;
             self.hasher.update(&buf[..n]);
-            if let Some(progress) = self.progress.as_mut() {
+            if let Some(progress) = self.progress.as_ref() {
                 progress.record(n as u64);
             }
         }
         Ok(n)
     }
+}
+
+fn planned_chunks_total_bytes(chunks: &[PlannedChunk]) -> Result<u64> {
+    chunks.iter().try_fold(0u64, |acc, chunk| {
+        let chunk_bytes = chunk.source_files.iter().try_fold(0u64, |chunk_acc, path| {
+            std::fs::metadata(path).map(|m| chunk_acc + m.len())
+        })?;
+        Ok(acc + chunk_bytes)
+    })
 }
 
 /// Collects all files in the output directory (non-recursive).
@@ -904,13 +978,23 @@ mod tests {
             remote.insert(ChunkFilename::format(key, 0, 499_999), 0u64);
         }
 
-        SnapshotGenerator::generate_manifest(
+        let previous_chunk_output_files = HashMap::from([(
+            "headers-0-499999.tar.zst".to_string(),
+            vec![OutputFileChecksum {
+                path: "static_files/static_file_headers_0_499999".to_string(),
+                size: 777,
+                blake3: "reused-from-previous-manifest".to_string(),
+            }],
+        )]);
+
+        SnapshotGenerator::generate_manifest_with_previous_chunk_output_files(
             source.path(),
             output.path(),
             8453,
             Some(2_000_000),
             Some(500_000),
             &remote,
+            &previous_chunk_output_files,
         )
         .unwrap();
 
@@ -927,6 +1011,10 @@ mod tests {
         assert!(
             chunk_output_files[0].as_array().is_some_and(|files| !files.is_empty()),
             "skipped chunk should still retain output-file metadata"
+        );
+        assert_eq!(
+            chunk_output_files[0][0]["blake3"], "reused-from-previous-manifest",
+            "skipped chunk should reuse previous manifest metadata when available"
         );
         assert!(
             headers.get("chunk_skipped").is_none(),

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -368,8 +368,23 @@ impl SnapshotGenerator {
         std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?)?;
         info!(block, components = manifest.components.len(), "manifest written");
 
-        let files = collect_output_files(output_dir)?;
+        let files = Self::collect_output_files(output_dir)?;
         info!(file_count = files.len(), "snapshot generation complete");
+        Ok(files)
+    }
+
+    /// Collects all files in a snapshot output directory (non-recursive).
+    pub fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
+        let mut files = Vec::new();
+        for entry in
+            std::fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))?
+        {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                files.push(entry.path());
+            }
+        }
+        files.sort_unstable();
         Ok(files)
     }
 
@@ -778,21 +793,6 @@ fn source_files_total_bytes(source_files: &[PathBuf]) -> Result<u64> {
     source_files.iter().try_fold(0u64, |chunk_acc, path| {
         std::fs::metadata(path).map(|m| chunk_acc + m.len()).map_err(Into::into)
     })
-}
-
-/// Collects all files in the output directory (non-recursive).
-pub fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    for entry in
-        std::fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))?
-    {
-        let entry = entry?;
-        if entry.file_type()?.is_file() {
-            files.push(entry.path());
-        }
-    }
-    files.sort_unstable();
-    Ok(files)
 }
 
 #[cfg(test)]

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -781,7 +781,7 @@ fn source_files_total_bytes(source_files: &[PathBuf]) -> Result<u64> {
 }
 
 /// Collects all files in the output directory (non-recursive).
-fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
+pub fn collect_output_files(dir: &Path) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     for entry in
         std::fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))?

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -21,7 +21,9 @@ pub use reth_cli_commands::download::manifest::{
 };
 use tracing::info;
 
-use crate::progress::{ComponentProgressLogger, ComponentProgressReporter};
+use crate::progress::{
+    ArchiveProgressReporter, ComponentProgressLogger, ComponentProgressReporter,
+};
 
 /// Default blocks per static file segment.
 const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
@@ -267,9 +269,6 @@ impl SnapshotGenerator {
                             &p.source_files,
                             progress_reporter.clone(),
                         )?;
-                        if let Some(progress_reporter) = progress_reporter.as_ref() {
-                            progress_reporter.archive_completed();
-                        }
                         let size = std::fs::metadata(&p.archive_path)?.len();
                         Ok(PackagedChunk { chunk_idx: p.chunk_idx, size, output_files })
                     })
@@ -604,6 +603,19 @@ fn write_chunk_archive(
     source_files: &[PathBuf],
     progress: Option<ComponentProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
+    let archive_progress = match progress.as_ref() {
+        Some(progress) => Some(
+            progress.start_archive(
+                path.file_name()
+                    .ok_or_else(|| anyhow::anyhow!("invalid archive path: {}", path.display()))?
+                    .to_string_lossy()
+                    .to_string(),
+                source_files_total_bytes(source_files)?,
+            ),
+        ),
+        None => None,
+    };
+
     let planned: Vec<PlannedFile> = source_files
         .iter()
         .map(|p| {
@@ -616,7 +628,21 @@ fn write_chunk_archive(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    write_archive_from_planned_files(path, &planned, progress)
+    let result = write_archive_from_planned_files(path, &planned, archive_progress.clone());
+    match result {
+        Ok(output_files) => {
+            if let Some(archive_progress) = archive_progress.as_ref() {
+                archive_progress.finish();
+            }
+            Ok(output_files)
+        }
+        Err(error) => {
+            if let Some(archive_progress) = archive_progress.as_ref() {
+                archive_progress.fail();
+            }
+            Err(error)
+        }
+    }
 }
 
 fn chunk_output_files_for_source_files(
@@ -640,7 +666,7 @@ fn chunk_output_files_for_source_files(
 fn write_archive_from_planned_files(
     path: &Path,
     files: &[PlannedFile],
-    progress: Option<ComponentProgressReporter>,
+    progress: Option<ArchiveProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let file = std::fs::File::create(path)?;
     let mut encoder = zstd::Encoder::new(file, 0)?;
@@ -665,7 +691,7 @@ fn compute_output_files_for_planned_files(
 fn compute_output_files_and_archive(
     files: &[PlannedFile],
     mut archive: Option<(&mut tar::Builder<zstd::Encoder<'_, std::fs::File>>, &Path)>,
-    progress: Option<ComponentProgressReporter>,
+    progress: Option<ArchiveProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let mut output_files = Vec::with_capacity(files.len());
     for planned in files {
@@ -714,11 +740,11 @@ struct HashingReader<R> {
     inner: R,
     hasher: blake3::Hasher,
     bytes_read: u64,
-    progress: Option<ComponentProgressReporter>,
+    progress: Option<ArchiveProgressReporter>,
 }
 
 impl<R: Read> HashingReader<R> {
-    fn new(inner: R, progress: Option<ComponentProgressReporter>) -> Self {
+    fn new(inner: R, progress: Option<ArchiveProgressReporter>) -> Self {
         Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0, progress }
     }
 
@@ -743,10 +769,14 @@ impl<R: Read> Read for HashingReader<R> {
 
 fn planned_chunks_total_bytes(chunks: &[PlannedChunk]) -> Result<u64> {
     chunks.iter().try_fold(0u64, |acc, chunk| {
-        let chunk_bytes = chunk.source_files.iter().try_fold(0u64, |chunk_acc, path| {
-            std::fs::metadata(path).map(|m| chunk_acc + m.len())
-        })?;
+        let chunk_bytes = source_files_total_bytes(&chunk.source_files)?;
         Ok(acc + chunk_bytes)
+    })
+}
+
+fn source_files_total_bytes(source_files: &[PathBuf]) -> Result<u64> {
+    source_files.iter().try_fold(0u64, |chunk_acc, path| {
+        std::fs::metadata(path).map(|m| chunk_acc + m.len()).map_err(Into::into)
     })
 }
 

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -943,9 +943,8 @@ impl SnapshotUploader {
             },
         )
         .await
-        .map_err(|error| {
+        .inspect_err(|_| {
             progress.fail_file(manifest_key);
-            error
         })?;
         progress.add_for_file(manifest_key, manifest_len);
         progress.finish_file(manifest_key);
@@ -959,11 +958,11 @@ enum UploadAttemptError {
 }
 
 impl UploadAttemptError {
-    fn retry(error: anyhow::Error) -> Self {
+    const fn retry(error: anyhow::Error) -> Self {
         Self::Retry(error)
     }
 
-    fn fatal(error: anyhow::Error) -> Self {
+    const fn fatal(error: anyhow::Error) -> Self {
         Self::Fatal(error)
     }
 }

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -29,7 +29,7 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    progress::UploadProgress,
+    progress::{UploadProgress, UploadStage},
     snapshot::{ChunkFilename, SnapshotManifest, SnapshotManifestExt},
 };
 
@@ -368,7 +368,7 @@ impl SnapshotUploader {
         }
         .await;
 
-        progress_logger.abort();
+        progress_logger.stop();
         if let Err(error) = upload_result {
             error!(
                 error = %error,
@@ -569,21 +569,34 @@ impl SnapshotUploader {
         let file_size = tokio::fs::metadata(file_path).await?.len();
 
         if file_size > MULTIPART_THRESHOLD {
-            info!(
+            debug!(
                 key = %key,
                 size = file_size,
                 part_size = MULTIPART_PART_SIZE,
                 parts = file_size.div_ceil(MULTIPART_PART_SIZE),
                 "starting multipart upload"
             );
-            self.upload_multipart(file_path, &key, file_size, progress).await?;
-            progress.file_completed();
+            progress.start_file(key.clone(), file_size, UploadStage::CreatingMultipart);
+            match self.upload_multipart(file_path, &key, file_size, progress).await {
+                Ok(()) => progress.finish_file(&key),
+                Err(error) => {
+                    progress.fail_file(&key);
+                    return Err(error);
+                }
+            }
         } else {
             debug!(key = %key, size = file_size, "uploading file");
-            let _activity = progress.start_item(key.clone());
-            self.upload_single(file_path, &key).await?;
-            progress.add(file_size);
-            progress.file_completed();
+            progress.start_file(key.clone(), file_size, UploadStage::Uploading);
+            match self.upload_single(file_path, &key).await {
+                Ok(()) => {
+                    progress.add_for_file(&key, file_size);
+                    progress.finish_file(&key);
+                }
+                Err(error) => {
+                    progress.fail_file(&key);
+                    return Err(error);
+                }
+            }
         }
 
         Ok(())
@@ -637,7 +650,8 @@ impl SnapshotUploader {
             .upload_id()
             .ok_or_else(|| anyhow::anyhow!("no upload_id returned for {key}"))?
             .to_string();
-        info!(
+        progress.set_stage(key, UploadStage::Uploading);
+        debug!(
             key = %key,
             upload_id,
             size = file_size,
@@ -690,7 +704,7 @@ impl SnapshotUploader {
     ) -> Result<aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput> {
         retry_upload(
             || async {
-                let _create_activity = progress.start_item(format!("{key}#create"));
+                progress.set_stage(key, UploadStage::CreatingMultipart);
                 self.client
                     .create_multipart_upload()
                     .bucket(&self.bucket)
@@ -726,7 +740,7 @@ impl SnapshotUploader {
     ) -> Result<()> {
         retry_upload(
             || async {
-                let _complete_activity = progress.start_item(format!("{key}#complete"));
+                progress.set_stage(key, UploadStage::CompletingMultipart);
                 let completed =
                     CompletedMultipartUpload::builder().set_parts(Some(parts.clone())).build();
                 match self
@@ -781,7 +795,7 @@ impl SnapshotUploader {
             },
         )
         .await?;
-        info!(key = %key, upload_id, size = file_size, "multipart upload completed");
+        debug!(key = %key, upload_id, size = file_size, "multipart upload completed");
         Ok(())
     }
 
@@ -808,11 +822,10 @@ impl SnapshotUploader {
             .map(|(offset, part_number)| {
                 let length = std::cmp::min(MULTIPART_PART_SIZE, file_size - offset);
                 async move {
-                    let _activity = progress.start_item(format!("{key}#part-{part_number}"));
                     let part = self
                         .upload_single_part(file_path, key, upload_id, part_number, offset, length)
                         .await?;
-                    progress.add(length);
+                    progress.add_for_file(key, length);
                     Ok::<CompletedPart, anyhow::Error>(part)
                 }
             })
@@ -902,9 +915,9 @@ impl SnapshotUploader {
         progress: &UploadProgress,
     ) -> Result<()> {
         let manifest_len = published_manifest.len() as u64;
+        progress.start_file(manifest_key.to_string(), manifest_len, UploadStage::Uploading);
         retry_upload(
             || async {
-                let _activity = progress.start_item(manifest_key.to_string());
                 self.client
                     .put_object()
                     .bucket(&self.bucket)
@@ -929,9 +942,13 @@ impl SnapshotUploader {
                 info!(key = manifest_key, attempt, "manifest upload succeeded after retrying");
             },
         )
-        .await?;
-        progress.add(manifest_len);
-        progress.file_completed();
+        .await
+        .map_err(|error| {
+            progress.fail_file(manifest_key);
+            error
+        })?;
+        progress.add_for_file(manifest_key, manifest_len);
+        progress.finish_file(manifest_key);
         Ok(())
     }
 }

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -13,7 +13,9 @@
 
 use std::{
     collections::HashMap,
+    future::Future,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, bail};
@@ -23,7 +25,8 @@ use aws_sdk_s3::{
     types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier},
 };
 use futures::stream::{self, StreamExt, TryStreamExt};
-use tracing::{debug, info, warn};
+use tokio::time::sleep;
+use tracing::{debug, error, info, warn};
 
 use crate::{
     progress::UploadProgress,
@@ -39,6 +42,12 @@ const MULTIPART_THRESHOLD: u64 = 100 * 1024 * 1024;
 
 /// Part size for multipart uploads (100 `MiB`).
 const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Base delay between upload retries. Backoff is linear to keep behavior simple and predictable.
+const UPLOAD_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+/// Cap for the retry backoff so uploads keep making progress instead of sleeping for minutes.
+const MAX_UPLOAD_RETRY_DELAY: Duration = Duration::from_secs(60);
 
 /// Maximum number of objects per S3-compatible delete batch.
 const DELETE_OBJECT_BATCH_SIZE: usize = 1000;
@@ -322,6 +331,9 @@ impl SnapshotUploader {
             "diff analysis complete"
         );
 
+        let static_upload_count = static_uploads.len();
+        let run_upload_count = run_uploads.len();
+
         let progress = UploadProgress::new(&static_uploads, &run_uploads, &manifest_path).await?;
         let progress_logger = progress.spawn_logger();
 
@@ -351,20 +363,24 @@ impl SnapshotUploader {
                 self.public_static_files_base_url().as_deref(),
                 timestamp,
             )?;
-            self.client
-                .put_object()
-                .bucket(&self.bucket)
-                .key(&manifest_key)
-                .body(ByteStream::from(published_manifest))
-                .send()
-                .await
-                .with_context(|| format!("failed to upload {manifest_key}"))?;
+            self.upload_manifest(&manifest_key, published_manifest, progress_ref).await?;
             Ok::<(), anyhow::Error>(())
         }
         .await;
 
         progress_logger.abort();
-        upload_result?;
+        if let Err(error) = upload_result {
+            error!(
+                error = %error,
+                run_prefix = %run_prefix,
+                manifest_key = %manifest_key,
+                static_uploads = static_upload_count,
+                run_uploads = run_upload_count,
+                skipped,
+                "snapshot artifact upload failed"
+            );
+            return Err(error);
+        }
 
         if let Err(e) = self.prune_old_runs(retain_runs).await {
             warn!(error = %e, retain_runs, "failed to prune old snapshot runs");
@@ -489,6 +505,15 @@ impl SnapshotUploader {
         }
     }
 
+    /// Returns the remote object size for a full object key when it already exists.
+    async fn remote_object_size(&self, key: &str) -> Result<Option<u64>> {
+        match self.client.head_object().bucket(&self.bucket).key(key).send().await {
+            Ok(resp) => Ok(resp.content_length().and_then(|len| u64::try_from(len).ok())),
+            Err(err) if err.as_service_error().is_some_and(|e| e.is_not_found()) => Ok(None),
+            Err(err) => Err(anyhow::anyhow!("failed to check object metadata for {key}: {err}")),
+        }
+    }
+
     /// Deletes all objects under a prefix and returns the number of deleted keys.
     async fn delete_prefix(&self, prefix: &str) -> Result<usize> {
         let keys = self.list_remote_keys(prefix).await?;
@@ -544,32 +569,59 @@ impl SnapshotUploader {
         let file_size = tokio::fs::metadata(file_path).await?.len();
 
         if file_size > MULTIPART_THRESHOLD {
-            debug!(key = %key, size = file_size, "uploading file (multipart)");
+            info!(
+                key = %key,
+                size = file_size,
+                part_size = MULTIPART_PART_SIZE,
+                parts = file_size.div_ceil(MULTIPART_PART_SIZE),
+                "starting multipart upload"
+            );
             self.upload_multipart(file_path, &key, file_size, progress).await?;
+            progress.file_completed();
         } else {
             debug!(key = %key, size = file_size, "uploading file");
+            let _activity = progress.start_item(key.clone());
             self.upload_single(file_path, &key).await?;
             progress.add(file_size);
+            progress.file_completed();
         }
 
         Ok(())
     }
 
     async fn upload_single(&self, file_path: &Path, key: &str) -> Result<()> {
-        let body = ByteStream::from_path(file_path)
-            .await
-            .with_context(|| format!("failed to read {}", file_path.display()))?;
+        retry_upload(
+            || async {
+                let body = ByteStream::from_path(file_path)
+                    .await
+                    .with_context(|| format!("failed to read {}", file_path.display()))
+                    .map_err(UploadAttemptError::fatal)?;
 
-        self.client
-            .put_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .body(body)
-            .send()
-            .await
-            .with_context(|| format!("failed to upload {key}"))?;
-
-        Ok(())
+                self.client
+                    .put_object()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .body(body)
+                    .send()
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| UploadAttemptError::retry(error.into()))
+            },
+            |attempt, error| {
+                warn!(
+                    key = %key,
+                    attempt,
+                    error = %error,
+                    error_debug = ?error,
+                    next_retry_delay_secs = retry_delay_secs(attempt),
+                    "single-part upload failed, retrying"
+                );
+            },
+            |attempt| {
+                info!(key = %key, attempt, "single-part upload succeeded after retrying");
+            },
+        )
+        .await
     }
 
     async fn upload_multipart(
@@ -579,51 +631,158 @@ impl SnapshotUploader {
         file_size: u64,
         progress: &UploadProgress,
     ) -> Result<()> {
-        let create_resp = self
-            .client
-            .create_multipart_upload()
-            .bucket(&self.bucket)
-            .key(key)
-            .send()
-            .await
-            .with_context(|| format!("failed to initiate multipart upload for {key}"))?;
+        let create_resp = self.create_multipart_upload_with_retry(key, progress).await?;
 
         let upload_id = create_resp
             .upload_id()
             .ok_or_else(|| anyhow::anyhow!("no upload_id returned for {key}"))?
             .to_string();
+        info!(
+            key = %key,
+            upload_id,
+            size = file_size,
+            parts = file_size.div_ceil(MULTIPART_PART_SIZE),
+            "multipart upload created"
+        );
 
         let result = self.upload_parts(file_path, key, &upload_id, file_size, progress).await;
 
         match result {
             Ok(parts) => {
-                let completed = CompletedMultipartUpload::builder().set_parts(Some(parts)).build();
-
-                self.client
-                    .complete_multipart_upload()
-                    .bucket(&self.bucket)
-                    .key(key)
-                    .upload_id(&upload_id)
-                    .multipart_upload(completed)
-                    .send()
-                    .await
-                    .with_context(|| format!("failed to complete multipart upload for {key}"))?;
-
-                Ok(())
+                self.complete_multipart_upload_with_retry(
+                    key, &upload_id, file_size, parts, progress,
+                )
+                .await
             }
             Err(e) => {
-                self.client
+                match self
+                    .client
                     .abort_multipart_upload()
                     .bucket(&self.bucket)
                     .key(key)
                     .upload_id(&upload_id)
                     .send()
                     .await
-                    .ok();
+                {
+                    Ok(_) => {
+                        warn!(key = %key, upload_id, "aborted multipart upload after failure")
+                    }
+                    Err(abort_error) => {
+                        error!(
+                            key = %key,
+                            upload_id,
+                            error = %abort_error,
+                            error_debug = ?abort_error,
+                            "failed to abort multipart upload after failure"
+                        );
+                    }
+                }
 
                 Err(e)
             }
         }
+    }
+
+    async fn create_multipart_upload_with_retry(
+        &self,
+        key: &str,
+        progress: &UploadProgress,
+    ) -> Result<aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput> {
+        retry_upload(
+            || async {
+                let _create_activity = progress.start_item(format!("{key}#create"));
+                self.client
+                    .create_multipart_upload()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .send()
+                    .await
+                    .map_err(|error| UploadAttemptError::retry(error.into()))
+            },
+            |attempt, error| {
+                warn!(
+                    key = %key,
+                    attempt,
+                    error = %error,
+                    error_debug = ?error,
+                    next_retry_delay_secs = retry_delay_secs(attempt),
+                    "multipart upload creation failed, retrying"
+                );
+            },
+            |attempt| {
+                info!(key = %key, attempt, "multipart upload creation succeeded after retrying");
+            },
+        )
+        .await
+    }
+
+    async fn complete_multipart_upload_with_retry(
+        &self,
+        key: &str,
+        upload_id: &str,
+        file_size: u64,
+        parts: Vec<CompletedPart>,
+        progress: &UploadProgress,
+    ) -> Result<()> {
+        retry_upload(
+            || async {
+                let _complete_activity = progress.start_item(format!("{key}#complete"));
+                let completed =
+                    CompletedMultipartUpload::builder().set_parts(Some(parts.clone())).build();
+                match self
+                    .client
+                    .complete_multipart_upload()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .upload_id(upload_id)
+                    .multipart_upload(completed)
+                    .send()
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(error) => {
+                        let error = anyhow::Error::from(error);
+                        if self.remote_object_size(key).await.map_err(UploadAttemptError::fatal)?
+                            == Some(file_size)
+                        {
+                            warn!(
+                                key = %key,
+                                upload_id,
+                                error = %error,
+                                error_debug = ?error,
+                                size = file_size,
+                                "multipart completion response failed after object appeared; treating upload as successful"
+                            );
+                            Ok(())
+                        } else {
+                            Err(UploadAttemptError::retry(error))
+                        }
+                    }
+                }
+            },
+            |attempt, error| {
+                warn!(
+                    key = %key,
+                    upload_id,
+                    attempt,
+                    error = %error,
+                    error_debug = ?error,
+                    next_retry_delay_secs = retry_delay_secs(attempt),
+                    "multipart upload completion failed, retrying"
+                );
+            },
+            |attempt| {
+                info!(
+                    key = %key,
+                    upload_id,
+                    attempt,
+                    "multipart upload completion succeeded after retrying"
+                );
+            },
+        )
+        .await?;
+        info!(key = %key, upload_id, size = file_size, "multipart upload completed");
+        Ok(())
     }
 
     async fn upload_parts(
@@ -649,6 +808,7 @@ impl SnapshotUploader {
             .map(|(offset, part_number)| {
                 let length = std::cmp::min(MULTIPART_PART_SIZE, file_size - offset);
                 async move {
+                    let _activity = progress.start_item(format!("{key}#part-{part_number}"));
                     let part = self
                         .upload_single_part(file_path, key, upload_id, part_number, offset, length)
                         .await?;
@@ -673,35 +833,160 @@ impl SnapshotUploader {
         offset: u64,
         length: u64,
     ) -> Result<CompletedPart> {
-        let body = ByteStream::read_from()
-            .path(file_path)
-            .offset(offset)
-            .length(aws_sdk_s3::primitives::Length::Exact(length))
-            .build()
-            .await
-            .with_context(|| {
-                format!("failed to read part {part_number} of {}", file_path.display())
-            })?;
+        retry_upload(
+            || async {
+                let body = ByteStream::read_from()
+                    .path(file_path)
+                    .offset(offset)
+                    .length(aws_sdk_s3::primitives::Length::Exact(length))
+                    .build()
+                    .await
+                    .with_context(|| {
+                        format!("failed to read part {part_number} of {}", file_path.display())
+                    })
+                    .map_err(UploadAttemptError::fatal)?;
 
-        let upload_resp = self
-            .client
-            .upload_part()
-            .bucket(&self.bucket)
-            .key(key)
-            .upload_id(upload_id)
-            .part_number(part_number)
-            .body(body)
-            .send()
-            .await
-            .with_context(|| format!("failed to upload part {part_number} of {key}"))?;
+                let upload_resp = self
+                    .client
+                    .upload_part()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .upload_id(upload_id)
+                    .part_number(part_number)
+                    .body(body)
+                    .send()
+                    .await
+                    .map_err(|error| UploadAttemptError::retry(error.into()))?;
 
-        let e_tag = upload_resp
-            .e_tag()
-            .ok_or_else(|| anyhow::anyhow!("no ETag for part {part_number} of {key}"))?
-            .to_string();
+                let e_tag = upload_resp
+                    .e_tag()
+                    .ok_or_else(|| anyhow::anyhow!("no ETag for part {part_number} of {key}"))
+                    .map_err(UploadAttemptError::fatal)?
+                    .to_string();
 
-        Ok(CompletedPart::builder().part_number(part_number).e_tag(e_tag).build())
+                Ok(CompletedPart::builder().part_number(part_number).e_tag(e_tag).build())
+            },
+            |attempt, error| {
+                warn!(
+                    key = %key,
+                    upload_id,
+                    part_number,
+                    attempt,
+                    offset,
+                    length,
+                    error = %error,
+                    error_debug = ?error,
+                    next_retry_delay_secs = retry_delay_secs(attempt),
+                    "multipart upload part failed, retrying"
+                );
+            },
+            |attempt| {
+                info!(
+                    key = %key,
+                    upload_id,
+                    part_number,
+                    attempt,
+                    offset,
+                    length,
+                    "multipart upload part succeeded after retrying"
+                );
+            },
+        )
+        .await
     }
+
+    async fn upload_manifest(
+        &self,
+        manifest_key: &str,
+        published_manifest: Vec<u8>,
+        progress: &UploadProgress,
+    ) -> Result<()> {
+        let manifest_len = published_manifest.len() as u64;
+        retry_upload(
+            || async {
+                let _activity = progress.start_item(manifest_key.to_string());
+                self.client
+                    .put_object()
+                    .bucket(&self.bucket)
+                    .key(manifest_key)
+                    .body(ByteStream::from(published_manifest.clone()))
+                    .send()
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| UploadAttemptError::retry(error.into()))
+            },
+            |attempt, error| {
+                warn!(
+                    key = manifest_key,
+                    attempt,
+                    error = %error,
+                    error_debug = ?error,
+                    next_retry_delay_secs = retry_delay_secs(attempt),
+                    "manifest upload failed, retrying"
+                );
+            },
+            |attempt| {
+                info!(key = manifest_key, attempt, "manifest upload succeeded after retrying");
+            },
+        )
+        .await?;
+        progress.add(manifest_len);
+        progress.file_completed();
+        Ok(())
+    }
+}
+
+enum UploadAttemptError {
+    Retry(anyhow::Error),
+    Fatal(anyhow::Error),
+}
+
+impl UploadAttemptError {
+    fn retry(error: anyhow::Error) -> Self {
+        Self::Retry(error)
+    }
+
+    fn fatal(error: anyhow::Error) -> Self {
+        Self::Fatal(error)
+    }
+}
+
+async fn retry_upload<T, F, Fut, OnRetry, OnSuccess>(
+    mut operation: F,
+    mut on_retry: OnRetry,
+    mut on_success_after_retry: OnSuccess,
+) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = std::result::Result<T, UploadAttemptError>>,
+    OnRetry: FnMut(usize, &anyhow::Error),
+    OnSuccess: FnMut(usize),
+{
+    let mut attempt = 1usize;
+    loop {
+        match operation().await {
+            Ok(value) => {
+                if attempt > 1 {
+                    on_success_after_retry(attempt);
+                }
+                return Ok(value);
+            }
+            Err(UploadAttemptError::Retry(error)) => {
+                on_retry(attempt, &error);
+                sleep(retry_delay(attempt)).await;
+                attempt = attempt.saturating_add(1);
+            }
+            Err(UploadAttemptError::Fatal(error)) => return Err(error),
+        }
+    }
+}
+
+fn retry_delay(attempt: usize) -> Duration {
+    UPLOAD_RETRY_DELAY.saturating_mul(attempt as u32).min(MAX_UPLOAD_RETRY_DELAY)
+}
+
+fn retry_delay_secs(attempt: usize) -> u64 {
+    retry_delay(attempt).as_secs()
 }
 
 /// Builds the single published manifest for a run.

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -97,6 +97,7 @@ fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig 
         tip_threshold_secs: base_snapshotter::DEFAULT_TIP_THRESHOLD_SECS,
         source_datadir: tmp.join("nonexistent-datadir"),
         output_dir: tmp.join("output"),
+        upload_existing_run_timestamp: None,
         bucket: bucket.to_string(),
         prefix: "test".to_string(),
         chain_id: 8453,
@@ -879,6 +880,42 @@ async fn orchestrator_skips_when_not_at_tip() -> Result<()> {
     assert!(result.is_ok(), "run should return Ok when skipping a not-at-tip node");
     assert!(!manager.was_stopped(), "container must not be stopped when EL is not at tip");
     assert!(!manager.was_started(), "container must not be started when EL is not at tip");
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn upload_existing_run_skips_container_lifecycle() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let manager = std::sync::Arc::new(MockContainerManager::new());
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "test".to_string(),
+        None,
+    );
+
+    let tmp = tempfile::tempdir()?;
+    let output_dir = tmp.path().join("output");
+    let run_timestamp = 1_700_000_123u64;
+    let run_dir = output_dir.join(format!("run-{run_timestamp}"));
+    create_fake_snapshot(&run_dir, 1_000_000)?;
+
+    let mut config = test_config(&harness.bucket_name, tmp.path());
+    config.output_dir = output_dir;
+    config.upload_existing_run_timestamp = Some(run_timestamp);
+
+    let snapshotter = base_snapshotter::Snapshotter::new(
+        std::sync::Arc::clone(&manager),
+        MockTipChecker::new(true),
+        uploader,
+        config,
+    );
+
+    snapshotter.run().await?;
+    assert!(!manager.was_stopped(), "upload-only mode should not stop the container");
+    assert!(!manager.was_started(), "upload-only mode should not restart the container");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- reuse previous manifest chunk metadata to avoid long serial hashing work for finalized static chunks
- add component-level compression progress and upload stall diagnostics with active upload context
- improve snapshot upload retries and structured logging for multipart and manifest uploads without aggressive client-side timeouts

## Validation
- cargo check -p base-snapshotter
- cargo test -p base-snapshotter --lib