### PR TITLE
feat(precompiles): add foo V3 as a standalone code copy

### DIFF
--- a/crates/common/precompiles/src/foo/dispatch.rs
+++ b/crates/common/precompiles/src/foo/dispatch.rs
@@ -120,6 +120,35 @@ mod tests {
     }
 
     #[test]
+    fn greet_greeting_changes_in_v3() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        let output = dispatch(&mut storage, &calldata, FooVersion::V3);
+
+        assert!(!output.is_revert());
+        assert_eq!(
+            IFoo::greetCall::abi_decode_returns(&output.bytes).unwrap(),
+            "Hey base, welcome to Base!"
+        );
+    }
+
+    #[test]
+    fn hello_world_is_unchanged_from_v2_in_v3() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata = IFoo::helloWorldCall {}.abi_encode();
+
+        let v2 = dispatch(&mut storage, &calldata, FooVersion::V2);
+        let v3 = dispatch(&mut storage, &calldata, FooVersion::V3);
+
+        assert_eq!(
+            IFoo::helloWorldCall::abi_decode_returns(&v2.bytes).unwrap(),
+            IFoo::helloWorldCall::abi_decode_returns(&v3.bytes).unwrap(),
+        );
+    }
+
+    #[test]
     fn dispatch_reverts_on_unknown_selector() {
         let mut storage = HashMapStorageProvider::new(1);
         let output = dispatch(&mut storage, &[0xde, 0xad, 0xbe, 0xef], FooVersion::V2);

--- a/crates/common/precompiles/src/foo/logic/mod.rs
+++ b/crates/common/precompiles/src/foo/logic/mod.rs
@@ -18,6 +18,9 @@ pub use v1::FooV1;
 mod v2;
 pub use v2::FooV2;
 
+mod v3;
+pub use v3::FooV3;
+
 /// Append-only business-logic interface shared by every `foo` version.
 pub trait FooLogic {
     /// Returns the greeting for `helloWorld()`.

--- a/crates/common/precompiles/src/foo/logic/v3.rs
+++ b/crates/common/precompiles/src/foo/logic/v3.rs
@@ -1,0 +1,35 @@
+//! Version 3 of the `foo` precompile logic, staged for the next hardfork.
+
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+
+use alloy_primitives::Address;
+use base_precompile_storage::Result;
+
+use crate::{FooLogic, FooStorage};
+
+/// Third `foo` implementation, written as a fully self-contained copy.
+///
+/// Rather than composing the previous version, it restates every method's
+/// behavior directly. This maximizes isolation — V3 shares no code with V1/V2
+/// and can never be affected by a change to them — at the cost of duplicating
+/// unchanged logic. Contrast with the composition style, where a version holds a
+/// `previous` and delegates unchanged methods to it.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV3;
+
+impl FooLogic for FooV3 {
+    fn hello_world(&self) -> String {
+        // Unchanged since V2, but copied verbatim rather than delegated.
+        "Hello, World! Welcome to Base.".to_string()
+    }
+
+    fn greet(&self, storage: &mut FooStorage<'_>, caller: Address, name: String) -> Result<String> {
+        // Goal 1: changed behavior. V2 returned "Hello, {name}!".
+        let greeting = format!("Hey {name}, welcome to Base!");
+        storage.record_greeting(caller, &greeting)?;
+        Ok(greeting)
+    }
+}

--- a/crates/common/precompiles/src/foo/mod.rs
+++ b/crates/common/precompiles/src/foo/mod.rs
@@ -22,7 +22,7 @@ mod versions;
 pub use versions::{FooVersion, FooVersions};
 
 mod logic;
-pub use logic::{FooLogic, FooV1, FooV2};
+pub use logic::{FooLogic, FooV1, FooV2, FooV3};
 
 mod dispatch;
 

--- a/crates/common/precompiles/src/foo/versions.rs
+++ b/crates/common/precompiles/src/foo/versions.rs
@@ -8,7 +8,7 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{FooLogic, FooV1, FooV2};
+use crate::{FooLogic, FooV1, FooV2, FooV3};
 
 /// An activated version of the `foo` precompile logic.
 ///
@@ -19,6 +19,8 @@ pub enum FooVersion {
     V1,
     /// Introduced at Cobalt: changes `helloWorld` and adds `greet`.
     V2,
+    /// Staged for the next hardfork: a self-contained copy that changes `greet`.
+    V3,
 }
 
 impl FooVersion {
@@ -32,9 +34,11 @@ impl FooVersion {
     pub fn logic(self) -> &'static dyn FooLogic {
         static FOO_V1: FooV1 = FooV1;
         static FOO_V2: FooV2 = FooV2 { previous: FooV1 };
+        static FOO_V3: FooV3 = FooV3;
         match self {
             Self::V1 => &FOO_V1,
             Self::V2 => &FOO_V2,
+            Self::V3 => &FOO_V3,
         }
     }
 }
@@ -51,7 +55,12 @@ impl FooVersions {
     /// Returns the version active at `upgrade`, or `None` before the
     /// introduction fork (Beryl), where `foo` is not installed at all.
     pub fn resolve(upgrade: BaseUpgrade) -> Option<FooVersion> {
-        if upgrade >= BaseUpgrade::Cobalt {
+        // V3 is staged behind the permanently-off `Zombie` gate: wired up and
+        // testable, but never selected on a live chain until this branch is
+        // repointed to a real, scheduled fork.
+        if upgrade >= BaseUpgrade::Zombie {
+            Some(FooVersion::V3)
+        } else if upgrade >= BaseUpgrade::Cobalt {
             Some(FooVersion::V2)
         } else if upgrade >= BaseUpgrade::Beryl {
             Some(FooVersion::V1)
@@ -83,8 +92,15 @@ mod tests {
     }
 
     #[test]
+    fn resolves_v3_at_zombie_gate() {
+        assert_eq!(FooVersions::resolve(BaseUpgrade::Zombie), Some(FooVersion::V3));
+    }
+
+    #[test]
     fn logic_hello_world_matches_version() {
         assert_eq!(FooVersion::V1.logic().hello_world(), "Hello, World!");
         assert_eq!(FooVersion::V2.logic().hello_world(), "Hello, World! Welcome to Base.");
+        // V3 copies V2's `helloWorld` value verbatim.
+        assert_eq!(FooVersion::V3.logic().hello_world(), "Hello, World! Welcome to Base.");
     }
 }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -85,4 +85,4 @@ mod nonce;
 pub use nonce::{INonceManager, NonceManager, NonceManagerStorage};
 
 mod foo;
-pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooVersion, FooVersions, IFoo};
+pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooV3, FooVersion, FooVersions, IFoo};


### PR DESCRIPTION
## Summary

Stacked on #3933. An **alternative** to #3939: adds `foo` V3, but written as a **fully self-contained code copy** rather than composing the previous version.

This exists to contrast the two versioning strategies:

| | #3939 (composition) | this PR (copy) |
|---|---|---|
| `FooV3` shape | `FooV3 { previous: FooV2 }` | unit struct `FooV3` |
| unchanged `helloWorld` | delegates to `self.previous` | restates the string verbatim |
| isolation | reuses frozen V2 code | shares no code with V1/V2 |
| duplication | none | duplicates unchanged logic |

The copy approach maximizes isolation — V3 can never be affected by a change to V1/V2 because it references neither — at the cost of duplicating the unchanged `helloWorld` body.

## Diff to add the version

- **`logic/v3.rs`** (new) — standalone `FooV3` (no `previous`).
- **`versions.rs`** — one variant, one `logic()` arm (`static FOO_V3: FooV3 = FooV3;`), one `resolve()` branch.
- re-exports.

**`logic/v1.rs` and `logic/v2.rs` are untouched** — activated versions stay frozen either way.

## Behavior

- `greet` → `"Hey <name>, welcome to Base!"` (Goal 1: changed from V2's `"Hello, <name>!"`).
- `helloWorld` → unchanged from V2 (a test asserts `V3 == V2`), but produced by a copied literal rather than delegation.

## Activation

Staged behind the permanently-off `Zombie` gate (`resolve(Zombie) == V3`); never selected on a live chain until repointed to a real fork.

## Test plan

- `cargo test -p base-common-precompiles foo` — 13 passed
- `cargo clippy -p base-common-precompiles --all-targets` — clean

Generated with Claude Code