### PR TITLE
feat(telemetry): add external EL reachability checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6399,11 +6399,19 @@ dependencies = [
 name = "base-telemetry-service"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
+ "async-trait",
  "axum 0.8.9",
  "base-health",
  "clap",
+ "ipnet",
  "reqwest 0.13.4",
+ "reth-ecies",
+ "reth-eth-wire",
+ "secp256k1 0.30.0",
+ "serde",
+ "serial_test",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6408,6 +6408,7 @@ dependencies = [
  "reqwest 0.13.4",
  "reth-ecies",
  "reth-eth-wire",
+ "reth-network-peers",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6412,6 +6412,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serial_test",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6405,7 +6405,6 @@ dependencies = [
  "axum 0.8.9",
  "base-health",
  "clap",
- "ipnet",
  "reqwest 0.13.4",
  "reth-ecies",
  "reth-eth-wire",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6411,7 +6411,6 @@ dependencies = [
  "reth-eth-wire",
  "secp256k1 0.30.0",
  "serde",
- "serial_test",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,7 +344,9 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
+reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-codecs = { version = "0.4.1", default-features = false, features = ["alloy"] }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }

--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -17,17 +17,16 @@ reachability check:
 curl --ipv4 https://telemetry.example/v1/p2p/reachability/el \
   --header 'content-type: application/json' \
   --data '{
-    "nodeId": "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4",
-    "tcpPort": 30303,
-    "addressFamily": "ipv4"
+    "enode": "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@203.0.113.7:30303"
   }'
 ```
 
-Run this request from the node host or from the same public NAT identity. The
-service probes the request's observed public IP and supplied port; it does not
-accept an arbitrary target address. Use `--ipv4` with `"ipv4"` or `--ipv6`
-with `"ipv6"` so the control connection matches the node's advertised address
-family.
+The `enode://` URL is printed on node startup and returned by
+`admin_nodeInfo`. Run this request from the node host or from the same public
+NAT identity. The service probes the request's observed public IP and the
+enode's TCP port; the IP embedded in the enode URL is never used as a target,
+so the API cannot probe arbitrary hosts. Use `--ipv4` or `--ipv6` so the
+control connection matches the address family the node advertises.
 
 ## Trusted proxies
 

--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -1,6 +1,6 @@
 # `base-telemetry`
 
-Base telemetry backend service scaffold.
+Base telemetry backend service.
 
 ## Usage
 
@@ -9,3 +9,51 @@ base-telemetry --listen-addr 0.0.0.0:8080
 ```
 
 The listen address can also be configured with `BASE_TELEMETRY_LISTEN_ADDR`.
+
+The service exposes health routes and an on-demand execution-layer
+reachability check:
+
+```sh
+curl --ipv4 https://telemetry.example/v1/p2p/reachability/el \
+  --header 'content-type: application/json' \
+  --data '{
+    "nodeId": "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4",
+    "tcpPort": 30303,
+    "addressFamily": "ipv4"
+  }'
+```
+
+Run this request from the node host or from the same public NAT identity. The
+service probes the request's observed public IP and supplied port; it does not
+accept an arbitrary target address. Use `--ipv4` with `"ipv4"` or `--ipv6`
+with `"ipv6"` so the control connection matches the node's advertised address
+family.
+
+## Trusted proxies
+
+Direct or source-preserving deployments need no additional client-IP
+configuration. For an HTTP proxy or load balancer, configure every network
+that is allowed to supply `X-Forwarded-For`:
+
+```sh
+base-telemetry \
+  --listen-addr 0.0.0.0:8080 \
+  --trusted-proxy-cidr 10.0.0.0/8
+```
+
+Multiple CIDRs can also be supplied through a comma-delimited environment
+variable:
+
+```sh
+BASE_TELEMETRY_TRUSTED_PROXY_CIDRS=10.0.0.0/8,192.168.0.0/16
+```
+
+Restrict backend ingress to the configured proxies. Requests carrying
+forwarding headers from any other source are rejected.
+
+## Deployment boundary
+
+For a real outside-in check, deploy this service outside the node's network
+with a public HTTPS endpoint and outbound TCP access to node P2P ports. This
+binary does not provision DNS, TLS certificates, load balancers, firewall
+rules, or edge rate limiting.

--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -14,45 +14,22 @@ The service exposes health routes and an on-demand execution-layer
 reachability check:
 
 ```sh
-curl --ipv4 https://telemetry.example/v1/p2p/reachability/el \
+curl https://telemetry.example/v1/p2p/reachability/el \
   --header 'content-type: application/json' \
   --data '{
-    "enode": "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@203.0.113.7:30303"
+    "enode": "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@YOUR_NODE_IP:30303"
   }'
 ```
 
 The `enode://` URL is printed on node startup and returned by
-`admin_nodeInfo`. Run this request from the node host or from the same public
-NAT identity. The service probes the request's observed public IP and the
-enode's TCP port; the IP embedded in the enode URL is never used as a target,
-so the API cannot probe arbitrary hosts. Use `--ipv4` or `--ipv6` so the
-control connection matches the address family the node advertises.
-
-## Trusted proxies
-
-Direct or source-preserving deployments need no additional client-IP
-configuration. For an HTTP proxy or load balancer, configure every network
-that is allowed to supply `X-Forwarded-For`:
-
-```sh
-base-telemetry \
-  --listen-addr 0.0.0.0:8080 \
-  --trusted-proxy-cidr 10.0.0.0/8
-```
-
-Multiple CIDRs can also be supplied through a comma-delimited environment
-variable:
-
-```sh
-BASE_TELEMETRY_TRUSTED_PROXY_CIDRS=10.0.0.0/8,192.168.0.0/16
-```
-
-Restrict backend ingress to the configured proxies. Requests carrying
-forwarding headers from any other source are rejected.
+`admin_nodeInfo`. Replace `YOUR_NODE_IP` with the node's advertised literal
+`IPv4` or bracketed `IPv6` address. The caller may be the node, an operator, or a
+monitoring system; the service probes the IP and TCP port in the supplied
+enode, including private addresses reachable from the service's network.
 
 ## Deployment boundary
 
-For a real outside-in check, deploy this service outside the node's network
-with a public HTTPS endpoint and outbound TCP access to node P2P ports. This
-binary does not provision DNS, TLS certificates, load balancers, firewall
-rules, or edge rate limiting.
+Results describe reachability from the service's network. Deploy outside the
+node's network for an outside-in check, or within the relevant network to check
+private nodes. This binary does not provision DNS, TLS certificates, load
+balancers, firewall rules, edge rate limiting, or outbound network policy.

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
 axum = { workspace = true, features = ["tokio", "http1", "json"] }
-secp256k1 = { workspace = true, features = ["global-context", "rand"] }
+secp256k1 = { workspace = true, features = ["rand"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
 axum = { workspace = true, features = ["tokio", "http1", "json"] }
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -19,11 +19,11 @@ alloy-primitives.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
+secp256k1 = { workspace = true, features = ["rand"] }
 serde = { workspace = true, features = ["derive", "std"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
 axum = { workspace = true, features = ["tokio", "http1", "json"] }
-secp256k1 = { workspace = true, features = ["rand"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-ipnet.workspace = true
 tokio-util.workspace = true
 async-trait.workspace = true
 reth-ecies.workspace = true

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -11,13 +11,21 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+ipnet.workspace = true
 tokio-util.workspace = true
+async-trait.workspace = true
+reth-ecies.workspace = true
+reth-eth-wire.workspace = true
+alloy-primitives.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive", "std"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
 axum = { workspace = true, features = ["tokio", "http1", "json"] }
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
-reqwest.workspace = true
+serial_test.workspace = true
+reqwest = { workspace = true, features = ["json"] }

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -19,6 +19,7 @@ reth-eth-wire.workspace = true
 alloy-primitives.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
+thiserror = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "std"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -28,5 +28,4 @@ secp256k1 = { workspace = true, features = ["global-context", "rand"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
-serial_test.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -11,17 +11,19 @@ Axum backend for Base telemetry services.
 ## Execution-layer reachability
 
 The reachability endpoint acts as an external observer. A caller sends its
-execution-layer node ID and advertised TCP port, then the service opens a
-separate connection to the caller's observed public IP. A node is reported as
-`reachable` only after TCP, ECIES authentication, and the devp2p Hello exchange
-all complete. A node that answers the Hello exchange with an authenticated
-Disconnect (for example because it is at peer capacity) is still `reachable`;
-its response omits `clientVersion`.
+execution-layer `enode://` URL (as printed on node startup and returned by
+`admin_nodeInfo`), then the service opens a separate connection to the
+caller's observed public IP. A node is reported as `reachable` only after TCP,
+ECIES authentication, and the devp2p Hello exchange all complete. A node that
+answers the Hello exchange with an authenticated Disconnect (for example
+because it is at peer capacity) is still `reachable`; its response omits
+`clientVersion`.
 
-The caller must run on the node host or behind the same public NAT. The API
-never accepts a target IP, so it cannot be used to probe arbitrary hosts. The
-request's `addressFamily` must match the HTTP connection source; callers should
-connect over the same family that the node advertises.
+The caller must run on the node host or behind the same public NAT. Only the
+node identity and TCP port are taken from the enode URL; the IP embedded in it
+is never probed, so the API cannot be used to probe arbitrary hosts. Hostnames
+in the enode URL are rejected. Callers should connect over the same address
+family that the node advertises.
 
 Request:
 
@@ -30,9 +32,7 @@ POST /v1/p2p/reachability/el
 Content-Type: application/json
 
 {
-  "nodeId": "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4",
-  "tcpPort": 30303,
-  "addressFamily": "ipv4"
+  "enode": "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@203.0.113.7:30303"
 }
 ```
 

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -10,20 +10,19 @@ Axum backend for Base telemetry services.
 
 ## Execution-layer reachability
 
-The reachability endpoint acts as an external observer. A caller sends its
+The reachability endpoint acts as a network observer. A caller sends an
 execution-layer `enode://` URL (as printed on node startup and returned by
-`admin_nodeInfo`), then the service opens a separate connection to the
-caller's observed public IP. A node is reported as `reachable` only after TCP,
-ECIES authentication, and the devp2p Hello exchange all complete. A node that
-answers the Hello exchange with an authenticated Disconnect (for example
+`admin_nodeInfo`), then the service opens a separate connection to the IP and
+TCP port advertised by that enode. A node is reported as `reachable` only after
+TCP, ECIES authentication, and the devp2p Hello exchange all complete. A node
+that answers the Hello exchange with an authenticated Disconnect (for example
 because it is at peer capacity) is still `reachable`; its response omits
 `clientVersion`.
 
-The caller must run on the node host or behind the same public NAT. Only the
-node identity and TCP port are taken from the enode URL; the IP embedded in it
-is never probed, so the API cannot be used to probe arbitrary hosts. Hostnames
-in the enode URL are rejected. Callers should connect over the same address
-family that the node advertises.
+The caller may be the node, an operator, or a monitoring system. The enode must
+contain a literal `IPv4` or `IPv6` address; hostnames are not resolved. Private
+addresses are allowed, so results describe reachability from the service's
+network rather than necessarily from the public internet.
 
 Request:
 
@@ -32,7 +31,7 @@ POST /v1/p2p/reachability/el
 Content-Type: application/json
 
 {
-  "enode": "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@203.0.113.7:30303"
+  "enode": "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@YOUR_NODE_IP:30303"
 }
 ```
 
@@ -43,33 +42,18 @@ Completed probes return HTTP `200` with an outcome of `reachable`,
 {
   "outcome": "reachable",
   "stage": "rlpx",
-  "observedAddress": "8.8.8.8:30303",
+  "observedAddress": "YOUR_NODE_IP:30303",
   "elapsedMs": 42,
   "clientVersion": "reth/v1.0.0"
 }
 ```
 
-Invalid requests or source headers return `400`, bodies over 1 `KiB` return
-`413`, and exhausted probe capacity returns `429`. Probes have a 10-second
-deadline, with at most 32 running globally and one per source IP. These limits
-do not apply to the health routes.
+Invalid requests return `400`, bodies over 1 `KiB` return `413`, and exhausted
+probe capacity returns `429`. Probes have a 10-second deadline, with at most 32
+running globally. These limits do not apply to the health routes.
 
-## Client IP policy
+## Target selection
 
-Direct requests use the TCP peer address. `X-Forwarded-For` is accepted only
-when the socket peer belongs to a configured trusted proxy CIDR. The service
-walks the complete chain from right to left, skips trusted proxy hops, and uses
-the first untrusted globally routable address. Missing, malformed, spoofed, or
-all-trusted chains are rejected without falling back to the proxy address.
-
-Configure trusted networks only when the service is behind a proxy that
-maintains this forwarding chain:
-
-```sh
-base-telemetry \
-  --trusted-proxy-cidr 10.0.0.0/8 \
-  --trusted-proxy-cidr 192.168.0.0/16
-```
-
-The equivalent environment variable is
-`BASE_TELEMETRY_TRUSTED_PROXY_CIDRS=10.0.0.0/8,192.168.0.0/16`.
+The service probes the exact literal `IPv4` or `IPv6` socket address advertised
+by the enode, including private and other non-public addresses. Routing,
+firewall, and egress policy determine whether the backend can reach the target.

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -1,8 +1,73 @@
 # `base-telemetry-service`
 
-Minimal Axum backend scaffold for Base telemetry.
+Axum backend for Base telemetry services.
 
 ## Routes
 
 - `GET /healthz`
 - `GET /readyz`
+- `POST /v1/p2p/reachability/el`
+
+## Execution-layer reachability
+
+The reachability endpoint acts as an external observer. A caller sends its
+execution-layer node ID and advertised TCP port, then the service opens a
+separate connection to the caller's observed public IP. A node is reported as
+`reachable` only after TCP, ECIES authentication, and the devp2p Hello exchange
+all complete.
+
+The caller must run on the node host or behind the same public NAT. The API
+never accepts a target IP, so it cannot be used to probe arbitrary hosts. The
+request's `addressFamily` must match the HTTP connection source; callers should
+connect over the same family that the node advertises.
+
+Request:
+
+```http
+POST /v1/p2p/reachability/el
+Content-Type: application/json
+
+{
+  "nodeId": "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4",
+  "tcpPort": 30303,
+  "addressFamily": "ipv4"
+}
+```
+
+Completed probes return HTTP `200` with an outcome of `reachable`,
+`connection_failed`, `timed_out`, or `handshake_failed`:
+
+```json
+{
+  "outcome": "reachable",
+  "stage": "rlpx",
+  "observedAddress": "8.8.8.8:30303",
+  "elapsedMs": 42,
+  "clientVersion": "reth/v1.0.0"
+}
+```
+
+Invalid requests or source headers return `400`, bodies over 1 `KiB` return
+`413`, and exhausted probe capacity returns `429`. Probes have a 10-second
+deadline, with at most 32 running globally and one per source IP. These limits
+do not apply to the health routes.
+
+## Client IP policy
+
+Direct requests use the TCP peer address. `X-Forwarded-For` is accepted only
+when the socket peer belongs to a configured trusted proxy CIDR. The service
+walks the complete chain from right to left, skips trusted proxy hops, and uses
+the first untrusted globally routable address. Missing, malformed, spoofed, or
+all-trusted chains are rejected without falling back to the proxy address.
+
+Configure trusted networks only when the service is behind a proxy that
+maintains this forwarding chain:
+
+```sh
+base-telemetry \
+  --trusted-proxy-cidr 10.0.0.0/8 \
+  --trusted-proxy-cidr 192.168.0.0/16
+```
+
+The equivalent environment variable is
+`BASE_TELEMETRY_TRUSTED_PROXY_CIDRS=10.0.0.0/8,192.168.0.0/16`.

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -14,7 +14,9 @@ The reachability endpoint acts as an external observer. A caller sends its
 execution-layer node ID and advertised TCP port, then the service opens a
 separate connection to the caller's observed public IP. A node is reported as
 `reachable` only after TCP, ECIES authentication, and the devp2p Hello exchange
-all complete.
+all complete. A node that answers the Hello exchange with an authenticated
+Disconnect (for example because it is at peer capacity) is still `reachable`;
+its response omits `clientVersion`.
 
 The caller must run on the node host or behind the same public NAT. The API
 never accepts a target IP, so it cannot be used to probe arbitrary hosts. The

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -4,10 +4,9 @@ mod p2p;
 #[cfg(test)]
 pub use p2p::TEST_NODE_ID;
 pub use p2p::{
-    ClientIpError, ClientIpResolver, P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-    P2P_REACHABILITY_MAX_REQUEST_BYTES, P2P_REACHABILITY_PATH, P2pApiError, P2pErrorResponse,
-    P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, P2pState, ProbeLimiter,
-    ProbePermit,
+    P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2P_REACHABILITY_MAX_REQUEST_BYTES,
+    P2P_REACHABILITY_PATH, P2pApiError, P2pErrorResponse, P2pReachabilityRequest,
+    P2pReachabilityResponse, P2pRoutes, P2pState,
 };
 
 mod prober;

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -5,15 +5,15 @@ mod p2p;
 pub use p2p::TEST_NODE_ID;
 pub use p2p::{
     ClientIpError, ClientIpResolver, P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-    P2P_REACHABILITY_MAX_REQUEST_BYTES, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pApiError,
-    P2pErrorResponse, P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, P2pState,
-    ProbeLimiter, ProbePermit,
+    P2P_REACHABILITY_MAX_REQUEST_BYTES, P2P_REACHABILITY_PATH, P2pApiError, P2pErrorResponse,
+    P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, P2pState, ProbeLimiter,
+    ProbePermit,
 };
 
 mod prober;
 pub use prober::{
-    RLPX_PROBE_TIMEOUT, ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
-    RlpxProbeTarget, RlpxProber,
+    RLPX_PROBE_TIMEOUT, ReachabilityProber, RlpxProbeError, RlpxProbeOutcome, RlpxProbeResult,
+    RlpxProbeStage, RlpxProbeTarget, RlpxProber,
 };
 
 mod server;

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -1,4 +1,20 @@
 #![doc = include_str!("../README.md")]
 
+mod p2p;
+#[cfg(test)]
+pub use p2p::TEST_NODE_ID;
+pub use p2p::{
+    ClientIpError, ClientIpResolver, P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+    P2P_REACHABILITY_MAX_REQUEST_BYTES, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pApiError,
+    P2pErrorResponse, P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, P2pState,
+    ProbeLimiter, ProbePermit,
+};
+
+mod prober;
+pub use prober::{
+    RLPX_PROBE_TIMEOUT, ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
+    RlpxProbeTarget, RlpxProber,
+};
+
 mod server;
 pub use server::{BaseTelemetryServer, ServerConfig};

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -68,9 +68,6 @@ impl P2pReachabilityRequest {
         }
 
         let raw_node_id = self.node_id.strip_prefix("0x").unwrap_or(&self.node_id);
-        if raw_node_id.len() != 128 || !raw_node_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            return None;
-        }
         let node_id = B512::from_str(raw_node_id).ok()?;
 
         let mut encoded_public_key = [0_u8; 65];
@@ -153,17 +150,22 @@ impl From<ClientIpError> for P2pApiError {
 }
 
 /// Error resolving the public client IP for a probe request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum ClientIpError {
     /// An untrusted client supplied `X-Forwarded-For`.
+    #[error("untrusted peer supplied X-Forwarded-For")]
     UntrustedForwardedFor,
     /// A trusted proxy did not supply `X-Forwarded-For`.
+    #[error("trusted proxy omitted X-Forwarded-For")]
     MissingForwardedFor,
     /// A forwarded hop was empty, non-UTF-8, or not an IP address.
+    #[error("malformed X-Forwarded-For chain")]
     MalformedForwardedFor,
     /// Every forwarded hop belonged to a trusted proxy network.
+    #[error("X-Forwarded-For chain contains only trusted proxies")]
     AllHopsTrusted,
     /// The resolved client IP was not globally routable.
+    #[error("resolved client IP is not globally routable")]
     NonGlobalClientIp,
 }
 
@@ -385,7 +387,7 @@ impl P2pRoutes {
         body: Result<Json<P2pReachabilityRequest>, JsonRejection>,
     ) -> Result<Json<P2pReachabilityResponse>, P2pApiError> {
         let source_ip = state.resolver.resolve(socket_peer, &headers).inspect_err(|error| {
-            debug!(error = ?error, "reachability request source rejected");
+            debug!(error = %error, "reachability request source rejected");
         })?;
         let Json(request) = body.map_err(|rejection| {
             debug!(status = %rejection.status(), "reachability request body rejected");
@@ -439,7 +441,7 @@ mod tests {
 
     use super::{
         ClientIpError, ClientIpResolver, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pErrorResponse,
-        P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, TEST_NODE_ID,
+        P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, ProbeLimiter, TEST_NODE_ID,
     };
     use crate::{
         ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
@@ -621,6 +623,29 @@ mod tests {
             address_family: P2pAddressFamily::Ipv6,
         };
         assert!(wrong_family.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+    }
+
+    #[test]
+    fn duplicate_source_does_not_consume_global_capacity() {
+        let limiter = ProbeLimiter::new(2);
+        let source = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+        let other = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
+        let _source_permit = limiter.try_acquire(source).unwrap();
+
+        assert!(limiter.try_acquire(source).is_none());
+        assert!(limiter.try_acquire(other).is_some());
+    }
+
+    #[test]
+    fn global_rejection_does_not_reserve_source() {
+        let limiter = ProbeLimiter::new(1);
+        let first = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+        let waiting = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
+        let first_permit = limiter.try_acquire(first).unwrap();
+
+        assert!(limiter.try_acquire(waiting).is_none());
+        drop(first_permit);
+        assert!(limiter.try_acquire(waiting).is_some());
     }
 
     #[tokio::test]

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -63,7 +63,7 @@ impl P2pReachabilityRequest {
     pub fn parse_enode(enode: &str) -> Option<(B512, u16)> {
         let rest = enode.strip_prefix("enode://")?;
         // Drop any query string, e.g. `?discport=30301`.
-        let rest = rest.split('?').next().unwrap_or(rest);
+        let rest = rest.split_once('?').map_or(rest, |(before, _)| before);
         let (raw_node_id, endpoint) = rest.split_once('@')?;
         let node_id = B512::from_str(raw_node_id).ok()?;
 

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -1,3 +1,6 @@
+//! HTTP API for execution-layer P2P reachability checks: request validation,
+//! trusted-proxy client IP resolution, and probe concurrency limits.
+
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -320,13 +323,14 @@ impl ProbeLimiter {
 
     /// Attempts to reserve global and per-source probe capacity.
     pub fn try_acquire(&self, source_ip: IpAddr) -> Option<ProbePermit> {
-        let mut active_sources = self.active_sources.lock().unwrap_or_else(PoisonError::into_inner);
-        if active_sources.contains(&source_ip) {
+        if !self.active_sources.lock().unwrap_or_else(PoisonError::into_inner).insert(source_ip) {
             return None;
         }
-        let global_permit = Arc::clone(&self.global).try_acquire_owned().ok()?;
-        active_sources.insert(source_ip);
-        drop(active_sources);
+
+        let Ok(global_permit) = Arc::clone(&self.global).try_acquire_owned() else {
+            self.active_sources.lock().unwrap_or_else(PoisonError::into_inner).remove(&source_ip);
+            return None;
+        };
 
         Some(ProbePermit {
             source_ip,
@@ -358,6 +362,20 @@ pub struct P2pState {
     prober: Arc<dyn ReachabilityProber>,
 }
 
+impl P2pState {
+    /// Creates handler state with default probe capacity limits.
+    pub fn new<P>(trusted_proxy_cidrs: Vec<IpNet>, prober: Arc<P>) -> Self
+    where
+        P: ReachabilityProber + 'static,
+    {
+        Self {
+            resolver: ClientIpResolver::new(trusted_proxy_cidrs),
+            limiter: Arc::new(ProbeLimiter::new(P2P_REACHABILITY_MAX_CONCURRENT_PROBES)),
+            prober,
+        }
+    }
+}
+
 /// Axum routes for execution-layer P2P reachability checks.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct P2pRoutes;
@@ -368,15 +386,10 @@ impl P2pRoutes {
     where
         P: ReachabilityProber + 'static,
     {
-        let state = P2pState {
-            resolver: ClientIpResolver::new(trusted_proxy_cidrs),
-            limiter: Arc::new(ProbeLimiter::new(P2P_REACHABILITY_MAX_CONCURRENT_PROBES)),
-            prober,
-        };
         Router::new()
             .route(P2P_REACHABILITY_PATH, post(Self::check))
             .layer(DefaultBodyLimit::max(P2P_REACHABILITY_MAX_REQUEST_BYTES))
-            .with_state(state)
+            .with_state(P2pState::new(trusted_proxy_cidrs, prober))
     }
 
     /// Handles one execution-layer P2P reachability check.
@@ -398,15 +411,16 @@ impl P2pRoutes {
             P2pApiError::InvalidRequest
         })?;
         let _permit = state.limiter.try_acquire(source_ip).ok_or_else(|| {
-            debug!("reachability probe capacity exhausted");
+            debug!(source = %source_ip, "reachability probe capacity exhausted");
             P2pApiError::Saturated
         })?;
         let result = state.prober.probe(target).await;
         let elapsed_ms = u64::try_from(result.elapsed.as_millis()).unwrap_or(u64::MAX);
 
         info!(
-            outcome = ?result.outcome,
-            stage = ?result.stage,
+            outcome = %result.outcome,
+            stage = %result.stage,
+            target = %target.address,
             elapsed_ms,
             "reachability probe completed"
         );

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -1,0 +1,706 @@
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    str::FromStr,
+    sync::{Arc, Mutex, PoisonError},
+};
+
+use alloy_primitives::B512;
+use axum::{
+    Json, Router,
+    extract::{ConnectInfo, DefaultBodyLimit, State, rejection::JsonRejection},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use ipnet::IpNet;
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::prober::{ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxProbeTarget};
+
+/// HTTP path for execution-layer P2P reachability checks.
+pub const P2P_REACHABILITY_PATH: &str = "/v1/p2p/reachability/el";
+/// Maximum JSON request body size accepted by the reachability route.
+pub const P2P_REACHABILITY_MAX_REQUEST_BYTES: usize = 1024;
+/// Maximum number of reachability probes allowed in flight globally.
+pub const P2P_REACHABILITY_MAX_CONCURRENT_PROBES: usize = 32;
+#[cfg(test)]
+/// Valid execution-layer node identity shared by reachability tests.
+pub const TEST_NODE_ID: &str = "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4";
+
+/// Public address family the caller expects the service to observe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum P2pAddressFamily {
+    /// `IPv4` source and probe target.
+    Ipv4,
+    /// `IPv6` source and probe target.
+    Ipv6,
+}
+
+impl P2pAddressFamily {
+    /// Returns whether an observed source IP matches this family.
+    pub const fn matches(self, ip: IpAddr) -> bool {
+        matches!((self, ip), (Self::Ipv4, IpAddr::V4(_)) | (Self::Ipv6, IpAddr::V6(_)))
+    }
+}
+
+/// JSON request for an execution-layer reachability check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct P2pReachabilityRequest {
+    /// Expected 64-byte `RLPx` node identity, encoded as 128 hexadecimal characters.
+    pub node_id: String,
+    /// Public TCP port advertised by the execution-layer node.
+    pub tcp_port: u16,
+    /// Address family of the node's advertised public endpoint.
+    pub address_family: P2pAddressFamily,
+}
+
+impl P2pReachabilityRequest {
+    /// Validates the request and combines it with the observed source IP.
+    pub fn target(&self, source_ip: IpAddr) -> Option<RlpxProbeTarget> {
+        if self.tcp_port == 0 || !self.address_family.matches(source_ip) {
+            return None;
+        }
+
+        let raw_node_id = self.node_id.strip_prefix("0x").unwrap_or(&self.node_id);
+        if raw_node_id.len() != 128 || !raw_node_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return None;
+        }
+        let node_id = B512::from_str(raw_node_id).ok()?;
+
+        let mut encoded_public_key = [0_u8; 65];
+        encoded_public_key[0] = 4;
+        encoded_public_key[1..].copy_from_slice(node_id.as_slice());
+        PublicKey::from_slice(&encoded_public_key).ok()?;
+
+        Some(RlpxProbeTarget { address: SocketAddr::new(source_ip, self.tcp_port), node_id })
+    }
+}
+
+/// JSON response for a completed execution-layer reachability check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct P2pReachabilityResponse {
+    /// Stable outcome of the probe.
+    pub outcome: RlpxProbeOutcome,
+    /// Protocol stage reached by the probe.
+    pub stage: RlpxProbeStage,
+    /// Public source address and requested TCP port probed by the service.
+    pub observed_address: SocketAddr,
+    /// Total probe duration in milliseconds.
+    pub elapsed_ms: u64,
+    /// Client version returned by the remote devp2p Hello.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_version: Option<String>,
+}
+
+/// JSON error returned before a reachability probe starts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct P2pErrorResponse {
+    /// Stable error code.
+    pub error: P2pApiError,
+}
+
+/// HTTP error returned before a reachability probe starts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum P2pApiError {
+    /// The JSON body, node identity, or port was invalid.
+    InvalidRequest,
+    /// The request source or forwarding information was invalid.
+    InvalidSource,
+    /// The JSON body exceeded the route limit.
+    PayloadTooLarge,
+    /// Probe capacity was exhausted.
+    Saturated,
+}
+
+impl P2pApiError {
+    /// Maps an Axum JSON rejection to the stable reachability API error surface.
+    pub fn from_json_rejection(rejection: JsonRejection) -> Self {
+        if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE {
+            Self::PayloadTooLarge
+        } else {
+            Self::InvalidRequest
+        }
+    }
+
+    /// Returns the HTTP status for this error.
+    pub const fn status(&self) -> StatusCode {
+        match self {
+            Self::InvalidRequest | Self::InvalidSource => StatusCode::BAD_REQUEST,
+            Self::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::Saturated => StatusCode::TOO_MANY_REQUESTS,
+        }
+    }
+}
+
+impl IntoResponse for P2pApiError {
+    fn into_response(self) -> Response {
+        (self.status(), Json(P2pErrorResponse { error: self })).into_response()
+    }
+}
+
+impl From<ClientIpError> for P2pApiError {
+    fn from(_: ClientIpError) -> Self {
+        Self::InvalidSource
+    }
+}
+
+/// Error resolving the public client IP for a probe request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientIpError {
+    /// An untrusted client supplied `X-Forwarded-For`.
+    UntrustedForwardedFor,
+    /// A trusted proxy did not supply `X-Forwarded-For`.
+    MissingForwardedFor,
+    /// A forwarded hop was empty, non-UTF-8, or not an IP address.
+    MalformedForwardedFor,
+    /// Every forwarded hop belonged to a trusted proxy network.
+    AllHopsTrusted,
+    /// The resolved client IP was not globally routable.
+    NonGlobalClientIp,
+}
+
+/// Resolves a probe target IP from the socket peer and trusted proxy chain.
+#[derive(Debug, Clone)]
+pub struct ClientIpResolver {
+    trusted_proxy_cidrs: Arc<[IpNet]>,
+}
+
+impl ClientIpResolver {
+    /// Creates a resolver with the supplied trusted proxy networks.
+    pub fn new(trusted_proxy_cidrs: Vec<IpNet>) -> Self {
+        Self { trusted_proxy_cidrs: trusted_proxy_cidrs.into() }
+    }
+
+    /// Resolves and validates the public client IP for one request.
+    pub fn resolve(
+        &self,
+        socket_peer: SocketAddr,
+        headers: &HeaderMap,
+    ) -> Result<IpAddr, ClientIpError> {
+        let socket_ip = Self::normalize(socket_peer.ip());
+        let forwarded_values = headers.get_all("x-forwarded-for").iter().collect::<Vec<_>>();
+
+        if forwarded_values.is_empty() {
+            if self.is_trusted(socket_ip) {
+                return Err(ClientIpError::MissingForwardedFor);
+            }
+            return Self::require_global(socket_ip);
+        }
+
+        if !self.is_trusted(socket_ip) {
+            return Err(ClientIpError::UntrustedForwardedFor);
+        }
+
+        let mut hops = Vec::new();
+        for value in forwarded_values {
+            let value = value.to_str().map_err(|_| ClientIpError::MalformedForwardedFor)?;
+            for raw_hop in value.split(',') {
+                let raw_hop = raw_hop.trim();
+                if raw_hop.is_empty() {
+                    return Err(ClientIpError::MalformedForwardedFor);
+                }
+                let hop = raw_hop
+                    .parse::<IpAddr>()
+                    .map(Self::normalize)
+                    .map_err(|_| ClientIpError::MalformedForwardedFor)?;
+                hops.push(hop);
+            }
+        }
+        hops.push(socket_ip);
+
+        for hop in hops.into_iter().rev() {
+            if !self.is_trusted(hop) {
+                return Self::require_global(hop);
+            }
+        }
+
+        Err(ClientIpError::AllHopsTrusted)
+    }
+
+    /// Returns whether an IP belongs to a configured trusted proxy network.
+    pub fn is_trusted(&self, ip: IpAddr) -> bool {
+        self.trusted_proxy_cidrs.iter().any(|network| network.contains(&ip))
+    }
+
+    /// Converts `IPv4`-mapped `IPv6` addresses to their canonical `IPv4` form.
+    pub fn normalize(ip: IpAddr) -> IpAddr {
+        match ip {
+            IpAddr::V6(ip) => ip.to_ipv4_mapped().map_or(IpAddr::V6(ip), IpAddr::V4),
+            IpAddr::V4(ip) => IpAddr::V4(ip),
+        }
+    }
+
+    /// Requires an address to be globally routable.
+    pub fn require_global(ip: IpAddr) -> Result<IpAddr, ClientIpError> {
+        if Self::is_global(ip) { Ok(ip) } else { Err(ClientIpError::NonGlobalClientIp) }
+    }
+
+    /// Returns whether an address is suitable for a public unicast TCP probe.
+    pub fn is_global(ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(ip) => Self::is_global_ipv4(ip),
+            IpAddr::V6(ip) => Self::is_global_ipv6(ip),
+        }
+    }
+
+    /// Returns whether an `IPv4` address is suitable for a public unicast TCP probe.
+    pub fn is_global_ipv4(ip: Ipv4Addr) -> bool {
+        let [a, b, c, d] = ip.octets();
+        !(a == 0
+            || ip.is_private()
+            || (a == 100 && (64..=127).contains(&b))
+            || ip.is_loopback()
+            || ip.is_link_local()
+            || (a == 192 && b == 0 && c == 0 && d != 9 && d != 10)
+            || ip.is_documentation()
+            || (a == 198 && matches!(b, 18 | 19))
+            || (a & 240) == 240
+            || ip.is_broadcast()
+            || ip.is_multicast())
+    }
+
+    /// Returns whether an `IPv6` address is suitable for a public unicast TCP probe.
+    pub fn is_global_ipv6(ip: Ipv6Addr) -> bool {
+        let segments = ip.segments();
+        let value = u128::from_be_bytes(ip.octets());
+        let ietf_protocol_assignment = matches!(segments, [0x2001, b, ..] if b < 0x200)
+            && !(value == 0x2001_0001_0000_0000_0000_0000_0000_0001
+                || value == 0x2001_0001_0000_0000_0000_0000_0000_0002
+                || matches!(segments, [0x2001, 3, ..])
+                || matches!(segments, [0x2001, 4, 0x112, ..])
+                || matches!(segments, [0x2001, b, ..] if (0x20..=0x3f).contains(&b)));
+        let documentation = matches!(segments, [0x2001, 0xdb8, ..] | [0x3fff, 0x0000..=0x0fff, ..]);
+
+        !(ip.is_unspecified()
+            || ip.is_loopback()
+            || matches!(segments, [0, 0, 0, 0, 0, 0xffff, _, _])
+            || matches!(segments, [0x64, 0xff9b, 1, ..])
+            || matches!(segments, [0x100, 0, 0, 0, ..])
+            || ietf_protocol_assignment
+            || matches!(segments, [0x2002, ..])
+            || documentation
+            || matches!(segments, [0x5f00, ..])
+            || ip.is_unique_local()
+            || ip.is_unicast_link_local()
+            || ip.is_multicast())
+    }
+}
+
+/// In-memory global and per-source concurrency limiter for probes.
+#[derive(Debug)]
+pub struct ProbeLimiter {
+    global: Arc<Semaphore>,
+    active_sources: Arc<Mutex<HashSet<IpAddr>>>,
+}
+
+impl ProbeLimiter {
+    /// Creates a limiter with the supplied global capacity and one probe per source.
+    pub fn new(global_capacity: usize) -> Self {
+        Self {
+            global: Arc::new(Semaphore::new(global_capacity)),
+            active_sources: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// Attempts to reserve global and per-source probe capacity.
+    pub fn try_acquire(&self, source_ip: IpAddr) -> Option<ProbePermit> {
+        let global_permit = Arc::clone(&self.global).try_acquire_owned().ok()?;
+        let mut active_sources = self.active_sources.lock().unwrap_or_else(PoisonError::into_inner);
+        if !active_sources.insert(source_ip) {
+            return None;
+        }
+        drop(active_sources);
+
+        Some(ProbePermit {
+            source_ip,
+            _global_permit: global_permit,
+            active_sources: Arc::clone(&self.active_sources),
+        })
+    }
+}
+
+/// Capacity reservation held for the lifetime of one probe.
+#[derive(Debug)]
+pub struct ProbePermit {
+    source_ip: IpAddr,
+    _global_permit: OwnedSemaphorePermit,
+    active_sources: Arc<Mutex<HashSet<IpAddr>>>,
+}
+
+impl Drop for ProbePermit {
+    fn drop(&mut self) {
+        self.active_sources.lock().unwrap_or_else(PoisonError::into_inner).remove(&self.source_ip);
+    }
+}
+
+/// State shared by execution-layer reachability handlers.
+#[derive(Debug, Clone)]
+pub struct P2pState {
+    resolver: ClientIpResolver,
+    limiter: Arc<ProbeLimiter>,
+    prober: Arc<dyn ReachabilityProber>,
+}
+
+/// Axum routes for execution-layer P2P reachability checks.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct P2pRoutes;
+
+impl P2pRoutes {
+    /// Returns a reachability router using an injected prober.
+    pub fn router_with_prober<P>(trusted_proxy_cidrs: Vec<IpNet>, prober: Arc<P>) -> Router
+    where
+        P: ReachabilityProber + 'static,
+    {
+        let state = P2pState {
+            resolver: ClientIpResolver::new(trusted_proxy_cidrs),
+            limiter: Arc::new(ProbeLimiter::new(P2P_REACHABILITY_MAX_CONCURRENT_PROBES)),
+            prober,
+        };
+        Router::new()
+            .route(P2P_REACHABILITY_PATH, post(Self::check))
+            .layer(DefaultBodyLimit::max(P2P_REACHABILITY_MAX_REQUEST_BYTES))
+            .with_state(state)
+    }
+
+    /// Handles one execution-layer P2P reachability check.
+    pub async fn check(
+        State(state): State<P2pState>,
+        ConnectInfo(socket_peer): ConnectInfo<SocketAddr>,
+        headers: HeaderMap,
+        body: Result<Json<P2pReachabilityRequest>, JsonRejection>,
+    ) -> Result<Json<P2pReachabilityResponse>, P2pApiError> {
+        let source_ip = state.resolver.resolve(socket_peer, &headers)?;
+        let Json(request) = body.map_err(P2pApiError::from_json_rejection)?;
+        let target = request.target(source_ip).ok_or(P2pApiError::InvalidRequest)?;
+        let _permit = state.limiter.try_acquire(source_ip).ok_or(P2pApiError::Saturated)?;
+        let result = state.prober.probe(target).await;
+
+        Ok(Json(P2pReachabilityResponse {
+            outcome: result.outcome,
+            stage: result.stage,
+            observed_address: target.address,
+            elapsed_ms: u64::try_from(result.elapsed.as_millis()).unwrap_or(u64::MAX),
+            client_version: result.client_version,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        str::FromStr,
+        sync::{Arc, Mutex, PoisonError},
+        time::Duration,
+    };
+
+    use alloy_primitives::B512;
+    use async_trait::async_trait;
+    use axum::{
+        Router,
+        http::{HeaderMap, HeaderValue, StatusCode},
+    };
+    use ipnet::IpNet;
+    use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
+
+    use super::{
+        ClientIpError, ClientIpResolver, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pErrorResponse,
+        P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, TEST_NODE_ID,
+    };
+    use crate::{
+        ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
+    };
+
+    #[derive(Debug, Clone, Default)]
+    struct FakeProber {
+        targets: Arc<Mutex<Vec<RlpxProbeTarget>>>,
+    }
+
+    #[async_trait]
+    impl ReachabilityProber for FakeProber {
+        async fn probe(&self, target: RlpxProbeTarget) -> RlpxProbeResult {
+            self.targets.lock().unwrap_or_else(PoisonError::into_inner).push(target);
+            RlpxProbeResult {
+                outcome: RlpxProbeOutcome::Reachable,
+                stage: RlpxProbeStage::Rlpx,
+                elapsed: Duration::from_millis(12),
+                client_version: Some("test-peer/1.0".to_string()),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct BlockingProber {
+        entered: Arc<Semaphore>,
+        release: Arc<Semaphore>,
+    }
+
+    #[async_trait]
+    impl ReachabilityProber for BlockingProber {
+        async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
+            self.entered.add_permits(1);
+            self.release.acquire().await.unwrap().forget();
+            RlpxProbeResult {
+                outcome: RlpxProbeOutcome::Reachable,
+                stage: RlpxProbeStage::Rlpx,
+                elapsed: Duration::from_millis(1),
+                client_version: None,
+            }
+        }
+    }
+
+    async fn start_test_server(router: Router) -> (SocketAddr, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
+                .await
+                .unwrap();
+        });
+        (address, handle)
+    }
+
+    fn trusted_loopback() -> Vec<IpNet> {
+        vec![IpNet::from_str("127.0.0.1/32").unwrap()]
+    }
+
+    #[test]
+    fn resolves_direct_global_client() {
+        let resolver = ClientIpResolver::new(Vec::new());
+        let resolved =
+            resolver.resolve(SocketAddr::from(([8, 8, 8, 8], 1234)), &HeaderMap::new()).unwrap();
+        assert_eq!(resolved, IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+    }
+
+    #[test]
+    fn walks_forwarded_chain_from_right_to_left() {
+        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("1.1.1.1, 9.9.9.9, 10.0.0.3"));
+
+        let resolved = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap();
+
+        assert_eq!(resolved, IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)));
+    }
+
+    #[test]
+    fn rejects_forwarding_header_from_untrusted_peer() {
+        let resolver = ClientIpResolver::new(Vec::new());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("8.8.8.8"));
+
+        let error = resolver.resolve(SocketAddr::from(([1, 1, 1, 1], 443)), &headers).unwrap_err();
+
+        assert_eq!(error, ClientIpError::UntrustedForwardedFor);
+    }
+
+    #[test]
+    fn rejects_trusted_proxy_without_forwarding_header() {
+        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
+
+        let error = resolver
+            .resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &HeaderMap::new())
+            .unwrap_err();
+
+        assert_eq!(error, ClientIpError::MissingForwardedFor);
+    }
+
+    #[test]
+    fn rejects_malformed_forwarding_chain() {
+        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("8.8.8.8,not-an-ip"));
+
+        let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
+
+        assert_eq!(error, ClientIpError::MalformedForwardedFor);
+    }
+
+    #[test]
+    fn rejects_forwarding_chain_with_only_trusted_hops() {
+        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("10.0.0.3"));
+
+        let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
+
+        assert_eq!(error, ClientIpError::AllHopsTrusted);
+    }
+
+    #[test]
+    fn rejects_non_global_direct_client() {
+        let resolver = ClientIpResolver::new(Vec::new());
+
+        let error = resolver
+            .resolve(SocketAddr::from(([127, 0, 0, 1], 1234)), &HeaderMap::new())
+            .unwrap_err();
+
+        assert_eq!(error, ClientIpError::NonGlobalClientIp);
+    }
+
+    #[test]
+    fn rejects_non_public_special_use_ranges() {
+        assert!(!ClientIpResolver::is_global(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
+        assert!(!ClientIpResolver::is_global(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
+        assert!(!ClientIpResolver::is_global(IpAddr::from_str("2001:db8::1").unwrap()));
+        assert!(!ClientIpResolver::is_global(IpAddr::from_str("ff02::1").unwrap()));
+    }
+
+    #[test]
+    fn validates_node_identity_and_port() {
+        let valid = P2pReachabilityRequest {
+            node_id: TEST_NODE_ID.to_string(),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv4,
+        };
+        assert!(valid.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_some());
+
+        let zero_port = P2pReachabilityRequest {
+            node_id: valid.node_id,
+            tcp_port: 0,
+            address_family: valid.address_family,
+        };
+        assert!(zero_port.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+
+        let invalid_identity = P2pReachabilityRequest {
+            node_id: "00".repeat(64),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv4,
+        };
+        assert!(invalid_identity.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+
+        let wrong_family = P2pReachabilityRequest {
+            node_id: TEST_NODE_ID.to_string(),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv6,
+        };
+        assert!(wrong_family.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+    }
+
+    #[tokio::test]
+    async fn returns_completed_probe_as_json() {
+        let prober = Arc::new(FakeProber::default());
+        let router = P2pRoutes::router_with_prober(trusted_loopback(), Arc::clone(&prober));
+        let (address, handle) = start_test_server(router).await;
+        let request = P2pReachabilityRequest {
+            node_id: TEST_NODE_ID.to_string(),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv4,
+        };
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
+            .header("x-forwarded-for", "8.8.8.8")
+            .json(&request)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = response.json::<P2pReachabilityResponse>().await.unwrap();
+        assert_eq!(response.outcome, RlpxProbeOutcome::Reachable);
+        assert_eq!(response.observed_address, SocketAddr::from(([8, 8, 8, 8], 30303)));
+        assert_eq!(response.client_version.as_deref(), Some("test-peer/1.0"));
+        assert_eq!(
+            prober.targets.lock().unwrap_or_else(PoisonError::into_inner).as_slice(),
+            &[RlpxProbeTarget {
+                address: SocketAddr::from(([8, 8, 8, 8], 30303)),
+                node_id: B512::from_str(request.node_id.trim_start_matches("0x")).unwrap(),
+            }]
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_spoofed_forwarding_header() {
+        let router = P2pRoutes::router_with_prober(Vec::new(), Arc::new(FakeProber::default()));
+        let (address, handle) = start_test_server(router).await;
+        let request = P2pReachabilityRequest {
+            node_id: TEST_NODE_ID.to_string(),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv4,
+        };
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
+            .header("x-forwarded-for", "8.8.8.8")
+            .json(&request)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let error = response.json::<P2pErrorResponse>().await.unwrap();
+        assert_eq!(error.error, super::P2pApiError::InvalidSource);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_body() {
+        let router =
+            P2pRoutes::router_with_prober(trusted_loopback(), Arc::new(FakeProber::default()));
+        let (address, handle) = start_test_server(router).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
+            .header("x-forwarded-for", "8.8.8.8")
+            .header("content-type", "application/json")
+            .body("x".repeat(2048))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_second_probe_from_same_source() {
+        let prober = Arc::new(BlockingProber {
+            entered: Arc::new(Semaphore::new(0)),
+            release: Arc::new(Semaphore::new(0)),
+        });
+        let router = P2pRoutes::router_with_prober(trusted_loopback(), Arc::clone(&prober));
+        let (address, handle) = start_test_server(router).await;
+        let request = P2pReachabilityRequest {
+            node_id: TEST_NODE_ID.to_string(),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv4,
+        };
+        let client = reqwest::Client::new();
+        let first_client = client.clone();
+        let first_request = request.clone();
+
+        let first = tokio::spawn(async move {
+            first_client
+                .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
+                .header("x-forwarded-for", "8.8.8.8")
+                .json(&first_request)
+                .send()
+                .await
+                .unwrap()
+        });
+        prober.entered.acquire().await.unwrap().forget();
+
+        let second = client
+            .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
+            .header("x-forwarded-for", "8.8.8.8")
+            .json(&request)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+        prober.release.add_permits(1);
+        assert_eq!(first.await.unwrap().status(), StatusCode::OK);
+        handle.abort();
+    }
+}

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -3,7 +3,6 @@
 
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
-use alloy_primitives::B512;
 use axum::{
     Json, Router,
     extract::{DefaultBodyLimit, State, rejection::JsonRejection},
@@ -11,7 +10,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::post,
 };
-use secp256k1::PublicKey;
+use reth_network_peers::{NodeRecord, id2pk};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 use tracing::{debug, info};
@@ -40,30 +39,11 @@ pub struct P2pReachabilityRequest {
 impl P2pReachabilityRequest {
     /// Validates the request and returns its advertised `RLPx` target.
     pub fn target(&self) -> Option<RlpxProbeTarget> {
-        let (node_id, address) = Self::parse_enode(&self.enode)?;
-        if address.port() == 0 {
-            return None;
-        }
-
-        Some(RlpxProbeTarget { address, node_id })
-    }
-
-    /// Parses an `enode://` URL into a validated node identity and socket address.
-    /// Hostnames are rejected; only IP literals are accepted.
-    pub fn parse_enode(enode: &str) -> Option<(B512, SocketAddr)> {
-        let rest = enode.strip_prefix("enode://")?;
-        // Drop any query string, e.g. `?discport=30301`.
-        let rest = rest.split_once('?').map_or(rest, |(before, _)| before);
-        let (raw_node_id, endpoint) = rest.split_once('@')?;
-        let node_id = B512::from_str(raw_node_id).ok()?;
-
-        let mut encoded_public_key = [0_u8; 65];
-        encoded_public_key[0] = 4;
-        encoded_public_key[1..].copy_from_slice(node_id.as_slice());
-        PublicKey::from_slice(&encoded_public_key).ok()?;
-
-        let endpoint = endpoint.parse::<SocketAddr>().ok()?;
-        Some((node_id, endpoint))
+        self.enode.strip_prefix("enode://")?;
+        let record = NodeRecord::from_str(&self.enode).ok()?;
+        id2pk(record.id).ok()?;
+        let address = record.tcp_addr();
+        (address.port() != 0).then_some(RlpxProbeTarget { address, node_id: record.id })
     }
 }
 
@@ -287,6 +267,11 @@ mod tests {
             with_discport.target().unwrap().address,
             SocketAddr::from(([8, 8, 8, 8], 30303))
         );
+
+        let invalid_discport = P2pReachabilityRequest {
+            enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303?discport=invalid"),
+        };
+        assert!(invalid_discport.target().is_none());
 
         let ipv6 = P2pReachabilityRequest {
             enode: format!("enode://{TEST_NODE_ID}@[2606:4700:4700::1111]:30303"),

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -1,25 +1,19 @@
-//! HTTP API for execution-layer P2P reachability checks: request validation,
-//! trusted-proxy client IP resolution, and probe concurrency limits.
+//! HTTP API for execution-layer P2P reachability checks: request validation
+//! and probe concurrency limits.
 
-use std::{
-    collections::HashSet,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-    str::FromStr,
-    sync::{Arc, Mutex, PoisonError},
-};
+use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use alloy_primitives::B512;
 use axum::{
     Json, Router,
-    extract::{ConnectInfo, DefaultBodyLimit, State, rejection::JsonRejection},
-    http::{HeaderMap, StatusCode},
+    extract::{DefaultBodyLimit, State, rejection::JsonRejection},
+    http::StatusCode,
     response::{IntoResponse, Response},
     routing::post,
 };
-use ipnet::IpNet;
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::Semaphore;
 use tracing::{debug, info};
 
 use crate::prober::{ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxProbeTarget};
@@ -44,23 +38,19 @@ pub struct P2pReachabilityRequest {
 }
 
 impl P2pReachabilityRequest {
-    /// Validates the request and combines it with the observed source IP.
-    ///
-    /// Only the node identity and TCP port are taken from the enode URL. The
-    /// embedded IP is never used as the probe target, so the endpoint cannot
-    /// probe arbitrary hosts.
-    pub fn target(&self, source_ip: IpAddr) -> Option<RlpxProbeTarget> {
-        let (node_id, tcp_port) = Self::parse_enode(&self.enode)?;
-        if tcp_port == 0 {
+    /// Validates the request and returns its advertised `RLPx` target.
+    pub fn target(&self) -> Option<RlpxProbeTarget> {
+        let (node_id, address) = Self::parse_enode(&self.enode)?;
+        if address.port() == 0 {
             return None;
         }
 
-        Some(RlpxProbeTarget { address: SocketAddr::new(source_ip, tcp_port), node_id })
+        Some(RlpxProbeTarget { address, node_id })
     }
 
-    /// Parses an `enode://` URL into a validated node identity and TCP port.
+    /// Parses an `enode://` URL into a validated node identity and socket address.
     /// Hostnames are rejected; only IP literals are accepted.
-    pub fn parse_enode(enode: &str) -> Option<(B512, u16)> {
+    pub fn parse_enode(enode: &str) -> Option<(B512, SocketAddr)> {
         let rest = enode.strip_prefix("enode://")?;
         // Drop any query string, e.g. `?discport=30301`.
         let rest = rest.split_once('?').map_or(rest, |(before, _)| before);
@@ -73,7 +63,7 @@ impl P2pReachabilityRequest {
         PublicKey::from_slice(&encoded_public_key).ok()?;
 
         let endpoint = endpoint.parse::<SocketAddr>().ok()?;
-        Some((node_id, endpoint.port()))
+        Some((node_id, endpoint))
     }
 }
 
@@ -85,7 +75,7 @@ pub struct P2pReachabilityResponse {
     pub outcome: RlpxProbeOutcome,
     /// Protocol stage reached by the probe.
     pub stage: RlpxProbeStage,
-    /// Public source address and requested TCP port probed by the service.
+    /// Advertised address probed by the service.
     pub observed_address: SocketAddr,
     /// Total probe duration in milliseconds.
     pub elapsed_ms: u64,
@@ -105,10 +95,8 @@ pub struct P2pErrorResponse {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum P2pApiError {
-    /// The JSON body, node identity, or port was invalid.
+    /// The JSON body, node identity, address, or port was invalid.
     InvalidRequest,
-    /// The request source or forwarding information was invalid.
-    InvalidSource,
     /// The JSON body exceeded the route limit.
     PayloadTooLarge,
     /// Probe capacity was exhausted.
@@ -128,7 +116,7 @@ impl P2pApiError {
     /// Returns the HTTP status for this error.
     pub const fn status(&self) -> StatusCode {
         match self {
-            Self::InvalidRequest | Self::InvalidSource => StatusCode::BAD_REQUEST,
+            Self::InvalidRequest => StatusCode::BAD_REQUEST,
             Self::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             Self::Saturated => StatusCode::TOO_MANY_REQUESTS,
         }
@@ -141,218 +129,20 @@ impl IntoResponse for P2pApiError {
     }
 }
 
-impl From<ClientIpError> for P2pApiError {
-    fn from(_: ClientIpError) -> Self {
-        Self::InvalidSource
-    }
-}
-
-/// Error resolving the public client IP for a probe request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum ClientIpError {
-    /// An untrusted client supplied `X-Forwarded-For`.
-    #[error("untrusted peer supplied X-Forwarded-For")]
-    UntrustedForwardedFor,
-    /// A trusted proxy did not supply `X-Forwarded-For`.
-    #[error("trusted proxy omitted X-Forwarded-For")]
-    MissingForwardedFor,
-    /// A forwarded hop was empty, non-UTF-8, or not an IP address.
-    #[error("malformed X-Forwarded-For chain")]
-    MalformedForwardedFor,
-    /// Every forwarded hop belonged to a trusted proxy network.
-    #[error("X-Forwarded-For chain contains only trusted proxies")]
-    AllHopsTrusted,
-    /// The resolved client IP was not globally routable.
-    #[error("resolved client IP is not globally routable")]
-    NonGlobalClientIp,
-}
-
-/// Resolves a probe target IP from the socket peer and trusted proxy chain.
-#[derive(Debug, Clone)]
-pub struct ClientIpResolver {
-    trusted_proxy_cidrs: Arc<[IpNet]>,
-}
-
-impl ClientIpResolver {
-    /// Maximum number of forwarded hops accepted from a trusted proxy.
-    pub const MAX_FORWARDED_HOPS: usize = 32;
-
-    /// Creates a resolver with the supplied trusted proxy networks.
-    pub fn new(trusted_proxy_cidrs: Vec<IpNet>) -> Self {
-        Self { trusted_proxy_cidrs: trusted_proxy_cidrs.into() }
-    }
-
-    /// Resolves and validates the public client IP for one request.
-    pub fn resolve(
-        &self,
-        socket_peer: SocketAddr,
-        headers: &HeaderMap,
-    ) -> Result<IpAddr, ClientIpError> {
-        let socket_ip = socket_peer.ip().to_canonical();
-        let forwarded_values = headers.get_all("x-forwarded-for").iter().collect::<Vec<_>>();
-
-        if forwarded_values.is_empty() {
-            if self.is_trusted(socket_ip) {
-                return Err(ClientIpError::MissingForwardedFor);
-            }
-            return Self::require_global(socket_ip);
-        }
-
-        if !self.is_trusted(socket_ip) {
-            return Err(ClientIpError::UntrustedForwardedFor);
-        }
-
-        let mut hops = Vec::new();
-        for value in forwarded_values {
-            let value = value.to_str().map_err(|_| ClientIpError::MalformedForwardedFor)?;
-            for raw_hop in value.split(',') {
-                let raw_hop = raw_hop.trim();
-                if raw_hop.is_empty() {
-                    return Err(ClientIpError::MalformedForwardedFor);
-                }
-                let hop = raw_hop
-                    .parse::<IpAddr>()
-                    .map(|ip| ip.to_canonical())
-                    .map_err(|_| ClientIpError::MalformedForwardedFor)?;
-                if hops.len() >= Self::MAX_FORWARDED_HOPS {
-                    return Err(ClientIpError::MalformedForwardedFor);
-                }
-                hops.push(hop);
-            }
-        }
-        hops.push(socket_ip);
-
-        for hop in hops.into_iter().rev() {
-            if !self.is_trusted(hop) {
-                return Self::require_global(hop);
-            }
-        }
-
-        Err(ClientIpError::AllHopsTrusted)
-    }
-
-    /// Returns whether an IP belongs to a configured trusted proxy network.
-    pub fn is_trusted(&self, ip: IpAddr) -> bool {
-        self.trusted_proxy_cidrs.iter().any(|network| network.contains(&ip))
-    }
-
-    /// Requires an address to be globally routable.
-    pub fn require_global(ip: IpAddr) -> Result<IpAddr, ClientIpError> {
-        if Self::is_global(ip) { Ok(ip) } else { Err(ClientIpError::NonGlobalClientIp) }
-    }
-
-    /// Returns whether an address is suitable for a public unicast TCP probe.
-    pub fn is_global(ip: IpAddr) -> bool {
-        match ip {
-            IpAddr::V4(ip) => Self::is_global_ipv4(ip),
-            IpAddr::V6(ip) => Self::is_global_ipv6(ip),
-        }
-    }
-
-    /// Returns whether an `IPv4` address is suitable for a public unicast TCP probe.
-    pub fn is_global_ipv4(ip: Ipv4Addr) -> bool {
-        let [a, b, c, d] = ip.octets();
-        !(a == 0
-            || ip.is_private()
-            || (a == 100 && (64..=127).contains(&b))
-            || ip.is_loopback()
-            || ip.is_link_local()
-            || (a == 192 && b == 0 && c == 0 && d != 9 && d != 10)
-            || ip.is_documentation()
-            || (a == 198 && matches!(b, 18 | 19))
-            || (a & 240) == 240
-            || ip.is_broadcast()
-            || ip.is_multicast())
-    }
-
-    /// Returns whether an `IPv6` address is suitable for a public unicast TCP probe.
-    pub const fn is_global_ipv6(ip: Ipv6Addr) -> bool {
-        let segments = ip.segments();
-        let documentation = matches!(segments, [0x2001, 0xdb8, ..] | [0x3fff, 0x0000..=0x0fff, ..]);
-
-        !(ip.is_unspecified()
-            || ip.is_loopback()
-            || matches!(segments, [0, 0, 0, 0, 0, 0xffff, _, _])
-            || matches!(segments, [0x64, 0xff9b, 1, ..])
-            || matches!(segments, [0x100, 0, 0, 0, ..])
-            || matches!(segments, [0x2001, b, ..] if b < 0x200)
-            || matches!(segments, [0x2002, ..])
-            || documentation
-            || matches!(segments, [0x5f00, ..])
-            || ip.is_unique_local()
-            || ip.is_unicast_link_local()
-            || ip.is_multicast())
-    }
-}
-
-/// In-memory global and per-source concurrency limiter for probes.
-#[derive(Debug)]
-pub struct ProbeLimiter {
-    global: Arc<Semaphore>,
-    active_sources: Arc<Mutex<HashSet<IpAddr>>>,
-}
-
-impl ProbeLimiter {
-    /// Creates a limiter with the supplied global capacity and one probe per source.
-    pub fn new(global_capacity: usize) -> Self {
-        Self {
-            global: Arc::new(Semaphore::new(global_capacity)),
-            active_sources: Arc::new(Mutex::new(HashSet::new())),
-        }
-    }
-
-    /// Attempts to reserve global and per-source probe capacity.
-    pub fn try_acquire(&self, source_ip: IpAddr) -> Option<ProbePermit> {
-        if !self.active_sources.lock().unwrap_or_else(PoisonError::into_inner).insert(source_ip) {
-            return None;
-        }
-
-        let Ok(global_permit) = Arc::clone(&self.global).try_acquire_owned() else {
-            self.active_sources.lock().unwrap_or_else(PoisonError::into_inner).remove(&source_ip);
-            return None;
-        };
-
-        Some(ProbePermit {
-            source_ip,
-            _global_permit: global_permit,
-            active_sources: Arc::clone(&self.active_sources),
-        })
-    }
-}
-
-/// Capacity reservation held for the lifetime of one probe.
-#[derive(Debug)]
-pub struct ProbePermit {
-    source_ip: IpAddr,
-    _global_permit: OwnedSemaphorePermit,
-    active_sources: Arc<Mutex<HashSet<IpAddr>>>,
-}
-
-impl Drop for ProbePermit {
-    fn drop(&mut self) {
-        self.active_sources.lock().unwrap_or_else(PoisonError::into_inner).remove(&self.source_ip);
-    }
-}
-
 /// State shared by execution-layer reachability handlers.
 #[derive(Debug, Clone)]
 pub struct P2pState {
-    resolver: ClientIpResolver,
-    limiter: Arc<ProbeLimiter>,
+    limiter: Arc<Semaphore>,
     prober: Arc<dyn ReachabilityProber>,
 }
 
 impl P2pState {
-    /// Creates handler state with default probe capacity limits.
-    pub fn new<P>(trusted_proxy_cidrs: Vec<IpNet>, prober: Arc<P>) -> Self
+    /// Creates handler state with the supplied global probe capacity.
+    pub fn new<P>(global_capacity: usize, prober: Arc<P>) -> Self
     where
         P: ReachabilityProber + 'static,
     {
-        Self {
-            resolver: ClientIpResolver::new(trusted_proxy_cidrs),
-            limiter: Arc::new(ProbeLimiter::new(P2P_REACHABILITY_MAX_CONCURRENT_PROBES)),
-            prober,
-        }
+        Self { limiter: Arc::new(Semaphore::new(global_capacity)), prober }
     }
 }
 
@@ -362,36 +152,31 @@ pub struct P2pRoutes;
 
 impl P2pRoutes {
     /// Returns a reachability router using an injected prober.
-    pub fn router_with_prober<P>(trusted_proxy_cidrs: Vec<IpNet>, prober: Arc<P>) -> Router
+    pub fn router_with_prober<P>(global_capacity: usize, prober: Arc<P>) -> Router
     where
         P: ReachabilityProber + 'static,
     {
         Router::new()
             .route(P2P_REACHABILITY_PATH, post(Self::check))
             .layer(DefaultBodyLimit::max(P2P_REACHABILITY_MAX_REQUEST_BYTES))
-            .with_state(P2pState::new(trusted_proxy_cidrs, prober))
+            .with_state(P2pState::new(global_capacity, prober))
     }
 
     /// Handles one execution-layer P2P reachability check.
     pub async fn check(
         State(state): State<P2pState>,
-        ConnectInfo(socket_peer): ConnectInfo<SocketAddr>,
-        headers: HeaderMap,
         body: Result<Json<P2pReachabilityRequest>, JsonRejection>,
     ) -> Result<Json<P2pReachabilityResponse>, P2pApiError> {
-        let source_ip = state.resolver.resolve(socket_peer, &headers).inspect_err(|error| {
-            debug!(error = %error, "reachability request source rejected");
-        })?;
         let Json(request) = body.map_err(|rejection| {
             debug!(status = %rejection.status(), "reachability request body rejected");
             P2pApiError::from_json_rejection(rejection)
         })?;
-        let target = request.target(source_ip).ok_or_else(|| {
+        let target = request.target().ok_or_else(|| {
             debug!("reachability request target validation failed");
             P2pApiError::InvalidRequest
         })?;
-        let _permit = state.limiter.try_acquire(source_ip).ok_or_else(|| {
-            debug!(source = %source_ip, "reachability probe capacity exhausted");
+        let _permit = Arc::clone(&state.limiter).try_acquire_owned().map_err(|_| {
+            debug!("reachability probe capacity exhausted");
             P2pApiError::Saturated
         })?;
         let result = state.prober.probe(target).await;
@@ -418,7 +203,7 @@ impl P2pRoutes {
 #[cfg(test)]
 mod tests {
     use std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::SocketAddr,
         str::FromStr,
         sync::{Arc, Mutex, PoisonError},
         time::Duration,
@@ -426,16 +211,12 @@ mod tests {
 
     use alloy_primitives::B512;
     use async_trait::async_trait;
-    use axum::{
-        Router,
-        http::{HeaderMap, HeaderValue, StatusCode},
-    };
-    use ipnet::IpNet;
+    use axum::{Router, http::StatusCode};
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use super::{
-        ClientIpError, ClientIpResolver, P2P_REACHABILITY_PATH, P2pErrorResponse,
-        P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, ProbeLimiter, TEST_NODE_ID,
+        P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2P_REACHABILITY_PATH, P2pReachabilityRequest,
+        P2pReachabilityResponse, P2pRoutes, TEST_NODE_ID,
     };
     use crate::{
         ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
@@ -483,15 +264,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let handle = tokio::spawn(async move {
-            axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
-                .await
-                .unwrap();
+            axum::serve(listener, router).await.unwrap();
         });
         (address, handle)
-    }
-
-    fn trusted_loopback() -> Vec<IpNet> {
-        vec![IpNet::from_str("127.0.0.1/32").unwrap()]
     }
 
     fn test_request() -> P2pReachabilityRequest {
@@ -499,171 +274,69 @@ mod tests {
     }
 
     #[test]
-    fn resolves_direct_global_client() {
-        let resolver = ClientIpResolver::new(Vec::new());
-        let resolved =
-            resolver.resolve(SocketAddr::from(([8, 8, 8, 8], 1234)), &HeaderMap::new()).unwrap();
-        assert_eq!(resolved, IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
-    }
-
-    #[test]
-    fn walks_forwarded_chain_from_right_to_left() {
-        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("1.1.1.1, 9.9.9.9, 10.0.0.3"));
-
-        let resolved = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap();
-
-        assert_eq!(resolved, IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)));
-    }
-
-    #[test]
-    fn rejects_forwarding_header_from_untrusted_peer() {
-        let resolver = ClientIpResolver::new(Vec::new());
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("8.8.8.8"));
-
-        let error = resolver.resolve(SocketAddr::from(([1, 1, 1, 1], 443)), &headers).unwrap_err();
-
-        assert_eq!(error, ClientIpError::UntrustedForwardedFor);
-    }
-
-    #[test]
-    fn rejects_trusted_proxy_without_forwarding_header() {
-        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
-
-        let error = resolver
-            .resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &HeaderMap::new())
-            .unwrap_err();
-
-        assert_eq!(error, ClientIpError::MissingForwardedFor);
-    }
-
-    #[test]
-    fn rejects_malformed_forwarding_chain() {
-        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("8.8.8.8,not-an-ip"));
-
-        let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
-
-        assert_eq!(error, ClientIpError::MalformedForwardedFor);
-    }
-
-    #[test]
-    fn rejects_forwarding_chain_over_hop_limit() {
-        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
-        let forwarded = vec!["8.8.8.8"; ClientIpResolver::MAX_FORWARDED_HOPS + 1].join(",");
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_str(&forwarded).unwrap());
-
-        let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
-
-        assert_eq!(error, ClientIpError::MalformedForwardedFor);
-    }
-
-    #[test]
-    fn rejects_forwarding_chain_with_only_trusted_hops() {
-        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("10.0.0.3"));
-
-        let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
-
-        assert_eq!(error, ClientIpError::AllHopsTrusted);
-    }
-
-    #[test]
-    fn rejects_non_global_direct_client() {
-        let resolver = ClientIpResolver::new(Vec::new());
-
-        let error = resolver
-            .resolve(SocketAddr::from(([127, 0, 0, 1], 1234)), &HeaderMap::new())
-            .unwrap_err();
-
-        assert_eq!(error, ClientIpError::NonGlobalClientIp);
-    }
-
-    #[test]
-    fn rejects_non_public_special_use_ranges() {
-        assert!(!ClientIpResolver::is_global(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
-        assert!(!ClientIpResolver::is_global(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
-        assert!(!ClientIpResolver::is_global(IpAddr::from_str("2001:db8::1").unwrap()));
-        assert!(!ClientIpResolver::is_global(IpAddr::from_str("ff02::1").unwrap()));
-    }
-
-    #[test]
-    fn validates_enode_identity_and_port() {
-        let source = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
-
-        assert!(test_request().target(source).is_some());
+    fn validates_enode_identity_address_and_port() {
+        assert_eq!(
+            test_request().target().unwrap().address,
+            SocketAddr::from(([8, 8, 8, 8], 30303))
+        );
 
         let with_discport = P2pReachabilityRequest {
             enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303?discport=30301"),
         };
-        assert!(with_discport.target(source).is_some());
+        assert_eq!(
+            with_discport.target().unwrap().address,
+            SocketAddr::from(([8, 8, 8, 8], 30303))
+        );
+
+        let ipv6 = P2pReachabilityRequest {
+            enode: format!("enode://{TEST_NODE_ID}@[2606:4700:4700::1111]:30303"),
+        };
+        assert_eq!(ipv6.target().unwrap().address, "[2606:4700:4700::1111]:30303".parse().unwrap());
 
         let zero_port =
             P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:0") };
-        assert!(zero_port.target(source).is_none());
+        assert!(zero_port.target().is_none());
 
         let invalid_identity =
             P2pReachabilityRequest { enode: format!("enode://{}@8.8.8.8:30303", "00".repeat(64)) };
-        assert!(invalid_identity.target(source).is_none());
+        assert!(invalid_identity.target().is_none());
 
         let missing_scheme =
             P2pReachabilityRequest { enode: format!("{TEST_NODE_ID}@8.8.8.8:30303") };
-        assert!(missing_scheme.target(source).is_none());
+        assert!(missing_scheme.target().is_none());
 
         let hostname =
             P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@example.com:30303") };
-        assert!(hostname.target(source).is_none());
+        assert!(hostname.target().is_none());
+
+        let private =
+            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@10.0.0.1:30303") };
+        assert_eq!(private.target().unwrap().address, SocketAddr::from(([10, 0, 0, 1], 30303)));
     }
 
     #[test]
-    fn probes_source_ip_instead_of_advertised_ip() {
-        let source = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+    fn probes_advertised_enode_address() {
         let request =
             P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@9.9.9.9:30303") };
 
-        let target = request.target(source).unwrap();
+        let target = request.target().unwrap();
 
-        assert_eq!(target.address, SocketAddr::from(([8, 8, 8, 8], 30303)));
-    }
-
-    #[test]
-    fn duplicate_source_does_not_consume_global_capacity() {
-        let limiter = ProbeLimiter::new(2);
-        let source = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
-        let other = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
-        let _source_permit = limiter.try_acquire(source).unwrap();
-
-        assert!(limiter.try_acquire(source).is_none());
-        assert!(limiter.try_acquire(other).is_some());
-    }
-
-    #[test]
-    fn global_rejection_does_not_reserve_source() {
-        let limiter = ProbeLimiter::new(1);
-        let first = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
-        let waiting = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
-        let first_permit = limiter.try_acquire(first).unwrap();
-
-        assert!(limiter.try_acquire(waiting).is_none());
-        drop(first_permit);
-        assert!(limiter.try_acquire(waiting).is_some());
+        assert_eq!(target.address, SocketAddr::from(([9, 9, 9, 9], 30303)));
     }
 
     #[tokio::test]
-    async fn returns_completed_probe_as_json() {
+    async fn ignores_forwarded_header_and_probes_enode_address() {
         let prober = Arc::new(FakeProber::default());
-        let router = P2pRoutes::router_with_prober(trusted_loopback(), Arc::clone(&prober));
+        let router = P2pRoutes::router_with_prober(
+            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::clone(&prober),
+        );
         let (address, handle) = start_test_server(router).await;
         let request = test_request();
 
         let response = reqwest::Client::new()
             .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
-            .header("x-forwarded-for", "8.8.8.8")
+            .header("x-forwarded-for", "1.1.1.1")
             .json(&request)
             .send()
             .await
@@ -686,34 +359,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_spoofed_forwarding_header() {
-        let router = P2pRoutes::router_with_prober(Vec::new(), Arc::new(FakeProber::default()));
+    async fn probes_private_target() {
+        let prober = Arc::new(FakeProber::default());
+        let router = P2pRoutes::router_with_prober(
+            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::clone(&prober),
+        );
         let (address, handle) = start_test_server(router).await;
-        let request = test_request();
+        let request =
+            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@10.0.0.1:30303") };
 
         let response = reqwest::Client::new()
             .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
-            .header("x-forwarded-for", "8.8.8.8")
             .json(&request)
             .send()
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let error = response.json::<P2pErrorResponse>().await.unwrap();
-        assert_eq!(error.error, super::P2pApiError::InvalidSource);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            prober.targets.lock().unwrap_or_else(PoisonError::into_inner)[0].address,
+            SocketAddr::from(([10, 0, 0, 1], 30303))
+        );
         handle.abort();
     }
 
     #[tokio::test]
     async fn rejects_oversized_body() {
-        let router =
-            P2pRoutes::router_with_prober(trusted_loopback(), Arc::new(FakeProber::default()));
+        let router = P2pRoutes::router_with_prober(
+            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::new(FakeProber::default()),
+        );
         let (address, handle) = start_test_server(router).await;
 
         let response = reqwest::Client::new()
             .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
-            .header("x-forwarded-for", "8.8.8.8")
             .header("content-type", "application/json")
             .body("x".repeat(2048))
             .send()
@@ -725,12 +405,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_second_probe_from_same_source() {
+    async fn rejects_probe_when_global_capacity_is_exhausted() {
         let prober = Arc::new(BlockingProber {
             entered: Arc::new(Semaphore::new(0)),
             release: Arc::new(Semaphore::new(0)),
         });
-        let router = P2pRoutes::router_with_prober(trusted_loopback(), Arc::clone(&prober));
+        let router = P2pRoutes::router_with_prober(1, Arc::clone(&prober));
         let (address, handle) = start_test_server(router).await;
         let request = test_request();
         let client = reqwest::Client::new();
@@ -740,7 +420,6 @@ mod tests {
         let first = tokio::spawn(async move {
             first_client
                 .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
-                .header("x-forwarded-for", "8.8.8.8")
                 .json(&first_request)
                 .send()
                 .await
@@ -750,7 +429,6 @@ mod tests {
 
         let second = client
             .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
-            .header("x-forwarded-for", "8.8.8.8")
             .json(&request)
             .send()
             .await

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -17,6 +17,7 @@ use ipnet::IpNet;
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::{debug, info};
 
 use crate::prober::{ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxProbeTarget};
 
@@ -173,6 +174,9 @@ pub struct ClientIpResolver {
 }
 
 impl ClientIpResolver {
+    /// Maximum number of forwarded hops accepted from a trusted proxy.
+    pub const MAX_FORWARDED_HOPS: usize = 32;
+
     /// Creates a resolver with the supplied trusted proxy networks.
     pub fn new(trusted_proxy_cidrs: Vec<IpNet>) -> Self {
         Self { trusted_proxy_cidrs: trusted_proxy_cidrs.into() }
@@ -210,6 +214,9 @@ impl ClientIpResolver {
                     .parse::<IpAddr>()
                     .map(Self::normalize)
                     .map_err(|_| ClientIpError::MalformedForwardedFor)?;
+                if hops.len() >= Self::MAX_FORWARDED_HOPS {
+                    return Err(ClientIpError::MalformedForwardedFor);
+                }
                 hops.push(hop);
             }
         }
@@ -311,11 +318,12 @@ impl ProbeLimiter {
 
     /// Attempts to reserve global and per-source probe capacity.
     pub fn try_acquire(&self, source_ip: IpAddr) -> Option<ProbePermit> {
-        let global_permit = Arc::clone(&self.global).try_acquire_owned().ok()?;
         let mut active_sources = self.active_sources.lock().unwrap_or_else(PoisonError::into_inner);
-        if !active_sources.insert(source_ip) {
+        if active_sources.contains(&source_ip) {
             return None;
         }
+        let global_permit = Arc::clone(&self.global).try_acquire_owned().ok()?;
+        active_sources.insert(source_ip);
         drop(active_sources);
 
         Some(ProbePermit {
@@ -376,17 +384,36 @@ impl P2pRoutes {
         headers: HeaderMap,
         body: Result<Json<P2pReachabilityRequest>, JsonRejection>,
     ) -> Result<Json<P2pReachabilityResponse>, P2pApiError> {
-        let source_ip = state.resolver.resolve(socket_peer, &headers)?;
-        let Json(request) = body.map_err(P2pApiError::from_json_rejection)?;
-        let target = request.target(source_ip).ok_or(P2pApiError::InvalidRequest)?;
-        let _permit = state.limiter.try_acquire(source_ip).ok_or(P2pApiError::Saturated)?;
+        let source_ip = state.resolver.resolve(socket_peer, &headers).inspect_err(|error| {
+            debug!(error = ?error, "reachability request source rejected");
+        })?;
+        let Json(request) = body.map_err(|rejection| {
+            debug!(status = %rejection.status(), "reachability request body rejected");
+            P2pApiError::from_json_rejection(rejection)
+        })?;
+        let target = request.target(source_ip).ok_or_else(|| {
+            debug!("reachability request target validation failed");
+            P2pApiError::InvalidRequest
+        })?;
+        let _permit = state.limiter.try_acquire(source_ip).ok_or_else(|| {
+            debug!("reachability probe capacity exhausted");
+            P2pApiError::Saturated
+        })?;
         let result = state.prober.probe(target).await;
+        let elapsed_ms = u64::try_from(result.elapsed.as_millis()).unwrap_or(u64::MAX);
+
+        info!(
+            outcome = ?result.outcome,
+            stage = ?result.stage,
+            elapsed_ms,
+            "reachability probe completed"
+        );
 
         Ok(Json(P2pReachabilityResponse {
             outcome: result.outcome,
             stage: result.stage,
             observed_address: target.address,
-            elapsed_ms: u64::try_from(result.elapsed.as_millis()).unwrap_or(u64::MAX),
+            elapsed_ms,
             client_version: result.client_version,
         }))
     }
@@ -517,6 +544,18 @@ mod tests {
         let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
         let mut headers = HeaderMap::new();
         headers.insert("x-forwarded-for", HeaderValue::from_static("8.8.8.8,not-an-ip"));
+
+        let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
+
+        assert_eq!(error, ClientIpError::MalformedForwardedFor);
+    }
+
+    #[test]
+    fn rejects_forwarding_chain_over_hop_limit() {
+        let resolver = ClientIpResolver::new(vec![IpNet::from_str("10.0.0.0/8").unwrap()]);
+        let forwarded = vec!["8.8.8.8"; ClientIpResolver::MAX_FORWARDED_HOPS + 1].join(",");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_str(&forwarded).unwrap());
 
         let error = resolver.resolve(SocketAddr::from(([10, 0, 0, 2], 443)), &headers).unwrap_err();
 

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -39,7 +39,9 @@ pub struct P2pReachabilityRequest {
 impl P2pReachabilityRequest {
     /// Validates the request and returns its advertised `RLPx` target.
     pub fn target(&self) -> Option<RlpxProbeTarget> {
-        self.enode.strip_prefix("enode://")?;
+        if !self.enode.starts_with("enode://") {
+            return None;
+        }
         let record = NodeRecord::from_str(&self.enode).ok()?;
         id2pk(record.id).ok()?;
         let address = record.tcp_addr();

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -24,8 +24,8 @@ pub const P2P_REACHABILITY_PATH: &str = "/v1/p2p/reachability/el";
 pub const P2P_REACHABILITY_MAX_REQUEST_BYTES: usize = 1024;
 /// Maximum number of reachability probes allowed in flight globally.
 pub const P2P_REACHABILITY_MAX_CONCURRENT_PROBES: usize = 32;
-#[cfg(test)]
 /// Valid execution-layer node identity shared by reachability tests.
+#[cfg(test)]
 pub const TEST_NODE_ID: &str = "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4";
 
 /// JSON request for an execution-layer reachability check.

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -188,7 +188,7 @@ impl ClientIpResolver {
         socket_peer: SocketAddr,
         headers: &HeaderMap,
     ) -> Result<IpAddr, ClientIpError> {
-        let socket_ip = Self::normalize(socket_peer.ip());
+        let socket_ip = socket_peer.ip().to_canonical();
         let forwarded_values = headers.get_all("x-forwarded-for").iter().collect::<Vec<_>>();
 
         if forwarded_values.is_empty() {
@@ -212,7 +212,7 @@ impl ClientIpResolver {
                 }
                 let hop = raw_hop
                     .parse::<IpAddr>()
-                    .map(Self::normalize)
+                    .map(|ip| ip.to_canonical())
                     .map_err(|_| ClientIpError::MalformedForwardedFor)?;
                 if hops.len() >= Self::MAX_FORWARDED_HOPS {
                     return Err(ClientIpError::MalformedForwardedFor);
@@ -234,14 +234,6 @@ impl ClientIpResolver {
     /// Returns whether an IP belongs to a configured trusted proxy network.
     pub fn is_trusted(&self, ip: IpAddr) -> bool {
         self.trusted_proxy_cidrs.iter().any(|network| network.contains(&ip))
-    }
-
-    /// Converts `IPv4`-mapped `IPv6` addresses to their canonical `IPv4` form.
-    pub fn normalize(ip: IpAddr) -> IpAddr {
-        match ip {
-            IpAddr::V6(ip) => ip.to_ipv4_mapped().map_or(IpAddr::V6(ip), IpAddr::V4),
-            IpAddr::V4(ip) => IpAddr::V4(ip),
-        }
     }
 
     /// Requires an address to be globally routable.
@@ -274,15 +266,8 @@ impl ClientIpResolver {
     }
 
     /// Returns whether an `IPv6` address is suitable for a public unicast TCP probe.
-    pub fn is_global_ipv6(ip: Ipv6Addr) -> bool {
+    pub const fn is_global_ipv6(ip: Ipv6Addr) -> bool {
         let segments = ip.segments();
-        let value = u128::from_be_bytes(ip.octets());
-        let ietf_protocol_assignment = matches!(segments, [0x2001, b, ..] if b < 0x200)
-            && !(value == 0x2001_0001_0000_0000_0000_0000_0000_0001
-                || value == 0x2001_0001_0000_0000_0000_0000_0000_0002
-                || matches!(segments, [0x2001, 3, ..])
-                || matches!(segments, [0x2001, 4, 0x112, ..])
-                || matches!(segments, [0x2001, b, ..] if (0x20..=0x3f).contains(&b)));
         let documentation = matches!(segments, [0x2001, 0xdb8, ..] | [0x3fff, 0x0000..=0x0fff, ..]);
 
         !(ip.is_unspecified()
@@ -290,7 +275,7 @@ impl ClientIpResolver {
             || matches!(segments, [0, 0, 0, 0, 0, 0xffff, _, _])
             || matches!(segments, [0x64, 0xff9b, 1, ..])
             || matches!(segments, [0x100, 0, 0, 0, ..])
-            || ietf_protocol_assignment
+            || matches!(segments, [0x2001, b, ..] if b < 0x200)
             || matches!(segments, [0x2002, ..])
             || documentation
             || matches!(segments, [0x5f00, ..])

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -34,43 +34,37 @@ pub const P2P_REACHABILITY_MAX_CONCURRENT_PROBES: usize = 32;
 /// Valid execution-layer node identity shared by reachability tests.
 pub const TEST_NODE_ID: &str = "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4";
 
-/// Public address family the caller expects the service to observe.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum P2pAddressFamily {
-    /// `IPv4` source and probe target.
-    Ipv4,
-    /// `IPv6` source and probe target.
-    Ipv6,
-}
-
-impl P2pAddressFamily {
-    /// Returns whether an observed source IP matches this family.
-    pub const fn matches(self, ip: IpAddr) -> bool {
-        matches!((self, ip), (Self::Ipv4, IpAddr::V4(_)) | (Self::Ipv6, IpAddr::V6(_)))
-    }
-}
-
 /// JSON request for an execution-layer reachability check.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct P2pReachabilityRequest {
-    /// Expected 64-byte `RLPx` node identity, encoded as 128 hexadecimal characters.
-    pub node_id: String,
-    /// Public TCP port advertised by the execution-layer node.
-    pub tcp_port: u16,
-    /// Address family of the node's advertised public endpoint.
-    pub address_family: P2pAddressFamily,
+    /// The node's advertised `enode://` URL, as printed on startup and
+    /// returned by `admin_nodeInfo`.
+    pub enode: String,
 }
 
 impl P2pReachabilityRequest {
     /// Validates the request and combines it with the observed source IP.
+    ///
+    /// Only the node identity and TCP port are taken from the enode URL. The
+    /// embedded IP is never used as the probe target, so the endpoint cannot
+    /// probe arbitrary hosts.
     pub fn target(&self, source_ip: IpAddr) -> Option<RlpxProbeTarget> {
-        if self.tcp_port == 0 || !self.address_family.matches(source_ip) {
+        let (node_id, tcp_port) = Self::parse_enode(&self.enode)?;
+        if tcp_port == 0 {
             return None;
         }
 
-        let raw_node_id = self.node_id.strip_prefix("0x").unwrap_or(&self.node_id);
+        Some(RlpxProbeTarget { address: SocketAddr::new(source_ip, tcp_port), node_id })
+    }
+
+    /// Parses an `enode://` URL into a validated node identity and TCP port.
+    /// Hostnames are rejected; only IP literals are accepted.
+    pub fn parse_enode(enode: &str) -> Option<(B512, u16)> {
+        let rest = enode.strip_prefix("enode://")?;
+        // Drop any query string, e.g. `?discport=30301`.
+        let rest = rest.split('?').next().unwrap_or(rest);
+        let (raw_node_id, endpoint) = rest.split_once('@')?;
         let node_id = B512::from_str(raw_node_id).ok()?;
 
         let mut encoded_public_key = [0_u8; 65];
@@ -78,7 +72,8 @@ impl P2pReachabilityRequest {
         encoded_public_key[1..].copy_from_slice(node_id.as_slice());
         PublicKey::from_slice(&encoded_public_key).ok()?;
 
-        Some(RlpxProbeTarget { address: SocketAddr::new(source_ip, self.tcp_port), node_id })
+        let endpoint = endpoint.parse::<SocketAddr>().ok()?;
+        Some((node_id, endpoint.port()))
     }
 }
 
@@ -454,7 +449,7 @@ mod tests {
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use super::{
-        ClientIpError, ClientIpResolver, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pErrorResponse,
+        ClientIpError, ClientIpResolver, P2P_REACHABILITY_PATH, P2pErrorResponse,
         P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, ProbeLimiter, TEST_NODE_ID,
     };
     use crate::{
@@ -512,6 +507,10 @@ mod tests {
 
     fn trusted_loopback() -> Vec<IpNet> {
         vec![IpNet::from_str("127.0.0.1/32").unwrap()]
+    }
+
+    fn test_request() -> P2pReachabilityRequest {
+        P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303") }
     }
 
     #[test]
@@ -609,34 +608,42 @@ mod tests {
     }
 
     #[test]
-    fn validates_node_identity_and_port() {
-        let valid = P2pReachabilityRequest {
-            node_id: TEST_NODE_ID.to_string(),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv4,
-        };
-        assert!(valid.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_some());
+    fn validates_enode_identity_and_port() {
+        let source = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
 
-        let zero_port = P2pReachabilityRequest {
-            node_id: valid.node_id,
-            tcp_port: 0,
-            address_family: valid.address_family,
-        };
-        assert!(zero_port.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+        assert!(test_request().target(source).is_some());
 
-        let invalid_identity = P2pReachabilityRequest {
-            node_id: "00".repeat(64),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv4,
+        let with_discport = P2pReachabilityRequest {
+            enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303?discport=30301"),
         };
-        assert!(invalid_identity.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+        assert!(with_discport.target(source).is_some());
 
-        let wrong_family = P2pReachabilityRequest {
-            node_id: TEST_NODE_ID.to_string(),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv6,
-        };
-        assert!(wrong_family.target(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))).is_none());
+        let zero_port =
+            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:0") };
+        assert!(zero_port.target(source).is_none());
+
+        let invalid_identity =
+            P2pReachabilityRequest { enode: format!("enode://{}@8.8.8.8:30303", "00".repeat(64)) };
+        assert!(invalid_identity.target(source).is_none());
+
+        let missing_scheme =
+            P2pReachabilityRequest { enode: format!("{TEST_NODE_ID}@8.8.8.8:30303") };
+        assert!(missing_scheme.target(source).is_none());
+
+        let hostname =
+            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@example.com:30303") };
+        assert!(hostname.target(source).is_none());
+    }
+
+    #[test]
+    fn probes_source_ip_instead_of_advertised_ip() {
+        let source = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+        let request =
+            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@9.9.9.9:30303") };
+
+        let target = request.target(source).unwrap();
+
+        assert_eq!(target.address, SocketAddr::from(([8, 8, 8, 8], 30303)));
     }
 
     #[test]
@@ -667,11 +674,7 @@ mod tests {
         let prober = Arc::new(FakeProber::default());
         let router = P2pRoutes::router_with_prober(trusted_loopback(), Arc::clone(&prober));
         let (address, handle) = start_test_server(router).await;
-        let request = P2pReachabilityRequest {
-            node_id: TEST_NODE_ID.to_string(),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv4,
-        };
+        let request = test_request();
 
         let response = reqwest::Client::new()
             .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
@@ -690,7 +693,7 @@ mod tests {
             prober.targets.lock().unwrap_or_else(PoisonError::into_inner).as_slice(),
             &[RlpxProbeTarget {
                 address: SocketAddr::from(([8, 8, 8, 8], 30303)),
-                node_id: B512::from_str(request.node_id.trim_start_matches("0x")).unwrap(),
+                node_id: B512::from_str(TEST_NODE_ID).unwrap(),
             }]
         );
 
@@ -701,11 +704,7 @@ mod tests {
     async fn rejects_spoofed_forwarding_header() {
         let router = P2pRoutes::router_with_prober(Vec::new(), Arc::new(FakeProber::default()));
         let (address, handle) = start_test_server(router).await;
-        let request = P2pReachabilityRequest {
-            node_id: TEST_NODE_ID.to_string(),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv4,
-        };
+        let request = test_request();
 
         let response = reqwest::Client::new()
             .post(format!("http://{address}{P2P_REACHABILITY_PATH}"))
@@ -748,11 +747,7 @@ mod tests {
         });
         let router = P2pRoutes::router_with_prober(trusted_loopback(), Arc::clone(&prober));
         let (address, handle) = start_test_server(router).await;
-        let request = P2pReachabilityRequest {
-            node_id: TEST_NODE_ID.to_string(),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv4,
-        };
+        let request = test_request();
         let client = reqwest::Client::new();
         let first_client = client.clone();
         let first_request = request.clone();

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -22,7 +22,9 @@ pub const RLPX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RlpxProbeOutcome {
-    /// TCP, ECIES, and devp2p Hello completed successfully.
+    /// TCP and ECIES completed, and the peer answered the devp2p Hello
+    /// exchange, either with its own Hello or with an authenticated
+    /// Disconnect (e.g. at peer capacity).
     Reachable,
     /// The TCP connection could not be established.
     ConnectionFailed,
@@ -160,6 +162,17 @@ impl ReachabilityProber for RlpxProber {
             Err(_) | Ok(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Timeout))) => {
                 finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Rlpx, None)
             }
+            Ok(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason)))) => {
+                // A Disconnect received here arrived over the authenticated ECIES
+                // stream, so the node is reachable even though it refused the
+                // session (e.g. it is at peer capacity).
+                debug!(
+                    reason = %reason,
+                    stage = ?RlpxProbeStage::Rlpx,
+                    "reachability probe disconnected by reachable peer"
+                );
+                finish(RlpxProbeOutcome::Reachable, RlpxProbeStage::Rlpx, None)
+            }
             Ok(Err(error)) => {
                 debug!(
                     error = %error,
@@ -183,7 +196,7 @@ mod tests {
 
     use alloy_primitives::B512;
     use reth_ecies::stream::ECIESStream;
-    use reth_eth_wire::{HelloMessage, UnauthedP2PStream};
+    use reth_eth_wire::{DisconnectReason, HelloMessage, UnauthedP2PStream};
     use secp256k1::{PublicKey, SECP256K1, SecretKey};
     use tokio::{net::TcpListener, sync::oneshot};
 
@@ -220,6 +233,30 @@ mod tests {
         assert_eq!(result.outcome, RlpxProbeOutcome::Reachable);
         assert_eq!(result.stage, RlpxProbeStage::Rlpx);
         assert_eq!(result.client_version.as_deref(), Some("test-peer/1.0"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_disconnect_during_hello_as_reachable() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (remote_secret, remote_id) = node_identity();
+
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let ecies = ECIESStream::incoming(tcp, remote_secret).await.unwrap();
+            UnauthedP2PStream::new(ecies)
+                .send_disconnect(DisconnectReason::TooManyPeers)
+                .await
+                .unwrap();
+        });
+
+        let result =
+            RlpxProber::ephemeral().probe(RlpxProbeTarget { address, node_id: remote_id }).await;
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::Reachable);
+        assert_eq!(result.stage, RlpxProbeStage::Rlpx);
+        assert_eq!(result.client_version, None);
         server.await.unwrap();
     }
 

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -10,7 +10,7 @@ use reth_eth_wire::{
     HelloMessage, UnauthedP2PStream,
     errors::{P2PHandshakeError, P2PStreamError},
 };
-use secp256k1::{PublicKey, SECP256K1, SecretKey};
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
 use tokio::{
     net::TcpStream,
@@ -155,7 +155,8 @@ impl RlpxProber {
     /// Creates a prober with a fresh ephemeral node identity.
     pub fn ephemeral() -> Self {
         let secret_key = SecretKey::new(&mut secp256k1::rand::thread_rng());
-        let public_key = PublicKey::from_secret_key(SECP256K1, &secret_key);
+        let secp = Secp256k1::signing_only();
+        let public_key = PublicKey::from_secret_key(&secp, &secret_key);
         let local_node_id = B512::from_slice(&public_key.serialize_uncompressed()[1..]);
 
         Self { secret_key, local_node_id, timeout: RLPX_PROBE_TIMEOUT }
@@ -250,7 +251,7 @@ mod tests {
     use alloy_primitives::B512;
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire::{DisconnectReason, HelloMessage, UnauthedP2PStream};
-    use secp256k1::{PublicKey, SECP256K1, SecretKey};
+    use secp256k1::{PublicKey, Secp256k1, SecretKey};
     use tokio::{net::TcpListener, sync::oneshot, time::Instant};
 
     use super::{
@@ -262,7 +263,8 @@ mod tests {
 
     fn node_identity() -> (SecretKey, B512) {
         let secret = SecretKey::new(&mut secp256k1::rand::thread_rng());
-        let public = PublicKey::from_secret_key(SECP256K1, &secret);
+        let secp = Secp256k1::signing_only();
+        let public = PublicKey::from_secret_key(&secp, &secret);
         let id = B512::from_slice(&public.serialize_uncompressed()[1..]);
         (secret, id)
     }

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -162,8 +162,8 @@ impl RlpxProber {
         Self { secret_key, local_node_id, timeout: RLPX_PROBE_TIMEOUT }
     }
 
-    #[cfg(test)]
     /// Creates an ephemeral prober with a test-specific timeout.
+    #[cfg(test)]
     pub fn ephemeral_with_timeout(timeout: Duration) -> Self {
         Self { timeout, ..Self::ephemeral() }
     }

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -13,6 +13,7 @@ use tokio::{
     net::TcpStream,
     time::{Instant, timeout_at},
 };
+use tracing::debug;
 
 /// Maximum time allowed for one complete reachability probe.
 pub const RLPX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -117,7 +118,12 @@ impl ReachabilityProber for RlpxProber {
             Err(_) => {
                 return finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Tcp, None);
             }
-            Ok(Err(_)) => {
+            Ok(Err(error)) => {
+                debug!(
+                    error = %error,
+                    stage = ?RlpxProbeStage::Tcp,
+                    "reachability probe transport failed"
+                );
                 return finish(RlpxProbeOutcome::ConnectionFailed, RlpxProbeStage::Tcp, None);
             }
             Ok(Ok(tcp)) => tcp,
@@ -132,7 +138,12 @@ impl ReachabilityProber for RlpxProber {
             Err(_) => {
                 return finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Ecies, None);
             }
-            Ok(Err(_)) => {
+            Ok(Err(error)) => {
+                debug!(
+                    error = %error,
+                    stage = ?RlpxProbeStage::Ecies,
+                    "reachability probe handshake failed"
+                );
                 return finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Ecies, None);
             }
             Ok(Ok(ecies)) => ecies,
@@ -149,7 +160,14 @@ impl ReachabilityProber for RlpxProber {
             Err(_) | Ok(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Timeout))) => {
                 finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Rlpx, None)
             }
-            Ok(Err(_)) => finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Rlpx, None),
+            Ok(Err(error)) => {
+                debug!(
+                    error = %error,
+                    stage = ?RlpxProbeStage::Rlpx,
+                    "reachability probe handshake failed"
+                );
+                finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Rlpx, None)
+            }
             Ok(Ok((_, remote_hello))) => finish(
                 RlpxProbeOutcome::Reachable,
                 RlpxProbeStage::Rlpx,

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -1,3 +1,6 @@
+//! Execution-layer `RLPx` reachability probing: dials a target over TCP,
+//! authenticates the ECIES transport, and exchanges the devp2p Hello.
+
 use std::{fmt, net::SocketAddr, time::Duration};
 
 use alloy_primitives::B512;
@@ -34,6 +37,17 @@ pub enum RlpxProbeOutcome {
     HandshakeFailed,
 }
 
+impl fmt::Display for RlpxProbeOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Reachable => "reachable",
+            Self::ConnectionFailed => "connection_failed",
+            Self::TimedOut => "timed_out",
+            Self::HandshakeFailed => "handshake_failed",
+        })
+    }
+}
+
 /// Protocol stage reached by an `RLPx` reachability probe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -44,6 +58,16 @@ pub enum RlpxProbeStage {
     Ecies,
     /// Exchanging the devp2p Hello message.
     Rlpx,
+}
+
+impl fmt::Display for RlpxProbeStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Tcp => "tcp",
+            Self::Ecies => "ecies",
+            Self::Rlpx => "rlpx",
+        })
+    }
 }
 
 /// Network target for an execution-layer `RLPx` probe.
@@ -123,7 +147,8 @@ impl ReachabilityProber for RlpxProber {
             Ok(Err(error)) => {
                 debug!(
                     error = %error,
-                    stage = ?RlpxProbeStage::Tcp,
+                    target = %target.address,
+                    stage = %RlpxProbeStage::Tcp,
                     "reachability probe transport failed"
                 );
                 return finish(RlpxProbeOutcome::ConnectionFailed, RlpxProbeStage::Tcp, None);
@@ -143,7 +168,8 @@ impl ReachabilityProber for RlpxProber {
             Ok(Err(error)) => {
                 debug!(
                     error = %error,
-                    stage = ?RlpxProbeStage::Ecies,
+                    target = %target.address,
+                    stage = %RlpxProbeStage::Ecies,
                     "reachability probe handshake failed"
                 );
                 return finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Ecies, None);
@@ -168,7 +194,8 @@ impl ReachabilityProber for RlpxProber {
                 // session (e.g. it is at peer capacity).
                 debug!(
                     reason = %reason,
-                    stage = ?RlpxProbeStage::Rlpx,
+                    target = %target.address,
+                    stage = %RlpxProbeStage::Rlpx,
                     "reachability probe disconnected by reachable peer"
                 );
                 finish(RlpxProbeOutcome::Reachable, RlpxProbeStage::Rlpx, None)
@@ -176,7 +203,8 @@ impl ReachabilityProber for RlpxProber {
             Ok(Err(error)) => {
                 debug!(
                     error = %error,
-                    stage = ?RlpxProbeStage::Rlpx,
+                    target = %target.address,
+                    stage = %RlpxProbeStage::Rlpx,
                     "reachability probe handshake failed"
                 );
                 finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Rlpx, None)

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -1,11 +1,11 @@
 //! Execution-layer `RLPx` reachability probing: dials a target over TCP,
 //! authenticates the ECIES transport, and exchanges the devp2p Hello.
 
-use std::{fmt, net::SocketAddr, time::Duration};
+use std::{fmt, io, net::SocketAddr, time::Duration};
 
 use alloy_primitives::B512;
 use async_trait::async_trait;
-use reth_ecies::stream::ECIESStream;
+use reth_ecies::{ECIESError, stream::ECIESStream};
 use reth_eth_wire::{
     HelloMessage, UnauthedP2PStream,
     errors::{P2PHandshakeError, P2PStreamError},
@@ -70,6 +70,44 @@ impl fmt::Display for RlpxProbeStage {
     }
 }
 
+/// Failure of one execution-layer `RLPx` reachability probe.
+#[derive(Debug, thiserror::Error)]
+pub enum RlpxProbeError {
+    /// The TCP connection could not be established.
+    #[error("tcp connect failed: {0}")]
+    Tcp(#[from] io::Error),
+    /// The encrypted ECIES transport could not be authenticated.
+    #[error("ecies handshake failed: {0}")]
+    Ecies(#[from] ECIESError),
+    /// The devp2p Hello exchange failed.
+    #[error("rlpx hello exchange failed: {0}")]
+    Rlpx(P2PStreamError),
+    /// The probe deadline elapsed at the given stage.
+    #[error("probe timed out at {0} stage")]
+    TimedOut(RlpxProbeStage),
+}
+
+impl RlpxProbeError {
+    /// Returns the stable outcome for this failure.
+    pub const fn outcome(&self) -> RlpxProbeOutcome {
+        match self {
+            Self::Tcp(_) => RlpxProbeOutcome::ConnectionFailed,
+            Self::Ecies(_) | Self::Rlpx(_) => RlpxProbeOutcome::HandshakeFailed,
+            Self::TimedOut(_) => RlpxProbeOutcome::TimedOut,
+        }
+    }
+
+    /// Returns the protocol stage at which the failure occurred.
+    pub const fn stage(&self) -> RlpxProbeStage {
+        match self {
+            Self::Tcp(_) => RlpxProbeStage::Tcp,
+            Self::Ecies(_) => RlpxProbeStage::Ecies,
+            Self::Rlpx(_) => RlpxProbeStage::Rlpx,
+            Self::TimedOut(stage) => *stage,
+        }
+    }
+}
+
 /// Network target for an execution-layer `RLPx` probe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RlpxProbeTarget {
@@ -126,56 +164,24 @@ impl RlpxProber {
     pub fn ephemeral_with_timeout(timeout: Duration) -> Self {
         Self { secret_key: SecretKey::new(&mut secp256k1::rand::thread_rng()), timeout }
     }
-}
 
-#[async_trait]
-impl ReachabilityProber for RlpxProber {
-    async fn probe(&self, target: RlpxProbeTarget) -> RlpxProbeResult {
-        let started = Instant::now();
-        let deadline = started + self.timeout;
-        let finish = |outcome, stage, client_version| RlpxProbeResult {
-            outcome,
-            stage,
-            elapsed: started.elapsed(),
-            client_version,
-        };
+    /// Runs one probe attempt against the deadline and returns the remote
+    /// client version advertised in its Hello, if any.
+    pub async fn try_probe(
+        &self,
+        target: RlpxProbeTarget,
+        deadline: Instant,
+    ) -> Result<Option<String>, RlpxProbeError> {
+        let tcp = timeout_at(deadline, TcpStream::connect(target.address))
+            .await
+            .map_err(|_| RlpxProbeError::TimedOut(RlpxProbeStage::Tcp))??;
 
-        let tcp = match timeout_at(deadline, TcpStream::connect(target.address)).await {
-            Err(_) => {
-                return finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Tcp, None);
-            }
-            Ok(Err(error)) => {
-                debug!(
-                    error = %error,
-                    target = %target.address,
-                    stage = %RlpxProbeStage::Tcp,
-                    "reachability probe transport failed"
-                );
-                return finish(RlpxProbeOutcome::ConnectionFailed, RlpxProbeStage::Tcp, None);
-            }
-            Ok(Ok(tcp)) => tcp,
-        };
-
-        let ecies = match timeout_at(
+        let ecies = timeout_at(
             deadline,
             ECIESStream::connect_without_timeout(tcp, self.secret_key, target.node_id),
         )
         .await
-        {
-            Err(_) => {
-                return finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Ecies, None);
-            }
-            Ok(Err(error)) => {
-                debug!(
-                    error = %error,
-                    target = %target.address,
-                    stage = %RlpxProbeStage::Ecies,
-                    "reachability probe handshake failed"
-                );
-                return finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Ecies, None);
-            }
-            Ok(Ok(ecies)) => ecies,
-        };
+        .map_err(|_| RlpxProbeError::TimedOut(RlpxProbeStage::Ecies))??;
 
         let public_key = PublicKey::from_secret_key(SECP256K1, &self.secret_key);
         let local_node_id = B512::from_slice(&public_key.serialize_uncompressed()[1..]);
@@ -184,36 +190,55 @@ impl ReachabilityProber for RlpxProber {
             .port(0)
             .build();
 
-        match timeout_at(deadline, UnauthedP2PStream::new(ecies).handshake(hello)).await {
-            Err(_) | Ok(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Timeout))) => {
-                finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Rlpx, None)
+        match timeout_at(deadline, UnauthedP2PStream::new(ecies).handshake(hello))
+            .await
+            .map_err(|_| RlpxProbeError::TimedOut(RlpxProbeStage::Rlpx))?
+        {
+            Ok((_, remote_hello)) => Ok(Some(remote_hello.client_version)),
+            Err(P2PStreamError::HandshakeError(P2PHandshakeError::Timeout)) => {
+                Err(RlpxProbeError::TimedOut(RlpxProbeStage::Rlpx))
             }
-            Ok(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason)))) => {
+            Err(P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason))) => {
                 // A Disconnect received here arrived over the authenticated ECIES
                 // stream, so the node is reachable even though it refused the
                 // session (e.g. it is at peer capacity).
                 debug!(
                     reason = %reason,
                     target = %target.address,
-                    stage = %RlpxProbeStage::Rlpx,
                     "reachability probe disconnected by reachable peer"
                 );
-                finish(RlpxProbeOutcome::Reachable, RlpxProbeStage::Rlpx, None)
+                Ok(None)
             }
-            Ok(Err(error)) => {
+            Err(error) => Err(RlpxProbeError::Rlpx(error)),
+        }
+    }
+}
+
+#[async_trait]
+impl ReachabilityProber for RlpxProber {
+    async fn probe(&self, target: RlpxProbeTarget) -> RlpxProbeResult {
+        let started = Instant::now();
+        match self.try_probe(target, started + self.timeout).await {
+            Ok(client_version) => RlpxProbeResult {
+                outcome: RlpxProbeOutcome::Reachable,
+                stage: RlpxProbeStage::Rlpx,
+                elapsed: started.elapsed(),
+                client_version,
+            },
+            Err(error) => {
                 debug!(
                     error = %error,
                     target = %target.address,
-                    stage = %RlpxProbeStage::Rlpx,
-                    "reachability probe handshake failed"
+                    stage = %error.stage(),
+                    "reachability probe failed"
                 );
-                finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Rlpx, None)
+                RlpxProbeResult {
+                    outcome: error.outcome(),
+                    stage: error.stage(),
+                    elapsed: started.elapsed(),
+                    client_version: None,
+                }
             }
-            Ok(Ok((_, remote_hello))) => finish(
-                RlpxProbeOutcome::Reachable,
-                RlpxProbeStage::Rlpx,
-                Some(remote_hello.client_version),
-            ),
         }
     }
 }

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -81,7 +81,7 @@ pub enum RlpxProbeError {
     Ecies(#[from] ECIESError),
     /// The devp2p Hello exchange failed.
     #[error("rlpx hello exchange failed: {0}")]
-    Rlpx(P2PStreamError),
+    Rlpx(#[source] P2PStreamError),
     /// The probe deadline elapsed at the given stage.
     #[error("probe timed out at {0} stage")]
     TimedOut(RlpxProbeStage),
@@ -141,6 +141,7 @@ pub trait ReachabilityProber: fmt::Debug + Send + Sync {
 #[derive(Clone)]
 pub struct RlpxProber {
     secret_key: SecretKey,
+    local_node_id: B512,
     timeout: Duration,
 }
 
@@ -153,16 +154,17 @@ impl fmt::Debug for RlpxProber {
 impl RlpxProber {
     /// Creates a prober with a fresh ephemeral node identity.
     pub fn ephemeral() -> Self {
-        Self {
-            secret_key: SecretKey::new(&mut secp256k1::rand::thread_rng()),
-            timeout: RLPX_PROBE_TIMEOUT,
-        }
+        let secret_key = SecretKey::new(&mut secp256k1::rand::thread_rng());
+        let public_key = PublicKey::from_secret_key(SECP256K1, &secret_key);
+        let local_node_id = B512::from_slice(&public_key.serialize_uncompressed()[1..]);
+
+        Self { secret_key, local_node_id, timeout: RLPX_PROBE_TIMEOUT }
     }
 
     #[cfg(test)]
     /// Creates an ephemeral prober with a test-specific timeout.
     pub fn ephemeral_with_timeout(timeout: Duration) -> Self {
-        Self { secret_key: SecretKey::new(&mut secp256k1::rand::thread_rng()), timeout }
+        Self { timeout, ..Self::ephemeral() }
     }
 
     /// Runs one probe attempt against the deadline and returns the remote
@@ -183,9 +185,7 @@ impl RlpxProber {
         .await
         .map_err(|_| RlpxProbeError::TimedOut(RlpxProbeStage::Ecies))??;
 
-        let public_key = PublicKey::from_secret_key(SECP256K1, &self.secret_key);
-        let local_node_id = B512::from_slice(&public_key.serialize_uncompressed()[1..]);
-        let hello = HelloMessage::builder(local_node_id)
+        let hello = HelloMessage::builder(self.local_node_id)
             .client_version(format!("base-telemetry/{}", env!("CARGO_PKG_VERSION")))
             .port(0)
             .build();
@@ -245,16 +245,17 @@ impl ReachabilityProber for RlpxProber {
 
 #[cfg(test)]
 mod tests {
-    use std::{future, time::Duration};
+    use std::{error::Error as _, future, time::Duration};
 
     use alloy_primitives::B512;
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire::{DisconnectReason, HelloMessage, UnauthedP2PStream};
     use secp256k1::{PublicKey, SECP256K1, SecretKey};
-    use tokio::{net::TcpListener, sync::oneshot};
+    use tokio::{net::TcpListener, sync::oneshot, time::Instant};
 
     use super::{
-        ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxProbeTarget, RlpxProber,
+        RLPX_PROBE_TIMEOUT, ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxProbeTarget,
+        RlpxProber,
     };
 
     const TEST_TIMEOUT: Duration = Duration::from_millis(100);
@@ -342,11 +343,17 @@ mod tests {
             drop(ecies);
         });
 
-        let result =
-            RlpxProber::ephemeral().probe(RlpxProbeTarget { address, node_id: remote_id }).await;
+        let error = RlpxProber::ephemeral()
+            .try_probe(
+                RlpxProbeTarget { address, node_id: remote_id },
+                Instant::now() + RLPX_PROBE_TIMEOUT,
+            )
+            .await
+            .unwrap_err();
 
-        assert_eq!(result.outcome, RlpxProbeOutcome::HandshakeFailed);
-        assert_eq!(result.stage, RlpxProbeStage::Rlpx);
+        assert_eq!(error.outcome(), RlpxProbeOutcome::HandshakeFailed);
+        assert_eq!(error.stage(), RlpxProbeStage::Rlpx);
+        assert!(error.source().is_some());
         server.await.unwrap();
     }
 

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -1,0 +1,313 @@
+use std::{fmt, net::SocketAddr, time::Duration};
+
+use alloy_primitives::B512;
+use async_trait::async_trait;
+use reth_ecies::stream::ECIESStream;
+use reth_eth_wire::{
+    HelloMessage, UnauthedP2PStream,
+    errors::{P2PHandshakeError, P2PStreamError},
+};
+use secp256k1::{PublicKey, SECP256K1, SecretKey};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    net::TcpStream,
+    time::{Instant, timeout_at},
+};
+
+/// Maximum time allowed for one complete reachability probe.
+pub const RLPX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Stable outcome returned by an `RLPx` reachability probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RlpxProbeOutcome {
+    /// TCP, ECIES, and devp2p Hello completed successfully.
+    Reachable,
+    /// The TCP connection could not be established.
+    ConnectionFailed,
+    /// The overall probe deadline elapsed.
+    TimedOut,
+    /// TCP connected, but ECIES or devp2p Hello failed.
+    HandshakeFailed,
+}
+
+/// Protocol stage reached by an `RLPx` reachability probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RlpxProbeStage {
+    /// Establishing the TCP connection.
+    Tcp,
+    /// Authenticating the encrypted ECIES transport.
+    Ecies,
+    /// Exchanging the devp2p Hello message.
+    Rlpx,
+}
+
+/// Network target for an execution-layer `RLPx` probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RlpxProbeTarget {
+    /// Public socket address to dial.
+    pub address: SocketAddr,
+    /// Expected 64-byte execution-layer node identity.
+    pub node_id: B512,
+}
+
+/// Result produced by an execution-layer `RLPx` probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RlpxProbeResult {
+    /// Stable probe outcome.
+    pub outcome: RlpxProbeOutcome,
+    /// Protocol stage reached by the probe.
+    pub stage: RlpxProbeStage,
+    /// Total probe duration.
+    pub elapsed: Duration,
+    /// Client version returned by the remote devp2p Hello.
+    pub client_version: Option<String>,
+}
+
+/// Interface used by the HTTP route to execute reachability probes.
+#[async_trait]
+pub trait ReachabilityProber: fmt::Debug + Send + Sync {
+    /// Probes one execution-layer target.
+    async fn probe(&self, target: RlpxProbeTarget) -> RlpxProbeResult;
+}
+
+/// Process-local execution-layer `RLPx` prober.
+#[derive(Clone)]
+pub struct RlpxProber {
+    secret_key: SecretKey,
+    timeout: Duration,
+}
+
+impl fmt::Debug for RlpxProber {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("RlpxProber").finish_non_exhaustive()
+    }
+}
+
+impl RlpxProber {
+    /// Creates a prober with a fresh ephemeral node identity.
+    pub fn ephemeral() -> Self {
+        Self {
+            secret_key: SecretKey::new(&mut secp256k1::rand::thread_rng()),
+            timeout: RLPX_PROBE_TIMEOUT,
+        }
+    }
+
+    #[cfg(test)]
+    /// Creates an ephemeral prober with a test-specific timeout.
+    pub fn ephemeral_with_timeout(timeout: Duration) -> Self {
+        Self { secret_key: SecretKey::new(&mut secp256k1::rand::thread_rng()), timeout }
+    }
+}
+
+#[async_trait]
+impl ReachabilityProber for RlpxProber {
+    async fn probe(&self, target: RlpxProbeTarget) -> RlpxProbeResult {
+        let started = Instant::now();
+        let deadline = started + self.timeout;
+        let finish = |outcome, stage, client_version| RlpxProbeResult {
+            outcome,
+            stage,
+            elapsed: started.elapsed(),
+            client_version,
+        };
+
+        let tcp = match timeout_at(deadline, TcpStream::connect(target.address)).await {
+            Err(_) => {
+                return finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Tcp, None);
+            }
+            Ok(Err(_)) => {
+                return finish(RlpxProbeOutcome::ConnectionFailed, RlpxProbeStage::Tcp, None);
+            }
+            Ok(Ok(tcp)) => tcp,
+        };
+
+        let ecies = match timeout_at(
+            deadline,
+            ECIESStream::connect_without_timeout(tcp, self.secret_key, target.node_id),
+        )
+        .await
+        {
+            Err(_) => {
+                return finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Ecies, None);
+            }
+            Ok(Err(_)) => {
+                return finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Ecies, None);
+            }
+            Ok(Ok(ecies)) => ecies,
+        };
+
+        let public_key = PublicKey::from_secret_key(SECP256K1, &self.secret_key);
+        let local_node_id = B512::from_slice(&public_key.serialize_uncompressed()[1..]);
+        let hello = HelloMessage::builder(local_node_id)
+            .client_version(format!("base-telemetry/{}", env!("CARGO_PKG_VERSION")))
+            .port(0)
+            .build();
+
+        match timeout_at(deadline, UnauthedP2PStream::new(ecies).handshake(hello)).await {
+            Err(_) | Ok(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Timeout))) => {
+                finish(RlpxProbeOutcome::TimedOut, RlpxProbeStage::Rlpx, None)
+            }
+            Ok(Err(_)) => finish(RlpxProbeOutcome::HandshakeFailed, RlpxProbeStage::Rlpx, None),
+            Ok(Ok((_, remote_hello))) => finish(
+                RlpxProbeOutcome::Reachable,
+                RlpxProbeStage::Rlpx,
+                Some(remote_hello.client_version),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future, time::Duration};
+
+    use alloy_primitives::B512;
+    use reth_ecies::stream::ECIESStream;
+    use reth_eth_wire::{HelloMessage, UnauthedP2PStream};
+    use secp256k1::{PublicKey, SECP256K1, SecretKey};
+    use tokio::{net::TcpListener, sync::oneshot};
+
+    use super::{
+        ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxProbeTarget, RlpxProber,
+    };
+
+    const TEST_TIMEOUT: Duration = Duration::from_millis(100);
+
+    fn node_identity() -> (SecretKey, B512) {
+        let secret = SecretKey::new(&mut secp256k1::rand::thread_rng());
+        let public = PublicKey::from_secret_key(SECP256K1, &secret);
+        let id = B512::from_slice(&public.serialize_uncompressed()[1..]);
+        (secret, id)
+    }
+
+    #[tokio::test]
+    async fn completes_rlpx_handshake_with_local_peer() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (remote_secret, remote_id) = node_identity();
+
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let ecies = ECIESStream::incoming(tcp, remote_secret).await.unwrap();
+            let hello =
+                HelloMessage::builder(remote_id).client_version("test-peer/1.0").port(0).build();
+            UnauthedP2PStream::new(ecies).handshake(hello).await.unwrap();
+        });
+
+        let result =
+            RlpxProber::ephemeral().probe(RlpxProbeTarget { address, node_id: remote_id }).await;
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::Reachable);
+        assert_eq!(result.stage, RlpxProbeStage::Rlpx);
+        assert_eq!(result.client_version.as_deref(), Some("test-peer/1.0"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_ecies_handshake_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (_, remote_id) = node_identity();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            drop(tcp);
+        });
+
+        let result =
+            RlpxProber::ephemeral().probe(RlpxProbeTarget { address, node_id: remote_id }).await;
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::HandshakeFailed);
+        assert_eq!(result.stage, RlpxProbeStage::Ecies);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_rlpx_handshake_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (remote_secret, remote_id) = node_identity();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let ecies = ECIESStream::incoming(tcp, remote_secret).await.unwrap();
+            drop(ecies);
+        });
+
+        let result =
+            RlpxProber::ephemeral().probe(RlpxProbeTarget { address, node_id: remote_id }).await;
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::HandshakeFailed);
+        assert_eq!(result.stage, RlpxProbeStage::Rlpx);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_ecies_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (_, remote_id) = node_identity();
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut byte = [0_u8; 1];
+            tcp.peek(&mut byte).await.unwrap();
+            accepted_tx.send(()).unwrap();
+            future::pending::<()>().await;
+            drop(tcp);
+        });
+        let probe = tokio::spawn(async move {
+            RlpxProber::ephemeral_with_timeout(TEST_TIMEOUT)
+                .probe(RlpxProbeTarget { address, node_id: remote_id })
+                .await
+        });
+
+        accepted_rx.await.unwrap();
+        let result = probe.await.unwrap();
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::TimedOut);
+        assert_eq!(result.stage, RlpxProbeStage::Ecies);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn reports_rlpx_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (remote_secret, remote_id) = node_identity();
+        let (authenticated_tx, authenticated_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let ecies = ECIESStream::incoming(tcp, remote_secret).await.unwrap();
+            authenticated_tx.send(()).unwrap();
+            future::pending::<()>().await;
+            drop(ecies);
+        });
+        let probe = tokio::spawn(async move {
+            RlpxProber::ephemeral_with_timeout(TEST_TIMEOUT)
+                .probe(RlpxProbeTarget { address, node_id: remote_id })
+                .await
+        });
+
+        authenticated_rx.await.unwrap();
+        let result = probe.await.unwrap();
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::TimedOut);
+        assert_eq!(result.stage, RlpxProbeStage::Rlpx);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn reports_closed_port_as_connection_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+
+        let result =
+            RlpxProber::ephemeral().probe(RlpxProbeTarget { address, node_id: B512::ZERO }).await;
+
+        assert_eq!(result.outcome, RlpxProbeOutcome::ConnectionFailed);
+        assert_eq!(result.stage, RlpxProbeStage::Tcp);
+        assert_eq!(result.client_version, None);
+    }
+}

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -72,8 +72,6 @@ impl BaseTelemetryServer {
 #[cfg(test)]
 mod tests {
     use std::{
-        env,
-        ffi::OsString,
         net::SocketAddr,
         str::FromStr,
         sync::{Arc, atomic::AtomicBool},
@@ -85,7 +83,6 @@ mod tests {
     use base_health::HealthServer;
     use clap::Parser;
     use ipnet::IpNet;
-    use serial_test::serial;
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use crate::{
@@ -98,32 +95,6 @@ mod tests {
     struct TestCli {
         #[command(flatten)]
         server: ServerConfig,
-    }
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = env::var_os(key);
-            // SAFETY: this helper is only used by a serial test for this unique variable.
-            unsafe { env::set_var(key, value) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // SAFETY: the creating test is serial and restores the variable before returning.
-            unsafe {
-                match &self.previous {
-                    Some(value) => env::set_var(self.key, value),
-                    None => env::remove_var(self.key),
-                }
-            }
-        }
     }
 
     #[derive(Debug, Clone)]
@@ -171,20 +142,6 @@ mod tests {
             "192.168.0.0/16",
         ])
         .unwrap();
-
-        assert_eq!(
-            cli.server.trusted_proxy_cidrs,
-            [IpNet::from_str("10.0.0.0/8").unwrap(), IpNet::from_str("192.168.0.0/16").unwrap(),]
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn parses_trusted_proxy_cidrs_from_env() {
-        let _guard =
-            EnvVarGuard::set("BASE_TELEMETRY_TRUSTED_PROXY_CIDRS", "10.0.0.0/8,192.168.0.0/16");
-
-        let cli = TestCli::try_parse_from(["test"]).unwrap();
 
         assert_eq!(
             cli.server.trusted_proxy_cidrs,

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -10,12 +10,11 @@ use anyhow::Context;
 use axum::Router;
 use base_health::HealthServer;
 use clap::Args;
-use ipnet::IpNet;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{P2pRoutes, RlpxProber};
+use crate::{P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2pRoutes, RlpxProber};
 
 /// Configuration for the Base telemetry HTTP server.
 #[derive(Args, Debug, Clone)]
@@ -23,13 +22,6 @@ pub struct ServerConfig {
     /// Socket address to bind the HTTP server to.
     #[arg(long, env = "BASE_TELEMETRY_LISTEN_ADDR", default_value = "0.0.0.0:8080")]
     pub listen_addr: SocketAddr,
-    /// Proxy networks trusted to supply the `X-Forwarded-For` client chain.
-    #[arg(
-        long = "trusted-proxy-cidr",
-        env = "BASE_TELEMETRY_TRUSTED_PROXY_CIDRS",
-        value_delimiter = ','
-    )]
-    pub trusted_proxy_cidrs: Vec<IpNet>,
 }
 
 /// Base telemetry Axum server scaffold.
@@ -38,18 +30,18 @@ pub struct BaseTelemetryServer;
 
 impl BaseTelemetryServer {
     /// Returns the application router for the telemetry service.
-    pub fn router(ready: Arc<AtomicBool>, trusted_proxy_cidrs: Vec<IpNet>) -> Router {
+    pub fn router(ready: Arc<AtomicBool>) -> Router {
         HealthServer::router(ready).merge(P2pRoutes::router_with_prober(
-            trusted_proxy_cidrs,
+            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
             Arc::new(RlpxProber::ephemeral()),
         ))
     }
 
     /// Starts the telemetry service with the provided configuration.
     pub async fn serve(config: ServerConfig, cancel: CancellationToken) -> anyhow::Result<()> {
-        let ServerConfig { listen_addr, trusted_proxy_cidrs } = config;
+        let ServerConfig { listen_addr } = config;
         let ready = Arc::new(AtomicBool::new(false));
-        let app = Self::router(Arc::clone(&ready), trusted_proxy_cidrs);
+        let app = Self::router(Arc::clone(&ready));
         let listener = TcpListener::bind(listen_addr)
             .await
             .with_context(|| format!("failed to bind base telemetry server to {listen_addr}"))?;
@@ -60,7 +52,7 @@ impl BaseTelemetryServer {
 
         info!(listen_addr = %listen_addr, "base telemetry server started");
 
-        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
+        axum::serve(listener, app)
             .with_graceful_shutdown(async move { cancel.cancelled().await })
             .await
             .context("base telemetry server exited unexpectedly")?;
@@ -73,7 +65,6 @@ impl BaseTelemetryServer {
 mod tests {
     use std::{
         net::SocketAddr,
-        str::FromStr,
         sync::{Arc, atomic::AtomicBool},
         time::Duration,
     };
@@ -81,21 +72,13 @@ mod tests {
     use async_trait::async_trait;
     use axum::{Router, http::StatusCode};
     use base_health::HealthServer;
-    use clap::Parser;
-    use ipnet::IpNet;
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use crate::{
         BaseTelemetryServer, P2P_REACHABILITY_PATH, P2pReachabilityRequest, P2pRoutes,
         ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
-        ServerConfig, TEST_NODE_ID,
+        TEST_NODE_ID,
     };
-
-    #[derive(Debug, Parser)]
-    struct TestCli {
-        #[command(flatten)]
-        server: ServerConfig,
-    }
 
     #[derive(Debug, Clone)]
     struct BlockingProber {
@@ -121,32 +104,13 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = tokio::spawn(async move {
-            axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
-                .await
-                .unwrap();
+            axum::serve(listener, router).await.unwrap();
         });
         (addr, handle)
     }
 
     async fn start_test_server() -> (SocketAddr, JoinHandle<()>) {
-        start_router(BaseTelemetryServer::router(Arc::new(AtomicBool::new(true)), Vec::new())).await
-    }
-
-    #[test]
-    fn parses_repeated_trusted_proxy_arguments() {
-        let cli = TestCli::try_parse_from([
-            "test",
-            "--trusted-proxy-cidr",
-            "10.0.0.0/8",
-            "--trusted-proxy-cidr",
-            "192.168.0.0/16",
-        ])
-        .unwrap();
-
-        assert_eq!(
-            cli.server.trusted_proxy_cidrs,
-            [IpNet::from_str("10.0.0.0/8").unwrap(), IpNet::from_str("192.168.0.0/16").unwrap(),]
-        );
+        start_router(BaseTelemetryServer::router(Arc::new(AtomicBool::new(true)))).await
     }
 
     #[tokio::test]
@@ -177,12 +141,8 @@ mod tests {
             entered: Arc::new(Semaphore::new(0)),
             release: Arc::new(Semaphore::new(0)),
         });
-        let router = HealthServer::router(Arc::new(AtomicBool::new(true))).merge(
-            P2pRoutes::router_with_prober(
-                vec![IpNet::from_str("127.0.0.1/32").unwrap()],
-                Arc::clone(&prober),
-            ),
-        );
+        let router = HealthServer::router(Arc::new(AtomicBool::new(true)))
+            .merge(P2pRoutes::router_with_prober(1, Arc::clone(&prober)));
         let (addr, handle) = start_router(router).await;
         let request =
             P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303") };
@@ -192,7 +152,6 @@ mod tests {
         let probe = tokio::spawn(async move {
             probe_client
                 .post(format!("http://{addr}{P2P_REACHABILITY_PATH}"))
-                .header("x-forwarded-for", "8.8.8.8")
                 .json(&request)
                 .send()
                 .await

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -89,9 +89,9 @@ mod tests {
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use crate::{
-        BaseTelemetryServer, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pReachabilityRequest,
-        P2pRoutes, ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
-        RlpxProbeTarget, ServerConfig, TEST_NODE_ID,
+        BaseTelemetryServer, P2P_REACHABILITY_PATH, P2pReachabilityRequest, P2pRoutes,
+        ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
+        ServerConfig, TEST_NODE_ID,
     };
 
     #[derive(Debug, Parser)]
@@ -227,11 +227,8 @@ mod tests {
             ),
         );
         let (addr, handle) = start_router(router).await;
-        let request = P2pReachabilityRequest {
-            node_id: TEST_NODE_ID.to_string(),
-            tcp_port: 30303,
-            address_family: P2pAddressFamily::Ipv4,
-        };
+        let request =
+            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303") };
         let client = reqwest::Client::new();
         let probe_client = client.clone();
 

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -10,9 +10,12 @@ use anyhow::Context;
 use axum::Router;
 use base_health::HealthServer;
 use clap::Args;
+use ipnet::IpNet;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
+
+use crate::{P2pRoutes, RlpxProber};
 
 /// Configuration for the Base telemetry HTTP server.
 #[derive(Args, Debug, Clone)]
@@ -20,6 +23,13 @@ pub struct ServerConfig {
     /// Socket address to bind the HTTP server to.
     #[arg(long, env = "BASE_TELEMETRY_LISTEN_ADDR", default_value = "0.0.0.0:8080")]
     pub listen_addr: SocketAddr,
+    /// Proxy networks trusted to supply the `X-Forwarded-For` client chain.
+    #[arg(
+        long = "trusted-proxy-cidr",
+        env = "BASE_TELEMETRY_TRUSTED_PROXY_CIDRS",
+        value_delimiter = ','
+    )]
+    pub trusted_proxy_cidrs: Vec<IpNet>,
 }
 
 /// Base telemetry Axum server scaffold.
@@ -28,17 +38,21 @@ pub struct BaseTelemetryServer;
 
 impl BaseTelemetryServer {
     /// Returns the application router for the telemetry service.
-    pub fn router(ready: Arc<AtomicBool>) -> Router {
-        HealthServer::router(ready)
+    pub fn router(ready: Arc<AtomicBool>, trusted_proxy_cidrs: Vec<IpNet>) -> Router {
+        HealthServer::router(ready).merge(P2pRoutes::router_with_prober(
+            trusted_proxy_cidrs,
+            Arc::new(RlpxProber::ephemeral()),
+        ))
     }
 
     /// Starts the telemetry service with the provided configuration.
     pub async fn serve(config: ServerConfig, cancel: CancellationToken) -> anyhow::Result<()> {
+        let ServerConfig { listen_addr, trusted_proxy_cidrs } = config;
         let ready = Arc::new(AtomicBool::new(false));
-        let app = Self::router(Arc::clone(&ready));
-        let listener = TcpListener::bind(config.listen_addr).await.with_context(|| {
-            format!("failed to bind base telemetry server to {}", config.listen_addr)
-        })?;
+        let app = Self::router(Arc::clone(&ready), trusted_proxy_cidrs);
+        let listener = TcpListener::bind(listen_addr)
+            .await
+            .with_context(|| format!("failed to bind base telemetry server to {listen_addr}"))?;
         let listen_addr =
             listener.local_addr().context("failed to read base telemetry listen address")?;
 
@@ -46,7 +60,7 @@ impl BaseTelemetryServer {
 
         info!(listen_addr = %listen_addr, "base telemetry server started");
 
-        axum::serve(listener, app)
+        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
             .with_graceful_shutdown(async move { cancel.cancelled().await })
             .await
             .context("base telemetry server exited unexpectedly")?;
@@ -58,24 +72,124 @@ impl BaseTelemetryServer {
 #[cfg(test)]
 mod tests {
     use std::{
+        env,
+        ffi::OsString,
         net::SocketAddr,
+        str::FromStr,
         sync::{Arc, atomic::AtomicBool},
+        time::Duration,
     };
 
-    use axum::http::StatusCode;
-    use tokio::{net::TcpListener, task::JoinHandle};
+    use async_trait::async_trait;
+    use axum::{Router, http::StatusCode};
+    use base_health::HealthServer;
+    use clap::Parser;
+    use ipnet::IpNet;
+    use serial_test::serial;
+    use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
-    use crate::BaseTelemetryServer;
+    use crate::{
+        BaseTelemetryServer, P2P_REACHABILITY_PATH, P2pAddressFamily, P2pReachabilityRequest,
+        P2pRoutes, ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
+        RlpxProbeTarget, ServerConfig, TEST_NODE_ID,
+    };
 
-    async fn start_test_server() -> (SocketAddr, JoinHandle<()>) {
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        server: ServerConfig,
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: this helper is only used by a serial test for this unique variable.
+            unsafe { env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: the creating test is serial and restores the variable before returning.
+            unsafe {
+                match &self.previous {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct BlockingProber {
+        entered: Arc<Semaphore>,
+        release: Arc<Semaphore>,
+    }
+
+    #[async_trait]
+    impl ReachabilityProber for BlockingProber {
+        async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
+            self.entered.add_permits(1);
+            self.release.acquire().await.unwrap().forget();
+            RlpxProbeResult {
+                outcome: RlpxProbeOutcome::Reachable,
+                stage: RlpxProbeStage::Rlpx,
+                elapsed: Duration::from_millis(1),
+                client_version: None,
+            }
+        }
+    }
+
+    async fn start_router(router: Router) -> (SocketAddr, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let ready = Arc::new(AtomicBool::new(true));
         let handle = tokio::spawn(async move {
-            axum::serve(listener, BaseTelemetryServer::router(ready)).await.unwrap();
+            axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
+                .await
+                .unwrap();
         });
-
         (addr, handle)
+    }
+
+    async fn start_test_server() -> (SocketAddr, JoinHandle<()>) {
+        start_router(BaseTelemetryServer::router(Arc::new(AtomicBool::new(true)), Vec::new())).await
+    }
+
+    #[test]
+    fn parses_repeated_trusted_proxy_arguments() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "--trusted-proxy-cidr",
+            "10.0.0.0/8",
+            "--trusted-proxy-cidr",
+            "192.168.0.0/16",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cli.server.trusted_proxy_cidrs,
+            [IpNet::from_str("10.0.0.0/8").unwrap(), IpNet::from_str("192.168.0.0/16").unwrap(),]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn parses_trusted_proxy_cidrs_from_env() {
+        let _guard =
+            EnvVarGuard::set("BASE_TELEMETRY_TRUSTED_PROXY_CIDRS", "10.0.0.0/8,192.168.0.0/16");
+
+        let cli = TestCli::try_parse_from(["test"]).unwrap();
+
+        assert_eq!(
+            cli.server.trusted_proxy_cidrs,
+            [IpNet::from_str("10.0.0.0/8").unwrap(), IpNet::from_str("192.168.0.0/16").unwrap(),]
+        );
     }
 
     #[tokio::test]
@@ -97,6 +211,54 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
 
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn health_routes_remain_available_during_saturated_probe() {
+        let prober = Arc::new(BlockingProber {
+            entered: Arc::new(Semaphore::new(0)),
+            release: Arc::new(Semaphore::new(0)),
+        });
+        let router = HealthServer::router(Arc::new(AtomicBool::new(true))).merge(
+            P2pRoutes::router_with_prober(
+                vec![IpNet::from_str("127.0.0.1/32").unwrap()],
+                Arc::clone(&prober),
+            ),
+        );
+        let (addr, handle) = start_router(router).await;
+        let request = P2pReachabilityRequest {
+            node_id: TEST_NODE_ID.to_string(),
+            tcp_port: 30303,
+            address_family: P2pAddressFamily::Ipv4,
+        };
+        let client = reqwest::Client::new();
+        let probe_client = client.clone();
+
+        let probe = tokio::spawn(async move {
+            probe_client
+                .post(format!("http://{addr}{P2P_REACHABILITY_PATH}"))
+                .header("x-forwarded-for", "8.8.8.8")
+                .json(&request)
+                .send()
+                .await
+                .unwrap()
+        });
+        prober.entered.acquire().await.unwrap().forget();
+
+        let health = client
+            .get(format!("http://{addr}/healthz"))
+            .body("x".repeat(2048))
+            .send()
+            .await
+            .unwrap();
+        let ready = client.get(format!("http://{addr}/readyz")).send().await.unwrap();
+
+        assert_eq!(health.status(), StatusCode::OK);
+        assert_eq!(ready.status(), StatusCode::OK);
+
+        prober.release.add_permits(1);
+        assert_eq!(probe.await.unwrap().status(), StatusCode::OK);
         handle.abort();
     }
 }


### PR DESCRIPTION
## Summary
- Add a source-bound endpoint for external EL reachability checks
- Verify TCP, ECIES, and devp2p Hello connectivity with structured outcomes
- Add trusted-proxy validation, concurrency limits, tests, and documentation

## Test Plan
- [x] `cargo check -p base-telemetry-service -p base-telemetry-bin`
- [x] `cargo test -p base-telemetry-service -p base-telemetry-bin`
- [x] `cargo clippy -p base-telemetry-service -p base-telemetry-bin --all-targets -- -D warnings`
- [x] Formatting and diff checks pass

## Breaking Changes
None.