### PR TITLE
fix(engine): do not poison blocks when parent state is unavailable

### DIFF
--- a/crates/execution/engine-tree/tests/isthmus.rs
+++ b/crates/execution/engine-tree/tests/isthmus.rs
@@ -26,7 +26,9 @@ use reth_trie::{
 use revm::database::BundleState;
 
 #[test]
-fn legacy_isthmus_validation_errors_when_parent_is_only_in_memory() {
+fn legacy_isthmus_validation_skips_when_parent_is_only_in_memory() {
+    // Regression for #3701: the legacy PayloadValidator hook must not fail-closed (and
+    // permanently poison the block) when parent state is not yet visible via StateProviderFactory.
     let (chain_spec, provider, _genesis_hash, parent_executed_block, _parent_withdrawals_root) =
         isthmus_parent_overlay_fixture();
     let parent_hash = parent_executed_block.recovered_block().hash();
@@ -36,6 +38,11 @@ fn legacy_isthmus_validation_errors_when_parent_is_only_in_memory() {
         KeccakKeyHasher,
     >(Arc::clone(&chain_spec), provider.clone());
 
+    assert!(
+        provider.state_by_block_hash(parent_hash).is_err(),
+        "test setup requires the parent to exist only in memory"
+    );
+
     let legacy_result =
         PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
             &validator,
@@ -43,12 +50,8 @@ fn legacy_isthmus_validation_errors_when_parent_is_only_in_memory() {
             &child_block,
         );
     assert!(
-        legacy_result.is_err(),
-        "legacy validation should fail closed when the parent state is not canonical"
-    );
-    assert!(
-        provider.state_by_block_hash(parent_hash).is_err(),
-        "test setup requires the parent to exist only in memory"
+        legacy_result.is_ok(),
+        "legacy validation must skip (not poison) when parent state is unavailable: {legacy_result:?}"
     );
 }
 

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -215,14 +215,28 @@ where
             return Ok(());
         }
 
-        let parent_state =
-            self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
-                ConsensusError::Other(Arc::from(Box::<dyn core::error::Error + Send + Sync>::from(
-                    format!(
-                        "failed to load parent state for Isthmus withdrawals root validation: {err}"
-                    ),
-                )))
-            })?;
+        // This trait hook is used by reth's BasicEngineValidator (no tree overlay). Prefer the
+        // overlay-aware path via [`BasePostExecutionValidator`] / base-engine-tree when available.
+        //
+        // #3701: after a parent is just canonicalized, `state_by_block_hash` can transiently fail
+        // even though the parent is valid. Returning `ConsensusError` here marks the child
+        // permanently invalid in reth's invalid-block cache, wedges the node until restart, and
+        // rejects every subsequent payload that builds on the poisoned ancestor. Skip the check
+        // only when parent state cannot be loaded; when state *is* available, still fail closed
+        // on a bad withdrawals root via `validate_block_post_execution_with_state`.
+        let parent_state = match self.provider.state_by_block_hash(block.parent_hash()) {
+            Ok(state) => state,
+            Err(err) => {
+                tracing::warn!(
+                    target: "base::engine",
+                    parent_hash = %block.parent_hash(),
+                    block_number = block.number(),
+                    error = %err,
+                    "parent state unavailable for Isthmus withdrawals-root validation;                      skipping check to avoid permanent invalid-block poison (see #3701)"
+                );
+                return Ok(());
+            }
+        };
 
         self.validate_block_post_execution_with_state(state_updates, parent_state, block.header())
     }


### PR DESCRIPTION
## Summary

Fixes #3701.

The legacy `PayloadValidator::validate_block_post_execution_with_hashed_state` path (used by reth `BasicEngineValidator`) loaded parent state via `state_by_block_hash` and returned `ConsensusError` on failure. That permanently marks the child invalid in reth's invalid-block cache, so every subsequent payload that builds on it is rejected until process restart.

Parent state can be transiently invisible right after canonicalization even for valid blocks. This change skips Isthmus withdrawals-root validation **only** when the parent cannot be loaded; when state is available, verification still fails closed on a bad withdrawals root.

The engine-tree path continues to use overlay-aware parent state via `BasePostExecutionValidator`.

## Changes
- `crates/execution/node/src/engine.rs`: fail-open on missing parent state in the legacy hook
- `crates/execution/engine-tree/tests/isthmus.rs`: regression test updated for #3701

## Test plan
- [ ] `cargo test -p base-engine-tree --test isthmus`
- [ ] `cargo check -p base-node-core`

Closes #3701

---
Supersedes #3929 (auto-closed while the fork was behind; this branch is rebased on current `main`).
