### PR TITLE
fix(ci): harden SP1 setup download

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -128,6 +128,8 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        # Commit for succinctlabs/sp1 v6.3.0; update alongside SP1_VERSION.
+        SP1UP_REF: ca8700effe99ef7331872cbb4f71f8e29be98c7a
         SP1_VERSION: ${{ inputs.sp1-version }}
       run: |
         if [ -x "$HOME/.sp1/bin/cargo-prove" ]; then
@@ -139,7 +141,7 @@ runs:
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "User-Agent: base-base-ci" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/succinctlabs/sp1/contents/sp1up/sp1up?ref=main" \
+            "https://api.github.com/repos/succinctlabs/sp1/contents/sp1up/sp1up?ref=$SP1UP_REF" \
             -o "$HOME/.sp1/bin/sp1up"
           chmod +x "$HOME/.sp1/bin/sp1up"
           "$HOME/.sp1/bin/sp1up" --version "$SP1_VERSION"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -127,12 +127,21 @@ runs:
       if: inputs.sp1 == 'true'
       shell: bash
       env:
+        GITHUB_TOKEN: ${{ github.token }}
         SP1_VERSION: ${{ inputs.sp1-version }}
       run: |
         if [ -x "$HOME/.sp1/bin/cargo-prove" ]; then
           echo "cargo-prove already installed"
         else
-          curl -L https://sp1up.succinct.xyz | bash
+          mkdir -p "$HOME/.sp1/bin"
+          curl --fail --show-error --location --retry 5 --retry-delay 2 --retry-all-errors \
+            -H "Accept: application/vnd.github.raw" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "User-Agent: base-base-ci" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/succinctlabs/sp1/contents/sp1up/sp1up?ref=main" \
+            -o "$HOME/.sp1/bin/sp1up"
+          chmod +x "$HOME/.sp1/bin/sp1up"
           "$HOME/.sp1/bin/sp1up" --version "$SP1_VERSION"
         fi
         echo "$HOME/.sp1/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary
- Replace the SP1 installer pipe with a direct sp1up download via the GitHub contents API.
- Use the workflow GITHUB_TOKEN, curl --fail, and retries so GitHub 429 responses are not saved as executable scripts.
- Keep the existing sp1up --version install flow after the download is validated by HTTP status.

## Validation
- ruby YAML parse for .github/actions/setup/action.yml
- git diff --check

## Notes
This only targets the urgent SP1 setup failure where CI executed a GitHub 429 response as /home/runner/.sp1/bin/sp1up. It intentionally does not address the older musl reth-tasks failure.