### PR TITLE
feat(telemetry): add base telemetry backend scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,6 +6381,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-telemetry-bin"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base-cli-utils",
+ "base-telemetry-service",
+ "clap",
+ "dotenvy",
+ "serde",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "base-telemetry-service"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.9",
+ "base-health",
+ "clap",
+ "reqwest 0.13.4",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "base-test-utils"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,7 @@ audit-archiver-lib = { path = "crates/infra/audit" }
 base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
 base-snapshotter = { path = "crates/infra/snapshotter" }
+base-telemetry-service = { path = "crates/infra/telemetry" }
 websocket-proxy = { path = "crates/infra/websocket-proxy" }
 base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 

--- a/bin/base-telemetry/Cargo.toml
+++ b/bin/base-telemetry/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "base-telemetry-bin"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-telemetry"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+dotenvy.workspace = true
+tokio-util.workspace = true
+base-cli-utils.workspace = true
+base-telemetry-service.workspace = true
+anyhow = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive", "env", "std"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -1,0 +1,11 @@
+# `base-telemetry`
+
+Base telemetry backend service scaffold.
+
+## Usage
+
+```sh
+base-telemetry --listen-addr 0.0.0.0:8080
+```
+
+The listen address can also be configured with `BASE_TELEMETRY_LISTEN_ADDR`.

--- a/bin/base-telemetry/src/main.rs
+++ b/bin/base-telemetry/src/main.rs
@@ -1,0 +1,38 @@
+//! Base telemetry service binary entry point.
+
+use anyhow::Result;
+use base_cli_utils::{LogConfig, RuntimeManager};
+use base_telemetry_service::{BaseTelemetryServer, ServerConfig};
+use clap::Parser;
+use tokio_util::sync::CancellationToken;
+
+base_cli_utils::define_log_args!("BASE_TELEMETRY");
+
+/// CLI entry point for the Base telemetry service.
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Service configuration.
+    #[command(flatten)]
+    config: ServerConfig,
+    /// Logging configuration.
+    #[command(flatten)]
+    log: LogArgs,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
+    let cli = Cli::parse();
+
+    LogConfig::from(cli.log).init_tracing_subscriber().expect("failed to initialize tracing");
+
+    let cancel = CancellationToken::new();
+    let signal_handle = RuntimeManager::install_signal_handler(cancel.clone());
+
+    let result = BaseTelemetryServer::serve(cli.config, cancel).await;
+    signal_handle.abort();
+
+    result
+}

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "base-telemetry-service"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tokio-util.workspace = true
+anyhow = { workspace = true, features = ["std"] }
+tracing = { workspace = true, features = ["std"] }
+base-health = { workspace = true, features = ["axum-server"] }
+clap = { workspace = true, features = ["derive", "env", "std"] }
+axum = { workspace = true, features = ["tokio", "http1", "json"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+
+[dev-dependencies]
+reqwest.workspace = true

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -1,0 +1,8 @@
+# `base-telemetry-service`
+
+Minimal Axum backend scaffold for Base telemetry.
+
+## Routes
+
+- `GET /healthz`
+- `GET /readyz`

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod server;
+pub use server::{BaseTelemetryServer, ServerConfig};

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -1,0 +1,102 @@
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use anyhow::Context;
+use axum::Router;
+use base_health::HealthServer;
+use clap::Args;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+/// Configuration for the Base telemetry HTTP server.
+#[derive(Args, Debug, Clone)]
+pub struct ServerConfig {
+    /// Socket address to bind the HTTP server to.
+    #[arg(long, env = "BASE_TELEMETRY_LISTEN_ADDR", default_value = "0.0.0.0:8080")]
+    pub listen_addr: SocketAddr,
+}
+
+/// Base telemetry Axum server scaffold.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BaseTelemetryServer;
+
+impl BaseTelemetryServer {
+    /// Returns the application router for the telemetry service.
+    pub fn router(ready: Arc<AtomicBool>) -> Router {
+        HealthServer::router(ready)
+    }
+
+    /// Starts the telemetry service with the provided configuration.
+    pub async fn serve(config: ServerConfig, cancel: CancellationToken) -> anyhow::Result<()> {
+        let ready = Arc::new(AtomicBool::new(false));
+        let app = Self::router(Arc::clone(&ready));
+        let listener = TcpListener::bind(config.listen_addr).await.with_context(|| {
+            format!("failed to bind base telemetry server to {}", config.listen_addr)
+        })?;
+        let listen_addr =
+            listener.local_addr().context("failed to read base telemetry listen address")?;
+
+        ready.store(true, Ordering::SeqCst);
+
+        info!(listen_addr = %listen_addr, "base telemetry server started");
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move { cancel.cancelled().await })
+            .await
+            .context("base telemetry server exited unexpectedly")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::{Arc, atomic::AtomicBool},
+    };
+
+    use axum::http::StatusCode;
+    use tokio::{net::TcpListener, task::JoinHandle};
+
+    use crate::BaseTelemetryServer;
+
+    async fn start_test_server() -> (SocketAddr, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let ready = Arc::new(AtomicBool::new(true));
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, BaseTelemetryServer::router(ready)).await.unwrap();
+        });
+
+        (addr, handle)
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_ok() {
+        let (addr, handle) = start_test_server().await;
+
+        let response = reqwest::get(format!("http://{addr}/healthz")).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_ok() {
+        let (addr, handle) = start_test_server().await;
+
+        let response = reqwest::get(format!("http://{addr}/readyz")).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        handle.abort();
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `base-telemetry-service` Axum backend scaffold under `crates/infra/telemetry`
- add a thin `base-telemetry` binary wrapper with CLI/env wiring, shared logging args, and signal-driven graceful shutdown
- expose `/healthz`, `/readyz`

## Testing
- `cargo +nightly fmt --check --package base-telemetry-service --package base-telemetry-bin`
- `cargo check -p base-telemetry-service -p base-telemetry-bin`
- `cargo test -p base-telemetry-service`
- `cargo clippy -p base-telemetry-service -p base-telemetry-bin --all-targets -- -D warnings`
- Manual e2e smoke test:
  - Started `cargo run -p base-telemetry-bin -- --listen-addr 127.0.0.1:18080`
  - Hit `http://127.0.0.1:18080/healthz` and got `HTTP/1.1 200 OK`
  - Hit `http://127.0.0.1:18080/readyz` and got `HTTP/1.1 200 OK`
  - Sent `SIGTERM` and confirmed the process exited cleanly and stopped listening on port `18080`

## Breaking Changes
- None