### PR TITLE
feat(precompiles): add foo versioned reference precompile (copy-fork, minimal)

### DIFF
--- a/crates/common/precompiles/src/foo/abi.rs
+++ b/crates/common/precompiles/src/foo/abi.rs
@@ -1,0 +1,34 @@
+//! ABI definitions for the `foo` reference precompile.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// `foo` reference precompile ABI.
+    ///
+    /// The interface is append-only across versions: methods and errors are
+    /// added, never removed or repurposed, so historical calldata keeps
+    /// decoding the same way.
+    interface IFoo {
+        /// Precompile cannot be executed via delegatecall or callcode.
+        error DelegateCallNotAllowed();
+
+        /// The called method is not supported by the version active at this block.
+        ///
+        /// Returned for methods that had not yet been introduced at the target
+        /// hardfork, preserving their original pre-activation revert behavior.
+        error UnsupportedBeforeActivation();
+
+        /// Emitted when `greet` records a greeting for `caller`.
+        event Greeted(address indexed caller, string greeting);
+
+        /// Returns a fixed greeting. The value is version-specific and frozen
+        /// once its version is activated.
+        function helloWorld() external view returns (string);
+
+        /// Records and returns a personalized greeting for the caller.
+        ///
+        /// Introduced in a later version; reverts with
+        /// `UnsupportedBeforeActivation` before its activation fork.
+        function greet(string name) external returns (string);
+    }
+}

--- a/crates/common/precompiles/src/foo/dispatch.rs
+++ b/crates/common/precompiles/src/foo/dispatch.rs
@@ -1,0 +1,128 @@
+//! ABI dispatch for the `foo` reference precompile.
+//!
+//! The dispatcher is handed the active implementation (`&dyn FooLogic`) by the
+//! entry point. It decodes calldata and routes each selector to that
+//! implementation — there is no per-selector match on the version, so adding a
+//! version touches only [`FooVersions::resolve`](crate::FooVersions::resolve).
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use revm::precompile::PrecompileResult;
+
+use crate::{
+    FooLogic, FooStorage,
+    IFoo::{self, IFooCalls as C},
+    macros::decode_precompile_call,
+};
+
+/// Per-word calldata gas charge (`G_SHA3WORD`), matching other Base precompiles.
+const CALLDATA_WORD_GAS: u64 = 6;
+
+impl FooStorage<'_> {
+    /// ABI-dispatches `foo` calldata against the `version` active for this block.
+    pub fn dispatch(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        logic: &'static dyn FooLogic,
+    ) -> PrecompileResult {
+        let calldata_cost =
+            (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
+        if let Err(error) = ctx.deduct_gas(calldata_cost) {
+            return error.into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+        }
+        self.inner(ctx, calldata, logic).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            0,
+            |output| output,
+        )
+    }
+
+    fn inner(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        logic: &'static dyn FooLogic,
+    ) -> base_precompile_storage::Result<Bytes> {
+        // The active implementation is handed in; just route ABI calls to it.
+        match decode_precompile_call!(calldata, IFoo::IFooCalls) {
+            C::helloWorld(_) => {
+                Ok(IFoo::helloWorldCall::abi_encode_returns(&logic.hello_world()).into())
+            }
+            C::greet(call) => {
+                let greeting = logic.greet(self, ctx.caller(), call.name)?;
+                Ok(IFoo::greetCall::abi_encode_returns(&greeting).into())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{FooLogic, FooStorage, FooV1, FooV2, IFoo};
+
+    const CALLER: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn dispatch(
+        storage: &mut HashMapStorageProvider,
+        calldata: &[u8],
+        logic: &'static dyn FooLogic,
+    ) -> revm::precompile::PrecompileOutput {
+        StorageCtx::enter(storage, |ctx| FooStorage::new(ctx).dispatch(ctx, calldata, logic))
+            .expect("dispatch should not fail fatally")
+    }
+
+    #[test]
+    fn hello_world_differs_across_versions() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata = IFoo::helloWorldCall {}.abi_encode();
+
+        let v1 = dispatch(&mut storage, &calldata, &FooV1);
+        assert!(!v1.is_revert());
+        assert_eq!(IFoo::helloWorldCall::abi_decode_returns(&v1.bytes).unwrap(), "Hello, World!");
+
+        let v2 = dispatch(&mut storage, &calldata, &FooV2);
+        assert!(!v2.is_revert());
+        assert_eq!(
+            IFoo::helloWorldCall::abi_decode_returns(&v2.bytes).unwrap(),
+            "Hello, World! Welcome to Base."
+        );
+    }
+
+    #[test]
+    fn greet_is_unsupported_before_v2() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        let output = dispatch(&mut storage, &calldata, &FooV1);
+
+        assert!(output.is_revert(), "greet must revert before its activation version");
+    }
+
+    #[test]
+    fn greet_returns_personalized_greeting_from_v2() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        let output = dispatch(&mut storage, &calldata, &FooV2);
+
+        assert!(!output.is_revert());
+        assert_eq!(IFoo::greetCall::abi_decode_returns(&output.bytes).unwrap(), "Hello, base!");
+    }
+
+    #[test]
+    fn dispatch_reverts_on_unknown_selector() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let output = dispatch(&mut storage, &[0xde, 0xad, 0xbe, 0xef], &FooV2);
+
+        assert!(output.is_revert());
+    }
+}

--- a/crates/common/precompiles/src/foo/logic/mod.rs
+++ b/crates/common/precompiles/src/foo/logic/mod.rs
@@ -1,0 +1,48 @@
+//! Versioned business logic for the `foo` precompile.
+//!
+//! [`FooLogic`] is the append-only business-logic interface. Each version is a
+//! distinct type implementing it; once a version is activated at a hardfork it
+//! is frozen. New behavior is introduced by a new version that restates the
+//! logic it needs in full — a self-contained copy — leaving earlier versions
+//! untouched.
+
+use alloc::string::String;
+
+use alloy_primitives::Address;
+use base_precompile_storage::{BasePrecompileError, Result};
+
+use crate::{FooStorage, IFoo};
+
+mod v1;
+pub use v1::FooV1;
+
+mod v2;
+pub use v2::FooV2;
+
+/// Append-only business-logic interface shared by every `foo` version.
+///
+/// `Sync` is required so a `&'static dyn FooLogic` can be captured by the
+/// (thread-safe) precompile closure; the zero-sized version types satisfy it
+/// trivially.
+pub trait FooLogic: Sync {
+    /// Returns the greeting for `helloWorld()`.
+    ///
+    /// Goal 1 (changes to existing logic): the returned value differs between
+    /// versions, and each version's value is frozen once activated.
+    fn hello_world(&self) -> String;
+
+    /// Handles `greet(name)`, returning a personalized greeting.
+    ///
+    /// Goal 3 (new methods): `greet` is appended in a later version. The
+    /// default implementation reproduces the pre-activation behavior — a revert
+    /// with [`IFoo::UnsupportedBeforeActivation`] — so versions that predate the
+    /// method stay unchanged.
+    fn greet(
+        &self,
+        _storage: &mut FooStorage<'_>,
+        _caller: Address,
+        _name: String,
+    ) -> Result<String> {
+        Err(BasePrecompileError::revert(IFoo::UnsupportedBeforeActivation {}))
+    }
+}

--- a/crates/common/precompiles/src/foo/logic/v1.rs
+++ b/crates/common/precompiles/src/foo/logic/v1.rs
@@ -1,0 +1,18 @@
+//! Version 1 of the `foo` precompile logic, activated at Beryl.
+
+use alloc::string::{String, ToString};
+
+use crate::FooLogic;
+
+/// First `foo` implementation. Frozen as of its activation at Beryl.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV1;
+
+impl FooLogic for FooV1 {
+    fn hello_world(&self) -> String {
+        "Hello, World!".to_string()
+    }
+
+    // `greet` did not exist in V1: it uses the default `FooLogic::greet`, which
+    // reverts as unsupported. Do not add it here — V1 is frozen.
+}

--- a/crates/common/precompiles/src/foo/logic/v2.rs
+++ b/crates/common/precompiles/src/foo/logic/v2.rs
@@ -1,0 +1,33 @@
+//! Version 2 of the `foo` precompile logic, activated at Cobalt.
+
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+
+use alloy_primitives::Address;
+use base_precompile_storage::Result;
+
+use crate::{FooLogic, FooStorage};
+
+/// Second `foo` implementation, activated at Cobalt.
+///
+/// A self-contained copy: it does not reference [`FooV1`](crate::FooV1).
+/// Changed behavior (`hello_world`) and new behavior (`greet`) are written out
+/// in full here, so this file alone describes V2. V1 stays frozen.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV2;
+
+impl FooLogic for FooV2 {
+    fn hello_world(&self) -> String {
+        // Goal 1: changed behavior. V1 returned "Hello, World!".
+        "Hello, World! Welcome to Base.".to_string()
+    }
+
+    fn greet(&self, storage: &mut FooStorage<'_>, caller: Address, name: String) -> Result<String> {
+        // Goal 3: new method, reachable only from Cobalt onward.
+        let greeting = format!("Hello, {name}!");
+        storage.record_greeting(caller, &greeting)?;
+        Ok(greeting)
+    }
+}

--- a/crates/common/precompiles/src/foo/mod.rs
+++ b/crates/common/precompiles/src/foo/mod.rs
@@ -1,0 +1,35 @@
+//! Reference precompile demonstrating hardfork-versioned execution logic.
+//!
+//! `foo` is a minimal, self-contained example of the execution-consensus
+//! versioning design. Business logic is split into immutable, fork-activated
+//! versions ([`FooV1`], [`FooV2`]) that are selected by a central version
+//! manager ([`FooVersions`]) and routed by an append-only dispatcher.
+//!
+//! Each version is a **self-contained copy**: when behavior changes, the new
+//! version restates the logic it needs in full rather than referencing its
+//! predecessor. Activated versions stay frozen, so historical replay is
+//! unaffected.
+//!
+//! - [`abi`](self) defines the append-only external interface [`IFoo`].
+//! - [`storage`](self) holds append-only state ([`FooStorage`]).
+//! - [`versions`](self) resolves the version active at a hardfork.
+//! - [`logic`](self) contains the frozen per-version implementations.
+//! - [`dispatch`](self) decodes calldata and routes to the active version.
+//! - [`precompile`](self) is the installable entry point [`Foo`].
+
+mod abi;
+pub use abi::IFoo;
+
+mod storage;
+pub use storage::FooStorage;
+
+mod versions;
+pub use versions::FooVersions;
+
+mod logic;
+pub use logic::{FooLogic, FooV1, FooV2};
+
+mod dispatch;
+
+mod precompile;
+pub use precompile::Foo;

--- a/crates/common/precompiles/src/foo/precompile.rs
+++ b/crates/common/precompiles/src/foo/precompile.rs
@@ -1,0 +1,60 @@
+//! Precompile entry point for the `foo` reference precompile.
+
+use alloy_evm::precompiles::PrecompilesMap;
+use base_common_genesis::BaseUpgrade;
+use base_precompile_macros::precompile;
+
+use crate::{FooLogic, FooStorage, FooVersions};
+
+/// Entry point for the `foo` reference precompile.
+///
+/// The `#[precompile]` macro generates `precompile(logic)`, which threads the
+/// active implementation into [`FooStorage::dispatch`]. Fork→implementation
+/// selection is owned here (via [`FooVersions`]); the dispatcher just calls the
+/// implementation it is handed. All version routing therefore stays inside the
+/// `foo` module.
+#[precompile(args(logic: &'static dyn FooLogic))]
+#[derive(Debug, Clone, Copy)]
+pub struct Foo;
+
+impl Foo {
+    /// Installs `foo` for `upgrade`, resolving the active version via
+    /// [`FooVersions`]. A no-op before the introduction fork (Beryl), where the
+    /// precompile does not exist.
+    pub fn install(precompiles: &mut PrecompilesMap, upgrade: BaseUpgrade) {
+        let Some(logic) = FooVersions::resolve(upgrade) else {
+            return;
+        };
+        precompiles.extend_precompiles(core::iter::once((
+            FooStorage::ADDRESS,
+            Self::precompile(logic),
+        )));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::precompiles::PrecompilesMap;
+    use base_common_genesis::BaseUpgrade;
+    use revm::precompile::Precompiles;
+
+    use crate::{Foo, FooStorage};
+
+    #[test]
+    fn install_registers_precompile_from_beryl() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+
+        Foo::install(&mut precompiles, BaseUpgrade::Beryl);
+
+        assert!(precompiles.get(&FooStorage::ADDRESS).is_some());
+    }
+
+    #[test]
+    fn install_is_noop_before_beryl() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+
+        Foo::install(&mut precompiles, BaseUpgrade::Azul);
+
+        assert!(precompiles.get(&FooStorage::ADDRESS).is_none());
+    }
+}

--- a/crates/common/precompiles/src/foo/storage.rs
+++ b/crates/common/precompiles/src/foo/storage.rs
@@ -1,0 +1,45 @@
+//! Storage layout for the `foo` reference precompile.
+
+use alloy_primitives::{Address, address};
+use base_precompile_macros::contract;
+use base_precompile_storage::{Handler, Mapping, Result};
+
+use crate::IFoo;
+
+/// Persistent state for the `foo` precompile.
+///
+/// State evolves append-only across versions (execution-consensus Goal 2): new
+/// fields may be added, but existing fields keep their slot and meaning so
+/// historical replay reads the same values.
+#[contract(addr = Self::ADDRESS)]
+#[namespace("base.foo")]
+pub struct FooStorage {
+    /// Number of times each caller has invoked `greet`.
+    pub greet_count: Mapping<Address, u64>,
+}
+
+impl FooStorage<'_> {
+    /// `foo` reference precompile address.
+    pub const ADDRESS: Address = address!("f00f000000000000000000000000000000000000");
+
+    /// Records a `greet` invocation: bumps the caller's counter and emits
+    /// [`IFoo::Greeted`].
+    ///
+    /// This is the shared storage primitive reused by every version that
+    /// supports `greet`; the version-specific behavior (the greeting text, and
+    /// whether `greet` exists at all) lives in [`crate::logic`].
+    pub fn record_greeting(&mut self, caller: Address, greeting: &str) -> Result<()> {
+        // The counter bump and its Greeted event must commit together; guard
+        // them with a checkpoint so a failure after the write reverts the
+        // advanced counter rather than leaving it advanced without a log.
+        let checkpoint = self.storage.checkpoint();
+
+        self.__initialize()?;
+        let count = self.greet_count.at(&caller).read()?;
+        self.greet_count.at_mut(&caller).write(count.saturating_add(1))?;
+        self.emit_event(IFoo::Greeted { caller, greeting: greeting.into() })?;
+
+        checkpoint.commit();
+        Ok(())
+    }
+}

--- a/crates/common/precompiles/src/foo/versions.rs
+++ b/crates/common/precompiles/src/foo/versions.rs
@@ -1,0 +1,58 @@
+//! Central version manager for the `foo` precompile.
+//!
+//! [`FooVersions::resolve`] is the single seam that maps a hardfork to the
+//! immutable implementation active at that fork. Each version is a distinct,
+//! self-contained type; nothing else in the module matches on "which version".
+
+use base_common_genesis::BaseUpgrade;
+
+use crate::{FooLogic, FooV1, FooV2};
+
+/// Resolver that selects the `foo` implementation active at a given hardfork.
+///
+/// Centralizing fork routing here keeps hardfork logic auditable and off the
+/// execution path: the implementation is resolved once at install time, not on
+/// every call. The versions are zero-sized, so the returned reference is a
+/// pointer hand-back, not an allocation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooVersions;
+
+impl FooVersions {
+    /// Returns the implementation active at `upgrade`, or `None` before the
+    /// introduction fork (Beryl), where `foo` is not installed at all.
+    pub fn resolve(upgrade: BaseUpgrade) -> Option<&'static dyn FooLogic> {
+        if upgrade >= BaseUpgrade::Cobalt {
+            Some(&FooV2)
+        } else if upgrade >= BaseUpgrade::Beryl {
+            Some(&FooV1)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::BaseUpgrade;
+
+    use crate::FooVersions;
+
+    #[test]
+    fn resolves_none_before_beryl() {
+        assert!(FooVersions::resolve(BaseUpgrade::Azul).is_none());
+    }
+
+    #[test]
+    fn resolves_v1_from_beryl() {
+        // `hello_world` fingerprints the active version.
+        assert_eq!(FooVersions::resolve(BaseUpgrade::Beryl).unwrap().hello_world(), "Hello, World!");
+    }
+
+    #[test]
+    fn resolves_v2_from_cobalt() {
+        assert_eq!(
+            FooVersions::resolve(BaseUpgrade::Cobalt).unwrap().hello_world(),
+            "Hello, World! Welcome to Base."
+        );
+    }
+}

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -83,3 +83,6 @@ pub use tx_context::{ITransactionContext, TxContext, TxContextStorage};
 
 mod nonce;
 pub use nonce::{INonceManager, NonceManager, NonceManagerStorage};
+
+mod foo;
+pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooVersions, IFoo};

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -15,7 +15,7 @@ use revm::{
 
 use crate::{
     ActivationAdminConfig, ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup,
-    NonceManager, NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver,
+    Foo, NonceManager, NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver,
     TxContext, bls12_381, bn254_pair,
 };
 
@@ -220,6 +220,10 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             TxContext::install(&mut precompiles);
             NonceManager::install(&mut precompiles);
         }
+        // The `foo` reference precompile self-gates by fork: `Foo::install`
+        // resolves the active version (absent before Beryl, V1 from Beryl, V2
+        // from Cobalt) and binds its implementation.
+        Foo::install(&mut precompiles, self.spec.upgrade());
         precompiles
     }
 }


### PR DESCRIPTION
type=routine
risk=low
impact=sev5

## Summary

Copy-fork counterpart to #3933, using the **most minimal abstraction that still keeps each version self-contained**. Same `foo` precompile, same append-only ABI/storage/dispatch, but:

- Each version is a **self-contained** type (`FooV1`, `FooV2`) — no `previous` composition.
- The **`FooVersion` enum and the `FooVersion::logic()` gate are gone**. A single seam maps fork → implementation:

```rust
impl FooVersions {
    pub fn resolve(upgrade: BaseUpgrade) -> Option<&'static dyn FooLogic> {
        if upgrade >= BaseUpgrade::Cobalt { Some(&FooV2) }
        else if upgrade >= BaseUpgrade::Beryl { Some(&FooV1) }
        else { None }
    }
}
```

## Abstractions kept vs cut

- **Kept:** the `FooLogic` trait (the one interface that lets the dispatcher stay version-agnostic and keeps each version a whole unit) and self-contained per-version structs.
- **Cut:** the `FooVersion` enum and the separate `logic()` method — `resolve` returns the `&'static dyn FooLogic` directly. Versions are zero-sized, so that reference is a static vtable pointer, not an allocation.
- `FooLogic` gains a `Sync` supertrait so the resolved `&'static dyn FooLogic` can be captured by the (thread-safe) precompile closure; the ZST versions satisfy it trivially.

## Trade-off vs #3933

- Versions are fully independent (no runtime link between them); each file fully describes its version.
- One consequence of dropping the enum: version *identity* is no longer a comparable value, so tests assert behavior (`resolve(Cobalt).hello_world() == "…"`) rather than `== Some(V2)`.

## Activation

Installed from Beryl (V1) and Cobalt (V2), self-gated in `Foo::install` via `FooVersions::resolve`. No-op before Beryl.

## Test plan

- \`cargo test -p base-common-precompiles foo\` — 9 passed
- \`cargo clippy -p base-common-precompiles --all-targets\` — clean