### PR TITLE
fix(consensus): preserve L2 finalization progress

### DIFF
--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -107,10 +107,11 @@ where
 
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
-        if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head }) = signal {
-            Metrics::derivation_l1_origin().absolute(_reset_safe_head.l1_origin.number);
-            // Clear the finalization queue on reset.
-            self.finalizer.clear();
+        if let Signal::Reset(ResetSignal { l2_safe_head: reset_safe_head }) = signal {
+            Metrics::derivation_l1_origin().absolute(reset_safe_head.l1_origin.number);
+            // Prune finalization queue entries above the reset anchor; entries at or
+            // below the safe head remain canonical across a reset.
+            self.finalizer.prune_above(reset_safe_head.block_info.number);
             // Discard any in-flight derived_from so that a stale pre-reset L1 inclusion
             // block is never recorded for a post-reset safe head confirmation.
             self.pending_derived_from = None;
@@ -343,6 +344,15 @@ where
 
         // Enqueue the payload attributes for finalization tracking.
         self.finalizer.enqueue_for_finalization(&payload_attributes);
+
+        // Retry finalization in case a finalized L1 signal arrived while the queue
+        // was empty (e.g. after a pipeline reset or during EL sync).
+        if let Some(l2_block_number) = self.finalizer.try_finalize_pending() {
+            self.engine_client
+                .send_finalized_l2_block(l2_block_number)
+                .await
+                .map_err(|e| DerivationError::Sender(Box::new(e)))?;
+        }
 
         // Remember the L1 inclusion block so that when the engine confirms this safe head we
         // can key the SafeDB entry by inclusion block rather than epoch origin.

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -22,6 +22,10 @@ pub struct L2Finalizer {
     /// block is received, the highest L2 block whose inputs are contained within the finalized
     /// L1 chain is finalized.
     awaiting_finalization: BTreeMap<L1BlockNumber, L2BlockNumber>,
+    /// The highest finalized L1 block number observed so far. Preserved across `clear()` calls
+    /// so that blocks enqueued after a pipeline reset can be finalized immediately if their
+    /// L1 origin is already finalized.
+    latest_finalized_l1: Option<L1BlockNumber>,
 }
 
 impl L2Finalizer {
@@ -39,9 +43,13 @@ impl L2Finalizer {
             .or_insert_with(|| attributes.block_number());
     }
 
-    /// Clears the finalization queue.
-    pub fn clear(&mut self) {
-        self.awaiting_finalization.clear();
+    /// Prunes queue entries whose L2 block number is above `l2_block_number`.
+    ///
+    /// Called on pipeline reset with the reset anchor (the L2 safe head): blocks at or
+    /// below the safe head remain canonical across a reset, so their entries stay valid.
+    /// `latest_finalized_l1` is preserved — L1 finality is independent of pipeline state.
+    pub fn prune_above(&mut self, l2_block_number: L2BlockNumber) {
+        self.awaiting_finalization.retain(|_, &mut l2| l2 <= l2_block_number);
     }
 
     /// Attempts to find L2 blocks that can be finalized based on the new finalized L1 block.
@@ -52,16 +60,33 @@ impl L2Finalizer {
         &mut self,
         new_finalized_l1_block: BlockInfo,
     ) -> Option<L2BlockNumber> {
+        self.latest_finalized_l1 = Some(
+            self.latest_finalized_l1
+                .map_or(new_finalized_l1_block.number, |n| n.max(new_finalized_l1_block.number)),
+        );
+
+        self.try_finalize_up_to(new_finalized_l1_block.number)
+    }
+
+    /// Attempts to finalize enqueued L2 blocks against the most recently observed
+    /// finalized L1 block, catching up on signals that arrived while the queue was empty.
+    pub fn try_finalize_pending(&mut self) -> Option<L2BlockNumber> {
+        let finalized_l1 = self.latest_finalized_l1?;
+        self.try_finalize_up_to(finalized_l1)
+    }
+
+    /// Finds the highest enqueued L2 block whose L1 origin is `<= l1_block_number`, drains
+    /// all queue entries contained in that finalized L1 range, and returns the L2 block.
+    fn try_finalize_up_to(&mut self, l1_block_number: L1BlockNumber) -> Option<L2BlockNumber> {
         // Find the highest safe L2 block that is contained within the finalized chain,
         // that the finalizer is aware of.
-        let highest_safe =
-            self.awaiting_finalization.range(..=new_finalized_l1_block.number).next_back();
+        let highest_safe = self.awaiting_finalization.range(..=l1_block_number).next_back();
 
         // If the highest safe block is found, return it and drain the
         // queue of all L1 blocks not contained in the finalized L1 chain.
         if let Some((_, highest_safe_number)) = highest_safe {
             let result = *highest_safe_number;
-            self.awaiting_finalization.retain(|&number, _| number > new_finalized_l1_block.number);
+            self.awaiting_finalization.retain(|&number, _| number > l1_block_number);
             Some(result)
         } else {
             None
@@ -149,11 +174,11 @@ mod tests {
     }
 
     #[test]
-    fn clear_empties_queue() {
+    fn prune_above_zero_empties_queue() {
         let mut f = L2Finalizer::default();
         f.enqueue_for_finalization(&attrs(4, 1));
         f.enqueue_for_finalization(&attrs(7, 2));
-        f.clear();
+        f.prune_above(0);
         assert!(f.try_finalize_next(l1_at(100)).is_none());
     }
 
@@ -178,5 +203,49 @@ mod tests {
         assert_eq!(f.try_finalize_next(l1_at(5)), Some(20));
         // Queue is now empty; an older signal cannot regress to a stale entry.
         assert!(f.try_finalize_next(l1_at(2)).is_none());
+    }
+
+    #[test]
+    fn finalized_signal_on_empty_queue_remembered_for_later() {
+        // A finalized L1 signal arriving on an empty queue must not be lost.
+        let mut f = L2Finalizer::default();
+        assert!(f.try_finalize_next(l1_at(100)).is_none());
+
+        f.enqueue_for_finalization(&attrs(999, 50)); // l2=1000, l1_origin=50
+        assert_eq!(f.try_finalize_pending(), Some(1000));
+    }
+
+    #[test]
+    fn try_finalize_pending_returns_none_without_prior_signal() {
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(4, 1)); // l2=5, l1_origin=1
+        assert!(f.try_finalize_pending().is_none());
+    }
+
+    #[test]
+    fn reset_preserves_latest_finalized_l1() {
+        // Blocks enqueued after a reset can finalize against a pre-reset signal.
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(4, 1)); // l2=5, l1_origin=1
+        assert_eq!(f.try_finalize_next(l1_at(10)), Some(5));
+
+        f.prune_above(5);
+
+        f.enqueue_for_finalization(&attrs(14, 3)); // l2=15, l1_origin=3
+        assert_eq!(f.try_finalize_pending(), Some(15));
+    }
+
+    #[test]
+    fn prune_above_keeps_entries_at_or_below_anchor() {
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(99, 10)); // l2=100, l1_origin=10
+        f.enqueue_for_finalization(&attrs(199, 20)); // l2=200, l1_origin=20
+        f.enqueue_for_finalization(&attrs(299, 30)); // l2=300, l1_origin=30
+
+        f.prune_above(200);
+
+        assert_eq!(f.try_finalize_next(l1_at(20)), Some(200));
+        // The pruned l2=300 entry must not resurface.
+        assert!(f.try_finalize_next(l1_at(30)).is_none());
     }
 }


### PR DESCRIPTION
We observed this issue across several of our RPC nodes. The investigation was initially triggered by unbounded memory growth and repeated OOM kills. We traced the root cause to lost finalization progress, applied this patch to our nodes, and confirmed it resolves the problem. Details in the commit message below:

The L2Finalizer loses finalization progress in two independent ways:

try_finalize_next() silently drops a finalized L1 signal when the awaiting_finalization queue is empty. The L1 watcher does not re-send signals, so the EL's finalized head can stay stuck indefinitely; nodes restarted during sync report finalized=0 for days. Since reth's changeset cache eviction keys off the finalized block, the wedge also causes unbounded memory growth and eventual OOM.

Every pipeline reset clears the whole queue. An entry only becomes finalizable once the finalized L1 overtakes its L1 origin (~2 L1 epochs, ~13 min). When resets occur more frequently than that (e.g. transient BlockNotFound resets every few minutes), entries never survive long enough, and finalization only advances in multi-hour batches.

Fix:

- Remember the highest finalized L1 block number observed and preserve it across clear(). After each enqueue, retry finalization against the stored signal via try_finalize_pending().

- On Signal::Reset, drop only the queue entries above the safe head instead of clearing the whole queue. Blocks at or below the safe head survive the reset unchanged, so their entries remain valid.

Neither change relaxes the finality rule: an L2 block is only ever finalized when its derived_from L1 block is itself finalized. The changes only stop already-satisfied finalizations from being lost.