### PR TITLE
feat(eip8130-rpc): accept senderActorId hint for estimateGas simulation

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -625,9 +625,7 @@ impl Eip8130Executor {
     ///
     /// `acting_actor_hint` is the optional `senderActorId` from the estimate
     /// request. Without it, simulation publishes the self-actor (backward
-    /// compatible). With it, policy-gated session-key estimates can name the
-    /// intended actor — including one authorized in the same request's
-    /// `accountChanges`, which is why policy is resolved *after* apply.
+    /// compatible).
     fn simulate_resolve<DB>(
         ctx: &mut BaseContext<DB>,
         signed: &base_common_consensus::Eip8130Signed,
@@ -686,8 +684,8 @@ impl Eip8130Executor {
             //    RPC hint names the intended actor (e.g. a session key); absent
             //    that, fall back to the account's self-actor. Policy is read from
             //    the post-apply journal so same-tx authorizations are visible.
-            //    Revocation/expiry are not enforced here because estimation
-            //    prices the happy-path gas.
+            //    Expiry is not enforced (estimation prices the happy path);
+            //    `get_policy` still treats a revoked default-EOA self as ungated.
             let acc = AccountConfigurationStorage::new(sctx);
             let sender_actor_id = acting_actor_hint
                 .unwrap_or_else(|| AccountConfigurationStorage::self_actor_id(sender));
@@ -1451,9 +1449,10 @@ impl Eip8130Executor {
 mod tests {
     use alloy_evm::{Evm, FromTxWithEncoded, precompiles::PrecompilesMap};
     use alloy_primitives::{Address, B256, Bytes, U256, address, bytes, keccak256};
+    use alloy_sol_types::{SolValue, sol};
     use base_common_consensus::{
-        AccountChange, BaseTxEnvelope, Call, CreateEntry, Eip8130Signed, InitialActor, Predeploys,
-        TxEip8130,
+        AccountChange, ActorChange, ActorChangeType, BaseTxEnvelope, Call, ConfigChange,
+        CreateEntry, Eip8130Signed, InitialActor, Predeploys, TxEip8130,
     };
     use base_execution_eip8130::AccountChangeApplier;
     use k256::ecdsa::SigningKey;
@@ -1468,7 +1467,10 @@ mod tests {
     };
 
     use super::*;
-    use crate::{BaseEvm, BaseSpecId, BaseTransaction, BaseUpgrade, Builder, DefaultBase};
+    use crate::{
+        BaseEvm, BaseSpecId, BaseTransaction, BaseUpgrade, Builder, DefaultBase,
+        Eip8130ExecutionMode,
+    };
 
     const CHAIN_ID: u64 = 8453;
     const NOW: u64 = 1_000;
@@ -1906,6 +1908,118 @@ mod tests {
             .expect("configured-account estimation should succeed");
         assert!(result.is_success(), "estimation should report success");
         assert!(result.tx_gas_used() > 0, "estimated gas should be positive");
+    }
+
+    sol! {
+        struct ActorConfigAbi {
+            address authenticator;
+            uint8 scope;
+            uint48 expiry;
+            uint8 policyType;
+        }
+    }
+
+    /// ABI-encodes `abi.encode(ActorConfig, bytes policyData)` for an authorize
+    /// change (mirrors `AccountChangeApplier`'s decode shape).
+    fn authorize_change_data(
+        authenticator: Address,
+        scope: u8,
+        expiry: u64,
+        policy_type: u8,
+        policy_data: &[u8],
+    ) -> Bytes {
+        let abi = ActorConfigAbi {
+            authenticator,
+            scope,
+            expiry: alloy_primitives::aliases::U48::from(expiry),
+            policyType: policy_type,
+        };
+        Bytes::from((abi, Bytes::copy_from_slice(policy_data)).abi_encode_params())
+    }
+
+    #[test]
+    fn simulate_sender_actor_id_hint_resolves_policy_after_account_changes() {
+        // Without a hint, simulate publishes the account's self-actor. Gate that
+        // self to `wrong` and authorize a session actor (gated to `allowed`) in
+        // the same estimate's accountChanges: a call to `allowed` then reverts
+        // under the self-actor, and succeeds only when `senderActorId` names the
+        // session actor — proving the hint changes policy resolution post-apply.
+        let owner = signing_key(0xa1);
+        let account = eoa_address(&owner);
+        let session = signing_key(0xa2);
+        let session_addr = eoa_address(&session);
+        let session_actor = AccountConfigurationStorage::self_actor_id(session_addr);
+        let allowed = address!("0x00000000000000000000000000000000000000d1");
+        let wrong = address!("0x00000000000000000000000000000000000000d2");
+        let commitment = B256::repeat_byte(0x42);
+
+        let mut policy_data = Vec::with_capacity(52);
+        policy_data.extend_from_slice(allowed.as_slice());
+        policy_data.extend_from_slice(commitment.as_slice());
+
+        let mut tx = base_tx();
+        tx.sender = Some(account);
+        tx.account_changes = vec![AccountChange::ConfigChange(ConfigChange {
+            chain_id: CHAIN_ID,
+            sequence: 0,
+            actor_changes: vec![ActorChange {
+                change_type: ActorChangeType::Authorize,
+                actor_id: session_actor,
+                data: authorize_change_data(
+                    Eip8130Constants::K1_AUTHENTICATOR,
+                    Eip8130Constants::SCOPE_SENDER,
+                    0,
+                    1,
+                    &policy_data,
+                ),
+            }],
+            // Simulate's apply path does not verify config auth.
+            auth: Bytes::new(),
+        })];
+        tx.calls = vec![vec![Call { to: allowed, data: Bytes::new() }]];
+        let signed = configured_signed(tx, &owner);
+
+        let mut evm = evm_with_accounts(
+            U256::from(10u64).pow(U256::from(18u64)),
+            account,
+            &[(allowed, bytes!("00")), (wrong, bytes!("00"))],
+        );
+        // Gate the account's self-actor away from `allowed` so the no-hint path
+        // hits the node policy gate.
+        seed_gated_sender(&mut evm, account, account, wrong);
+
+        // No hint → self-actor (gated to `wrong`) → ActorPolicyViolation.
+        {
+            let mut tx = into_base_tx(&signed);
+            tx.base.caller = account;
+            if let Some(parts) = tx.eip8130.as_mut() {
+                parts.mode = Eip8130ExecutionMode::Simulate;
+                parts.simulation_sender_actor_id = None;
+            }
+            evm.ctx_mut().tx = tx;
+            let result = Eip8130Executor::simulate(&mut evm).expect("simulate should not error");
+            let ExecutionResult::Revert { output, .. } = &result else {
+                panic!("expected policy-gate revert without hint, got {result:?}");
+            };
+            let expected = keccak256(b"ActorPolicyViolation(bytes32,address)");
+            assert_eq!(&output[..4], &expected[..4]);
+        }
+
+        // Hint → session actor (gated to `allowed`, authorized in accountChanges).
+        {
+            let mut tx = into_base_tx(&signed);
+            tx.base.caller = account;
+            if let Some(parts) = tx.eip8130.as_mut() {
+                parts.mode = Eip8130ExecutionMode::Simulate;
+                parts.simulation_sender_actor_id = Some(session_actor);
+            }
+            evm.ctx_mut().tx = tx;
+            let result = Eip8130Executor::simulate(&mut evm).expect("simulate should not error");
+            assert!(
+                result.is_success(),
+                "hinted session actor should pass the policy gate, got {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -362,15 +362,16 @@ impl Eip8130Executor {
                 Journal: core::fmt::Debug,
             >,
     {
-        let signed = evm
+        // Clone the envelope + optional acting-actor hint before taking a mutable
+        // borrow of `ctx` (same pattern as `execute`).
+        let (signed, acting_actor_hint) = evm
             .ctx()
             .tx()
             .eip8130_parts()
+            .map(|parts| (parts.signed.clone(), parts.simulation_sender_actor_id))
             .ok_or_else(|| {
                 BaseTransactionError::eip8130("transaction is not an EIP-8130 transaction")
-            })?
-            .signed
-            .clone();
+            })?;
 
         let ctx = evm.ctx_mut();
         let from = ctx.tx().base.caller;
@@ -384,13 +385,15 @@ impl Eip8130Executor {
             })?;
 
         let checkpoint = ctx.journal_mut().checkpoint();
-        let outcome = match Self::simulate_resolve(ctx, &signed, &encoded, from, base_fee) {
-            Ok(outcome) => outcome,
-            Err(err) => {
-                ctx.journal_mut().checkpoint_revert(checkpoint);
-                return Err(err.into());
-            }
-        };
+        let outcome =
+            match Self::simulate_resolve(ctx, &signed, &encoded, from, base_fee, acting_actor_hint)
+            {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    ctx.journal_mut().checkpoint_revert(checkpoint);
+                    return Err(err.into());
+                }
+            };
 
         // Dispatch `calls` from the resolved sender so `tx.origin` reads correctly
         // (mirrors `prepay`'s caller overwrite on the execution path).
@@ -610,20 +613,28 @@ impl Eip8130Executor {
         Ok(highest)
     }
 
-    /// Resolves the [`Eip8130Outcome`] for [`Self::simulate`]: derives the
-    /// sender's owner self-actor from `sender` and reads its policy from
-    /// committed account state (no signature recovery), then applies account
-    /// changes, auto-delegates, and prices intrinsic gas — without validating or
-    /// advancing the nonce or checking the payer balance. The authentication gas
-    /// for the sender's (and any payer's) declared authenticator is priced from
-    /// the synthesized auth-blob shape via [`IntrinsicGas`]. Storage writes land
-    /// on the journal; the caller's checkpoint reverts them.
+    /// Resolves the [`Eip8130Outcome`] for [`Self::simulate`]: applies account
+    /// changes, then resolves the acting actor (an optional RPC hint, else the
+    /// account's self-actor) and its policy from the post-apply journal — no
+    /// signature recovery — then auto-delegates and prices intrinsic gas without
+    /// validating or advancing the nonce or checking the payer balance. The
+    /// authentication gas for the sender's (and any payer's) declared
+    /// authenticator is priced from the synthesized auth-blob shape via
+    /// [`IntrinsicGas`]. Storage writes land on the journal; the caller's
+    /// checkpoint reverts them.
+    ///
+    /// `acting_actor_hint` is the optional `senderActorId` from the estimate
+    /// request. Without it, simulation publishes the self-actor (backward
+    /// compatible). With it, policy-gated session-key estimates can name the
+    /// intended actor — including one authorized in the same request's
+    /// `accountChanges`, which is why policy is resolved *after* apply.
     fn simulate_resolve<DB>(
         ctx: &mut BaseContext<DB>,
         signed: &base_common_consensus::Eip8130Signed,
         encoded: &[u8],
         sender: Address,
         base_fee: u128,
+        acting_actor_hint: Option<B256>,
     ) -> Result<Eip8130Outcome, BaseTransactionError>
     where
         DB: AlloyDatabase,
@@ -650,23 +661,9 @@ impl Eip8130Executor {
         let mut provider = JournalStorageProvider::new(internals, Address::ZERO);
 
         StorageCtx::enter(&mut provider, |sctx| {
-            let acc = AccountConfigurationStorage::new(sctx);
             let nonce_mgr = NonceManagerStorage::new(sctx);
 
-            // 1. Resolve the default-EOA self actor from committed account state.
-            //    No signature recovery: revocation/expiry are not enforced here
-            //    because estimation prices the happy-path gas.
-            let sender_actor_id = AccountConfigurationStorage::self_actor_id(sender);
-            let state = acc.get_account_state(sender).map_err(BaseTransactionError::eip8130)?;
-            let policy_type = state.default_eoa_policy_type;
-            let policy_target = if policy_type == 0 {
-                Address::ZERO
-            } else {
-                acc.get_policy_manager(sender, sender_actor_id)
-                    .map_err(BaseTransactionError::eip8130)?
-            };
-
-            // 2. Nonce-channel first-use flag (drives intrinsic gas). Estimation
+            // 1. Nonce-channel first-use flag (drives intrinsic gas). Estimation
             //    neither validates nor advances the nonce.
             let protocol_nonce = sctx
                 .with_account_info(sender, |info| Ok(info.nonce))
@@ -679,10 +676,23 @@ impl Eip8130Executor {
                 nonce_mgr.get_nonce(sender, nonce_key).map_err(BaseTransactionError::eip8130)? == 0
             };
 
-            // 3. Apply account changes and install deferred code effects so the
+            // 2. Apply account changes and install deferred code effects so the
             //    calls run against post-change code and create/delegation gas is
-            //    priced.
+            //    priced. Must precede actor/policy resolution so an actor
+            //    authorized in this same estimate request is visible.
             Self::apply_account_changes(signed, sctx, sender)?;
+
+            // 3. Resolve the acting actor. No signature recovery: the optional
+            //    RPC hint names the intended actor (e.g. a session key); absent
+            //    that, fall back to the account's self-actor. Policy is read from
+            //    the post-apply journal so same-tx authorizations are visible.
+            //    Revocation/expiry are not enforced here because estimation
+            //    prices the happy-path gas.
+            let acc = AccountConfigurationStorage::new(sctx);
+            let sender_actor_id = acting_actor_hint
+                .unwrap_or_else(|| AccountConfigurationStorage::self_actor_id(sender));
+            let (policy_type, policy_target, _) =
+                acc.get_policy(sender, sender_actor_id).map_err(BaseTransactionError::eip8130)?;
 
             // 4. Auto-delegate a code-less sender to the default account. Unlike
             //    the verifying path this is unconditional on a code-less sender: a

--- a/crates/common/evm/src/transaction/eip8130.rs
+++ b/crates/common/evm/src/transaction/eip8130.rs
@@ -1,4 +1,5 @@
 //! Contains EIP-8130 account-abstraction transaction parts.
+use alloy_primitives::B256;
 pub use base_common_consensus::EIP8130_TX_TYPE_ID as EIP8130_TRANSACTION_TYPE;
 use base_common_consensus::Eip8130Signed;
 
@@ -56,14 +57,20 @@ pub struct Eip8130TransactionParts {
     /// [`Eip8130ExecutionMode::Verified`], so block execution and txpool
     /// admission never reach the unverified path.
     pub mode: Eip8130ExecutionMode,
+    /// Optional acting-actor hint for the RPC simulation path. Estimation never
+    /// recovers a signature, so without this the simulate path publishes the
+    /// account's self-actor. Set only by `to_eip8130_simulation_tx`; always
+    /// [`None`] on the verified consensus path.
+    pub simulation_sender_actor_id: Option<B256>,
 }
 
 impl Eip8130TransactionParts {
     /// Create new EIP-8130 transaction parts from a signed envelope, for the
     /// verified consensus/block-execution path. The RPC simulation path builds
     /// parts through the consensus-tx conversion and then sets
-    /// [`Eip8130ExecutionMode::Simulate`] on the result.
+    /// [`Eip8130ExecutionMode::Simulate`] (and optionally
+    /// [`Self::simulation_sender_actor_id`]) on the result.
     pub const fn new(signed: Eip8130Signed) -> Self {
-        Self { signed, mode: Eip8130ExecutionMode::Verified }
+        Self { signed, mode: Eip8130ExecutionMode::Verified, simulation_sender_actor_id: None }
     }
 }

--- a/crates/common/rpc-types/src/reth.rs
+++ b/crates/common/rpc-types/src/reth.rs
@@ -184,9 +184,11 @@ impl BaseTransactionRequest {
         let envelope = BaseTxEnvelope::Eip8130(Eip8130Signed::new(tx, sender_auth, payer_auth));
         let mut sim_tx = BaseRevm::from_recovered_tx(&envelope, account);
         // Route to the unverified `Eip8130Executor::simulate` path rather than
-        // the verifying `execute` path.
+        // the verifying `execute` path. Thread the optional acting-actor hint so
+        // policy-gated session-key estimates publish the intended actor id.
         if let Some(parts) = sim_tx.eip8130.as_mut() {
             parts.mode = Eip8130ExecutionMode::Simulate;
+            parts.simulation_sender_actor_id = aa.sender_actor_id;
         }
         Some(sim_tx)
     }
@@ -693,5 +695,38 @@ mod tests {
             "the default payer authorization is prefixed with the k1 authenticator",
         );
         assert_eq!(auth.len(), 20 + Eip8130AuthScheme::Secp256k1.default_data_len());
+    }
+
+    #[test]
+    fn sender_actor_id_is_threaded_to_parts() {
+        // The optional acting-actor hint is RPC-only metadata: it must land on
+        // the simulation parts so `simulate_resolve` can publish it to TxContext
+        // (and resolve that actor's policy) instead of always using the self-actor.
+        let actor = alloy_primitives::b256!(
+            "0x30df39d5edcf9ed82b6d77d27bff1192ac265918000000000000000000000000"
+        );
+        let tx = sim_tx(json!({
+            "sender": SENDER,
+            "calls": [],
+            "senderActorId": actor,
+        }));
+        let parts = tx.eip8130.as_ref().expect("eip8130 parts");
+        assert_eq!(parts.mode, Eip8130ExecutionMode::Simulate);
+        assert_eq!(
+            parts.simulation_sender_actor_id,
+            Some(actor),
+            "senderActorId must be threaded onto the simulation parts",
+        );
+    }
+
+    #[test]
+    fn absent_sender_actor_id_leaves_parts_hint_unset() {
+        let tx = sim_tx(json!({ "sender": SENDER, "calls": [] }));
+        let parts = tx.eip8130.as_ref().expect("eip8130 parts");
+        assert_eq!(parts.mode, Eip8130ExecutionMode::Simulate);
+        assert_eq!(
+            parts.simulation_sender_actor_id, None,
+            "without a hint the simulate path keeps the self-actor default",
+        );
     }
 }

--- a/crates/common/rpc-types/src/transaction/request.rs
+++ b/crates/common/rpc-types/src/transaction/request.rs
@@ -179,8 +179,12 @@ pub struct Eip8130RequestFields {
 }
 
 impl Eip8130RequestFields {
-    /// Whether any EIP-8130 field is present, marking the request as an
-    /// EIP-8130 simulation rather than a plain transaction request.
+    /// Whether any field that defines an EIP-8130 request is present.
+    ///
+    /// [`Self::sender_actor_id`] is excluded: it is a simulation-only auxiliary
+    /// hint about an already-8130 request, not an indicator of one. A stray
+    /// `senderActorId` on a plain transaction is therefore ignored rather than
+    /// routing the request onto the AA simulation path.
     pub const fn is_some(&self) -> bool {
         self.nonce_key.is_some()
             || self.account_changes.is_some()
@@ -191,7 +195,6 @@ impl Eip8130RequestFields {
             || self.sender_auth.is_some()
             || self.payer.is_some()
             || self.payer_auth.is_some()
-            || self.sender_actor_id.is_some()
     }
 }
 
@@ -605,5 +608,21 @@ mod tests {
         assert_eq!(calls[0].len(), 1);
         // The base fields still deserialize into the inner request.
         assert_eq!(req.as_ref().max_fee_per_gas, Some(5));
+    }
+
+    #[test]
+    fn sender_actor_id_alone_does_not_mark_request_as_eip8130() {
+        // `senderActorId` is metadata about an 8130 request, not a defining
+        // field — a lone hint must not route a plain request onto the AA path.
+        let json = r#"{
+            "from":"0x0000000000000000000000000000000000000001",
+            "to":"0x0000000000000000000000000000000000000002",
+            "senderActorId":"0x30df39d5edcf9ed82b6d77d27bff1192ac265918000000000000000000000000"
+        }"#;
+        let req: BaseTransactionRequest = serde_json::from_str(json).unwrap();
+        assert!(
+            req.as_eip8130().is_none(),
+            "senderActorId alone must not classify the request as EIP-8130",
+        );
     }
 }

--- a/crates/common/rpc-types/src/transaction/request.rs
+++ b/crates/common/rpc-types/src/transaction/request.rs
@@ -7,7 +7,7 @@ use alloy_eips::eip7702::SignedAuthorization;
 #[cfg(feature = "reth")]
 use alloy_network::TransactionBuilder;
 use alloy_network_primitives::TransactionBuilder7702;
-use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
 use base_common_consensus::{
     AccountChange, BaseTxEnvelope, BaseTypedTransaction, Call, Eip8130Constants, Eip8130Contracts,
@@ -167,6 +167,15 @@ pub struct Eip8130RequestFields {
     /// unrecognized selector is rejected as `INVALID_PARAMS` rather than priced.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub payer_auth: Option<Bytes>,
+    /// Optional acting-actor hint for simulation. Estimation never recovers a
+    /// signature, so without this hint the simulate path publishes the account's
+    /// self-actor to the `TxContext` precompile — which makes policy-gated
+    /// session-key calls look up the wrong policy and revert. When set, the
+    /// simulate path publishes this actor id (and resolves its policy) after
+    /// applying `account_changes`, so an actor authorized in the same estimate
+    /// request is visible. Ignored on the verifying execution path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_actor_id: Option<B256>,
 }
 
 impl Eip8130RequestFields {
@@ -182,6 +191,7 @@ impl Eip8130RequestFields {
             || self.sender_auth.is_some()
             || self.payer.is_some()
             || self.payer_auth.is_some()
+            || self.sender_actor_id.is_some()
     }
 }
 

--- a/crates/execution/eip8130-rpc/README.md
+++ b/crates/execution/eip8130-rpc/README.md
@@ -31,12 +31,16 @@ the common `nonce_key != 0` case while keeping layout ownership inside
 
 Exposes [`Eip8130GasEstimator`], which estimates gas for an `eth_estimateGas`
 request carrying EIP-8130 fields (the sender account via `sender` or `from`,
-account changes, calls, `nonce_key`, expiry, metadata). It builds an unsigned
-simulation transaction — the caller's `sender_auth` blob (a prefixed
+account changes, calls, `nonce_key`, expiry, metadata, and an optional
+`sender_actor_id` acting-actor hint). It builds an unsigned simulation
+transaction — the caller's `sender_auth` blob (a prefixed
 `authenticator(20) || data` blob for a configured account, a bare signature for
 the default EOA, or a stub when absent) lets the intrinsic schedule price
-authentication gas from its shape — and runs a single read-only
-`base_common_evm::Eip8130Executor::simulate` against the block state.
+authentication gas from its shape, and an optional `sender_actor_id` names the
+acting actor published to the `TxContext` precompile (default: the account's
+self-actor) so policy-gated session-key estimates resolve the right policy —
+and runs a single read-only `base_common_evm::Eip8130Executor::simulate`
+against the block state.
 
 Because the EIP-8130 pipeline charges a deterministic, signature-independent
 amount (intrinsic + phased-call gas, less the EIP-3529-capped refund, plus payer


### PR DESCRIPTION
## Summary
- Estimation never recovers a signature, so `simulate` always published the account's **self-actor** to the `TxContext` precompile. Policy-gated session-key calls then looked up the wrong policy (`NoActivePolicy`) and the estimate threw.
- Add optional `senderActorId` on the EIP-8130 `eth_estimateGas` request (orthogonal to the existing `senderAuth` / verifier shape hint for auth-gas pricing).
- Thread it onto `Eip8130TransactionParts.simulation_sender_actor_id` (RPC-only; consensus path stays `None`).
- In `simulate_resolve`, apply `accountChanges` first, then resolve the hinted actor's policy via `get_policy` so same-tx authorizations are visible. Absent hint → self-actor (backward compatible).

## Test plan
- [x] `cargo test -p base-common-rpc-types --features reth --lib reth::tests` (24 passed, including new `sender_actor_id_*` tests)
- [x] `cargo test -p base-common-evm --lib eip8130::tests::simulate` (4 passed)
- [x] `just check::format`