### PR TITLE
feat(prover-service): route zk jobs by requested backend

### DIFF
--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -13,7 +13,7 @@ use base_proof_zk_backend::{
 use base_proof_zk_host::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
     DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, ProofGeneratorHeartbeatConfig,
-    ZkHost, ZkHostConfig,
+    ZkBackend, ZkHost, ZkHostConfig,
 };
 use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::{Parser, ValueEnum};
@@ -201,14 +201,20 @@ enum ZkBackendArg {
     Network,
 }
 
+impl ZkBackendArg {
+    const fn protocol(self) -> ZkBackend {
+        match self {
+            Self::Mock => ZkBackend::Mock,
+            Self::DryRun => ZkBackend::DryRun,
+            Self::Cluster => ZkBackend::Cluster,
+            Self::Network => ZkBackend::Network,
+        }
+    }
+}
+
 impl AsRef<str> for ZkBackendArg {
     fn as_ref(&self) -> &str {
-        match self {
-            Self::Mock => "mock",
-            Self::DryRun => "dry_run",
-            Self::Cluster => "cluster",
-            Self::Network => "network",
-        }
+        self.protocol().as_str()
     }
 }
 
@@ -355,6 +361,7 @@ impl WorkerArgs {
         let worker_id =
             args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
         let host_config = ZkHostConfig::sp1(worker_id.clone())
+            .with_zk_backend(args.backend.protocol())
             .with_job_discovery_poll_interval(Duration::from_millis(
                 args.job_discovery_poll_interval_ms,
             ))

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -27,7 +27,9 @@ use base_proof_primitives::ProofRequest as TeeProofRequest;
 use base_proof_rpc::L2Provider;
 use base_proof_submission::KnownRevert;
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{SnarkGroth16ProofRequest, TeeKind, ZkProofRequest, ZkVm};
+use base_prover_service_protocol::{
+    SnarkGroth16ProofRequest, TeeKind, ZkBackend, ZkProofRequest, ZkVm,
+};
 use base_runtime::{Clock, TokioRuntime};
 use base_tx_manager::{TxManager, TxManagerError};
 use tokio::select;
@@ -662,6 +664,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
                 l1_head: Some(candidate.l1_head),
                 intermediate_root_interval: Some(candidate.intermediate_block_interval),
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             },
             prover_address: self.submitter.sender_address(),
         })
@@ -1098,6 +1101,7 @@ mod tests {
                 l1_head: Some(B256::repeat_byte(0xAA)),
                 intermediate_root_interval: Some(10),
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             },
             prover_address: Address::repeat_byte(0xCC),
         }

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -121,7 +121,7 @@ mod tests {
     use base_proof_primitives::{PROOF_TYPE_TEE, Proposal};
     use base_prover_service_protocol::{
         ProofRequestKind, ProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult, TeeKind,
-        TeeProofResult, ZkProofRequest, ZkProofResult, ZkVm,
+        TeeProofResult, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
     };
 
     use super::ChallengerProofAdapter;
@@ -198,6 +198,7 @@ mod tests {
             l1_head: Some(l1_head),
             intermediate_root_interval: Some(150),
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         };
         let request = SnarkGroth16ProofRequest { proof, prover_address };
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -26,7 +26,7 @@ use base_proof_primitives::Proposal;
 use base_protocol::OutputRoot;
 use base_prover_service_protocol::{
     ProofResult as ApiProofResult, ProofStatus, SnarkGroth16ProofRequest, TeeKind, TeeProofResult,
-    ZkProofRequest, ZkVm,
+    ZkBackend, ZkProofRequest, ZkVm,
 };
 use base_runtime::TokioRuntime;
 use base_tx_manager::TxManagerError;
@@ -158,6 +158,7 @@ fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
             l1_head: Some(DEFAULT_L1_HEAD),
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         },
         prover_address: addr(0),
     };
@@ -1753,6 +1754,7 @@ const fn minimal_prove_request() -> SnarkGroth16ProofRequest {
             l1_head: None,
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         },
         prover_address: Address::ZERO,
     }

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -244,7 +244,7 @@ mod tests {
         DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
         ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
         ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
-        ZkProofRequest, ZkProofResult, ZkVm,
+        ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -478,6 +478,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     zk_vm: ZkVm::Sp1,
+                    zk_backend: ZkBackend::Cluster,
                 }),
             },
         }

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -296,7 +296,7 @@ mod tests {
         BackendSession, BackendSessionState, GetProofSessionRequest, GetProofSessionResponse,
         ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind, ProofResult, ProofType,
         ProverWorkerApiServer, RecordProofSessionRequest, RecordProofSessionResponse, SessionType,
-        ZkProofRequest, ZkProofResult, ZkVm,
+        ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -614,6 +614,7 @@ mod tests {
             proof_type: ProofType::Compressed,
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
+            zk_backends: vec![ZkBackend::Cluster],
             lock_duration_seconds: 60,
         }
     }
@@ -689,6 +690,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }),
         }
     }
@@ -711,6 +713,7 @@ mod tests {
             proof_type: ProofType::Compressed,
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
+            zk_backends: vec![ZkBackend::Cluster],
             lock_duration_seconds: 60,
         };
         let provider: &dyn ProverWorkerProvider = &server.client;

--- a/crates/proof/prover-service/db/migrations/014_add_zk_backend.sql
+++ b/crates/proof/prover-service/db/migrations/014_add_zk_backend.sql
@@ -1,0 +1,62 @@
+-- Migration 014: Persist the ZK proving backend selected by each request.
+--
+-- Callers choose mock / dry_run / cluster / network per request. Workers claim
+-- jobs whose zk_backend is in their advertised capability list.
+BEGIN;
+
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS zk_backend VARCHAR(32);
+
+-- Preserve historical updated_at values while backfilling.
+ALTER TABLE proof_requests DISABLE TRIGGER update_proof_requests_updated_at;
+
+-- Existing ZK rows were always executed by cluster-configured hosts.
+UPDATE proof_requests
+SET zk_backend = COALESCE(zk_backend, 'cluster')
+WHERE api_proof_type IN ('compressed', 'snark_groth16')
+   OR (api_proof_type IS NULL AND proof_type IS NOT NULL);
+
+-- Backfill request_payload JSON so legacy rows deserialize with zk_backend.
+UPDATE proof_requests
+SET request_payload = CASE
+    WHEN request_payload -> 'request' ->> 'proof_type' = 'snark_groth16' THEN
+        jsonb_set(
+            request_payload,
+            '{request,payload,proof,zk_backend}',
+            '"cluster"'::jsonb,
+            true
+        )
+    WHEN request_payload -> 'request' ->> 'proof_type' = 'compressed' THEN
+        jsonb_set(
+            request_payload,
+            '{request,payload,zk_backend}',
+            '"cluster"'::jsonb,
+            true
+        )
+    ELSE request_payload
+END
+WHERE request_payload IS NOT NULL
+  AND (
+      (request_payload -> 'request' ->> 'proof_type' = 'compressed'
+          AND request_payload -> 'request' -> 'payload' ->> 'zk_backend' IS NULL)
+      OR (request_payload -> 'request' ->> 'proof_type' = 'snark_groth16'
+          AND request_payload -> 'request' -> 'payload' -> 'proof' ->> 'zk_backend' IS NULL)
+  );
+
+ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
+
+-- Keep NULL equivalent to the compatibility default while legacy service
+-- binaries may still insert rows during a rolling deployment.
+CREATE INDEX IF NOT EXISTS idx_proof_requests_zk_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    zk_vm,
+    (COALESCE(zk_backend, 'cluster')),
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type IN ('compressed', 'snark_groth16');
+
+COMMENT ON COLUMN proof_requests.zk_backend IS 'Protocol ZK proving backend: mock, dry_run, cluster, network.';
+
+COMMIT;

--- a/crates/proof/prover-service/db/migrations/014_add_zk_backend.sql
+++ b/crates/proof/prover-service/db/migrations/014_add_zk_backend.sql
@@ -15,33 +15,6 @@ SET zk_backend = COALESCE(zk_backend, 'cluster')
 WHERE api_proof_type IN ('compressed', 'snark_groth16')
    OR (api_proof_type IS NULL AND proof_type IS NOT NULL);
 
--- Backfill request_payload JSON so legacy rows deserialize with zk_backend.
-UPDATE proof_requests
-SET request_payload = CASE
-    WHEN request_payload -> 'request' ->> 'proof_type' = 'snark_groth16' THEN
-        jsonb_set(
-            request_payload,
-            '{request,payload,proof,zk_backend}',
-            '"cluster"'::jsonb,
-            true
-        )
-    WHEN request_payload -> 'request' ->> 'proof_type' = 'compressed' THEN
-        jsonb_set(
-            request_payload,
-            '{request,payload,zk_backend}',
-            '"cluster"'::jsonb,
-            true
-        )
-    ELSE request_payload
-END
-WHERE request_payload IS NOT NULL
-  AND (
-      (request_payload -> 'request' ->> 'proof_type' = 'compressed'
-          AND request_payload -> 'request' -> 'payload' ->> 'zk_backend' IS NULL)
-      OR (request_payload -> 'request' ->> 'proof_type' = 'snark_groth16'
-          AND request_payload -> 'request' -> 'payload' -> 'proof' ->> 'zk_backend' IS NULL)
-  );
-
 ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
 
 -- Keep NULL equivalent to the compatibility default while legacy service

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -260,7 +260,9 @@ impl ProofRequest {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_protocol::{ProofRequest as ProtocolProofRequest, ProofRequestKind};
+    use base_prover_service_protocol::{
+        ProofRequest as ProtocolProofRequest, ProofRequestKind, ZkBackend as ProtocolZkBackend,
+    };
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -276,6 +278,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ProtocolZkVm::Sp1,
+                zk_backend: ProtocolZkBackend::Cluster,
             }),
         })
         .expect("protocol request should serialize")

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -2,7 +2,8 @@ use std::convert::TryFrom;
 
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
-    ProofResult as ProtocolProofResult, TeeKind as ProtocolTeeKind, ZkVm as ProtocolZkVm,
+    ProofResult as ProtocolProofResult, TeeKind as ProtocolTeeKind, ZkBackend,
+    ZkVm as ProtocolZkVm,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -318,14 +319,17 @@ pub enum CreateProofRequestValidationError {
     },
 }
 
-/// Type of proof that determines success criteria
+/// Legacy SP1 proof-shape discriminator retained for receipt compatibility.
+///
+/// Backend routing uses [`ZkBackend`]; the persisted strings keep their
+/// historical `cluster` names for schema compatibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "VARCHAR")]
 pub enum ProofType {
-    /// Compressed proof generated via the Succinct SP1 cluster.
+    /// Compressed SP1 proof.
     #[sqlx(rename = "op_succinct_sp1_cluster_compressed")]
     OpSuccinctSp1ClusterCompressed,
-    /// SNARK Groth16 proof generated via the Succinct SP1 cluster.
+    /// Groth16 SNARK SP1 proof.
     #[sqlx(rename = "op_succinct_sp1_cluster_snark_groth16")]
     OpSuccinctSp1ClusterSnarkGroth16,
 }
@@ -747,6 +751,8 @@ pub struct CreateProofRequest {
     pub zk_vm: Option<ZkVmKind>,
     /// Protocol-level TEE discriminator for TEE proofs.
     pub tee_kind: Option<TeeKind>,
+    /// Protocol-level ZK proving backend for ZK proofs.
+    pub zk_backend: Option<ZkBackend>,
     /// Backend-specific proof type for current OP Succinct backends.
     pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
@@ -776,6 +782,7 @@ impl CreateProofRequest {
             api_proof_type: fields.api_proof_type,
             zk_vm: fields.zk_vm,
             tee_kind: fields.tee_kind,
+            zk_backend: fields.zk_backend,
             proof_type: fields.proof_type,
             start_block_number: fields.start_block_number,
             number_of_blocks_to_prove: fields.number_of_blocks_to_prove,
@@ -805,6 +812,9 @@ impl CreateProofRequest {
         }
         if self.tee_kind != expected.tee_kind {
             return Err(CreateProofRequestValidationError::FieldMismatch { field: "tee_kind" });
+        }
+        if self.zk_backend != expected.zk_backend {
+            return Err(CreateProofRequestValidationError::FieldMismatch { field: "zk_backend" });
         }
         if self.proof_type != expected.proof_type {
             return Err(CreateProofRequestValidationError::FieldMismatch { field: "proof_type" });
@@ -851,6 +861,8 @@ pub struct DerivedProofRequestFields {
     pub zk_vm: Option<ZkVmKind>,
     /// Protocol-level TEE discriminator for TEE proofs.
     pub tee_kind: Option<TeeKind>,
+    /// Protocol-level ZK proving backend for ZK proofs.
+    pub zk_backend: Option<ZkBackend>,
     /// Backend-specific proof type for current OP Succinct backends.
     pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
@@ -877,6 +889,7 @@ impl DerivedProofRequestFields {
                 api_proof_type: ApiProofType::Compressed,
                 zk_vm: Some(protocol_zk_vm(proof.zk_vm)),
                 tee_kind: None,
+                zk_backend: Some(proof.zk_backend),
                 proof_type: Some(ProofType::OpSuccinctSp1ClusterCompressed),
                 start_block_number: proof.start_block_number,
                 number_of_blocks_to_prove: proof.number_of_blocks_to_prove,
@@ -889,6 +902,7 @@ impl DerivedProofRequestFields {
                 api_proof_type: ApiProofType::SnarkGroth16,
                 zk_vm: Some(protocol_zk_vm(request.proof.zk_vm)),
                 tee_kind: None,
+                zk_backend: Some(request.proof.zk_backend),
                 proof_type: Some(ProofType::OpSuccinctSp1ClusterSnarkGroth16),
                 start_block_number: request.proof.start_block_number,
                 number_of_blocks_to_prove: request.proof.number_of_blocks_to_prove,
@@ -901,6 +915,7 @@ impl DerivedProofRequestFields {
                 api_proof_type: ApiProofType::Tee,
                 zk_vm: None,
                 tee_kind: Some(protocol_tee_kind(request.tee_kind)),
+                zk_backend: None,
                 proof_type: None,
                 start_block_number: request.proof.claimed_l2_block_number,
                 number_of_blocks_to_prove: 1,
@@ -1004,6 +1019,8 @@ pub struct ClaimProofJob {
     pub tee_kinds: Vec<TeeKind>,
     /// ZK virtual machines this worker can execute (matched for ZK proofs).
     pub zk_vms: Vec<ZkVmKind>,
+    /// ZK proving backends this worker can execute (matched for ZK proofs).
+    pub zk_backends: Vec<ZkBackend>,
     /// Lock duration in seconds. Callers must resolve the server default first.
     pub lock_duration_seconds: u32,
     /// Reclaim budget for expired claims.
@@ -1208,7 +1225,7 @@ pub struct FailExpiredProofJobs<'a> {
 #[cfg(test)]
 mod tests {
     use base_prover_service_protocol::{
-        SnarkGroth16ProofResult, ZkProofRequest, ZkProofResult, ZkVm,
+        SnarkGroth16ProofResult, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
     };
 
     use super::*;
@@ -1251,6 +1268,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }),
         }
     }

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -2388,6 +2388,9 @@ fn request_payload_matches(
     incoming: &serde_json::Value,
     mode: RequestMismatchMode,
 ) -> bool {
+    if existing == incoming {
+        return true;
+    }
     comparable_request_payload(existing, mode) == comparable_request_payload(incoming, mode)
 }
 

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -2388,17 +2388,26 @@ fn request_payload_matches(
     incoming: &serde_json::Value,
     mode: RequestMismatchMode,
 ) -> bool {
-    match mode {
-        RequestMismatchMode::Strict => existing == incoming,
-        RequestMismatchMode::AllowL1HeadReplacement => {
-            payload_without_l1_head_fields(existing) == payload_without_l1_head_fields(incoming)
-        }
-    }
+    comparable_request_payload(existing, mode) == comparable_request_payload(incoming, mode)
 }
 
-fn payload_without_l1_head_fields(value: &serde_json::Value) -> serde_json::Value {
+fn comparable_request_payload(
+    value: &serde_json::Value,
+    mode: RequestMismatchMode,
+) -> serde_json::Value {
     let mut value = value.clone();
-    remove_l1_head_fields(&mut value);
+    let zk_backend_path =
+        match value.pointer("/request/proof_type").and_then(serde_json::Value::as_str) {
+            Some("compressed") => Some("/request/payload"),
+            Some("snark_groth16") => Some("/request/payload/proof"),
+            _ => None,
+        };
+    if let Some(map) = zk_backend_path.and_then(|path| value.pointer_mut(path)?.as_object_mut()) {
+        map.entry("zk_backend").or_insert_with(|| serde_json::Value::String("cluster".to_owned()));
+    }
+    if mode == RequestMismatchMode::AllowL1HeadReplacement {
+        remove_l1_head_fields(&mut value);
+    }
     value
 }
 
@@ -2603,6 +2612,43 @@ mod tests {
             &new_unrelated_l1_head,
             RequestMismatchMode::AllowL1HeadReplacement,
         ));
+    }
+
+    #[test]
+    fn legacy_zk_payload_defaults_to_cluster_for_idempotency() {
+        let payloads = [
+            (
+                serde_json::json!({
+                    "request": {"proof_type": "compressed", "payload": {"start_block_number": 1}}
+                }),
+                serde_json::json!({
+                    "request": {
+                        "proof_type": "compressed",
+                        "payload": {"start_block_number": 1, "zk_backend": "cluster"}
+                    }
+                }),
+            ),
+            (
+                serde_json::json!({
+                    "request": {
+                        "proof_type": "snark_groth16",
+                        "payload": {"proof": {"start_block_number": 1}}
+                    }
+                }),
+                serde_json::json!({
+                    "request": {
+                        "proof_type": "snark_groth16",
+                        "payload": {
+                            "proof": {"start_block_number": 1, "zk_backend": "cluster"}
+                        }
+                    }
+                }),
+            ),
+        ];
+
+        for (legacy, current) in payloads {
+            assert!(request_payload_matches(&legacy, &current, RequestMismatchMode::Strict));
+        }
     }
 
     fn tee_protocol_request(session_id: &str) -> ProtocolProofRequest {

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,5 +1,5 @@
 use base_prover_service_protocol::{
-    ProofResult as ProtocolProofResult, SnarkGroth16ProofResult, ZkProofResult, ZkVm,
+    ProofResult as ProtocolProofResult, SnarkGroth16ProofResult, ZkBackend, ZkProofResult, ZkVm,
 };
 use chrono::Utc;
 use sqlx::{PgPool, Result, Row};
@@ -38,11 +38,11 @@ impl ProofRequestRepo {
         sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
-                number_of_blocks_to_prove, sequence_window, proof_type, status,
+                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             "#,
         )
         .bind(prepared.id)
@@ -51,6 +51,7 @@ impl ProofRequestRepo {
         .bind(prepared.api_proof_type.as_str())
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
+        .bind(prepared.zk_backend.map(|zk_backend| zk_backend.as_str()))
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
@@ -77,11 +78,11 @@ impl ProofRequestRepo {
         let insert_result = sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, start_block_number,
-                number_of_blocks_to_prove, sequence_window, proof_type, status,
+                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             ON CONFLICT ((COALESCE(session_id, id::text))) DO NOTHING
             "#,
         )
@@ -91,6 +92,7 @@ impl ProofRequestRepo {
         .bind(prepared.api_proof_type.as_str())
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
+        .bind(prepared.zk_backend.map(|zk_backend| zk_backend.as_str()))
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
@@ -111,7 +113,7 @@ impl ProofRequestRepo {
         let row = sqlx::query(
             r#"
             SELECT id, COALESCE(session_id, id::text) AS session_id,
-                   request_payload, api_proof_type, zk_vm, tee_kind,
+                   request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
                    start_block_number, number_of_blocks_to_prove, sequence_window,
                    proof_type, status, prover_address, l1_head,
                    intermediate_root_interval, retry_count
@@ -137,6 +139,7 @@ impl ProofRequestRepo {
             api_proof_type: prepared.api_proof_type.as_str(),
             zk_vm: prepared.zk_vm.map(|zk_vm| zk_vm.as_str()),
             tee_kind: prepared.tee_kind.map(|tee_kind| tee_kind.as_str()),
+            zk_backend: prepared.zk_backend.map(|zk_backend| zk_backend.as_str()),
             start_block_number: prepared.start_block_number,
             number_of_blocks_to_prove: prepared.number_of_blocks_to_prove,
             sequence_window: prepared.sequence_window,
@@ -201,6 +204,7 @@ impl ProofRequestRepo {
                     SET status = $1,
                         request_payload = $2,
                         l1_head = $3,
+                        zk_backend = $4,
                         job_status = 'PENDING',
                         retry_count = retry_count + 1,
                         error_message = NULL,
@@ -216,12 +220,13 @@ impl ProofRequestRepo {
                         claimed_at = NULL,
                         last_heartbeat_at = NULL,
                         attempt = 0
-                    WHERE id = $4
+                    WHERE id = $5
                     "#,
                 )
                 .bind(ProofStatus::Created.as_str())
                 .bind(&prepared.request_payload)
                 .bind(&prepared.l1_head)
+                .bind(prepared.zk_backend.map(|backend| backend.as_str()))
                 .bind(existing_id)
                 .execute(&mut *tx)
                 .await?;
@@ -285,7 +290,7 @@ impl ProofRequestRepo {
             r#"
             SELECT
                 id, COALESCE(session_id, id::text) AS session_id,
-                request_payload, api_proof_type, zk_vm, tee_kind,
+                request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                 stark_receipt, snark_receipt, result_payload,
                 submitted_by_worker_id, submitted_lock_id,
@@ -311,7 +316,7 @@ impl ProofRequestRepo {
             r#"
             SELECT
                 id, COALESCE(session_id, id::text) AS session_id,
-                request_payload, api_proof_type, zk_vm, tee_kind,
+                request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                 stark_receipt, snark_receipt, result_payload,
                 submitted_by_worker_id, submitted_lock_id,
@@ -574,17 +579,38 @@ impl ProofRequestRepo {
     pub async fn claim_next_proof_job(&self, req: ClaimProofJob) -> Result<Option<ProofJob>> {
         let lock_id = Uuid::new_v4();
         let sql = claim_query(req.api_proof_type);
-        let cap_values = worker_capability_values(&req);
 
-        let row = sqlx::query(&sql)
-            .bind(&req.worker_id)
-            .bind(lock_id)
-            .bind(i64::from(req.lock_duration_seconds))
-            .bind(req.api_proof_type.as_str())
-            .bind(&cap_values)
-            .bind(i64::from(req.max_attempts))
-            .fetch_optional(&self.pool)
-            .await?;
+        let row = match req.api_proof_type {
+            ApiProofType::Tee => {
+                let tee_kinds: Vec<String> =
+                    req.tee_kinds.iter().map(|kind| kind.as_str().to_owned()).collect();
+                sqlx::query(&sql)
+                    .bind(&req.worker_id)
+                    .bind(lock_id)
+                    .bind(i64::from(req.lock_duration_seconds))
+                    .bind(req.api_proof_type.as_str())
+                    .bind(&tee_kinds)
+                    .bind(i64::from(req.max_attempts))
+                    .fetch_optional(&self.pool)
+                    .await?
+            }
+            ApiProofType::Compressed | ApiProofType::SnarkGroth16 => {
+                let zk_vms: Vec<String> =
+                    req.zk_vms.iter().map(|vm| vm.as_str().to_owned()).collect();
+                let zk_backends: Vec<String> =
+                    req.zk_backends.iter().map(|backend| backend.as_str().to_owned()).collect();
+                sqlx::query(&sql)
+                    .bind(&req.worker_id)
+                    .bind(lock_id)
+                    .bind(i64::from(req.lock_duration_seconds))
+                    .bind(req.api_proof_type.as_str())
+                    .bind(&zk_vms)
+                    .bind(&zk_backends)
+                    .bind(i64::from(req.max_attempts))
+                    .fetch_optional(&self.pool)
+                    .await?
+            }
+        };
 
         row.as_ref().map(row_to_proof_job).transpose()
     }
@@ -1356,7 +1382,7 @@ impl ProofRequestRepo {
         let rows = sqlx::query(
             r#"
             SELECT id, COALESCE(session_id, id::text) AS session_id,
-                   request_payload, api_proof_type, zk_vm, tee_kind,
+                   request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
                    start_block_number, number_of_blocks_to_prove,
                    sequence_window, proof_type, stark_receipt, snark_receipt,
                    result_payload, submitted_by_worker_id, submitted_lock_id,
@@ -1386,7 +1412,7 @@ impl ProofRequestRepo {
             SELECT
                 pr.id, COALESCE(pr.session_id, pr.id::text) AS session_id,
                 pr.request_payload, pr.api_proof_type, pr.zk_vm,
-                pr.tee_kind, pr.start_block_number, pr.number_of_blocks_to_prove,
+                pr.tee_kind, pr.zk_backend, pr.start_block_number, pr.number_of_blocks_to_prove,
                 pr.sequence_window, pr.proof_type, pr.stark_receipt, pr.snark_receipt,
                 pr.result_payload, pr.submitted_by_worker_id, pr.submitted_lock_id,
                 pr.status, pr.error_message, pr.prover_address, pr.l1_head,
@@ -1603,7 +1629,7 @@ impl ProofRequestRepo {
                 r#"
                 SELECT
                     id, COALESCE(session_id, id::text) AS session_id,
-                    request_payload, api_proof_type, zk_vm, tee_kind,
+                    request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
                     start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                     stark_receipt, snark_receipt, result_payload,
                     submitted_by_worker_id, submitted_lock_id,
@@ -1625,7 +1651,7 @@ impl ProofRequestRepo {
                 r#"
                 SELECT
                     id, COALESCE(session_id, id::text) AS session_id,
-                    request_payload, api_proof_type, zk_vm, tee_kind,
+                    request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
                     start_block_number, number_of_blocks_to_prove, sequence_window, proof_type,
                     stark_receipt, snark_receipt, result_payload,
                     submitted_by_worker_id, submitted_lock_id,
@@ -1755,6 +1781,7 @@ struct PreparedProofRequest {
     api_proof_type: ApiProofType,
     zk_vm: Option<ZkVmKind>,
     tee_kind: Option<TeeKind>,
+    zk_backend: Option<ZkBackend>,
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -1809,6 +1836,7 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
             api_proof_type: req.api_proof_type,
             zk_vm: req.zk_vm,
             tee_kind: req.tee_kind,
+            zk_backend: req.zk_backend,
             start_block_number,
             number_of_blocks_to_prove,
             sequence_window,
@@ -1915,6 +1943,13 @@ const fn fallback_zk_vm_for_request(api_proof_type: ApiProofType) -> Option<ZkVm
     }
 }
 
+const fn fallback_zk_backend_for_request(api_proof_type: ApiProofType) -> Option<ZkBackend> {
+    match api_proof_type {
+        ApiProofType::Compressed | ApiProofType::SnarkGroth16 => Some(ZkBackend::Cluster),
+        ApiProofType::Tee => None,
+    }
+}
+
 /// Fields needed to build the canonical protocol request payload.
 #[derive(Debug, Clone, Copy)]
 struct ProtocolRequestPayloadParams<'a> {
@@ -1924,6 +1959,7 @@ struct ProtocolRequestPayloadParams<'a> {
     sequence_window: Option<i64>,
     api_proof_type: ApiProofType,
     tee_kind: Option<TeeKind>,
+    zk_backend: Option<ZkBackend>,
     prover_address: Option<&'a str>,
     l1_head: Option<&'a str>,
     intermediate_root_interval: Option<i64>,
@@ -1938,6 +1974,7 @@ impl ProtocolRequestPayloadParams<'_> {
             "l1_head": self.l1_head,
             "intermediate_root_interval": self.intermediate_root_interval,
             "zk_vm": ZkVmKind::Sp1.as_str(),
+            "zk_backend": self.zk_backend.unwrap_or(ZkBackend::Cluster).as_str(),
         });
         strip_null_object_fields(&mut zk_payload);
 
@@ -2045,6 +2082,11 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
         .map(parse_zk_vm_kind)
         .transpose()?
         .or_else(|| fallback_zk_vm_for_request(api_proof_type));
+    let zk_backend = row
+        .get::<Option<&str>, _>("zk_backend")
+        .map(parse_zk_backend)
+        .transpose()?
+        .or_else(|| fallback_zk_backend_for_request(api_proof_type));
     let tee_kind = row.get::<Option<&str>, _>("tee_kind").map(parse_tee_kind).transpose()?;
     let mut request_payload =
         row.get::<Option<serde_json::Value>, _>("request_payload").unwrap_or_else(|| {
@@ -2055,6 +2097,7 @@ fn row_to_proof_request(row: &sqlx::postgres::PgRow) -> Result<ProofRequest> {
                 sequence_window,
                 api_proof_type,
                 tee_kind,
+                zk_backend,
                 prover_address: prover_address.as_deref(),
                 l1_head: l1_head.as_deref(),
                 intermediate_root_interval,
@@ -2096,6 +2139,11 @@ fn parse_zk_vm_kind(value: &str) -> Result<ZkVmKind> {
         .map_err(|e| sqlx::Error::Protocol(format!("Unknown zk_vm '{value}': {e}")))
 }
 
+fn parse_zk_backend(value: &str) -> Result<ZkBackend> {
+    ZkBackend::try_from(value)
+        .map_err(|e| sqlx::Error::Protocol(format!("Unknown zk_backend '{value}': {e}")))
+}
+
 fn parse_tee_kind(value: &str) -> Result<TeeKind> {
     TeeKind::try_from(value)
         .map_err(|e| sqlx::Error::Protocol(format!("Unknown tee_kind '{value}': {e}")))
@@ -2103,7 +2151,7 @@ fn parse_tee_kind(value: &str) -> Result<TeeKind> {
 
 /// Columns returned by the claim query.
 const PROOF_JOB_RETURNING_COLUMNS: &str = "id, COALESCE(session_id, id::text) AS session_id, \
-     request_payload, api_proof_type, zk_vm, tee_kind, \
+     request_payload, api_proof_type, zk_vm, tee_kind, zk_backend, \
      start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, \
      stark_receipt, snark_receipt, result_payload, \
      submitted_by_worker_id, submitted_lock_id, status, error_message, \
@@ -2111,25 +2159,11 @@ const PROOF_JOB_RETURNING_COLUMNS: &str = "id, COALESCE(session_id, id::text) AS
      created_at, updated_at, completed_at, retry_count, \
      job_status, worker_id, lock_id, lock_expires_at, claimed_at, attempt, last_heartbeat_at";
 
-/// Capability values bound (as `$5`) into the claim query.
-///
-/// TEE workers contribute their `tee_kinds`, ZK workers their `zk_vms`. An empty
-/// list binds `ANY('{}')`, which matches no rows, so a worker that advertises no
-/// matching capabilities simply claims nothing.
-fn worker_capability_values(req: &ClaimProofJob) -> Vec<String> {
-    match req.api_proof_type {
-        ApiProofType::Tee => req.tee_kinds.iter().map(|kind| kind.as_str().to_owned()).collect(),
-        ApiProofType::Compressed | ApiProofType::SnarkGroth16 => {
-            req.zk_vms.iter().map(|vm| vm.as_str().to_owned()).collect()
-        }
-    }
-}
-
 /// Build the atomic claim query for a proof type.
 ///
-/// The capability column (`tee_kind` for TEE, `zk_vm` for ZK) is hardcoded as a
-/// literal in each variant rather than interpolated from a value, so no
-/// caller-derived string can ever reach the SQL as a column name. The only
+/// Capability columns (`tee_kind` for TEE, `zk_vm`/`zk_backend` for ZK) are
+/// hardcoded as literals in each variant rather than interpolated from a value,
+/// so no caller-derived string can ever reach the SQL as a column name. The only
 /// interpolated token is the fixed [`PROOF_JOB_RETURNING_COLUMNS`] constant.
 fn claim_query(api_proof_type: ApiProofType) -> String {
     let columns = PROOF_JOB_RETURNING_COLUMNS;
@@ -2175,9 +2209,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 SELECT id FROM proof_requests
                 WHERE api_proof_type = $4
                   AND zk_vm = ANY($5::text[])
+                  AND COALESCE(zk_backend, 'cluster') = ANY($6::text[])
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $6)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2253,6 +2288,7 @@ struct CreateRequestParams<'a> {
     api_proof_type: &'a str,
     zk_vm: Option<&'a str>,
     tee_kind: Option<&'a str>,
+    zk_backend: Option<&'a str>,
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -2321,6 +2357,12 @@ impl CreateRequestParams<'_> {
         {
             return Some("tee_kind");
         }
+        let stored_zk_backend = row.get::<Option<&str>, _>("zk_backend").or_else(|| {
+            matches!(self.api_proof_type, "compressed" | "snark_groth16").then_some("cluster")
+        });
+        if stored_zk_backend != self.zk_backend {
+            return Some("zk_backend");
+        }
         if let Some(request_payload) = row.get::<Option<serde_json::Value>, _>("request_payload")
             && !request_payload_matches(&request_payload, self.request_payload, mode)
         {
@@ -2373,7 +2415,7 @@ fn remove_l1_head_fields(value: &mut serde_json::Value) {
 mod tests {
     use base_prover_service_protocol::{
         ProofRequest as ProtocolProofRequest, ProofRequestKind, TeeKind as ProtocolTeeKind,
-        TeeProofRequest, ZkProofRequest, ZkVm,
+        TeeProofRequest, ZkBackend, ZkProofRequest, ZkVm,
     };
 
     use super::*;
@@ -2390,6 +2432,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: Some(5),
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }),
         })
         .expect("request should validate");
@@ -2425,6 +2468,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }),
         })
         .expect("request should validate");
@@ -2457,6 +2501,7 @@ mod tests {
             sequence_window: None,
             api_proof_type: ApiProofType::Tee,
             tee_kind: Some(TeeKind::AwsNitro),
+            zk_backend: None,
             prover_address: None,
             l1_head: Some(ZERO_HASH),
             intermediate_root_interval: Some(10),
@@ -2599,6 +2644,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }),
         })
         .expect("request should validate");

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -597,8 +597,13 @@ impl ProofRequestRepo {
             ApiProofType::Compressed | ApiProofType::SnarkGroth16 => {
                 let zk_vms: Vec<String> =
                     req.zk_vms.iter().map(|vm| vm.as_str().to_owned()).collect();
-                let zk_backends: Vec<String> =
-                    req.zk_backends.iter().map(|backend| backend.as_str().to_owned()).collect();
+                let zk_backends: Vec<String> = req
+                    .zk_backends
+                    .iter()
+                    .copied()
+                    .chain(req.zk_backends.is_empty().then_some(ZkBackend::Cluster))
+                    .map(|backend| backend.as_str().to_owned())
+                    .collect();
                 sqlx::query(&sql)
                     .bind(&req.worker_id)
                     .bind(lock_id)

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -26,7 +26,7 @@ use base_prover_service_db::{
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
     ProofResult as ProtocolProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
-    TeeKind as ProtocolTeeKind, TeeProofRequest, ZkProofRequest, ZkProofResult, ZkVm,
+    TeeKind as ProtocolTeeKind, TeeProofRequest, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -56,6 +56,13 @@ fn compressed_request() -> CreateProofRequest {
 }
 
 fn compressed_request_at(start_block_number: u64) -> CreateProofRequest {
+    compressed_request_at_with_backend(start_block_number, ZkBackend::Cluster)
+}
+
+fn compressed_request_at_with_backend(
+    start_block_number: u64,
+    zk_backend: ZkBackend,
+) -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
         request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
@@ -65,6 +72,7 @@ fn compressed_request_at(start_block_number: u64) -> CreateProofRequest {
             l1_head: None,
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend,
         }),
     })
     .expect("compressed request should validate")
@@ -80,6 +88,7 @@ fn compressed_request_with_l1_head(l1_head: &str) -> CreateProofRequest {
             l1_head: Some(l1_head.parse().expect("valid hash")),
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         }),
     })
     .expect("compressed request should validate")
@@ -100,6 +109,7 @@ fn snark_request() -> CreateProofRequest {
                 ),
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             },
             prover_address: "0x1234567890abcdef1234567890abcdef12345678"
                 .parse()
@@ -1085,19 +1095,49 @@ async fn test_create_for_worker_queue_accepts_tee_requests() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
-async fn test_create_for_worker_queue_idempotent() {
+async fn test_create_for_worker_queue_idempotent_for_legacy_null_backend() {
     let pool = test_pool().await;
-    let repo = test_repo(pool);
+    let repo = test_repo(pool.clone());
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
     set_request_session_id(&mut req, explicit_id.to_string());
 
     let first = repo.create_for_worker_queue(req.clone(), TEST_MAX_PROOF_RETRIES).await.unwrap();
+    sqlx::query("UPDATE proof_requests SET zk_backend = NULL WHERE id = $1")
+        .bind(explicit_id)
+        .execute(&pool)
+        .await
+        .unwrap();
     let second = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
 
     assert!(matches!(first, CreateProofRequestOutcome::Created(id) if id == explicit_id));
     assert!(matches!(second, CreateProofRequestOutcome::Replayed(id) if id == explicit_id));
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("legacy-cluster-worker", 3))
+        .await
+        .unwrap()
+        .expect("legacy NULL backend should be claimable as cluster");
+    assert_eq!(claimed.id, explicit_id);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_for_worker_queue_rejects_backend_collision() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut cluster = compressed_request_at_with_backend(100, ZkBackend::Cluster);
+    set_request_session_id(&mut cluster, explicit_id.to_string());
+    repo.create_for_worker_queue(cluster, TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    let mut network = compressed_request_at_with_backend(100, ZkBackend::Network);
+    set_request_session_id(&mut network, explicit_id.to_string());
+    assert!(matches!(
+        repo.create_for_worker_queue(network, TEST_MAX_PROOF_RETRIES).await.unwrap_err(),
+        CreateProofRequestError::IdCollision { id, field: "zk_backend" } if id == explicit_id
+    ));
 }
 
 #[tokio::test]
@@ -1483,6 +1523,11 @@ fn claim_job(
         api_proof_type,
         tee_kinds,
         zk_vms,
+        zk_backends: if api_proof_type == ApiProofType::Tee {
+            Vec::new()
+        } else {
+            vec![ZkBackend::Cluster]
+        },
         lock_duration_seconds: 3600,
         max_attempts,
     }

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -1627,9 +1627,10 @@ async fn test_claim_next_proof_job_claim_and_capabilities() {
     repo.create(compressed_request()).await.unwrap();
     assert!(repo.claim_next_proof_job(tee_claim("worker-2", 3)).await.unwrap().is_none());
 
-    // A ZK worker can claim a compressed job (block-number ordering may surface a
-    // lower-block pending ZK job from another test, so we only assert the proof type).
-    let zk = claim_job("zk-worker", ApiProofType::Compressed, vec![], vec![ZkVmKind::Sp1], 3);
+    // An empty backend list defaults to cluster. Block-number ordering may surface a lower-block
+    // pending ZK job from another test, so we only assert the proof type.
+    let mut zk = claim_job("zk-worker", ApiProofType::Compressed, vec![], vec![ZkVmKind::Sp1], 3);
+    zk.zk_backends.clear();
     let job = repo
         .claim_next_proof_job(zk)
         .await

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -20,5 +20,5 @@ pub use types::{
     ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
     RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
     TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
-    ZkProofRequest, ZkProofResult, ZkVm,
+    ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -50,9 +50,7 @@ pub enum ZkVm {
 }
 
 /// ZK proving backend that executes a proof request.
-#[derive(
-    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ZkBackend {
     /// Instant placeholder proofs for tests and local smoke checks.

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -49,6 +49,55 @@ pub enum ZkVm {
     Sp1,
 }
 
+/// ZK proving backend that executes a proof request.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ZkBackend {
+    /// Instant placeholder proofs for tests and local smoke checks.
+    Mock,
+    /// Local SP1 execution statistics without proof bytes.
+    DryRun,
+    /// Self-hosted SP1 cluster.
+    #[default]
+    Cluster,
+    /// Succinct SP1 prover network.
+    Network,
+}
+
+impl ZkBackend {
+    /// Returns the canonical wire and database representation.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mock => "mock",
+            Self::DryRun => "dry_run",
+            Self::Cluster => "cluster",
+            Self::Network => "network",
+        }
+    }
+}
+
+impl fmt::Display for ZkBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for ZkBackend {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "mock" => Ok(Self::Mock),
+            "dry_run" => Ok(Self::DryRun),
+            "cluster" => Ok(Self::Cluster),
+            "network" => Ok(Self::Network),
+            other => Err(format!("Unknown ZK backend: {other}")),
+        }
+    }
+}
+
 /// Status of a submitted proof request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -137,6 +186,11 @@ pub struct ZkProofRequest {
     pub intermediate_root_interval: Option<u64>,
     /// ZK virtual machine implementation to use.
     pub zk_vm: ZkVm,
+    /// Proving backend that should execute this request.
+    ///
+    /// Defaults to [`ZkBackend::Cluster`] when omitted so older clients keep working.
+    #[serde(default)]
+    pub zk_backend: ZkBackend,
 }
 
 /// Groth16 SNARK proof request parameters.
@@ -327,6 +381,9 @@ pub struct GetNextProofRequest {
     /// ZK virtual machines this worker can execute for ZK proofs.
     #[serde(default)]
     pub zk_vms: Vec<ZkVm>,
+    /// ZK proving backends this worker can execute for ZK proofs.
+    #[serde(default)]
+    pub zk_backends: Vec<ZkBackend>,
     /// Requested lock duration in seconds. Zero uses the server default.
     pub lock_duration_seconds: u32,
 }
@@ -478,6 +535,7 @@ mod tests {
                     l1_head: Some(B256::repeat_byte(0xab)),
                     intermediate_root_interval: Some(128),
                     zk_vm: ZkVm::Sp1,
+                    zk_backend: ZkBackend::Cluster,
                 }),
             },
         };
@@ -496,7 +554,8 @@ mod tests {
                             "number_of_blocks_to_prove": 20,
                             "l1_head": format!("{:#x}", B256::repeat_byte(0xab)),
                             "intermediate_root_interval": 128,
-                            "zk_vm": "sp1"
+                            "zk_vm": "sp1",
+                            "zk_backend": "cluster"
                         }
                     }
                 }
@@ -813,6 +872,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }
         );
     }
@@ -836,6 +896,7 @@ mod tests {
             proof_type: ProofType::Compressed,
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
+            zk_backends: vec![ZkBackend::Cluster, ZkBackend::DryRun],
             lock_duration_seconds: 30,
         };
 
@@ -848,6 +909,7 @@ mod tests {
                 "proof_type": "compressed",
                 "tee_kinds": [],
                 "zk_vms": ["sp1"],
+                "zk_backends": ["cluster", "dry_run"],
                 "lock_duration_seconds": 30
             })
         );
@@ -864,6 +926,7 @@ mod tests {
 
         assert_eq!(request.tee_kinds, Vec::new());
         assert_eq!(request.zk_vms, Vec::new());
+        assert_eq!(request.zk_backends, Vec::new());
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -8,7 +8,7 @@ use base_prover_service_protocol::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
     HeartbeatRequest, HeartbeatResponse, ProofJob as ProtocolProofJob, ProverWorkerApiServer,
     RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse, ZkBackend,
+    WorkerSubmitProofResponse,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -77,17 +77,12 @@ impl ProverServiceServer {
         &self,
         request: GetNextProofRequest,
     ) -> RpcResult<GetNextProofResponse> {
-        let zk_backends = if request.zk_backends.is_empty() {
-            vec![ZkBackend::Cluster]
-        } else {
-            request.zk_backends
-        };
         let claim = ClaimProofJob {
             worker_id: request.worker_id,
             api_proof_type: request.proof_type.into(),
             tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
             zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),
-            zk_backends,
+            zk_backends: request.zk_backends,
             lock_duration_seconds: resolve_lock_duration(
                 self.config.worker,
                 request.lock_duration_seconds,

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -8,7 +8,7 @@ use base_prover_service_protocol::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
     HeartbeatRequest, HeartbeatResponse, ProofJob as ProtocolProofJob, ProverWorkerApiServer,
     RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse,
+    WorkerSubmitProofResponse, ZkBackend,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -77,11 +77,17 @@ impl ProverServiceServer {
         &self,
         request: GetNextProofRequest,
     ) -> RpcResult<GetNextProofResponse> {
+        let zk_backends = if request.zk_backends.is_empty() {
+            vec![ZkBackend::Cluster]
+        } else {
+            request.zk_backends
+        };
         let claim = ClaimProofJob {
             worker_id: request.worker_id,
             api_proof_type: request.proof_type.into(),
             tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
             zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),
+            zk_backends,
             lock_duration_seconds: resolve_lock_duration(
                 self.config.worker,
                 request.lock_duration_seconds,

--- a/crates/proof/prover-service/tests/idempotency.rs
+++ b/crates/proof/prover-service/tests/idempotency.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProverRequesterApiClient,
+    ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProverRequesterApiClient, ZkBackend,
     ZkProofRequest, ZkVm,
 };
 use common::connect;
@@ -23,6 +23,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> ProveBlockRa
                 l1_head: None,
                 intermediate_root_interval: None,
                 zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
             }),
         },
     }

--- a/crates/proof/prover-service/tests/worker_api_e2e.rs
+++ b/crates/proof/prover-service/tests/worker_api_e2e.rs
@@ -21,7 +21,8 @@ use base_prover_service_db::{
 use base_prover_service_protocol::{
     GetNextProofRequest, HeartbeatRequest, ProofJobStatus, ProofRequest as ProtocolProofRequest,
     ProofRequestKind, ProofResult, ProofType, ProverRequesterApiServer, ProverWorkerApiClient,
-    ProverWorkerApiServer, WorkerSubmitProofRequest, ZkProofRequest, ZkProofResult, ZkVm,
+    ProverWorkerApiServer, WorkerSubmitProofRequest, ZkBackend, ZkProofRequest, ZkProofResult,
+    ZkVm,
 };
 use jsonrpsee::{
     core::client::Error as ClientError,
@@ -105,6 +106,7 @@ async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
         api_proof_type: ApiProofType::Compressed,
         tee_kinds: Vec::new(),
         zk_vms: vec![ZkVmKind::Sp1],
+        zk_backends: vec![ZkBackend::Cluster],
         lock_duration_seconds: 3600,
         max_attempts: u32::MAX,
     };
@@ -127,6 +129,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> CreateProofR
             l1_head: None,
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         }),
     })
     .expect("compressed request should validate")
@@ -138,6 +141,8 @@ fn worker_claim(worker_id: &str) -> GetNextProofRequest {
         proof_type: ProofType::Compressed,
         tee_kinds: Vec::new(),
         zk_vms: vec![ZkVm::Sp1],
+        // Omitted by legacy workers; the server defaults this capability to cluster.
+        zk_backends: Vec::new(),
         lock_duration_seconds: 60,
     }
 }

--- a/crates/proof/tee/nitro-host/src/job_discovery.rs
+++ b/crates/proof/tee/nitro-host/src/job_discovery.rs
@@ -3,7 +3,7 @@
 use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
-use base_prover_service_protocol::{GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkBackend};
+use base_prover_service_protocol::{GetNextProofRequest, ProofJob, ProofType, TeeKind};
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
     task::{JoinError, JoinHandle, JoinSet},
@@ -334,7 +334,7 @@ mod tests {
         GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
         HeartbeatResponse, ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind,
         RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
-        WorkerSubmitProofResponse, ZkProofRequest, ZkVm,
+        WorkerSubmitProofResponse, ZkBackend, ZkProofRequest, ZkVm,
     };
     use chrono::Utc;
     use tokio::time::timeout;

--- a/crates/proof/tee/nitro-host/src/job_discovery.rs
+++ b/crates/proof/tee/nitro-host/src/job_discovery.rs
@@ -3,7 +3,7 @@
 use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
-use base_prover_service_protocol::{GetNextProofRequest, ProofJob, ProofType, TeeKind};
+use base_prover_service_protocol::{GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkBackend};
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
     task::{JoinError, JoinHandle, JoinSet},
@@ -95,6 +95,7 @@ impl JobDiscoveryConfig {
             proof_type: ProofType::Tee,
             tee_kinds: vec![TeeKind::AwsNitro],
             zk_vms: Vec::new(),
+            zk_backends: Vec::new(),
             lock_duration_seconds: self.lock_duration_seconds,
         }
     }
@@ -477,6 +478,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     zk_vm: ZkVm::Sp1,
+                    zk_backend: ZkBackend::Cluster,
                 }),
             },
             attempt: 1,

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -640,6 +640,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     zk_vm: base_prover_service_protocol::ZkVm::Sp1,
+                    zk_backend: base_prover_service_protocol::ZkBackend::Cluster,
                 })
             }
         };

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -11,7 +11,9 @@ use std::{
 };
 
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
-use base_prover_service_protocol::{GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkVm};
+use base_prover_service_protocol::{
+    GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkBackend, ZkVm,
+};
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
     task::{JoinError, JoinHandle, JoinSet},
@@ -50,10 +52,12 @@ pub enum JobClaimFilter {
         /// TEE kinds this worker can execute.
         tee_kinds: Vec<TeeKind>,
     },
-    /// Claim ZK proof jobs for the configured virtual machines.
+    /// Claim ZK proof jobs for the configured virtual machines and backends.
     Zk {
         /// ZK virtual machines this worker can execute.
         zk_vms: Vec<ZkVm>,
+        /// ZK proving backends this worker can execute.
+        zk_backends: Vec<ZkBackend>,
     },
 }
 
@@ -64,8 +68,8 @@ impl JobClaimFilter {
     }
 
     /// Creates a ZK claim filter.
-    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>) -> Self {
-        Self::Zk { zk_vms: zk_vms.into() }
+    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>, zk_backends: impl Into<Vec<ZkBackend>>) -> Self {
+        Self::Zk { zk_vms: zk_vms.into(), zk_backends: zk_backends.into() }
     }
 
     /// Returns the prover-service proof types for this claim filter.
@@ -107,12 +111,14 @@ impl JobClaimFilter {
                     proof_type: ProofType::Tee,
                     tee_kinds: tee_kinds.clone(),
                     zk_vms: Vec::new(),
+                    zk_backends: Vec::new(),
                     lock_duration_seconds,
                 }),
                 None,
             ],
-            Self::Zk { zk_vms } => {
+            Self::Zk { zk_vms, zk_backends } => {
                 let zk_vms = zk_vms.clone();
+                let zk_backends = zk_backends.clone();
                 let proof_types = if proof_type_offset.is_multiple_of(ZK_PROOF_TYPES.len()) {
                     ZK_PROOF_TYPES
                 } else {
@@ -126,6 +132,7 @@ impl JobClaimFilter {
                         proof_type: first_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
+                        zk_backends: zk_backends.clone(),
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
@@ -133,6 +140,7 @@ impl JobClaimFilter {
                         proof_type: second_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms,
+                        zk_backends,
                         lock_duration_seconds,
                     }),
                 ]
@@ -160,8 +168,12 @@ impl JobDiscoveryConfig {
     }
 
     /// Creates a ZK job discovery config using default timings.
-    pub fn zk(worker_id: impl Into<String>, zk_vms: impl Into<Vec<ZkVm>>) -> Self {
-        Self::new(worker_id, JobClaimFilter::zk(zk_vms))
+    pub fn zk(
+        worker_id: impl Into<String>,
+        zk_vms: impl Into<Vec<ZkVm>>,
+        zk_backends: impl Into<Vec<ZkBackend>>,
+    ) -> Self {
+        Self::new(worker_id, JobClaimFilter::zk(zk_vms, zk_backends))
     }
 
     /// Creates a job discovery config using default timings.
@@ -611,6 +623,7 @@ mod tests {
             l1_head: None,
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         }
     }
 
@@ -643,7 +656,7 @@ mod tests {
 
     #[test]
     fn config_builds_zk_claim_requests() {
-        let config = JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1])
+        let config = JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster])
             .with_lock_duration_seconds(30)
             .with_max_concurrent_jobs(0);
 
@@ -654,11 +667,13 @@ mod tests {
         assert_eq!(requests[0].proof_type, ProofType::Compressed);
         assert!(requests[0].tee_kinds.is_empty());
         assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
+        assert_eq!(requests[0].zk_backends, vec![ZkBackend::Cluster]);
         assert_eq!(requests[0].lock_duration_seconds, 30);
         assert_eq!(requests[1].worker_id, "worker-a");
         assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
         assert!(requests[1].tee_kinds.is_empty());
         assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
+        assert_eq!(requests[1].zk_backends, vec![ZkBackend::Cluster]);
         assert_eq!(requests[1].lock_duration_seconds, 30);
         assert_eq!(config.normalized_max_concurrent_jobs(), 1);
     }
@@ -686,7 +701,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -704,7 +719,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator::default()),
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -719,7 +734,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator { can_claim: true, ..Default::default() }),
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
         discovery.generator_permits.close();
 
@@ -737,7 +752,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client,
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -760,7 +775,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
         discovery.claim_offset.store(1, Ordering::Relaxed);
 
@@ -788,7 +803,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let error =

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -52,12 +52,12 @@ pub enum JobClaimFilter {
         /// TEE kinds this worker can execute.
         tee_kinds: Vec<TeeKind>,
     },
-    /// Claim ZK proof jobs for the configured virtual machines and backends.
+    /// Claim ZK proof jobs for the configured virtual machines and backend.
     Zk {
         /// ZK virtual machines this worker can execute.
         zk_vms: Vec<ZkVm>,
-        /// ZK proving backends this worker can execute.
-        zk_backends: Vec<ZkBackend>,
+        /// ZK proving backend this worker can execute.
+        zk_backend: ZkBackend,
     },
 }
 
@@ -68,8 +68,8 @@ impl JobClaimFilter {
     }
 
     /// Creates a ZK claim filter.
-    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>, zk_backends: impl Into<Vec<ZkBackend>>) -> Self {
-        Self::Zk { zk_vms: zk_vms.into(), zk_backends: zk_backends.into() }
+    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>, zk_backend: ZkBackend) -> Self {
+        Self::Zk { zk_vms: zk_vms.into(), zk_backend }
     }
 
     /// Returns the prover-service proof types for this claim filter.
@@ -116,9 +116,8 @@ impl JobClaimFilter {
                 }),
                 None,
             ],
-            Self::Zk { zk_vms, zk_backends } => {
+            Self::Zk { zk_vms, zk_backend } => {
                 let zk_vms = zk_vms.clone();
-                let zk_backends = zk_backends.clone();
                 let proof_types = if proof_type_offset.is_multiple_of(ZK_PROOF_TYPES.len()) {
                     ZK_PROOF_TYPES
                 } else {
@@ -132,7 +131,7 @@ impl JobClaimFilter {
                         proof_type: first_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
-                        zk_backends: zk_backends.clone(),
+                        zk_backends: vec![*zk_backend],
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
@@ -140,7 +139,7 @@ impl JobClaimFilter {
                         proof_type: second_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms,
-                        zk_backends,
+                        zk_backends: vec![*zk_backend],
                         lock_duration_seconds,
                     }),
                 ]
@@ -171,9 +170,9 @@ impl JobDiscoveryConfig {
     pub fn zk(
         worker_id: impl Into<String>,
         zk_vms: impl Into<Vec<ZkVm>>,
-        zk_backends: impl Into<Vec<ZkBackend>>,
+        zk_backend: ZkBackend,
     ) -> Self {
-        Self::new(worker_id, JobClaimFilter::zk(zk_vms, zk_backends))
+        Self::new(worker_id, JobClaimFilter::zk(zk_vms, zk_backend))
     }
 
     /// Creates a job discovery config using default timings.
@@ -656,7 +655,7 @@ mod tests {
 
     #[test]
     fn config_builds_zk_claim_requests() {
-        let config = JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster])
+        let config = JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Network)
             .with_lock_duration_seconds(30)
             .with_max_concurrent_jobs(0);
 
@@ -667,13 +666,13 @@ mod tests {
         assert_eq!(requests[0].proof_type, ProofType::Compressed);
         assert!(requests[0].tee_kinds.is_empty());
         assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
-        assert_eq!(requests[0].zk_backends, vec![ZkBackend::Cluster]);
+        assert_eq!(requests[0].zk_backends, vec![ZkBackend::Network]);
         assert_eq!(requests[0].lock_duration_seconds, 30);
         assert_eq!(requests[1].worker_id, "worker-a");
         assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
         assert!(requests[1].tee_kinds.is_empty());
         assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
-        assert_eq!(requests[1].zk_backends, vec![ZkBackend::Cluster]);
+        assert_eq!(requests[1].zk_backends, vec![ZkBackend::Network]);
         assert_eq!(requests[1].lock_duration_seconds, 30);
         assert_eq!(config.normalized_max_concurrent_jobs(), 1);
     }
@@ -701,7 +700,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -719,7 +718,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator::default()),
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -734,7 +733,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator { can_claim: true, ..Default::default() }),
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
         );
         discovery.generator_permits.close();
 
@@ -752,7 +751,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client,
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -775,7 +774,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
         );
         discovery.claim_offset.store(1, Ordering::Relaxed);
 
@@ -803,7 +802,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
         );
 
         let error =

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -322,7 +322,8 @@ mod tests {
     use base_prover_service_protocol::{
         GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
         ProofJob, ProofJobStatus, ProofRequest, ProofRequestKind, ProofResult,
-        RecordProofSessionRequest, RecordProofSessionResponse, ZkProofRequest, ZkProofResult, ZkVm,
+        RecordProofSessionRequest, RecordProofSessionResponse, ZkBackend, ZkProofRequest,
+        ZkProofResult, ZkVm,
     };
     use chrono::Utc;
     use tokio::{sync::Notify, time::timeout};
@@ -447,6 +448,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     zk_vm: ZkVm::Sp1,
+                    zk_backend: ZkBackend::Cluster,
                 }),
             },
             attempt: 1,

--- a/crates/proof/zk/backend/src/succinct/mock.rs
+++ b/crates/proof/zk/backend/src/succinct/mock.rs
@@ -63,7 +63,7 @@ impl ZkProver for MockZkProver {
 #[cfg(test)]
 mod tests {
     use base_proof_zk_host::ZkProofRequestKind;
-    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkProofRequest, ZkVm};
+    use base_prover_service_protocol::{SnarkGroth16ProofRequest, ZkBackend, ZkProofRequest, ZkVm};
 
     use super::*;
 
@@ -75,6 +75,7 @@ mod tests {
             l1_head: None,
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         }
     }
 

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -17,6 +17,7 @@ use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkProver, ZkVm};
 pub struct ZkHostConfig {
     worker_id: String,
     zk_vms: Vec<ZkVm>,
+    zk_backend: ZkBackend,
     job_discovery_poll_interval: Duration,
     job_discovery_lock_duration_seconds: u32,
     job_discovery_max_concurrent_jobs: usize,
@@ -29,6 +30,7 @@ impl ZkHostConfig {
         Self {
             worker_id: worker_id.into(),
             zk_vms: zk_vms.into(),
+            zk_backend: ZkBackend::Cluster,
             job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             job_discovery_max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -49,6 +51,11 @@ impl ZkHostConfig {
     /// Returns the ZK VMs claimed by the worker.
     pub fn zk_vms(&self) -> &[ZkVm] {
         &self.zk_vms
+    }
+
+    /// Returns the ZK backend claimed by the worker.
+    pub const fn zk_backend(&self) -> ZkBackend {
+        self.zk_backend
     }
 
     /// Returns the heartbeat settings used while proofs are generated.
@@ -101,6 +108,13 @@ impl ZkHostConfig {
         self
     }
 
+    /// Sets the ZK backend claimed by the worker.
+    #[must_use]
+    pub const fn with_zk_backend(mut self, zk_backend: ZkBackend) -> Self {
+        self.zk_backend = zk_backend;
+        self
+    }
+
     /// Sets the heartbeat settings used while proofs are generated.
     #[must_use]
     pub const fn with_proof_generator_heartbeat(
@@ -113,19 +127,15 @@ impl ZkHostConfig {
 
     /// Builds the shared worker discovery config.
     pub fn job_discovery_config(&self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(
-            self.worker_id.clone(),
-            self.zk_vms.clone(),
-            vec![ZkBackend::Cluster],
-        )
-        .with_poll_interval(self.job_discovery_poll_interval)
-        .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
-        .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
+        JobDiscoveryConfig::zk(self.worker_id.clone(), self.zk_vms.clone(), self.zk_backend)
+            .with_poll_interval(self.job_discovery_poll_interval)
+            .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
+            .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
     }
 
     /// Converts this config into the shared worker discovery config.
     pub fn into_job_discovery_config(self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id, self.zk_vms, vec![ZkBackend::Cluster])
+        JobDiscoveryConfig::zk(self.worker_id, self.zk_vms, self.zk_backend)
             .with_poll_interval(self.job_discovery_poll_interval)
             .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
             .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
@@ -166,5 +176,21 @@ where
             JobDiscovery::new(client, proof_generator, config.into_job_discovery_config());
 
         discovery.run_until_cancelled(cancel).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertises_selected_backend() {
+        let requests = ZkHostConfig::sp1("worker")
+            .with_zk_backend(ZkBackend::Network)
+            .job_discovery_config()
+            .get_next_proof_requests()
+            .collect::<Vec<_>>();
+
+        assert!(requests.iter().all(|request| request.zk_backends == [ZkBackend::Network]));
     }
 }

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -7,6 +7,7 @@ use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobDiscovery, JobDiscoveryConfig, ProofSubmitter,
 };
 use base_prover_service_client::ProverWorkerProvider;
+use base_prover_service_protocol::ZkBackend;
 use tokio_util::sync::CancellationToken;
 
 use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkProver, ZkVm};
@@ -112,15 +113,19 @@ impl ZkHostConfig {
 
     /// Builds the shared worker discovery config.
     pub fn job_discovery_config(&self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id.clone(), self.zk_vms.clone())
-            .with_poll_interval(self.job_discovery_poll_interval)
-            .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
-            .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
+        JobDiscoveryConfig::zk(
+            self.worker_id.clone(),
+            self.zk_vms.clone(),
+            vec![ZkBackend::Cluster],
+        )
+        .with_poll_interval(self.job_discovery_poll_interval)
+        .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
+        .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
     }
 
     /// Converts this config into the shared worker discovery config.
     pub fn into_job_discovery_config(self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id, self.zk_vms)
+        JobDiscoveryConfig::zk(self.worker_id, self.zk_vms, vec![ZkBackend::Cluster])
             .with_poll_interval(self.job_discovery_poll_interval)
             .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
             .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)

--- a/crates/proof/zk/host/src/lib.rs
+++ b/crates/proof/zk/host/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-pub use base_prover_service_protocol::ZkVm;
+pub use base_prover_service_protocol::{ZkBackend, ZkVm};
 
 mod prover;
 pub use prover::{

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -141,7 +141,7 @@ impl ZkProver for UnimplementedZkProver {
 
 #[cfg(test)]
 mod tests {
-    use base_prover_service_protocol::ZkVm;
+    use base_prover_service_protocol::{ZkBackend, ZkVm};
 
     use super::*;
 
@@ -153,6 +153,7 @@ mod tests {
             l1_head: None,
             intermediate_root_interval: None,
             zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
         }
     }
 

--- a/etc/systems/benches/common/zk_proof.rs
+++ b/etc/systems/benches/common/zk_proof.rs
@@ -10,7 +10,7 @@ use base_optimism_rpc::OptimismRollupProviderExt;
 use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
 use base_prover_service_protocol::{
     ExecutionStats, GetProofRequest, GetProofResponse, ProofRequest, ProofRequestKind, ProofResult,
-    ProofStatus, ProveBlockRangeRequest, ZkProofRequest, ZkVm,
+    ProofStatus, ProveBlockRangeRequest, ZkBackend, ZkProofRequest, ZkVm,
 };
 use eyre::{Result, WrapErr, ensure};
 use nanoid::nanoid;
@@ -126,6 +126,7 @@ impl ZkProofBench {
                         l1_head: Some(l1_head),
                         intermediate_root_interval: None,
                         zk_vm: ZkVm::Sp1,
+                        zk_backend: ZkBackend::DryRun,
                     }),
                 },
             })


### PR DESCRIPTION
## Summary
- add a protocol-level ZK backend selector with cluster-compatible defaults
- persist backend selection and filter claims by worker-advertised capabilities
- preserve rolling-deploy behavior for legacy requests and nullable database rows

## Stack
1. **Backend-aware prover queue** (this PR)
2. Host backend routing
3. Simultaneous backend configuration


Made with [Cursor](https://cursor.com)