### PR TITLE
feat(zk-host): route requests to configured backends

### DIFF
--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -1,6 +1,6 @@
 //! CLI definition for the ZK prover host worker binary.
 
-use std::{fmt, time::Duration};
+use std::{collections::HashMap, fmt, time::Duration};
 
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_proof_worker::{
@@ -224,6 +224,17 @@ impl fmt::Display for ZkBackendArg {
     }
 }
 
+impl From<ZkBackendArg> for ZkBackend {
+    fn from(backend: ZkBackendArg) -> Self {
+        match backend {
+            ZkBackendArg::Mock => Self::Mock,
+            ZkBackendArg::DryRun => Self::DryRun,
+            ZkBackendArg::Cluster => Self::Cluster,
+            ZkBackendArg::Network => Self::Network,
+        }
+    }
+}
+
 impl WorkerArgs {
     fn backend_config(&self) -> eyre::Result<SuccinctZkBackendConfig> {
         match self.backend {
@@ -368,7 +379,7 @@ impl WorkerArgs {
             .with_job_discovery_lock_duration_seconds(args.job_discovery_lock_duration_seconds)
             .with_job_discovery_max_concurrent_jobs(args.job_discovery_max_concurrent_jobs)
             .with_proof_generator_heartbeat(heartbeat);
-        let host = ZkHost::new(client, prover, host_config);
+        let host = ZkHost::new(client, HashMap::from([(args.backend.into(), prover)]), host_config);
 
         info!(
             worker_id = %worker_id,

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -226,12 +226,7 @@ impl fmt::Display for ZkBackendArg {
 
 impl From<ZkBackendArg> for ZkBackend {
     fn from(backend: ZkBackendArg) -> Self {
-        match backend {
-            ZkBackendArg::Mock => Self::Mock,
-            ZkBackendArg::DryRun => Self::DryRun,
-            ZkBackendArg::Cluster => Self::Cluster,
-            ZkBackendArg::Network => Self::Network,
-        }
+        backend.protocol()
     }
 }
 
@@ -372,7 +367,6 @@ impl WorkerArgs {
         let worker_id =
             args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
         let host_config = ZkHostConfig::sp1(worker_id.clone())
-            .with_zk_backend(args.backend.protocol())
             .with_job_discovery_poll_interval(Duration::from_millis(
                 args.job_discovery_poll_interval_ms,
             ))

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -50,7 +50,7 @@ pub enum ZkVm {
 }
 
 /// ZK proving backend that executes a proof request.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ZkBackend {
     /// Instant placeholder proofs for tests and local smoke checks.

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -52,12 +52,12 @@ pub enum JobClaimFilter {
         /// TEE kinds this worker can execute.
         tee_kinds: Vec<TeeKind>,
     },
-    /// Claim ZK proof jobs for the configured virtual machines and backend.
+    /// Claim ZK proof jobs for the configured virtual machines and backends.
     Zk {
         /// ZK virtual machines this worker can execute.
         zk_vms: Vec<ZkVm>,
-        /// ZK proving backend this worker can execute.
-        zk_backend: ZkBackend,
+        /// ZK proving backends this worker can execute.
+        zk_backends: Vec<ZkBackend>,
     },
 }
 
@@ -68,8 +68,8 @@ impl JobClaimFilter {
     }
 
     /// Creates a ZK claim filter.
-    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>, zk_backend: ZkBackend) -> Self {
-        Self::Zk { zk_vms: zk_vms.into(), zk_backend }
+    pub fn zk(zk_vms: impl Into<Vec<ZkVm>>, zk_backends: impl Into<Vec<ZkBackend>>) -> Self {
+        Self::Zk { zk_vms: zk_vms.into(), zk_backends: zk_backends.into() }
     }
 
     /// Returns the prover-service proof types for this claim filter.
@@ -116,8 +116,9 @@ impl JobClaimFilter {
                 }),
                 None,
             ],
-            Self::Zk { zk_vms, zk_backend } => {
+            Self::Zk { zk_vms, zk_backends } => {
                 let zk_vms = zk_vms.clone();
+                let zk_backends = zk_backends.clone();
                 let proof_types = if proof_type_offset.is_multiple_of(ZK_PROOF_TYPES.len()) {
                     ZK_PROOF_TYPES
                 } else {
@@ -131,7 +132,7 @@ impl JobClaimFilter {
                         proof_type: first_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
-                        zk_backends: vec![*zk_backend],
+                        zk_backends: zk_backends.clone(),
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
@@ -139,7 +140,7 @@ impl JobClaimFilter {
                         proof_type: second_proof_type,
                         tee_kinds: Vec::new(),
                         zk_vms,
-                        zk_backends: vec![*zk_backend],
+                        zk_backends,
                         lock_duration_seconds,
                     }),
                 ]
@@ -170,9 +171,9 @@ impl JobDiscoveryConfig {
     pub fn zk(
         worker_id: impl Into<String>,
         zk_vms: impl Into<Vec<ZkVm>>,
-        zk_backend: ZkBackend,
+        zk_backends: impl Into<Vec<ZkBackend>>,
     ) -> Self {
-        Self::new(worker_id, JobClaimFilter::zk(zk_vms, zk_backend))
+        Self::new(worker_id, JobClaimFilter::zk(zk_vms, zk_backends))
     }
 
     /// Creates a job discovery config using default timings.
@@ -655,9 +656,13 @@ mod tests {
 
     #[test]
     fn config_builds_zk_claim_requests() {
-        let config = JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Network)
-            .with_lock_duration_seconds(30)
-            .with_max_concurrent_jobs(0);
+        let config = JobDiscoveryConfig::zk(
+            "worker-a",
+            vec![ZkVm::Sp1],
+            vec![ZkBackend::Cluster, ZkBackend::Network],
+        )
+        .with_lock_duration_seconds(30)
+        .with_max_concurrent_jobs(0);
 
         let requests = config.get_next_proof_requests().collect::<Vec<_>>();
 
@@ -666,13 +671,13 @@ mod tests {
         assert_eq!(requests[0].proof_type, ProofType::Compressed);
         assert!(requests[0].tee_kinds.is_empty());
         assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
-        assert_eq!(requests[0].zk_backends, vec![ZkBackend::Network]);
+        assert_eq!(requests[0].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
         assert_eq!(requests[0].lock_duration_seconds, 30);
         assert_eq!(requests[1].worker_id, "worker-a");
         assert_eq!(requests[1].proof_type, ProofType::SnarkGroth16);
         assert!(requests[1].tee_kinds.is_empty());
         assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
-        assert_eq!(requests[1].zk_backends, vec![ZkBackend::Network]);
+        assert_eq!(requests[1].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
         assert_eq!(requests[1].lock_duration_seconds, 30);
         assert_eq!(config.normalized_max_concurrent_jobs(), 1);
     }
@@ -700,7 +705,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -718,7 +723,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator::default()),
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -733,7 +738,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             Arc::new(MockGenerator { can_claim: true, ..Default::default() }),
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
         discovery.generator_permits.close();
 
@@ -751,7 +756,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client,
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let outcome = discovery.claim_once().await.expect("claim should succeed");
@@ -774,7 +779,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
         discovery.claim_offset.store(1, Ordering::Relaxed);
 
@@ -802,7 +807,7 @@ mod tests {
         let discovery = JobDiscovery::new(
             client.clone(),
             generator,
-            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], ZkBackend::Cluster),
+            JobDiscoveryConfig::zk("worker-a", vec![ZkVm::Sp1], vec![ZkBackend::Cluster]),
         );
 
         let error =

--- a/crates/proof/zk/host/README.md
+++ b/crates/proof/zk/host/README.md
@@ -3,8 +3,13 @@
 Host-side ZK proving worker for the prover service.
 
 This crate adapts the shared worker machinery for ZK proving jobs. It provides
-[`ZkHost`] and [`ProofGenerator`], which claim ZK jobs, drive a [`ZkProver`]
-backend to completion, and hand proof results to `base_proof_worker::ProofSubmitter`.
+[`ZkHost`] and [`ProofGenerator`], which claim ZK jobs, drive the matching
+[`ZkProver`] backend to completion, and hand proof results to
+`base_proof_worker::ProofSubmitter`.
+
+A host can run multiple backends at once. Each claimed job selects its backend
+via `zk_backend` on the proof request; the host only claims backends it has
+configured.
 
 Concrete SP1 proving backends are provided by `base-proof-zk-backend`.
 

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -126,6 +126,7 @@ impl<Client> ZkHost<Client> {
         provers: HashMap<ZkBackend, Arc<dyn ZkProver>>,
         config: ZkHostConfig,
     ) -> Self {
+        assert!(!provers.is_empty(), "ZK host requires at least one prover backend");
         Self { client, provers, config }
     }
 
@@ -142,7 +143,8 @@ where
     /// Runs the host until cancellation is requested.
     pub async fn run_until_cancelled(self, cancel: CancellationToken) {
         let Self { client, provers, config } = self;
-        let zk_backends = provers.keys().copied().collect::<Vec<_>>();
+        let mut zk_backends = provers.keys().copied().collect::<Vec<_>>();
+        zk_backends.sort_unstable_by_key(|backend| backend.as_str());
         let discovery_config = JobDiscoveryConfig::zk(config.worker_id, config.zk_vms, zk_backends)
             .with_poll_interval(config.job_discovery_poll_interval)
             .with_lock_duration_seconds(config.job_discovery_lock_duration_seconds)

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -1,23 +1,21 @@
 //! ZK host orchestration.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
     DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobDiscovery, JobDiscoveryConfig, ProofSubmitter,
 };
 use base_prover_service_client::ProverWorkerProvider;
-use base_prover_service_protocol::ZkBackend;
 use tokio_util::sync::CancellationToken;
 
-use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkProver, ZkVm};
+use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkBackend, ZkProver, ZkVm};
 
 /// Settings for running a ZK host against the prover service.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ZkHostConfig {
     worker_id: String,
     zk_vms: Vec<ZkVm>,
-    zk_backend: ZkBackend,
     job_discovery_poll_interval: Duration,
     job_discovery_lock_duration_seconds: u32,
     job_discovery_max_concurrent_jobs: usize,
@@ -30,7 +28,6 @@ impl ZkHostConfig {
         Self {
             worker_id: worker_id.into(),
             zk_vms: zk_vms.into(),
-            zk_backend: ZkBackend::Cluster,
             job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             job_discovery_max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -51,11 +48,6 @@ impl ZkHostConfig {
     /// Returns the ZK VMs claimed by the worker.
     pub fn zk_vms(&self) -> &[ZkVm] {
         &self.zk_vms
-    }
-
-    /// Returns the ZK backend claimed by the worker.
-    pub const fn zk_backend(&self) -> ZkBackend {
-        self.zk_backend
     }
 
     /// Returns the heartbeat settings used while proofs are generated.
@@ -108,13 +100,6 @@ impl ZkHostConfig {
         self
     }
 
-    /// Sets the ZK backend claimed by the worker.
-    #[must_use]
-    pub const fn with_zk_backend(mut self, zk_backend: ZkBackend) -> Self {
-        self.zk_backend = zk_backend;
-        self
-    }
-
     /// Sets the heartbeat settings used while proofs are generated.
     #[must_use]
     pub const fn with_proof_generator_heartbeat(
@@ -124,36 +109,24 @@ impl ZkHostConfig {
         self.proof_generator_heartbeat = proof_generator_heartbeat;
         self
     }
-
-    /// Builds the shared worker discovery config.
-    pub fn job_discovery_config(&self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id.clone(), self.zk_vms.clone(), self.zk_backend)
-            .with_poll_interval(self.job_discovery_poll_interval)
-            .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
-            .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
-    }
-
-    /// Converts this config into the shared worker discovery config.
-    pub fn into_job_discovery_config(self) -> JobDiscoveryConfig {
-        JobDiscoveryConfig::zk(self.worker_id, self.zk_vms, self.zk_backend)
-            .with_poll_interval(self.job_discovery_poll_interval)
-            .with_lock_duration_seconds(self.job_discovery_lock_duration_seconds)
-            .with_max_concurrent_jobs(self.job_discovery_max_concurrent_jobs)
-    }
 }
 
 /// Runs ZK proof generation jobs claimed from the prover service.
 #[derive(Debug)]
 pub struct ZkHost<Client> {
     client: Client,
-    prover: Arc<dyn ZkProver>,
+    provers: HashMap<ZkBackend, Arc<dyn ZkProver>>,
     config: ZkHostConfig,
 }
 
 impl<Client> ZkHost<Client> {
-    /// Creates a ZK host from a prover-service client and ZK prover backend.
-    pub const fn new(client: Client, prover: Arc<dyn ZkProver>, config: ZkHostConfig) -> Self {
-        Self { client, prover, config }
+    /// Creates a ZK host from a prover-service client and ZK prover backends.
+    pub const fn new(
+        client: Client,
+        provers: HashMap<ZkBackend, Arc<dyn ZkProver>>,
+        config: ZkHostConfig,
+    ) -> Self {
+        Self { client, provers, config }
     }
 
     /// Returns the host config.
@@ -168,29 +141,17 @@ where
 {
     /// Runs the host until cancellation is requested.
     pub async fn run_until_cancelled(self, cancel: CancellationToken) {
-        let Self { client, prover, config } = self;
+        let Self { client, provers, config } = self;
+        let zk_backends = provers.keys().copied().collect::<Vec<_>>();
+        let discovery_config = JobDiscoveryConfig::zk(config.worker_id, config.zk_vms, zk_backends)
+            .with_poll_interval(config.job_discovery_poll_interval)
+            .with_lock_duration_seconds(config.job_discovery_lock_duration_seconds)
+            .with_max_concurrent_jobs(config.job_discovery_max_concurrent_jobs);
         let submitter = ProofSubmitter::new(client.clone());
         let proof_generator =
-            Arc::new(ProofGenerator::new(prover, submitter, config.proof_generator_heartbeat));
-        let discovery =
-            JobDiscovery::new(client, proof_generator, config.into_job_discovery_config());
+            Arc::new(ProofGenerator::new(provers, submitter, config.proof_generator_heartbeat));
+        let discovery = JobDiscovery::new(client, proof_generator, discovery_config);
 
         discovery.run_until_cancelled(cancel).await;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn advertises_selected_backend() {
-        let requests = ZkHostConfig::sp1("worker")
-            .with_zk_backend(ZkBackend::Network)
-            .job_discovery_config()
-            .get_next_proof_requests()
-            .collect::<Vec<_>>();
-
-        assert!(requests.iter().all(|request| request.zk_backends == [ZkBackend::Network]));
     }
 }

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -121,7 +121,7 @@ pub struct ZkHost<Client> {
 
 impl<Client> ZkHost<Client> {
     /// Creates a ZK host from a prover-service client and ZK prover backends.
-    pub const fn new(
+    pub fn new(
         client: Client,
         provers: HashMap<ZkBackend, Arc<dyn ZkProver>>,
         config: ZkHostConfig,

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -1,6 +1,6 @@
 //! Proof generation orchestration for claimed ZK worker jobs.
 
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base_proof_worker::{
@@ -17,7 +17,7 @@ pub use base_proof_worker::{
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
     BackendSession, BackendSessionState, ProofJob, ProofRequestKind, ProofResult, SessionType,
-    WorkerSubmitProofRequest,
+    WorkerSubmitProofRequest, ZkBackend,
 };
 use thiserror::Error;
 use tokio::time::{sleep, timeout};
@@ -71,7 +71,7 @@ impl TryFrom<ProofJob> for ProofGeneratorRequest {
 /// Orchestrates ZK proof generation, claim heartbeats, and async proof submission.
 #[derive(Debug)]
 pub struct ProofGenerator<Client> {
-    prover: Arc<dyn ZkProver>,
+    provers: HashMap<ZkBackend, Arc<dyn ZkProver>>,
     submitter: ProofSubmitter<Client>,
     tasks: ProofTaskController,
     heartbeat: ProofGeneratorHeartbeatConfig,
@@ -81,12 +81,12 @@ pub struct ProofGenerator<Client> {
 impl<Client> ProofGenerator<Client> {
     /// Create a proof generator with its own submission cancellation token.
     pub fn new(
-        prover: Arc<dyn ZkProver>,
+        provers: HashMap<ZkBackend, Arc<dyn ZkProver>>,
         submitter: ProofSubmitter<Client>,
         heartbeat: ProofGeneratorHeartbeatConfig,
     ) -> Self {
         Self {
-            prover,
+            provers,
             submitter,
             tasks: ProofTaskController::new(),
             heartbeat,
@@ -127,6 +127,14 @@ impl<Client> ProofGenerator<Client> {
     pub fn normalized_poll_interval(&self) -> Duration {
         self.poll_interval.max(MIN_PROOF_GENERATOR_POLL_INTERVAL)
     }
+
+    fn prover_for(
+        &self,
+        request: &ZkProofRequestKind,
+    ) -> Result<&Arc<dyn ZkProver>, ZkProverError> {
+        let backend = request.zk_backend();
+        self.provers.get(&backend).ok_or(ZkProverError::UnsupportedBackend { backend })
+    }
 }
 
 impl<Client> ProofGenerator<Client>
@@ -146,6 +154,7 @@ where
             worker_id = %request.claim.worker_id,
             start_block = request.request.start_block_number(),
             block_count = request.request.number_of_blocks_to_prove(),
+            zk_backend = ?request.request.zk_backend(),
             "starting zk proof generation"
         );
 
@@ -159,6 +168,7 @@ where
                     session_id = %request.claim.session_id,
                     lock_id = %request.claim.lock_id,
                     worker_id = %request.claim.worker_id,
+                    zk_backend = ?request.request.zk_backend(),
                     error = %source,
                     "zk proof generation failed"
                 );
@@ -170,6 +180,7 @@ where
                     session_id = %request.claim.session_id,
                     lock_id = %request.claim.lock_id,
                     worker_id = %request.claim.worker_id,
+                    zk_backend = ?request.request.zk_backend(),
                     error = %source,
                     "aborting zk proof generation due to heartbeat failure"
                 );
@@ -215,6 +226,8 @@ where
         &self,
         request: &ProofGeneratorRequest,
     ) -> Result<ProofResult, ZkProverError> {
+        let prover = self.prover_for(&request.request)?;
+
         let handle = ProofSessionHandle::new(
             self.submitter.client().clone(),
             request.claim.session_id.clone(),
@@ -233,7 +246,8 @@ where
                 request,
                 &handle,
                 SessionType::Stark,
-                self.prover.submit(range_request, &request.claim.session_id),
+                prover,
+                prover.submit(range_request, &request.claim.session_id),
             )
             .await?;
 
@@ -246,17 +260,18 @@ where
                         request,
                         &handle,
                         SessionType::Snark,
-                        self.prover.submit_next(
+                        prover,
+                        prover.submit_next(
                             proof_request,
                             &request.claim.session_id,
                             &range_session_id,
                         ),
                     )
                     .await?;
-                self.prover.download(SessionType::Snark, &snark_session_id).await
+                prover.download(SessionType::Snark, &snark_session_id).await
             }
             ZkProofRequestKind::Compressed(_) => {
-                self.prover.download(SessionType::Stark, &range_session_id).await
+                prover.download(SessionType::Stark, &range_session_id).await
             }
         }
     }
@@ -271,6 +286,7 @@ where
         request: &ProofGeneratorRequest,
         handle: &ProofSessionHandle<Client>,
         session_type: SessionType,
+        prover: &Arc<dyn ZkProver>,
         submit: impl Future<Output = Result<String, ZkProverError>>,
     ) -> Result<String, ZkProverError> {
         let backend_session_id = match handle
@@ -310,7 +326,7 @@ where
             }
         };
 
-        self.poll_to_completion(request, handle, session_type, backend_session_id).await
+        self.poll_to_completion(request, handle, session_type, prover, backend_session_id).await
     }
 
     /// Poll a running backend session until it reaches a terminal state.
@@ -319,10 +335,11 @@ where
         request: &ProofGeneratorRequest,
         handle: &ProofSessionHandle<Client>,
         session_type: SessionType,
+        prover: &Arc<dyn ZkProver>,
         backend_session_id: String,
     ) -> Result<String, ZkProverError> {
         loop {
-            match self.prover.poll(&backend_session_id).await? {
+            match prover.poll(&backend_session_id).await? {
                 ZkSessionState::Running => {
                     debug!(
                         session_id = %request.claim.session_id,

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -154,7 +154,7 @@ where
             worker_id = %request.claim.worker_id,
             start_block = request.request.start_block_number(),
             block_count = request.request.number_of_blocks_to_prove(),
-            zk_backend = ?request.request.zk_backend(),
+            zk_backend = %request.request.zk_backend(),
             "starting zk proof generation"
         );
 
@@ -168,7 +168,7 @@ where
                     session_id = %request.claim.session_id,
                     lock_id = %request.claim.lock_id,
                     worker_id = %request.claim.worker_id,
-                    zk_backend = ?request.request.zk_backend(),
+                    zk_backend = %request.request.zk_backend(),
                     error = %source,
                     "zk proof generation failed"
                 );
@@ -180,7 +180,7 @@ where
                     session_id = %request.claim.session_id,
                     lock_id = %request.claim.lock_id,
                     worker_id = %request.claim.worker_id,
-                    zk_backend = ?request.request.zk_backend(),
+                    zk_backend = %request.request.zk_backend(),
                     error = %source,
                     "aborting zk proof generation due to heartbeat failure"
                 );

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use base_prover_service_protocol::{
-    ProofResult, SessionType, SnarkGroth16ProofRequest, ZkProofRequest,
+    ProofResult, SessionType, SnarkGroth16ProofRequest, ZkBackend, ZkProofRequest,
 };
 use thiserror::Error;
 
@@ -29,6 +29,14 @@ impl ZkProofRequestKind {
         match self {
             Self::Compressed(request) => request.number_of_blocks_to_prove,
             Self::SnarkGroth16(request) => request.proof.number_of_blocks_to_prove,
+        }
+    }
+
+    /// Returns the proving backend selected for this request.
+    pub const fn zk_backend(&self) -> ZkBackend {
+        match self {
+            Self::Compressed(request) => request.zk_backend,
+            Self::SnarkGroth16(request) => request.proof.zk_backend,
         }
     }
 }
@@ -65,6 +73,12 @@ pub enum ZkProverError {
     BackendSessionNotFound {
         /// Backend proving session identifier.
         backend_session_id: String,
+    },
+    /// The proving backend selected by the request is not configured on this host.
+    #[error("zk backend {backend:?} is not configured on this host")]
+    UnsupportedBackend {
+        /// Backend requested by the proof job.
+        backend: ZkBackend,
     },
     /// The proving backend failed to produce a proof.
     #[error("zk proving backend failed")]

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -75,7 +75,7 @@ pub enum ZkProverError {
         backend_session_id: String,
     },
     /// The proving backend selected by the request is not configured on this host.
-    #[error("zk backend {backend:?} is not configured on this host")]
+    #[error("zk backend {backend} is not configured on this host")]
     UnsupportedBackend {
         /// Backend requested by the proof job.
         backend: ZkBackend,


### PR DESCRIPTION
## Summary
- store ZK provers in a backend-keyed map and dispatch each claimed request to its selected backend
- advertise only the backend capabilities present in the host map
- keep the existing single-backend CLI behavior as a one-entry map during this layer

## Stack
1. Backend-aware prover queue: #3918
2. **Host backend routing** (this PR)
3. Simultaneous backend configuration

Made with [Cursor](https://cursor.com)