### PR TITLE
feat: add zombie permanently-off upgrade gate

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -121,7 +121,7 @@ impl Index<EthereumHardfork> for ChainUpgrades {
 mod tests {
     use BaseUpgrade::{
         Azul, Bedrock, Beryl, Canyon, Cobalt, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian,
-        Regolith,
+        Regolith, Zombie,
     };
     use alloy_hardforks::EthereumHardfork;
 
@@ -176,6 +176,7 @@ mod tests {
             ForkCondition::Timestamp(ChainConfig::mainnet().beryl_timestamp.unwrap())
         );
         assert_eq!(base_mainnet_forks[Cobalt], ForkCondition::Never);
+        assert_eq!(base_mainnet_forks[Zombie], ForkCondition::Never);
     }
 
     #[test]
@@ -226,6 +227,7 @@ mod tests {
             ForkCondition::Timestamp(ChainConfig::sepolia().beryl_timestamp.unwrap())
         );
         assert_eq!(base_sepolia_forks[Cobalt], ForkCondition::Never);
+        assert_eq!(base_sepolia_forks[Zombie], ForkCondition::Never);
     }
 
     #[test]
@@ -306,6 +308,16 @@ mod tests {
         assert!(!zeronet_forks.is_beryl_active_at_timestamp(1_782_349_187));
         assert!(zeronet_forks.is_beryl_active_at_timestamp(1_782_349_188));
         assert!(zeronet_forks.is_beryl_active_at_timestamp(u64::MAX));
+    }
+
+    #[test]
+    fn is_zombie_active_at_timestamp() {
+        let base_mainnet_forks = ChainUpgrades::mainnet();
+        assert!(!base_mainnet_forks.is_zombie_active_at_timestamp(0));
+        assert!(!base_mainnet_forks.is_zombie_active_at_timestamp(u64::MAX));
+
+        let devnet_forks = ChainUpgrades::devnet();
+        assert!(!devnet_forks.is_zombie_active_at_timestamp(0));
     }
 
     #[test]

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -56,8 +56,8 @@ impl BaseUpgradeExt for BaseUpgrade {
             | Self::Holocene
             | Self::PectraBlobSchedule => SpecId::CANCUN,
             Self::Isthmus | Self::Jovian => SpecId::PRAGUE,
-            // Azul, Beryl, Cobalt, and newer Base upgrades inherit the latest known Ethereum spec
-            // until explicitly mapped.
+            // Azul, Beryl, Cobalt, Zombie, and newer Base upgrades inherit the latest known
+            // Ethereum spec until explicitly mapped.
             _ => SpecId::OSAKA,
         }
     }
@@ -126,7 +126,7 @@ mod tests {
     fn check_base_upgrade_from_str() {
         let upgrade_str = [
             "beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD", "GRaNiTe", "hOlOcEnE", "isthMUS",
-            "jOvIaN", "aZuL", "bErYl", "cObAlT",
+            "jOvIaN", "aZuL", "bErYl", "cObAlT", "zOmBiE",
         ];
         let expected_upgrades = [
             BaseUpgrade::Bedrock,
@@ -141,6 +141,7 @@ mod tests {
             BaseUpgrade::Azul,
             BaseUpgrade::Beryl,
             BaseUpgrade::Cobalt,
+            BaseUpgrade::Zombie,
         ];
 
         let upgrades: alloc::vec::Vec<BaseUpgrade> =
@@ -223,6 +224,7 @@ mod tests {
             (BaseUpgrade::Azul, SpecId::OSAKA),
             (BaseUpgrade::Beryl, SpecId::OSAKA),
             (BaseUpgrade::Cobalt, SpecId::OSAKA),
+            (BaseUpgrade::Zombie, SpecId::OSAKA),
         ];
 
         for (base_upgrade, eth_spec) in test_cases {
@@ -249,9 +251,19 @@ mod tests {
     }
 
     #[test]
+    fn zombie_is_a_permanently_off_gate() {
+        // Zombie is a gate, not an upgrade: it is not contract-backed, not signalable via the L1
+        // contract, and absent from the contract-backed set, so it can never be activated.
+        assert!(!BaseUpgrade::Zombie.is_contract_backed());
+        assert_eq!(BaseUpgrade::from_contract_fork_name("zombie"), None);
+        assert!(!BaseUpgrade::CONTRACT_VARIANTS.contains(&BaseUpgrade::Zombie));
+        assert!(!BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zombie));
+    }
+
+    #[test]
     fn contract_only_upgrades_are_absent_from_execution_ladder() {
-        // Delta and PectraBlobSchedule are contract-backed config upgrades that do not change
-        // EVM execution, so they have no execution index and are excluded from the ladder.
+        // Delta and PectraBlobSchedule are contract-backed config upgrades that do not
+        // change EVM execution, so they have no execution index and are excluded from the ladder.
         for upgrade in [BaseUpgrade::Delta, BaseUpgrade::PectraBlobSchedule] {
             assert!(!upgrade.is_execution());
             assert_eq!(upgrade.execution_idx(), None);

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -78,6 +78,13 @@ pub trait Upgrades: EthereumHardforks {
     fn is_cobalt_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.upgrade_activation(BaseUpgrade::Cobalt).active_at_timestamp(timestamp)
     }
+
+    /// Returns `true` if the [`Zombie`](BaseUpgrade::Zombie) gate is active at the given block
+    /// timestamp. Zombie is a permanently-off gate, so this always returns `false`; use it to
+    /// keep not-yet-ready features disabled behind a fork check like any other upgrade.
+    fn is_zombie_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.upgrade_activation(BaseUpgrade::Zombie).active_at_timestamp(timestamp)
+    }
 }
 
 impl Upgrades for RollupConfig {
@@ -128,8 +135,8 @@ impl Upgrades for RollupConfig {
                 .contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
-            // Contract-only upgrades (Delta, PectraBlobSchedule) and any future variants are
-            // absent from the execution fork ladder.
+            // Contract-only upgrades (Delta, PectraBlobSchedule), the permanently-off Zombie gate,
+            // and any future variants are absent from the execution fork ladder.
             _ => ForkCondition::Never,
         }
     }
@@ -165,6 +172,7 @@ mod tests {
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Azul), ForkCondition::Never);
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Beryl), ForkCondition::Never);
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Cobalt), ForkCondition::Never);
+        assert_eq!(cfg.upgrade_activation(BaseUpgrade::Zombie), ForkCondition::Never);
     }
 
     #[cfg(feature = "std")]
@@ -186,12 +194,15 @@ mod tests {
             BaseUpgrade::Cobalt,
             ACTIVATION + 1,
         );
+        // Even a runtime override cannot activate the permanently-off Zombie gate.
+        RuntimeUpgradeRegistry::set_activation_timestamp(CHAIN_ID, BaseUpgrade::Zombie, u64::MAX);
 
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Azul), ForkCondition::Timestamp(ACTIVATION));
         assert_eq!(
             cfg.upgrade_activation(BaseUpgrade::Cobalt),
             ForkCondition::Timestamp(ACTIVATION + 1)
         );
+        assert_eq!(cfg.upgrade_activation(BaseUpgrade::Zombie), ForkCondition::Never);
 
         RuntimeUpgradeRegistry::clear_chain(CHAIN_ID);
     }

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -238,7 +238,8 @@ impl BaseUpgrade {
             "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
             "beryl" | "baseberyl" | "v2" => Self::Beryl,
             "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
-            // Zombie is a permanently-off gate: it is not addressable by the L1 upgrade signal.
+            // Zombie is a permanently-off gate: even though `contract_id` emits "zombie", it is
+            // deliberately not resolvable here, so the L1 upgrade signal can never address it.
             _ => return None,
         };
         Some(upgrade)

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -335,6 +335,11 @@ impl UpgradeActivationOverrides {
 
     /// Sets the runtime activation override for a contract upgrade ID.
     pub fn set_activation(&mut self, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
+        // Zombie is a permanently-off gate: never store it as an override so the "Zombie is
+        // never stored as active" invariant holds at the write side, not just at consumers.
+        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+            return;
+        }
         self.activations.insert(upgrade_id, activation);
     }
 
@@ -811,11 +816,14 @@ mod runtime_tests {
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Beryl);
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
+        // Zombie is permanently off: the registry drops the write, so it is never stored.
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Zombie, u64::MAX);
 
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
             Some(UpgradeActivation::Never)
@@ -836,8 +844,10 @@ mod runtime_tests {
         overrides.clear_activation_timestamp(BaseUpgrade::Canyon);
         overrides.set_activation_timestamp(BaseUpgrade::Azul, 42);
         overrides.set_activation_timestamp(BaseUpgrade::Cobalt, 84);
-        // Even an explicit override cannot activate the permanently-off Zombie gate.
+        // Even an explicit override cannot activate the permanently-off Zombie gate. The write
+        // side drops it entirely, so it is never even stored as an override.
         overrides.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
+        assert_eq!(overrides.activation(BaseUpgrade::Zombie), None);
 
         upgrades.apply_activation_overrides(&overrides);
 

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -46,11 +46,15 @@ hardfork!(
     ///   the L1 upgrade-signal contract `hardforkId` strings and the genesis [`UpgradeConfig`]
     ///   timestamp fields.
     ///
-    /// Variants are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock) is
-    /// execution-only (block-activated, not contract-backed), while
+    /// Real network upgrades are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock)
+    /// is execution-only (block-activated, not contract-backed), while
     /// [`Delta`](BaseUpgrade::Delta) and [`PectraBlobSchedule`](BaseUpgrade::PectraBlobSchedule)
     /// are contract-backed config upgrades that do not change EVM execution and therefore never
     /// enter the execution fork ladder.
+    ///
+    /// [`Zombie`](BaseUpgrade::Zombie) is a permanently-off gate: it is a known upgrade identity
+    /// used to gate not-yet-ready features (checked like any other fork), but it is neither
+    /// contract-backed nor configurable and can never activate.
     ///
     /// When building a list of upgrades for a chain, it's still expected to zip with
     /// [`EthereumHardfork`](alloy_hardforks::EthereumHardfork).
@@ -87,6 +91,9 @@ hardfork!(
         Beryl,
         /// Cobalt: Third Base-specific network upgrade.
         Cobalt,
+        /// Zombie: permanently-off gate used to keep not-yet-ready features disabled. Never
+        /// activates and is not contract-backed or configurable.
+        Zombie,
     }
 );
 
@@ -98,7 +105,7 @@ impl BaseUpgrade {
     ///
     /// These are the upgrades that participate in the reth/revm hardfork schedule. Excludes the
     /// contract-only [`Delta`](Self::Delta) and [`PectraBlobSchedule`](Self::PectraBlobSchedule)
-    /// upgrades, which do not change EVM execution.
+    /// upgrades and the [`Zombie`](Self::Zombie) gate, which do not change EVM execution.
     pub const EXECUTION_VARIANTS: [Self; 12] = [
         Self::Bedrock,
         Self::Regolith,
@@ -117,7 +124,8 @@ impl BaseUpgrade {
     /// The contract-backed upgrade set, in activation order.
     ///
     /// These are the upgrades addressable by the L1 upgrade-signal contract and stored in the
-    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock).
+    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock) and the
+    /// [`Zombie`](Self::Zombie) gate, which is never signaled or configured.
     pub const CONTRACT_VARIANTS: [Self; 13] = [
         Self::Regolith,
         Self::Canyon,
@@ -140,9 +148,10 @@ impl BaseUpgrade {
     }
 
     /// Returns true if this upgrade is contract-backed (i.e. signaled by the L1 upgrade-signal
-    /// contract and stored in [`UpgradeConfig`]). False only for [`Bedrock`](Self::Bedrock).
+    /// contract and stored in [`UpgradeConfig`]). False for block-activated
+    /// [`Bedrock`](Self::Bedrock) and the never-activating [`Zombie`](Self::Zombie) gate.
     pub const fn is_contract_backed(self) -> bool {
-        !matches!(self, Self::Bedrock)
+        !matches!(self, Self::Bedrock | Self::Zombie)
     }
 
     /// Returns this upgrade's index within [`EXECUTION_VARIANTS`](Self::EXECUTION_VARIANTS), or
@@ -161,7 +170,7 @@ impl BaseUpgrade {
             Self::Azul => 9,
             Self::Beryl => 10,
             Self::Cobalt => 11,
-            Self::Delta | Self::PectraBlobSchedule => return None,
+            Self::Delta | Self::PectraBlobSchedule | Self::Zombie => return None,
         })
     }
 
@@ -186,6 +195,7 @@ impl BaseUpgrade {
             Self::Azul => "azul",
             Self::Beryl => "beryl",
             Self::Cobalt => "cobalt",
+            Self::Zombie => "zombie",
         }
     }
 
@@ -228,6 +238,7 @@ impl BaseUpgrade {
             "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
             "beryl" | "baseberyl" | "v2" => Self::Beryl,
             "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
+            // Zombie is a permanently-off gate: it is not addressable by the L1 upgrade signal.
             _ => return None,
         };
         Some(upgrade)
@@ -520,7 +531,9 @@ impl UpgradeConfig {
     /// Clears a timestamp-based activation time by contract upgrade ID.
     pub const fn clear_activation_timestamp(&mut self, upgrade_id: BaseUpgrade) {
         match upgrade_id {
-            BaseUpgrade::Bedrock => {}
+            // Bedrock is block-activated and Zombie is a permanently-off gate; neither has a
+            // timestamp slot.
+            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => {}
             BaseUpgrade::Regolith => self.regolith_time = None,
             BaseUpgrade::Canyon => self.canyon_time = None,
             BaseUpgrade::Delta => self.delta_time = None,
@@ -557,7 +570,8 @@ impl UpgradeConfig {
     /// Returns the activation for a timestamp-based contract upgrade ID.
     pub const fn activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
         let timestamp = match upgrade_id {
-            BaseUpgrade::Bedrock => None,
+            // Bedrock is block-activated; Zombie is a permanently-off gate that never activates.
+            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => None,
             BaseUpgrade::Regolith => self.regolith_time,
             BaseUpgrade::Canyon => self.canyon_time,
             BaseUpgrade::Delta => self.delta_time,
@@ -584,7 +598,9 @@ impl UpgradeConfig {
     /// Sets a timestamp-based activation time by contract upgrade ID.
     pub const fn set_activation_timestamp(&mut self, upgrade_id: BaseUpgrade, timestamp: u64) {
         match upgrade_id {
-            BaseUpgrade::Bedrock => {}
+            // Bedrock is block-activated and Zombie is a permanently-off gate; neither can be
+            // scheduled by timestamp, so setting one is a no-op.
+            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => {}
             BaseUpgrade::Regolith => self.regolith_time = Some(timestamp),
             BaseUpgrade::Canyon => self.canyon_time = Some(timestamp),
             BaseUpgrade::Delta => self.delta_time = Some(timestamp),
@@ -759,19 +775,23 @@ mod tests {
         upgrades.set_activation_timestamp(BaseUpgrade::Regolith, 1);
         upgrades.set_activation_timestamp(BaseUpgrade::PectraBlobSchedule, 2);
         upgrades.set_activation_timestamp(BaseUpgrade::Azul, 3);
-        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 4);
-        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 5);
+        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 5);
+        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 6);
+        // Zombie is a permanently-off gate: setting a timestamp is a no-op, it stays Never.
+        upgrades.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
 
         assert_eq!(upgrades.regolith_time, Some(1));
         assert_eq!(upgrades.pectra_blob_schedule_time, Some(2));
         assert_eq!(upgrades.base.azul, Some(3));
-        assert_eq!(upgrades.base.beryl, Some(4));
-        assert_eq!(upgrades.base.cobalt, Some(5));
+        assert_eq!(upgrades.base.beryl, Some(5));
+        assert_eq!(upgrades.base.cobalt, Some(6));
+        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
 
         upgrades.clear_activation_timestamp(BaseUpgrade::Azul);
         assert_eq!(upgrades.base.azul, None);
-        assert_eq!(upgrades.base.beryl, Some(4));
-        assert_eq!(upgrades.base.cobalt, Some(5));
+        assert_eq!(upgrades.base.beryl, Some(5));
+        assert_eq!(upgrades.base.cobalt, Some(6));
+        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
 
         upgrades.clear_activation_timestamps();
 
@@ -816,11 +836,14 @@ mod runtime_tests {
         overrides.clear_activation_timestamp(BaseUpgrade::Canyon);
         overrides.set_activation_timestamp(BaseUpgrade::Azul, 42);
         overrides.set_activation_timestamp(BaseUpgrade::Cobalt, 84);
+        // Even an explicit override cannot activate the permanently-off Zombie gate.
+        overrides.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
 
         upgrades.apply_activation_overrides(&overrides);
 
         assert_eq!(upgrades.canyon_time, None);
         assert_eq!(upgrades.base.azul, Some(42));
         assert_eq!(upgrades.base.cobalt, Some(84));
+        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
     }
 }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -875,8 +875,7 @@ mod tests {
 
         // Osaka↔Azul: azul drives Osaka activation; standalone (not cascaded from Jovian).
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base =
-            BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None };
+        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -884,8 +883,7 @@ mod tests {
 
         // Beryl follows Azul; Osaka still activates at Azul when both are configured.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base =
-            BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None };
+        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -895,8 +893,7 @@ mod tests {
 
         // Beryl requires Azul, and does not independently activate Osaka.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base =
-            BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None };
+        cfg.upgrades.base = BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None };
         assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);
 
         // Jovian set but Azul unset → Osaka is Never.
@@ -955,7 +952,10 @@ mod tests {
         assert_eq!(materialized.upgrades.canyon_time, None);
         assert_eq!(materialized.upgrades.base.azul, Some(42));
         assert_eq!(materialized.upgrades.base.cobalt, Some(84));
-        assert_eq!(materialized.contract_upgrade_activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
+        assert_eq!(
+            materialized.contract_upgrade_activation(BaseUpgrade::Zombie),
+            UpgradeActivation::Never
+        );
 
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -463,6 +463,10 @@ impl UpgradeActivationSink for RollupConfig {
         upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
+        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+            return Ok(false);
+        }
+
         self.apply_upgrade_activation(upgrade_id, activation);
         Ok(true)
     }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -195,6 +195,11 @@ macro_rules! rollup_fork_methods {
 impl RollupConfig {
     /// Returns this rollup config's runtime-aware activation for a contract upgrade ID.
     pub fn contract_upgrade_activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
+        // Zombie is a permanently-off gate: it can never activate, not even via a runtime
+        // override, so short-circuit before consulting the registry or genesis config.
+        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+            return UpgradeActivation::Never;
+        }
         RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
             .unwrap_or_else(|| self.upgrades.activation(upgrade_id))
     }
@@ -324,6 +329,11 @@ impl RollupConfig {
         is_first_cobalt_block,
         [contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)],
         "Cobalt";
+
+        is_zombie_active,
+        is_first_zombie_block,
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Zombie)],
+        "Zombie";
     }
 
     /// Returns the max sequencer drift for the given timestamp.
@@ -865,7 +875,8 @@ mod tests {
 
         // Osaka↔Azul: azul drives Osaka activation; standalone (not cascaded from Jovian).
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -873,7 +884,8 @@ mod tests {
 
         // Beryl follows Azul; Osaka still activates at Azul when both are configured.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -883,7 +895,8 @@ mod tests {
 
         // Beryl requires Azul, and does not independently activate Osaka.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None };
         assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);
 
         // Jovian set but Azul unset → Osaka is Never.
@@ -925,15 +938,24 @@ mod tests {
         crate::RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Canyon);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
+        // The Zombie gate stays off even when a runtime override tries to activate it.
+        crate::RuntimeUpgradeRegistry::set_activation_timestamp(
+            chain_id,
+            BaseUpgrade::Zombie,
+            u64::MAX,
+        );
 
         assert!(!cfg.is_canyon_active(10));
         assert!(cfg.is_base_azul_active(42));
         assert!(cfg.is_cobalt_active(84));
+        assert!(!cfg.is_zombie_active(84));
+        assert!(!cfg.is_zombie_active(u64::MAX));
 
         let materialized = cfg.with_runtime_upgrade_overrides();
         assert_eq!(materialized.upgrades.canyon_time, None);
         assert_eq!(materialized.upgrades.base.azul, Some(42));
         assert_eq!(materialized.upgrades.base.cobalt, Some(84));
+        assert_eq!(materialized.contract_upgrade_activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
 
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -48,7 +48,9 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             BaseUpgrade::Jovian => Self::jovian(),
             BaseUpgrade::Azul => Self::azul(),
             BaseUpgrade::Beryl => Self::beryl(),
-            BaseUpgrade::Cobalt => Self::cobalt(),
+            // Zombie is a placeholder that never activates; it tracks the latest precompile set so
+            // it evolves with the newest hardfork (keep it grouped with the latest arm).
+            BaseUpgrade::Cobalt | BaseUpgrade::Zombie => Self::cobalt(),
             upgrade => panic!("unsupported Base precompile upgrade: {upgrade}"),
         };
 

--- a/crates/common/rpc-types/src/genesis.rs
+++ b/crates/common/rpc-types/src/genesis.rs
@@ -34,8 +34,11 @@ impl TryFrom<&OtherFields> for ChainInfo {
 }
 
 /// Base-specific upgrade configuration in a genesis file.
+///
+/// `deny_unknown_fields` ensures a genesis cannot smuggle in a `zombie` (or any other unknown)
+/// activation time: Zombie is a permanently-off gate and is not configurable.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpgradeInfo {
     /// Base Azul upgrade timestamp.
     #[serde(alias = "v1")]

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -119,11 +119,7 @@ mod tests {
             upgrades: UpgradeConfig {
                 ecotone_time: Some(20),
                 jovian_time: Some(30),
-                base: BaseUpgradeConfig {
-                    azul: Some(40),
-                    beryl: Some(50),
-                    cobalt: Some(60),
-                },
+                base: BaseUpgradeConfig { azul: Some(40), beryl: Some(50), cobalt: Some(60) },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -119,7 +119,11 @@ mod tests {
             upgrades: UpgradeConfig {
                 ecotone_time: Some(20),
                 jovian_time: Some(30),
-                base: BaseUpgradeConfig { azul: Some(40), beryl: Some(50), cobalt: Some(60) },
+                base: BaseUpgradeConfig {
+                    azul: Some(40),
+                    beryl: Some(50),
+                    cobalt: Some(60),
+                },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -447,7 +447,7 @@ impl BaseChainSpec {
             inserted = true;
         }
         // Only execution-ladder upgrades enter the reth hardfork schedule; contract-only
-        // upgrades (Delta, PectraBlobSchedule) are ignored here.
+        // upgrades (Delta, PectraBlobSchedule) and the permanently-off Zombie gate are ignored.
         if hardfork_id.is_execution() {
             hardforks.insert(hardfork_id, condition);
             inserted = true;
@@ -960,6 +960,17 @@ mod tests {
     }
 
     #[test]
+    fn builtin_chain_specs_never_activate_zombie() {
+        // Zombie is a permanently-off gate: it never enters any chain's fork schedule, so it is
+        // always `Never` and never active.
+        for spec in [BaseChainSpec::mainnet(), BaseChainSpec::sepolia(), BaseChainSpec::devnet()] {
+            assert_eq!(spec.fork(BaseUpgrade::Zombie), ForkCondition::Never);
+            assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zombie, 0));
+            assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zombie, u64::MAX));
+        }
+    }
+
+    #[test]
     fn base_mainnet_genesis() {
         let base_mainnet_spec = BaseChainSpec::mainnet();
         let genesis = base_mainnet_spec.genesis_header();
@@ -1202,7 +1213,8 @@ mod tests {
         "jovianTime": 54,
         "base": {
           "v1": 55,
-          "v2": 60
+          "v2": 60,
+          "v3": 65
         },
         "activationAdminAddress": "0xcb00000000000000000000000000000000000000",
         "optimism": {
@@ -1243,6 +1255,12 @@ mod tests {
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Azul, 55));
         assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Beryl, 59));
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Beryl, 60));
+        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Cobalt, 64));
+        assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Cobalt, 65));
+
+        // Zombie is a permanently-off gate: never scheduled, always Never.
+        assert_eq!(chain_spec.fork(BaseUpgrade::Zombie), ForkCondition::Never);
+        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zombie, 9999));
     }
 
     #[test]

--- a/crates/proof/succinct/utils/client/src/precompiles/mod.rs
+++ b/crates/proof/succinct/utils/client/src/precompiles/mod.rs
@@ -457,9 +457,12 @@ mod tests {
             token_address,
         ];
 
-        for (upgrade, expected) in
-            [(BaseUpgrade::Azul, false), (BaseUpgrade::Beryl, true), (BaseUpgrade::Cobalt, true)]
-        {
+        for (upgrade, expected) in [
+            (BaseUpgrade::Azul, false),
+            (BaseUpgrade::Beryl, true),
+            (BaseUpgrade::Cobalt, true),
+            (BaseUpgrade::Zombie, true),
+        ] {
             let spec = BaseSpecId::new(upgrade);
             let base_precompiles = BasePrecompiles::new_with_spec(spec).install();
             let zkvm_precompiles = BaseZkvmPrecompiles::new_with_spec(spec);

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -30,6 +30,10 @@ impl UpgradeActivationSink for RuntimeRegistrySink {
         upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
+        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+            return Ok(false);
+        }
+
         self.updates.set_activation(upgrade_id, activation);
         Ok(true)
     }


### PR DESCRIPTION
Adds a `Zombie` Base upgrade that keeps a full gate identity (enum variant, `name()`, and `is_zombie_active*` query helpers) but can never be activated by any path (config, genesis, runtime override, contract signal, or chainspec schedule), so it always resolves to `ForkCondition::Never`. Use it like any other `is_xxx_activated_at_timestamp` gate to guard not-yet-ready features until Zombie is replaced by a real named fork. Zombie tracks the latest precompile set so it evolves with new hard forks.