### PR TITLE
test(consensus-engine): guard safe-head preservation, pruned-body startup recovery, and sync-start search

### DIFF
--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -338,11 +338,92 @@ async fn get_block_compat<EngineClient_: EngineClient>(
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::transaction::Recovered;
+    use alloy_eips::BlockId;
     use alloy_eips::BlockNumberOrTag;
     use alloy_json_rpc::ErrorPayload;
+    use alloy_primitives::{Address, B256, b256};
+    use alloy_rpc_types_eth::{Block as RpcBlock, BlockTransactions};
+    use base_common_consensus::{BaseTxEnvelope, TxDeposit};
+    use base_common_genesis::{ChainGenesis, RollupConfig};
+    use base_common_rpc_types::Transaction;
+    use base_protocol::L1BlockInfoBedrock;
+    use rstest::rstest;
 
-    use super::get_block_compat;
+    use super::{find_earliest_unpruned_block, get_block_compat};
+    use crate::SyncStartError;
     use crate::test_utils::{MockL2BlockError, test_engine_client_builder};
+
+    #[derive(Debug, Clone, Copy)]
+    enum PrunedTipScenario {
+        EqualsPrunedAllPruned,
+        PrunedAboveBoundary,
+        BoundaryPlusOne,
+        HealthySeparation,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum PrunedTipExpectation {
+        NoUnprunedBlockAvailable,
+        EarliestUnprunedBlockNumber(u64),
+    }
+
+    fn pruned_tip_rollup_config() -> RollupConfig {
+        RollupConfig {
+            genesis: ChainGenesis {
+                l1: alloy_eips::BlockNumHash {
+                    number: 0,
+                    hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+                },
+                l2: alloy_eips::BlockNumHash {
+                    number: 0,
+                    hash: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+                },
+                l2_time: 0,
+                system_config: None,
+            },
+            ..Default::default()
+        }
+    }
+
+    fn l1_info_rpc_transaction(block_number: u64) -> Transaction {
+        let envelope = BaseTxEnvelope::Deposit(alloy_primitives::Sealed::new_unchecked(
+            TxDeposit {
+                input: L1BlockInfoBedrock::default().encode_calldata(),
+                ..Default::default()
+            },
+            B256::ZERO,
+        ));
+        Transaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: Recovered::new_unchecked(envelope, Address::ZERO),
+                block_hash: None,
+                block_number: Some(block_number),
+                block_timestamp: None,
+                effective_gas_price: Some(0),
+                transaction_index: Some(0),
+            },
+            deposit_nonce: None,
+            deposit_receipt_version: None,
+        }
+    }
+
+    fn pruned_tip_block(number: u64, parent_hash: B256, has_l1_info: bool) -> RpcBlock<Transaction> {
+        let mut block = RpcBlock::<Transaction>::default();
+        block.header.inner.number = number;
+        block.header.inner.parent_hash = parent_hash;
+        block.header.inner.timestamp = number;
+        block.transactions = if has_l1_info {
+            BlockTransactions::Full(vec![l1_info_rpc_transaction(number)])
+        } else {
+            BlockTransactions::Full(vec![])
+        };
+        block
+    }
+
+    fn pruned_tip_parent_hash(number: u64) -> B256 {
+        B256::from([number as u8; 32])
+    }
 
     #[tokio::test]
     async fn get_block_compat_eip4444_error_code_returns_none() {
@@ -386,5 +467,118 @@ mod tests {
 
         let err = get_block_compat(&client, BlockNumberOrTag::Latest.into()).await.unwrap_err();
         assert!(err.to_string().contains("connection refused"));
+    }
+
+    #[rstest]
+    #[case::latest_equals_pruned_all_pruned(
+        PrunedTipScenario::EqualsPrunedAllPruned,
+        10,
+        PrunedTipExpectation::NoUnprunedBlockAvailable
+    )]
+    #[case::latest_pruned_above_boundary(
+        PrunedTipScenario::PrunedAboveBoundary,
+        10,
+        PrunedTipExpectation::NoUnprunedBlockAvailable
+    )]
+    #[case::latest_is_boundary_plus_one(
+        PrunedTipScenario::BoundaryPlusOne,
+        10,
+        PrunedTipExpectation::EarliestUnprunedBlockNumber(11)
+    )]
+    #[case::latest_healthy_separation(
+        PrunedTipScenario::HealthySeparation,
+        10,
+        PrunedTipExpectation::EarliestUnprunedBlockNumber(13)
+    )]
+    #[tokio::test]
+    async fn find_earliest_unpruned_block_boundary_cases(
+        #[case] scenario: PrunedTipScenario,
+        #[case] pruned_block_number: u64,
+        #[case] expected: PrunedTipExpectation,
+    ) {
+        let cfg = pruned_tip_rollup_config();
+
+        let mut client_builder = test_engine_client_builder();
+
+        let latest_number = match scenario {
+            PrunedTipScenario::EqualsPrunedAllPruned => {
+                let latest = pruned_tip_block(10, pruned_tip_parent_hash(9), false);
+                client_builder = client_builder
+                    .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest)
+                    .with_l2_block(
+                        BlockId::Number(10u64.into()),
+                        pruned_tip_block(10, pruned_tip_parent_hash(9), false),
+                );
+                10
+            }
+            PrunedTipScenario::PrunedAboveBoundary => {
+                let latest = pruned_tip_block(14, pruned_tip_parent_hash(13), false);
+                client_builder = client_builder
+                    .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest)
+                    .with_l2_block(
+                        BlockId::Number(12u64.into()),
+                        pruned_tip_block(12, pruned_tip_parent_hash(11), false),
+                    )
+                    .with_l2_block(
+                        BlockId::Number(13u64.into()),
+                        pruned_tip_block(13, pruned_tip_parent_hash(12), false),
+                    );
+                14
+            }
+            PrunedTipScenario::BoundaryPlusOne => {
+                let latest = pruned_tip_block(11, pruned_tip_parent_hash(10), true);
+                client_builder = client_builder
+                    .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest)
+                    .with_l2_block(
+                        BlockId::Number(10u64.into()),
+                        pruned_tip_block(10, pruned_tip_parent_hash(9), false),
+                    );
+                11
+            }
+            PrunedTipScenario::HealthySeparation => {
+                let latest = pruned_tip_block(14, pruned_tip_parent_hash(13), true);
+                client_builder = client_builder
+                    .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest)
+                    .with_l2_block(
+                        BlockId::Number(12u64.into()),
+                        pruned_tip_block(12, pruned_tip_parent_hash(11), false),
+                    )
+                    .with_l2_block(
+                        BlockId::Number(13u64.into()),
+                        pruned_tip_block(13, pruned_tip_parent_hash(12), true),
+                    );
+                14
+            }
+        };
+
+        let client = client_builder.build();
+
+        let result = find_earliest_unpruned_block(&cfg, &client, pruned_block_number).await;
+
+        match expected {
+            PrunedTipExpectation::NoUnprunedBlockAvailable => {
+                // Startup liveness: binary search must terminate and surface
+                // `NoUnprunedBlockAvailable` (not `MissingL1InfoDeposit`) when no
+                // unpruned upper bound exists.
+                let err = result.expect_err("expected no unpruned block to be available");
+                assert!(
+                    matches!(
+                        err,
+                        SyncStartError::NoUnprunedBlockAvailable {
+                            pruned_block_number: p,
+                            latest_block_number: l,
+                        } if p == pruned_block_number && l == latest_number
+                    ),
+                    "expected SyncStartError::NoUnprunedBlockAvailable, got: {err:?}"
+                );
+            }
+            PrunedTipExpectation::EarliestUnprunedBlockNumber(expected_number) => {
+                // Startup liveness: boundary conditions (`pruned + 1` and wider
+                // separations) must still return the earliest unpruned block, proving the
+                // search guard is not overly conservative.
+                let block = result.expect("expected earliest unpruned block");
+                assert_eq!(block.block_info.number, expected_number);
+            }
+        }
     }
 }

--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -408,7 +408,11 @@ mod tests {
         }
     }
 
-    fn pruned_tip_block(number: u64, parent_hash: B256, has_l1_info: bool) -> RpcBlock<Transaction> {
+    fn pruned_tip_block(
+        number: u64,
+        parent_hash: B256,
+        has_l1_info: bool,
+    ) -> RpcBlock<Transaction> {
         let mut block = RpcBlock::<Transaction>::default();
         block.header.inner.number = number;
         block.header.inner.parent_hash = parent_hash;
@@ -508,7 +512,7 @@ mod tests {
                     .with_l2_block(
                         BlockId::Number(10u64.into()),
                         pruned_tip_block(10, pruned_tip_parent_hash(9), false),
-                );
+                    );
                 10
             }
             PrunedTipScenario::PrunedAboveBoundary => {

--- a/crates/consensus/engine/src/sync/forkchoice.rs
+++ b/crates/consensus/engine/src/sync/forkchoice.rs
@@ -339,8 +339,7 @@ async fn get_block_compat<EngineClient_: EngineClient>(
 #[cfg(test)]
 mod tests {
     use alloy_consensus::transaction::Recovered;
-    use alloy_eips::BlockId;
-    use alloy_eips::BlockNumberOrTag;
+    use alloy_eips::{BlockId, BlockNumberOrTag};
     use alloy_json_rpc::ErrorPayload;
     use alloy_primitives::{Address, B256, b256};
     use alloy_rpc_types_eth::{Block as RpcBlock, BlockTransactions};
@@ -351,8 +350,10 @@ mod tests {
     use rstest::rstest;
 
     use super::{find_earliest_unpruned_block, get_block_compat};
-    use crate::SyncStartError;
-    use crate::test_utils::{MockL2BlockError, test_engine_client_builder};
+    use crate::{
+        SyncStartError,
+        test_utils::{MockL2BlockError, test_engine_client_builder},
+    };
 
     #[derive(Debug, Clone, Copy)]
     enum PrunedTipScenario {

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -249,7 +249,10 @@ mod tests {
             block_info: BlockInfo::from(
                 &block.clone().into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
             ),
-            l1_origin: BlockNumHash { number: 1, hash: b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") },
+            l1_origin: BlockNumHash {
+                number: 1,
+                hash: b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            },
             seq_num: 0,
         }
     }
@@ -343,22 +346,25 @@ mod tests {
             ..Default::default()
         };
 
-        let finalized_labeled_pruned =
-            l2_block_without_l1_info(10, b256!("0303030303030303030303030303030303030303030303030303030303030303"));
+        let finalized_labeled_pruned = l2_block_without_l1_info(
+            10,
+            b256!("0303030303030303030303030303030303030303030303030303030303030303"),
+        );
         let safe_labeled_pruned = l2_block_without_l1_info(
             11,
             finalized_labeled_pruned.clone().into_consensus().hash_slow(),
         );
         let safe_labeled_hash = safe_labeled_pruned.clone().into_consensus().hash_slow();
-        let middle_unpruned = l2_block_with_l1_info(11, b256!("0404040404040404040404040404040404040404040404040404040404040404"));
+        let middle_unpruned = l2_block_with_l1_info(
+            11,
+            b256!("0404040404040404040404040404040404040404040404040404040404040404"),
+        );
         let latest_unpruned = l2_block_with_l1_info(12, safe_labeled_hash);
 
         let checkpoint_safe = checkpoint_from_header(&safe_labeled_pruned);
         let checkpoint_finalized = checkpoint_from_header(&finalized_labeled_pruned);
-        let checkpoint_reader = ScriptedCheckpointReader {
-            safe: checkpoint_safe,
-            finalized: checkpoint_finalized,
-        };
+        let checkpoint_reader =
+            ScriptedCheckpointReader { safe: checkpoint_safe, finalized: checkpoint_finalized };
 
         let client = Arc::new(
             test_engine_client_builder()
@@ -392,7 +398,8 @@ mod tests {
         };
 
         if use_scripted_checkpoint_reader {
-            let forkchoice = result.expect("scripted checkpoint reader should recover pruned labels");
+            let forkchoice =
+                result.expect("scripted checkpoint reader should recover pruned labels");
             assert_eq!(forkchoice.safe, checkpoint_safe);
             assert_eq!(forkchoice.finalized, checkpoint_finalized);
         } else {

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -155,6 +155,8 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_consensus::transaction::Recovered;
     use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
     use alloy_primitives::{Address, B256, Sealed, b256};
@@ -162,12 +164,15 @@ mod tests {
     use alloy_rpc_types_eth::{
         Block as RpcBlock, BlockTransactions, Transaction as EthTransaction,
     };
+    use async_trait::async_trait;
     use base_common_consensus::{BaseTxEnvelope, TxDeposit};
     use base_common_genesis::ChainGenesis;
     use base_common_network::Base;
     use base_common_rpc_types::Transaction as BaseTransaction;
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
+    use rstest::rstest;
 
+    use super::{ForkchoiceCheckpointLabel, ForkchoiceCheckpointReader, SyncStartError};
     use crate::test_utils::test_engine_client_builder;
 
     const BASE_SEPOLIA_GENESIS_HASH: B256 =
@@ -230,6 +235,45 @@ mod tests {
         block
     }
 
+    fn l2_block_without_l1_info(number: u64, parent_hash: B256) -> RpcBlock<BaseTransaction> {
+        let mut block = RpcBlock::<BaseTransaction>::default();
+        block.header.inner.number = number;
+        block.header.inner.parent_hash = parent_hash;
+        block.header.inner.timestamp = number;
+        block.transactions = BlockTransactions::Full(vec![]);
+        block
+    }
+
+    fn checkpoint_from_header(block: &RpcBlock<BaseTransaction>) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo::from(
+                &block.clone().into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()),
+            ),
+            l1_origin: BlockNumHash { number: 1, hash: b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") },
+            seq_num: 0,
+        }
+    }
+
+    #[derive(Debug)]
+    struct ScriptedCheckpointReader {
+        safe: L2BlockInfo,
+        finalized: L2BlockInfo,
+    }
+
+    #[async_trait]
+    impl ForkchoiceCheckpointReader for ScriptedCheckpointReader {
+        async fn checkpoint(
+            &self,
+            label: ForkchoiceCheckpointLabel,
+        ) -> Result<Option<L2BlockInfo>, super::ForkchoiceCheckpointError> {
+            let checkpoint = match label {
+                ForkchoiceCheckpointLabel::Safe => self.safe,
+                ForkchoiceCheckpointLabel::Finalized => self.finalized,
+            };
+            Ok(Some(checkpoint))
+        }
+    }
+
     #[tokio::test]
     async fn current_uses_config_genesis_when_finalized_label_is_unavailable() {
         let rollup_config = base_common_genesis::RollupConfig {
@@ -272,5 +316,88 @@ mod tests {
         assert_eq!(forkchoice.un_safe.block_info.hash, latest_hash);
         assert_eq!(forkchoice.safe, expected_genesis);
         assert_eq!(forkchoice.finalized, expected_genesis);
+    }
+
+    #[rstest]
+    #[case::noop_reader_errs(false)]
+    #[case::scripted_reader_recovers(true)]
+    #[tokio::test]
+    async fn recover_pruned_safe_finalized_via_checkpoint_reader(
+        #[case] use_scripted_checkpoint_reader: bool,
+    ) {
+        // Design decision: existing `MockEngineClient` is sufficient because this test only needs
+        // deterministic per-method responses and not call-order assertions.
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: BlockNumHash {
+                    number: 0,
+                    hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+                },
+                l2: BlockNumHash {
+                    number: 0,
+                    hash: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+                },
+                l2_time: 0,
+                system_config: None,
+            },
+            ..Default::default()
+        };
+
+        let finalized_labeled_pruned =
+            l2_block_without_l1_info(10, b256!("0303030303030303030303030303030303030303030303030303030303030303"));
+        let safe_labeled_pruned = l2_block_without_l1_info(
+            11,
+            finalized_labeled_pruned.clone().into_consensus().hash_slow(),
+        );
+        let safe_labeled_hash = safe_labeled_pruned.clone().into_consensus().hash_slow();
+        let middle_unpruned = l2_block_with_l1_info(11, b256!("0404040404040404040404040404040404040404040404040404040404040404"));
+        let latest_unpruned = l2_block_with_l1_info(12, safe_labeled_hash);
+
+        let checkpoint_safe = checkpoint_from_header(&safe_labeled_pruned);
+        let checkpoint_finalized = checkpoint_from_header(&finalized_labeled_pruned);
+        let checkpoint_reader = ScriptedCheckpointReader {
+            safe: checkpoint_safe,
+            finalized: checkpoint_finalized,
+        };
+
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest_unpruned)
+                .with_l2_block(BlockId::Number(BlockNumberOrTag::Safe), safe_labeled_pruned.clone())
+                .with_l2_block(
+                    BlockId::Number(BlockNumberOrTag::Finalized),
+                    finalized_labeled_pruned.clone(),
+                )
+                .with_l2_block(BlockId::Number(10u64.into()), finalized_labeled_pruned)
+                .with_l2_block(BlockId::Number(11u64.into()), middle_unpruned)
+                .with_l2_block(BlockId::Hash(safe_labeled_hash.into()), safe_labeled_pruned)
+                .with_l1_block(BlockId::from(B256::ZERO), RpcBlock::<EthTransaction>::default())
+                .build(),
+        );
+
+        let result = if use_scripted_checkpoint_reader {
+            super::find_starting_forkchoice_with_checkpoint_reader(
+                &rollup_config,
+                client.as_ref(),
+                &checkpoint_reader,
+            )
+            .await
+        } else {
+            super::find_starting_forkchoice_with_checkpoint_reader(
+                &rollup_config,
+                client.as_ref(),
+                &super::NoopForkchoiceCheckpointReader,
+            )
+            .await
+        };
+
+        if use_scripted_checkpoint_reader {
+            let forkchoice = result.expect("scripted checkpoint reader should recover pruned labels");
+            assert_eq!(forkchoice.safe, checkpoint_safe);
+            assert_eq!(forkchoice.finalized, checkpoint_finalized);
+        } else {
+            let err = result.expect_err("noop checkpoint reader should fail pruned recovery path");
+            assert!(matches!(err, SyncStartError::FromBlock(_)), "unexpected error: {err:?}");
+        }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task_test.rs
@@ -303,10 +303,7 @@ async fn syncing_then_valid_advances_state_on_second_call() {
     assert!(state.el_sync_finished);
 }
 
-mod tests {
-    use super::*;
-
-    mod forkchoice_update_commit_policy {
+mod forkchoice_update_commit_policy {
     //! Design decision: `MockEngineClient` is sufficient here because we only need one
     //! scripted `fork_choice_updated_v3` response per execution and no call-sequence
     //! assertions or per-call response queueing.
@@ -540,6 +537,5 @@ mod tests {
                 }
             }
         }
-    }
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task_test.rs
@@ -2,8 +2,10 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
 use base_common_genesis::RollupConfig;
+use rstest::rstest;
 
 use crate::{
     EngineTaskExt, SynchronizeTask,
@@ -24,6 +26,16 @@ fn syncing_fcu() -> ForkchoiceUpdated {
 fn valid_fcu() -> ForkchoiceUpdated {
     ForkchoiceUpdated {
         payload_status: PayloadStatus { status: PayloadStatusEnum::Valid, latest_valid_hash: None },
+        payload_id: None,
+    }
+}
+
+fn invalid_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus {
+            status: PayloadStatusEnum::Invalid { validation_error: "test-invalid".into() },
+            latest_valid_hash: Some(B256::ZERO),
+        },
         payload_id: None,
     }
 }
@@ -289,4 +301,245 @@ async fn syncing_then_valid_advances_state_on_second_call() {
         "unsafe_head must advance after Valid"
     );
     assert!(state.el_sync_finished);
+}
+
+mod tests {
+    use super::*;
+
+    mod forkchoice_update_commit_policy {
+    //! Design decision: `MockEngineClient` is sufficient here because we only need one
+    //! scripted `fork_choice_updated_v3` response per execution and no call-sequence
+    //! assertions or per-call response queueing.
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy)]
+    enum ElResponse {
+        Valid,
+        Syncing,
+        Invalid,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct SyncUpdateCase {
+        update: EngineSyncStateUpdate,
+        expected_valid_unsafe_number: u64,
+        expected_syncing_safe_number_when_allowed: u64,
+        expected_syncing_local_safe_number_when_allowed: u64,
+        expected_syncing_finalized_number_when_allowed: u64,
+    }
+
+    const INITIAL_UNSAFE_NUMBER: u64 = 100;
+    const INITIAL_LOCAL_SAFE_NUMBER: u64 = 89;
+    const INITIAL_SAFE_NUMBER: u64 = 89;
+    const INITIAL_FINALIZED_NUMBER: u64 = 88;
+
+    fn update_case_safe_only() -> SyncUpdateCase {
+        SyncUpdateCase {
+            update: EngineSyncStateUpdate {
+                safe_head: Some(test_block_info(90)),
+                ..Default::default()
+            },
+            expected_valid_unsafe_number: INITIAL_UNSAFE_NUMBER,
+            expected_syncing_safe_number_when_allowed: 90,
+            expected_syncing_local_safe_number_when_allowed: INITIAL_LOCAL_SAFE_NUMBER,
+            expected_syncing_finalized_number_when_allowed: INITIAL_FINALIZED_NUMBER,
+        }
+    }
+
+    fn update_case_safe_and_local_safe() -> SyncUpdateCase {
+        SyncUpdateCase {
+            update: EngineSyncStateUpdate {
+                local_safe_head: Some(test_block_info(91)),
+                safe_head: Some(test_block_info(91)),
+                ..Default::default()
+            },
+            expected_valid_unsafe_number: INITIAL_UNSAFE_NUMBER,
+            expected_syncing_safe_number_when_allowed: 91,
+            expected_syncing_local_safe_number_when_allowed: 91,
+            expected_syncing_finalized_number_when_allowed: INITIAL_FINALIZED_NUMBER,
+        }
+    }
+
+    fn update_case_safe_local_safe_finalized() -> SyncUpdateCase {
+        SyncUpdateCase {
+            update: EngineSyncStateUpdate {
+                local_safe_head: Some(test_block_info(92)),
+                safe_head: Some(test_block_info(92)),
+                finalized_head: Some(test_block_info(92)),
+                ..Default::default()
+            },
+            expected_valid_unsafe_number: INITIAL_UNSAFE_NUMBER,
+            expected_syncing_safe_number_when_allowed: 92,
+            expected_syncing_local_safe_number_when_allowed: 92,
+            expected_syncing_finalized_number_when_allowed: 92,
+        }
+    }
+
+    fn update_case_composite_with_unsafe() -> SyncUpdateCase {
+        SyncUpdateCase {
+            update: EngineSyncStateUpdate {
+                unsafe_head: Some(test_block_info(101)),
+                local_safe_head: Some(test_block_info(93)),
+                safe_head: Some(test_block_info(93)),
+                finalized_head: Some(test_block_info(93)),
+            },
+            expected_valid_unsafe_number: 101,
+            expected_syncing_safe_number_when_allowed: 93,
+            expected_syncing_local_safe_number_when_allowed: 93,
+            expected_syncing_finalized_number_when_allowed: 93,
+        }
+    }
+
+    fn fcu_for(response: ElResponse) -> ForkchoiceUpdated {
+        match response {
+            ElResponse::Valid => valid_fcu(),
+            ElResponse::Syncing => syncing_fcu(),
+            ElResponse::Invalid => invalid_fcu(),
+        }
+    }
+
+    #[rstest]
+    #[case::safe_only_valid(update_case_safe_only(), ElResponse::Valid, true)]
+    #[case::safe_only_syncing_el_synced(update_case_safe_only(), ElResponse::Syncing, true)]
+    #[case::safe_only_syncing_el_not_synced(update_case_safe_only(), ElResponse::Syncing, false)]
+    #[case::safe_only_invalid(update_case_safe_only(), ElResponse::Invalid, true)]
+    #[case::safe_local_valid(update_case_safe_and_local_safe(), ElResponse::Valid, true)]
+    #[case::safe_local_syncing_el_synced(
+        update_case_safe_and_local_safe(),
+        ElResponse::Syncing,
+        true
+    )]
+    #[case::safe_local_syncing_el_not_synced(
+        update_case_safe_and_local_safe(),
+        ElResponse::Syncing,
+        false
+    )]
+    #[case::safe_local_invalid(update_case_safe_and_local_safe(), ElResponse::Invalid, true)]
+    #[case::safe_local_finalized_valid(
+        update_case_safe_local_safe_finalized(),
+        ElResponse::Valid,
+        true
+    )]
+    #[case::safe_local_finalized_syncing_el_synced(
+        update_case_safe_local_safe_finalized(),
+        ElResponse::Syncing,
+        true
+    )]
+    #[case::safe_local_finalized_syncing_el_not_synced(
+        update_case_safe_local_safe_finalized(),
+        ElResponse::Syncing,
+        false
+    )]
+    #[case::safe_local_finalized_invalid(
+        update_case_safe_local_safe_finalized(),
+        ElResponse::Invalid,
+        true
+    )]
+    #[case::composite_with_unsafe_valid(
+        update_case_composite_with_unsafe(),
+        ElResponse::Valid,
+        true
+    )]
+    #[case::composite_with_unsafe_syncing_el_synced(
+        update_case_composite_with_unsafe(),
+        ElResponse::Syncing,
+        true
+    )]
+    #[case::composite_with_unsafe_syncing_el_not_synced(
+        update_case_composite_with_unsafe(),
+        ElResponse::Syncing,
+        false
+    )]
+    #[case::composite_with_unsafe_invalid(
+        update_case_composite_with_unsafe(),
+        ElResponse::Invalid,
+        true
+    )]
+    #[tokio::test]
+    async fn forkchoice_update_commit_policy_matrix(
+        #[case] update_case: SyncUpdateCase,
+        #[case] response: ElResponse,
+        #[case] el_sync_finished: bool,
+    ) {
+        let cfg = Arc::new(RollupConfig::default());
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_fork_choice_updated_v3_response(fcu_for(response))
+                .build(),
+        );
+
+        let mut state = TestEngineStateBuilder::new()
+            .with_unsafe_head(test_block_info(INITIAL_UNSAFE_NUMBER))
+            .with_safe_head(test_block_info(INITIAL_SAFE_NUMBER))
+            .with_finalized_head(test_block_info(INITIAL_FINALIZED_NUMBER))
+            .with_el_sync_finished(el_sync_finished)
+            .build();
+        state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+            local_safe_head: Some(test_block_info(INITIAL_LOCAL_SAFE_NUMBER)),
+            ..Default::default()
+        });
+        let pre_state = state;
+
+        let task = SynchronizeTask::new(client, cfg, update_case.update);
+        let result = task.execute(&mut state).await;
+
+        match response {
+            ElResponse::Valid => {
+                assert!(result.is_ok());
+                assert_eq!(
+                    state.sync_state.unsafe_head().block_info.number,
+                    update_case.expected_valid_unsafe_number
+                );
+                assert_eq!(
+                    state.sync_state.safe_head().block_info.number,
+                    update_case.expected_syncing_safe_number_when_allowed
+                );
+                assert_eq!(
+                    state.sync_state.local_safe_head().block_info.number,
+                    update_case.expected_syncing_local_safe_number_when_allowed
+                );
+                assert_eq!(
+                    state.sync_state.finalized_head().block_info.number,
+                    update_case.expected_syncing_finalized_number_when_allowed
+                );
+            }
+            ElResponse::Invalid => {
+                assert!(result.is_err());
+                assert_eq!(state.sync_state, pre_state.sync_state);
+            }
+            ElResponse::Syncing => {
+                assert!(result.is_ok());
+                assert!(
+                    state.sync_state.unsafe_head().block_info.number
+                        <= pre_state.sync_state.unsafe_head().block_info.number
+                );
+                if el_sync_finished {
+                    assert_eq!(
+                        state.sync_state.safe_head().block_info.number,
+                        update_case.expected_syncing_safe_number_when_allowed
+                    );
+                    assert_eq!(
+                        state.sync_state.local_safe_head().block_info.number,
+                        update_case.expected_syncing_local_safe_number_when_allowed
+                    );
+                    assert_eq!(
+                        state.sync_state.finalized_head().block_info.number,
+                        update_case.expected_syncing_finalized_number_when_allowed
+                    );
+                } else {
+                    assert_eq!(state.sync_state.safe_head().block_info.number, INITIAL_SAFE_NUMBER);
+                    assert_eq!(
+                        state.sync_state.local_safe_head().block_info.number,
+                        INITIAL_LOCAL_SAFE_NUMBER
+                    );
+                    assert_eq!(
+                        state.sync_state.finalized_head().block_info.number,
+                        INITIAL_FINALIZED_NUMBER
+                    );
+                }
+            }
+        }
+    }
+    }
 }


### PR DESCRIPTION
## What

Adds regression tests to `base-consensus-engine` that lock in three CL/EL correctness guarantees. Each test reproduces a real failure mode that was fixed previously but had no dedicated guard against reintroduction. Test-only — no production behavior changes.

### 1. Safe head is preserved across a `Syncing` forkchoice update
When consolidation produces a composite sync-state update (advancing safe/local-safe/finalized together) and the EL replies `Syncing` to the forkchoice update, the already-consolidated safe-head advance must **not** be silently discarded. Dropping it strands derivation waiting forever for a confirmation of a safe head that was thrown away — a validator wedge.
`task_queue/tasks/synchronize/task_test.rs`: a 16-case matrix over (update shape × EL response × `el_sync_finished`). Bisect-proven: on the pre-fix parent the four `Syncing + el_sync_finished` cases fail with the exact stale-safe-head signature.

### 2. Startup recovery when the EL has pruned block bodies
On boot, if the EL has pruned the body of the block the CL wants to start from, sync-start must fall back to a forkchoice checkpoint reader and cross-validate, rather than erroring out.
`sync/mod.rs`: `NoopForkchoiceCheckpointReader` errors as expected; a scripted `ForkchoiceCheckpointReader` recovers the correct forkchoice.

### 3. Sync-start block search handles pruned tips
The binary search that locates the earliest unpruned block must handle boundary conditions (latest == pruned boundary, latest itself pruned, off-by-one above the boundary) without misreporting.
`sync/forkchoice.rs`: 4 corner-case tests.

## Verification
- `cargo clippy -p base-consensus-engine --all-targets -- -D warnings` — clean
- `cargo test -p base-consensus-engine --tests` — **132 passed, 0 failed, 0 ignored**

<sub>Provenance: guards the fixes originally shipped in #3803 (safe-head preservation), #2698 (pruned-body startup recovery), and #2967 (sync-start search hardening).</sub>

Draft — part of a CL/EL invariant-testing effort.
