### PR TITLE
refactor(zk-host): narrow ZkProver::submit + shared groth16 aggregation base

### DIFF
--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -12,7 +12,7 @@ use std::{
 use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::{ClusterArtifactStore, ClusterProofConfig};
-use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
+use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
 use base_prover_service_protocol::{ProofResult, SessionType, ZkProofResult, ZkVm};
 use serde::{Deserialize, Serialize};
 use sp1_cluster_common::{
@@ -679,17 +679,10 @@ impl ClusterZkProver {
 impl ZkProver for ClusterZkProver {
     async fn submit(
         &self,
-        request: &ZkProofRequestKind,
+        request: &base_prover_service_protocol::ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
-        match request {
-            ZkProofRequestKind::Compressed(request) => {
-                self.submit_range_proof(request, request_session_id).await
-            }
-            ZkProofRequestKind::SnarkGroth16(_) => Err(backend_error!(
-                "SP1 cluster Groth16 aggregation is not yet supported in the stateless ZK host"
-            )),
-        }
+        self.submit_range_proof(request, request_session_id).await
     }
 
     async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::{ClusterArtifactStore, ClusterProofConfig};
 use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, SessionType, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{ProofResult, SessionType, ZkProofRequest, ZkProofResult, ZkVm};
 use serde::{Deserialize, Serialize};
 use sp1_cluster_common::{
     client::ClusterServiceClient,
@@ -389,7 +389,7 @@ impl ClusterZkProver {
     /// Submit a compressed range proof to the cluster.
     pub async fn submit_range_proof(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         let mut proof_id = None;
@@ -679,7 +679,7 @@ impl ClusterZkProver {
 impl ZkProver for ClusterZkProver {
     async fn submit(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         self.submit_range_proof(request, request_session_id).await

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -9,7 +9,9 @@ use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::get_range_elf_embedded;
 use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ExecutionStats, ProofResult, SessionType, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{
+    ExecutionStats, ProofResult, SessionType, ZkProofRequest, ZkProofResult, ZkVm,
+};
 use sp1_sdk::{
     Elf, SP1Stdin,
     blocking::{LightProver, Prover},
@@ -130,7 +132,7 @@ impl DryRunZkProver {
     /// Generate the witness, execute it locally, and return an empty-proof dry-run result.
     pub async fn prove_range(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<ProofResult, ZkProverError> {
         if request.number_of_blocks_to_prove == 0 {
@@ -217,7 +219,7 @@ impl DryRunZkProver {
 impl ZkProver for DryRunZkProver {
     async fn submit(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         let backend_session_id = format!("{DRY_RUN_PREFIX}{request_session_id}");

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -8,7 +8,7 @@ use std::{
 use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_succinct_proof_utils::get_range_elf_embedded;
-use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
+use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
 use base_prover_service_protocol::{ExecutionStats, ProofResult, SessionType, ZkProofResult, ZkVm};
 use sp1_sdk::{
     Elf, SP1Stdin,
@@ -217,15 +217,9 @@ impl DryRunZkProver {
 impl ZkProver for DryRunZkProver {
     async fn submit(
         &self,
-        request: &ZkProofRequestKind,
+        request: &base_prover_service_protocol::ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
-        let ZkProofRequestKind::Compressed(request) = request else {
-            return Err(backend_error!(
-                "dry-run backend only supports compressed proof types; SNARK_GROTH16 requires a proof-producing backend"
-            ));
-        };
-
         let backend_session_id = format!("{DRY_RUN_PREFIX}{request_session_id}");
         let result = self.prove_range(request, request_session_id).await?;
         self.completed_results

--- a/crates/proof/zk/backend/src/succinct/mock.rs
+++ b/crates/proof/zk/backend/src/succinct/mock.rs
@@ -1,10 +1,10 @@
 //! Mock [`ZkProver`] that produces instant placeholder proofs.
 
 use async_trait::async_trait;
-use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
+use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
 use base_prover_service_protocol::{
-    ProofResult, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, ZkProofResult,
-    ZkVm,
+    ProofResult, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, ZkProofRequest,
+    ZkProofResult, ZkVm,
 };
 
 /// Placeholder proof bytes returned by the mock prover.
@@ -21,7 +21,7 @@ pub struct MockZkProver;
 impl ZkProver for MockZkProver {
     async fn submit(
         &self,
-        _request: &ZkProofRequestKind,
+        _request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         Ok(format!("mock-stark-{request_session_id}"))
@@ -62,6 +62,7 @@ impl ZkProver for MockZkProver {
 
 #[cfg(test)]
 mod tests {
+    use base_proof_zk_host::ZkProofRequestKind;
     use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
 
     use super::*;
@@ -77,10 +78,6 @@ mod tests {
         }
     }
 
-    fn compressed() -> ZkProofRequestKind {
-        ZkProofRequestKind::Compressed(zk_request())
-    }
-
     fn snark_groth16() -> ZkProofRequestKind {
         ZkProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
             proof: zk_request(),
@@ -91,8 +88,8 @@ mod tests {
     #[tokio::test]
     async fn submit_is_deterministic() {
         let prover = MockZkProver;
-        let first = prover.submit(&compressed(), "session-1").await.unwrap();
-        let second = prover.submit(&compressed(), "session-1").await.unwrap();
+        let first = prover.submit(&zk_request(), "session-1").await.unwrap();
+        let second = prover.submit(&zk_request(), "session-1").await.unwrap();
 
         assert_eq!(first, second);
         assert_eq!(first, "mock-stark-session-1");
@@ -101,7 +98,7 @@ mod tests {
     #[tokio::test]
     async fn poll_completes_immediately_and_downloads_compressed() {
         let prover = MockZkProver;
-        let id = prover.submit(&compressed(), "session-1").await.unwrap();
+        let id = prover.submit(&zk_request(), "session-1").await.unwrap();
 
         assert_eq!(prover.poll(&id).await.unwrap(), ZkSessionState::Completed);
         assert!(matches!(
@@ -114,7 +111,7 @@ mod tests {
     async fn submit_next_advances_groth16_to_snark_session() {
         let prover = MockZkProver;
         let request = snark_groth16();
-        let range_id = prover.submit(&request, "session-1").await.unwrap();
+        let range_id = prover.submit(&zk_request(), "session-1").await.unwrap();
         assert_eq!(range_id, "mock-stark-session-1");
 
         let ZkProofRequestKind::SnarkGroth16(proof_request) = &request else {

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -10,7 +10,7 @@ use std::{fmt, sync::Arc, time::Duration};
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
-use base_proof_zk_host::{ZkProofRequestKind, ZkProver, ZkProverError, ZkSessionState};
+use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
 use base_prover_service_protocol::{ProofResult, SessionType, ZkProofResult, ZkVm};
 use sp1_sdk::{
     HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey,
@@ -372,17 +372,10 @@ impl NetworkZkProver {
 impl ZkProver for NetworkZkProver {
     async fn submit(
         &self,
-        request: &ZkProofRequestKind,
+        request: &base_prover_service_protocol::ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
-        match request {
-            ZkProofRequestKind::Compressed(request) => {
-                self.submit_range_proof(request, request_session_id).await
-            }
-            ZkProofRequestKind::SnarkGroth16(_) => Err(backend_error!(
-                "SP1 Network Groth16 aggregation is not yet supported in the stateless ZK host"
-            )),
-        }
+        self.submit_range_proof(request, request_session_id).await
     }
 
     async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError> {

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -11,7 +11,7 @@ use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_proof_succinct_client_utils::client::DEFAULT_INTERMEDIATE_ROOT_INTERVAL;
 use base_proof_zk_host::{ZkProver, ZkProverError, ZkSessionState};
-use base_prover_service_protocol::{ProofResult, SessionType, ZkProofResult, ZkVm};
+use base_prover_service_protocol::{ProofResult, SessionType, ZkProofRequest, ZkProofResult, ZkVm};
 use sp1_sdk::{
     HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey,
     SP1ProofWithPublicValues, SP1ProvingKey,
@@ -282,7 +282,7 @@ impl NetworkZkProver {
     /// Submit a compressed range proof to the SP1 prover network.
     pub async fn submit_range_proof(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         let start_block = request.start_block_number;
@@ -372,7 +372,7 @@ impl NetworkZkProver {
 impl ZkProver for NetworkZkProver {
     async fn submit(
         &self,
-        request: &base_prover_service_protocol::ZkProofRequest,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         self.submit_range_proof(request, request_session_id).await

--- a/crates/proof/zk/backend/src/succinct/provider.rs
+++ b/crates/proof/zk/backend/src/succinct/provider.rs
@@ -2,10 +2,13 @@
 
 use std::{error::Error as StdError, fmt, sync::Arc};
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use base_l1_head::{L1HeadCalculator, L1HeadError};
-use base_proof_succinct_host_utils::{fetcher::OPSuccinctDataFetcher, host::SuccinctHost};
-use sp1_sdk::SP1Stdin;
+use base_proof_succinct_client_utils::boot::BootInfoStruct;
+use base_proof_succinct_host_utils::{
+    fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, host::SuccinctHost,
+};
+use sp1_sdk::{SP1ProofWithPublicValues, SP1Stdin, SP1VerifyingKey};
 use thiserror::Error;
 use tracing::{debug, info};
 
@@ -97,6 +100,27 @@ pub enum WitnessError {
     #[error("failed to build SP1 stdin from Succinct witness")]
     Stdin {
         /// Underlying witness conversion error.
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    /// Fetching the latest L1 checkpoint head for aggregation failed.
+    #[error("failed to fetch latest L1 checkpoint head for aggregation")]
+    AggregationL1Head {
+        /// Underlying header fetch error.
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    /// Fetching L1 header preimages for aggregation failed.
+    #[error("failed to fetch L1 header preimages for aggregation")]
+    AggregationHeaders {
+        /// Underlying header fetch error.
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    /// Building aggregation stdin failed.
+    #[error("failed to build aggregation stdin")]
+    AggregationStdin {
+        /// Underlying aggregation stdin error.
         #[source]
         source: Box<dyn StdError + Send + Sync>,
     },
@@ -194,5 +218,45 @@ impl OpSuccinctWitnessProvider {
         info!(start_block = start_block, end_block = end_block, "witness generation completed");
 
         Ok(stdin)
+    }
+
+    /// Generate aggregation stdin from completed compressed range proofs.
+    pub async fn generate_aggregation_witness(
+        &self,
+        range_proof: SP1ProofWithPublicValues,
+        range_vk: &SP1VerifyingKey,
+        prover_address: Address,
+    ) -> Result<SP1Stdin, WitnessError> {
+        let (boot_info, _): (BootInfoStruct, _) = bincode::serde::decode_from_slice(
+            range_proof.public_values.as_slice(),
+            // The SP1 SDK serialises `public_values` with bincode-1 (legacy) encoding, so the
+            // range proof output must be decoded with `legacy()` rather than `standard()`.
+            bincode::config::legacy(),
+        )
+        .map_err(|source| WitnessError::AggregationStdin { source: source.into() })?;
+        let boot_infos = vec![boot_info];
+        let proofs = vec![range_proof.proof];
+
+        let header =
+            self.host.fetcher.get_latest_l1_head_in_batch(&boot_infos).await.map_err(|source| {
+                WitnessError::AggregationL1Head { source: source.into_boxed_dyn_error() }
+            })?;
+        let l1_head_hash = header.hash_slow();
+
+        let headers =
+            self.host.fetcher.get_header_preimages(&boot_infos, l1_head_hash).await.map_err(
+                |source| WitnessError::AggregationHeaders { source: source.into_boxed_dyn_error() },
+            )?;
+
+        info!(
+            l1_head_hash = %l1_head_hash,
+            num_headers = headers.len(),
+            "fetched L1 headers for aggregation proof"
+        );
+
+        get_agg_proof_stdin(proofs, boot_infos, headers, range_vk, l1_head_hash, prover_address)
+            .map_err(|source| WitnessError::AggregationStdin {
+                source: source.into_boxed_dyn_error(),
+            })
     }
 }

--- a/crates/proof/zk/backend/src/succinct/provider.rs
+++ b/crates/proof/zk/backend/src/succinct/provider.rs
@@ -220,20 +220,14 @@ impl OpSuccinctWitnessProvider {
         Ok(stdin)
     }
 
-    /// Generate aggregation stdin from completed compressed range proofs.
+    /// Generate aggregation stdin from a completed compressed range proof.
     pub async fn generate_aggregation_witness(
         &self,
-        range_proof: SP1ProofWithPublicValues,
+        mut range_proof: SP1ProofWithPublicValues,
         range_vk: &SP1VerifyingKey,
         prover_address: Address,
     ) -> Result<SP1Stdin, WitnessError> {
-        let (boot_info, _): (BootInfoStruct, _) = bincode::serde::decode_from_slice(
-            range_proof.public_values.as_slice(),
-            // The SP1 SDK serialises `public_values` with bincode-1 (legacy) encoding, so the
-            // range proof output must be decoded with `legacy()` rather than `standard()`.
-            bincode::config::legacy(),
-        )
-        .map_err(|source| WitnessError::AggregationStdin { source: source.into() })?;
+        let boot_info: BootInfoStruct = range_proof.public_values.read();
         let boot_infos = vec![boot_info];
         let proofs = vec![range_proof.proof];
 

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -222,21 +222,18 @@ where
             request.claim.worker_id.clone(),
         );
 
-        // Every request begins with a range (STARK) proof. A Groth16 job proves the range over the
-        // compressed request nested in its SNARK request, since backends only submit compressed
-        // proofs in the first stage.
+        // Every request begins with a range (STARK) proof. For a Groth16 job that is the compressed
+        // request nested in its SNARK request.
         let range_request = match &request.request {
-            ZkProofRequestKind::Compressed(proof) => ZkProofRequestKind::Compressed(proof.clone()),
-            ZkProofRequestKind::SnarkGroth16(snark) => {
-                ZkProofRequestKind::Compressed(snark.proof.clone())
-            }
+            ZkProofRequestKind::Compressed(proof) => proof,
+            ZkProofRequestKind::SnarkGroth16(snark) => &snark.proof,
         };
         let range_session_id = self
             .drive_stage(
                 request,
                 &handle,
                 SessionType::Stark,
-                self.prover.submit(&range_request, &request.claim.session_id),
+                self.prover.submit(range_request, &request.claim.session_id),
             )
             .await?;
 

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -77,10 +77,13 @@ pub enum ZkProverError {
 /// Drives a single ZK proving job on a backend.
 #[async_trait]
 pub trait ZkProver: Send + Sync + std::fmt::Debug {
-    /// Submit the proving job to the backend and return its backend session id.
+    /// Submit the range (STARK) proof to the backend and return its backend session id.
+    ///
+    /// Every job's first stage is a compressed range proof; SNARK aggregation (when required) is
+    /// driven separately via [`ZkProver::submit_next`].
     async fn submit(
         &self,
-        request: &ZkProofRequestKind,
+        request: &ZkProofRequest,
         request_session_id: &str,
     ) -> Result<String, ZkProverError>;
 
@@ -117,7 +120,7 @@ pub struct UnimplementedZkProver;
 impl ZkProver for UnimplementedZkProver {
     async fn submit(
         &self,
-        _request: &ZkProofRequestKind,
+        _request: &ZkProofRequest,
         _request_session_id: &str,
     ) -> Result<String, ZkProverError> {
         Err(ZkProverError::Unimplemented)
@@ -171,7 +174,7 @@ mod tests {
     async fn unimplemented_prover_reports_unimplemented() {
         let prover = UnimplementedZkProver;
         let error = prover
-            .submit(&ZkProofRequestKind::Compressed(zk_request()), "session-1")
+            .submit(&zk_request(), "session-1")
             .await
             .expect_err("stub prover should not produce a proof");
 


### PR DESCRIPTION
## Summary

Base prep for the groth16 aggregation backends: narrows `ZkProver::submit` to take `&ZkProofRequest` instead of the broader `ZkProofRequestKind` (every job's first stage is a compressed range proof, so this drops the dead `SnarkGroth16` rejection branches and the caller's re-wrap while leaving the compressed-vs-aggregation decision in `proof_generator` untouched — addressing @jackchuma's nit on #3863).

This also adds the shared `OpSuccinctWitnessProvider::generate_aggregation_witness` helper so the cluster (#3870) and network (#3871) aggregation PRs can each stack on this branch as independent siblings rather than one depending on the other.


Made with [Cursor](https://cursor.com)