### PR TITLE
feat(derive): insert BaseTime metadata deposit

### DIFF
--- a/actions/harness/src/sequencer/attributes.rs
+++ b/actions/harness/src/sequencer/attributes.rs
@@ -35,8 +35,10 @@ impl AttributesBuilder for ActionSequencerAttributesBuilder {
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: alloy_eips::BlockNumHash,
+        timestamp_millis_part: Option<u16>,
     ) -> PipelineResult<BasePayloadAttributes> {
-        let mut attrs = self.inner.prepare_payload_attributes(l2_parent, epoch).await?;
+        let mut attrs =
+            self.inner.prepare_payload_attributes(l2_parent, epoch, timestamp_millis_part).await?;
         let user_txs = self
             .user_txs
             .lock()

--- a/crates/common/genesis/Cargo.toml
+++ b/crates/common/genesis/Cargo.toml
@@ -44,6 +44,7 @@ alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 
 [features]
 default = []
+test-utils = []
 std = [
 	"alloy-chains/std",
 	"alloy-consensus/std",

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -432,25 +432,31 @@ impl RuntimeUpgradeRegistry {
     pub fn activate_zombie_for_testing(chain_id: u64, timestamp: u64) -> impl Drop {
         struct ZombieActivationGuard {
             chain_id: u64,
-            previous: Option<UpgradeActivationOverrides>,
+            previous: Option<UpgradeActivation>,
+            remove_chain_if_empty: bool,
         }
 
         impl Drop for ZombieActivationGuard {
             fn drop(&mut self) {
                 let mut registry = RuntimeUpgradeRegistry::write_registry();
-                if let Some(previous) = self.previous.take() {
-                    registry.insert(self.chain_id, previous);
+                let overrides = registry.entry(self.chain_id).or_default();
+                if let Some(previous) = self.previous {
+                    overrides.activations.insert(BaseUpgrade::Zombie, previous);
                 } else {
+                    overrides.activations.remove(&BaseUpgrade::Zombie);
+                }
+                if self.remove_chain_if_empty && overrides.is_empty() {
                     registry.remove(&self.chain_id);
                 }
             }
         }
 
         let mut registry = Self::write_registry();
-        let previous = registry.get(&chain_id).cloned();
+        let remove_chain_if_empty = !registry.contains_key(&chain_id);
         let overrides = registry.entry(chain_id).or_default();
+        let previous = overrides.activation(BaseUpgrade::Zombie);
         overrides.activations.insert(BaseUpgrade::Zombie, UpgradeActivation::Timestamp(timestamp));
-        ZombieActivationGuard { chain_id, previous }
+        ZombieActivationGuard { chain_id, previous, remove_chain_if_empty }
     }
 
     /// Sets one runtime override that clears a chain upgrade activation.

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -425,6 +425,34 @@ impl RuntimeUpgradeRegistry {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Timestamp(timestamp))
     }
 
+    /// Activates the permanently-off Zombie gate for a chain for the lifetime of the returned
+    /// test guard.
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use = "the guard must be held for the duration of the test activation"]
+    pub fn activate_zombie_for_testing(chain_id: u64, timestamp: u64) -> impl Drop {
+        struct ZombieActivationGuard {
+            chain_id: u64,
+            previous: Option<UpgradeActivationOverrides>,
+        }
+
+        impl Drop for ZombieActivationGuard {
+            fn drop(&mut self) {
+                let mut registry = RuntimeUpgradeRegistry::write_registry();
+                if let Some(previous) = self.previous.take() {
+                    registry.insert(self.chain_id, previous);
+                } else {
+                    registry.remove(&self.chain_id);
+                }
+            }
+        }
+
+        let mut registry = Self::write_registry();
+        let previous = registry.get(&chain_id).cloned();
+        let overrides = registry.entry(chain_id).or_default();
+        overrides.activations.insert(BaseUpgrade::Zombie, UpgradeActivation::Timestamp(timestamp));
+        ZombieActivationGuard { chain_id, previous }
+    }
+
     /// Sets one runtime override that clears a chain upgrade activation.
     pub fn clear_activation_timestamp(chain_id: u64, upgrade_id: BaseUpgrade) {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Never)

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -979,10 +979,22 @@ mod tests {
             assert!(!cfg.is_zombie_active(41));
             assert!(cfg.is_zombie_active(42));
             assert!(cfg.is_zombie_active(u64::MAX));
+            crate::RuntimeUpgradeRegistry::set_activation_timestamp(
+                chain_id,
+                BaseUpgrade::Azul,
+                22,
+            );
+            {
+                let _nested =
+                    crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 84);
+                assert!(!cfg.is_zombie_active(83));
+                assert!(cfg.is_zombie_active(84));
+            }
+            assert!(cfg.is_zombie_active(42));
         }
         assert_eq!(
             crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
-            Some(UpgradeActivation::Timestamp(21))
+            Some(UpgradeActivation::Timestamp(22))
         );
         assert_eq!(crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -195,9 +195,12 @@ macro_rules! rollup_fork_methods {
 impl RollupConfig {
     /// Returns this rollup config's runtime-aware activation for a contract upgrade ID.
     pub fn contract_upgrade_activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
-        // Zombie is a permanently-off gate: it can never activate, not even via a runtime
-        // override, so short-circuit before consulting the registry or genesis config.
+        // Zombie is a permanently-off production gate: runtime overrides cannot activate it.
         if matches!(upgrade_id, BaseUpgrade::Zombie) {
+            #[cfg(any(test, feature = "test-utils"))]
+            return RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
+                .unwrap_or(UpgradeActivation::Never);
+            #[cfg(not(any(test, feature = "test-utils")))]
             return UpgradeActivation::Never;
         }
         RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
@@ -961,6 +964,27 @@ mod tests {
             UpgradeActivation::Never
         );
 
+        crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn zombie_activation_can_be_enabled_for_testing() {
+        let chain_id = 9_100_003;
+        crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 21);
+        let cfg = RollupConfig { l2_chain_id: Chain::from_id(chain_id), ..Default::default() };
+        {
+            let _activation =
+                crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 42);
+
+            assert!(!cfg.is_zombie_active(41));
+            assert!(cfg.is_zombie_active(42));
+            assert!(cfg.is_zombie_active(u64::MAX));
+        }
+        assert_eq!(
+            crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(21))
+        );
+        assert_eq!(crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 

--- a/crates/consensus/derive/Cargo.toml
+++ b/crates/consensus/derive/Cargo.toml
@@ -52,6 +52,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 base-protocol = { workspace = true, features = ["test-utils"] }
+base-common-genesis = { workspace = true, features = ["test-utils"] }
 alloy-primitives = { workspace = true, features = ["rlp", "k256", "map", "arbitrary"] }
 
 [[bench]]

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -181,7 +181,15 @@ where
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
-        let base_time_update = if self.rollup_cfg.is_zombie_active(next_l2_time) {
+        let base_time_active = self.rollup_cfg.is_zombie_active(next_l2_time);
+        let mut txs = Vec::with_capacity(
+            1 + usize::from(base_time_active)
+                + deposit_transactions.len()
+                + upgrade_transactions.len(),
+        );
+        txs.push(encoded_l1_info_tx.into());
+
+        let payload_timestamp_millis_part = if base_time_active {
             let timestamp_millis_part = timestamp_millis_part.ok_or_else(|| {
                 PipelineError::AttributesBuilder(BuilderError::MissingBaseTimeTimestampMillisPart)
                     .crit()
@@ -198,22 +206,12 @@ where
             })?;
             let mut encoded = Vec::with_capacity(envelope.length());
             envelope.encode_2718(&mut encoded);
-            Some((timestamp_millis_part, Bytes::from(encoded)))
+            txs.push(encoded.into());
+            Some(timestamp_millis_part)
         } else {
             None
         };
 
-        let payload_timestamp_millis_part =
-            base_time_update.as_ref().map(|(timestamp_millis_part, _)| *timestamp_millis_part);
-        let mut txs = Vec::with_capacity(
-            1 + usize::from(base_time_update.is_some())
-                + deposit_transactions.len()
-                + upgrade_transactions.len(),
-        );
-        txs.push(encoded_l1_info_tx.into());
-        if let Some((_, tx)) = base_time_update {
-            txs.push(tx);
-        }
         txs.extend(deposit_transactions);
         txs.extend(upgrade_transactions);
 

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -296,8 +296,10 @@ mod tests {
     use alloc::vec;
 
     use alloy_consensus::Header;
+    use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
     use base_common_chains::Sepolia;
+    use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
     use base_common_genesis::{SystemConfig, SystemConfigUpdate, UpgradeConfig};
     use base_protocol::{BlockInfo, DepositDecodeError};
 
@@ -537,6 +539,71 @@ mod tests {
         };
         assert_eq!(payload, expected);
         assert_eq!(payload.transactions.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_prepare_payload_inserts_base_time_update_at_tx_one() {
+        let block_time = 2;
+        let timestamp = 100;
+        let chain_id = 9_100_004;
+        let _activation =
+            base_common_genesis::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 102);
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            l2_chain_id: chain_id.into(),
+            upgrades: UpgradeConfig { ecotone_time: Some(102), ..Default::default() },
+            ..Default::default()
+        });
+        let l1_cfg = Arc::new(Sepolia::l1_config());
+        let l2_number = 1;
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert(l2_number, SystemConfig::default());
+        let mut provider = TestChainProvider::default();
+        let header = Header { timestamp, ..Default::default() };
+        let hash = header.hash_slow();
+        provider.insert_header(hash, header);
+        let mut builder = StatefulAttributesBuilder::new(cfg, l1_cfg, fetcher, provider);
+        let epoch = BlockNumHash { hash, number: l2_number };
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::ZERO,
+                number: l2_number,
+                timestamp,
+                parent_hash: hash,
+            },
+            l1_origin: BlockNumHash { hash, number: l2_number },
+            seq_num: 0,
+        };
+
+        let payload =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(400)).await.unwrap();
+        assert_eq!(payload.timestamp_millis_part, Some(400));
+        let transactions = payload.transactions.unwrap();
+        assert_eq!(transactions.len(), 8);
+        let envelope = BaseTxEnvelope::decode_2718_exact(&transactions[1]).unwrap();
+        let deposit = envelope.as_deposit().unwrap();
+        assert_eq!(deposit.from, SystemAddresses::DEPOSITOR_ACCOUNT);
+        assert_eq!(deposit.to, alloy_primitives::TxKind::Call(Predeploys::BASE_TIME));
+        assert_eq!(
+            BaseTimeUpdateTx::decode_calldata(&deposit.input).unwrap().timestamp_millis_part(),
+            400
+        );
+
+        let missing = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
+        assert_eq!(
+            missing,
+            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
+                "missing BaseTime timestamp millis part".to_string()
+            )))
+        );
+        let invalid =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(100)).await.unwrap_err();
+        assert_eq!(
+            invalid,
+            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
+                "invalid BaseTime timestamp millis part: 100".to_string()
+            )))
+        );
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -36,9 +36,6 @@ where
     config_fetcher: L2P,
     /// The L1 receipts fetcher.
     receipts_fetcher: L1P,
-    #[cfg(test)]
-    /// Overrides the permanently-off activation gate in focused tests.
-    zombie_active: bool,
 }
 
 impl<L1P, L2P> StatefulAttributesBuilder<L1P, L2P>
@@ -58,8 +55,6 @@ where
             l1_cfg,
             config_fetcher: sys_cfg_fetcher,
             receipts_fetcher: receipts,
-            #[cfg(test)]
-            zombie_active: false,
         }
     }
 }
@@ -186,10 +181,7 @@ where
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
-        let zombie_active = self.rollup_cfg.is_zombie_active(next_l2_time);
-        #[cfg(test)]
-        let zombie_active = zombie_active || self.zombie_active;
-        let base_time_update = if zombie_active {
+        let base_time_update = if self.rollup_cfg.is_zombie_active(next_l2_time) {
             let timestamp_millis_part = timestamp_millis_part.ok_or_else(|| {
                 PipelineError::AttributesBuilder(BuilderError::Custom(
                     "missing BaseTime timestamp millis part".to_string(),
@@ -304,10 +296,8 @@ mod tests {
     use alloc::vec;
 
     use alloy_consensus::Header;
-    use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
     use base_common_chains::Sepolia;
-    use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
     use base_common_genesis::{SystemConfig, SystemConfigUpdate, UpgradeConfig};
     use base_protocol::{BlockInfo, DepositDecodeError};
 
@@ -547,68 +537,6 @@ mod tests {
         };
         assert_eq!(payload, expected);
         assert_eq!(payload.transactions.unwrap().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_prepare_payload_inserts_base_time_update_at_tx_one() {
-        let block_time = 2;
-        let timestamp = 100;
-        let cfg = Arc::new(RollupConfig {
-            block_time,
-            upgrades: UpgradeConfig { ecotone_time: Some(102), ..Default::default() },
-            ..Default::default()
-        });
-        let l1_cfg = Arc::new(Sepolia::l1_config());
-        let l2_number = 1;
-        let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
-        let mut provider = TestChainProvider::default();
-        let header = Header { timestamp, ..Default::default() };
-        let hash = header.hash_slow();
-        provider.insert_header(hash, header);
-        let mut builder = StatefulAttributesBuilder::new(cfg, l1_cfg, fetcher, provider);
-        builder.zombie_active = true;
-        let epoch = BlockNumHash { hash, number: l2_number };
-        let l2_parent = L2BlockInfo {
-            block_info: BlockInfo {
-                hash: B256::ZERO,
-                number: l2_number,
-                timestamp,
-                parent_hash: hash,
-            },
-            l1_origin: BlockNumHash { hash, number: l2_number },
-            seq_num: 0,
-        };
-
-        let payload =
-            builder.prepare_payload_attributes(l2_parent, epoch, Some(400)).await.unwrap();
-        assert_eq!(payload.timestamp_millis_part, Some(400));
-        let transactions = payload.transactions.unwrap();
-        assert_eq!(transactions.len(), 8);
-        let envelope = BaseTxEnvelope::decode_2718_exact(&transactions[1]).unwrap();
-        let deposit = envelope.as_deposit().unwrap();
-        assert_eq!(deposit.from, SystemAddresses::DEPOSITOR_ACCOUNT);
-        assert_eq!(deposit.to, alloy_primitives::TxKind::Call(Predeploys::BASE_TIME));
-        assert_eq!(
-            BaseTimeUpdateTx::decode_calldata(&deposit.input).unwrap().timestamp_millis_part(),
-            400
-        );
-
-        let missing = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
-        assert_eq!(
-            missing,
-            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
-                "missing BaseTime timestamp millis part".to_string()
-            )))
-        );
-        let invalid =
-            builder.prepare_payload_attributes(l2_parent, epoch, Some(100)).await.unwrap_err();
-        assert_eq!(
-            invalid,
-            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
-                "invalid BaseTime timestamp millis part: 100".to_string()
-            )))
-        );
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -183,10 +183,8 @@ where
 
         let base_time_update = if self.rollup_cfg.is_zombie_active(next_l2_time) {
             let timestamp_millis_part = timestamp_millis_part.ok_or_else(|| {
-                PipelineError::AttributesBuilder(BuilderError::Custom(
-                    "missing BaseTime timestamp millis part".to_string(),
-                ))
-                .crit()
+                PipelineError::AttributesBuilder(BuilderError::MissingBaseTimeTimestampMillisPart)
+                    .crit()
             })?;
             let (_, envelope) = BaseTimeUpdateTx::try_new_with_deposit_tx(
                 &self.rollup_cfg,
@@ -196,7 +194,7 @@ where
                 next_l2_time,
             )
             .map_err(|e| {
-                PipelineError::AttributesBuilder(BuilderError::Custom(e.to_string())).crit()
+                PipelineError::AttributesBuilder(BuilderError::BaseTimeUpdate(e)).crit()
             })?;
             let mut encoded = Vec::with_capacity(envelope.length());
             envelope.encode_2718(&mut encoded);
@@ -301,7 +299,7 @@ mod tests {
     use base_common_chains::Sepolia;
     use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
     use base_common_genesis::{SystemConfig, SystemConfigUpdate, UpgradeConfig};
-    use base_protocol::{BlockInfo, DepositDecodeError};
+    use base_protocol::{BaseTimeUpdateError, BlockInfo, DepositDecodeError};
 
     use super::*;
     use crate::{
@@ -592,17 +590,17 @@ mod tests {
         let missing = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(
             missing,
-            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
-                "missing BaseTime timestamp millis part".to_string()
-            )))
+            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(
+                BuilderError::MissingBaseTimeTimestampMillisPart
+            ))
         );
         let invalid =
             builder.prepare_payload_attributes(l2_parent, epoch, Some(100)).await.unwrap_err();
         assert_eq!(
             invalid,
-            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
-                "invalid BaseTime timestamp millis part: 100".to_string()
-            )))
+            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(
+                BuilderError::BaseTimeUpdate(BaseTimeUpdateError::InvalidTimestampMillisPart(100))
+            ))
         );
     }
 

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -13,7 +13,7 @@ use base_common_consensus::Predeploys;
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
-use base_protocol::{Deposits, L1BlockInfoTx, L2BlockInfo};
+use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo};
 use tracing::warn;
 
 use crate::{
@@ -36,6 +36,9 @@ where
     config_fetcher: L2P,
     /// The L1 receipts fetcher.
     receipts_fetcher: L1P,
+    #[cfg(test)]
+    /// Overrides the permanently-off activation gate in focused tests.
+    zombie_active: bool,
 }
 
 impl<L1P, L2P> StatefulAttributesBuilder<L1P, L2P>
@@ -55,6 +58,8 @@ where
             l1_cfg,
             config_fetcher: sys_cfg_fetcher,
             receipts_fetcher: receipts,
+            #[cfg(test)]
+            zombie_active: false,
         }
     }
 }
@@ -69,6 +74,7 @@ where
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
+        timestamp_millis_part: Option<u16>,
     ) -> PipelineResult<BasePayloadAttributes> {
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
@@ -180,9 +186,44 @@ where
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
-        let mut txs =
-            Vec::with_capacity(1 + deposit_transactions.len() + upgrade_transactions.len());
+        let zombie_active = self.rollup_cfg.is_zombie_active(next_l2_time);
+        #[cfg(test)]
+        let zombie_active = zombie_active || self.zombie_active;
+        let base_time_update = if zombie_active {
+            let timestamp_millis_part = timestamp_millis_part.ok_or_else(|| {
+                PipelineError::AttributesBuilder(BuilderError::Custom(
+                    "missing BaseTime timestamp millis part".to_string(),
+                ))
+                .crit()
+            })?;
+            let (_, envelope) = BaseTimeUpdateTx::try_new_with_deposit_tx(
+                &self.rollup_cfg,
+                l2_parent.block_info.number + 1,
+                timestamp_millis_part,
+                l2_parent.block_info.timestamp,
+                next_l2_time,
+            )
+            .map_err(|e| {
+                PipelineError::AttributesBuilder(BuilderError::Custom(e.to_string())).crit()
+            })?;
+            let mut encoded = Vec::with_capacity(envelope.length());
+            envelope.encode_2718(&mut encoded);
+            Some((timestamp_millis_part, Bytes::from(encoded)))
+        } else {
+            None
+        };
+
+        let payload_timestamp_millis_part =
+            base_time_update.as_ref().map(|(timestamp_millis_part, _)| *timestamp_millis_part);
+        let mut txs = Vec::with_capacity(
+            1 + usize::from(base_time_update.is_some())
+                + deposit_transactions.len()
+                + upgrade_transactions.len(),
+        );
         txs.push(encoded_l1_info_tx.into());
+        if let Some((_, tx)) = base_time_update {
+            txs.push(tx);
+        }
         txs.extend(deposit_transactions);
         txs.extend(upgrade_transactions);
 
@@ -221,7 +262,7 @@ where
                 .is_jovian_active(next_l2_time)
                 .then(|| sys_config.min_base_fee.unwrap_or_default()), /* Default to zero if not
                                                                         * set at Jovian */
-            timestamp_millis_part: None,
+            timestamp_millis_part: payload_timestamp_millis_part,
         })
     }
 }
@@ -263,8 +304,10 @@ mod tests {
     use alloc::vec;
 
     use alloy_consensus::Header;
+    use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
     use base_common_chains::Sepolia;
+    use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
     use base_common_genesis::{SystemConfig, SystemConfigUpdate, UpgradeConfig};
     use base_protocol::{BlockInfo, DepositDecodeError};
 
@@ -394,7 +437,7 @@ mod tests {
         // hash. Here we use the default header whose hash will not equal the custom `l2_hash`.
         let expected =
             BuilderError::BlockMismatchEpochReset(epoch, l2_parent.l1_origin, B256::default());
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(err, PipelineErrorKind::Reset(expected.into()));
     }
 
@@ -419,7 +462,7 @@ mod tests {
         // This should error because the l2 parent's l1_origin.hash should equal the epoch hash
         // Here the default header is used whose hash will not equal the custom `l2_hash` above.
         let expected = BuilderError::BlockMismatch(epoch, l2_parent.l1_origin);
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(err, PipelineErrorKind::Reset(ResetError::AttributesBuilder(expected)));
     }
 
@@ -451,7 +494,7 @@ mod tests {
             block_id,
             timestamp,
         );
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(err, PipelineErrorKind::Reset(ResetError::AttributesBuilder(expected)));
     }
 
@@ -482,7 +525,8 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = l2_parent.block_info.timestamp + block_time;
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(400)).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -503,6 +547,68 @@ mod tests {
         };
         assert_eq!(payload, expected);
         assert_eq!(payload.transactions.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_prepare_payload_inserts_base_time_update_at_tx_one() {
+        let block_time = 2;
+        let timestamp = 100;
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            upgrades: UpgradeConfig { ecotone_time: Some(102), ..Default::default() },
+            ..Default::default()
+        });
+        let l1_cfg = Arc::new(Sepolia::l1_config());
+        let l2_number = 1;
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert(l2_number, SystemConfig::default());
+        let mut provider = TestChainProvider::default();
+        let header = Header { timestamp, ..Default::default() };
+        let hash = header.hash_slow();
+        provider.insert_header(hash, header);
+        let mut builder = StatefulAttributesBuilder::new(cfg, l1_cfg, fetcher, provider);
+        builder.zombie_active = true;
+        let epoch = BlockNumHash { hash, number: l2_number };
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::ZERO,
+                number: l2_number,
+                timestamp,
+                parent_hash: hash,
+            },
+            l1_origin: BlockNumHash { hash, number: l2_number },
+            seq_num: 0,
+        };
+
+        let payload =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(400)).await.unwrap();
+        assert_eq!(payload.timestamp_millis_part, Some(400));
+        let transactions = payload.transactions.unwrap();
+        assert_eq!(transactions.len(), 8);
+        let envelope = BaseTxEnvelope::decode_2718_exact(&transactions[1]).unwrap();
+        let deposit = envelope.as_deposit().unwrap();
+        assert_eq!(deposit.from, SystemAddresses::DEPOSITOR_ACCOUNT);
+        assert_eq!(deposit.to, alloy_primitives::TxKind::Call(Predeploys::BASE_TIME));
+        assert_eq!(
+            BaseTimeUpdateTx::decode_calldata(&deposit.input).unwrap().timestamp_millis_part(),
+            400
+        );
+
+        let missing = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
+        assert_eq!(
+            missing,
+            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
+                "missing BaseTime timestamp millis part".to_string()
+            )))
+        );
+        let invalid =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(100)).await.unwrap_err();
+        assert_eq!(
+            invalid,
+            PipelineErrorKind::Critical(PipelineError::AttributesBuilder(BuilderError::Custom(
+                "invalid BaseTime timestamp millis part: 100".to_string()
+            )))
+        );
     }
 
     #[tokio::test]
@@ -536,7 +642,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = l2_parent.block_info.timestamp + block_time;
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -591,7 +697,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = l2_parent.block_info.timestamp + block_time;
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -645,7 +751,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = l2_parent.block_info.timestamp + block_time;
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -712,6 +818,6 @@ mod tests {
         };
 
         // Should succeed despite the malformed system config receipt.
-        assert!(builder.prepare_payload_attributes(l2_parent, epoch).await.is_ok());
+        assert!(builder.prepare_payload_attributes(l2_parent, epoch, None).await.is_ok());
     }
 }

--- a/crates/consensus/derive/src/errors/attributes.rs
+++ b/crates/consensus/derive/src/errors/attributes.rs
@@ -4,6 +4,7 @@ use alloc::string::String;
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
+use base_protocol::BaseTimeUpdateError;
 use thiserror::Error;
 
 /// An [`AttributesBuilder`] Error.
@@ -30,6 +31,12 @@ pub enum BuilderError {
     /// Attributes unavailable.
     #[error("Attributes unavailable")]
     AttributesUnavailable,
+    /// The `BaseTime` timestamp millisecond part is missing.
+    #[error("missing BaseTime timestamp millis part")]
+    MissingBaseTimeTimestampMillisPart,
+    /// The `BaseTime` metadata deposit could not be built.
+    #[error(transparent)]
+    BaseTimeUpdate(#[from] BaseTimeUpdateError),
     /// A custom error.
     #[error("Error in attributes builder: {0}")]
     Custom(String),

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -121,7 +121,8 @@ where
 
         // Prepare the payload attributes
         let tx_count = batch.transactions.len();
-        let mut attributes = self.builder.prepare_payload_attributes(parent, batch.epoch()).await?;
+        let mut attributes =
+            self.builder.prepare_payload_attributes(parent, batch.epoch(), None).await?;
         attributes.no_tx_pool = Some(true);
         match attributes.transactions {
             Some(ref mut txs) => txs.extend(batch.transactions),

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -28,6 +28,7 @@ impl AttributesBuilder for TestAttributesBuilder {
         &mut self,
         _l2_parent: L2BlockInfo,
         _epoch: BlockNumHash,
+        _timestamp_millis_part: Option<u16>,
     ) -> PipelineResult<BasePayloadAttributes> {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -43,10 +43,13 @@ pub trait AttributesBuilder: Debug + Send {
     /// By default, the [`BasePayloadAttributes`] template will have `no_tx_pool` set to true,
     /// and no sequencer transactions. The caller has to modify the template to add transactions.
     /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
-    /// batch transactions as the verifier.
+    /// batch transactions as the verifier. `timestamp_millis_part` is the child block's sub-second
+    /// timestamp component. It is ignored before the gated `BaseTime` metadata deposit activates;
+    /// once active, it is required and must be one of `0`, `200`, `400`, `600`, or `800`.
     async fn prepare_payload_attributes(
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
+        timestamp_millis_part: Option<u16>,
     ) -> PipelineResult<BasePayloadAttributes>;
 }

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -168,7 +168,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     ) -> Result<Option<AttributesWithParent>, SequencerActorError> {
         let mut attributes = match self
             .attributes_builder
-            .prepare_payload_attributes(unsafe_head, l1_origin.id())
+            .prepare_payload_attributes(unsafe_head, l1_origin.id(), None)
             .await
         {
             Ok(attrs) => attrs,


### PR DESCRIPTION
Adds an explicit child millisecond input to payload derivation and, once gated activation is active, encodes it as the BaseTime metadata deposit at tx[1]. Missing or invalid active metadata fails closed.

Zombie remains a permanently-off production gate. Activation-path tests enable it through a scoped `base-common-genesis/test-utils` runtime-registry guard, so they exercise the ordinary `RollupConfig::is_zombie_active` branch without adding test state or conditionals to derivation code.

Current production callers pass `None`; sourcing the real millisecond value is intentionally outside this PR.