### PR TITLE
feat(docker): bundle reth-node and consensus binaries into base image

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -162,6 +162,8 @@ WORKDIR /app
 
 FROM runtime-base AS base
 COPY --from=base-builder /app/base ./base
+COPY --from=execution-builder /app/base-reth-node ./base-reth-node
+COPY --from=consensus-builder /app/base-consensus ./base-consensus
 ENTRYPOINT ["./base"]
 
 FROM runtime-base AS execution

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -72,6 +72,11 @@ target "base" {
   inherits = ["_rust-service-common"]
   target = "base"
   tags = ["base:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-execution-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-consensus-${PLATFORM_PAIR}",
+  ]
 }
 
 target "execution" {


### PR DESCRIPTION
## Summary

Bundle `base-reth-node` and `base-consensus` into the `base` Docker image alongside the `base` umbrella binary. A single image can now serve as sequencer, validator, RPC node, or standalone execution/consensus process by overriding the entrypoint at runtime.

## Changes

- **`etc/docker/Dockerfile.rust-services`** — The `base` runtime stage now `COPY`s `base-reth-node` and `base-consensus` from their respective builder stages. `ENTRYPOINT ["./base"]` is unchanged, so existing `image: base:local` + `entrypoint: /app/base` usage in `docker-compose.yml` and `docker-compose.ha.yml` keeps working. Callers that need the individual binaries can `entrypoint: /app/base-reth-node` (or `/app/base-consensus`).
- **`etc/docker/docker-bake.hcl`** — The `base` target now pulls from `cache-execution-*` and `cache-consensus-*` in addition to `cache-*`, so CI benefits from cached builder layers when only one of the three components has changed.

## Rationale

The compose files already use `base:local` for every L2 role (sequencer, validators, RPC), driven by the `base` umbrella binary's `sequencer`, `rpc`, and `bootnode` subcommands. Merging the two standalone binaries into that image means one CI push-by-digest pipeline instead of three, and one image pull in prod deployments instead of three.

## Tradeoff

Image grows by the size of the two additional release binaries (roughly 100–300 MB depending on features). If that's a concern for prod pulls, we can split them back out later.

## Follow-ups (not in this PR)

- The standalone `execution` and `consensus` bake targets + Dockerfile runtime stages are still present. Nothing in this repo consumes `base-execution:local` or `base-consensus:local`, but they might still be pulled by external CI. If we're comfortable removing them, that's a follow-up.
- If we remove those targets, prune them from the `rust-services` and `devnet` bake groups.

## Testing

- [ ] Build locally: `docker buildx bake -f etc/docker/docker-bake.hcl base`
- [ ] Verify all three binaries present: `docker run --rm --entrypoint ls base:local /app`
- [ ] Devnet still boots: `just devnet up`
