### PR TITLE
fix(load-test): report end time for FB latency when txHash is seen from the websocket 

### DIFF
--- a/crates/infra/load-tests/src/metrics/collector.rs
+++ b/crates/infra/load-tests/src/metrics/collector.rs
@@ -79,10 +79,15 @@ impl MetricsCollector {
         } else {
             self.rolling.push_gas(live_gas, at);
         }
-        if let Some(flashblocks_latency) = metrics.flashblocks_latency {
-            self.flashblocks_rolling.push_latency(flashblocks_latency, at);
-        }
         self.transactions.push(metrics);
+    }
+
+    /// Records a flashblock observation from the WS stream.
+    ///
+    /// Called when a transaction is first seen in the flashblock websocket, using
+    /// the actual WS observation time — not canonical block confirmation time.
+    pub fn record_flashblock_observed(&mut self, latency: Duration, observed_at: Instant) {
+        self.flashblocks_rolling.push_latency(latency, observed_at);
     }
 
     /// Backfills gas, effective gas price, and revert status onto landed transactions

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -1222,6 +1222,11 @@ impl LoadRunner {
                 &mut self.collector,
             );
 
+            // Drain flashblock observations for the rolling window (separate from
+            // confirmed metrics to avoid double-counting in the final summary).
+            for (latency, observed_at) in results_tracker.drain_flashblock_observations() {
+                self.collector.record_flashblock_observed(latency, observed_at);
+            }
             // Drain confirmed metrics non-blocking so the rolling window stays
             // current during the run (not just during the post-run drain).
             for metrics in results_tracker.drain_confirmed_metrics() {
@@ -1462,6 +1467,9 @@ impl LoadRunner {
         let mut last_confirmed_at = start.elapsed();
 
         while drain_start.elapsed() < CONFIRMATION_DRAIN_TIMEOUT {
+            for (latency, observed_at) in results_tracker.drain_flashblock_observations() {
+                self.collector.record_flashblock_observed(latency, observed_at);
+            }
             let metrics = results_tracker.drain_confirmed_metrics();
             if !metrics.is_empty() {
                 last_confirmed_at = start.elapsed();
@@ -1485,6 +1493,9 @@ impl LoadRunner {
             tokio::time::sleep(results_poll_interval).await;
         }
 
+        for (latency, observed_at) in results_tracker.drain_flashblock_observations() {
+            self.collector.record_flashblock_observed(latency, observed_at);
+        }
         for metrics in results_tracker.drain_confirmed_metrics() {
             self.collector.record_confirmed(metrics);
             last_confirmed_at = start.elapsed();

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -71,6 +71,10 @@ struct ResultsTrackerInner {
     flashblocks: HashMap<TxHash, Instant>,
     flashblock_eviction_queue: VecDeque<TxHash>,
     unreported_confirmations: VecDeque<TransactionMetrics>,
+    /// Flashblock latency observations for the rolling window. These are drained
+    /// separately from confirmed metrics and do NOT enter `self.transactions` in the
+    /// collector, avoiding double-counting in the final summary.
+    unreported_flashblock_observations: VecDeque<(Duration, Instant)>,
     in_flight_per_sender: HashMap<Address, u64>,
     total_in_flight: u64,
     /// Block numbers in which at least one of our transactions landed, used to scope
@@ -97,6 +101,7 @@ impl ResultsTracker {
                 flashblocks: HashMap::new(),
                 flashblock_eviction_queue: VecDeque::new(),
                 unreported_confirmations: VecDeque::new(),
+                unreported_flashblock_observations: VecDeque::new(),
                 in_flight_per_sender,
                 total_in_flight: 0,
                 landed_blocks: BTreeSet::new(),
@@ -133,20 +138,24 @@ impl ResultsTracker {
 
     /// Records transaction inclusions observed from the flashblock stream.
     ///
-    /// When a pending transaction is seen in a flashblock, its flashblock latency is
-    /// recorded immediately and its in-flight slot is released so the sender can submit
-    /// new transactions without waiting for the slower canonical block receipt.
+    /// When a pending transaction is seen in a flashblock, its in-flight slot is released
+    /// immediately and the latency observation is queued for the rolling window. The
+    /// flashblock latency is also stored in the cache so that `land_if_pending` can join
+    /// it onto the canonical block metric for the final summary.
     pub fn on_new_flashblock(&self, inclusions: Vec<FlashblockInclusion>) {
         let mut inner = self.inner.write();
 
         for inclusion in inclusions {
-            if let Entry::Vacant(e) = inner.flashblocks.entry(inclusion.tx_hash) {
-                e.insert(inclusion.included_at);
-                inner.flashblock_eviction_queue.push_back(inclusion.tx_hash);
-            }
+            let first_observation =
+                if let Entry::Vacant(e) = inner.flashblocks.entry(inclusion.tx_hash) {
+                    e.insert(inclusion.included_at);
+                    inner.flashblock_eviction_queue.push_back(inclusion.tx_hash);
+                    true
+                } else {
+                    false
+                };
 
-            if let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash) {
-                // Capture fields before releasing the borrow.
+            if first_observation && let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash) {
                 let submit_time = pending.submit_time;
                 let should_release = !pending.in_flight_released;
                 let from = pending.from;
@@ -154,18 +163,12 @@ impl ResultsTracker {
                     pending.in_flight_released = true;
                 }
 
-                // Emit flashblock latency immediately when seen in the WS stream.
-                let flashblocks_latency =
-                    inclusion.included_at.checked_duration_since(submit_time);
-                let metrics = TransactionMetrics::new(
-                    inclusion.tx_hash,
-                    None,
-                    flashblocks_latency,
-                    0,
-                    0,
-                    None,
-                );
-                inner.unreported_confirmations.push_back(metrics);
+                // Queue flashblock latency for the rolling window (drained separately).
+                if let Some(latency) = inclusion.included_at.checked_duration_since(submit_time) {
+                    inner
+                        .unreported_flashblock_observations
+                        .push_back((latency, inclusion.included_at));
+                }
 
                 if should_release {
                     inner.decrement_in_flight(&from);
@@ -227,6 +230,16 @@ impl ResultsTracker {
         inner.unreported_confirmations.drain(..).collect()
     }
 
+    /// Drains flashblock latency observations for the rolling window.
+    ///
+    /// Returns `(latency, observed_at)` pairs that feed `record_flashblock_observed`
+    /// on the collector. These are separate from confirmed metrics and do not enter
+    /// the final summary's transaction list.
+    pub fn drain_flashblock_observations(&self) -> Vec<(Duration, Instant)> {
+        let mut inner = self.inner.write();
+        inner.unreported_flashblock_observations.drain(..).collect()
+    }
+
     /// Returns the current pending transaction count.
     pub fn pending_count(&self) -> usize {
         self.inner.read().pending.len()
@@ -261,20 +274,27 @@ impl ResultsTrackerInner {
     /// landing metrics. Idempotent: a tx is removed from `pending` on first landing,
     /// so later blocks containing the same hash are ignored.
     ///
-    /// Flashblock latency is NOT emitted here — it is recorded immediately when the
-    /// tx is first seen in the flashblock WS stream via `on_new_flashblock`.
+    /// Flashblock latency (computed from the WS observation time) is joined here so
+    /// that the final summary only includes FB latency for canonically confirmed txs.
     fn land_if_pending(&mut self, tx_hash: TxHash, block: &BlockObservation) {
         let Some(pending) = self.pending.remove(&tx_hash) else {
             return;
         };
 
         let block_latency = block.observed_at.checked_duration_since(pending.submit_time);
+        let flashblocks_latency = self
+            .flashblocks
+            .remove(&tx_hash)
+            .and_then(|included_at| included_at.checked_duration_since(pending.submit_time));
 
-        // Clean up the flashblock cache entry if present (already emitted).
-        self.flashblocks.remove(&tx_hash);
-
-        let mut metrics =
-            TransactionMetrics::new(tx_hash, block_latency, None, 0, 0, Some(block.number));
+        let mut metrics = TransactionMetrics::new(
+            tx_hash,
+            block_latency,
+            flashblocks_latency,
+            0,
+            0,
+            Some(block.number),
+        );
         metrics.confirmed_at = Some(block.observed_at);
 
         self.landed_blocks.insert(block.number);
@@ -352,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn emits_flashblock_latency_at_ws_observation() {
+    fn flashblock_observation_feeds_rolling_and_joins_at_block_landing() {
         let from = address!("0000000000000000000000000000000000000001");
         let tx_hash = TxHash::repeat_byte(2);
         let tracker = ResultsTracker::new(&[from]);
@@ -364,20 +384,20 @@ mod tests {
             included_at: now + Duration::from_millis(50),
         }]);
 
-        // Flashblock latency emitted immediately — no canonical block needed.
-        let metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(metrics.len(), 1, "FB latency emitted at WS observation");
-        assert!(metrics[0].flashblocks_latency.is_some(), "FB latency must be set");
-        assert!(metrics[0].block_latency.is_none(), "no block latency yet");
-        assert_eq!(metrics[0].block_number, None, "no block number yet");
+        // Flashblock observation goes to separate rolling queue, not confirmed metrics.
+        let confirmed = tracker.drain_confirmed_metrics();
+        assert!(confirmed.is_empty(), "no confirmed metrics until canonical block");
+        let fb_obs = tracker.drain_flashblock_observations();
+        assert_eq!(fb_obs.len(), 1, "one rolling observation from WS");
+        assert!(fb_obs[0].0 >= Duration::from_millis(50), "latency from submit to WS observation");
 
-        // Canonical block landing produces a separate metric without FB latency.
+        // Canonical block landing produces a single metric with FB latency joined.
         tracker.on_new_block_hashes(block_at(8, now + Duration::from_millis(200)), vec![tx_hash]);
-        let block_metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(block_metrics.len(), 1, "block landing still emits its own metric");
-        assert!(block_metrics[0].flashblocks_latency.is_none(), "FB latency not duplicated");
-        assert!(block_metrics[0].block_latency.is_some(), "block latency recorded");
-        assert_eq!(block_metrics[0].block_number, Some(8));
+        let metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(metrics.len(), 1, "exactly one confirmed metric");
+        assert!(metrics[0].flashblocks_latency.is_some(), "FB latency joined from WS time");
+        assert!(metrics[0].block_latency.is_some(), "block latency recorded");
+        assert_eq!(metrics[0].block_number, Some(8));
     }
 
     #[test]
@@ -395,18 +415,17 @@ mod tests {
         assert_eq!(tracker.total_in_flight(), 0, "flashblock should release in-flight slot");
         assert_eq!(tracker.in_flight_for(&from), 0);
 
-        // Drain the flashblock metric emitted immediately.
-        let fb_metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(fb_metrics.len(), 1, "FB metric emitted at WS observation");
-        assert!(fb_metrics[0].flashblocks_latency.is_some());
+        // Flashblock observation is in the rolling queue, not confirmed metrics.
+        assert!(tracker.drain_confirmed_metrics().is_empty());
+        assert_eq!(tracker.drain_flashblock_observations().len(), 1);
 
         let observed_at = Instant::now() + Duration::from_millis(500);
         tracker.on_new_block_hashes(block_at(10, observed_at), vec![tx_hash]);
 
         assert_eq!(tracker.total_in_flight(), 0, "block landing should not double-decrement");
-        let block_metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(block_metrics.len(), 1, "block landing metric still produced");
-        assert!(block_metrics[0].flashblocks_latency.is_none(), "FB latency not on block metric");
+        let metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(metrics.len(), 1, "block landing metric produced");
+        assert!(metrics[0].flashblocks_latency.is_some(), "FB latency joined at landing");
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -133,9 +133,9 @@ impl ResultsTracker {
 
     /// Records transaction inclusions observed from the flashblock stream.
     ///
-    /// When a pending transaction is seen in a flashblock, its in-flight slot is released
-    /// immediately so the sender can submit new transactions without waiting for the slower
-    /// canonical block receipt.
+    /// When a pending transaction is seen in a flashblock, its flashblock latency is
+    /// recorded immediately and its in-flight slot is released so the sender can submit
+    /// new transactions without waiting for the slower canonical block receipt.
     pub fn on_new_flashblock(&self, inclusions: Vec<FlashblockInclusion>) {
         let mut inner = self.inner.write();
 
@@ -145,12 +145,31 @@ impl ResultsTracker {
                 inner.flashblock_eviction_queue.push_back(inclusion.tx_hash);
             }
 
-            if let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash)
-                && !pending.in_flight_released
-            {
-                pending.in_flight_released = true;
+            if let Some(pending) = inner.pending.get_mut(&inclusion.tx_hash) {
+                // Capture fields before releasing the borrow.
+                let submit_time = pending.submit_time;
+                let should_release = !pending.in_flight_released;
                 let from = pending.from;
-                inner.decrement_in_flight(&from);
+                if should_release {
+                    pending.in_flight_released = true;
+                }
+
+                // Emit flashblock latency immediately when seen in the WS stream.
+                let flashblocks_latency =
+                    inclusion.included_at.checked_duration_since(submit_time);
+                let metrics = TransactionMetrics::new(
+                    inclusion.tx_hash,
+                    None,
+                    flashblocks_latency,
+                    0,
+                    0,
+                    None,
+                );
+                inner.unreported_confirmations.push_back(metrics);
+
+                if should_release {
+                    inner.decrement_in_flight(&from);
+                }
             }
         }
 
@@ -241,25 +260,21 @@ impl ResultsTrackerInner {
     /// Records the first observation of `tx_hash` in a polled block, emitting its
     /// landing metrics. Idempotent: a tx is removed from `pending` on first landing,
     /// so later blocks containing the same hash are ignored.
+    ///
+    /// Flashblock latency is NOT emitted here — it is recorded immediately when the
+    /// tx is first seen in the flashblock WS stream via `on_new_flashblock`.
     fn land_if_pending(&mut self, tx_hash: TxHash, block: &BlockObservation) {
         let Some(pending) = self.pending.remove(&tx_hash) else {
             return;
         };
 
         let block_latency = block.observed_at.checked_duration_since(pending.submit_time);
-        let flashblocks_latency = self
-            .flashblocks
-            .remove(&tx_hash)
-            .and_then(|included_at| included_at.checked_duration_since(pending.submit_time));
 
-        let mut metrics = TransactionMetrics::new(
-            tx_hash,
-            block_latency,
-            flashblocks_latency,
-            0,
-            0,
-            Some(block.number),
-        );
+        // Clean up the flashblock cache entry if present (already emitted).
+        self.flashblocks.remove(&tx_hash);
+
+        let mut metrics =
+            TransactionMetrics::new(tx_hash, block_latency, None, 0, 0, Some(block.number));
         metrics.confirmed_at = Some(block.observed_at);
 
         self.landed_blocks.insert(block.number);
@@ -337,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn joins_flashblock_latency() {
+    fn emits_flashblock_latency_at_ws_observation() {
         let from = address!("0000000000000000000000000000000000000001");
         let tx_hash = TxHash::repeat_byte(2);
         let tracker = ResultsTracker::new(&[from]);
@@ -348,11 +363,21 @@ mod tests {
             tx_hash,
             included_at: now + Duration::from_millis(50),
         }]);
-        tracker.on_new_block_hashes(block_at(8, now + Duration::from_millis(200)), vec![tx_hash]);
 
+        // Flashblock latency emitted immediately — no canonical block needed.
         let metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(metrics.len(), 1);
-        assert!(metrics[0].flashblocks_latency.is_some(), "FB latency joined at landing");
+        assert_eq!(metrics.len(), 1, "FB latency emitted at WS observation");
+        assert!(metrics[0].flashblocks_latency.is_some(), "FB latency must be set");
+        assert!(metrics[0].block_latency.is_none(), "no block latency yet");
+        assert_eq!(metrics[0].block_number, None, "no block number yet");
+
+        // Canonical block landing produces a separate metric without FB latency.
+        tracker.on_new_block_hashes(block_at(8, now + Duration::from_millis(200)), vec![tx_hash]);
+        let block_metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(block_metrics.len(), 1, "block landing still emits its own metric");
+        assert!(block_metrics[0].flashblocks_latency.is_none(), "FB latency not duplicated");
+        assert!(block_metrics[0].block_latency.is_some(), "block latency recorded");
+        assert_eq!(block_metrics[0].block_number, Some(8));
     }
 
     #[test]
@@ -370,13 +395,18 @@ mod tests {
         assert_eq!(tracker.total_in_flight(), 0, "flashblock should release in-flight slot");
         assert_eq!(tracker.in_flight_for(&from), 0);
 
+        // Drain the flashblock metric emitted immediately.
+        let fb_metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(fb_metrics.len(), 1, "FB metric emitted at WS observation");
+        assert!(fb_metrics[0].flashblocks_latency.is_some());
+
         let observed_at = Instant::now() + Duration::from_millis(500);
         tracker.on_new_block_hashes(block_at(10, observed_at), vec![tx_hash]);
 
         assert_eq!(tracker.total_in_flight(), 0, "block landing should not double-decrement");
-        let metrics = tracker.drain_confirmed_metrics();
-        assert_eq!(metrics.len(), 1, "metrics should still be produced from block landing");
-        assert!(metrics[0].flashblocks_latency.is_some());
+        let block_metrics = tracker.drain_confirmed_metrics();
+        assert_eq!(block_metrics.len(), 1, "block landing metric still produced");
+        assert!(block_metrics[0].flashblocks_latency.is_none(), "FB latency not on block metric");
     }
 
     #[test]


### PR DESCRIPTION
- load test measures from a black box POV, replicating what clients/users would experience when interacting with our chain
- FB latency should be defined as the moment the tool sees the txhash from the FB WSS. Previously we marked ack when we see from the WSS but only marked the end time on canonical inclusion. FBs are preconfs, so we should using the WSS. It also explains why the metrics of FB and canonical block inclusion were very similar 
- The new fix , along w/ some load test param tuning showed reasonable metrics:

```
load-test === Results ===
load-test TPS: 3110.00 | GPS: 350645186
load-test Block Latency:       min=1.2s  p50=2.6s  mean=2.6s  p95=3.6s  p99=3.9s  max=4.4s
load-test FB Latency:          min=12.1ms  p50=399.0ms  mean=445.8ms  p95=854.5ms  p99=1.0s  max=1.4s  (n=93181)
```