### PR TITLE
refactor(challenger): extract anchor updater

### DIFF
--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -99,6 +99,7 @@ impl AnchorUpdater {
                     status = %status,
                     "next game cannot update anchor"
                 );
+                self.cached_next_game = None;
                 return;
             }
             Err(e) => {
@@ -467,11 +468,14 @@ mod tests {
             mock_state(GameStatus::ChallengerWins, Address::ZERO, 100),
         )]));
         let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+        let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
+        updater.poll(&verifier, &submitter).await;
+        factory.uuid_games.lock().unwrap().clear();
         updater.poll(&verifier, &submitter).await;
 
         assert!(submitter.recorded_calls().is_empty());
+        assert_eq!(verifier.status_read_count(challenger_win), 1);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -1,0 +1,486 @@
+//! Anchor root update management.
+
+use std::sync::Arc;
+
+use alloy_primitives::Address;
+use base_proof_contracts::{
+    AggregateVerifierClient, AnchorRoot, AnchorSnapshot, AnchorStateRegistryClient,
+    DisputeGameFactoryClient, GameStatus, encode_set_anchor_state_calldata, game_lookup_blocks,
+    game_lookup_key,
+};
+use base_proof_rpc::L2Provider;
+use futures::stream::{self, StreamExt};
+use tracing::{debug, info, warn};
+
+use crate::{BondTransactionSubmitter, ChallengerMetrics, OutputValidator};
+
+/// Best-effort updater for the `AnchorStateRegistry`.
+pub struct AnchorUpdater {
+    factory_client: Arc<dyn DisputeGameFactoryClient>,
+    anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
+    output_validator: OutputValidator<dyn L2Provider>,
+    cached_next_game: Option<(AnchorSnapshot, Address)>,
+    anchor_state_registry_address: Address,
+    game_type: u32,
+    block_interval: u64,
+    intermediate_block_interval: u64,
+}
+
+impl std::fmt::Debug for AnchorUpdater {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnchorUpdater")
+            .field("anchor_state_registry_address", &self.anchor_state_registry_address)
+            .field("game_type", &self.game_type)
+            .field("block_interval", &self.block_interval)
+            .field("intermediate_block_interval", &self.intermediate_block_interval)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AnchorUpdater {
+    /// Creates an anchor updater.
+    pub fn new(
+        factory_client: Arc<dyn DisputeGameFactoryClient>,
+        anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
+        l2_provider: Arc<dyn L2Provider>,
+        anchor_state_registry_address: Address,
+        game_type: u32,
+        block_interval: u64,
+        intermediate_block_interval: u64,
+    ) -> Self {
+        Self {
+            factory_client,
+            anchor_registry_client,
+            output_validator: OutputValidator::new(l2_provider),
+            cached_next_game: None,
+            anchor_state_registry_address,
+            game_type,
+            block_interval,
+            intermediate_block_interval,
+        }
+    }
+
+    /// Finds the next game after the anchor game and advances the anchor root if it is ready.
+    pub async fn poll(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) {
+        let anchor = match self.anchor_registry_client.anchor_snapshot().await {
+            Ok(anchor) => anchor,
+            Err(e) => {
+                warn!(error = %e, "failed to read anchor snapshot for anchor update");
+                return;
+            }
+        };
+
+        let game_address = match self.cached_next_game {
+            Some((cached_anchor, address)) if cached_anchor == anchor => address,
+            _ => {
+                self.cached_next_game = None;
+                let Some(address) = self.next_game(anchor.anchor_root, anchor.anchor_game).await
+                else {
+                    return;
+                };
+                self.cached_next_game = Some((anchor, address));
+                address
+            }
+        };
+
+        match verifier_client.status(game_address).await {
+            Ok(GameStatus::DefenderWins) => {}
+            Ok(GameStatus::InProgress) => {
+                debug!(game = %game_address, "anchor update waiting for next game");
+                return;
+            }
+            Ok(status) => {
+                debug!(
+                    game = %game_address,
+                    status = %status,
+                    "next game cannot update anchor"
+                );
+                return;
+            }
+            Err(e) => {
+                warn!(game = %game_address, error = %e, "failed to read next game status for anchor update");
+                return;
+            }
+        }
+
+        Self::try_update(game_address, verifier_client, submitter).await;
+    }
+
+    async fn next_game(&self, anchor_root: AnchorRoot, anchor_game: Address) -> Option<Address> {
+        let blocks = match game_lookup_blocks(
+            anchor_root.l2_block_number,
+            self.block_interval,
+            self.intermediate_block_interval,
+        ) {
+            Ok(blocks) => blocks,
+            Err(e) => {
+                warn!(error = %e, "invalid anchor update lookup blocks");
+                return None;
+            }
+        };
+
+        let block_count = blocks.len();
+        let mut roots =
+            stream::iter(blocks)
+                .map(|block| async move {
+                    (block, self.output_validator.compute_output_root(block).await)
+                })
+                .buffered(OutputValidator::<dyn L2Provider>::VALIDATION_CONCURRENCY);
+
+        let mut intermediate_roots = Vec::with_capacity(block_count);
+        while let Some((block, result)) = roots.next().await {
+            match result {
+                Ok(root) => intermediate_roots.push(root),
+                Err(e) => {
+                    debug!(block, error = %e, "anchor update waiting for output root");
+                    return None;
+                }
+            }
+        }
+
+        let parent = if anchor_game == Address::ZERO {
+            self.anchor_state_registry_address
+        } else {
+            anchor_game
+        };
+        let key = match game_lookup_key(
+            anchor_root.l2_block_number,
+            parent,
+            self.block_interval,
+            self.intermediate_block_interval,
+            &intermediate_roots,
+        ) {
+            Ok(key) => key,
+            Err(e) => {
+                warn!(error = %e, "failed to build anchor update game lookup key");
+                return None;
+            }
+        };
+
+        match self.factory_client.games(self.game_type, key.root_claim, key.extra_data).await {
+            Ok(Address::ZERO) => {
+                debug!(
+                    target_block = key.target_block,
+                    parent = %parent,
+                    output_root = %key.root_claim,
+                    "next anchor game not found"
+                );
+                None
+            }
+            Ok(address) => Some(address),
+            Err(e) => {
+                warn!(target_block = key.target_block, parent = %parent, output_root = %key.root_claim, error = %e, "failed to look up next anchor game");
+                None
+            }
+        }
+    }
+
+    async fn try_update(
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) {
+        let asr_address = match verifier_client.anchor_state_registry(game_address).await {
+            Ok(address) => address,
+            Err(e) => {
+                warn!(game = %game_address, error = %e, "failed to read anchor registry for game");
+                return;
+            }
+        };
+
+        match verifier_client.is_game_finalized(asr_address, game_address).await {
+            Ok(true) => {}
+            Ok(false) => {
+                debug!(game = %game_address, asr = %asr_address, "anchor update waiting for finality");
+                return;
+            }
+            Err(e) => {
+                warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game finality for anchor update");
+                return;
+            }
+        }
+
+        let preflight = match verifier_client.anchor_preflight(asr_address, game_address).await {
+            Ok(preflight) => preflight,
+            Err(e) => {
+                warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read anchor preflight");
+                return;
+            }
+        };
+
+        if preflight.permanently_ineligible() {
+            info!(
+                game = %game_address,
+                asr = %asr_address,
+                blacklisted = preflight.blacklisted,
+                retired = preflight.retired,
+                "skipping permanently ineligible anchor update"
+            );
+            ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
+                .increment(1);
+            return;
+        }
+
+        if preflight.paused || !preflight.respected {
+            debug!(
+                game = %game_address,
+                asr = %asr_address,
+                paused = preflight.paused,
+                respected = preflight.respected,
+                "anchor update waiting for registry eligibility"
+            );
+            return;
+        }
+
+        let game_info = match verifier_client.game_info(game_address).await {
+            Ok(info) => info,
+            Err(e) => {
+                warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game info for anchor update");
+                return;
+            }
+        };
+
+        if game_info.l2_block_number <= preflight.anchor_root.l2_block_number {
+            info!(
+                game = %game_address,
+                asr = %asr_address,
+                game_l2_block = game_info.l2_block_number,
+                anchor_l2_block = preflight.anchor_root.l2_block_number,
+                "skipping stale anchor update"
+            );
+            ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
+                .increment(1);
+            return;
+        }
+
+        let calldata = encode_set_anchor_state_calldata(game_address);
+        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    tx_hash = %tx_hash,
+                    "anchor state registry updated"
+                );
+                ChallengerMetrics::anchor_update_tx_outcome_total(
+                    ChallengerMetrics::STATUS_SUCCESS,
+                )
+                .increment(1);
+                ChallengerMetrics::anchor_l2_block_number().set(game_info.l2_block_number as f64);
+            }
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    asr = %asr_address,
+                    error = %e,
+                    "anchor update transaction failed"
+                );
+                ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use alloy_primitives::B256;
+    use base_protocol::OutputRoot;
+
+    use super::*;
+    use crate::test_utils::{
+        MockAggregateVerifier, MockAnchorStateRegistry, MockBondTransactionSubmitter,
+        MockDisputeGameFactory, MockL2Provider, addr, build_test_header_and_account, mock_state,
+    };
+
+    const ASR_ADDRESS: Address = Address::new([0xAA; 20]);
+    const GAME_TYPE: u32 = 1;
+    const BLOCK_INTERVAL: u64 = 100;
+    const INTERMEDIATE_BLOCK_INTERVAL: u64 = 100;
+
+    fn insert_l2_block(l2: &mut MockL2Provider, block: u64) -> B256 {
+        let storage_hash = B256::repeat_byte(block as u8);
+        let (header, account) = build_test_header_and_account(block, storage_hash);
+        let output_root =
+            OutputRoot::from_parts(header.state_root, storage_hash, header.hash_slow()).hash();
+        l2.insert_block(block, header, account);
+        output_root
+    }
+
+    fn insert_next_game(
+        factory: &MockDisputeGameFactory,
+        parent: Address,
+        output_root: B256,
+        game: Address,
+    ) {
+        let extra_data =
+            game_lookup_key(0, parent, BLOCK_INTERVAL, INTERMEDIATE_BLOCK_INTERVAL, &[output_root])
+                .unwrap()
+                .extra_data;
+        factory.insert_uuid_game(GAME_TYPE, output_root, extra_data, game);
+    }
+
+    fn updater(
+        factory: Arc<MockDisputeGameFactory>,
+        anchor_registry: Arc<MockAnchorStateRegistry>,
+        l2: Arc<MockL2Provider>,
+    ) -> AnchorUpdater {
+        AnchorUpdater::new(
+            factory as Arc<dyn DisputeGameFactoryClient>,
+            anchor_registry as Arc<dyn AnchorStateRegistryClient>,
+            l2 as Arc<dyn L2Provider>,
+            ASR_ADDRESS,
+            GAME_TYPE,
+            BLOCK_INTERVAL,
+            INTERMEDIATE_BLOCK_INTERVAL,
+        )
+    }
+
+    #[tokio::test]
+    async fn poll_updates_next_defender_win() {
+        let game = addr(1);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = ASR_ADDRESS;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, game);
+        assert_eq!(calls[0].1, ASR_ADDRESS);
+    }
+
+    #[tokio::test]
+    async fn poll_waits_for_in_progress_next_game() {
+        let game = addr(1);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
+        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_reuses_cached_next_game_while_anchor_is_unchanged() {
+        let game = addr(1);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
+        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+        factory.uuid_games.lock().unwrap().clear();
+
+        let mut resolved_state = state;
+        resolved_state.status = GameStatus::DefenderWins;
+        resolved_state.anchor_state_registry = ASR_ADDRESS;
+        verifier.update_game(game, resolved_state);
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, game);
+    }
+
+    #[tokio::test]
+    async fn poll_stops_at_challenger_wins_next_game() {
+        let challenger_win = addr(10);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, ASR_ADDRESS, output_root, challenger_win);
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(
+            challenger_win,
+            mock_state(GameStatus::ChallengerWins, Address::ZERO, 100),
+        )]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_starts_after_current_anchor_game() {
+        let anchor_game = addr(10);
+        let next_game = addr(11);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, anchor_game, output_root, next_game);
+        let mut next_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 200);
+        next_state.anchor_state_registry = ASR_ADDRESS;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([
+            (anchor_game, mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
+            (next_game, next_state),
+        ]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash)]);
+        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, next_game);
+    }
+
+    #[tokio::test]
+    async fn poll_waits_for_finalized_defender_win() {
+        let game = addr(1);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = ASR_ADDRESS;
+        state.is_finalized = false;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+        let mut updater = updater(factory, anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+
+        assert!(submitter.recorded_calls().is_empty());
+    }
+}

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -107,7 +107,9 @@ impl AnchorUpdater {
             }
         }
 
-        Self::try_update(game_address, verifier_client, submitter).await;
+        if Self::try_update(game_address, verifier_client, submitter).await {
+            self.cached_next_game = None;
+        }
     }
 
     async fn next_game(&self, anchor_root: AnchorRoot, anchor_game: Address) -> Option<Address> {
@@ -173,7 +175,13 @@ impl AnchorUpdater {
             }
             Ok(address) => Some(address),
             Err(e) => {
-                warn!(target_block = key.target_block, parent = %parent, output_root = %key.root_claim, error = %e, "failed to look up next anchor game");
+                warn!(
+                    target_block = key.target_block,
+                    parent = %parent,
+                    output_root = %key.root_claim,
+                    error = %e,
+                    "failed to look up next anchor game"
+                );
                 None
             }
         }
@@ -183,12 +191,12 @@ impl AnchorUpdater {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) {
+    ) -> bool {
         let asr_address = match verifier_client.anchor_state_registry(game_address).await {
             Ok(address) => address,
             Err(e) => {
                 warn!(game = %game_address, error = %e, "failed to read anchor registry for game");
-                return;
+                return false;
             }
         };
 
@@ -196,11 +204,11 @@ impl AnchorUpdater {
             Ok(true) => {}
             Ok(false) => {
                 debug!(game = %game_address, asr = %asr_address, "anchor update waiting for finality");
-                return;
+                return false;
             }
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game finality for anchor update");
-                return;
+                return false;
             }
         }
 
@@ -208,7 +216,7 @@ impl AnchorUpdater {
             Ok(preflight) => preflight,
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read anchor preflight");
-                return;
+                return false;
             }
         };
 
@@ -222,7 +230,7 @@ impl AnchorUpdater {
             );
             ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
                 .increment(1);
-            return;
+            return false;
         }
 
         if preflight.paused || !preflight.respected {
@@ -233,14 +241,14 @@ impl AnchorUpdater {
                 respected = preflight.respected,
                 "anchor update waiting for registry eligibility"
             );
-            return;
+            return false;
         }
 
         let game_info = match verifier_client.game_info(game_address).await {
             Ok(info) => info,
             Err(e) => {
                 warn!(game = %game_address, asr = %asr_address, error = %e, "failed to read game info for anchor update");
-                return;
+                return false;
             }
         };
 
@@ -254,7 +262,7 @@ impl AnchorUpdater {
             );
             ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
                 .increment(1);
-            return;
+            return false;
         }
 
         let calldata = encode_set_anchor_state_calldata(game_address);
@@ -271,6 +279,7 @@ impl AnchorUpdater {
                 )
                 .increment(1);
                 ChallengerMetrics::anchor_l2_block_number().set(game_info.l2_block_number as f64);
+                true
             }
             Err(e) => {
                 warn!(
@@ -281,6 +290,7 @@ impl AnchorUpdater {
                 );
                 ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
+                false
             }
         }
     }
@@ -408,6 +418,32 @@ mod tests {
         resolved_state.anchor_state_registry = ASR_ADDRESS;
         verifier.update_game(game, resolved_state);
 
+        updater.poll(&verifier, &submitter).await;
+
+        let calls = submitter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, game);
+    }
+
+    #[tokio::test]
+    async fn poll_clears_cached_next_game_after_successful_update() {
+        let game = addr(1);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut l2 = MockL2Provider::new();
+        let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
+        insert_next_game(&factory, ASR_ADDRESS, output_root, game);
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.anchor_state_registry = ASR_ADDRESS;
+
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter =
+            MockBondTransactionSubmitter::with_responses(vec![Ok(tx_hash), Ok(tx_hash)]);
+        let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
+
+        updater.poll(&verifier, &submitter).await;
+        factory.uuid_games.lock().unwrap().clear();
         updater.poll(&verifier, &submitter).await;
 
         let calls = submitter.recorded_calls();

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -221,6 +221,8 @@ impl AnchorUpdater {
         };
 
         if preflight.permanently_ineligible() {
+            // Later games are keyed from their parent game, so re-running the same-anchor lookup
+            // would rediscover this game. External anchor advancement is required to move past it.
             info!(
                 game = %game_address,
                 asr = %asr_address,

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -35,7 +35,6 @@ use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, DelayedWETHClient, DelayedWETHContractClient,
     DisputeGameFactoryClient, GameStatus, encode_claim_credit_calldata, encode_resolve_calldata,
-    encode_set_anchor_state_calldata,
 };
 use base_runtime::Clock;
 use futures::stream::{self, StreamExt};
@@ -82,42 +81,12 @@ pub struct TrackedGame {
     pub phase: BondPhase,
     /// The address that will receive the bond.
     pub bond_recipient: Address,
-    /// Whether the anchor state update has been completed (or skipped)
-    /// for this game. Set to `true` after a successful
-    /// `setAnchorState()` call or when the game is not eligible
-    /// (e.g. `CHALLENGER_WINS`).
-    pub anchor_update_complete: bool,
-    /// Cached on-chain game status. Populated on the first successful
-    /// `status()` RPC read; subsequent ticks reuse the cached value
-    /// because the status is immutable after resolution.
-    pub cached_status: Option<GameStatus>,
-    /// Cached `AnchorStateRegistry` address for this game. Read from the
-    /// game contract on first use and reused thereafter (immutable per game).
-    pub cached_asr_address: Option<Address>,
-    /// Cached L2 block number for this game. Read from immutable game info
-    /// once the game is finalized and reused for retries.
-    pub cached_l2_block_number: Option<u64>,
-    /// Monotonic timestamp for games whose bond lifecycle is complete but
-    /// which remain tracked until the anchor update completes.
-    pub anchor_update_retained_since: Option<Duration>,
-    /// Removal reason to use once a retained game is finally evicted.
-    pub anchor_update_retention_reason: Option<RemovalReason>,
 }
 
 impl TrackedGame {
-    /// Creates a freshly-tracked game in the given phase. All caches and
-    /// retention timestamps start unset.
+    /// Creates a freshly-tracked game in the given phase.
     pub const fn new(phase: BondPhase, bond_recipient: Address) -> Self {
-        Self {
-            phase,
-            bond_recipient,
-            anchor_update_complete: false,
-            cached_status: None,
-            cached_asr_address: None,
-            cached_l2_block_number: None,
-            anchor_update_retained_since: None,
-            anchor_update_retention_reason: None,
-        }
+        Self { phase, bond_recipient }
     }
 }
 
@@ -161,9 +130,6 @@ pub struct BondManager<C: Clock> {
     /// How often a full rescan of the lookback window is performed to catch
     /// state transitions (games challenged or resolved by other actors).
     discovery_interval: Duration,
-    /// Maximum time to retain a completed bond game while waiting for its
-    /// anchor update to complete.
-    anchor_update_retention: Duration,
 }
 
 impl<C: Clock> BondManager<C> {
@@ -171,10 +137,6 @@ impl<C: Clock> BondManager<C> {
     /// been read yet. If the real delay is shorter the withdraw will simply
     /// succeed earlier; if longer, the attempt reverts and is retried.
     const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-
-    /// Default maximum time to keep a completed bond game tracked while
-    /// waiting for its best-effort anchor update to finish.
-    const DEFAULT_ANCHOR_UPDATE_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 
     /// How long to wait before retrying a reverted withdraw attempt.
     const WITHDRAW_REVERT_RETRY_DELAY: Duration = Duration::from_secs(60);
@@ -202,7 +164,6 @@ impl<C: Clock> BondManager<C> {
             last_full_scan,
             lookback,
             discovery_interval,
-            anchor_update_retention: Self::DEFAULT_ANCHOR_UPDATE_RETENTION,
         }
     }
 
@@ -227,13 +188,6 @@ impl<C: Clock> BondManager<C> {
             debug!(game = %game_address, "WETH delay not yet known, using default 7 days");
             Self::DEFAULT_WETH_DELAY
         })
-    }
-
-    /// Sets the maximum time a completed bond game remains tracked while
-    /// waiting for its anchor update to complete.
-    pub fn set_anchor_update_retention(&mut self, retention: Duration) {
-        info!(retention_secs = retention.as_secs(), "anchor update retention configured");
-        self.anchor_update_retention = retention;
     }
 
     /// Returns the number of games currently being tracked.
@@ -568,7 +522,7 @@ impl<C: Clock> BondManager<C> {
         )
         .await;
 
-        let mut discovered = 0u64;
+        let mut discovered = 0;
 
         for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
             if self.tracked.contains_key(&game_address) {
@@ -629,26 +583,11 @@ impl<C: Clock> BondManager<C> {
         let mut removed = Vec::new();
 
         for game_address in addresses {
-            if let Some(reason) =
-                self.tracked.get(&game_address).and_then(|g| g.anchor_update_retention_reason)
-            {
-                self.try_anchor_update(game_address, verifier_client, submitter).await;
-                if self.handle_lifecycle_completion(game_address, reason) {
-                    removed.push((game_address, reason));
-                }
-                continue;
-            }
-
             match self.advance_game(game_address, verifier_client, submitter).await {
                 Ok(Some(reason)) => {
-                    self.try_anchor_update(game_address, verifier_client, submitter).await;
-                    if self.handle_lifecycle_completion(game_address, reason) {
-                        removed.push((game_address, reason));
-                    }
+                    removed.push((game_address, reason));
                 }
-                Ok(None) => {
-                    self.try_anchor_update(game_address, verifier_client, submitter).await;
-                }
+                Ok(None) => {}
                 Err(e) => {
                     warn!(
                         game = %game_address,
@@ -674,57 +613,6 @@ impl<C: Clock> BondManager<C> {
         if !removed.is_empty() {
             ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         }
-        let retained =
-            self.tracked.values().filter(|g| g.anchor_update_retained_since.is_some()).count();
-        ChallengerMetrics::anchor_update_retained_games().set(retained as f64);
-    }
-
-    /// Decides whether a game whose bond lifecycle has finished should be
-    /// removed now or retained until [`try_anchor_update`] succeeds.
-    ///
-    /// Returns `true` if the caller should remove the game from tracking.
-    fn handle_lifecycle_completion(
-        &mut self,
-        game_address: Address,
-        reason: RemovalReason,
-    ) -> bool {
-        let now = self.clock.now();
-        let Some(game) = self.tracked.get_mut(&game_address) else {
-            return true;
-        };
-        if game.anchor_update_complete {
-            return true;
-        }
-        if let Some(retained_since) = game.anchor_update_retained_since {
-            game.anchor_update_retention_reason = Some(reason);
-            let retained_duration = now.saturating_sub(retained_since);
-            if retained_duration >= self.anchor_update_retention {
-                warn!(
-                    game = %game_address,
-                    reason = ?reason,
-                    retained_secs = retained_duration.as_secs(),
-                    retention_secs = self.anchor_update_retention.as_secs(),
-                    "evicting game after anchor update retention timeout"
-                );
-                return true;
-            }
-            debug!(
-                game = %game_address,
-                reason = ?reason,
-                retained_secs = retained_duration.as_secs(),
-                "keeping game tracked until anchor update completes"
-            );
-            return false;
-        }
-        game.anchor_update_retained_since = Some(now);
-        game.anchor_update_retention_reason = Some(reason);
-        warn!(
-            game = %game_address,
-            reason = ?reason,
-            "retaining completed bond game until anchor update completes"
-        );
-        ChallengerMetrics::anchor_update_retained_games_total().increment(1);
-        false
     }
 
     /// Advances a single game through the bond lifecycle state machine.
@@ -793,23 +681,6 @@ impl<C: Clock> BondManager<C> {
                     );
                     ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                         .increment(1);
-                    // Re-read and cache the now-immutable status so that
-                    // try_anchor_update (called later this tick) can use
-                    // it without a redundant RPC call.
-                    match verifier_client.status(game_address).await {
-                        Ok(resolved_status) => {
-                            if let Some(g) = self.tracked.get_mut(&game_address) {
-                                g.cached_status = Some(resolved_status);
-                            }
-                        }
-                        Err(e) => {
-                            debug!(
-                                game = %game_address,
-                                error = %e,
-                                "failed to cache status after resolve, will re-read later"
-                            );
-                        }
-                    }
                 }
                 Err(e) => {
                     warn!(
@@ -826,12 +697,6 @@ impl<C: Clock> BondManager<C> {
             ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
                 .increment(1);
             info!(game = %game_address, status = ?status, "game already resolved");
-            // Status is immutable after resolution — cache it so that
-            // try_anchor_update (called later this tick) can skip the
-            // redundant RPC round-trip.
-            if let Some(g) = self.tracked.get_mut(&game_address) {
-                g.cached_status = Some(status);
-            }
         }
 
         // Re-read the onchain bondRecipient — resolve may have changed it
@@ -1059,7 +924,7 @@ impl<C: Clock> BondManager<C> {
     ///
     /// Computes how long ago `unix_secs` occurred relative to `unix_now`
     /// and subtracts that age from the current monotonic time. Used when
-    /// recovering on-chain timestamps (e.g. `resolved_at`) into the
+    /// recovering onchain timestamps (e.g. `resolved_at`) into the
     /// local monotonic time domain.
     ///
     /// `unix_now` is accepted as a parameter (callers obtain it via
@@ -1163,235 +1028,6 @@ impl<C: Clock> BondManager<C> {
         }
     }
 
-    /// Marks the anchor update as complete for a tracked game. No-op if the
-    /// game is no longer tracked.
-    fn mark_anchor_update_complete(&mut self, game_address: Address) {
-        if let Some(game) = self.tracked.get_mut(&game_address) {
-            game.anchor_update_complete = true;
-        }
-    }
-
-    /// Marks an anchor update as permanently skipped: the game cannot become
-    /// a valid anchor and we increment the SKIPPED outcome metric.
-    fn skip_anchor_update_permanently(&mut self, game_address: Address) {
-        self.mark_anchor_update_complete(game_address);
-        ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_SKIPPED)
-            .increment(1);
-    }
-
-    /// Best-effort attempt to update the `AnchorStateRegistry` for a
-    /// resolved game.
-    ///
-    /// Skips updates for games that are permanently ineligible (blacklisted,
-    /// retired, or already stale relative to the current anchor) so the tx
-    /// submitter is not spammed each poll tick. Transient ineligibility
-    /// (airgap delay not elapsed, not yet finalized, or currently
-    /// unrespected) is left to retry on the next tick — the on-chain
-    /// `setAnchorState()` call is permissionless and self-validating.
-    async fn try_anchor_update(
-        &mut self,
-        game_address: Address,
-        verifier_client: &dyn AggregateVerifierClient,
-        submitter: &dyn BondTransactionSubmitter,
-    ) {
-        let game = match self.tracked.get(&game_address) {
-            Some(g) => g,
-            None => return,
-        };
-
-        if game.anchor_update_complete
-            || (game.cached_status.is_none() && matches!(game.phase, BondPhase::NeedsResolve))
-        {
-            return;
-        }
-
-        // Only DEFENDER_WINS games can update the anchor state.
-        // The status is immutable after resolution, so we cache it
-        // after the first successful RPC read to avoid redundant calls.
-        let status = if let Some(cached) = game.cached_status {
-            cached
-        } else {
-            match verifier_client.status(game_address).await {
-                Ok(s) => {
-                    if let Some(g) = self.tracked.get_mut(&game_address) {
-                        g.cached_status = Some(s);
-                    }
-                    s
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read status for anchor update"
-                    );
-                    return;
-                }
-            }
-        };
-
-        if status != GameStatus::DefenderWins {
-            self.skip_anchor_update_permanently(game_address);
-            return;
-        }
-
-        // Resolve the ASR address from the game contract (cached after first read).
-        let asr_address = if let Some(cached) =
-            self.tracked.get(&game_address).and_then(|g| g.cached_asr_address)
-        {
-            cached
-        } else {
-            match verifier_client.anchor_state_registry(game_address).await {
-                Ok(addr) => {
-                    if let Some(g) = self.tracked.get_mut(&game_address) {
-                        g.cached_asr_address = Some(addr);
-                    }
-                    addr
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        error = %e,
-                        "failed to read anchorStateRegistry for anchor update"
-                    );
-                    return;
-                }
-            }
-        };
-
-        // Keep the cheap finality read before the heavier preflight batch. With
-        // a nonzero ASR airgap, blacklisted/retired games may retry this single
-        // read until finality, but moving preflight earlier would add several
-        // reads for every ordinary not-yet-finalized game.
-        match verifier_client.is_game_finalized(asr_address, game_address).await {
-            Ok(true) => {}
-            Ok(false) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    "anchor state update not ready because game is not finalized"
-                );
-                return;
-            }
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "failed to read isGameFinalized, will retry"
-                );
-                return;
-            }
-        }
-
-        let preflight = match verifier_client.anchor_preflight(asr_address, game_address).await {
-            Ok(p) => p,
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "failed to read anchor preflight state, will retry"
-                );
-                return;
-            }
-        };
-
-        if preflight.permanently_ineligible() {
-            info!(
-                game = %game_address,
-                asr = %asr_address,
-                blacklisted = preflight.blacklisted,
-                retired = preflight.retired,
-                respected = preflight.respected,
-                "skipping permanently ineligible anchor update"
-            );
-            self.skip_anchor_update_permanently(game_address);
-            return;
-        }
-
-        if preflight.paused {
-            debug!(
-                game = %game_address,
-                asr = %asr_address,
-                "anchor state update not ready because registry is paused"
-            );
-            return;
-        }
-
-        if !preflight.respected {
-            debug!(
-                game = %game_address,
-                asr = %asr_address,
-                "anchor state update not ready because game is not currently respected"
-            );
-            return;
-        }
-
-        let game_l2_block_number = if let Some(cached) =
-            self.tracked.get(&game_address).and_then(|g| g.cached_l2_block_number)
-        {
-            cached
-        } else {
-            match verifier_client.game_info(game_address).await {
-                Ok(info) => {
-                    if let Some(g) = self.tracked.get_mut(&game_address) {
-                        g.cached_l2_block_number = Some(info.l2_block_number);
-                    }
-                    info.l2_block_number
-                }
-                Err(e) => {
-                    debug!(
-                        game = %game_address,
-                        asr = %asr_address,
-                        error = %e,
-                        "failed to read game info for anchor preflight, will retry"
-                    );
-                    return;
-                }
-            }
-        };
-
-        if game_l2_block_number <= preflight.anchor_root.l2_block_number {
-            info!(
-                game = %game_address,
-                asr = %asr_address,
-                game_l2_block = game_l2_block_number,
-                anchor_l2_block = preflight.anchor_root.l2_block_number,
-                "skipping stale anchor state update"
-            );
-            self.skip_anchor_update_permanently(game_address);
-            return;
-        }
-
-        let calldata = encode_set_anchor_state_calldata(game_address);
-        match submitter.send_bond_tx(game_address, asr_address, calldata).await {
-            Ok(tx_hash) => {
-                info!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    tx_hash = %tx_hash,
-                    "anchor state registry updated"
-                );
-                self.mark_anchor_update_complete(game_address);
-                ChallengerMetrics::anchor_update_tx_outcome_total(
-                    ChallengerMetrics::STATUS_SUCCESS,
-                )
-                .increment(1);
-                ChallengerMetrics::anchor_l2_block_number().set(game_l2_block_number as f64);
-            }
-            Err(e) => {
-                debug!(
-                    game = %game_address,
-                    asr = %asr_address,
-                    error = %e,
-                    "anchor state update failed, will retry"
-                );
-                ChallengerMetrics::anchor_update_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                    .increment(1);
-            }
-        }
-    }
-
     /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
     async fn resolve_weth_delay(
         &mut self,
@@ -1406,8 +1042,7 @@ impl<C: Clock> BondManager<C> {
     }
 }
 
-/// Trait for submitting bond lifecycle transactions (resolve, claimCredit,
-/// setAnchorState).
+/// Trait for submitting dispute game transactions (`resolve`, `claimCredit`, `setAnchorState`).
 ///
 /// This abstracts the transaction submission layer so the [`BondManager`]
 /// can be tested with mock submitters.
@@ -1426,14 +1061,14 @@ pub trait BondTransactionSubmitter: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use std::{future::Future, pin::Pin};
+    use std::{collections::HashMap, future::Future, pin::Pin};
 
     use alloy_primitives::B256;
     use futures::stream::BoxStream;
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory, MockGameState,
+        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory,
         TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
     };
 
@@ -1510,6 +1145,25 @@ mod tests {
         assert!(!mgr.is_tracking(&game));
         mgr.track_game(game, addr);
         assert!(mgr.is_tracking(&game));
+    }
+
+    #[tokio::test]
+    async fn already_resolved_game_advances_to_unlock() {
+        let claim_addr = Address::repeat_byte(0x01);
+        let game = addr(0);
+        let mut mgr = make_manager(vec![claim_addr]);
+        mgr.track_game(game, claim_addr);
+
+        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
+        state.bond_recipient = claim_addr;
+        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+        let result = mgr.advance_game(game, &verifier, &submitter).await.unwrap();
+
+        assert!(result.is_none());
+        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsUnlock));
+        assert!(submitter.recorded_calls().is_empty());
     }
 
     #[test]
@@ -1771,7 +1425,7 @@ mod tests {
 
     #[test]
     fn unix_to_monotonic_future_timestamp_clamps() {
-        // If the on-chain timestamp is ahead of local wall clock
+        // If the onchain timestamp is ahead of local wall clock
         // (clock skew), age saturates to 0 → monotonic = clock.now().
         let clock = fixed_clock(500);
         let result = BondManager::unix_to_monotonic(&clock, 2100, 2000);
@@ -2299,276 +1953,5 @@ mod tests {
 
         assert_eq!(mgr.bond_scan_head, game_count);
         assert_eq!(mgr.tracked_count(), game_count as usize);
-    }
-
-    // ---- anchor state update tests ----
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_needs_resolve_phase() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        // Game is still in NeedsResolve — should not attempt anchor update.
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(!mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_challenger_wins() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        // ChallengerWins — not eligible for anchor update.
-        let mut state = mock_state(GameStatus::ChallengerWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        // No tx submitted, but marked complete (won't retry).
-        assert!(submitter.recorded_calls().is_empty());
-        assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_sends_tx_for_defender_wins() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        // DefenderWins — eligible for anchor update.
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let tx_hash = B256::repeat_byte(0xDD);
-        let submitter = MockBondTransactionSubmitter::success(tx_hash);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        let calls = submitter.recorded_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, game, "tx should carry game address as context");
-        assert_eq!(calls[0].1, asr, "tx should be sent to ASR address");
-        assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_retries_on_failure() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(
-            game,
-            BondPhase::AwaitingDelay {
-                unlocked_at: Duration::from_secs(0),
-                unlocked_at_unix_secs: None,
-            },
-        );
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        // First attempt fails (e.g. airgap not elapsed → tx reverted).
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![Err(
-            crate::ChallengeSubmitError::TxReverted { tx_hash: B256::ZERO },
-        )]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        // Should NOT be marked complete — will retry next tick.
-        assert!(!mgr.tracked.get(&game).unwrap().anchor_update_complete);
-    }
-
-    #[tokio::test]
-    async fn anchor_update_not_retried_after_success() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        // First call succeeds.
-        let tx_hash = B256::repeat_byte(0xDD);
-        let submitter = MockBondTransactionSubmitter::success(tx_hash);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-        assert!(mgr.tracked.get(&game).unwrap().anchor_update_complete);
-
-        // Second call should be a no-op (no submitter response needed).
-        let submitter2 = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter2).await;
-        assert!(submitter2.recorded_calls().is_empty());
-    }
-
-    async fn run_anchor_update_skip_case(
-        mutate: impl FnOnce(&mut MockGameState),
-        expect_complete: bool,
-    ) {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::NeedsUnlock);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        mutate(&mut state);
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.try_anchor_update(game, &*verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty(), "no tx expected");
-        assert_eq!(
-            mgr.tracked.get(&game).unwrap().anchor_update_complete,
-            expect_complete,
-            "anchor_update_complete mismatch"
-        );
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_blacklisted_game() {
-        run_anchor_update_skip_case(|s| s.is_blacklisted = true, true).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_retired_game() {
-        run_anchor_update_skip_case(|s| s.is_retired = true, true).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_retries_for_unrespected_game() {
-        run_anchor_update_skip_case(|s| s.is_respected = false, false).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_retries_when_registry_paused() {
-        run_anchor_update_skip_case(|s| s.is_paused = true, false).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_skipped_for_stale_game() {
-        run_anchor_update_skip_case(|s| s.anchor_root.l2_block_number = 200, true).await;
-    }
-
-    #[tokio::test]
-    async fn anchor_update_waits_for_finalization() {
-        run_anchor_update_skip_case(|s| s.is_finalized = false, false).await;
-    }
-
-    #[tokio::test]
-    async fn poll_keeps_game_until_anchor_update_completes() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::Completed);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-        mgr.poll(&*verifier, &submitter).await;
-
-        assert!(submitter.recorded_calls().is_empty(), "no tx should be sent before finalization");
-        assert!(mgr.is_tracking(&game), "game should stay tracked until anchor update completes");
-    }
-
-    #[tokio::test]
-    async fn poll_evicts_game_after_anchor_update_retention_timeout() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.set_anchor_update_retention(Duration::from_secs(10));
-        mgr.track_game(game, claim_addr);
-        mgr.set_phase(game, BondPhase::Completed);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = claim_addr;
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(mgr.is_tracking(&game), "game should be retained before timeout");
-
-        mgr.clock.monotonic = Duration::from_secs(10);
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(!mgr.is_tracking(&game), "game should be evicted at retention timeout");
-    }
-
-    #[tokio::test]
-    async fn poll_skips_bond_lifecycle_for_retained_not_claimable_game() {
-        let claim_addr = Address::repeat_byte(0xCC);
-        let other_recipient = Address::repeat_byte(0xDD);
-        let asr = Address::repeat_byte(0xAA);
-        let game = addr(0);
-
-        let mut mgr = make_manager(vec![claim_addr]);
-        mgr.track_game(game, claim_addr);
-
-        let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
-        state.bond_recipient = other_recipient;
-        state.anchor_state_registry = asr;
-        state.is_finalized = false;
-        let verifier = Arc::new(MockAggregateVerifier::new([(game, state)].into_iter().collect()));
-        let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
-
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(mgr.is_tracking(&game), "game should be retained for anchor update");
-        assert_eq!(verifier.bond_recipient_read_count(game), 1);
-
-        mgr.poll(&*verifier, &submitter).await;
-        assert!(mgr.is_tracking(&game), "game should remain retained before finalization");
-        assert_eq!(
-            verifier.bond_recipient_read_count(game),
-            1,
-            "retained game should not re-run the bond lifecycle"
-        );
     }
 }

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -60,6 +60,10 @@ pub struct ChallengerArgs {
     #[arg(long = "anchor-state-registry-addr", env = cli_env!("ANCHOR_STATE_REGISTRY_ADDR"))]
     pub anchor_state_registry_addr: Address,
 
+    /// Game type ID for `AggregateVerifier` dispute games.
+    #[arg(long = "game-type", env = cli_env!("GAME_TYPE"))]
+    pub game_type: u32,
+
     /// Polling interval for new dispute games (e.g., "12s", "1m").
     #[arg(
         long = "poll-interval",
@@ -137,16 +141,6 @@ pub struct ChallengerArgs {
         value_parser = humantime::parse_duration
     )]
     pub bond_discovery_interval: Duration,
-
-    /// Maximum time to keep a completed bond game tracked while waiting for
-    /// its anchor update to complete.
-    #[arg(
-        long = "anchor-update-retention",
-        env = cli_env!("ANCHOR_UPDATE_RETENTION"),
-        default_value = "24h",
-        value_parser = humantime::parse_duration
-    )]
-    pub anchor_update_retention: Duration,
 
     /// Comma-separated list of addresses to claim bonds on behalf of.
     ///

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -91,6 +91,8 @@ pub struct ChallengerConfig {
     pub dispute_game_factory_addr: Address,
     /// Address of the `AnchorStateRegistry` contract on L1.
     pub anchor_state_registry_addr: Address,
+    /// Game type ID for `AggregateVerifier` dispute games.
+    pub game_type: u32,
     /// Polling interval for new dispute games.
     pub poll_interval: Duration,
     /// URL of the ZK RPC endpoint.
@@ -111,9 +113,6 @@ pub struct ChallengerConfig {
     pub bond_discovery_lookback_games: u64,
     /// How often a full rescan of the bond lookback window is performed.
     pub bond_discovery_interval: Duration,
-    /// Maximum time to keep a completed bond game tracked while waiting for
-    /// its anchor update to complete.
-    pub anchor_update_retention: Duration,
     /// Addresses to claim bonds on behalf of.
     pub bond_claim_addresses: Vec<Address>,
     /// Health server socket address.
@@ -192,10 +191,6 @@ impl ChallengerConfig {
             cli.challenger.bond_discovery_interval,
             "bond-discovery-interval",
         )?;
-        require_nonzero_duration(
-            cli.challenger.anchor_update_retention,
-            "anchor-update-retention",
-        )?;
 
         // Health server is always started, so the port must be valid.
         require_nonzero(cli.health.port.into(), "health.port")?;
@@ -218,6 +213,7 @@ impl ChallengerConfig {
             l2_eth_rpc,
             dispute_game_factory_addr: cli.challenger.dispute_game_factory_addr,
             anchor_state_registry_addr: cli.challenger.anchor_state_registry_addr,
+            game_type: cli.challenger.game_type,
             poll_interval: cli.challenger.poll_interval,
             zk_rpc_url,
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
@@ -228,7 +224,6 @@ impl ChallengerConfig {
             tx_manager,
             bond_discovery_lookback_games: cli.challenger.bond_discovery_lookback_games,
             bond_discovery_interval: cli.challenger.bond_discovery_interval,
-            anchor_update_retention: cli.challenger.anchor_update_retention,
             bond_claim_addresses: cli.challenger.bond_claim_addresses,
             health_addr,
             log: LogConfig::from(cli.logging),
@@ -260,6 +255,7 @@ mod tests {
             ("--l2-eth-rpc", "http://localhost:9545"),
             ("--dispute-game-factory-addr", "0x1234567890123456789012345678901234567890"),
             ("--anchor-state-registry-addr", "0x2234567890123456789012345678901234567890"),
+            ("--game-type", "1"),
             ("--zk-rpc-url", "http://localhost:5000"),
         ];
 
@@ -298,9 +294,9 @@ mod tests {
             config.anchor_state_registry_addr,
             "0x2234567890123456789012345678901234567890".parse::<Address>().unwrap()
         );
+        assert_eq!(config.game_type, 1);
         assert_eq!(config.bond_discovery_lookback_games, 1000);
         assert_eq!(config.bond_discovery_interval, Duration::from_secs(300));
-        assert_eq!(config.anchor_update_retention, Duration::from_secs(24 * 60 * 60));
         assert_eq!(config.health_addr, "0.0.0.0:8080".parse::<SocketAddr>().unwrap());
         assert!(matches!(config.signing, SignerConfig::Remote { .. }));
         assert_eq!(config.tx_manager.num_confirmations, 10);
@@ -334,7 +330,6 @@ mod tests {
         "bond-discovery-lookback-games"
     )]
     #[case::bond_discovery_interval("--bond-discovery-interval", "0s", "bond-discovery-interval")]
-    #[case::anchor_update_retention("--anchor-update-retention", "0s", "anchor-update-retention")]
     #[case::max_proof_duration("--max-proof-duration", "0s", "max-proof-duration")]
     fn test_zero_value_rejected(#[case] flag: &str, #[case] value: &str, #[case] field: &str) {
         let all_args = [&LOCAL_SIGNER_ARGS[..], &[flag, value]].concat();

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -153,6 +153,9 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     pub const MAX_PROOF_RETRIES: u32 = 3;
 
     /// Maximum number of terminally ignored games retained to avoid rediscovery churn.
+    ///
+    /// Evicted games may be rediscovered by a later scan, then re-ignored after
+    /// one check.
     pub const MAX_IGNORED_GAMES: usize = 10_000;
 
     /// Creates a new driver with the given components.

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -16,7 +16,7 @@
 //!    After the TEE proof is nullified, the game is re-scanned as Path 3.
 
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -35,10 +35,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    BondManager, CandidateGame, ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics,
-    DisputeIntent, GameCategory, GameScanner, IntermediateValidationParams, L1HeadProvider,
-    OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate,
-    ValidatorError,
+    AnchorUpdater, BondManager, CandidateGame, ChallengeSubmitError, ChallengeSubmitter,
+    ChallengerMetrics, DisputeIntent, GameCategory, GameScanner, IntermediateValidationParams,
+    L1HeadProvider, OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase,
+    ProofUpdate, ValidatorError,
 };
 
 /// Configuration for the challenger [`Driver`].
@@ -82,6 +82,8 @@ pub struct DriverComponents<
     pub verifier_client: Arc<dyn AggregateVerifierClient>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
     pub bond_manager: Option<BondManager<C>>,
+    /// Best-effort anchor state updater.
+    pub anchor_updater: AnchorUpdater,
 }
 
 impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt::Debug
@@ -119,8 +121,11 @@ where
     pub pending_proofs: PendingProofs,
     /// Games that hit terminal contract reverts and should not be rediscovered.
     ignored_games: HashSet<Address>,
+    ignored_game_order: VecDeque<Address>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
     pub bond_manager: Option<BondManager<C>>,
+    /// Best-effort anchor state updater.
+    pub anchor_updater: AnchorUpdater,
     /// Interval between polling cycles.
     pub poll_interval: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
@@ -147,6 +152,9 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     /// Maximum number of times a failed proof job will be retried before being dropped.
     pub const MAX_PROOF_RETRIES: u32 = 3;
 
+    /// Maximum number of terminally ignored games retained to avoid rediscovery churn.
+    pub const MAX_IGNORED_GAMES: usize = 10_000;
+
     /// Creates a new driver with the given components.
     pub fn new(config: DriverConfig, components: DriverComponents<L2, P, T, C>) -> Self {
         Self {
@@ -158,7 +166,9 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             verifier_client: components.verifier_client,
             pending_proofs: PendingProofs::new(),
             ignored_games: HashSet::new(),
+            ignored_game_order: VecDeque::new(),
             bond_manager: components.bond_manager,
+            anchor_updater: components.anchor_updater,
             poll_interval: config.poll_interval,
             max_proof_duration: config.max_proof_duration,
             tee_submit_retry_limit: config.tee_submit_retry_limit,
@@ -197,11 +207,13 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     ///
     /// First polls any in-flight proof sessions that are not in the current
     /// scan batch, then discovers claimable bonds, advances bond lifecycle
-    /// claims, and finally scans for new candidates and processes them.
+    /// claims, polls anchor updates, and finally scans for new candidates and
+    /// processes them.
     pub async fn step(&mut self) -> eyre::Result<()> {
         self.poll_pending_proofs().await;
         self.discover_claimable_bonds().await;
         self.poll_bond_claims().await;
+        self.anchor_updater.poll(&*self.verifier_client, &self.submitter).await;
 
         let candidates = self.scanner.scan().await?;
 
@@ -220,10 +232,13 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
     /// so that newly discovered games are immediately eligible for
     /// advancement in the same tick.
     async fn discover_claimable_bonds(&mut self) {
-        if let Some(ref mut bond_manager) = self.bond_manager
-            && let Err(e) = bond_manager.discover_claimable_games(&*self.verifier_client).await
-        {
-            warn!(error = %e, "bond discovery scan failed");
+        let Some(ref mut bond_manager) = self.bond_manager else {
+            return;
+        };
+
+        match bond_manager.discover_claimable_games(&*self.verifier_client).await {
+            Ok(_) => {}
+            Err(e) => warn!(error = %e, "bond discovery scan failed"),
         }
     }
 
@@ -319,7 +334,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                     }
 
                     // Persistent configuration errors: these indicate a
-                    // mismatch between the cached interval and on-chain
+                    // mismatch between the cached interval and onchain
                     // state (e.g. after a governance `setImplementation`
                     // that changed `INTERMEDIATE_BLOCK_INTERVAL`).
                     // Propagate so the caller logs the error at game level
@@ -496,7 +511,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
     /// Attempts TEE-first proof sourcing with ZK fallback.
     ///
-    /// The `intent` determines the on-chain action for the ZK fallback path.
+    /// The `intent` determines the onchain action for the ZK fallback path.
     /// TEE proofs always use `nullify()` regardless of `intent`.
     ///
     /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
@@ -604,7 +619,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             .ok_or_else(|| eyre::eyre!("claimed_l2_block_number overflow"))?;
 
         // Use the game's stored L1 head (from CWIA) so the enclave signs a
-        // journal whose `l1OriginHash` matches what the on-chain `nullify()`
+        // journal whose `l1OriginHash` matches what the onchain `nullify()`
         // will use for verification. Look up its block number concurrently
         // with the agreed L2 state computation.
         let l1_head = candidate.l1_head;
@@ -807,8 +822,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             Ok(_) => {
                 self.pending_proofs.remove(&game_address);
 
-                // After a successful challenge(), register the game for bond
-                // tracking so the BondManager can resolve and claim the bond.
                 if intent == DisputeIntent::Challenge
                     && let Some(ref mut bond_manager) = self.bond_manager
                 {
@@ -947,7 +960,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
 
     fn ignore_game(&mut self, game_address: Address) {
         self.pending_proofs.remove(&game_address);
-        self.ignored_games.insert(game_address);
+        if self.ignored_games.insert(game_address) {
+            self.ignored_game_order.push_back(game_address);
+        }
+        while self.ignored_games.len() > Self::MAX_IGNORED_GAMES {
+            if let Some(game_address) = self.ignored_game_order.pop_front() {
+                self.ignored_games.remove(&game_address);
+            }
+        }
         ChallengerMetrics::ignored_games().set(self.ignored_games.len() as f64);
     }
 
@@ -1096,20 +1116,31 @@ mod tests {
         verifier_games.insert(game_address, mock_state(GameStatus::InProgress, Address::ZERO, 100));
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = mock_anchor_registry(Address::ZERO);
         let scanner = GameScanner::new(
-            factory,
+            Arc::clone(&factory) as Arc<dyn base_proof_contracts::DisputeGameFactoryClient>,
             Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-            mock_anchor_registry(Address::ZERO),
+            Arc::clone(&anchor_registry),
         );
         let proof_requester = Arc::new(MockZkProofProvider::default());
+        let l2_provider = Arc::new(MockL2Provider::new());
         let components = DriverComponents {
             scanner,
-            validator: OutputValidator::new(Arc::new(MockL2Provider::new())),
+            validator: OutputValidator::new(Arc::clone(&l2_provider)),
             proof_requester: Arc::clone(&proof_requester),
             submitter: ChallengeSubmitter::new(tx_manager),
             tee: None,
             verifier_client: verifier,
             bond_manager: None,
+            anchor_updater: AnchorUpdater::new(
+                factory,
+                anchor_registry,
+                l2_provider,
+                Address::repeat_byte(0xAA),
+                1,
+                100,
+                100,
+            ),
         };
         let driver = Driver::new(
             DriverConfig {
@@ -1237,6 +1268,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn challenge_success_does_not_track_anchor_update() {
+        let tx_hash = B256::repeat_byte(0x44);
+        let (mut driver, _proof_requester) =
+            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, tx_hash))));
+        insert_ready_proof(&mut driver);
+
+        driver.poll_or_submit(addr(0)).await.unwrap();
+
+        assert!(!driver.pending_proofs.contains_key(&addr(0)));
+    }
+
+    #[tokio::test]
     async fn stale_l1_origin_revert_drops_pending_zk_proof() {
         let (mut driver, proof_requester) =
             driver_with_tx_error(TxManagerError::ExecutionReverted {
@@ -1268,6 +1311,21 @@ mod tests {
         assert!(driver.ignored_games.contains(&addr(0)));
         let state = proof_requester.state.lock().unwrap();
         assert!(state.prove_block_range_log.is_empty());
+    }
+
+    #[test]
+    fn ignored_games_are_bounded() {
+        let (mut driver, _proof_requester) =
+            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, B256::ZERO))));
+        let max = Driver::<MockL2Provider, MockZkProofProvider, MockTxManager>::MAX_IGNORED_GAMES;
+
+        for i in 0..=max {
+            driver.ignore_game(addr(i as u64));
+        }
+
+        assert_eq!(driver.ignored_games.len(), max);
+        assert!(!driver.ignored_games.contains(&addr(0)));
+        assert!(driver.ignored_games.contains(&addr(max as u64)));
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -9,6 +9,9 @@
 mod cli;
 pub use cli::{ChallengerArgs, Cli, HealthArgs, LogArgs, MetricsArgs, SignerCli, TxManagerCli};
 
+mod anchor;
+pub use anchor::AnchorUpdater;
+
 mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};
 

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -126,16 +126,6 @@ base_metrics::define_metrics! {
     anchor_update_tx_outcome_total: counter,
 
     #[describe(
-        "Number of otherwise-removable games currently retained while awaiting anchor state update"
-    )]
-    anchor_update_retained_games: gauge,
-
-    #[describe(
-        "Total games retained past bond lifecycle completion while awaiting anchor state update"
-    )]
-    anchor_update_retained_games_total: counter,
-
-    #[describe(
         "L2 block number of the most recent anchor state successfully advanced by this challenger. \
          Monotonically increases as the challenger drives the anchor forward; absent until the \
          first successful setAnchorState() observation."
@@ -158,7 +148,7 @@ impl ChallengerMetrics {
     pub const STATUS_ERROR: &str = "error";
 
     /// Label value when a resolve was skipped because the game was already
-    /// resolved on-chain (e.g. by another actor).
+    /// resolved onchain (e.g. by another actor).
     pub const STATUS_ALREADY_RESOLVED: &str = "already_resolved";
 
     /// Label value when an anchor update was skipped (game not eligible).

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -5,15 +5,16 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
 use base_balance_monitor::BalanceMonitorLayer;
 use base_cli_utils::RuntimeManager;
 use base_health::HealthServer;
 use base_proof_contracts::{
-    AggregateVerifierClient, AggregateVerifierContractClient, AnchorStateRegistryContractClient,
-    DisputeGameFactoryClient, DisputeGameFactoryContractClient,
+    AggregateVerifierClient, AggregateVerifierContractClient, AnchorStateRegistryClient,
+    AnchorStateRegistryContractClient, DisputeGameFactoryClient, DisputeGameFactoryContractClient,
 };
-use base_proof_rpc::{L1Client, L1ClientConfig, L2Client, L2ClientConfig};
+use base_proof_rpc::{L1Client, L1ClientConfig, L2Client, L2ClientConfig, L2Provider};
 use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
 use base_runtime::TokioRuntime;
 use base_tx_manager::{BaseTxMetrics, SimpleTxManager};
@@ -22,8 +23,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
-    BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver, DriverComponents,
-    DriverConfig, GameScanner, OutputValidator,
+    AnchorUpdater, BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver,
+    DriverComponents, DriverConfig, GameScanner, OutputValidator,
 };
 
 /// Top-level challenger service.
@@ -109,6 +110,36 @@ impl ChallengerService {
         );
 
         let verifier_client = AggregateVerifierContractClient::new(l1_rpc_url.clone())?;
+        let impl_address = factory_client.game_impls(config.game_type).await?;
+        if impl_address == Address::ZERO {
+            return Err(eyre::eyre!(
+                "no AggregateVerifier implementation registered for game type {}",
+                config.game_type
+            ));
+        }
+        let (block_interval, intermediate_block_interval) = tokio::try_join!(
+            verifier_client.read_block_interval(impl_address),
+            verifier_client.read_intermediate_block_interval(impl_address),
+        )?;
+        if block_interval == 0 || intermediate_block_interval == 0 {
+            return Err(eyre::eyre!(
+                "BLOCK_INTERVAL ({block_interval}) and INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval}) must be non-zero"
+            ));
+        }
+        if block_interval % intermediate_block_interval != 0 {
+            return Err(eyre::eyre!(
+                "BLOCK_INTERVAL ({block_interval}) is not divisible by INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
+            ));
+        }
+        info!(
+            block_interval,
+            intermediate_block_interval,
+            intermediate_roots_count = block_interval / intermediate_block_interval,
+            impl_address = %impl_address,
+            game_type = config.game_type,
+            "Read onchain config from AggregateVerifier"
+        );
+
         let anchor_registry_client = AnchorStateRegistryContractClient::new(
             config.anchor_state_registry_addr,
             l1_rpc_url.clone(),
@@ -147,7 +178,23 @@ impl ChallengerService {
             .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
         let tee = Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) });
 
-        // ── 7. Bond manager (optional) ─────────────────────────────────────
+        // ── 7. Scanner, anchor updater, and bond manager ──────────────────
+        let scanner = GameScanner::new(
+            Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&verifier_client),
+            Arc::clone(&anchor_registry_client) as Arc<dyn AnchorStateRegistryClient>,
+        );
+
+        let anchor_updater = AnchorUpdater::new(
+            Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&anchor_registry_client) as Arc<dyn AnchorStateRegistryClient>,
+            Arc::clone(&l2_client) as Arc<dyn L2Provider>,
+            config.anchor_state_registry_addr,
+            config.game_type,
+            block_interval,
+            intermediate_block_interval,
+        );
+
         let bond_manager = if !config.bond_claim_addresses.is_empty() {
             let mut bm = BondManager::new(
                 config.bond_claim_addresses,
@@ -157,15 +204,17 @@ impl ChallengerService {
                 config.bond_discovery_interval,
                 TokioRuntime::new(),
             );
-            bm.set_anchor_update_retention(config.anchor_update_retention);
             info!("starting bond recovery scan");
-            if let Err(e) = bm.startup_scan(&*verifier_client).await {
-                // On failure `bond_scan_head` stays at 0, so
-                // `discover_claimable_games` will progressively scan the
-                // factory over multiple ticks (capped at `lookback` games
-                // per tick). This is intentional: progressive catch-up
-                // is preferable to disabling bond claiming entirely.
-                warn!(error = %e, "bond startup scan failed, continuing without recovery");
+            match bm.startup_scan(&*verifier_client).await {
+                Ok(_) => {}
+                Err(e) => {
+                    // On failure `bond_scan_head` stays at 0, so
+                    // `discover_claimable_games` will progressively scan the
+                    // factory over multiple ticks (capped at `lookback` games
+                    // per tick). This is intentional: progressive catch-up
+                    // is preferable to disabling bond claiming entirely.
+                    warn!(error = %e, "bond startup scan failed, continuing without recovery");
+                }
             }
             info!(tracked = bm.tracked_count(), "bond manager ready");
             Some(bm)
@@ -174,10 +223,7 @@ impl ChallengerService {
             None
         };
 
-        // ── 7b. Assemble scanner, validator, and driver ─────────────────────
-        let scanner =
-            GameScanner::new(factory_client, Arc::clone(&verifier_client), anchor_registry_client);
-
+        // ── 7b. Assemble validator and driver ──────────────────────────────
         let validator = OutputValidator::new(l2_client);
 
         // ── 8. Start health HTTP server ──────────────────────────────────────
@@ -206,6 +252,7 @@ impl ChallengerService {
                 tee,
                 verifier_client,
                 bond_manager,
+                anchor_updater,
             },
         );
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -133,17 +133,30 @@ impl Default for MockGameState {
 pub struct MockDisputeGameFactory {
     /// Ordered list of games in the factory.
     pub games: Mutex<Vec<GameAtIndex>>,
+    /// Games keyed by `(game_type, root_claim, extra_data)` for UUID lookups.
+    pub uuid_games: Mutex<HashMap<(u32, B256, Bytes), Address>>,
 }
 
 impl MockDisputeGameFactory {
     /// Creates a new mock from an initial set of games.
-    pub const fn new(games: Vec<GameAtIndex>) -> Self {
-        Self { games: Mutex::new(games) }
+    pub fn new(games: Vec<GameAtIndex>) -> Self {
+        Self { games: Mutex::new(games), uuid_games: Mutex::new(HashMap::new()) }
     }
 
     /// Appends a single game to the factory.
     pub fn push(&self, game: GameAtIndex) {
         self.games.lock().unwrap().push(game);
+    }
+
+    /// Inserts a UUID-addressable game.
+    pub fn insert_uuid_game(
+        &self,
+        game_type: u32,
+        root_claim: B256,
+        extra_data: Bytes,
+        proxy: Address,
+    ) {
+        self.uuid_games.lock().unwrap().insert((game_type, root_claim, extra_data), proxy);
     }
 }
 
@@ -172,11 +185,17 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
 
     async fn games(
         &self,
-        _game_type: u32,
-        _root_claim: B256,
-        _extra_data: Bytes,
+        game_type: u32,
+        root_claim: B256,
+        extra_data: Bytes,
     ) -> Result<Address, ContractError> {
-        Ok(Address::ZERO)
+        Ok(self
+            .uuid_games
+            .lock()
+            .unwrap()
+            .get(&(game_type, root_claim, extra_data))
+            .copied()
+            .unwrap_or(Address::ZERO))
     }
 }
 
@@ -237,15 +256,42 @@ pub struct MockAggregateVerifier {
     /// Per-address game state lookup, wrapped in a `Mutex` for interior
     /// mutability in multi-step tests.
     pub games: Mutex<HashMap<Address, MockGameState>>,
+    /// Per-address count of status calls that should fail before reading state.
+    pub status_failures: Mutex<HashMap<Address, u64>>,
     /// Addresses passed to `bond_recipient`, used by tests that assert polling
     /// avoids redundant lifecycle reads.
     pub bond_recipient_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `game_info`, used by tests that assert cached reads.
+    pub game_info_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `status`, used by tests that assert cached reads.
+    pub status_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `zk_prover`, used by tests that assert cheap pending polls.
+    pub zk_prover_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `tee_prover`, used by tests that assert cheap pending polls.
+    pub tee_prover_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `countered_index`, used by tests that assert cheap pending polls.
+    pub countered_index_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `game_over`, used by tests that assert cheap pending polls.
+    pub game_over_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `anchor_state_registry`, used by tests that assert cached reads.
+    pub anchor_state_registry_reads: Mutex<Vec<Address>>,
 }
 
 impl MockAggregateVerifier {
     /// Creates a new mock verifier from a pre-built game state map.
-    pub const fn new(games: HashMap<Address, MockGameState>) -> Self {
-        Self { games: Mutex::new(games), bond_recipient_reads: Mutex::new(Vec::new()) }
+    pub fn new(games: HashMap<Address, MockGameState>) -> Self {
+        Self {
+            games: Mutex::new(games),
+            status_failures: Mutex::new(HashMap::new()),
+            bond_recipient_reads: Mutex::new(Vec::new()),
+            game_info_reads: Mutex::new(Vec::new()),
+            status_reads: Mutex::new(Vec::new()),
+            zk_prover_reads: Mutex::new(Vec::new()),
+            tee_prover_reads: Mutex::new(Vec::new()),
+            countered_index_reads: Mutex::new(Vec::new()),
+            game_over_reads: Mutex::new(Vec::new()),
+            anchor_state_registry_reads: Mutex::new(Vec::new()),
+        }
     }
 
     /// Updates the state for a specific game address.
@@ -256,9 +302,46 @@ impl MockAggregateVerifier {
         self.games.lock().unwrap().insert(address, state);
     }
 
+    /// Causes the next `count` status reads for a game to fail.
+    pub fn fail_status_reads(&self, address: Address, count: u64) {
+        if count > 0 {
+            self.status_failures.lock().unwrap().insert(address, count);
+        }
+    }
+
     /// Returns how many times `bond_recipient` was read for a game.
     pub fn bond_recipient_read_count(&self, game_address: Address) -> usize {
         self.bond_recipient_reads
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&read_address| read_address == game_address)
+            .count()
+    }
+
+    /// Returns how many times `game_info` was read for a game.
+    pub fn game_info_read_count(&self, game_address: Address) -> usize {
+        self.game_info_reads
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&read_address| read_address == game_address)
+            .count()
+    }
+
+    /// Returns how many times `status` was read for a game.
+    pub fn status_read_count(&self, game_address: Address) -> usize {
+        self.status_reads
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&read_address| read_address == game_address)
+            .count()
+    }
+
+    /// Returns how many times `anchor_state_registry` was read for a game.
+    pub fn anchor_state_registry_read_count(&self, game_address: Address) -> usize {
+        self.anchor_state_registry_reads
             .lock()
             .unwrap()
             .iter()
@@ -283,18 +366,32 @@ impl MockAggregateVerifier {
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError> {
+        self.game_info_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_info)
     }
 
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
+        self.status_reads.lock().unwrap().push(game_address);
+        let mut failures = self.status_failures.lock().unwrap();
+        if let Some(remaining) = failures.get_mut(&game_address) {
+            *remaining -= 1;
+            if *remaining == 0 {
+                failures.remove(&game_address);
+            }
+            return Err(ContractError::Validation(format!(
+                "simulated status error for game {game_address}"
+            )));
+        }
         self.get(game_address, |s| s.status)
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.zk_prover_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.zk_prover)
     }
 
     async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.tee_prover_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.tee_prover)
     }
 
@@ -339,10 +436,12 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.countered_index_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.countered_index)
     }
 
     async fn game_over(&self, game_address: Address) -> Result<bool, ContractError> {
+        self.game_over_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_over)
     }
 
@@ -380,6 +479,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn anchor_state_registry(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.anchor_state_registry_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.anchor_state_registry)
     }
 
@@ -557,7 +657,7 @@ pub struct RecordingDisputeGameFactory {
 
 impl RecordingDisputeGameFactory {
     /// Creates a new recording factory.
-    pub const fn new(games: Vec<GameAtIndex>, error_indices: Vec<u64>) -> Self {
+    pub fn new(games: Vec<GameAtIndex>, error_indices: Vec<u64>) -> Self {
         Self {
             inner: MockDisputeGameFactory::new(games),
             error_indices,

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -138,17 +138,17 @@ struct Checkpoint {
 ///
 /// Fetches L2 block headers and `L2ToL1MessagePasser` storage proofs to
 /// recompute expected output roots and compare them against onchain claims.
-pub struct OutputValidator<L2: L2Provider> {
+pub struct OutputValidator<L2: L2Provider + ?Sized> {
     l2_provider: Arc<L2>,
 }
 
-impl<L2: L2Provider> std::fmt::Debug for OutputValidator<L2> {
+impl<L2: L2Provider + ?Sized> std::fmt::Debug for OutputValidator<L2> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OutputValidator").finish_non_exhaustive()
     }
 }
 
-impl<L2: L2Provider> OutputValidator<L2> {
+impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
     /// Maximum number of intermediate output roots to validate concurrently.
     pub const VALIDATION_CONCURRENCY: usize = 32;
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,9 +8,9 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
-    BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
+    AnchorUpdater, BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
     DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofPhase, ProofUpdate, TeeConfig,
+    PendingProofs, ProofKind, ProofPhase, ProofUpdate, TeeConfig,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
         MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager,
@@ -19,7 +19,9 @@ use base_challenger::{
         mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
-use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex, GameStatus};
+use base_proof_contracts::{
+    AggregateVerifierClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameStatus,
+};
 use base_proof_primitives::Proposal;
 use base_protocol::OutputRoot;
 use base_prover_service_protocol::{
@@ -76,12 +78,13 @@ fn test_driver_with_tee(
     tx_manager: MockTxManager,
     tee: Option<TeeConfig>,
 ) -> Driver<MockL2Provider, MockZkProofProvider, MockTxManager> {
+    let anchor_registry = mock_anchor_registry(Address::ZERO);
     let scanner = GameScanner::new(
-        factory,
+        Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
         Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-        mock_anchor_registry(Address::ZERO),
+        Arc::clone(&anchor_registry),
     );
-    let validator = OutputValidator::new(l2_provider);
+    let validator = OutputValidator::new(Arc::clone(&l2_provider));
     let submitter = ChallengeSubmitter::new(tx_manager);
 
     let config = DriverConfig {
@@ -101,6 +104,15 @@ fn test_driver_with_tee(
             tee,
             verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
             bond_manager: None,
+            anchor_updater: AnchorUpdater::new(
+                factory,
+                anchor_registry,
+                l2_provider as Arc<dyn base_proof_rpc::L2Provider>,
+                Address::repeat_byte(0xAA),
+                1,
+                100,
+                100,
+            ),
         },
     )
 }
@@ -293,7 +305,7 @@ async fn test_step_invalid_game_proof_succeeded() {
         "proof should be pending after initiation"
     );
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -376,15 +388,16 @@ async fn test_step_scan_error_propagated() {
     }
 
     let factory = Arc::new(FailingFactory);
+    let anchor_registry = mock_anchor_registry(Address::ZERO);
     let verifier = empty_verifier();
     let scanner = GameScanner::new(
-        factory,
+        Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
         Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-        mock_anchor_registry(Address::ZERO),
+        Arc::clone(&anchor_registry),
     );
 
     let l2 = default_l2();
-    let validator = OutputValidator::new(l2);
+    let validator = OutputValidator::new(Arc::clone(&l2));
     let submitter = ChallengeSubmitter::new(default_tx_manager());
 
     let config = DriverConfig {
@@ -404,6 +417,15 @@ async fn test_step_scan_error_propagated() {
             tee: None,
             verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
             bond_manager: None::<BondManager<TokioRuntime>>,
+            anchor_updater: AnchorUpdater::new(
+                factory,
+                anchor_registry,
+                l2 as Arc<dyn base_proof_rpc::L2Provider>,
+                Address::repeat_byte(0xAA),
+                1,
+                100,
+                100,
+            ),
         },
     );
 
@@ -435,7 +457,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     // Simulate the proof completing before the next poll.
     zk.state.lock().unwrap().proof_status = ProofStatus::Succeeded;
 
-    // Simulate the on-chain effect: game is resolved after challenge tx.
+    // Simulate the onchain effect: game is resolved after challenge tx.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -478,7 +500,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     let entry = driver.pending_proofs.get(&addr(0)).expect("proof should be preserved");
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -586,7 +608,7 @@ async fn test_step_proof_retry_succeeds() {
     // Simulate proof succeeding on the retry session.
     zk.state.lock().unwrap().proof_status = ProofStatus::Succeeded;
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -704,7 +726,7 @@ async fn test_step_proof_exceeds_max_retries() {
         assert_eq!(entry.retry_count, i + 1);
     }
 
-    // Simulate the on-chain effect: mark the game as resolved so the
+    // Simulate the onchain effect: mark the game as resolved so the
     // stateless scanner does not re-discover it after the entry is dropped.
     verifier.update_game(
         addr(0),
@@ -789,7 +811,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         "ZK proof should be pending after TEE fallback"
     );
 
-    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
         addr(0),
         MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
@@ -865,7 +887,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
 
 #[tokio::test]
 async fn test_step_tee_contract_revert_falls_back_to_zk() {
-    // TEE proof succeeds but the on-chain nullify() call reverts.
+    // TEE proof succeeds but the onchain nullify() call reverts.
     // Contract-level failures are proof-specific enough to fall back to ZK.
     let (l2, factory, root_15, root_20) = base_game_mocks();
 
@@ -1063,6 +1085,36 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
 }
 
 #[tokio::test]
+async fn test_successful_nullify_does_not_track_anchor_update() {
+    let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+    let l2 = default_l2();
+    let verifier = single_game_verifier(mock_state_with_tee(
+        GameStatus::InProgress,
+        ZK_PROVER_ADDR,
+        DEFAULT_TEE_PROVER,
+        20,
+    ));
+
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.pending_proofs.insert(
+        addr(0),
+        PendingProof {
+            phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from_static(&[0x00, 0xAA]) },
+            kind: ProofKind::Tee { zk_fallback_request: None, zk_fallback_intent: None },
+            invalid_index: 1,
+            expected_root: BOGUS_ROOT,
+            retry_count: 0,
+            tee_submit_retry_count: 0,
+            intent: DisputeIntent::Nullify,
+        },
+    );
+
+    driver.step().await.unwrap();
+
+    assert!(!driver.pending_proofs.contains_key(&addr(0)));
+}
+
+#[tokio::test]
 async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
     // A pending proof with DisputeIntent::Challenge should be dropped
     // when zkProver is non-zero (game already challenged).
@@ -1094,10 +1146,10 @@ async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
 /// root is at 0-based index 1 (block 20).
 ///
 /// Layout: starting=10, `l2_block=20`, interval=5, checkpoints at 15 and 20.
-/// `correct_root_at_20` controls whether the on-chain root at index 1
+/// `correct_root_at_20` controls whether the onchain root at index 1
 /// (block 20) matches the L2-computed root:
-/// - `true`: on-chain root is correct → ZK challenge was fraudulent → nullify.
-/// - `false`: on-chain root is bogus → ZK challenge was legitimate → skip.
+/// - `true`: onchain root is correct → ZK challenge was fraudulent → nullify.
+/// - `false`: onchain root is bogus → ZK challenge was legitimate → skip.
 fn fraudulent_zk_challenge_mocks(
     correct_root_at_20: bool,
 ) -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
@@ -1117,7 +1169,7 @@ fn fraudulent_zk_challenge_mocks(
 
 #[tokio::test]
 async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
-    // The on-chain root at the challenged index is wrong, meaning the ZK
+    // The onchain root at the challenged index is wrong, meaning the ZK
     // challenge was legitimate. The driver should skip without initiating
     // a proof.
     let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(false);
@@ -1133,7 +1185,7 @@ async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
 
 #[tokio::test]
 async fn test_step_fraudulent_zk_challenge_nullifies() {
-    // The on-chain root at the challenged index is correct, meaning the
+    // The onchain root at the challenged index is correct, meaning the
     // ZK challenge was fraudulent. The driver should initiate a ZK proof
     // with DisputeIntent::Nullify.
     let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(true);
@@ -1411,7 +1463,7 @@ async fn test_bond_manager_full_lifecycle() {
     //
     // The mock verifier uses a static game state, so we set
     // ChallengerWins to represent a game that has already been
-    // resolved on-chain. The manager detects this and advances directly
+    // resolved onchain. The manager detects this and advances directly
     // to NeedsUnlock without submitting a resolve transaction.
     let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
@@ -1570,9 +1622,7 @@ async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
     state.status = GameStatus::DefenderWins;
     let verifier = single_game_verifier(state);
 
-    // One response for the anchor state update that is attempted after
-    // advance_game (DEFENDER_WINS triggers a setAnchorState call).
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(DEFAULT_TX_HASH)]);
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
     let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
@@ -1599,10 +1649,7 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
     state.bond_recipient = other_addr; // bond goes to someone else
     let verifier = single_game_verifier(state);
 
-    // One response for the anchor state update — even though the bond is
-    // not claimable, anchor updates are a public good and are still
-    // attempted for DEFENDER_WINS games before removal.
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![Ok(DEFAULT_TX_HASH)]);
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
     let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
@@ -1616,9 +1663,8 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
         "game should be removed when bondRecipient is not in claim addresses"
     );
 
-    // The only transaction submitted should be the anchor state update.
     let calls = submitter.recorded_calls();
-    assert_eq!(calls.len(), 1, "only the anchor update tx should be submitted");
+    assert!(calls.is_empty(), "bond manager should not submit anchor update txs");
 }
 
 #[tokio::test]
@@ -1681,7 +1727,7 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
 
     // The mock verifier's `read_intermediate_block_interval` returns 5,
     // so the scanner caches interval=5. With span=10, the validator
-    // expects 10/5 = 2 intermediate roots, but only 1 is on-chain.
+    // expects 10/5 = 2 intermediate roots, but only 1 is onchain.
     let l2 = default_l2();
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());

--- a/crates/proof/contracts/src/anchor_state_registry.rs
+++ b/crates/proof/contracts/src/anchor_state_registry.rs
@@ -60,7 +60,7 @@ pub fn encode_set_anchor_state_calldata(game: Address) -> Bytes {
 }
 
 /// Anchor root returned by `AnchorStateRegistry.getAnchorRoot()`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnchorRoot {
     /// The output root hash.
     pub root: B256,
@@ -69,7 +69,7 @@ pub struct AnchorRoot {
 }
 
 /// Consistent snapshot of the anchor root and anchor game.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnchorSnapshot {
     /// Current anchor root in the registry.
     pub anchor_root: AnchorRoot,

--- a/crates/proof/contracts/src/dispute_game_factory.rs
+++ b/crates/proof/contracts/src/dispute_game_factory.rs
@@ -177,6 +177,114 @@ pub fn encode_extra_data(
     Bytes::from(data)
 }
 
+/// Values used to look up a dispute game by UUID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GameLookupKey {
+    /// L2 block number encoded into `extraData`.
+    pub target_block: u64,
+    /// Final output root used as the factory `rootClaim`.
+    pub root_claim: B256,
+    /// Packed factory `extraData`.
+    pub extra_data: Bytes,
+}
+
+/// Error while building a dispute game lookup key.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum GameLookupError {
+    /// `BLOCK_INTERVAL` must not be zero.
+    #[error("block_interval must not be zero")]
+    ZeroBlockInterval,
+    /// `INTERMEDIATE_BLOCK_INTERVAL` must not be zero.
+    #[error("intermediate_block_interval must not be zero")]
+    ZeroIntermediateBlockInterval,
+    /// `BLOCK_INTERVAL` must be divisible by `INTERMEDIATE_BLOCK_INTERVAL`.
+    #[error(
+        "block_interval {block_interval} is not divisible by intermediate_block_interval {intermediate_block_interval}"
+    )]
+    InvalidInterval {
+        /// Number of L2 blocks between games.
+        block_interval: u64,
+        /// Number of L2 blocks between intermediate roots.
+        intermediate_block_interval: u64,
+    },
+    /// Arithmetic overflow while computing checkpoint blocks.
+    #[error("overflow computing game lookup block")]
+    BlockOverflow,
+    /// The supplied roots must cover every checkpoint, including the final root.
+    #[error("intermediate root count mismatch: expected {expected}, got {actual}")]
+    IntermediateRootCount {
+        /// Expected root count.
+        expected: usize,
+        /// Actual root count.
+        actual: usize,
+    },
+}
+
+/// Returns the number of roots needed to build a game UUID lookup key.
+pub fn game_lookup_count(
+    block_interval: u64,
+    intermediate_block_interval: u64,
+) -> Result<usize, GameLookupError> {
+    if block_interval == 0 {
+        return Err(GameLookupError::ZeroBlockInterval);
+    }
+    if intermediate_block_interval == 0 {
+        return Err(GameLookupError::ZeroIntermediateBlockInterval);
+    }
+    if !block_interval.is_multiple_of(intermediate_block_interval) {
+        return Err(GameLookupError::InvalidInterval {
+            block_interval,
+            intermediate_block_interval,
+        });
+    }
+
+    usize::try_from(block_interval / intermediate_block_interval)
+        .map_err(|_| GameLookupError::BlockOverflow)
+}
+
+/// Returns the checkpoint blocks used by a game UUID lookup.
+pub fn game_lookup_blocks(
+    starting_block_number: u64,
+    block_interval: u64,
+    intermediate_block_interval: u64,
+) -> Result<Vec<u64>, GameLookupError> {
+    let count = game_lookup_count(block_interval, intermediate_block_interval)?;
+
+    (1..=count)
+        .map(|i| {
+            let multiplier = u64::try_from(i).map_err(|_| GameLookupError::BlockOverflow)?;
+            let offset = intermediate_block_interval
+                .checked_mul(multiplier)
+                .ok_or(GameLookupError::BlockOverflow)?;
+            starting_block_number.checked_add(offset).ok_or(GameLookupError::BlockOverflow)
+        })
+        .collect()
+}
+
+/// Builds the key used by `DisputeGameFactory.games()`.
+pub fn game_lookup_key(
+    starting_block_number: u64,
+    parent_address: Address,
+    block_interval: u64,
+    intermediate_block_interval: u64,
+    intermediate_roots: &[B256],
+) -> Result<GameLookupKey, GameLookupError> {
+    let expected = game_lookup_count(block_interval, intermediate_block_interval)?;
+    if intermediate_roots.len() != expected {
+        return Err(GameLookupError::IntermediateRootCount {
+            expected,
+            actual: intermediate_roots.len(),
+        });
+    }
+
+    let target_block =
+        starting_block_number.checked_add(block_interval).ok_or(GameLookupError::BlockOverflow)?;
+    let root_claim = intermediate_roots[expected - 1];
+    let extra_data = encode_extra_data(target_block, parent_address, intermediate_roots);
+
+    Ok(GameLookupKey { target_block, root_claim, extra_data })
+}
+
 /// Encodes the calldata for `DisputeGameFactory.createWithInitData()`.
 pub fn encode_create_calldata(
     game_type: u32,
@@ -244,5 +352,47 @@ mod tests {
         assert_eq!(selector.len(), 4);
         // Just verify we get a non-zero selector
         assert_ne!(selector, [0u8; 4]);
+    }
+
+    #[test]
+    fn test_game_lookup_blocks() {
+        let blocks = game_lookup_blocks(100, 30, 10).unwrap();
+
+        assert_eq!(blocks, vec![110, 120, 130]);
+    }
+
+    #[test]
+    fn test_game_lookup_blocks_rejects_bad_intervals() {
+        assert_eq!(game_lookup_blocks(100, 0, 10).unwrap_err(), GameLookupError::ZeroBlockInterval);
+        assert_eq!(
+            game_lookup_blocks(100, 30, 0).unwrap_err(),
+            GameLookupError::ZeroIntermediateBlockInterval
+        );
+        assert_eq!(
+            game_lookup_blocks(100, 30, 20).unwrap_err(),
+            GameLookupError::InvalidInterval {
+                block_interval: 30,
+                intermediate_block_interval: 20
+            }
+        );
+    }
+
+    #[test]
+    fn test_game_lookup_key() {
+        let parent = Address::repeat_byte(0x42);
+        let roots = vec![B256::repeat_byte(0xAA), B256::repeat_byte(0xBB)];
+
+        let key = game_lookup_key(100, parent, 20, 10, &roots).unwrap();
+
+        assert_eq!(key.target_block, 120);
+        assert_eq!(key.root_claim, roots[1]);
+        assert_eq!(key.extra_data, encode_extra_data(120, parent, &roots));
+    }
+
+    #[test]
+    fn test_game_lookup_key_rejects_wrong_root_count() {
+        let err = game_lookup_key(100, Address::ZERO, 20, 10, &[B256::ZERO]).unwrap_err();
+
+        assert_eq!(err, GameLookupError::IntermediateRootCount { expected: 2, actual: 1 });
     }
 }

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -28,8 +28,9 @@ pub use anchor_state_registry::{
 
 mod dispute_game_factory;
 pub use dispute_game_factory::{
-    DisputeGameFactoryClient, DisputeGameFactoryContractClient, GameAtIndex,
-    encode_create_calldata, encode_extra_data, game_already_exists_selector,
+    DisputeGameFactoryClient, DisputeGameFactoryContractClient, GameAtIndex, GameLookupError,
+    GameLookupKey, encode_create_calldata, encode_extra_data, game_already_exists_selector,
+    game_lookup_blocks, game_lookup_count, game_lookup_key,
 };
 
 mod tee_prover_registry;

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -390,7 +390,7 @@ mod tests {
 
     use alloy_primitives::{Address, B256};
     use base_proof_contracts::{
-        AggregateVerifierClient, DisputeGameFactoryClient, encode_extra_data,
+        AggregateVerifierClient, DisputeGameFactoryClient, game_lookup_key,
     };
     use base_proof_primitives::ProofRequest;
     use base_proof_submission::ProofSubmissionError;
@@ -559,14 +559,24 @@ mod tests {
         }
 
         let mut factory = MockDisputeGameFactory::default();
-        factory.uuid_games.insert(
-            (0, first_root, encode_extra_data(first_target, Address::ZERO, &[first_root])),
+        let first_key = game_lookup_key(
+            first_target - BLOCK_INTERVAL,
+            Address::ZERO,
+            BLOCK_INTERVAL,
+            BLOCK_INTERVAL,
+            &[first_root],
+        )
+        .unwrap();
+        let second_key = game_lookup_key(
+            second_target - BLOCK_INTERVAL,
             first_game,
-        );
-        factory.uuid_games.insert(
-            (0, second_root, encode_extra_data(second_target, first_game, &[second_root])),
-            second_game,
-        );
+            BLOCK_INTERVAL,
+            BLOCK_INTERVAL,
+            &[second_root],
+        )
+        .unwrap();
+        factory.uuid_games.insert((0, first_key.root_claim, first_key.extra_data), first_game);
+        factory.uuid_games.insert((0, second_key.root_claim, second_key.extra_data), second_game);
 
         let rollup_client = Arc::new(MockRollupClient {
             sync_status: test_sync_status(second_target, B256::ZERO),

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -3,9 +3,7 @@
 use std::sync::Arc;
 
 use alloy_primitives::Address;
-use base_proof_contracts::{
-    AnchorStateRegistryClient, DisputeGameFactoryClient, encode_extra_data,
-};
+use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient, game_lookup_key};
 use base_proof_rpc::{RollupProvider, RpcError};
 use futures::{StreamExt, TryStreamExt, stream};
 use tracing::{debug, info, warn};
@@ -229,22 +227,23 @@ impl ProofRecovery {
                 }
             };
 
-            let canonical_root = *intermediate_roots.last().ok_or_else(|| {
-                ProposerError::Internal(format!(
-                    "missing canonical root for expected block {expected_block}"
-                ))
-            })?;
-
-            let extra_data =
-                encode_extra_data(expected_block, state.parent_address, &intermediate_roots);
+            let key = game_lookup_key(
+                state.l2_block_number,
+                state.parent_address,
+                self.config.block_interval,
+                self.config.intermediate_block_interval,
+                &intermediate_roots,
+            )
+            .map_err(|e| ProposerError::Config(e.to_string()))?;
 
             let lookup = self
                 .factory_client
-                .games(self.config.game_type, canonical_root, extra_data)
+                .games(self.config.game_type, key.root_claim, key.extra_data)
                 .await
                 .map_err(|e| {
                     ProposerError::Contract(format!(
-                        "games lookup failed at block {expected_block}: {e}"
+                        "games lookup failed at block {}: {e}",
+                        key.target_block
                     ))
                 })?;
 
@@ -260,8 +259,8 @@ impl ProofRecovery {
 
             state = RecoveredState {
                 parent_address: lookup,
-                output_root: canonical_root,
-                l2_block_number: expected_block,
+                output_root: key.root_claim,
+                l2_block_number: key.target_block,
             };
         }
 
@@ -282,7 +281,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use alloy_primitives::{Address, B256};
-    use base_proof_contracts::{AnchorRoot, encode_extra_data};
+    use base_proof_contracts::AnchorRoot;
 
     use super::*;
     use crate::test_utils::{
@@ -328,10 +327,17 @@ mod tests {
             })
             .collect::<Vec<_>>();
             output_roots.insert(block, root_claim);
-            let extra_data = encode_extra_data(block, parent, &intermediate_roots);
+            let key = game_lookup_key(
+                parent_block,
+                parent,
+                block_interval,
+                intermediate_block_interval,
+                &intermediate_roots,
+            )
+            .unwrap();
             let proxy = proxy_addr(i as u64);
 
-            uuid_games.insert((TEST_GAME_TYPE, root_claim, extra_data), proxy);
+            uuid_games.insert((TEST_GAME_TYPE, key.root_claim, key.extra_data), proxy);
 
             parent = proxy;
         }

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -3,7 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, Bytes};
-use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, encode_extra_data};
+use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, game_lookup_key};
 use base_proof_primitives::Proposal;
 use base_proof_rpc::RollupProvider;
 use base_proof_submission::ProofSubmissionError;
@@ -179,10 +179,17 @@ impl ProofSubmitter {
             }
         }
 
-        let extra_data = encode_extra_data(target_block, parent_address, &intermediate_roots);
+        let key = game_lookup_key(
+            starting_block_number,
+            parent_address,
+            self.block_interval,
+            self.intermediate_block_interval,
+            &intermediate_roots,
+        )
+        .map_err(|e| SubmitAction::Failed(ProposerError::Config(e.to_string())))?;
         let existing_game = self
             .factory_client
-            .games(self.game_type, aggregate_proposal.output_root, extra_data.clone())
+            .games(self.game_type, key.root_claim, key.extra_data.clone())
             .await
             .map_err(|e| {
                 SubmitAction::Failed(ProposerError::Contract(format!(
@@ -217,7 +224,7 @@ impl ProofSubmitter {
                 info!(target_block, "Dispute game created successfully");
                 Metrics::l2_output_proposals_total().increment(1);
                 let game_address = self
-                    .lookup_recent_game(aggregate_proposal.output_root, &extra_data, target_block)
+                    .lookup_recent_game(key.root_claim, &key.extra_data, key.target_block)
                     .await?;
                 Ok(RecoveredState {
                     parent_address: game_address,
@@ -229,7 +236,7 @@ impl ProofSubmitter {
                 drop(propose_timer);
                 info!(target_block, "Game already exists, checking fresh state from chain");
                 let raced_game = self
-                    .lookup_recent_game(aggregate_proposal.output_root, &extra_data, target_block)
+                    .lookup_recent_game(key.root_claim, &key.extra_data, key.target_block)
                     .await?;
                 self.attach_existing_game_proof(raced_game, aggregate_proposal, target_block).await
             }

--- a/crates/proof/proposer/src/proposal_intervals.rs
+++ b/crates/proof/proposer/src/proposal_intervals.rs
@@ -1,5 +1,7 @@
 //! Computes proposal checkpoint block intervals shared by recovery and submission.
 
+use base_proof_contracts::game_lookup_blocks;
+
 use crate::error::ProposerError;
 
 /// Shared proposal interval calculations.
@@ -14,27 +16,8 @@ impl ProposalIntervals {
         intermediate_block_interval: u64,
         starting_block_number: u64,
     ) -> Result<Vec<u64>, ProposerError> {
-        if intermediate_block_interval == 0 {
-            return Err(ProposerError::Config(
-                "intermediate_block_interval must not be zero".into(),
-            ));
-        }
-        if block_interval == 0 {
-            return Err(ProposerError::Config("block_interval must not be zero".into()));
-        }
-
-        let count = block_interval / intermediate_block_interval;
-        (1..=count)
-            .map(|i| {
-                starting_block_number.checked_add(i * intermediate_block_interval).ok_or_else(
-                    || {
-                        ProposerError::Internal(
-                            "overflow computing intermediate block number".into(),
-                        )
-                    },
-                )
-            })
-            .collect()
+        game_lookup_blocks(starting_block_number, block_interval, intermediate_block_interval)
+            .map_err(|e| ProposerError::Config(e.to_string()))
     }
 }
 


### PR DESCRIPTION
### What changed? Why?

Extracts anchor advancement out of `BondManager` into a dedicated `AnchorUpdater` owned by the challenger driver. Each poll reads the current `AnchorStateRegistry` snapshot, computes the next dispute-game UUID from the current anchor, L2 output roots, and AggregateVerifier intervals, then submits `setAnchorState()` only after that next game is a finalized defender win and passes registry preflight checks.

Challenger startup now reads the respected game type from `AnchorStateRegistry`, resolves its AggregateVerifier implementation from `DisputeGameFactory`, and validates the onchain block intervals before constructing the updater. The old `--anchor-update-retention` CLI/config path, retained-game metrics, and per-game anchor update caches are removed so `BondManager` is back to bond lifecycle only: discovery, resolve, unlock, and claim.

Shared `DisputeGameFactory` game lookup helpers now build the checkpoint blocks, `rootClaim`, and `extraData` used by challenger anchor updates and proposer submit/recovery paths. This keeps proposer and challenger UUID lookups consistent for game chains with intermediate roots, while terminally ignored challenger games are bounded to avoid unbounded memory growth.

### Notes to reviewers

`AnchorUpdater` follows only the next game after the current anchor instead of collecting candidates from successful challenges or bond discovery. It caches that lookup while the anchor is unchanged, waits on transient readiness checks, and relies on external anchor advancement to move past stale or permanently ineligible next games.

The respected game type and AggregateVerifier intervals are read once during challenger startup. Startup fails fast if the respected game type has no registered implementation, either interval is zero, or the block interval is not divisible by the intermediate interval.

Successful challenges still register games for bond tracking when bond claiming is enabled, but they no longer register anchor update work with the bond manager.

### How has it been tested?

- `cargo fmt --package base-challenger --check`
- `cargo test -p base-challenger anchor`
- `cargo test -p base-proof-contracts game_lookup`
- `cargo test -p base-proposer recovery`