### PR TITLE
fix(consensus): bound L1 RPC requests with shared transport timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6296,6 +6296,7 @@ dependencies = [
  "base-consensus-gossip",
  "base-consensus-node",
  "base-consensus-peers",
+ "base-consensus-providers",
  "base-consensus-rpc",
  "base-consensus-sources",
  "base-execution-chainspec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,6 +4241,7 @@ dependencies = [
  "alloy-rpc-client 2.0.5",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-serde 2.0.5",
  "alloy-transport 2.0.5",
  "alloy-transport-http 2.0.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,6 +4068,7 @@ dependencies = [
  "base-common-network",
  "base-common-rpc-types",
  "base-common-rpc-types-engine",
+ "base-consensus-providers",
  "base-metrics",
  "base-protocol",
  "derive_more 2.1.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4070,6 +4070,7 @@ dependencies = [
  "base-common-network",
  "base-common-rpc-types",
  "base-common-rpc-types-engine",
+ "base-consensus-providers",
  "base-metrics",
  "base-protocol",
  "derive_more 2.1.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,7 @@ dependencies = [
  "alloy-rpc-client 2.0.5",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-serde 2.0.5",
  "alloy-transport 2.0.5",
  "alloy-transport-http 2.0.5",

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -9,7 +9,7 @@ use base_common_network::Base;
 use base_consensus_node::{
     EngineConfig, FollowNode, FollowNodeConfig, L1Config, NodeMode, RemoteL2Client,
 };
-use base_consensus_providers::OnlineBeaconClient;
+use base_consensus_providers::{L1RpcProvider, OnlineBeaconClient};
 use base_consensus_rpc::RpcBuilder;
 use clap::Args;
 use reth_node_core::args::TraceArgs;
@@ -265,7 +265,7 @@ impl ConsensusFollowNodeArgs {
             chain_config: Arc::new(l1_chain_config),
             trust_rpc: self.config.l1_rpc_args.l1_trust_rpc,
             beacon_client: l1_beacon,
-            engine_provider: RootProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone()),
+            engine_provider: L1RpcProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone()),
             finalized_poll_interval: L1Config::default_finalized_poll_interval(cfg.l1_chain_id),
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,
         })

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -192,12 +192,15 @@ impl ConsensusFollowNodeArgs {
         };
         let engine_client =
             Arc::new(engine_config.build_engine_client().await.map_err(|e| eyre::eyre!(e))?);
-        let l2_source = RemoteL2Client::new(self.config.source_l2_rpc.clone());
+        let l1_provider = RootProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone());
+        let l2_source =
+            RemoteL2Client::new(self.config.source_l2_rpc.clone(), Arc::clone(&rollup_config));
         let rpc_builder = Option::<RpcBuilder>::from(self.config.rpc_flags.clone());
 
         Ok(FollowNode::new(FollowNodeConfig {
             rollup_config,
             engine_client,
+            l1_provider,
             local_l2_provider,
             l2_source,
             rpc_builder,

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -192,9 +192,8 @@ impl ConsensusFollowNodeArgs {
         };
         let engine_client =
             Arc::new(engine_config.build_engine_client().await.map_err(|e| eyre::eyre!(e))?);
-        let l1_provider = RootProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone());
-        let l2_source =
-            RemoteL2Client::new(self.config.source_l2_rpc.clone(), Arc::clone(&rollup_config));
+        let l1_provider = L1RpcProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone());
+        let l2_source = RemoteL2Client::new(self.config.source_l2_rpc.clone());
         let rpc_builder = Option::<RpcBuilder>::from(self.config.rpc_flags.clone());
 
         Ok(FollowNode::new(FollowNodeConfig {

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -3,7 +3,6 @@
 use std::{path::PathBuf, sync::Arc};
 
 use alloy_primitives::Address;
-use alloy_provider::RootProvider;
 use alloy_rpc_types_engine::JwtSecret;
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_common_chains::ChainConfig;
@@ -12,6 +11,7 @@ use base_consensus_node::{
     EngineConfig, L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder,
     UpgradeSignalBuilderConfig,
 };
+use base_consensus_providers::L1RpcProvider;
 use base_upgrade_signal::{
     UpgradeSignalArgs, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalRuntimeApplier,
     UpgradeSignalSchedule, UpgradeSignalStartupMode,
@@ -504,7 +504,7 @@ impl ConsensusNodeArgs {
         signal_config: &UpgradeSignalConfig,
         upgrade_signal_l1_rpc: Option<&Url>,
     ) -> eyre::Result<()> {
-        let reader = signal_config.reader(RootProvider::new_http(
+        let reader = signal_config.reader(L1RpcProvider::new_http(
             self.resolved_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc),
         ));
         let schedule = signal_config

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -3,7 +3,6 @@
 use std::{path::PathBuf, sync::Arc};
 
 use alloy_primitives::Address;
-use alloy_provider::RootProvider;
 use alloy_rpc_types_engine::JwtSecret;
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_common_chains::ChainConfig;
@@ -12,6 +11,7 @@ use base_consensus_node::{
     EngineConfig, L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder,
     UpgradeSignalBuilderConfig,
 };
+use base_consensus_providers::L1RpcProvider;
 use base_upgrade_signal::{
     UpgradeSignalArgs, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalRuntimeApplier,
     UpgradeSignalRuntimeValidation, UpgradeSignalSchedule, UpgradeSignalStartupMode,
@@ -517,7 +517,7 @@ impl ConsensusNodeArgs {
         runtime_validation: UpgradeSignalRuntimeValidation,
         upgrade_signal_l1_rpc: Option<&Url>,
     ) -> eyre::Result<()> {
-        let reader = signal_config.reader(RootProvider::new_http(
+        let reader = signal_config.reader(L1RpcProvider::new_http(
             self.resolved_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc),
         ));
         let schedule = signal_config

--- a/crates/consensus/engine/Cargo.toml
+++ b/crates/consensus/engine/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # workspace
 base-metrics.workspace = true
 base-common-genesis.workspace = true
+base-consensus-providers.workspace = true
 base-protocol = {workspace = true, features = ["serde", "std"]}
 
 # alloy

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -25,6 +25,7 @@ use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
     BaseExecutionPayloadV4, BasePayloadAttributes,
 };
+use base_consensus_providers::L1RpcProvider;
 use base_protocol::{FromBlockError, L2BlockInfo};
 use http_body_util::Full;
 use thiserror::Error;
@@ -186,7 +187,7 @@ impl EngineClientBuilder {
         )
         .await?;
 
-        let l1_provider = RootProvider::new_http(self.l1_rpc);
+        let l1_provider = L1RpcProvider::new_http(self.l1_rpc);
 
         Ok(BaseEngineClient { engine, l1_provider, cfg: self.cfg })
     }

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -24,6 +24,7 @@ use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
     BaseExecutionPayloadV4, BasePayloadAttributes,
 };
+use base_consensus_providers::L1RpcProvider;
 use base_protocol::{FromBlockError, L2BlockInfo};
 use http_body_util::Full;
 use thiserror::Error;
@@ -187,7 +188,7 @@ impl EngineClientBuilder {
         )
         .await?;
 
-        let l1_provider = RootProvider::new_http(self.l1_rpc);
+        let l1_provider = L1RpcProvider::new_http(self.l1_rpc);
 
         Ok(BaseEngineClient { engine, l1_provider, cfg: self.cfg })
     }

--- a/crates/consensus/providers/Cargo.toml
+++ b/crates/consensus/providers/Cargo.toml
@@ -62,6 +62,7 @@ metrics = [
 ]
 
 [dev-dependencies]
+alloy-rpc-types-eth.workspace = true
 tokio = { workspace = true, features = ["macros", "test-util"] }
 httpmock.workspace = true
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/consensus/providers/src/beacon_client.rs
+++ b/crates/consensus/providers/src/beacon_client.rs
@@ -428,7 +428,10 @@ mod tests {
             .await
             .expect("beacon requests must not remain pending");
 
-        assert!(result.is_err(), "beacon request should fail at the request deadline");
+        assert!(
+            matches!(result, Err(BeaconClientError::Http(error)) if error.is_timeout()),
+            "beacon request should fail with a request timeout"
+        );
         mock.assert_async().await;
     }
 }

--- a/crates/consensus/providers/src/beacon_client.rs
+++ b/crates/consensus/providers/src/beacon_client.rs
@@ -1,6 +1,6 @@
 //! Contains an online implementation of the `BeaconClient` trait.
 
-use std::{boxed::Box, collections::HashMap, format, string::String, vec::Vec};
+use std::{boxed::Box, collections::HashMap, format, string::String, time::Duration, vec::Vec};
 
 use alloy_eips::eip4844::{env_settings::EnvKzgSettings, kzg_to_versioned_hash};
 use alloy_primitives::{B256, FixedBytes};
@@ -142,7 +142,11 @@ impl OnlineBeaconClient {
     /// Creates a new [`OnlineBeaconClient`] from the provided base URL string.
     ///
     /// Requests use the shared [`crate::L1_RPC_TIMEOUT`] deadline.
-    pub fn new_http(mut base: String) -> Self {
+    pub fn new_http(base: String) -> Self {
+        Self::with_timeout(base, crate::L1_RPC_TIMEOUT)
+    }
+
+    fn with_timeout(mut base: String, timeout: Duration) -> Self {
         // If base ends with a slash, remove it
         if base.ends_with('/') {
             base.remove(base.len() - 1);
@@ -150,7 +154,7 @@ impl OnlineBeaconClient {
         Self {
             base,
             inner: Client::builder()
-                .timeout(crate::L1_RPC_TIMEOUT)
+                .timeout(timeout)
                 .build()
                 .expect("Failed to create beacon client"),
             l1_slot_duration: None,
@@ -298,6 +302,8 @@ mod tests {
 
     const TEST_BLOB_HASH_HEX: &str =
         "0x016c357b8b3a6b3fd82386e7bebf77143d537cdb1c856509661c412602306a04";
+    const TEST_REQUEST_TIMEOUT: Duration = Duration::from_millis(25);
+    const TEST_RESPONSE_DELAY: Duration = Duration::from_millis(250);
 
     /// Computes the versioned hash for a blob using the same path as production code.
     fn versioned_hash_for(blob: &Blob) -> B256 {
@@ -405,5 +411,24 @@ mod tests {
             matches!(response, Err(BeaconClientError::SlotNotFound(s)) if s == slot),
             "expected SlotNotFound({slot}), got {response:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn beacon_requests_timeout_at_the_client_boundary() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/eth/v1/config/spec");
+                then.status(200).delay(TEST_RESPONSE_DELAY);
+            })
+            .await;
+        let client = OnlineBeaconClient::with_timeout(server.base_url(), TEST_REQUEST_TIMEOUT);
+
+        let result = tokio::time::timeout(Duration::from_millis(500), client.slot_interval())
+            .await
+            .expect("beacon requests must not remain pending");
+
+        assert!(result.is_err(), "beacon request should fail at the request deadline");
+        mock.assert_async().await;
     }
 }

--- a/crates/consensus/providers/src/beacon_client.rs
+++ b/crates/consensus/providers/src/beacon_client.rs
@@ -140,6 +140,8 @@ pub struct OnlineBeaconClient {
 
 impl OnlineBeaconClient {
     /// Creates a new [`OnlineBeaconClient`] from the provided base URL string.
+    ///
+    /// Requests use the shared [`crate::L1_RPC_TIMEOUT`] deadline.
     pub fn new_http(mut base: String) -> Self {
         // If base ends with a slash, remove it
         if base.ends_with('/') {
@@ -147,7 +149,10 @@ impl OnlineBeaconClient {
         }
         Self {
             base,
-            inner: Client::builder().build().expect("Failed to create beacon client"),
+            inner: Client::builder()
+                .timeout(crate::L1_RPC_TIMEOUT)
+                .build()
+                .expect("Failed to create beacon client"),
             l1_slot_duration: None,
         }
     }

--- a/crates/consensus/providers/src/chain_provider.rs
+++ b/crates/consensus/providers/src/chain_provider.rs
@@ -12,7 +12,7 @@ use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind, Res
 use base_protocol::BlockInfo;
 use lru::LruCache;
 
-use crate::Metrics;
+use crate::{L1RpcProvider, Metrics};
 
 /// The [`AlloyChainProvider`] is a concrete implementation of the [`ChainProvider`] trait, providing
 /// data over Ethereum JSON-RPC using an alloy provider as the backend.
@@ -56,8 +56,10 @@ impl AlloyChainProvider {
     }
 
     /// Creates a new [`AlloyChainProvider`] from the provided [`url::Url`].
+    ///
+    /// The underlying HTTP provider uses the shared [`crate::L1_RPC_TIMEOUT`] deadline.
     pub fn new_http(url: url::Url, cache_size: usize) -> Self {
-        let inner = RootProvider::new_http(url);
+        let inner = L1RpcProvider::new_http(url);
         Self::new(inner, cache_size)
     }
 

--- a/crates/consensus/providers/src/l1_rpc.rs
+++ b/crates/consensus/providers/src/l1_rpc.rs
@@ -18,11 +18,55 @@ pub struct L1RpcProvider;
 impl L1RpcProvider {
     /// Creates an L1 execution JSON-RPC provider with the shared request deadline.
     pub fn new_http(url: Url) -> RootProvider {
-        let client = Client::builder()
-            .timeout(L1_RPC_TIMEOUT)
-            .build()
-            .expect("failed to build L1 RPC HTTP client");
+        Self::with_timeout(url, L1_RPC_TIMEOUT)
+    }
+
+    fn with_timeout(url: Url, timeout: Duration) -> RootProvider {
+        let client =
+            Client::builder().timeout(timeout).build().expect("failed to build L1 RPC HTTP client");
 
         RootProvider::new(RpcClient::new_http_with_client(client, url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use alloy_eips::BlockId;
+    use alloy_provider::Provider;
+    use alloy_rpc_types_eth::Filter;
+    use httpmock::prelude::*;
+
+    use super::*;
+
+    const TEST_REQUEST_TIMEOUT: Duration = Duration::from_millis(25);
+    const TEST_RESPONSE_DELAY: Duration = Duration::from_millis(250);
+
+    #[tokio::test]
+    async fn execution_requests_timeout_at_the_provider_boundary() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(200).delay(TEST_RESPONSE_DELAY);
+            })
+            .await;
+        let provider = L1RpcProvider::with_timeout(
+            server.url("/").parse().expect("mock server URL must parse"),
+            TEST_REQUEST_TIMEOUT,
+        );
+
+        let requests = tokio::time::timeout(Duration::from_millis(500), async {
+            let logs = provider.get_logs(&Filter::new()).await;
+            let block = provider.get_block(BlockId::Number(1u64.into())).await;
+            (logs, block)
+        })
+        .await
+        .expect("provider requests must not remain pending");
+
+        assert!(requests.0.is_err(), "eth_getLogs should fail at the request deadline");
+        assert!(requests.1.is_err(), "eth_getBlockByNumber should fail at the request deadline");
+        mock.assert_calls_async(2).await;
     }
 }

--- a/crates/consensus/providers/src/l1_rpc.rs
+++ b/crates/consensus/providers/src/l1_rpc.rs
@@ -1,3 +1,5 @@
+//! Shared HTTP providers for consensus L1 execution and Beacon API requests.
+
 use std::time::Duration;
 
 use alloy_provider::RootProvider;
@@ -43,6 +45,16 @@ mod tests {
     const TEST_REQUEST_TIMEOUT: Duration = Duration::from_millis(25);
     const TEST_RESPONSE_DELAY: Duration = Duration::from_millis(250);
 
+    fn is_reqwest_timeout<T>(result: &alloy_transport::TransportResult<T>) -> bool {
+        result
+            .as_ref()
+            .err()
+            .and_then(|error| error.as_transport_err())
+            .and_then(|error| error.as_custom())
+            .and_then(|error| error.downcast_ref::<reqwest::Error>())
+            .is_some_and(reqwest::Error::is_timeout)
+    }
+
     #[tokio::test]
     async fn execution_requests_timeout_at_the_provider_boundary() {
         let server = MockServer::start_async().await;
@@ -65,8 +77,11 @@ mod tests {
         .await
         .expect("provider requests must not remain pending");
 
-        assert!(requests.0.is_err(), "eth_getLogs should fail at the request deadline");
-        assert!(requests.1.is_err(), "eth_getBlockByNumber should fail at the request deadline");
+        assert!(is_reqwest_timeout(&requests.0), "eth_getLogs should fail with a request timeout");
+        assert!(
+            is_reqwest_timeout(&requests.1),
+            "eth_getBlockByNumber should fail with a request timeout"
+        );
         mock.assert_calls_async(2).await;
     }
 }

--- a/crates/consensus/providers/src/l1_rpc.rs
+++ b/crates/consensus/providers/src/l1_rpc.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+use alloy_provider::RootProvider;
+use alloy_rpc_client::RpcClient;
+use reqwest::Client;
+use url::Url;
+
+/// Maximum duration for every HTTP request made by a consensus L1 client.
+///
+/// This deadline is shared by L1 execution JSON-RPC and Beacon API requests. It is intentionally
+/// not operation-specific: all standard consensus L1 clients use the same transport deadline.
+pub const L1_RPC_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Constructs standard consensus L1 HTTP providers.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct L1RpcProvider;
+
+impl L1RpcProvider {
+    /// Creates an L1 execution JSON-RPC provider with the shared request deadline.
+    pub fn new_http(url: Url) -> RootProvider {
+        let client = Client::builder()
+            .timeout(L1_RPC_TIMEOUT)
+            .build()
+            .expect("failed to build L1 RPC HTTP client");
+
+        RootProvider::new(RpcClient::new_http_with_client(client, url))
+    }
+}

--- a/crates/consensus/providers/src/lib.rs
+++ b/crates/consensus/providers/src/lib.rs
@@ -6,6 +6,9 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+mod l1_rpc;
+pub use l1_rpc::{L1_RPC_TIMEOUT, L1RpcProvider};
+
 mod metrics;
 pub use metrics::Metrics;
 

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -352,7 +352,7 @@ mod tests {
     type BoxedBlockStream = Pin<Box<dyn Stream<Item = BlockInfo> + Unpin + Send>>;
 
     // ---------------------------------------------------------------------------
-    // Mock L1BlockFetcher used by LogRetrier tests (unchanged)
+    // Mock L1BlockFetcher used by LogRetrier tests.
     // ---------------------------------------------------------------------------
 
     struct MockFetcher {
@@ -404,11 +404,14 @@ mod tests {
         None,
         /// Always return an error.
         Err,
+        /// Return an error once, then a default [`Block`].
+        ErrorOnceThenDefault,
     }
 
     struct ConfigurableFetcher {
         get_block_behavior: GetBlockBehavior,
         get_block_requested_ids: Arc<Mutex<Vec<BlockId>>>,
+        get_block_call_count: Arc<AtomicU32>,
     }
 
     impl ConfigurableFetcher {
@@ -416,6 +419,7 @@ mod tests {
             Self {
                 get_block_behavior: GetBlockBehavior::Default,
                 get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+                get_block_call_count: Arc::new(AtomicU32::new(0)),
             }
         }
 
@@ -423,6 +427,7 @@ mod tests {
             Self {
                 get_block_behavior: GetBlockBehavior::None,
                 get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+                get_block_call_count: Arc::new(AtomicU32::new(0)),
             }
         }
 
@@ -430,6 +435,15 @@ mod tests {
             Self {
                 get_block_behavior: GetBlockBehavior::Err,
                 get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+                get_block_call_count: Arc::new(AtomicU32::new(0)),
+            }
+        }
+
+        fn error_once_then_default() -> Self {
+            Self {
+                get_block_behavior: GetBlockBehavior::ErrorOnceThenDefault,
+                get_block_requested_ids: Arc::new(Mutex::new(Vec::new())),
+                get_block_call_count: Arc::new(AtomicU32::new(0)),
             }
         }
     }
@@ -444,8 +458,14 @@ mod tests {
 
         async fn get_block(&self, id: BlockId) -> Result<Option<Block>, Self::Error> {
             self.get_block_requested_ids.lock().unwrap().push(id);
+            let call_count = self.get_block_call_count.fetch_add(1, Ordering::SeqCst);
             match self.get_block_behavior {
-                GetBlockBehavior::Default => Ok(Some(Block::default())),
+                GetBlockBehavior::ErrorOnceThenDefault if call_count == 0 => {
+                    Err("provider request timed out".to_string())
+                }
+                GetBlockBehavior::Default | GetBlockBehavior::ErrorOnceThenDefault => {
+                    Ok(Some(Block::default()))
+                }
                 GetBlockBehavior::None => Ok(None),
                 GetBlockBehavior::Err => Err("provider error".to_string()),
             }
@@ -568,8 +588,10 @@ mod tests {
     #[tokio::test]
     async fn fetch_logs_exhausted_retries_returns_error() {
         let cancel = CancellationToken::new();
+        let fetcher = MockFetcher::always_fail();
+        let call_count = Arc::clone(&fetcher.call_count);
         let result = LogRetrier::fetch_logs_with_retry(
-            &MockFetcher::always_fail(),
+            &fetcher,
             Filter::new(),
             &cancel,
             dummy_block(),
@@ -578,6 +600,7 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Err(L1WatcherActorError::RetriesExhausted)));
+        assert_eq!(call_count.load(Ordering::SeqCst), 10);
     }
 
     #[tokio::test]
@@ -698,6 +721,23 @@ mod tests {
 
         // Watch channel still has the real head.
         assert_eq!(rx.borrow().unwrap().number, 100);
+    }
+
+    #[tokio::test]
+    async fn confs_delayed_block_timeout_skips_head_and_continues() {
+        let fetcher = ConfigurableFetcher::error_once_then_default();
+        let ids = Arc::clone(&fetcher.get_block_requested_ids);
+        let (client, rx, _) = run_actor(fetcher, vec![block_at(100), block_at(104)], 4).await;
+
+        let heads = client.sent_heads();
+        assert_eq!(heads.len(), 1);
+        // The first provider timeout is skipped. The second request succeeds with
+        // Block::default().
+        assert_eq!(heads[0].number, 0);
+        assert_eq!(rx.borrow().unwrap().number, 104);
+
+        let requested = ids.lock().unwrap().clone();
+        assert_eq!(requested, vec![BlockId::Number(96u64.into()), BlockId::Number(100u64.into())]);
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -287,12 +287,14 @@ where
                             if let Ok(SystemConfigUpdate::UnsafeBlockSigner(UnsafeBlockSignerUpdate { unsafe_block_signer })) = sys_cfg_log.build() {
                                 info!(
                                     target: "l1_watcher",
-                                    "Unsafe block signer update: {unsafe_block_signer}"
+                                    unsafe_block_signer = %unsafe_block_signer,
+                                    "Unsafe block signer update"
                                 );
                                 if let Some(ref block_signer_sender) = self.block_signer_sender && let Err(e) = block_signer_sender.send(unsafe_block_signer).await {
                                     error!(
                                         target: "l1_watcher",
-                                        "Error sending unsafe block signer update: {e}"
+                                        error = %e,
+                                        "Error sending unsafe block signer update"
                                     );
                                 }
                             }

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -41,10 +41,14 @@ use crate::{
 pub struct LogRetrier;
 
 impl LogRetrier {
-    /// Fetch logs matching `filter` with capped exponential backoff, retrying up to 10 times.
+    /// Fetch logs matching `filter` with capped exponential backoff, trying up to 10 times.
     ///
     /// Returns `Ok(Some(logs))` on success, `Ok(None)` if `cancel` fires during a backoff sleep,
     /// or `Err(`[`L1WatcherActorError::RetriesExhausted`]`)` once all attempts fail.
+    ///
+    /// Provider failures, including request timeouts, use the same bounded retry path. Exhausting
+    /// those attempts returns an actor error so the node service can shut down instead of waiting
+    /// indefinitely on an L1 request.
     ///
     /// `initial_backoff` and `max_backoff` are caller-supplied so tests can use tiny values.
     pub async fn fetch_logs_with_retry<F>(
@@ -224,6 +228,8 @@ where
                             && head_block_info.number >= self.verifier_l1_confs
                         {
                             let target = head_block_info.number - self.verifier_l1_confs;
+                            // Delayed block reads are best effort. A request timeout is handled
+                            // like any other fetch error: skip this head and try the next one.
                             match self.l1_provider.get_block(BlockId::Number(target.into())).await {
                                 Ok(Some(block)) => block.into_consensus().into(),
                                 Ok(None) => {
@@ -268,6 +274,8 @@ where
                             .address(filter_address)
                             .select(derivation_block.hash);
 
+                        // Log requests are retried with bounded backoff. If all attempts time out
+                        // or otherwise fail, the actor returns an error instead of hanging.
                         let Some(logs) = LogRetrier::fetch_logs_with_retry(
                             &self.l1_provider,
                             filter,

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -295,14 +295,12 @@ where
                             if let Ok(SystemConfigUpdate::UnsafeBlockSigner(UnsafeBlockSignerUpdate { unsafe_block_signer })) = sys_cfg_log.build() {
                                 info!(
                                     target: "l1_watcher",
-                                    unsafe_block_signer = %unsafe_block_signer,
-                                    "Unsafe block signer update"
+                                    "Unsafe block signer update: {unsafe_block_signer}"
                                 );
                                 if let Some(ref block_signer_sender) = self.block_signer_sender && let Err(e) = block_signer_sender.send(unsafe_block_signer).await {
                                     error!(
                                         target: "l1_watcher",
-                                        error = %e,
-                                        "Error sending unsafe block signer update"
+                                        "Error sending unsafe block signer update: {e}"
                                     );
                                 }
                             }

--- a/crates/consensus/service/src/actors/upgrade_signal.rs
+++ b/crates/consensus/service/src/actors/upgrade_signal.rs
@@ -2,6 +2,7 @@
 
 use alloy_provider::RootProvider;
 use base_common_genesis::BaseUpgrade;
+use base_consensus_providers::L1RpcProvider;
 use base_upgrade_signal::{
     AlloyUpgradeSignalReader, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalError,
     UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
@@ -39,7 +40,7 @@ impl UpgradeSignalNodeConfig {
         runtime_validation: Option<UpgradeSignalRuntimeValidation>,
     ) -> Self {
         let l1_provider =
-            l1_rpc.map(|url| RootProvider::new_http(url.clone())).unwrap_or(default_l1_provider);
+            l1_rpc.map(|url| L1RpcProvider::new_http(url.clone())).unwrap_or(default_l1_provider);
         let runtime_validation =
             runtime_validation.unwrap_or_else(UpgradeSignalRuntimeValidation::fail_closed);
         Self { config, l1_provider, chain_id, runtime_validation }

--- a/crates/consensus/service/src/actors/upgrade_signal.rs
+++ b/crates/consensus/service/src/actors/upgrade_signal.rs
@@ -1,6 +1,7 @@
 //! Upgrade signal metrics observer actor.
 
 use alloy_provider::RootProvider;
+use base_consensus_providers::L1RpcProvider;
 use base_upgrade_signal::{
     AlloyUpgradeSignalReader, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalError,
     UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
@@ -33,7 +34,7 @@ impl UpgradeSignalNodeConfig {
         chain_id: u64,
     ) -> Self {
         let l1_provider =
-            l1_rpc.map(|url| RootProvider::new_http(url.clone())).unwrap_or(default_l1_provider);
+            l1_rpc.map(|url| L1RpcProvider::new_http(url.clone())).unwrap_or(default_l1_provider);
         Self { config, l1_provider, chain_id }
     }
 

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -26,6 +26,34 @@ pub enum FollowError {
     #[error("failed to build local L2 block info: {0}")]
     LocalBlockInfo(#[from] FromBlockError),
 
+    /// Fetching a block from the local L1 node failed.
+    #[error("failed to fetch local L1 block {number}: {source}")]
+    LocalL1BlockFetch {
+        /// Requested L1 block number.
+        number: u64,
+        /// Underlying transport error.
+        source: alloy_transport::TransportError,
+    },
+
+    /// The local L1 node did not return the source label's claimed L1 origin.
+    #[error("local L1 block unavailable at block {0}")]
+    LocalL1BlockUnavailable(u64),
+
+    /// A source L2 label claims an L1 origin that is not canonical locally.
+    #[error(
+        "source L2 block {l2_number} claims L1 origin {remote} at block {l1_number}, but local L1 has {local}"
+    )]
+    SourceL1OriginMismatch {
+        /// Source L2 label block number.
+        l2_number: u64,
+        /// Claimed L1 origin block number.
+        l1_number: u64,
+        /// Hash from the local canonical L1 provider.
+        local: B256,
+        /// L1 origin hash encoded in the source L2 block.
+        remote: B256,
+    },
+
     /// Fetching the local proofs sync status failed.
     #[error("failed to fetch proofs sync status: {0}")]
     ProofsStatus(alloy_transport::TransportError),

--- a/crates/consensus/service/src/follow/local.rs
+++ b/crates/consensus/service/src/follow/local.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
@@ -20,21 +21,25 @@ struct ProofsSyncStatus {
 pub(super) trait FollowLocalClient: Debug + Send + Sync {
     async fn block_info(&self, tag: BlockNumberOrTag) -> Result<Option<L2BlockInfo>, FollowError>;
 
+    async fn l1_block_hash(&self, number: u64) -> Result<Option<B256>, FollowError>;
+
     async fn proofs_latest(&self) -> Result<Option<u64>, FollowError>;
 }
 
 #[derive(Clone, Debug)]
 pub(super) struct LocalL2Client {
     provider: RootProvider<Base>,
+    l1_provider: RootProvider,
     rollup_config: Arc<RollupConfig>,
 }
 
 impl LocalL2Client {
     pub(super) const fn new(
         provider: RootProvider<Base>,
+        l1_provider: RootProvider,
         rollup_config: Arc<RollupConfig>,
     ) -> Self {
-        Self { provider, rollup_config }
+        Self { provider, l1_provider, rollup_config }
     }
 }
 
@@ -59,6 +64,14 @@ impl FollowLocalClient for LocalL2Client {
         )
         .map(Some)
         .map_err(FollowError::from)
+    }
+
+    async fn l1_block_hash(&self, number: u64) -> Result<Option<B256>, FollowError> {
+        self.l1_provider
+            .get_block_by_number(number.into())
+            .await
+            .map(|block| block.map(|block| block.header.hash))
+            .map_err(|source| FollowError::LocalL1BlockFetch { number, source })
     }
 
     async fn proofs_latest(&self) -> Result<Option<u64>, FollowError> {

--- a/crates/consensus/service/src/follow/local.rs
+++ b/crates/consensus/service/src/follow/local.rs
@@ -68,9 +68,9 @@ impl FollowLocalClient for LocalL2Client {
 
     async fn l1_block_hash(&self, number: u64) -> Result<Option<B256>, FollowError> {
         self.l1_provider
-            .get_block_by_number(number.into())
+            .get_header_by_number(number.into())
             .await
-            .map(|block| block.map(|block| block.header.hash))
+            .map(|header| header.map(|header| header.hash))
             .map_err(|source| FollowError::LocalL1BlockFetch { number, source })
     }
 

--- a/crates/consensus/service/src/follow/node.rs
+++ b/crates/consensus/service/src/follow/node.rs
@@ -31,6 +31,7 @@ where
 {
     config: Arc<RollupConfig>,
     engine_client: Arc<E>,
+    l1_provider: RootProvider,
     local_l2_provider: RootProvider<Base>,
     l2_source: RemoteL2Client,
     proofs_enabled: bool,
@@ -51,6 +52,8 @@ where
     pub engine_client: Arc<E>,
     /// Provider for reading local L2 state.
     pub local_l2_provider: RootProvider<Base>,
+    /// Provider for validating source label L1 origins against canonical L1.
+    pub l1_provider: RootProvider,
     /// Source L2 client used to fetch payloads to follow.
     pub l2_source: RemoteL2Client,
     /// Optional RPC server configuration.
@@ -72,6 +75,7 @@ where
         Self {
             config: config.rollup_config,
             engine_client: config.engine_client,
+            l1_provider: config.l1_provider,
             local_l2_provider: config.local_l2_provider,
             l2_source: config.l2_source,
             rpc_builder: config.rpc_builder,
@@ -84,8 +88,11 @@ where
     /// Starts the follow node.
     pub async fn start(&self) -> Result<(), FollowError> {
         let cancellation = CancellationToken::new();
-        let local =
-            Arc::new(LocalL2Client::new(self.local_l2_provider.clone(), Arc::clone(&self.config)));
+        let local = Arc::new(LocalL2Client::new(
+            self.local_l2_provider.clone(),
+            self.l1_provider.clone(),
+            Arc::clone(&self.config),
+        ));
         let latest = local
             .block_info(BlockNumberOrTag::Latest)
             .await?

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -135,7 +135,6 @@ where
 
         // Read number and hash from the same response, matching op-node's `L2BlockRefByLabel`.
         let source_safe = source.get_block_info(BlockNumberOrTag::Safe).await?;
-        Self::validate_source_l1_origin(local.as_ref(), &source_safe).await?;
         let safe = Self::verified_local_block(
             &local,
             &source_safe,
@@ -143,12 +142,14 @@ where
             latest.block_info.number,
         )
         .await?;
+        if safe.is_some() {
+            Self::validate_source_l1_origin(local.as_ref(), &source_safe).await?;
+        }
 
         let safe_limit = safe.as_ref().unwrap_or(&local_safe).block_info.number;
 
         // Finalized floor at the local finalized head (never unwind), ceiling at the safe head.
         let source_finalized = source.get_block_info(BlockNumberOrTag::Finalized).await?;
-        Self::validate_source_l1_origin(local.as_ref(), &source_finalized).await?;
         let local_finalized_number =
             local_finalized.map(|block| block.block_info.number).unwrap_or_default();
         let finalized = Self::verified_local_block(
@@ -158,6 +159,9 @@ where
             latest.block_info.number.min(safe_limit),
         )
         .await?;
+        if finalized.is_some() {
+            Self::validate_source_l1_origin(local.as_ref(), &source_finalized).await?;
+        }
 
         engine.update_safe_finalized_blocks(safe, finalized).await
     }
@@ -654,6 +658,46 @@ mod tests {
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
         FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
             local,
+            Arc::new(source),
+            engine_for_update,
+        )
+        .await
+        .expect("labels");
+
+        assert!(engine.labels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn out_of_range_source_labels_skip_l1_origin_validation() {
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Latest => block_info(10),
+                BlockNumberOrTag::Safe => block_info(8),
+                BlockNumberOrTag::Finalized => block_info(7),
+                _ => panic!("unexpected local block lookup: {tag:?}"),
+            }))
+        });
+        local.expect_l1_block_hash().times(0);
+
+        let mut source = MockRemoteClient::new();
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Safe))
+            .returning(|_| Ok(source_block_info(20)));
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Finalized))
+            .returning(|_| Ok(source_block_info(6)));
+        let engine = Arc::new(RecordingEngine {
+            inserted: Mutex::new(Vec::new()),
+            labels: Mutex::new(Vec::new()),
+            delay: Duration::ZERO,
+        });
+        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+
+        FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
+            Arc::new(local),
             Arc::new(source),
             engine_for_update,
         )

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
-use base_protocol::{BlockInfo, L2BlockInfo};
+use base_protocol::L2BlockInfo;
 use tokio::{
     sync::mpsc,
     time::{self, MissedTickBehavior},
@@ -135,6 +135,7 @@ where
 
         // Read number and hash from the same response, matching op-node's `L2BlockRefByLabel`.
         let source_safe = source.get_block_info(BlockNumberOrTag::Safe).await?;
+        Self::validate_source_l1_origin(local.as_ref(), &source_safe).await?;
         let safe = Self::verified_local_block(
             &local,
             &source_safe,
@@ -147,6 +148,7 @@ where
 
         // Finalized floor at the local finalized head (never unwind), ceiling at the safe head.
         let source_finalized = source.get_block_info(BlockNumberOrTag::Finalized).await?;
+        Self::validate_source_l1_origin(local.as_ref(), &source_finalized).await?;
         let local_finalized_number =
             local_finalized.map(|block| block.block_info.number).unwrap_or_default();
         let finalized = Self::verified_local_block(
@@ -166,18 +168,18 @@ where
     /// divergence returns `SourceBlockHashMismatch`.
     async fn verified_local_block(
         local: &Local,
-        source_block: &BlockInfo,
+        source_block: &L2BlockInfo,
         floor: u64,
         ceiling: u64,
     ) -> Result<Option<L2BlockInfo>, FollowError> {
-        let number = source_block.number;
+        let number = source_block.block_info.number;
         if number < floor || number > ceiling {
             debug!(
                 target: "follow",
                 number,
                 floor,
                 ceiling,
-                hash = %source_block.hash,
+                hash = %source_block.block_info.hash,
                 "Skipping source label outside local range"
             );
             return Ok(None);
@@ -185,14 +187,35 @@ where
         let Some(local_block) = local.block_info(number.into()).await? else {
             return Ok(None);
         };
-        if local_block.block_info.hash != source_block.hash {
+        if local_block.block_info.hash != source_block.block_info.hash {
             return Err(FollowError::SourceBlockHashMismatch {
                 number,
                 local: local_block.block_info.hash,
-                remote: source_block.hash,
+                remote: source_block.block_info.hash,
             });
         }
         Ok(Some(local_block))
+    }
+
+    /// Verifies that the source label's claimed L1 origin is canonical in the local L1 view.
+    async fn validate_source_l1_origin(
+        local: &Local,
+        source_block: &L2BlockInfo,
+    ) -> Result<(), FollowError> {
+        let origin = source_block.l1_origin;
+        let local_hash = local
+            .l1_block_hash(origin.number)
+            .await?
+            .ok_or(FollowError::LocalL1BlockUnavailable(origin.number))?;
+        if local_hash != origin.hash {
+            return Err(FollowError::SourceL1OriginMismatch {
+                l2_number: source_block.block_info.number,
+                l1_number: origin.number,
+                local: local_hash,
+                remote: origin.hash,
+            });
+        }
+        Ok(())
     }
 }
 
@@ -248,7 +271,7 @@ mod tests {
     use alloy_rpc_types_engine::ExecutionPayloadV1;
     use async_trait::async_trait;
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
-    use base_protocol::L2BlockInfo;
+    use base_protocol::{BlockInfo, L2BlockInfo};
     use mockall::predicate::eq;
     use tokio::{sync::Mutex, time};
     use tokio_util::sync::CancellationToken;
@@ -294,7 +317,7 @@ mod tests {
         async fn get_block_info(
             &self,
             tag: BlockNumberOrTag,
-        ) -> Result<BlockInfo, crate::RemoteL2ClientError> {
+        ) -> Result<L2BlockInfo, crate::RemoteL2ClientError> {
             Ok(match tag {
                 BlockNumberOrTag::Latest => source_block_info(self.latest),
                 BlockNumberOrTag::Number(number) => source_block_info(number),
@@ -350,8 +373,15 @@ mod tests {
         }
     }
 
-    fn source_block_info(number: u64) -> BlockInfo {
-        BlockInfo { number, hash: B256::from([number as u8; 32]), ..Default::default() }
+    fn source_block_info(number: u64) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo {
+                number,
+                hash: B256::from([number as u8; 32]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 
     fn payload(number: u64) -> BaseExecutionPayloadEnvelope {
@@ -392,6 +422,7 @@ mod tests {
                 _ => block_info(0),
             }))
         });
+        local.expect_l1_block_hash().returning(|_| Ok(Some(B256::ZERO)));
         local.expect_proofs_latest().returning(move || Ok(Some(proofs_latest)));
         local
     }
@@ -522,6 +553,7 @@ mod tests {
                 _ => block_info(0),
             }))
         });
+        local.expect_l1_block_hash().returning(|_| Ok(Some(B256::ZERO)));
         let proofs_for_mock = Arc::clone(&proofs_latest);
         local
             .expect_proofs_latest()
@@ -665,7 +697,14 @@ mod tests {
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).times(1).returning(|_| {
-            Ok(BlockInfo { number: 10, hash: B256::from([99; 32]), ..Default::default() })
+            Ok(L2BlockInfo {
+                block_info: BlockInfo {
+                    number: 10,
+                    hash: B256::from([99; 32]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
         });
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),
@@ -688,6 +727,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_safe_l1_origin_must_be_canonical_locally() {
+        let local = Arc::new(local_client(10, 8, 7, 100));
+        let mut source = MockRemoteClient::new();
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
+            Ok(L2BlockInfo {
+                l1_origin: alloy_eips::BlockNumHash { number: 0, hash: B256::with_last_byte(1) },
+                ..source_block_info(9)
+            })
+        });
+        let engine = Arc::new(RecordingEngine {
+            inserted: Mutex::new(Vec::new()),
+            labels: Mutex::new(Vec::new()),
+            delay: Duration::ZERO,
+        });
+        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+
+        let error =
+            FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
+                local,
+                Arc::new(source),
+                engine_for_update,
+            )
+            .await
+            .expect_err("source L1 origin must match local canonical L1");
+
+        assert!(matches!(
+            error,
+            FollowError::SourceL1OriginMismatch { l2_number: 9, l1_number: 0, .. }
+        ));
+        assert!(engine.labels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
     async fn finalized_label_rejects_source_hash_mismatch() {
         // The same coherent-read check applies to the finalized label. Here the safe label is
         // consistent (so evaluation reaches the finalized read), but the in-range finalized block's
@@ -699,7 +771,16 @@ mod tests {
             .with(eq(BlockNumberOrTag::Safe))
             .returning(|_| Ok(source_block_info(9)));
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Finalized)).times(1).returning(
-            |_| Ok(BlockInfo { number: 8, hash: B256::from([99; 32]), ..Default::default() }),
+            |_| {
+                Ok(L2BlockInfo {
+                    block_info: BlockInfo {
+                        number: 8,
+                        hash: B256::from([99; 32]),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            },
         );
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
-use base_protocol::L2BlockInfo;
+use base_protocol::{BlockInfo, L2BlockInfo};
 use tokio::{
     sync::mpsc,
     time::{self, MissedTickBehavior},
@@ -142,8 +142,8 @@ where
             latest.block_info.number,
         )
         .await?;
-        if safe.is_some() {
-            Self::validate_source_l1_origin(local.as_ref(), &source_safe).await?;
+        if let Some(safe_block) = safe.as_ref() {
+            Self::validate_source_l1_origin(local.as_ref(), safe_block).await?;
         }
 
         let safe_limit = safe.as_ref().unwrap_or(&local_safe).block_info.number;
@@ -159,8 +159,8 @@ where
             latest.block_info.number.min(safe_limit),
         )
         .await?;
-        if finalized.is_some() {
-            Self::validate_source_l1_origin(local.as_ref(), &source_finalized).await?;
+        if let Some(finalized_block) = finalized.as_ref() {
+            Self::validate_source_l1_origin(local.as_ref(), finalized_block).await?;
         }
 
         engine.update_safe_finalized_blocks(safe, finalized).await
@@ -172,18 +172,18 @@ where
     /// divergence returns `SourceBlockHashMismatch`.
     async fn verified_local_block(
         local: &Local,
-        source_block: &L2BlockInfo,
+        source_block: &BlockInfo,
         floor: u64,
         ceiling: u64,
     ) -> Result<Option<L2BlockInfo>, FollowError> {
-        let number = source_block.block_info.number;
+        let number = source_block.number;
         if number < floor || number > ceiling {
             debug!(
                 target: "follow",
                 number,
                 floor,
                 ceiling,
-                hash = %source_block.block_info.hash,
+                hash = %source_block.hash,
                 "Skipping source label outside local range"
             );
             return Ok(None);
@@ -191,29 +191,29 @@ where
         let Some(local_block) = local.block_info(number.into()).await? else {
             return Ok(None);
         };
-        if local_block.block_info.hash != source_block.block_info.hash {
+        if local_block.block_info.hash != source_block.hash {
             return Err(FollowError::SourceBlockHashMismatch {
                 number,
                 local: local_block.block_info.hash,
-                remote: source_block.block_info.hash,
+                remote: source_block.hash,
             });
         }
         Ok(Some(local_block))
     }
 
-    /// Verifies that the source label's claimed L1 origin is canonical in the local L1 view.
+    /// Verifies that a hash-verified local block's L1 origin is canonical in the local L1 view.
     async fn validate_source_l1_origin(
         local: &Local,
-        source_block: &L2BlockInfo,
+        block: &L2BlockInfo,
     ) -> Result<(), FollowError> {
-        let origin = source_block.l1_origin;
+        let origin = block.l1_origin;
         let local_hash = local
             .l1_block_hash(origin.number)
             .await?
             .ok_or(FollowError::LocalL1BlockUnavailable(origin.number))?;
         if local_hash != origin.hash {
             return Err(FollowError::SourceL1OriginMismatch {
-                l2_number: source_block.block_info.number,
+                l2_number: block.block_info.number,
                 l1_number: origin.number,
                 local: local_hash,
                 remote: origin.hash,
@@ -321,7 +321,7 @@ mod tests {
         async fn get_block_info(
             &self,
             tag: BlockNumberOrTag,
-        ) -> Result<L2BlockInfo, crate::RemoteL2ClientError> {
+        ) -> Result<BlockInfo, crate::RemoteL2ClientError> {
             Ok(match tag {
                 BlockNumberOrTag::Latest => source_block_info(self.latest),
                 BlockNumberOrTag::Number(number) => source_block_info(number),
@@ -377,15 +377,8 @@ mod tests {
         }
     }
 
-    fn source_block_info(number: u64) -> L2BlockInfo {
-        L2BlockInfo {
-            block_info: BlockInfo {
-                number,
-                hash: B256::from([number as u8; 32]),
-                ..Default::default()
-            },
-            ..Default::default()
-        }
+    fn source_block_info(number: u64) -> BlockInfo {
+        BlockInfo { number, hash: B256::from([number as u8; 32]), ..Default::default() }
     }
 
     fn payload(number: u64) -> BaseExecutionPayloadEnvelope {
@@ -736,19 +729,12 @@ mod tests {
 
     #[tokio::test]
     async fn safe_label_rejects_source_hash_mismatch() {
-        // A safe label whose hash disagrees with the local block surfaces SourceBlockHashMismatch
-        // and promotes nothing. `.times(1)` asserts there is exactly one source read for the label.
+        // Safe label hash disagrees with the local block at that height; returns
+        // SourceBlockHashMismatch and does not promote labels.
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).times(1).returning(|_| {
-            Ok(L2BlockInfo {
-                block_info: BlockInfo {
-                    number: 10,
-                    hash: B256::from([99; 32]),
-                    ..Default::default()
-                },
-                ..Default::default()
-            })
+            Ok(BlockInfo { number: 10, hash: B256::from([99; 32]), ..Default::default() })
         });
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),
@@ -771,15 +757,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn source_safe_l1_origin_must_be_canonical_locally() {
-        let local = Arc::new(local_client(10, 8, 7, 100));
-        let mut source = MockRemoteClient::new();
-        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).returning(|_| {
-            Ok(L2BlockInfo {
-                l1_origin: alloy_eips::BlockNumHash { number: 0, hash: B256::with_last_byte(1) },
-                ..source_block_info(9)
-            })
+    async fn verified_local_l1_origin_must_be_canonical_locally() {
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Latest => block_info(10),
+                BlockNumberOrTag::Safe => block_info(8),
+                BlockNumberOrTag::Finalized => block_info(7),
+                BlockNumberOrTag::Number(9) => L2BlockInfo {
+                    l1_origin: alloy_eips::BlockNumHash {
+                        number: 0,
+                        hash: B256::with_last_byte(1),
+                    },
+                    ..block_info(9)
+                },
+                _ => panic!("unexpected local block lookup: {tag:?}"),
+            }))
         });
+        local.expect_l1_block_hash().returning(|_| Ok(Some(B256::ZERO)));
+        let mut source = MockRemoteClient::new();
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Safe))
+            .returning(|_| Ok(source_block_info(9)));
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),
             labels: Mutex::new(Vec::new()),
@@ -794,7 +794,7 @@ mod tests {
                 engine_for_update,
             )
             .await
-            .expect_err("source L1 origin must match local canonical L1");
+            .expect_err("verified local L1 origin must match local canonical L1");
 
         assert!(matches!(
             error,
@@ -805,9 +805,8 @@ mod tests {
 
     #[tokio::test]
     async fn finalized_label_rejects_source_hash_mismatch() {
-        // The same coherent-read check applies to the finalized label. Here the safe label is
-        // consistent (so evaluation reaches the finalized read), but the in-range finalized block's
-        // hash disagrees with the local block: surface SourceBlockHashMismatch and promote nothing.
+        // Safe label is consistent so evaluation reaches finalized; the in-range finalized hash
+        // disagrees with local, which returns SourceBlockHashMismatch.
         let local = Arc::new(local_client(10, 9, 7, 100));
         let mut source = MockRemoteClient::new();
         source
@@ -815,16 +814,7 @@ mod tests {
             .with(eq(BlockNumberOrTag::Safe))
             .returning(|_| Ok(source_block_info(9)));
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Finalized)).times(1).returning(
-            |_| {
-                Ok(L2BlockInfo {
-                    block_info: BlockInfo {
-                        number: 8,
-                        hash: B256::from([99; 32]),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                })
-            },
+            |_| Ok(BlockInfo { number: 8, hash: B256::from([99; 32]), ..Default::default() }),
         );
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -789,7 +789,7 @@ mod tests {
 
         let error =
             FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
-                local,
+                Arc::new(local),
                 Arc::new(source),
                 engine_for_update,
             )

--- a/crates/consensus/service/src/follow/source.rs
+++ b/crates/consensus/service/src/follow/source.rs
@@ -1,13 +1,14 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use alloy_consensus::Block;
 use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
 use base_common_consensus::BaseTxEnvelope;
+use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
-use base_protocol::BlockInfo;
+use base_protocol::{FromBlockError, L2BlockInfo};
 use thiserror::Error;
 use url::Url;
 
@@ -26,6 +27,10 @@ pub enum RemoteL2ClientError {
     /// Block not found at the requested tag.
     #[error("block not found at {0}")]
     BlockNotFound(String),
+
+    /// Failed to decode rollup metadata from a source L2 block.
+    #[error("failed to build source L2 block info: {0}")]
+    BlockInfo(#[from] FromBlockError),
 }
 
 /// Trait for fetching L2 block data from the remote node.
@@ -36,8 +41,10 @@ pub trait RemoteClient: Debug + Send + Sync {
     async fn get_block_number(&self, tag: BlockNumberOrTag) -> Result<u64, RemoteL2ClientError>;
 
     /// Fetches the block info at the given tag.
-    async fn get_block_info(&self, tag: BlockNumberOrTag)
-    -> Result<BlockInfo, RemoteL2ClientError>;
+    async fn get_block_info(
+        &self,
+        tag: BlockNumberOrTag,
+    ) -> Result<L2BlockInfo, RemoteL2ClientError>;
 
     /// Fetches a block by number and converts it to an [`BaseExecutionPayloadEnvelope`].
     async fn get_payload_by_number(
@@ -51,13 +58,21 @@ pub trait RemoteClient: Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub struct RemoteL2Client {
     provider: RootProvider<Base>,
+    rollup_config: Arc<RollupConfig>,
 }
 
 impl RemoteL2Client {
     /// Creates a new [`RemoteL2Client`] from a source L2 node URL.
-    pub fn new(url: Url) -> Self {
+    pub fn new(url: Url, rollup_config: Arc<RollupConfig>) -> Self {
         let provider = RootProvider::<Base>::new_http(url);
-        Self { provider }
+        Self { provider, rollup_config }
+    }
+
+    fn block_info(
+        &self,
+        block: alloy_consensus::Block<BaseTxEnvelope>,
+    ) -> Result<L2BlockInfo, RemoteL2ClientError> {
+        L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis).map_err(Into::into)
     }
 }
 
@@ -70,22 +85,23 @@ impl RemoteClient for RemoteL2Client {
             });
         }
 
-        self.get_block_info(tag).await.map(|block| block.number)
+        self.get_block_info(tag).await.map(|block| block.block_info.number)
     }
 
     async fn get_block_info(
         &self,
         tag: BlockNumberOrTag,
-    ) -> Result<BlockInfo, RemoteL2ClientError> {
+    ) -> Result<L2BlockInfo, RemoteL2ClientError> {
         let block = self
             .provider
             .get_block_by_number(tag)
+            .full()
             .await
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{tag:?}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{tag:?}")))?;
         let block = block.map_header(|header| header.into_inner());
 
-        Ok(BlockInfo::from(&block))
+        self.block_info(block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()))
     }
 
     async fn get_payload_by_number(

--- a/crates/consensus/service/src/follow/source.rs
+++ b/crates/consensus/service/src/follow/source.rs
@@ -1,14 +1,13 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use alloy_consensus::Block;
 use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
 use base_common_consensus::BaseTxEnvelope;
-use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
-use base_protocol::{FromBlockError, L2BlockInfo};
+use base_protocol::BlockInfo;
 use thiserror::Error;
 use url::Url;
 
@@ -27,10 +26,6 @@ pub enum RemoteL2ClientError {
     /// Block not found at the requested tag.
     #[error("block not found at {0}")]
     BlockNotFound(String),
-
-    /// Failed to decode rollup metadata from a source L2 block.
-    #[error("failed to build source L2 block info: {0}")]
-    BlockInfo(#[from] FromBlockError),
 }
 
 /// Trait for fetching L2 block data from the remote node.
@@ -41,10 +36,8 @@ pub trait RemoteClient: Debug + Send + Sync {
     async fn get_block_number(&self, tag: BlockNumberOrTag) -> Result<u64, RemoteL2ClientError>;
 
     /// Fetches the block info at the given tag.
-    async fn get_block_info(
-        &self,
-        tag: BlockNumberOrTag,
-    ) -> Result<L2BlockInfo, RemoteL2ClientError>;
+    async fn get_block_info(&self, tag: BlockNumberOrTag)
+    -> Result<BlockInfo, RemoteL2ClientError>;
 
     /// Fetches a block by number and converts it to an [`BaseExecutionPayloadEnvelope`].
     async fn get_payload_by_number(
@@ -58,21 +51,13 @@ pub trait RemoteClient: Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub struct RemoteL2Client {
     provider: RootProvider<Base>,
-    rollup_config: Arc<RollupConfig>,
 }
 
 impl RemoteL2Client {
     /// Creates a new [`RemoteL2Client`] from a source L2 node URL.
-    pub fn new(url: Url, rollup_config: Arc<RollupConfig>) -> Self {
+    pub fn new(url: Url) -> Self {
         let provider = RootProvider::<Base>::new_http(url);
-        Self { provider, rollup_config }
-    }
-
-    fn block_info(
-        &self,
-        block: alloy_consensus::Block<BaseTxEnvelope>,
-    ) -> Result<L2BlockInfo, RemoteL2ClientError> {
-        L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis).map_err(Into::into)
+        Self { provider }
     }
 }
 
@@ -85,23 +70,22 @@ impl RemoteClient for RemoteL2Client {
             });
         }
 
-        self.get_block_info(tag).await.map(|block| block.block_info.number)
+        self.get_block_info(tag).await.map(|block| block.number)
     }
 
     async fn get_block_info(
         &self,
         tag: BlockNumberOrTag,
-    ) -> Result<L2BlockInfo, RemoteL2ClientError> {
+    ) -> Result<BlockInfo, RemoteL2ClientError> {
         let block = self
             .provider
             .get_block_by_number(tag)
-            .full()
             .await
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{tag:?}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{tag:?}")))?;
         let block = block.map_header(|header| header.into_inner());
 
-        self.block_info(block.into_consensus().map_transactions(|tx| tx.inner.inner.into_inner()))
+        Ok(BlockInfo::from(&block))
     }
 
     async fn get_payload_by_number(

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -8,7 +8,7 @@ use alloy_transport::TransportResult;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_consensus_engine::BaseEngineClient;
-use base_consensus_providers::OnlineBeaconClient;
+use base_consensus_providers::{L1RpcProvider, OnlineBeaconClient};
 use base_consensus_rpc::RpcBuilder;
 use base_upgrade_signal::UpgradeSignalConfig;
 use url::Url;
@@ -208,7 +208,7 @@ impl RollupNodeBuilder {
             chain_config: Arc::new(self.l1_config_builder.chain_config),
             trust_rpc: self.l1_config_builder.trust_rpc,
             beacon_client: l1_beacon,
-            engine_provider: RootProvider::new_http(self.l1_config_builder.rpc_url.clone()),
+            engine_provider: L1RpcProvider::new_http(self.l1_config_builder.rpc_url.clone()),
             finalized_poll_interval,
             verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
         };

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -8,7 +8,7 @@ use alloy_transport::TransportResult;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_consensus_engine::BaseEngineClient;
-use base_consensus_providers::OnlineBeaconClient;
+use base_consensus_providers::{L1RpcProvider, OnlineBeaconClient};
 use base_consensus_rpc::RpcBuilder;
 use base_upgrade_signal::{UpgradeSignalConfig, UpgradeSignalRuntimeValidation};
 use url::Url;
@@ -211,7 +211,7 @@ impl RollupNodeBuilder {
             chain_config: Arc::new(self.l1_config_builder.chain_config),
             trust_rpc: self.l1_config_builder.trust_rpc,
             beacon_client: l1_beacon,
-            engine_provider: RootProvider::new_http(self.l1_config_builder.rpc_url.clone()),
+            engine_provider: L1RpcProvider::new_http(self.l1_config_builder.rpc_url.clone()),
             finalized_poll_interval,
             verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
         };

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -49,10 +49,9 @@ pub struct L1Config {
     pub chain_config: Arc<GenesisChainConfig>,
     /// Whether to trust the L1 RPC.
     pub trust_rpc: bool,
-    /// The L1 beacon client, configured with the shared L1 request timeout.
+    /// The L1 beacon API client.
     pub beacon_client: OnlineBeaconClient,
-    /// The L1 execution provider. Standard construction bounds every request with
-    /// [`base_consensus_providers::L1_RPC_TIMEOUT`].
+    /// The L1 execution JSON-RPC provider.
     pub engine_provider: RootProvider,
     /// How frequently to poll L1 for a new finalized block.
     ///

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -49,9 +49,10 @@ pub struct L1Config {
     pub chain_config: Arc<GenesisChainConfig>,
     /// Whether to trust the L1 RPC.
     pub trust_rpc: bool,
-    /// The L1 beacon client.
+    /// The L1 beacon client, configured with the shared L1 request timeout.
     pub beacon_client: OnlineBeaconClient,
-    /// The L1 engine provider.
+    /// The L1 execution provider. Standard construction bounds every request with
+    /// [`base_consensus_providers::L1_RPC_TIMEOUT`].
     pub engine_provider: RootProvider,
     /// How frequently to poll L1 for a new finalized block.
     ///

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -33,6 +33,7 @@ base-consensus-node.workspace = true
 base-consensus-peers.workspace = true
 base-consensus-gossip.workspace = true
 base-consensus-sources.workspace = true
+base-consensus-providers.workspace = true
 base-common-genesis.workspace = true
 
 # reth

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -13,6 +13,7 @@ use base_builder_core::test_utils::get_available_port;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_consensus_node::{EngineConfig, FollowNode, FollowNodeConfig, NodeMode, RemoteL2Client};
+use base_consensus_providers::L1RpcProvider;
 use base_consensus_rpc::RpcBuilder;
 use eyre::{Result, WrapErr};
 use tokio::task::JoinHandle;
@@ -75,7 +76,7 @@ impl InProcessFollowConsensus {
                 .map_err(eyre::Report::from)
                 .wrap_err("failed to build follow engine client")?,
         );
-        let l1_provider = RootProvider::new_http(config.l1_rpc_url);
+        let l1_provider = L1RpcProvider::new_http(config.l1_rpc_url);
         let local_l2_provider = RootProvider::<Base>::new_http(config.local_l2_rpc_url);
         let l2_source = RemoteL2Client::new(config.source_l2_rpc_url, Arc::clone(&rollup_config));
         let rpc_builder = RpcBuilder {

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -65,7 +65,7 @@ impl InProcessFollowConsensus {
             config: Arc::clone(&rollup_config),
             l2_url: config.l2_engine_url,
             l2_jwt_secret: config.jwt_secret,
-            l1_url: config.l1_rpc_url,
+            l1_url: config.l1_rpc_url.clone(),
             mode: NodeMode::Validator,
         };
         let engine_client = Arc::new(
@@ -75,8 +75,9 @@ impl InProcessFollowConsensus {
                 .map_err(eyre::Report::from)
                 .wrap_err("failed to build follow engine client")?,
         );
+        let l1_provider = RootProvider::new_http(config.l1_rpc_url);
         let local_l2_provider = RootProvider::<Base>::new_http(config.local_l2_rpc_url);
-        let l2_source = RemoteL2Client::new(config.source_l2_rpc_url);
+        let l2_source = RemoteL2Client::new(config.source_l2_rpc_url, Arc::clone(&rollup_config));
         let rpc_builder = RpcBuilder {
             no_restart: true,
             socket: rpc_addr,
@@ -91,6 +92,7 @@ impl InProcessFollowConsensus {
         let node = FollowNode::new(FollowNodeConfig {
             rollup_config,
             engine_client,
+            l1_provider,
             local_l2_provider,
             l2_source,
             rpc_builder: Some(rpc_builder),

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -78,7 +78,7 @@ impl InProcessFollowConsensus {
         );
         let l1_provider = L1RpcProvider::new_http(config.l1_rpc_url);
         let local_l2_provider = RootProvider::<Base>::new_http(config.local_l2_rpc_url);
-        let l2_source = RemoteL2Client::new(config.source_l2_rpc_url, Arc::clone(&rollup_config));
+        let l2_source = RemoteL2Client::new(config.source_l2_rpc_url);
         let rpc_builder = RpcBuilder {
             no_restart: true,
             socket: rpc_addr,


### PR DESCRIPTION
## Summary

Standard L1 execution JSON-RPC and Beacon HTTP clients now share a 15-second transport deadline. All standard consensus L1 construction routes through these bounded clients, and L1 watcher timeout/retry behavior remains bounded so request errors surface instead of hanging.

## Motivation

An unbounded L1 request can stall consensus progress. The deadline is above the normal proxy response window while preventing indefinite waits.

## Behavior

Request timeouts follow the existing bounded retry/error path.

## Testing

- Provider execution and Beacon timeout tests.
- L1 watcher timeout and retry coverage.

type=routine
risk=low
impact=sev5