### PR TITLE
fix(consensus-engine): reset on invalid forkchoice status instead of wedging

### DIFF
--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -138,13 +138,6 @@ pub struct EngineState {
 
     /// Whether or not the EL has finished syncing.
     pub el_sync_finished: bool,
-
-    /// Track when the rollup node changes the forkchoice to restore previous
-    /// known unsafe chain. e.g. Unsafe Reorg caused by Invalid span batch.
-    /// This update does not retry except engine returns non-input error
-    /// because engine may forgot backupUnsafeHead or backupUnsafeHead is not part
-    /// of the chain.
-    pub need_fcu_call_backup_unsafe_reorg: bool,
 }
 
 impl EngineState {

--- a/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
@@ -183,7 +183,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case::holocene_invalid_flush(SealTaskError::HoloceneInvalidFlush, EngineTaskErrorSeverity::Flush)]
+    #[case::holocene_invalid_flush(
+        SealTaskError::HoloceneInvalidFlush,
+        EngineTaskErrorSeverity::Flush
+    )]
     #[case::unsafe_head_changed(
         SealTaskError::UnsafeHeadChangedSinceBuild,
         EngineTaskErrorSeverity::Reset
@@ -195,6 +198,22 @@ mod tests {
     #[case::deposit_only_failed(
         SealTaskError::DepositOnlyPayloadFailed,
         EngineTaskErrorSeverity::Critical
+    )]
+    #[case::deposit_only_reattempt_failed(
+        SealTaskError::DepositOnlyPayloadReattemptFailed,
+        EngineTaskErrorSeverity::Critical
+    )]
+    #[case::from_block(
+        SealTaskError::FromBlock(FromBlockError::InvalidGenesisHash),
+        EngineTaskErrorSeverity::Critical
+    )]
+    #[case::clock_went_backwards(
+        SealTaskError::ClockWentBackwards,
+        EngineTaskErrorSeverity::Critical
+    )]
+    #[case::unexpected_payload_version(
+        SealTaskError::UnexpectedPayloadVersion("V3".to_string()),
+        EngineTaskErrorSeverity::Temporary
     )]
     fn seal_task_error_severity(
         #[case] error: SealTaskError,

--- a/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
@@ -181,4 +181,25 @@ mod tests {
         let err = SealTaskError::PayloadInsertionFailed(Box::new(insert_err));
         assert_eq!(err.is_fatal(), expected);
     }
+
+    #[rstest]
+    #[case::holocene_invalid_flush(SealTaskError::HoloceneInvalidFlush, EngineTaskErrorSeverity::Flush)]
+    #[case::unsafe_head_changed(
+        SealTaskError::UnsafeHeadChangedSinceBuild,
+        EngineTaskErrorSeverity::Reset
+    )]
+    #[case::get_payload_failed(
+        SealTaskError::GetPayloadFailed(rpc_error()),
+        EngineTaskErrorSeverity::Temporary
+    )]
+    #[case::deposit_only_failed(
+        SealTaskError::DepositOnlyPayloadFailed,
+        EngineTaskErrorSeverity::Critical
+    )]
+    fn seal_task_error_severity(
+        #[case] error: SealTaskError,
+        #[case] expected: EngineTaskErrorSeverity,
+    ) {
+        assert_eq!(error.severity(), expected);
+    }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/error.rs
@@ -27,10 +27,50 @@ impl EngineTaskError for SynchronizeTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::FinalizedAheadOfUnsafe(_, _) => EngineTaskErrorSeverity::Critical,
-            Self::ForkchoiceUpdateFailed(_) | Self::UnexpectedPayloadStatus(_) => {
-                EngineTaskErrorSeverity::Temporary
+            // Transient RPC failure: retry the forkchoice call in place.
+            Self::ForkchoiceUpdateFailed(_) => EngineTaskErrorSeverity::Temporary,
+            // An INVALID forkchoice status means the engine rejected the current head (a poisoned
+            // unsafe head). Retrying in place wedges derivation forever, so escalate to a reset,
+            // which re-discovers a canonical head from the EL. Mirrors op-node's
+            // `tryUpdateEngineInternal`, which maps a non-VALID forkchoice status to a reset.
+            Self::UnexpectedPayloadStatus(_) | Self::InvalidForkchoiceState => {
+                EngineTaskErrorSeverity::Reset
             }
-            Self::InvalidForkchoiceState => EngineTaskErrorSeverity::Reset,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_rpc_types_engine::PayloadStatusEnum;
+    use alloy_transport::RpcError;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::finalized_ahead_of_unsafe(
+        SynchronizeTaskError::FinalizedAheadOfUnsafe(10, 5),
+        EngineTaskErrorSeverity::Critical
+    )]
+    #[case::rpc_failure_is_temporary(
+        SynchronizeTaskError::ForkchoiceUpdateFailed(RpcError::local_usage_str("test")),
+        EngineTaskErrorSeverity::Temporary
+    )]
+    #[case::invalid_forkchoice_state_resets(
+        SynchronizeTaskError::InvalidForkchoiceState,
+        EngineTaskErrorSeverity::Reset
+    )]
+    #[case::invalid_payload_status_resets(
+        SynchronizeTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid {
+            validation_error: String::new(),
+        }),
+        EngineTaskErrorSeverity::Reset
+    )]
+    fn severity_escalates_invalid_forkchoice_to_reset(
+        #[case] error: SynchronizeTaskError,
+        #[case] expected: EngineTaskErrorSeverity,
+    ) {
+        assert_eq!(error.severity(), expected);
     }
 }


### PR DESCRIPTION
## Root cause

The sequencer produced a block with a receipt-root mismatch (2026-06-25 mainnet incident, block 47806543). Validators' EL permanently flagged that block and all its descendants as invalid. The validator's unsafe head had already advanced onto that chain via P2P gossip, so every forkchoice update carried the poisoned head and the EL returned `INVALID` on every call.

kona classified `INVALID` forkchoice status as **`Temporary`**, so the engine retried the same forkchoice forever. Safe head froze at 47806526, derivation stalled in `AwaitingSafeHeadConfirmation`, and the node never self-recovered — production required manual per-node restarts to wipe the EL's in-memory invalid-ancestors set.

## Fix

Escalate `SynchronizeTaskError::UnexpectedPayloadStatus` and `InvalidForkchoiceState` from `Temporary` to **`Reset`**. A reset re-discovers a canonical head from the EL (`find_starting_forkchoice`) below the poisoned block, and derivation resumes. Transient RPC failures (`ForkchoiceUpdateFailed`) stay `Temporary`.

This mirrors op-node's `tryUpdateEngineInternal`, which maps a non-`VALID` forkchoice status to a reset.

Also removes the dead `need_fcu_call_backup_unsafe_reorg` field from `EngineState` (never read anywhere in production) and adds exhaustive severity tests for `SynchronizeTaskError` and `SealTaskError`.

## Tests

- `severity_escalates_invalid_forkchoice_to_reset` (4 cases) — invalid payload status/forkchoice-state → Reset; RPC failure → Temporary; finalized-ahead → Critical.
- `seal_task_error_severity` (8 cases) — exhaustive severity coverage for all non-delegating seal error variants.
