### PR TITLE
feat(execution): validate BaseTime metadata on import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,6 +4448,7 @@ dependencies = [
  "base-common-genesis",
  "base-execution-chainspec",
  "base-node-core",
+ "base-protocol",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,6 @@ dependencies = [
  "base-proof-host",
  "base-proof-preimage",
  "base-proof-primitives",
- "base-proof-rpc",
  "base-proof-succinct-client-utils",
  "base-protocol",
  "bincode 2.0.1",
@@ -6031,7 +6030,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -6302,7 +6300,6 @@ dependencies = [
  "base-node-core",
  "base-node-runner",
  "base-optimism-rpc",
- "base-proof-rpc",
  "base-protocol",
  "base-prover-service-client",
  "base-prover-service-protocol",

--- a/crates/common/evm/src/base_time.rs
+++ b/crates/common/evm/src/base_time.rs
@@ -152,16 +152,19 @@ impl BaseTime {
         Ok(())
     }
 
-    /// Fetches the `timestamp_millis_part` directly from the `BaseTime` predeploy storage.
-    pub fn fetch_timestamp_millis_part<DB: Database>(db: &mut DB) -> Result<u16, DB::Error> {
-        let slot = db
-            .storage(Predeploys::BASE_TIME, Self::TIMESTAMP_MILLIS_PART_SLOT)?
-            .to_be_bytes::<32>();
-
-        Ok(u16::from_be_bytes([
+    /// Decodes the packed low `uint16` millisecond component from a storage word.
+    pub const fn decode_timestamp_millis_part(value: U256) -> u16 {
+        let slot = value.to_be_bytes::<32>();
+        u16::from_be_bytes([
             slot[Self::TIMESTAMP_MILLIS_PART_OFFSET],
             slot[Self::TIMESTAMP_MILLIS_PART_OFFSET + 1],
-        ]))
+        ])
+    }
+
+    /// Fetches the `timestamp_millis_part` directly from the `BaseTime` predeploy storage.
+    pub fn fetch_timestamp_millis_part<DB: Database>(db: &mut DB) -> Result<u16, DB::Error> {
+        let slot = db.storage(Predeploys::BASE_TIME, Self::TIMESTAMP_MILLIS_PART_SLOT)?;
+        Ok(Self::decode_timestamp_millis_part(slot))
     }
 
     /// Loads the current `BaseTime` state from the database.
@@ -203,6 +206,12 @@ mod tests {
         let mut db = base_time_db(600);
 
         assert_eq!(BaseTime::fetch_timestamp_millis_part(&mut db).unwrap(), 600);
+    }
+
+    #[test]
+    fn decode_timestamp_millis_part_reads_only_low_uint16() {
+        let value = (U256::from(1) << 200) | U256::from(800);
+        assert_eq!(BaseTime::decode_timestamp_millis_part(value), 800);
     }
 
     #[test]

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -194,16 +194,10 @@ where
                 PipelineError::AttributesBuilder(BuilderError::MissingBaseTimeTimestampMillisPart)
                     .crit()
             })?;
-            let (_, envelope) = BaseTimeUpdateTx::try_new_with_deposit_tx(
-                &self.rollup_cfg,
-                l2_parent.block_info.number + 1,
-                timestamp_millis_part,
-                l2_parent.block_info.timestamp,
-                next_l2_time,
-            )
-            .map_err(|e| {
+            let base_time = BaseTimeUpdateTx::new(timestamp_millis_part).map_err(|e| {
                 PipelineError::AttributesBuilder(BuilderError::BaseTimeUpdate(e)).crit()
             })?;
+            let envelope = base_time.into_deposit_tx(l2_parent.block_info.number + 1);
             let mut encoded = Vec::with_capacity(envelope.length());
             envelope.encode_2718(&mut encoded);
             txs.push(encoded.into());

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -4,9 +4,9 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Bytes, Sealable, Sealed, TxKind, U256};
 use base_common_consensus::{
-    BaseTimeDepositSource, DepositSourceDomain, Predeploys, SystemAddresses, TxDeposit,
+    BaseTimeDepositSource, BaseTxEnvelope, DepositSourceDomain, Predeploys, SystemAddresses,
+    TxDeposit,
 };
-use base_common_genesis::RollupConfig;
 
 use crate::REGOLITH_SYSTEM_TX_GAS;
 
@@ -80,22 +80,82 @@ impl BaseTimeUpdateTx {
             .map_err(BaseTimeUpdateDecodeError::InvalidTimestampMillisPart)
     }
 
-    /// Returns a typed deposit transaction for inclusion at `tx[1]`.
+    /// Extracts and validates the `BaseTime` metadata deposit at `tx[1]`.
+    pub fn extract_from_transactions(
+        transactions: &[BaseTxEnvelope],
+        block_number: u64,
+    ) -> Result<Self, BaseTimeMetadataError> {
+        let transaction = transactions.get(1).ok_or(BaseTimeMetadataError::Missing)?;
+        let deposit = transaction.as_deposit().ok_or(BaseTimeMetadataError::NotDeposit)?;
+        let base_time = Self::validate_deposit(deposit, block_number)?;
+
+        if transactions[2..].iter().any(|transaction| {
+            transaction.as_deposit().is_some_and(|deposit| {
+                deposit.from == SystemAddresses::DEPOSITOR_ACCOUNT
+                    && deposit.to == TxKind::Call(Predeploys::BASE_TIME)
+            })
+        }) {
+            return Err(BaseTimeMetadataError::Duplicate);
+        }
+
+        Ok(base_time)
+    }
+
+    /// Validates and decodes a `BaseTime` metadata deposit.
+    pub fn validate_deposit(
+        deposit: &TxDeposit,
+        block_number: u64,
+    ) -> Result<Self, BaseTimeMetadataError> {
+        let expected_source_hash =
+            DepositSourceDomain::BaseTime(BaseTimeDepositSource { block_number }).source_hash();
+        if deposit.source_hash != expected_source_hash {
+            return Err(BaseTimeMetadataError::InvalidSourceHash);
+        }
+        if deposit.from != SystemAddresses::DEPOSITOR_ACCOUNT {
+            return Err(BaseTimeMetadataError::InvalidSender);
+        }
+        if deposit.to != TxKind::Call(Predeploys::BASE_TIME) {
+            return Err(BaseTimeMetadataError::InvalidRecipient);
+        }
+        if deposit.mint != 0 {
+            return Err(BaseTimeMetadataError::NonZeroMint);
+        }
+        if deposit.value != U256::ZERO {
+            return Err(BaseTimeMetadataError::NonZeroValue);
+        }
+        if deposit.gas_limit != REGOLITH_SYSTEM_TX_GAS {
+            return Err(BaseTimeMetadataError::InvalidGasLimit);
+        }
+        if deposit.is_system_transaction {
+            return Err(BaseTimeMetadataError::SystemTransaction);
+        }
+
+        Self::decode_calldata(&deposit.input).map_err(BaseTimeMetadataError::InvalidCalldata)
+    }
+
+    /// Validates that consecutive activated blocks advance by exactly one `BaseTime` slot.
+    pub fn validate_progression(
+        parent_timestamp: u64,
+        parent: &Self,
+        child_timestamp: u64,
+        child: &Self,
+    ) -> Result<(), BaseTimeProgressionError> {
+        let parent_timestamp_ms =
+            u128::from(parent_timestamp) * 1_000 + u128::from(parent.timestamp_millis_part);
+        let child_timestamp_ms =
+            u128::from(child_timestamp) * 1_000 + u128::from(child.timestamp_millis_part);
+
+        if child_timestamp_ms != parent_timestamp_ms + u128::from(Self::BLOCK_INTERVAL_MILLIS) {
+            return Err(BaseTimeProgressionError { parent_timestamp_ms, child_timestamp_ms });
+        }
+
+        Ok(())
+    }
+
+    /// Converts this update into a typed deposit transaction for inclusion at `tx[1]`.
     ///
-    /// Callers are responsible for activation gating; this helper only validates and encodes the
-    /// `BaseTime` metadata deposit once the surrounding protocol has decided it is allowed.
-    ///
-    /// `_l2_parent_block_time` is reserved so later hard-fork activation logic can make the same
-    /// same-second boundary decisions here that [`crate::L1BlockInfoTx::try_new_with_deposit_tx`]
-    /// already needs.
-    pub fn try_new_with_deposit_tx(
-        _rollup_config: &RollupConfig,
-        l2_block_number: u64,
-        timestamp_millis_part: u16,
-        _l2_parent_block_time: u64,
-        _l2_block_time: u64,
-    ) -> Result<(Self, Sealed<TxDeposit>), BaseTimeUpdateError> {
-        let base_time = Self::new(timestamp_millis_part)?;
+    /// Callers are responsible for activation gating.
+    pub fn into_deposit_tx(self, l2_block_number: u64) -> Sealed<TxDeposit> {
         let source =
             DepositSourceDomain::BaseTime(BaseTimeDepositSource { block_number: l2_block_number });
 
@@ -109,10 +169,10 @@ impl BaseTimeUpdateTx {
             // ordinary-deposit semantics introduced there.
             gas_limit: REGOLITH_SYSTEM_TX_GAS,
             is_system_transaction: false,
-            input: base_time.encode_calldata(),
+            input: self.encode_calldata(),
         };
 
-        Ok((base_time, deposit_tx.seal_slow()))
+        deposit_tx.seal_slow()
     }
 }
 
@@ -144,14 +204,92 @@ pub enum BaseTimeUpdateDecodeError {
     InvalidTimestampMillisPart(BaseTimeUpdateError),
 }
 
+/// An error extracting or validating a `BaseTime` metadata deposit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BaseTimeMetadataError {
+    /// The block does not contain a transaction at `tx[1]`.
+    #[error("missing BaseTime metadata deposit at tx[1]")]
+    Missing,
+    /// The transaction at `tx[1]` is not a deposit transaction.
+    #[error("BaseTime metadata transaction is not a deposit")]
+    NotDeposit,
+    /// Another authorized depositor deposit targets `BaseTime` after the canonical transaction.
+    #[error("duplicate BaseTime metadata deposit after tx[1]")]
+    Duplicate,
+    /// The deposit source hash does not commit to the block number and `BaseTime` domain.
+    #[error("invalid BaseTime metadata source hash")]
+    InvalidSourceHash,
+    /// The deposit sender is not the protocol depositor.
+    #[error("invalid BaseTime metadata sender")]
+    InvalidSender,
+    /// The deposit does not call the `BaseTime` predeploy.
+    #[error("invalid BaseTime metadata recipient")]
+    InvalidRecipient,
+    /// The deposit mints ETH.
+    #[error("BaseTime metadata deposit has non-zero mint")]
+    NonZeroMint,
+    /// The deposit transfers ETH.
+    #[error("BaseTime metadata deposit has non-zero value")]
+    NonZeroValue,
+    /// The deposit gas limit does not match the protocol constant.
+    #[error("invalid BaseTime metadata gas limit")]
+    InvalidGasLimit,
+    /// The deposit uses pre-Regolith system-transaction semantics.
+    #[error("BaseTime metadata deposit is a system transaction")]
+    SystemTransaction,
+    /// The deposit calldata is not a canonical `BaseTime` setter call.
+    #[error("invalid BaseTime metadata calldata: {0}")]
+    InvalidCalldata(BaseTimeUpdateDecodeError),
+}
+
+/// An error validating full-millisecond timestamp progression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "invalid BaseTime progression from {parent_timestamp_ms}ms to {child_timestamp_ms}ms; expected exactly 200ms"
+)]
+pub struct BaseTimeProgressionError {
+    /// The parent's full-millisecond timestamp.
+    pub parent_timestamp_ms: u128,
+    /// The child's full-millisecond timestamp.
+    pub child_timestamp_ms: u128,
+}
+
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{TxKind, U256};
-    use base_common_consensus::{Predeploys, SystemAddresses};
-    use base_common_genesis::RollupConfig;
+    use alloy_consensus::{Sealable, TxLegacy};
+    use alloy_primitives::{Address, B256, Signature, TxKind, U256};
+    use base_common_consensus::{
+        BaseTransactionSigned, BaseTypedTransaction, Predeploys, SystemAddresses, TxDeposit,
+    };
 
-    use super::{BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx};
+    use super::{
+        BaseTimeMetadataError, BaseTimeProgressionError, BaseTimeUpdateDecodeError,
+        BaseTimeUpdateError, BaseTimeUpdateTx,
+    };
     use crate::REGOLITH_SYSTEM_TX_GAS;
+
+    fn base_time_deposit(block_number: u64, timestamp_millis_part: u16) -> TxDeposit {
+        BaseTimeUpdateTx::new(timestamp_millis_part)
+            .unwrap()
+            .into_deposit_tx(block_number)
+            .into_inner()
+    }
+
+    fn user_transaction() -> BaseTransactionSigned {
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Default::default(),
+        };
+        BaseTransactionSigned::new_unhashed(
+            BaseTypedTransaction::Legacy(tx),
+            Signature::new(U256::ZERO, U256::ZERO, false),
+        )
+    }
 
     #[test]
     fn base_time_update_roundtrips() {
@@ -193,12 +331,9 @@ mod tests {
 
     #[test]
     fn base_time_update_builds_deposit_tx() {
-        let rollup_config = RollupConfig::default();
         let l2_block_number = 9;
-
-        let (base_time, deposit_tx) =
-            BaseTimeUpdateTx::try_new_with_deposit_tx(&rollup_config, l2_block_number, 600, 1, 2)
-                .unwrap();
+        let base_time = BaseTimeUpdateTx::new(600).unwrap();
+        let deposit_tx = base_time.into_deposit_tx(l2_block_number);
 
         assert_eq!(deposit_tx.from, SystemAddresses::DEPOSITOR_ACCOUNT);
         assert_eq!(deposit_tx.to, TxKind::Call(Predeploys::BASE_TIME));
@@ -207,5 +342,174 @@ mod tests {
         assert_eq!(deposit_tx.gas_limit, REGOLITH_SYSTEM_TX_GAS);
         assert!(!deposit_tx.is_system_transaction);
         assert_eq!(deposit_tx.input, base_time.encode_calldata());
+    }
+
+    #[test]
+    fn extracts_valid_base_time_metadata_at_tx_one() {
+        let transactions = vec![
+            TxDeposit::default().seal_slow().into(),
+            base_time_deposit(9, 600).seal_slow().into(),
+        ];
+
+        let base_time = BaseTimeUpdateTx::extract_from_transactions(&transactions, 9).unwrap();
+
+        assert_eq!(base_time.timestamp_millis_part(), 600);
+    }
+
+    #[test]
+    fn rejects_missing_or_mispositioned_base_time_metadata() {
+        let l1_info = TxDeposit::default().seal_slow().into();
+        assert_eq!(
+            BaseTimeUpdateTx::extract_from_transactions(&[l1_info], 9),
+            Err(BaseTimeMetadataError::Missing)
+        );
+
+        let transactions = vec![
+            TxDeposit::default().seal_slow().into(),
+            user_transaction(),
+            base_time_deposit(9, 600).seal_slow().into(),
+        ];
+        assert_eq!(
+            BaseTimeUpdateTx::extract_from_transactions(&transactions, 9),
+            Err(BaseTimeMetadataError::NotDeposit)
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_authorized_base_time_deposit_after_tx_one() {
+        let transactions = vec![
+            TxDeposit::default().seal_slow().into(),
+            base_time_deposit(9, 600).seal_slow().into(),
+            base_time_deposit(9, 800).seal_slow().into(),
+        ];
+
+        assert_eq!(
+            BaseTimeUpdateTx::extract_from_transactions(&transactions, 9),
+            Err(BaseTimeMetadataError::Duplicate)
+        );
+
+        let mut unauthorized = base_time_deposit(9, 800);
+        unauthorized.from = Address::ZERO;
+        let transactions = vec![
+            TxDeposit::default().seal_slow().into(),
+            base_time_deposit(9, 600).seal_slow().into(),
+            unauthorized.seal_slow().into(),
+        ];
+        assert!(BaseTimeUpdateTx::extract_from_transactions(&transactions, 9).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_base_time_deposit_envelope() {
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.source_hash = B256::ZERO;
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidSourceHash)
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.from = Address::ZERO;
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidSender)
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.to = TxKind::Call(Address::ZERO);
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidRecipient)
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.mint = 1;
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::NonZeroMint)
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.value = U256::from(1);
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::NonZeroValue)
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.gas_limit -= 1;
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidGasLimit)
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.is_system_transaction = true;
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::SystemTransaction)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_base_time_deposit_calldata() {
+        let mut deposit = base_time_deposit(9, 600);
+        let mut input = deposit.input.to_vec();
+        input[0] ^= 0xff;
+        deposit.input = input.into();
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidCalldata(BaseTimeUpdateDecodeError::InvalidSelector))
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        let mut input = deposit.input.to_vec();
+        input[34..].copy_from_slice(&100_u16.to_be_bytes());
+        deposit.input = input.into();
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidCalldata(
+                BaseTimeUpdateDecodeError::InvalidTimestampMillisPart(
+                    BaseTimeUpdateError::InvalidTimestampMillisPart(100)
+                )
+            ))
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        deposit.input = deposit.input[..3].to_vec().into();
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidCalldata(BaseTimeUpdateDecodeError::MissingSelector))
+        );
+
+        let mut deposit = base_time_deposit(9, 600);
+        let mut input = deposit.input.to_vec();
+        input.push(0);
+        deposit.input = input.into();
+        assert_eq!(
+            BaseTimeUpdateTx::validate_deposit(&deposit, 9),
+            Err(BaseTimeMetadataError::InvalidCalldata(BaseTimeUpdateDecodeError::InvalidLength(
+                36, 37
+            )))
+        );
+    }
+
+    #[test]
+    fn validates_exact_200ms_progression() {
+        let parent = BaseTimeUpdateTx::new(200).unwrap();
+        let same_second_child = BaseTimeUpdateTx::new(400).unwrap();
+        BaseTimeUpdateTx::validate_progression(10, &parent, 10, &same_second_child).unwrap();
+
+        let boundary_parent = BaseTimeUpdateTx::new(800).unwrap();
+        let boundary_child = BaseTimeUpdateTx::new(0).unwrap();
+        BaseTimeUpdateTx::validate_progression(10, &boundary_parent, 11, &boundary_child).unwrap();
+
+        let skipped_slot = BaseTimeUpdateTx::new(600).unwrap();
+        assert_eq!(
+            BaseTimeUpdateTx::validate_progression(10, &parent, 10, &skipped_slot),
+            Err(BaseTimeProgressionError {
+                parent_timestamp_ms: 10_200,
+                child_timestamp_ms: 10_600,
+            })
+        );
     }
 }

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Bytes, Sealable, Sealed, TxKind, U256};
 use base_common_consensus::{
-    BaseTimeDepositSource, BaseTxEnvelope, DepositSourceDomain, Predeploys, SystemAddresses,
+    BaseTimeDepositSource, BaseTransaction, DepositSourceDomain, Predeploys, SystemAddresses,
     TxDeposit,
 };
 
@@ -81,8 +81,8 @@ impl BaseTimeUpdateTx {
     }
 
     /// Extracts and validates the `BaseTime` metadata deposit at `tx[1]`.
-    pub fn extract_from_transactions(
-        transactions: &[BaseTxEnvelope],
+    pub fn extract_from_transactions<T: BaseTransaction>(
+        transactions: &[T],
         block_number: u64,
     ) -> Result<Self, BaseTimeMetadataError> {
         let transaction = transactions.get(1).ok_or(BaseTimeMetadataError::Missing)?;
@@ -122,25 +122,6 @@ impl BaseTimeUpdateTx {
         }
 
         Self::decode_calldata(&deposit.input).map_err(BaseTimeMetadataError::InvalidCalldata)
-    }
-
-    /// Validates that consecutive activated blocks advance by exactly one `BaseTime` slot.
-    pub fn validate_progression(
-        parent_timestamp: u64,
-        parent: &Self,
-        child_timestamp: u64,
-        child: &Self,
-    ) -> Result<(), BaseTimeProgressionError> {
-        let parent_timestamp_ms =
-            u128::from(parent_timestamp) * 1_000 + u128::from(parent.timestamp_millis_part);
-        let child_timestamp_ms =
-            u128::from(child_timestamp) * 1_000 + u128::from(child.timestamp_millis_part);
-
-        if child_timestamp_ms != parent_timestamp_ms + u128::from(Self::BLOCK_INTERVAL_MILLIS) {
-            return Err(BaseTimeProgressionError { parent_timestamp_ms, child_timestamp_ms });
-        }
-
-        Ok(())
     }
 
     /// Converts this update into a typed deposit transaction for inclusion at `tx[1]`.
@@ -230,18 +211,6 @@ pub enum BaseTimeMetadataError {
     InvalidCalldata(BaseTimeUpdateDecodeError),
 }
 
-/// An error validating full-millisecond timestamp progression.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error(
-    "invalid BaseTime progression from {parent_timestamp_ms}ms to {child_timestamp_ms}ms; expected exactly 200ms"
-)]
-pub struct BaseTimeProgressionError {
-    /// The parent's full-millisecond timestamp.
-    pub parent_timestamp_ms: u128,
-    /// The child's full-millisecond timestamp.
-    pub child_timestamp_ms: u128,
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Sealable, TxLegacy};
@@ -251,8 +220,7 @@ mod tests {
     };
 
     use super::{
-        BaseTimeMetadataError, BaseTimeProgressionError, BaseTimeUpdateDecodeError,
-        BaseTimeUpdateError, BaseTimeUpdateTx,
+        BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
     };
     use crate::REGOLITH_SYSTEM_TX_GAS;
 
@@ -334,7 +302,7 @@ mod tests {
 
     #[test]
     fn extracts_valid_base_time_metadata_at_tx_one() {
-        let transactions = vec![
+        let transactions: Vec<BaseTransactionSigned> = vec![
             TxDeposit::default().seal_slow().into(),
             base_time_deposit(9, 600).seal_slow().into(),
         ];
@@ -346,7 +314,7 @@ mod tests {
 
     #[test]
     fn rejects_missing_or_mispositioned_base_time_metadata() {
-        let l1_info = TxDeposit::default().seal_slow().into();
+        let l1_info: BaseTransactionSigned = TxDeposit::default().seal_slow().into();
         assert_eq!(
             BaseTimeUpdateTx::extract_from_transactions(&[l1_info], 9),
             Err(BaseTimeMetadataError::Missing)
@@ -455,26 +423,6 @@ mod tests {
             Err(BaseTimeMetadataError::InvalidCalldata(BaseTimeUpdateDecodeError::InvalidLength(
                 36, 37
             )))
-        );
-    }
-
-    #[test]
-    fn validates_exact_200ms_progression() {
-        let parent = BaseTimeUpdateTx::new(200).unwrap();
-        let same_second_child = BaseTimeUpdateTx::new(400).unwrap();
-        BaseTimeUpdateTx::validate_progression(10, &parent, 10, &same_second_child).unwrap();
-
-        let boundary_parent = BaseTimeUpdateTx::new(800).unwrap();
-        let boundary_child = BaseTimeUpdateTx::new(0).unwrap();
-        BaseTimeUpdateTx::validate_progression(10, &boundary_parent, 11, &boundary_child).unwrap();
-
-        let skipped_slot = BaseTimeUpdateTx::new(600).unwrap();
-        assert_eq!(
-            BaseTimeUpdateTx::validate_progression(10, &parent, 10, &skipped_slot),
-            Err(BaseTimeProgressionError {
-                parent_timestamp_ms: 10_200,
-                child_timestamp_ms: 10_600,
-            })
         );
     }
 }

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -204,9 +204,6 @@ pub enum BaseTimeMetadataError {
     /// The transaction at `tx[1]` is not a deposit transaction.
     #[error("BaseTime metadata transaction is not a deposit")]
     NotDeposit,
-    /// Another authorized depositor deposit targets `BaseTime` after the canonical transaction.
-    #[error("duplicate BaseTime metadata deposit after tx[1]")]
-    Duplicate,
     /// The deposit source hash does not commit to the block number and `BaseTime` domain.
     #[error("invalid BaseTime metadata source hash")]
     InvalidSourceHash,
@@ -364,29 +361,6 @@ mod tests {
             BaseTimeUpdateTx::extract_from_transactions(&transactions, 9),
             Err(BaseTimeMetadataError::NotDeposit)
         );
-    }
-
-    #[test]
-    fn rejects_duplicate_authorized_base_time_deposit_after_tx_one() {
-        let transactions = vec![
-            TxDeposit::default().seal_slow().into(),
-            base_time_deposit(9, 600).seal_slow().into(),
-            base_time_deposit(9, 800).seal_slow().into(),
-        ];
-
-        assert_eq!(
-            BaseTimeUpdateTx::extract_from_transactions(&transactions, 9),
-            Err(BaseTimeMetadataError::Duplicate)
-        );
-
-        let mut unauthorized = base_time_deposit(9, 800);
-        unauthorized.from = Address::ZERO;
-        let transactions = vec![
-            TxDeposit::default().seal_slow().into(),
-            base_time_deposit(9, 600).seal_slow().into(),
-            unauthorized.seal_slow().into(),
-        ];
-        assert!(BaseTimeUpdateTx::extract_from_transactions(&transactions, 9).is_ok());
     }
 
     #[test]

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -89,15 +89,6 @@ impl BaseTimeUpdateTx {
         let deposit = transaction.as_deposit().ok_or(BaseTimeMetadataError::NotDeposit)?;
         let base_time = Self::validate_deposit(deposit, block_number)?;
 
-        if transactions[2..].iter().any(|transaction| {
-            transaction.as_deposit().is_some_and(|deposit| {
-                deposit.from == SystemAddresses::DEPOSITOR_ACCOUNT
-                    && deposit.to == TxKind::Call(Predeploys::BASE_TIME)
-            })
-        }) {
-            return Err(BaseTimeMetadataError::Duplicate);
-        }
-
         Ok(base_time)
     }
 

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -52,7 +52,10 @@ mod deposits;
 pub use deposits::{DepositDecodeError, Deposits};
 
 mod base_time;
-pub use base_time::{BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx};
+pub use base_time::{
+    BaseTimeMetadataError, BaseTimeProgressionError, BaseTimeUpdateDecodeError,
+    BaseTimeUpdateError, BaseTimeUpdateTx,
+};
 
 mod info;
 pub use info::{

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -53,8 +53,7 @@ pub use deposits::{DepositDecodeError, Deposits};
 
 mod base_time;
 pub use base_time::{
-    BaseTimeMetadataError, BaseTimeProgressionError, BaseTimeUpdateDecodeError,
-    BaseTimeUpdateError, BaseTimeUpdateTx,
+    BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
 };
 
 mod info;

--- a/crates/execution/consensus/Cargo.toml
+++ b/crates/execution/consensus/Cargo.toml
@@ -21,7 +21,8 @@ reth-execution-types.workspace = true
 reth-consensus-common.workspace = true
 reth-primitives-traits.workspace = true
 
-# op-reth
+# base
+base-protocol.workspace = true
 base-common-chains.workspace = true
 base-common-consensus = { workspace = true, features = ["reth"] }
 
@@ -59,6 +60,7 @@ std = [
 	"base-common-chains/std",
 	"base-common-consensus/std",
 	"base-execution-chainspec/std",
+	"base-protocol/std",
 	"reth-consensus-common/std",
 	"reth-consensus/std",
 	"reth-execution-types/std",

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -7,9 +7,9 @@ use reth_storage_errors::provider::ProviderError;
 /// Base consensus error.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum BaseConsensusError {
-    /// Generic post-execution validation cannot inspect the canonical `BaseBlock` body.
-    #[error("Zombie BaseTime validation requires a recovered BaseBlock body")]
-    BaseTimeBlockBodyRequired,
+    /// Generic post-execution validation lacks the context required to validate `BaseTime`.
+    #[error("Zombie BaseTime post-execution validation requires parent and block context")]
+    BaseTimeValidationContextRequired,
     /// The parent's committed `BaseTime` value is not a valid 200ms slot.
     #[error("invalid parent committed BaseTime millis part: {0}")]
     InvalidParentBaseTimeMillis(u16),

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -7,28 +7,6 @@ use reth_storage_errors::provider::ProviderError;
 /// Base consensus error.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum BaseConsensusError {
-    /// The expected `BaseTime` timestamp cannot be derived from the chain configuration.
-    #[error(
-        "cannot derive BaseTime timestamp for block {block_number} on chain {chain_id}: {reason}"
-    )]
-    BaseTimeTimestampUnavailable {
-        /// L2 chain ID.
-        chain_id: u64,
-        /// L2 block number.
-        block_number: u64,
-        /// Why the expected timestamp could not be derived.
-        reason: &'static str,
-    },
-    /// The block's full-millisecond timestamp does not match the hardfork schedule.
-    #[error(
-        "BaseTime timestamp {actual_timestamp_ms}ms does not match expected {expected_timestamp_ms}ms"
-    )]
-    BaseTimeTimestampMismatch {
-        /// Full-millisecond timestamp derived from the hardfork schedule and block number.
-        expected_timestamp_ms: u128,
-        /// Full-millisecond timestamp encoded by the header and `BaseTime` metadata.
-        actual_timestamp_ms: u128,
-    },
     /// The canonical metadata claim does not match the post-execution committed value.
     #[error("BaseTime metadata claim {claim} does not match committed value {committed}")]
     BaseTimeClaimCommittedMismatch {

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -7,14 +7,6 @@ use reth_storage_errors::provider::ProviderError;
 /// Base consensus error.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum BaseConsensusError {
-    /// The canonical metadata claim does not match the post-execution committed value.
-    #[error("BaseTime metadata claim {claim} does not match committed value {committed}")]
-    BaseTimeClaimCommittedMismatch {
-        /// Millisecond component claimed by the canonical metadata transaction.
-        claim: u16,
-        /// Millisecond component committed in post-execution state.
-        committed: u16,
-    },
     /// Block body has non-empty withdrawals list (l1 withdrawals).
     #[error("non-empty block body withdrawals list")]
     WithdrawalsNonEmpty,

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -7,6 +7,20 @@ use reth_storage_errors::provider::ProviderError;
 /// Base consensus error.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum BaseConsensusError {
+    /// Generic post-execution validation cannot inspect the canonical `BaseBlock` body.
+    #[error("Zombie BaseTime validation requires a recovered BaseBlock body")]
+    BaseTimeBlockBodyRequired,
+    /// The parent's committed `BaseTime` value is not a valid 200ms slot.
+    #[error("invalid parent committed BaseTime millis part: {0}")]
+    InvalidParentBaseTimeMillis(u16),
+    /// The canonical metadata claim does not match the post-execution committed value.
+    #[error("BaseTime metadata claim {claim} does not match committed value {committed}")]
+    BaseTimeClaimCommittedMismatch {
+        /// Millisecond component claimed by the canonical metadata transaction.
+        claim: u16,
+        /// Millisecond component committed in post-execution state.
+        committed: u16,
+    },
     /// Block body has non-empty withdrawals list (l1 withdrawals).
     #[error("non-empty block body withdrawals list")]
     WithdrawalsNonEmpty,

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -7,12 +7,24 @@ use reth_storage_errors::provider::ProviderError;
 /// Base consensus error.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum BaseConsensusError {
-    /// Generic post-execution validation lacks the context required to validate `BaseTime`.
-    #[error("Zombie BaseTime post-execution validation requires parent and block context")]
-    BaseTimeValidationContextRequired,
-    /// The parent's committed `BaseTime` value is not a valid 200ms slot.
-    #[error("invalid parent committed BaseTime millis part: {0}")]
-    InvalidParentBaseTimeMillis(u16),
+    /// The expected `BaseTime` timestamp cannot be derived from the chain configuration.
+    #[error("cannot derive BaseTime timestamp for block {block_number} on chain {chain_id}")]
+    BaseTimeTimestampUnavailable {
+        /// L2 chain ID.
+        chain_id: u64,
+        /// L2 block number.
+        block_number: u64,
+    },
+    /// The block's full-millisecond timestamp does not match the hardfork schedule.
+    #[error(
+        "BaseTime timestamp {actual_timestamp_ms}ms does not match expected {expected_timestamp_ms}ms"
+    )]
+    BaseTimeTimestampMismatch {
+        /// Full-millisecond timestamp derived from the hardfork schedule and block number.
+        expected_timestamp_ms: u64,
+        /// Full-millisecond timestamp encoded by the header and `BaseTime` metadata.
+        actual_timestamp_ms: u64,
+    },
     /// The canonical metadata claim does not match the post-execution committed value.
     #[error("BaseTime metadata claim {claim} does not match committed value {committed}")]
     BaseTimeClaimCommittedMismatch {

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -8,12 +8,16 @@ use reth_storage_errors::provider::ProviderError;
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum BaseConsensusError {
     /// The expected `BaseTime` timestamp cannot be derived from the chain configuration.
-    #[error("cannot derive BaseTime timestamp for block {block_number} on chain {chain_id}")]
+    #[error(
+        "cannot derive BaseTime timestamp for block {block_number} on chain {chain_id}: {reason}"
+    )]
     BaseTimeTimestampUnavailable {
         /// L2 chain ID.
         chain_id: u64,
         /// L2 block number.
         block_number: u64,
+        /// Why the expected timestamp could not be derived.
+        reason: &'static str,
     },
     /// The block's full-millisecond timestamp does not match the hardfork schedule.
     #[error(
@@ -21,9 +25,9 @@ pub enum BaseConsensusError {
     )]
     BaseTimeTimestampMismatch {
         /// Full-millisecond timestamp derived from the hardfork schedule and block number.
-        expected_timestamp_ms: u64,
+        expected_timestamp_ms: u128,
         /// Full-millisecond timestamp encoded by the header and `BaseTime` metadata.
-        actual_timestamp_ms: u64,
+        actual_timestamp_ms: u128,
     },
     /// The canonical metadata claim does not match the post-execution committed value.
     #[error("BaseTime metadata claim {claim} does not match committed value {committed}")]

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -17,14 +17,15 @@ use alloy_consensus::{
 };
 use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_primitives::{B64, B256};
+use alloy_trie::EMPTY_ROOT_HASH;
 use base_common_chains::Upgrades;
-use base_common_consensus::DepositReceiptExt;
+use base_common_consensus::{BaseTxEnvelope, DepositReceiptExt};
 use base_execution_chainspec::BaseChainSpec;
+use base_protocol::BaseTimeMetadataError;
 use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
 use reth_consensus_common::validation::{
     validate_against_parent_eip1559_base_fee, validate_against_parent_hash_number,
-    validate_against_parent_timestamp, validate_cancun_gas, validate_header_base_fee,
-    validate_header_extra_data, validate_header_gas,
+    validate_cancun_gas, validate_header_base_fee, validate_header_extra_data, validate_header_gas,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
@@ -35,7 +36,7 @@ mod proof;
 pub use proof::{calculate_receipt_root, calculate_receipt_root_no_memo};
 
 pub mod validation;
-pub use validation::{canyon, isthmus, validate_block_post_execution};
+pub use validation::{canyon, isthmus, validate_base_time_metadata, validate_block_post_execution};
 
 pub mod error;
 pub use error::BaseConsensusError;
@@ -71,7 +72,7 @@ impl BaseBeaconConsensus {
 
 impl<N> FullConsensus<N> for BaseBeaconConsensus
 where
-    N: NodePrimitives<BlockHeader = Header, Receipt: DepositReceiptExt>,
+    N: NodePrimitives<BlockHeader = Header, Receipt: DepositReceiptExt, SignedTx = BaseTxEnvelope>,
 {
     fn validate_block_post_execution(
         &self,
@@ -86,14 +87,23 @@ where
 
 impl<B> Consensus<B> for BaseBeaconConsensus
 where
-    B: Block<Header = Header>,
+    B: Block<Header = Header, Body: BlockBody<Transaction = BaseTxEnvelope>>,
 {
     fn validate_body_against_header(
         &self,
         body: &B::Body,
         header: &SealedHeader<B::Header>,
     ) -> Result<(), ConsensusError> {
-        validation::validate_body_against_header_base(&self.chain_spec, body, header.header())
+        validation::validate_body_against_header_base(&self.chain_spec, body, header.header())?;
+        // This is also checked by `validate_block_pre_execution` because callers may invoke either
+        // consensus entry point independently.
+        validation::validate_base_time_metadata(
+            &self.chain_spec,
+            header.timestamp(),
+            header.number(),
+            body.transactions(),
+        )
+        .map_err(ConsensusError::other)
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), ConsensusError> {
@@ -113,6 +123,14 @@ where
         if let Err(error) = block.ensure_transaction_root_valid() {
             return Err(ConsensusError::BodyTransactionRootDiff(error.into()));
         }
+
+        validation::validate_base_time_metadata(
+            &self.chain_spec,
+            block.timestamp(),
+            block.number(),
+            block.body().transactions(),
+        )
+        .map_err(ConsensusError::other)?;
 
         // Check empty shanghai-withdrawals
         if self.chain_spec.is_canyon_active_at_timestamp(block.timestamp()) {
@@ -203,6 +221,14 @@ impl HeaderValidator<Header> for BaseBeaconConsensus {
             return Err(ConsensusError::RequestsHashUnexpected);
         }
 
+        // Reject a trivially empty body early; `validate_base_time_metadata` performs the
+        // authoritative check once the transactions are available.
+        if self.chain_spec.is_zombie_active_at_timestamp(header.timestamp())
+            && header.transactions_root() == EMPTY_ROOT_HASH
+        {
+            return Err(ConsensusError::other(BaseTimeMetadataError::Missing));
+        }
+
         Ok(())
     }
 
@@ -213,8 +239,16 @@ impl HeaderValidator<Header> for BaseBeaconConsensus {
     ) -> Result<(), ConsensusError> {
         validate_against_parent_hash_number(header.header(), parent)?;
 
-        if self.chain_spec.is_bedrock_active_at_block(header.number()) {
-            validate_against_parent_timestamp(header.header(), parent.header())?;
+        let allows_same_timestamp =
+            self.chain_spec.is_zombie_active_at_timestamp(header.timestamp())
+                && self.chain_spec.is_zombie_active_at_timestamp(parent.timestamp());
+        let timestamp_is_invalid = header.timestamp() < parent.timestamp()
+            || (header.timestamp() == parent.timestamp() && !allows_same_timestamp);
+        if self.chain_spec.is_bedrock_active_at_block(header.number()) && timestamp_is_invalid {
+            return Err(ConsensusError::TimestampIsInPast {
+                parent_timestamp: parent.timestamp(),
+                timestamp: header.timestamp(),
+            });
         }
 
         validate_against_parent_eip1559_base_fee(
@@ -269,8 +303,9 @@ mod tests {
         BasePrimitives, BaseReceipt, BaseTransactionSigned, BaseTypedTransaction,
         HoloceneExtraData, JovianExtraData,
     };
+    use base_common_genesis::BaseUpgrade;
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
-    use reth_chainspec::BaseFeeParams;
+    use reth_chainspec::{BaseFeeParams, EthChainSpec, ForkCondition};
     use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator};
     use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader, proofs};
     use reth_provider::BlockExecutionResult;
@@ -301,6 +336,63 @@ mod tests {
         BaseChainSpecBuilder::default()
             .genesis(base_mainnet.genesis.clone())
             .chain(base_mainnet.chain)
+    }
+
+    #[test]
+    fn activated_parent_validation_allows_same_second_headers() {
+        let mut chain_spec = BaseChainSpec::mainnet();
+        chain_spec.set_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(10));
+        let parent_header = Header {
+            number: 8,
+            timestamp: 10,
+            gas_limit: 30_000_000,
+            gas_used: 15_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            ..Default::default()
+        };
+        let child_base_fee = chain_spec.next_block_base_fee(&parent_header, 10).unwrap();
+        let consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
+        let parent = SealedHeader::seal_slow(parent_header);
+        let child = SealedHeader::seal_slow(Header {
+            number: 9,
+            parent_hash: parent.hash(),
+            timestamp: 10,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(child_base_fee),
+            ..Default::default()
+        });
+
+        consensus.validate_header_against_parent(&child, &parent).unwrap();
+    }
+
+    #[test]
+    fn activated_parent_validation_rejects_timestamp_in_past() {
+        let mut chain_spec = BaseChainSpec::mainnet();
+        chain_spec.set_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(10));
+        let parent_header = Header {
+            number: 8,
+            timestamp: 11,
+            gas_limit: 30_000_000,
+            gas_used: 15_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            ..Default::default()
+        };
+        let child_base_fee = chain_spec.next_block_base_fee(&parent_header, 10).unwrap();
+        let consensus = BaseBeaconConsensus::new(Arc::new(chain_spec));
+        let parent = SealedHeader::seal_slow(parent_header);
+        let child = SealedHeader::seal_slow(Header {
+            number: 9,
+            parent_hash: parent.hash(),
+            timestamp: 10,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(child_base_fee),
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            consensus.validate_header_against_parent(&child, &parent),
+            Err(ConsensusError::TimestampIsInPast { parent_timestamp: 11, timestamp: 10 })
+        ));
     }
 
     #[test]

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -17,11 +17,9 @@ use alloy_consensus::{
 };
 use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_primitives::{B64, B256};
-use alloy_trie::EMPTY_ROOT_HASH;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseTxEnvelope, DepositReceiptExt};
 use base_execution_chainspec::BaseChainSpec;
-use base_protocol::BaseTimeMetadataError;
 use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
 use reth_consensus_common::validation::{
     validate_against_parent_eip1559_base_fee, validate_against_parent_hash_number,
@@ -219,14 +217,6 @@ impl HeaderValidator<Header> for BaseBeaconConsensus {
             }
         } else if header.requests_hash().is_some() {
             return Err(ConsensusError::RequestsHashUnexpected);
-        }
-
-        // Reject a trivially empty body early; `validate_base_time_metadata` performs the
-        // authoritative check once the transactions are available.
-        if self.chain_spec.is_zombie_active_at_timestamp(header.timestamp())
-            && header.transactions_root() == EMPTY_ROOT_HASH
-        {
-            return Err(ConsensusError::other(BaseTimeMetadataError::Missing));
         }
 
         Ok(())

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -10,7 +10,8 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, Bloom, Bytes};
 use alloy_trie::EMPTY_ROOT_HASH;
 use base_common_chains::Upgrades;
-use base_common_consensus::DepositReceiptExt;
+use base_common_consensus::{BaseTxEnvelope, DepositReceiptExt};
+use base_protocol::{BaseTimeMetadataError, BaseTimeUpdateTx};
 use reth_consensus::ConsensusError;
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{BlockBody, GotExpected, receipt::gas_spent_by_transactions};
@@ -20,6 +21,20 @@ use crate::proof::calculate_receipt_root;
 
 fn should_trust_precomputed_receipt_root(chain_spec: &impl Upgrades, timestamp: u64) -> bool {
     chain_spec.is_canyon_active_at_timestamp(timestamp)
+}
+
+/// Validates the `BaseTime` metadata deposit when its activation gate is active.
+pub fn validate_base_time_metadata(
+    chain_spec: &impl Upgrades,
+    timestamp: u64,
+    block_number: u64,
+    transactions: &[BaseTxEnvelope],
+) -> Result<(), BaseTimeMetadataError> {
+    if chain_spec.is_zombie_active_at_timestamp(timestamp) {
+        BaseTimeUpdateTx::extract_from_transactions(transactions, block_number)?;
+    }
+
+    Ok(())
 }
 
 /// Ensures the block response data matches the header.
@@ -227,13 +242,14 @@ fn compare_receipts_root_and_logs_bloom(
 mod tests {
     use std::sync::Arc;
 
-    use alloy_consensus::{Header, Receipt, TxReceipt};
+    use alloy_consensus::{Header, Receipt, Sealable, TxReceipt};
     use alloy_eips::{eip2718::Encodable2718, eip7685::Requests};
     use alloy_primitives::{Bloom, Bytes, b256, hex};
     use alloy_trie::root::ordered_trie_root_with_encoder;
-    use base_common_consensus::{BaseReceipt, BaseTxEnvelope, DepositReceipt};
+    use base_common_consensus::{BaseReceipt, BaseTxEnvelope, DepositReceipt, TxDeposit};
     use base_common_genesis::BaseUpgrade;
     use base_execution_chainspec::BaseChainSpec;
+    use base_protocol::{BaseTimeMetadataError, BaseTimeUpdateTx};
     use reth_chainspec::{BaseFeeParams, EthChainSpec, ForkCondition};
 
     use super::*;
@@ -269,6 +285,28 @@ mod tests {
             deposit_nonce: Some(4_012_991),
             deposit_receipt_version: None,
         })
+    }
+
+    fn base_time_transactions(
+        block_number: u64,
+        timestamp_millis_part: u16,
+    ) -> Vec<BaseTxEnvelope> {
+        let metadata =
+            BaseTimeUpdateTx::new(timestamp_millis_part).unwrap().into_deposit_tx(block_number);
+        vec![TxDeposit::default().seal_slow().into(), metadata.into()]
+    }
+
+    #[test]
+    fn validates_base_time_metadata_only_after_activation() {
+        let mut chain_spec = BaseChainSpec::sepolia();
+        chain_spec.set_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(10));
+
+        validate_base_time_metadata(&chain_spec, 10, 9, &base_time_transactions(9, 400)).unwrap();
+        assert!(matches!(
+            validate_base_time_metadata(&chain_spec, 10, 9, &[]),
+            Err(BaseTimeMetadataError::Missing)
+        ));
+        validate_base_time_metadata(&chain_spec, 9, 9, &[]).unwrap();
     }
 
     fn plain_precomputed_receipt_root_bloom(receipts: &[BaseReceipt]) -> (B256, Bloom) {

--- a/crates/execution/evm/tests/block_execution.rs
+++ b/crates/execution/evm/tests/block_execution.rs
@@ -100,14 +100,7 @@ fn execute_same_block_base_time_read(getter_selector: [u8; 4]) -> U256 {
         ..Default::default()
     }
     .into();
-    let (_, base_time_tx) = BaseTimeUpdateTx::try_new_with_deposit_tx(
-        &Default::default(),
-        1,
-        CURRENT_MILLIS_PART,
-        BLOCK_TIMESTAMP,
-        BLOCK_TIMESTAMP,
-    )
-    .unwrap();
+    let base_time_tx = BaseTimeUpdateTx::new(CURRENT_MILLIS_PART).unwrap().into_deposit_tx(1);
     let base_time_tx: BaseTransactionSigned = base_time_tx.into();
     let user_tx: BaseTransactionSigned = TxEip1559 {
         chain_id: chain_spec.chain.id(),

--- a/crates/execution/node/Cargo.toml
+++ b/crates/execution/node/Cargo.toml
@@ -131,6 +131,7 @@ test-utils = [
 	"base-common-consensus/arbitrary",
 	"base-execution-exex/test-utils",
 	"base-node-core/test-utils",
+	"base-protocol/test-utils",
 	"reth-chainspec/test-utils",
 	"reth-codec",
 	"reth-consensus/test-utils",

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{B256, Bytes, U256};
+use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseBlock, Predeploys};
@@ -136,9 +136,8 @@ where
     /// Verifies upgrade-gated post-execution rules against the supplied parent state.
     ///
     /// Authoritative implementation of all Base-specific post-execution checks that require
-    /// access to parent state (currently: Isthmus' L2-to-L1 message-passer storage root).
-    /// Callers supply `parent_state` explicitly so engine pipelines can pass in-memory-aware
-    /// overlay providers when the parent block isn't canonical yet.
+    /// access to parent state. Callers supply `parent_state` explicitly so engine pipelines can
+    /// pass in-memory-aware overlay providers when the parent block isn't canonical yet.
     ///
     /// To add a check for a future upgrade, extend the body with another
     /// `if chain_spec.is_<X>_active_at_timestamp(...)` arm.
@@ -152,66 +151,100 @@ where
     where
         DB: StateProvider,
     {
-        if self.chain_spec().is_zombie_active_at_timestamp(block.timestamp()) {
-            let claim = BaseTimeUpdateTx::extract_from_transactions(
-                &block.body().transactions,
-                block.number(),
-            )
-            .map_err(ConsensusError::other)?;
-            let storage_updates = state_updates.storages.get(&self.hashed_addr_base_time);
-            let committed_word = if let Some(value) = storage_updates.and_then(|storage| {
-                storage.storage.get(&self.hashed_slot_base_time_millis).copied()
-            }) {
-                value
-            } else if storage_updates.is_some_and(|storage| storage.wiped) {
-                U256::ZERO
-            } else {
-                parent_state
-                    .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
-                    .map_err(ConsensusError::other)?
-                    .unwrap_or_default()
-            };
-            let committed = BaseTime::decode_timestamp_millis_part(committed_word);
-            if claim.timestamp_millis_part() != committed {
-                return Err(ConsensusError::other(
-                    BaseConsensusError::BaseTimeClaimCommittedMismatch {
-                        claim: claim.timestamp_millis_part(),
-                        committed,
-                    },
-                ));
-            }
+        let timestamp = block.timestamp();
 
-            if self.chain_spec().is_zombie_active_at_timestamp(parent_timestamp) {
-                let parent_word = parent_state
-                    .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
-                    .map_err(ConsensusError::other)?
-                    .unwrap_or_default();
-                let parent_millis = BaseTime::decode_timestamp_millis_part(parent_word);
-                let parent = BaseTimeUpdateTx::new(parent_millis).map_err(|_| {
-                    ConsensusError::other(BaseConsensusError::InvalidParentBaseTimeMillis(
-                        parent_millis,
-                    ))
-                })?;
-                BaseTimeUpdateTx::validate_progression(
-                    parent_timestamp,
-                    &parent,
-                    block.timestamp(),
-                    &claim,
-                )
-                .map_err(ConsensusError::other)?;
-            }
+        if self.chain_spec().is_isthmus_active_at_timestamp(timestamp) {
+            self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())?;
         }
 
-        if self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
-            let predeploy_storage_updates = state_updates
-                .storages
-                .get(&self.hashed_addr_l2tol1_msg_passer)
-                .cloned()
-                .unwrap_or_default();
-            isthmus::verify_withdrawals_root_prehashed(
-                predeploy_storage_updates,
-                parent_state,
-                block.header(),
+        if self.chain_spec().is_zombie_active_at_timestamp(timestamp) {
+            self.validate_base_time_post_execution(
+                state_updates,
+                &parent_state,
+                parent_timestamp,
+                block,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Verifies the Isthmus L2-to-L1 message-passer storage root after block execution.
+    pub fn validate_isthmus_post_execution<DB, H>(
+        &self,
+        state_updates: &HashedPostState,
+        parent_state: &DB,
+        header: H,
+    ) -> Result<(), ConsensusError>
+    where
+        DB: StateProvider + ?Sized,
+        H: BlockHeader,
+    {
+        let predeploy_storage_updates = state_updates
+            .storages
+            .get(&self.hashed_addr_l2tol1_msg_passer)
+            .cloned()
+            .unwrap_or_default();
+        isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, parent_state, header)
+            .map_err(ConsensusError::other)
+    }
+
+    /// Verifies the BaseTime claim, committed state, and block-to-block progression after block
+    /// execution.
+    pub fn validate_base_time_post_execution<DB>(
+        &self,
+        state_updates: &HashedPostState,
+        parent_state: &DB,
+        parent_timestamp: u64,
+        block: &RecoveredBlock<BaseBlock>,
+    ) -> Result<(), ConsensusError>
+    where
+        DB: StateProvider + ?Sized,
+    {
+        let claimed_base_time =
+            BaseTimeUpdateTx::extract_from_transactions(&block.body().transactions, block.number())
+                .map_err(ConsensusError::other)?;
+        let claimed_millis_part = claimed_base_time.timestamp_millis_part();
+
+        let read_parent_millis_part = || {
+            parent_state
+                .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
+                .map(|word| BaseTime::decode_timestamp_millis_part(word.unwrap_or_default()))
+                .map_err(ConsensusError::other)
+        };
+
+        let storage_updates = state_updates.storages.get(&self.hashed_addr_base_time);
+        let updated_word = storage_updates
+            .and_then(|storage| storage.storage.get(&self.hashed_slot_base_time_millis));
+        let committed_millis_part = match updated_word {
+            Some(word) => BaseTime::decode_timestamp_millis_part(*word),
+            None if storage_updates.is_some_and(|storage| storage.wiped) => 0,
+            None => read_parent_millis_part()?,
+        };
+
+        if claimed_millis_part != committed_millis_part {
+            return Err(ConsensusError::other(
+                BaseConsensusError::BaseTimeClaimCommittedMismatch {
+                    claim: claimed_millis_part,
+                    committed: committed_millis_part,
+                },
+            ));
+        }
+
+        // A parent at the activation second is itself Zombie-active; its committed millis part
+        // distinguishes same-second slots. Skip progression only when the parent predates Zombie.
+        if self.chain_spec().is_zombie_active_at_timestamp(parent_timestamp) {
+            let parent_millis_part = read_parent_millis_part()?;
+            let parent_base_time = BaseTimeUpdateTx::new(parent_millis_part).map_err(|_| {
+                ConsensusError::other(BaseConsensusError::InvalidParentBaseTimeMillis(
+                    parent_millis_part,
+                ))
+            })?;
+            BaseTimeUpdateTx::validate_progression(
+                parent_timestamp,
+                &parent_base_time,
+                block.timestamp(),
+                &claimed_base_time,
             )
             .map_err(ConsensusError::other)?;
         }
@@ -277,35 +310,27 @@ where
         state_updates: &HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
-        if self.chain_spec().is_zombie_active_at_timestamp(block.timestamp()) {
+        let timestamp = block.timestamp();
+        if self.chain_spec().is_isthmus_active_at_timestamp(timestamp) {
+            let parent_state =
+                self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
+                    ConsensusError::Other(Arc::from(Box::<dyn core::error::Error + Send + Sync>::from(
+                        format!(
+                            "failed to load parent state for Isthmus withdrawals root validation: {err}"
+                        ),
+                    )))
+                })?;
+
+            self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())?;
+        }
+
+        if self.chain_spec().is_zombie_active_at_timestamp(timestamp) {
             return Err(ConsensusError::other(
                 BaseConsensusError::BaseTimeValidationContextRequired,
             ));
         }
-        if !self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
-            return Ok(());
-        }
 
-        let parent_state =
-            self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
-                ConsensusError::Other(Arc::from(Box::<dyn core::error::Error + Send + Sync>::from(
-                    format!(
-                        "failed to load parent state for Isthmus withdrawals root validation: {err}"
-                    ),
-                )))
-            })?;
-
-        let predeploy_storage_updates = state_updates
-            .storages
-            .get(&self.hashed_addr_l2tol1_msg_passer)
-            .cloned()
-            .unwrap_or_default();
-        isthmus::verify_withdrawals_root_prehashed(
-            predeploy_storage_updates,
-            parent_state,
-            block.header(),
-        )
-        .map_err(ConsensusError::other)
+        Ok(())
     }
 
     fn convert_payload_to_block(
@@ -870,7 +895,12 @@ mod tests {
         state
     }
 
-    fn base_time_block(number: u64, timestamp: u64, millis_part: u16) -> RecoveredBlock<BaseBlock> {
+    fn base_time_block(
+        number: u64,
+        timestamp: u64,
+        millis_part: u16,
+        withdrawals_root: B256,
+    ) -> RecoveredBlock<BaseBlock> {
         let metadata = BaseTimeUpdateTx::new(millis_part)
             .expect("valid BaseTime metadata")
             .into_deposit_tx(number);
@@ -878,7 +908,7 @@ mod tests {
             header: Header {
                 number,
                 timestamp,
-                withdrawals_root: Some(EMPTY_ROOT_HASH),
+                withdrawals_root: Some(withdrawals_root),
                 ..Default::default()
             },
             body: BlockBody {
@@ -904,7 +934,7 @@ mod tests {
             &state_updates(committed_millis_part, wiped),
             parent_state(parent_millis_part),
             parent_timestamp,
-            &base_time_block(9, child_timestamp, claimed_millis_part),
+            &base_time_block(9, child_timestamp, claimed_millis_part, EMPTY_ROOT_HASH),
         )
     }
 
@@ -984,8 +1014,29 @@ mod tests {
     }
 
     #[test]
-    fn generic_post_execution_validation_fails_closed_after_zombie() {
-        let block = base_time_block(9, 42, 200);
+    fn generic_post_execution_validation_checks_isthmus_before_zombie() {
+        let block = base_time_block(9, 42, 200, EMPTY_ROOT_HASH);
+        let error =
+            PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
+                &zombie_validator(),
+                &HashedPostState::default(),
+                &block,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::L2WithdrawalsRootMismatch { .. })
+                )
+        ));
+    }
+
+    #[test]
+    fn generic_post_execution_validation_fails_closed_after_valid_isthmus() {
+        let block = base_time_block(9, 42, 200, B256::ZERO);
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
                 &zombie_validator(),

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -172,38 +172,38 @@ where
 
         // TODO: Validate against the parent timestamp once BasicEngineValidatorBuilder provides it.
         let chain_id = self.chain_spec().chain().id();
-        let unavailable = || {
+        let unavailable = |reason| {
             ConsensusError::other(BaseConsensusError::BaseTimeTimestampUnavailable {
                 chain_id,
                 block_number: block.number(),
+                reason,
             })
         };
-        let config = ChainConfig::by_chain_id(chain_id).ok_or_else(unavailable)?;
+        let config = ChainConfig::by_chain_id(chain_id)
+            .ok_or_else(|| unavailable("unknown chain configuration"))?;
         let ForkCondition::Timestamp(activation_timestamp) =
             self.chain_spec().upgrade_activation(BaseUpgrade::Zombie)
         else {
-            return Err(unavailable());
+            return Err(unavailable("non-timestamp activation"));
         };
-        let activation_offset =
-            activation_timestamp.checked_sub(config.genesis_l2_time).ok_or_else(unavailable)?;
-        if config.block_time == 0 || !activation_offset.is_multiple_of(config.block_time) {
-            return Err(unavailable());
+        let activation_offset = activation_timestamp
+            .checked_sub(config.genesis_l2_time)
+            .ok_or_else(|| unavailable("activation before genesis"))?;
+        if config.block_time == 0 {
+            return Err(unavailable("zero block time"));
+        }
+        if !activation_offset.is_multiple_of(config.block_time) {
+            return Err(unavailable("misaligned activation"));
         }
         let activation_block = activation_offset / config.block_time;
-        let elapsed_millis = block
+        let elapsed_blocks = block
             .number()
             .checked_sub(activation_block)
-            .and_then(|slots| slots.checked_mul(u64::from(BaseTimeUpdateTx::BLOCK_INTERVAL_MILLIS)))
-            .ok_or_else(unavailable)?;
-        let expected_timestamp_ms = activation_timestamp
-            .checked_mul(1_000)
-            .and_then(|timestamp| timestamp.checked_add(elapsed_millis))
-            .ok_or_else(unavailable)?;
-        let actual_timestamp_ms = block
-            .timestamp()
-            .checked_mul(1_000)
-            .and_then(|timestamp| timestamp.checked_add(u64::from(claimed_millis_part)))
-            .ok_or_else(unavailable)?;
+            .ok_or_else(|| unavailable("block before activation"))?;
+        let expected_timestamp_ms = u128::from(activation_timestamp) * 1_000
+            + u128::from(elapsed_blocks) * u128::from(BaseTimeUpdateTx::BLOCK_INTERVAL_MILLIS);
+        let actual_timestamp_ms =
+            u128::from(block.timestamp()) * 1_000 + u128::from(claimed_millis_part);
         if actual_timestamp_ms != expected_timestamp_ms {
             return Err(ConsensusError::other(BaseConsensusError::BaseTimeTimestampMismatch {
                 expected_timestamp_ms,
@@ -912,6 +912,13 @@ mod tests {
         )
     }
 
+    fn base_consensus_error(error: &ConsensusError) -> Option<&BaseConsensusError> {
+        let ConsensusError::Other(error) = error else {
+            return None;
+        };
+        error.downcast_ref()
+    }
+
     #[test]
     fn base_time_post_execution_accepts_first_scheduled_slot_without_storage_update() {
         validate_base_time(ZOMBIE_ACTIVATION_BLOCK, 0, ZOMBIE_TIMESTAMP, 0, None, false).unwrap();
@@ -955,15 +962,11 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeTimestampMismatch {
-                        expected_timestamp_ms: 1_800_000_001_400,
-                        actual_timestamp_ms: 1_800_000_001_600,
-                    })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::BaseTimeTimestampMismatch {
+                expected_timestamp_ms: 1_800_000_001_400,
+                actual_timestamp_ms: 1_800_000_001_600,
+            })
         ));
     }
 
@@ -988,15 +991,12 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeTimestampUnavailable {
-                        block_number: ZOMBIE_ACTIVATION_BLOCK,
-                        ..
-                    })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::BaseTimeTimestampUnavailable {
+                block_number: ZOMBIE_ACTIVATION_BLOCK,
+                reason: "unknown chain configuration",
+                ..
+            })
         ));
     }
 
@@ -1019,15 +1019,12 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeTimestampUnavailable {
-                        chain_id: 8453,
-                        block_number: ZOMBIE_ACTIVATION_BLOCK,
-                    })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::BaseTimeTimestampUnavailable {
+                chain_id: 8453,
+                block_number: ZOMBIE_ACTIVATION_BLOCK,
+                reason: "misaligned activation",
+            })
         ));
     }
 
@@ -1043,15 +1040,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeClaimCommittedMismatch {
-                        claim: 400,
-                        committed: 600,
-                    })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::BaseTimeClaimCommittedMismatch { claim: 400, committed: 600 })
         ));
     }
 
@@ -1067,15 +1057,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeClaimCommittedMismatch {
-                        claim: 400,
-                        committed: 200,
-                    })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::BaseTimeClaimCommittedMismatch { claim: 400, committed: 200 })
         ));
     }
 
@@ -1097,12 +1080,8 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::L2WithdrawalsRootMismatch { .. })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::L2WithdrawalsRootMismatch { .. })
         ));
     }
 
@@ -1131,15 +1110,11 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeTimestampMismatch {
-                        expected_timestamp_ms: 1_800_000_001_200,
-                        actual_timestamp_ms: 1_800_000_002_200,
-                    })
-                )
+            base_consensus_error(&error),
+            Some(BaseConsensusError::BaseTimeTimestampMismatch {
+                expected_timestamp_ms: 1_800_000_001_200,
+                actual_timestamp_ms: 1_800_000_002_200,
+            })
         ));
     }
 }

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -1,15 +1,16 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{B256, Bytes, U256};
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseBlock, Predeploys};
+use base_common_evm::BaseTime;
 use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
     ExecutionData,
 };
-use base_execution_consensus::isthmus;
+use base_execution_consensus::{BaseConsensusError, isthmus};
 use base_execution_payload_builder::{
     Attributes, BaseExecutionPayloadValidator, BasePayloadBuilderAttributes, BasePayloadTypes,
 };
@@ -82,6 +83,8 @@ pub struct BaseEngineValidator<P, Tx, ChainSpec> {
     inner: BaseExecutionPayloadValidator<ChainSpec>,
     provider: P,
     hashed_addr_l2tol1_msg_passer: B256,
+    hashed_addr_base_time: B256,
+    hashed_slot_base_time_millis: B256,
     phantom: PhantomData<Tx>,
 }
 
@@ -89,10 +92,15 @@ impl<P, Tx, ChainSpec> BaseEngineValidator<P, Tx, ChainSpec> {
     /// Instantiates a new validator.
     pub fn new<KH: KeyHasher>(chain_spec: Arc<ChainSpec>, provider: P) -> Self {
         let hashed_addr_l2tol1_msg_passer = KH::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER);
+        let hashed_addr_base_time = KH::hash_key(Predeploys::BASE_TIME);
+        let hashed_slot_base_time_millis =
+            KH::hash_key(B256::from(BaseTime::TIMESTAMP_MILLIS_PART_SLOT));
         Self {
             inner: BaseExecutionPayloadValidator::new(chain_spec),
             provider,
             hashed_addr_l2tol1_msg_passer,
+            hashed_addr_base_time,
+            hashed_slot_base_time_millis,
             phantom: PhantomData,
         }
     }
@@ -108,6 +116,8 @@ where
             inner: BaseExecutionPayloadValidator::new(self.inner.clone()),
             provider: self.provider.clone(),
             hashed_addr_l2tol1_msg_passer: self.hashed_addr_l2tol1_msg_passer,
+            hashed_addr_base_time: self.hashed_addr_base_time,
+            hashed_slot_base_time_millis: self.hashed_slot_base_time_millis,
             phantom: Default::default(),
         }
     }
@@ -132,31 +142,81 @@ where
     ///
     /// To add a check for a future upgrade, extend the body with another
     /// `if chain_spec.is_<X>_active_at_timestamp(...)` arm.
-    pub fn validate_block_post_execution_with_state<DB, H>(
+    pub fn validate_block_post_execution_with_state<DB>(
         &self,
         state_updates: &HashedPostState,
         parent_state: DB,
-        header: H,
+        parent_timestamp: u64,
+        block: &RecoveredBlock<BaseBlock>,
     ) -> Result<(), ConsensusError>
     where
         DB: StateProvider,
-        H: BlockHeader,
     {
-        if !self.chain_spec().is_isthmus_active_at_timestamp(header.timestamp()) {
-            return Ok(());
+        if self.chain_spec().is_zombie_active_at_timestamp(block.timestamp()) {
+            let claim = BaseTimeUpdateTx::extract_from_transactions(
+                &block.body().transactions,
+                block.number(),
+            )
+            .map_err(ConsensusError::other)?;
+            let storage_updates = state_updates.storages.get(&self.hashed_addr_base_time);
+            let committed_word = if let Some(value) = storage_updates.and_then(|storage| {
+                storage.storage.get(&self.hashed_slot_base_time_millis).copied()
+            }) {
+                value
+            } else if storage_updates.is_some_and(|storage| storage.wiped) {
+                U256::ZERO
+            } else {
+                parent_state
+                    .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
+                    .map_err(ConsensusError::other)?
+                    .unwrap_or_default()
+            };
+            let committed = BaseTime::decode_timestamp_millis_part(committed_word);
+            if claim.timestamp_millis_part() != committed {
+                return Err(ConsensusError::other(
+                    BaseConsensusError::BaseTimeClaimCommittedMismatch {
+                        claim: claim.timestamp_millis_part(),
+                        committed,
+                    },
+                ));
+            }
+
+            if self.chain_spec().is_zombie_active_at_timestamp(parent_timestamp) {
+                let parent_word = parent_state
+                    .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
+                    .map_err(ConsensusError::other)?
+                    .unwrap_or_default();
+                let parent_millis = BaseTime::decode_timestamp_millis_part(parent_word);
+                let parent = BaseTimeUpdateTx::new(parent_millis).map_err(|_| {
+                    ConsensusError::other(BaseConsensusError::InvalidParentBaseTimeMillis(
+                        parent_millis,
+                    ))
+                })?;
+                BaseTimeUpdateTx::validate_progression(
+                    parent_timestamp,
+                    &parent,
+                    block.timestamp(),
+                    &claim,
+                )
+                .map_err(ConsensusError::other)?;
+            }
         }
 
-        let predeploy_storage_updates = state_updates
-            .storages
-            .get(&self.hashed_addr_l2tol1_msg_passer)
-            .cloned()
-            .unwrap_or_default();
-        isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, parent_state, header)
-            .map_err(|err| {
-                ConsensusError::Other(Arc::from(Box::<dyn core::error::Error + Send + Sync>::from(
-                    format!("failed to verify block post-execution: {err}"),
-                )))
-            })
+        if self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
+            let predeploy_storage_updates = state_updates
+                .storages
+                .get(&self.hashed_addr_l2tol1_msg_passer)
+                .cloned()
+                .unwrap_or_default();
+            isthmus::verify_withdrawals_root_prehashed(
+                predeploy_storage_updates,
+                parent_state,
+                block.header(),
+            )
+            .map_err(ConsensusError::other)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -173,6 +233,7 @@ pub trait BasePostExecutionValidator<Types: PayloadTypes>:
         &self,
         state_updates: &HashedPostState,
         parent_state: DB,
+        parent_timestamp: u64,
         block: &RecoveredBlock<BaseBlock>,
     ) -> Result<(), ConsensusError>;
 }
@@ -188,13 +249,15 @@ where
         &self,
         state_updates: &HashedPostState,
         parent_state: DB,
+        parent_timestamp: u64,
         block: &RecoveredBlock<BaseBlock>,
     ) -> Result<(), ConsensusError> {
         Self::validate_block_post_execution_with_state(
             self,
             state_updates,
             parent_state,
-            block.header(),
+            parent_timestamp,
+            block,
         )
     }
 }
@@ -214,6 +277,9 @@ where
         state_updates: &HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
+        if self.chain_spec().is_zombie_active_at_timestamp(block.timestamp()) {
+            return Err(ConsensusError::other(BaseConsensusError::BaseTimeBlockBodyRequired));
+        }
         if !self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
             return Ok(());
         }
@@ -227,7 +293,17 @@ where
                 )))
             })?;
 
-        self.validate_block_post_execution_with_state(state_updates, parent_state, block.header())
+        let predeploy_storage_updates = state_updates
+            .storages
+            .get(&self.hashed_addr_l2tol1_msg_passer)
+            .cloned()
+            .unwrap_or_default();
+        isthmus::verify_withdrawals_root_prehashed(
+            predeploy_storage_updates,
+            parent_state,
+            block.header(),
+        )
+        .map_err(ConsensusError::other)
     }
 
     fn convert_payload_to_block(
@@ -428,16 +504,19 @@ pub fn validate_withdrawals_presence(
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::Header;
-    use alloy_primitives::{Address, B64, B256, b64};
+    use alloy_consensus::{BlockBody, EMPTY_ROOT_HASH, Header, Sealable};
+    use alloy_primitives::{Address, B64, B256, U256, b64, keccak256};
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_common_chains::{BaseUpgrade, ChainConfig};
-    use base_common_consensus::BaseTxEnvelope;
+    use base_common_consensus::{BasePrimitives, BaseTxEnvelope, TxDeposit};
     use base_common_rpc_types_engine::BasePayloadAttributes;
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
     use reth_ethereum_forks::ForkCondition;
-    use reth_provider::noop::NoopProvider;
-    use reth_trie_common::KeccakKeyHasher;
+    use reth_provider::{
+        noop::NoopProvider,
+        test_utils::{ExtendedAccount, MockEthProvider},
+    };
+    use reth_trie_common::{HashedStorage, KeccakKeyHasher};
 
     use super::*;
     use crate::engine;
@@ -759,6 +838,167 @@ mod tests {
         assert!(matches!(
             validate_against_parent(&validator, 42, Some(999), 42),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
+        ));
+    }
+
+    fn parent_state(millis_part: u16) -> MockEthProvider<BasePrimitives> {
+        let provider = MockEthProvider::<BasePrimitives>::new();
+        provider.add_account(
+            Predeploys::BASE_TIME,
+            ExtendedAccount::new(0, U256::ZERO).extend_storage([(
+                BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into(),
+                U256::from(millis_part),
+            )]),
+        );
+        provider
+    }
+
+    fn state_updates(millis_part: Option<u16>, wiped: bool) -> HashedPostState {
+        let mut state = HashedPostState::default();
+        let storage = HashedStorage::from_iter(
+            wiped,
+            millis_part.into_iter().map(|millis_part| {
+                (
+                    keccak256(B256::from(BaseTime::TIMESTAMP_MILLIS_PART_SLOT)),
+                    U256::from(millis_part),
+                )
+            }),
+        );
+        state.storages.insert(keccak256(Predeploys::BASE_TIME), storage);
+        state
+    }
+
+    fn base_time_block(number: u64, timestamp: u64, millis_part: u16) -> RecoveredBlock<BaseBlock> {
+        let metadata = BaseTimeUpdateTx::new(millis_part)
+            .expect("valid BaseTime metadata")
+            .into_deposit_tx(number);
+        let block = BaseBlock {
+            header: Header {
+                number,
+                timestamp,
+                withdrawals_root: Some(EMPTY_ROOT_HASH),
+                ..Default::default()
+            },
+            body: BlockBody {
+                transactions: vec![TxDeposit::default().seal_slow().into(), metadata.into()],
+                ..Default::default()
+            },
+        };
+        RecoveredBlock::new_sealed(
+            SealedBlock::seal_slow(block),
+            vec![Address::ZERO, Address::ZERO],
+        )
+    }
+
+    fn validate_base_time(
+        parent_timestamp: u64,
+        parent_millis_part: u16,
+        child_timestamp: u64,
+        claimed_millis_part: u16,
+        committed_millis_part: Option<u16>,
+        wiped: bool,
+    ) -> Result<(), ConsensusError> {
+        zombie_validator().validate_block_post_execution_with_state(
+            &state_updates(committed_millis_part, wiped),
+            parent_state(parent_millis_part),
+            parent_timestamp,
+            &base_time_block(9, child_timestamp, claimed_millis_part),
+        )
+    }
+
+    #[test]
+    fn base_time_post_execution_accepts_first_active_child() {
+        validate_base_time(41, 0, 42, 600, Some(600), false).unwrap();
+    }
+
+    #[test]
+    fn base_time_post_execution_accepts_same_second_200ms_progression() {
+        validate_base_time(42, 200, 42, 400, Some(400), false).unwrap();
+    }
+
+    #[test]
+    fn base_time_post_execution_accepts_second_boundary_progression() {
+        validate_base_time(42, 800, 43, 0, Some(0), false).unwrap();
+    }
+
+    #[test]
+    fn base_time_post_execution_rejects_skipped_slot() {
+        let error = validate_base_time(42, 200, 42, 600, Some(600), false).unwrap_err();
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if error.downcast_ref::<base_protocol::BaseTimeProgressionError>().is_some()
+        ));
+    }
+
+    #[test]
+    fn base_time_post_execution_rejects_claim_committed_mismatch() {
+        let error = validate_base_time(42, 200, 42, 400, Some(600), false).unwrap_err();
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::BaseTimeClaimCommittedMismatch {
+                        claim: 400,
+                        committed: 600,
+                    })
+                )
+        ));
+    }
+
+    #[test]
+    fn base_time_post_execution_uses_parent_when_child_slot_is_absent() {
+        let error = validate_base_time(42, 200, 42, 400, None, false).unwrap_err();
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::BaseTimeClaimCommittedMismatch {
+                        claim: 400,
+                        committed: 200,
+                    })
+                )
+        ));
+    }
+
+    #[test]
+    fn base_time_post_execution_treats_wiped_storage_as_zero() {
+        validate_base_time(42, 800, 43, 0, None, true).unwrap();
+    }
+
+    #[test]
+    fn base_time_post_execution_rejects_invalid_parent_state() {
+        let error = validate_base_time(42, 100, 42, 200, Some(200), false).unwrap_err();
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::InvalidParentBaseTimeMillis(100))
+                )
+        ));
+    }
+
+    #[test]
+    fn generic_post_execution_validation_fails_closed_after_zombie() {
+        let block = base_time_block(9, 42, 200);
+        let error =
+            PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
+                &zombie_validator(),
+                &HashedPostState::default(),
+                &block,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::BaseTimeBlockBodyRequired)
+                )
         ));
     }
 }

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -374,7 +374,7 @@ pub fn validate_withdrawals_presence(
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::{EMPTY_ROOT_HASH, Header, Sealable};
+    use alloy_consensus::{EMPTY_ROOT_HASH, Header};
     use alloy_primitives::{Address, B64, B256, b64};
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_common_chains::{BaseUpgrade, ChainConfig};

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -278,7 +278,9 @@ where
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         if self.chain_spec().is_zombie_active_at_timestamp(block.timestamp()) {
-            return Err(ConsensusError::other(BaseConsensusError::BaseTimeBlockBodyRequired));
+            return Err(ConsensusError::other(
+                BaseConsensusError::BaseTimeValidationContextRequired,
+            ));
         }
         if !self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
             return Ok(());
@@ -997,7 +999,7 @@ mod tests {
             ConsensusError::Other(error)
                 if matches!(
                     error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeBlockBodyRequired)
+                    Some(BaseConsensusError::BaseTimeValidationContextRequired)
                 )
         ));
     }

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -5,12 +5,11 @@ use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseBlock, BaseTransaction, Predeploys};
-use base_common_evm::BaseTime;
 use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
     ExecutionData,
 };
-use base_execution_consensus::{BaseConsensusError, isthmus};
+use base_execution_consensus::isthmus;
 use base_execution_payload_builder::{
     Attributes, BaseExecutionPayloadValidator, BasePayloadBuilderAttributes, BasePayloadTypes,
 };
@@ -84,8 +83,6 @@ pub struct BaseEngineValidator<P, Tx, ChainSpec> {
     inner: BaseExecutionPayloadValidator<ChainSpec>,
     provider: P,
     hashed_addr_l2tol1_msg_passer: B256,
-    hashed_addr_base_time: B256,
-    hashed_slot_base_time_millis: B256,
     phantom: PhantomData<Tx>,
 }
 
@@ -93,15 +90,10 @@ impl<P, Tx, ChainSpec> BaseEngineValidator<P, Tx, ChainSpec> {
     /// Instantiates a new validator.
     pub fn new<KH: KeyHasher>(chain_spec: Arc<ChainSpec>, provider: P) -> Self {
         let hashed_addr_l2tol1_msg_passer = KH::hash_key(Predeploys::L2_TO_L1_MESSAGE_PASSER);
-        let hashed_addr_base_time = KH::hash_key(Predeploys::BASE_TIME);
-        let hashed_slot_base_time_millis =
-            KH::hash_key(B256::from(BaseTime::TIMESTAMP_MILLIS_PART_SLOT));
         Self {
             inner: BaseExecutionPayloadValidator::new(chain_spec),
             provider,
             hashed_addr_l2tol1_msg_passer,
-            hashed_addr_base_time,
-            hashed_slot_base_time_millis,
             phantom: PhantomData,
         }
     }
@@ -117,8 +109,6 @@ where
             inner: BaseExecutionPayloadValidator::new(self.inner.clone()),
             provider: self.provider.clone(),
             hashed_addr_l2tol1_msg_passer: self.hashed_addr_l2tol1_msg_passer,
-            hashed_addr_base_time: self.hashed_addr_base_time,
-            hashed_slot_base_time_millis: self.hashed_slot_base_time_millis,
             phantom: Default::default(),
         }
     }
@@ -153,51 +143,6 @@ where
         isthmus::verify_withdrawals_root_prehashed(predeploy_storage_updates, parent_state, header)
             .map_err(ConsensusError::other)
     }
-
-    /// Verifies the `BaseTime` claim and committed state after block execution.
-    pub fn validate_base_time_post_execution<DB>(
-        &self,
-        state_updates: &HashedPostState,
-        parent_state: &DB,
-        block: &RecoveredBlock<alloy_consensus::Block<Tx>>,
-    ) -> Result<(), ConsensusError>
-    where
-        DB: StateProvider + ?Sized,
-        Tx: BaseTransaction + SignedTransaction,
-    {
-        let claimed_base_time =
-            BaseTimeUpdateTx::extract_from_transactions(&block.body().transactions, block.number())
-                .map_err(ConsensusError::other)?;
-        let claimed_millis_part = claimed_base_time.timestamp_millis_part();
-
-        // ponytail: compare full timestamps when Reth exposes the parent header to this hook.
-        let read_parent_millis_part = || {
-            parent_state
-                .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
-                .map(|word| BaseTime::decode_timestamp_millis_part(word.unwrap_or_default()))
-                .map_err(ConsensusError::other)
-        };
-
-        let storage_updates = state_updates.storages.get(&self.hashed_addr_base_time);
-        let updated_word = storage_updates
-            .and_then(|storage| storage.storage.get(&self.hashed_slot_base_time_millis));
-        let committed_millis_part = match updated_word {
-            Some(word) => BaseTime::decode_timestamp_millis_part(*word),
-            None if storage_updates.is_some_and(|storage| storage.wiped) => 0,
-            None => read_parent_millis_part()?,
-        };
-
-        if claimed_millis_part != committed_millis_part {
-            return Err(ConsensusError::other(
-                BaseConsensusError::BaseTimeClaimCommittedMismatch {
-                    claim: claimed_millis_part,
-                    committed: committed_millis_part,
-                },
-            ));
-        }
-
-        Ok(())
-    }
 }
 
 impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
@@ -228,13 +173,7 @@ where
                 )))
             })?;
 
-        self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())?;
-
-        if self.chain_spec().is_zombie_active_at_timestamp(timestamp) {
-            self.validate_base_time_post_execution(state_updates, &parent_state, block)?;
-        }
-
-        Ok(())
+        self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())
     }
 
     fn convert_payload_to_block(
@@ -435,25 +374,22 @@ pub fn validate_withdrawals_presence(
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::{BlockBody, EMPTY_ROOT_HASH, Header, Sealable};
-    use alloy_primitives::{Address, B64, B256, U256, b64, keccak256};
+    use alloy_consensus::{EMPTY_ROOT_HASH, Header, Sealable};
+    use alloy_primitives::{Address, B64, B256, b64};
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_common_chains::{BaseUpgrade, ChainConfig};
-    use base_common_consensus::{BasePrimitives, BaseTxEnvelope, TxDeposit};
+    use base_common_consensus::BaseTxEnvelope;
     use base_common_rpc_types_engine::BasePayloadAttributes;
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
+    use base_execution_consensus::BaseConsensusError;
     use reth_ethereum_forks::ForkCondition;
-    use reth_provider::{
-        noop::NoopProvider,
-        test_utils::{ExtendedAccount, MockEthProvider},
-    };
-    use reth_trie_common::{HashedStorage, KeccakKeyHasher};
+    use reth_provider::noop::NoopProvider;
+    use reth_trie_common::KeccakKeyHasher;
 
     use super::*;
     use crate::engine;
 
     const ZOMBIE_TIMESTAMP: u64 = 1_800_000_001;
-    const BASE_TIME_BLOCK_NUMBER: u64 = 56_605_327;
 
     fn validator_with_chain_spec(
         chain_spec: BaseChainSpec,
@@ -780,79 +716,16 @@ mod tests {
         ));
     }
 
-    fn parent_state(millis_part: u16) -> MockEthProvider<BasePrimitives> {
-        let provider = MockEthProvider::<BasePrimitives>::new();
-        provider.add_account(
-            Predeploys::BASE_TIME,
-            ExtendedAccount::new(0, U256::ZERO).extend_storage([(
-                BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into(),
-                U256::from(millis_part),
-            )]),
-        );
-        provider
-    }
-
-    fn state_updates(millis_part: Option<u16>, wiped: bool) -> HashedPostState {
-        let mut state = HashedPostState::default();
-        if millis_part.is_none() && !wiped {
-            return state;
-        }
-        let storage = HashedStorage::from_iter(
-            wiped,
-            millis_part.into_iter().map(|millis_part| {
-                (
-                    keccak256(B256::from(BaseTime::TIMESTAMP_MILLIS_PART_SLOT)),
-                    U256::from(millis_part),
-                )
-            }),
-        );
-        state.storages.insert(keccak256(Predeploys::BASE_TIME), storage);
-        state
-    }
-
-    fn base_time_block(
-        number: u64,
-        timestamp: u64,
-        millis_part: u16,
-        withdrawals_root: B256,
-    ) -> RecoveredBlock<BaseBlock> {
-        let metadata = BaseTimeUpdateTx::new(millis_part)
-            .expect("valid BaseTime metadata")
-            .into_deposit_tx(number);
+    fn post_execution_block(withdrawals_root: B256) -> RecoveredBlock<BaseBlock> {
         let block = BaseBlock {
             header: Header {
-                number,
-                timestamp,
+                timestamp: ZOMBIE_TIMESTAMP,
                 withdrawals_root: Some(withdrawals_root),
                 ..Default::default()
             },
-            body: BlockBody {
-                transactions: vec![TxDeposit::default().seal_slow().into(), metadata.into()],
-                ..Default::default()
-            },
+            body: Default::default(),
         };
-        RecoveredBlock::new_sealed(
-            SealedBlock::seal_slow(block),
-            vec![Address::ZERO, Address::ZERO],
-        )
-    }
-
-    fn validate_base_time(
-        parent_millis_part: u16,
-        claimed_millis_part: u16,
-        committed_millis_part: Option<u16>,
-        wiped: bool,
-    ) -> Result<(), ConsensusError> {
-        zombie_validator().validate_base_time_post_execution(
-            &state_updates(committed_millis_part, wiped),
-            &parent_state(parent_millis_part),
-            &base_time_block(
-                BASE_TIME_BLOCK_NUMBER,
-                ZOMBIE_TIMESTAMP,
-                claimed_millis_part,
-                EMPTY_ROOT_HASH,
-            ),
-        )
+        RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), vec![])
     }
 
     fn base_consensus_error(error: &ConsensusError) -> Option<&BaseConsensusError> {
@@ -863,36 +736,8 @@ mod tests {
     }
 
     #[test]
-    fn base_time_post_execution_accepts_valid_commitment() {
-        validate_base_time(200, 600, Some(600), false).unwrap();
-    }
-
-    #[test]
-    fn base_time_post_execution_rejects_claim_committed_mismatch() {
-        let error = validate_base_time(200, 400, Some(600), false).unwrap_err();
-        assert!(matches!(
-            base_consensus_error(&error),
-            Some(BaseConsensusError::BaseTimeClaimCommittedMismatch { claim: 400, committed: 600 })
-        ));
-    }
-
-    #[test]
-    fn base_time_post_execution_uses_parent_when_child_slot_is_absent() {
-        let error = validate_base_time(200, 400, None, false).unwrap_err();
-        assert!(matches!(
-            base_consensus_error(&error),
-            Some(BaseConsensusError::BaseTimeClaimCommittedMismatch { claim: 400, committed: 200 })
-        ));
-    }
-
-    #[test]
-    fn base_time_post_execution_treats_wiped_storage_as_zero() {
-        validate_base_time(800, 0, None, true).unwrap();
-    }
-
-    #[test]
-    fn generic_post_execution_validation_checks_isthmus_before_zombie() {
-        let block = base_time_block(BASE_TIME_BLOCK_NUMBER, ZOMBIE_TIMESTAMP, 0, EMPTY_ROOT_HASH);
+    fn generic_post_execution_validation_checks_isthmus() {
+        let block = post_execution_block(EMPTY_ROOT_HASH);
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
                 &zombie_validator(),
@@ -905,17 +750,5 @@ mod tests {
             base_consensus_error(&error),
             Some(BaseConsensusError::L2WithdrawalsRootMismatch { .. })
         ));
-    }
-
-    #[test]
-    fn generic_post_execution_validation_accepts_valid_base_time_commitment() {
-        let block = base_time_block(BASE_TIME_BLOCK_NUMBER, ZOMBIE_TIMESTAMP + 1, 200, B256::ZERO);
-
-        PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
-            &zombie_validator(),
-            &state_updates(Some(200), false),
-            &block,
-        )
-        .unwrap();
     }
 }

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -3,8 +3,8 @@ use std::{marker::PhantomData, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
-use base_common_chains::Upgrades;
-use base_common_consensus::{BaseBlock, Predeploys};
+use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
+use base_common_consensus::{BaseBlock, BaseTransaction, Predeploys};
 use base_common_evm::BaseTime;
 use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
@@ -15,6 +15,7 @@ use base_execution_payload_builder::{
     Attributes, BaseExecutionPayloadValidator, BasePayloadBuilderAttributes, BasePayloadTypes,
 };
 use base_protocol::BaseTimeUpdateTx;
+use reth_chainspec::{EthChainSpec, ForkCondition};
 use reth_consensus::ConsensusError;
 use reth_node_api::{
     BuiltPayload, EngineApiValidator, EngineTypes, NodePrimitives, PayloadValidator,
@@ -125,48 +126,12 @@ where
 
 impl<P, Tx, ChainSpec> BaseEngineValidator<P, Tx, ChainSpec>
 where
-    ChainSpec: Upgrades,
+    ChainSpec: EthChainSpec + Upgrades,
 {
     /// Returns the chain spec used by the validator.
     #[inline]
     pub fn chain_spec(&self) -> &ChainSpec {
         self.inner.chain_spec()
-    }
-
-    /// Verifies upgrade-gated post-execution rules against the supplied parent state.
-    ///
-    /// Authoritative implementation of all Base-specific post-execution checks that require
-    /// access to parent state. Callers supply `parent_state` explicitly so engine pipelines can
-    /// pass in-memory-aware overlay providers when the parent block isn't canonical yet.
-    ///
-    /// To add a check for a future upgrade, extend the body with another
-    /// `if chain_spec.is_<X>_active_at_timestamp(...)` arm.
-    pub fn validate_block_post_execution_with_state<DB>(
-        &self,
-        state_updates: &HashedPostState,
-        parent_state: DB,
-        parent_timestamp: u64,
-        block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<(), ConsensusError>
-    where
-        DB: StateProvider,
-    {
-        let timestamp = block.timestamp();
-
-        if self.chain_spec().is_isthmus_active_at_timestamp(timestamp) {
-            self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())?;
-        }
-
-        if self.chain_spec().is_zombie_active_at_timestamp(timestamp) {
-            self.validate_base_time_post_execution(
-                state_updates,
-                &parent_state,
-                parent_timestamp,
-                block,
-            )?;
-        }
-
-        Ok(())
     }
 
     /// Verifies the Isthmus L2-to-L1 message-passer storage root after block execution.
@@ -189,22 +154,62 @@ where
             .map_err(ConsensusError::other)
     }
 
-    /// Verifies the `BaseTime` claim, committed state, and block-to-block progression after block
-    /// execution.
+    /// Verifies the `BaseTime` claim, committed state, and expected timestamp after block execution.
     pub fn validate_base_time_post_execution<DB>(
         &self,
         state_updates: &HashedPostState,
         parent_state: &DB,
-        parent_timestamp: u64,
-        block: &RecoveredBlock<BaseBlock>,
+        block: &RecoveredBlock<alloy_consensus::Block<Tx>>,
     ) -> Result<(), ConsensusError>
     where
         DB: StateProvider + ?Sized,
+        Tx: BaseTransaction + SignedTransaction,
     {
         let claimed_base_time =
             BaseTimeUpdateTx::extract_from_transactions(&block.body().transactions, block.number())
                 .map_err(ConsensusError::other)?;
         let claimed_millis_part = claimed_base_time.timestamp_millis_part();
+
+        // TODO: Validate against the parent timestamp once BasicEngineValidatorBuilder provides it.
+        let chain_id = self.chain_spec().chain().id();
+        let unavailable = || {
+            ConsensusError::other(BaseConsensusError::BaseTimeTimestampUnavailable {
+                chain_id,
+                block_number: block.number(),
+            })
+        };
+        let config = ChainConfig::by_chain_id(chain_id).ok_or_else(unavailable)?;
+        let ForkCondition::Timestamp(activation_timestamp) =
+            self.chain_spec().upgrade_activation(BaseUpgrade::Zombie)
+        else {
+            return Err(unavailable());
+        };
+        let activation_offset =
+            activation_timestamp.checked_sub(config.genesis_l2_time).ok_or_else(unavailable)?;
+        if config.block_time == 0 || !activation_offset.is_multiple_of(config.block_time) {
+            return Err(unavailable());
+        }
+        let activation_block = activation_offset / config.block_time;
+        let elapsed_millis = block
+            .number()
+            .checked_sub(activation_block)
+            .and_then(|slots| slots.checked_mul(u64::from(BaseTimeUpdateTx::BLOCK_INTERVAL_MILLIS)))
+            .ok_or_else(unavailable)?;
+        let expected_timestamp_ms = activation_timestamp
+            .checked_mul(1_000)
+            .and_then(|timestamp| timestamp.checked_add(elapsed_millis))
+            .ok_or_else(unavailable)?;
+        let actual_timestamp_ms = block
+            .timestamp()
+            .checked_mul(1_000)
+            .and_then(|timestamp| timestamp.checked_add(u64::from(claimed_millis_part)))
+            .ok_or_else(unavailable)?;
+        if actual_timestamp_ms != expected_timestamp_ms {
+            return Err(ConsensusError::other(BaseConsensusError::BaseTimeTimestampMismatch {
+                expected_timestamp_ms,
+                actual_timestamp_ms,
+            }));
+        }
 
         let read_parent_millis_part = || {
             parent_state
@@ -231,75 +236,15 @@ where
             ));
         }
 
-        // A parent at the activation second is itself Zombie-active; its committed millis part
-        // distinguishes same-second slots. Skip progression only when the parent predates Zombie.
-        if self.chain_spec().is_zombie_active_at_timestamp(parent_timestamp) {
-            let parent_millis_part = read_parent_millis_part()?;
-            let parent_base_time = BaseTimeUpdateTx::new(parent_millis_part).map_err(|_| {
-                ConsensusError::other(BaseConsensusError::InvalidParentBaseTimeMillis(
-                    parent_millis_part,
-                ))
-            })?;
-            BaseTimeUpdateTx::validate_progression(
-                parent_timestamp,
-                &parent_base_time,
-                block.timestamp(),
-                &claimed_base_time,
-            )
-            .map_err(ConsensusError::other)?;
-        }
-
         Ok(())
-    }
-}
-
-/// Extension trait that exposes [`BaseEngineValidator::validate_block_post_execution_with_state`]
-/// through generic engine pipelines.
-///
-/// The inherent method on [`BaseEngineValidator`] is the source of truth; this trait is just a
-/// dispatch surface so callers that don't know the concrete validator type can still invoke it.
-pub trait BasePostExecutionValidator<Types: PayloadTypes>:
-    PayloadValidator<Types, Block = BaseBlock>
-{
-    /// See [`BaseEngineValidator::validate_block_post_execution_with_state`].
-    fn validate_block_post_execution_with_parent_state<DB: StateProvider>(
-        &self,
-        state_updates: &HashedPostState,
-        parent_state: DB,
-        parent_timestamp: u64,
-        block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<(), ConsensusError>;
-}
-
-impl<Types, P, Tx, ChainSpec> BasePostExecutionValidator<Types>
-    for BaseEngineValidator<P, Tx, ChainSpec>
-where
-    Types: PayloadTypes,
-    Self: PayloadValidator<Types, Block = BaseBlock>,
-    ChainSpec: Upgrades,
-{
-    fn validate_block_post_execution_with_parent_state<DB: StateProvider>(
-        &self,
-        state_updates: &HashedPostState,
-        parent_state: DB,
-        parent_timestamp: u64,
-        block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<(), ConsensusError> {
-        Self::validate_block_post_execution_with_state(
-            self,
-            state_updates,
-            parent_state,
-            parent_timestamp,
-            block,
-        )
     }
 }
 
 impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for BaseEngineValidator<P, Tx, ChainSpec>
 where
     P: StateProviderFactory + Unpin + 'static,
-    Tx: SignedTransaction + Unpin + 'static,
-    ChainSpec: Upgrades + Send + Sync + 'static,
+    Tx: BaseTransaction + SignedTransaction + Unpin + 'static,
+    ChainSpec: EthChainSpec + Upgrades + Send + Sync + 'static,
     Types: PayloadTypes<ExecutionData = ExecutionData>,
     Types::PayloadAttributes: Attributes<Transaction = Tx>,
 {
@@ -311,23 +256,22 @@ where
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         let timestamp = block.timestamp();
-        if self.chain_spec().is_isthmus_active_at_timestamp(timestamp) {
-            let parent_state =
-                self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
-                    ConsensusError::Other(Arc::from(Box::<dyn core::error::Error + Send + Sync>::from(
-                        format!(
-                            "failed to load parent state for Isthmus withdrawals root validation: {err}"
-                        ),
-                    )))
-                })?;
 
-            self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())?;
+        if !self.chain_spec().is_isthmus_active_at_timestamp(timestamp) {
+            return Ok(());
         }
 
+        let parent_state =
+            self.provider.state_by_block_hash(block.parent_hash()).map_err(|err| {
+                ConsensusError::Other(Arc::from(Box::<dyn core::error::Error + Send + Sync>::from(
+                    format!("failed to load parent state for post-execution validation: {err}"),
+                )))
+            })?;
+
+        self.validate_isthmus_post_execution(state_updates, &parent_state, block.header())?;
+
         if self.chain_spec().is_zombie_active_at_timestamp(timestamp) {
-            return Err(ConsensusError::other(
-                BaseConsensusError::BaseTimeValidationContextRequired,
-            ));
+            self.validate_base_time_post_execution(state_updates, &parent_state, block)?;
         }
 
         Ok(())
@@ -359,8 +303,8 @@ where
             return Err(InvalidPayloadAttributesError::InvalidTimestamp);
         }
 
-        // The parent header does not contain its millisecond component. Exact 200ms progression is
-        // enforced against committed BaseTime state during post-execution validation.
+        // The parent header does not contain its millisecond component. The exact 200ms slot is
+        // enforced against the hardfork schedule during post-execution validation.
         (timestamp >= header.timestamp())
             .then_some(())
             .ok_or(InvalidPayloadAttributesError::InvalidTimestamp)
@@ -376,7 +320,7 @@ where
         >,
     P: StateProviderFactory + Unpin + 'static,
     Tx: SignedTransaction + Unpin + 'static,
-    ChainSpec: Upgrades + Send + Sync + 'static,
+    ChainSpec: EthChainSpec + Upgrades + Send + Sync + 'static,
 {
     fn validate_version_specific_fields(
         &self,
@@ -548,6 +492,9 @@ mod tests {
     use super::*;
     use crate::engine;
 
+    const ZOMBIE_TIMESTAMP: u64 = 1_800_000_001;
+    const ZOMBIE_ACTIVATION_BLOCK: u64 = 56_605_327;
+
     fn validator_with_chain_spec(
         chain_spec: BaseChainSpec,
     ) -> BaseEngineValidator<NoopProvider, BaseTxEnvelope, BaseChainSpec> {
@@ -564,8 +511,7 @@ mod tests {
     fn zombie_validator() -> BaseEngineValidator<NoopProvider, BaseTxEnvelope, BaseChainSpec> {
         validator_with_chain_spec(
             BaseChainSpecBuilder::base_mainnet()
-                .cobalt_activated()
-                .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(42))
+                .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP))
                 .build(),
         )
     }
@@ -772,7 +718,7 @@ mod tests {
     #[test]
     fn test_malformed_attributes_post_zombie_without_timestamp_millis_part() {
         let validator = zombie_validator();
-        let attributes = zombie_attributes(42);
+        let attributes = zombie_attributes(ZOMBIE_TIMESTAMP);
 
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
             BaseEngineTypes,
@@ -785,7 +731,7 @@ mod tests {
     #[test]
     fn test_malformed_attributes_post_zombie_with_invalid_timestamp_millis_part() {
         let validator = zombie_validator();
-        let mut attributes = zombie_attributes(42);
+        let mut attributes = zombie_attributes(ZOMBIE_TIMESTAMP);
         attributes.timestamp_millis_part = Some(100);
 
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
@@ -799,7 +745,7 @@ mod tests {
     #[test]
     fn test_well_formed_attributes_post_zombie_with_valid_timestamp_millis_part() {
         let validator = zombie_validator();
-        let mut attributes = zombie_attributes(42);
+        let mut attributes = zombie_attributes(ZOMBIE_TIMESTAMP);
         attributes.timestamp_millis_part = Some(200);
 
         let result = <engine::BaseEngineValidator<_, _, _> as EngineApiValidator<
@@ -828,14 +774,20 @@ mod tests {
     fn test_payload_attributes_post_zombie_accept_same_second() {
         let validator = zombie_validator();
 
-        assert!(validate_against_parent(&validator, 42, Some(200), 42).is_ok());
+        assert!(
+            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, Some(200), ZOMBIE_TIMESTAMP,)
+                .is_ok()
+        );
     }
 
     #[test]
     fn test_payload_attributes_post_zombie_accept_next_second() {
         let validator = zombie_validator();
 
-        assert!(validate_against_parent(&validator, 43, Some(0), 42).is_ok());
+        assert!(
+            validate_against_parent(&validator, ZOMBIE_TIMESTAMP + 1, Some(0), ZOMBIE_TIMESTAMP,)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -843,7 +795,7 @@ mod tests {
         let validator = zombie_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, 42, Some(800), 43),
+            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, Some(800), ZOMBIE_TIMESTAMP + 1,),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
@@ -853,7 +805,7 @@ mod tests {
         let validator = zombie_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, 42, None, 42),
+            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, None, ZOMBIE_TIMESTAMP),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
@@ -863,7 +815,7 @@ mod tests {
         let validator = zombie_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, 42, Some(999), 42),
+            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, Some(999), ZOMBIE_TIMESTAMP,),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
@@ -882,6 +834,9 @@ mod tests {
 
     fn state_updates(millis_part: Option<u16>, wiped: bool) -> HashedPostState {
         let mut state = HashedPostState::default();
+        if millis_part.is_none() && !wiped {
+            return state;
+        }
         let storage = HashedStorage::from_iter(
             wiped,
             millis_part.into_iter().map(|millis_part| {
@@ -922,50 +877,171 @@ mod tests {
         )
     }
 
-    fn validate_base_time(
-        parent_timestamp: u64,
+    fn validate_base_time_with(
+        validator: &BaseEngineValidator<NoopProvider, BaseTxEnvelope, BaseChainSpec>,
+        block_number: u64,
         parent_millis_part: u16,
         child_timestamp: u64,
         claimed_millis_part: u16,
         committed_millis_part: Option<u16>,
         wiped: bool,
     ) -> Result<(), ConsensusError> {
-        zombie_validator().validate_block_post_execution_with_state(
+        validator.validate_base_time_post_execution(
             &state_updates(committed_millis_part, wiped),
-            parent_state(parent_millis_part),
-            parent_timestamp,
-            &base_time_block(9, child_timestamp, claimed_millis_part, EMPTY_ROOT_HASH),
+            &parent_state(parent_millis_part),
+            &base_time_block(block_number, child_timestamp, claimed_millis_part, EMPTY_ROOT_HASH),
+        )
+    }
+
+    fn validate_base_time(
+        block_number: u64,
+        parent_millis_part: u16,
+        child_timestamp: u64,
+        claimed_millis_part: u16,
+        committed_millis_part: Option<u16>,
+        wiped: bool,
+    ) -> Result<(), ConsensusError> {
+        validate_base_time_with(
+            &zombie_validator(),
+            block_number,
+            parent_millis_part,
+            child_timestamp,
+            claimed_millis_part,
+            committed_millis_part,
+            wiped,
         )
     }
 
     #[test]
-    fn base_time_post_execution_accepts_first_active_child() {
-        validate_base_time(41, 0, 42, 600, Some(600), false).unwrap();
+    fn base_time_post_execution_accepts_first_scheduled_slot_without_storage_update() {
+        validate_base_time(ZOMBIE_ACTIVATION_BLOCK, 0, ZOMBIE_TIMESTAMP, 0, None, false).unwrap();
     }
 
     #[test]
-    fn base_time_post_execution_accepts_same_second_200ms_progression() {
-        validate_base_time(42, 200, 42, 400, Some(400), false).unwrap();
+    fn base_time_post_execution_accepts_scheduled_same_second_slot() {
+        validate_base_time(
+            ZOMBIE_ACTIVATION_BLOCK + 2,
+            200,
+            ZOMBIE_TIMESTAMP,
+            400,
+            Some(400),
+            false,
+        )
+        .unwrap();
     }
 
     #[test]
-    fn base_time_post_execution_accepts_second_boundary_progression() {
-        validate_base_time(42, 800, 43, 0, Some(0), false).unwrap();
+    fn base_time_post_execution_accepts_scheduled_second_boundary() {
+        validate_base_time(
+            ZOMBIE_ACTIVATION_BLOCK + 5,
+            800,
+            ZOMBIE_TIMESTAMP + 1,
+            0,
+            Some(0),
+            false,
+        )
+        .unwrap();
     }
 
     #[test]
-    fn base_time_post_execution_rejects_skipped_slot() {
-        let error = validate_base_time(42, 200, 42, 600, Some(600), false).unwrap_err();
+    fn base_time_post_execution_rejects_millis_not_scheduled_for_block_number() {
+        let error = validate_base_time(
+            ZOMBIE_ACTIVATION_BLOCK + 2,
+            200,
+            ZOMBIE_TIMESTAMP,
+            600,
+            Some(600),
+            false,
+        )
+        .unwrap_err();
         assert!(matches!(
             error,
             ConsensusError::Other(error)
-                if error.downcast_ref::<base_protocol::BaseTimeProgressionError>().is_some()
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::BaseTimeTimestampMismatch {
+                        expected_timestamp_ms: 1_800_000_001_400,
+                        actual_timestamp_ms: 1_800_000_001_600,
+                    })
+                )
+        ));
+    }
+
+    #[test]
+    fn base_time_post_execution_rejects_unknown_chain_config() {
+        let chain_spec = BaseChainSpecBuilder::base_mainnet()
+            .chain(Default::default())
+            .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP))
+            .build();
+        assert!(ChainConfig::by_chain_id(chain_spec.chain().id()).is_none());
+
+        let validator = validator_with_chain_spec(chain_spec);
+        let error = validate_base_time_with(
+            &validator,
+            ZOMBIE_ACTIVATION_BLOCK,
+            0,
+            ZOMBIE_TIMESTAMP,
+            0,
+            None,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::BaseTimeTimestampUnavailable {
+                        block_number: ZOMBIE_ACTIVATION_BLOCK,
+                        ..
+                    })
+                )
+        ));
+    }
+
+    #[test]
+    fn base_time_post_execution_rejects_misaligned_zombie_activation() {
+        let validator = validator_with_chain_spec(
+            BaseChainSpecBuilder::base_mainnet()
+                .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP + 1))
+                .build(),
+        );
+        let error = validate_base_time_with(
+            &validator,
+            ZOMBIE_ACTIVATION_BLOCK,
+            0,
+            ZOMBIE_TIMESTAMP + 1,
+            0,
+            None,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConsensusError::Other(error)
+                if matches!(
+                    error.downcast_ref::<BaseConsensusError>(),
+                    Some(BaseConsensusError::BaseTimeTimestampUnavailable {
+                        chain_id: 8453,
+                        block_number: ZOMBIE_ACTIVATION_BLOCK,
+                    })
+                )
         ));
     }
 
     #[test]
     fn base_time_post_execution_rejects_claim_committed_mismatch() {
-        let error = validate_base_time(42, 200, 42, 400, Some(600), false).unwrap_err();
+        let error = validate_base_time(
+            ZOMBIE_ACTIVATION_BLOCK + 2,
+            200,
+            ZOMBIE_TIMESTAMP,
+            400,
+            Some(600),
+            false,
+        )
+        .unwrap_err();
         assert!(matches!(
             error,
             ConsensusError::Other(error)
@@ -981,7 +1057,15 @@ mod tests {
 
     #[test]
     fn base_time_post_execution_uses_parent_when_child_slot_is_absent() {
-        let error = validate_base_time(42, 200, 42, 400, None, false).unwrap_err();
+        let error = validate_base_time(
+            ZOMBIE_ACTIVATION_BLOCK + 2,
+            200,
+            ZOMBIE_TIMESTAMP,
+            400,
+            None,
+            false,
+        )
+        .unwrap_err();
         assert!(matches!(
             error,
             ConsensusError::Other(error)
@@ -997,25 +1081,13 @@ mod tests {
 
     #[test]
     fn base_time_post_execution_treats_wiped_storage_as_zero() {
-        validate_base_time(42, 800, 43, 0, None, true).unwrap();
-    }
-
-    #[test]
-    fn base_time_post_execution_rejects_invalid_parent_state() {
-        let error = validate_base_time(42, 100, 42, 200, Some(200), false).unwrap_err();
-        assert!(matches!(
-            error,
-            ConsensusError::Other(error)
-                if matches!(
-                    error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::InvalidParentBaseTimeMillis(100))
-                )
-        ));
+        validate_base_time(ZOMBIE_ACTIVATION_BLOCK + 5, 800, ZOMBIE_TIMESTAMP + 1, 0, None, true)
+            .unwrap();
     }
 
     #[test]
     fn generic_post_execution_validation_checks_isthmus_before_zombie() {
-        let block = base_time_block(9, 42, 200, EMPTY_ROOT_HASH);
+        let block = base_time_block(ZOMBIE_ACTIVATION_BLOCK, ZOMBIE_TIMESTAMP, 0, EMPTY_ROOT_HASH);
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
                 &zombie_validator(),
@@ -1035,12 +1107,25 @@ mod tests {
     }
 
     #[test]
-    fn generic_post_execution_validation_fails_closed_after_valid_isthmus() {
-        let block = base_time_block(9, 42, 200, B256::ZERO);
+    fn generic_post_execution_validation_accepts_derived_child_timestamp() {
+        let block = base_time_block(ZOMBIE_ACTIVATION_BLOCK + 1, ZOMBIE_TIMESTAMP, 200, B256::ZERO);
+
+        PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
+            &zombie_validator(),
+            &state_updates(Some(200), false),
+            &block,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn generic_post_execution_validation_rejects_inexact_derived_child_timestamp() {
+        let block =
+            base_time_block(ZOMBIE_ACTIVATION_BLOCK + 1, ZOMBIE_TIMESTAMP + 1, 200, B256::ZERO);
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
                 &zombie_validator(),
-                &HashedPostState::default(),
+                &state_updates(Some(200), false),
                 &block,
             )
             .unwrap_err();
@@ -1050,7 +1135,10 @@ mod tests {
             ConsensusError::Other(error)
                 if matches!(
                     error.downcast_ref::<BaseConsensusError>(),
-                    Some(BaseConsensusError::BaseTimeValidationContextRequired)
+                    Some(BaseConsensusError::BaseTimeTimestampMismatch {
+                        expected_timestamp_ms: 1_800_000_001_200,
+                        actual_timestamp_ms: 1_800_000_002_200,
+                    })
                 )
         ));
     }

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
-use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
+use base_common_chains::Upgrades;
 use base_common_consensus::{BaseBlock, BaseTransaction, Predeploys};
 use base_common_evm::BaseTime;
 use base_common_rpc_types_engine::{
@@ -15,7 +15,7 @@ use base_execution_payload_builder::{
     Attributes, BaseExecutionPayloadValidator, BasePayloadBuilderAttributes, BasePayloadTypes,
 };
 use base_protocol::BaseTimeUpdateTx;
-use reth_chainspec::{EthChainSpec, ForkCondition};
+use reth_chainspec::EthChainSpec;
 use reth_consensus::ConsensusError;
 use reth_node_api::{
     BuiltPayload, EngineApiValidator, EngineTypes, NodePrimitives, PayloadValidator,
@@ -154,7 +154,7 @@ where
             .map_err(ConsensusError::other)
     }
 
-    /// Verifies the `BaseTime` claim, committed state, and expected timestamp after block execution.
+    /// Verifies the `BaseTime` claim and committed state after block execution.
     pub fn validate_base_time_post_execution<DB>(
         &self,
         state_updates: &HashedPostState,
@@ -170,47 +170,7 @@ where
                 .map_err(ConsensusError::other)?;
         let claimed_millis_part = claimed_base_time.timestamp_millis_part();
 
-        // TODO: Validate against the parent timestamp once BasicEngineValidatorBuilder provides it.
-        let chain_id = self.chain_spec().chain().id();
-        let unavailable = |reason| {
-            ConsensusError::other(BaseConsensusError::BaseTimeTimestampUnavailable {
-                chain_id,
-                block_number: block.number(),
-                reason,
-            })
-        };
-        let config = ChainConfig::by_chain_id(chain_id)
-            .ok_or_else(|| unavailable("unknown chain configuration"))?;
-        let ForkCondition::Timestamp(activation_timestamp) =
-            self.chain_spec().upgrade_activation(BaseUpgrade::Zombie)
-        else {
-            return Err(unavailable("non-timestamp activation"));
-        };
-        let activation_offset = activation_timestamp
-            .checked_sub(config.genesis_l2_time)
-            .ok_or_else(|| unavailable("activation before genesis"))?;
-        if config.block_time == 0 {
-            return Err(unavailable("zero block time"));
-        }
-        if !activation_offset.is_multiple_of(config.block_time) {
-            return Err(unavailable("misaligned activation"));
-        }
-        let activation_block = activation_offset / config.block_time;
-        let elapsed_blocks = block
-            .number()
-            .checked_sub(activation_block)
-            .ok_or_else(|| unavailable("block before activation"))?;
-        let expected_timestamp_ms = u128::from(activation_timestamp) * 1_000
-            + u128::from(elapsed_blocks) * u128::from(BaseTimeUpdateTx::BLOCK_INTERVAL_MILLIS);
-        let actual_timestamp_ms =
-            u128::from(block.timestamp()) * 1_000 + u128::from(claimed_millis_part);
-        if actual_timestamp_ms != expected_timestamp_ms {
-            return Err(ConsensusError::other(BaseConsensusError::BaseTimeTimestampMismatch {
-                expected_timestamp_ms,
-                actual_timestamp_ms,
-            }));
-        }
-
+        // ponytail: compare full timestamps when Reth exposes the parent header to this hook.
         let read_parent_millis_part = || {
             parent_state
                 .storage(Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT.into())
@@ -303,8 +263,8 @@ where
             return Err(InvalidPayloadAttributesError::InvalidTimestamp);
         }
 
-        // The parent header does not contain its millisecond component. The exact 200ms slot is
-        // enforced against the hardfork schedule during post-execution validation.
+        // The parent header does not contain its millisecond component, so only whole-second
+        // ordering can be checked here.
         (timestamp >= header.timestamp())
             .then_some(())
             .ok_or(InvalidPayloadAttributesError::InvalidTimestamp)
@@ -493,7 +453,7 @@ mod tests {
     use crate::engine;
 
     const ZOMBIE_TIMESTAMP: u64 = 1_800_000_001;
-    const ZOMBIE_ACTIVATION_BLOCK: u64 = 56_605_327;
+    const BASE_TIME_BLOCK_NUMBER: u64 = 56_605_327;
 
     fn validator_with_chain_spec(
         chain_spec: BaseChainSpec,
@@ -877,38 +837,21 @@ mod tests {
         )
     }
 
-    fn validate_base_time_with(
-        validator: &BaseEngineValidator<NoopProvider, BaseTxEnvelope, BaseChainSpec>,
-        block_number: u64,
+    fn validate_base_time(
         parent_millis_part: u16,
-        child_timestamp: u64,
         claimed_millis_part: u16,
         committed_millis_part: Option<u16>,
         wiped: bool,
     ) -> Result<(), ConsensusError> {
-        validator.validate_base_time_post_execution(
+        zombie_validator().validate_base_time_post_execution(
             &state_updates(committed_millis_part, wiped),
             &parent_state(parent_millis_part),
-            &base_time_block(block_number, child_timestamp, claimed_millis_part, EMPTY_ROOT_HASH),
-        )
-    }
-
-    fn validate_base_time(
-        block_number: u64,
-        parent_millis_part: u16,
-        child_timestamp: u64,
-        claimed_millis_part: u16,
-        committed_millis_part: Option<u16>,
-        wiped: bool,
-    ) -> Result<(), ConsensusError> {
-        validate_base_time_with(
-            &zombie_validator(),
-            block_number,
-            parent_millis_part,
-            child_timestamp,
-            claimed_millis_part,
-            committed_millis_part,
-            wiped,
+            &base_time_block(
+                BASE_TIME_BLOCK_NUMBER,
+                ZOMBIE_TIMESTAMP,
+                claimed_millis_part,
+                EMPTY_ROOT_HASH,
+            ),
         )
     }
 
@@ -920,125 +863,13 @@ mod tests {
     }
 
     #[test]
-    fn base_time_post_execution_accepts_first_scheduled_slot_without_storage_update() {
-        validate_base_time(ZOMBIE_ACTIVATION_BLOCK, 0, ZOMBIE_TIMESTAMP, 0, None, false).unwrap();
-    }
-
-    #[test]
-    fn base_time_post_execution_accepts_scheduled_same_second_slot() {
-        validate_base_time(
-            ZOMBIE_ACTIVATION_BLOCK + 2,
-            200,
-            ZOMBIE_TIMESTAMP,
-            400,
-            Some(400),
-            false,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn base_time_post_execution_accepts_scheduled_second_boundary() {
-        validate_base_time(
-            ZOMBIE_ACTIVATION_BLOCK + 5,
-            800,
-            ZOMBIE_TIMESTAMP + 1,
-            0,
-            Some(0),
-            false,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn base_time_post_execution_rejects_millis_not_scheduled_for_block_number() {
-        let error = validate_base_time(
-            ZOMBIE_ACTIVATION_BLOCK + 2,
-            200,
-            ZOMBIE_TIMESTAMP,
-            600,
-            Some(600),
-            false,
-        )
-        .unwrap_err();
-        assert!(matches!(
-            base_consensus_error(&error),
-            Some(BaseConsensusError::BaseTimeTimestampMismatch {
-                expected_timestamp_ms: 1_800_000_001_400,
-                actual_timestamp_ms: 1_800_000_001_600,
-            })
-        ));
-    }
-
-    #[test]
-    fn base_time_post_execution_rejects_unknown_chain_config() {
-        let chain_spec = BaseChainSpecBuilder::base_mainnet()
-            .chain(Default::default())
-            .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP))
-            .build();
-        assert!(ChainConfig::by_chain_id(chain_spec.chain().id()).is_none());
-
-        let validator = validator_with_chain_spec(chain_spec);
-        let error = validate_base_time_with(
-            &validator,
-            ZOMBIE_ACTIVATION_BLOCK,
-            0,
-            ZOMBIE_TIMESTAMP,
-            0,
-            None,
-            false,
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            base_consensus_error(&error),
-            Some(BaseConsensusError::BaseTimeTimestampUnavailable {
-                block_number: ZOMBIE_ACTIVATION_BLOCK,
-                reason: "unknown chain configuration",
-                ..
-            })
-        ));
-    }
-
-    #[test]
-    fn base_time_post_execution_rejects_misaligned_zombie_activation() {
-        let validator = validator_with_chain_spec(
-            BaseChainSpecBuilder::base_mainnet()
-                .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP + 1))
-                .build(),
-        );
-        let error = validate_base_time_with(
-            &validator,
-            ZOMBIE_ACTIVATION_BLOCK,
-            0,
-            ZOMBIE_TIMESTAMP + 1,
-            0,
-            None,
-            false,
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            base_consensus_error(&error),
-            Some(BaseConsensusError::BaseTimeTimestampUnavailable {
-                chain_id: 8453,
-                block_number: ZOMBIE_ACTIVATION_BLOCK,
-                reason: "misaligned activation",
-            })
-        ));
+    fn base_time_post_execution_accepts_valid_commitment() {
+        validate_base_time(200, 600, Some(600), false).unwrap();
     }
 
     #[test]
     fn base_time_post_execution_rejects_claim_committed_mismatch() {
-        let error = validate_base_time(
-            ZOMBIE_ACTIVATION_BLOCK + 2,
-            200,
-            ZOMBIE_TIMESTAMP,
-            400,
-            Some(600),
-            false,
-        )
-        .unwrap_err();
+        let error = validate_base_time(200, 400, Some(600), false).unwrap_err();
         assert!(matches!(
             base_consensus_error(&error),
             Some(BaseConsensusError::BaseTimeClaimCommittedMismatch { claim: 400, committed: 600 })
@@ -1047,15 +878,7 @@ mod tests {
 
     #[test]
     fn base_time_post_execution_uses_parent_when_child_slot_is_absent() {
-        let error = validate_base_time(
-            ZOMBIE_ACTIVATION_BLOCK + 2,
-            200,
-            ZOMBIE_TIMESTAMP,
-            400,
-            None,
-            false,
-        )
-        .unwrap_err();
+        let error = validate_base_time(200, 400, None, false).unwrap_err();
         assert!(matches!(
             base_consensus_error(&error),
             Some(BaseConsensusError::BaseTimeClaimCommittedMismatch { claim: 400, committed: 200 })
@@ -1064,13 +887,12 @@ mod tests {
 
     #[test]
     fn base_time_post_execution_treats_wiped_storage_as_zero() {
-        validate_base_time(ZOMBIE_ACTIVATION_BLOCK + 5, 800, ZOMBIE_TIMESTAMP + 1, 0, None, true)
-            .unwrap();
+        validate_base_time(800, 0, None, true).unwrap();
     }
 
     #[test]
     fn generic_post_execution_validation_checks_isthmus_before_zombie() {
-        let block = base_time_block(ZOMBIE_ACTIVATION_BLOCK, ZOMBIE_TIMESTAMP, 0, EMPTY_ROOT_HASH);
+        let block = base_time_block(BASE_TIME_BLOCK_NUMBER, ZOMBIE_TIMESTAMP, 0, EMPTY_ROOT_HASH);
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
                 &zombie_validator(),
@@ -1086,8 +908,8 @@ mod tests {
     }
 
     #[test]
-    fn generic_post_execution_validation_accepts_derived_child_timestamp() {
-        let block = base_time_block(ZOMBIE_ACTIVATION_BLOCK + 1, ZOMBIE_TIMESTAMP, 200, B256::ZERO);
+    fn generic_post_execution_validation_accepts_valid_base_time_commitment() {
+        let block = base_time_block(BASE_TIME_BLOCK_NUMBER, ZOMBIE_TIMESTAMP + 1, 200, B256::ZERO);
 
         PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
             &zombie_validator(),
@@ -1095,26 +917,5 @@ mod tests {
             &block,
         )
         .unwrap();
-    }
-
-    #[test]
-    fn generic_post_execution_validation_rejects_inexact_derived_child_timestamp() {
-        let block =
-            base_time_block(ZOMBIE_ACTIVATION_BLOCK + 1, ZOMBIE_TIMESTAMP + 1, 200, B256::ZERO);
-        let error =
-            PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
-                &zombie_validator(),
-                &state_updates(Some(200), false),
-                &block,
-            )
-            .unwrap_err();
-
-        assert!(matches!(
-            base_consensus_error(&error),
-            Some(BaseConsensusError::BaseTimeTimestampMismatch {
-                expected_timestamp_ms: 1_800_000_001_200,
-                actual_timestamp_ms: 1_800_000_002_200,
-            })
-        ));
     }
 }

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -189,7 +189,7 @@ where
             .map_err(ConsensusError::other)
     }
 
-    /// Verifies the BaseTime claim, committed state, and block-to-block progression after block
+    /// Verifies the `BaseTime` claim, committed state, and block-to-block progression after block
     /// execution.
     pub fn validate_base_time_post_execution<DB>(
         &self,

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -20,7 +20,7 @@ pub use args::{
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)
 /// trait.
 pub mod engine;
-pub use engine::{BaseEngineTypes, BasePostExecutionValidator};
+pub use engine::BaseEngineTypes;
 
 pub mod node;
 pub use node::*;

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -10,7 +10,7 @@ use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, B64, B256, Bytes, bytes::BytesMut};
 use alloy_rlp::Encodable;
 use base_common_chains::Upgrades;
-use base_common_consensus::{BasePrimitives, BaseTxEnvelope};
+use base_common_consensus::{BasePrimitives, BaseTransaction, BaseTxEnvelope};
 use base_common_rpc_types_engine::{BasePayloadAttributes, ExecutionData};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_consensus::BaseBeaconConsensus;
@@ -1333,6 +1333,7 @@ where
     <<Node::Types as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes: Attributes<
         Transaction = <<Node::Types as NodeTypes>::Primitives as NodePrimitives>::SignedTx,
     >,
+    <<Node::Types as NodeTypes>::Primitives as NodePrimitives>::SignedTx: BaseTransaction,
 {
     type Validator = BaseEngineValidator<
         Node::Provider,

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -34,7 +34,6 @@ rstest.workspace = true
 chrono.workspace = true
 jsonrpsee = { workspace = true, features = ["http-client"] }
 metrics-util = { workspace = true, features = ["debugging"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 base-prover-service-protocol = { workspace = true, features = ["rpc-client"] }
 
 [lints]

--- a/crates/proof/succinct/utils/host/Cargo.toml
+++ b/crates/proof/succinct/utils/host/Cargo.toml
@@ -29,7 +29,6 @@ base-common-genesis.workspace = true
 base-optimism-rpc.workspace = true
 base-proof-host.workspace = true
 base-proof-preimage.workspace = true
-base-proof-rpc.workspace = true
 base-proof.workspace = true
 base-protocol = { workspace = true, features = ["serde"] }
 base-common-chains.workspace = true

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -105,7 +105,6 @@ base-common-consensus.workspace = true
 base-common-rpc-types-engine.workspace = true
 
 # proof
-base-proof-rpc.workspace = true
 base-optimism-rpc.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true


### PR DESCRIPTION
## Summary

After Zombie activation, this PR validates the canonical `BaseTime` metadata deposit during block import:

- requires the metadata deposit at `tx[1]`
- binds its source hash to the `BaseTime` domain and imported block number
- validates the depositor, `BaseTime` recipient, zero mint/value, gas limit, and non-system transaction semantics
- requires canonical setter calldata with a millisecond component in `0`, `200`, `400`, `600`, or `800`
- runs the check from both body/header and pre-execution consensus entry points

It also permits same-second child headers after Zombie activation while continuing to reject backwards whole-second timestamps, and simplifies construction and decoding of the canonical `BaseTime` deposit used by derivation.

## Scope

This PR intentionally does not enforce exact `+200 ms` block-to-block progression or compare the metadata claim with committed `BaseTime` storage. The current Reth validation interfaces do not expose the parent millisecond component needed for full timestamp ordering; claim-versus-state behavior will instead be covered by system testing.

Intended to merge after #3935, which introduces the millisecond payload-attribute plumbing and Engine API gating.