### PR TITLE
feat(precompiles): add foo V3 — demonstrate adding a new version

### DIFF
--- a/crates/common/precompiles/src/foo/dispatch.rs
+++ b/crates/common/precompiles/src/foo/dispatch.rs
@@ -120,6 +120,35 @@ mod tests {
     }
 
     #[test]
+    fn greet_greeting_changes_in_v3() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        let output = dispatch(&mut storage, &calldata, FooVersion::V3);
+
+        assert!(!output.is_revert());
+        assert_eq!(
+            IFoo::greetCall::abi_decode_returns(&output.bytes).unwrap(),
+            "Hey base, welcome to Base!"
+        );
+    }
+
+    #[test]
+    fn hello_world_is_unchanged_from_v2_in_v3() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata = IFoo::helloWorldCall {}.abi_encode();
+
+        let v2 = dispatch(&mut storage, &calldata, FooVersion::V2);
+        let v3 = dispatch(&mut storage, &calldata, FooVersion::V3);
+
+        assert_eq!(
+            IFoo::helloWorldCall::abi_decode_returns(&v2.bytes).unwrap(),
+            IFoo::helloWorldCall::abi_decode_returns(&v3.bytes).unwrap(),
+        );
+    }
+
+    #[test]
     fn dispatch_reverts_on_unknown_selector() {
         let mut storage = HashMapStorageProvider::new(1);
         let output = dispatch(&mut storage, &[0xde, 0xad, 0xbe, 0xef], FooVersion::V2);

--- a/crates/common/precompiles/src/foo/logic/mod.rs
+++ b/crates/common/precompiles/src/foo/logic/mod.rs
@@ -18,6 +18,9 @@ pub use v1::FooV1;
 mod v2;
 pub use v2::FooV2;
 
+mod v3;
+pub use v3::FooV3;
+
 /// Append-only business-logic interface shared by every `foo` version.
 pub trait FooLogic {
     /// Returns the greeting for `helloWorld()`.

--- a/crates/common/precompiles/src/foo/logic/v3.rs
+++ b/crates/common/precompiles/src/foo/logic/v3.rs
@@ -1,0 +1,34 @@
+//! Version 3 of the `foo` precompile logic, staged for the next hardfork.
+
+use alloc::{format, string::String};
+
+use alloy_primitives::Address;
+use base_precompile_storage::Result;
+
+use crate::{FooLogic, FooStorage, FooV2};
+
+/// Third `foo` implementation.
+///
+/// Shows both halves of the composition pattern in one version: `hello_world`
+/// is unchanged since V2, so it delegates to `self.previous` rather than copying
+/// the string; `greet` changes, so it is overridden here. V1 and V2 stay frozen.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV3 {
+    /// The immutable predecessor this version builds on.
+    pub previous: FooV2,
+}
+
+impl FooLogic for FooV3 {
+    fn hello_world(&self) -> String {
+        // Unchanged since V2: reuse the frozen implementation instead of
+        // duplicating it.
+        self.previous.hello_world()
+    }
+
+    fn greet(&self, storage: &mut FooStorage<'_>, caller: Address, name: String) -> Result<String> {
+        // Goal 1: changed behavior. V2 returned "Hello, {name}!".
+        let greeting = format!("Hey {name}, welcome to Base!");
+        storage.record_greeting(caller, &greeting)?;
+        Ok(greeting)
+    }
+}

--- a/crates/common/precompiles/src/foo/mod.rs
+++ b/crates/common/precompiles/src/foo/mod.rs
@@ -22,7 +22,7 @@ mod versions;
 pub use versions::{FooVersion, FooVersions};
 
 mod logic;
-pub use logic::{FooLogic, FooV1, FooV2};
+pub use logic::{FooLogic, FooV1, FooV2, FooV3};
 
 mod dispatch;
 

--- a/crates/common/precompiles/src/foo/versions.rs
+++ b/crates/common/precompiles/src/foo/versions.rs
@@ -8,7 +8,7 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{FooLogic, FooV1, FooV2};
+use crate::{FooLogic, FooV1, FooV2, FooV3};
 
 /// An activated version of the `foo` precompile logic.
 ///
@@ -19,6 +19,8 @@ pub enum FooVersion {
     V1,
     /// Introduced at Cobalt: changes `helloWorld` and adds `greet`.
     V2,
+    /// Staged for the next hardfork: changes `greet`, keeps `helloWorld`.
+    V3,
 }
 
 impl FooVersion {
@@ -32,9 +34,11 @@ impl FooVersion {
     pub fn logic(self) -> &'static dyn FooLogic {
         static FOO_V1: FooV1 = FooV1;
         static FOO_V2: FooV2 = FooV2 { previous: FooV1 };
+        static FOO_V3: FooV3 = FooV3 { previous: FooV2 { previous: FooV1 } };
         match self {
             Self::V1 => &FOO_V1,
             Self::V2 => &FOO_V2,
+            Self::V3 => &FOO_V3,
         }
     }
 }
@@ -51,7 +55,13 @@ impl FooVersions {
     /// Returns the version active at `upgrade`, or `None` before the
     /// introduction fork (Beryl), where `foo` is not installed at all.
     pub fn resolve(upgrade: BaseUpgrade) -> Option<FooVersion> {
-        if upgrade >= BaseUpgrade::Cobalt {
+        // V3 is staged behind the permanently-off `Zombie` gate: wired up and
+        // testable, but never selected on a live chain until this branch is
+        // repointed to a real, scheduled fork. This is the intended way to land
+        // a new version ahead of its activation without disturbing V1/V2.
+        if upgrade >= BaseUpgrade::Zombie {
+            Some(FooVersion::V3)
+        } else if upgrade >= BaseUpgrade::Cobalt {
             Some(FooVersion::V2)
         } else if upgrade >= BaseUpgrade::Beryl {
             Some(FooVersion::V1)
@@ -83,8 +93,15 @@ mod tests {
     }
 
     #[test]
+    fn resolves_v3_at_zombie_gate() {
+        assert_eq!(FooVersions::resolve(BaseUpgrade::Zombie), Some(FooVersion::V3));
+    }
+
+    #[test]
     fn logic_hello_world_matches_version() {
         assert_eq!(FooVersion::V1.logic().hello_world(), "Hello, World!");
         assert_eq!(FooVersion::V2.logic().hello_world(), "Hello, World! Welcome to Base.");
+        // V3 delegates `helloWorld` to V2, so the value is unchanged.
+        assert_eq!(FooVersion::V3.logic().hello_world(), "Hello, World! Welcome to Base.");
     }
 }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -85,4 +85,4 @@ mod nonce;
 pub use nonce::{INonceManager, NonceManager, NonceManagerStorage};
 
 mod foo;
-pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooVersion, FooVersions, IFoo};
+pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooV3, FooVersion, FooVersions, IFoo};


### PR DESCRIPTION
## Summary

Stacked on #3933. Demonstrates how a **new version** of the `foo` precompile is added under the execution-consensus versioning design — the whole selling point being that it's a small, additive change that leaves activated versions frozen.

## The entire diff to add a version

- **`logic/v3.rs`** (new) — `FooV3 { previous: FooV2 }`.
- **`versions.rs`** — one enum variant, one `logic()` match arm, one `resolve()` branch.
- **`logic/mod.rs` / `foo/mod.rs` / `lib.rs`** — re-exports.

**`logic/v1.rs` and `logic/v2.rs` have zero changes** — activated versions stay frozen, so historical replay is unaffected.

## What V3 shows

- **Composition / delegation:** `helloWorld` is unchanged since V2, so `FooV3` **delegates to `self.previous`** rather than copying the string — the half of the composition pattern V2 didn't get to exercise. A test asserts `V3.helloWorld == V2.helloWorld`.
- **Goal 1 (change existing logic):** `greet` is overridden to return `"Hey <name>, welcome to Base!"` (V2 returned `"Hello, <name>!"`).

## Activation

V3 is staged behind the permanently-off **`Zombie`** gate — Base's designated "not-yet-ready features" sentinel. It's wired up and unit-testable (`resolve(Zombie) == V3`), but never selected on a live chain (Zombie never activates; `LATEST` is `Azul`) until the branch is repointed to a real, scheduled fork. This mirrors the real workflow: land the version ahead of its fork without disturbing V1/V2.

## Test plan

- `cargo test -p base-common-precompiles foo` — 13 passed (adds V3 resolve, changed `greet`, delegated `helloWorld`)
- `cargo clippy -p base-common-precompiles --all-targets` — clean

Generated with Claude Code