### PR TITLE
feat(precompiles): add foo V3 — demonstrate adding a new version (copy-fork, minimal)

### DIFF
--- a/crates/common/precompiles/src/foo/dispatch.rs
+++ b/crates/common/precompiles/src/foo/dispatch.rs
@@ -65,7 +65,7 @@ mod tests {
     use alloy_sol_types::SolCall;
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
-    use crate::{FooLogic, FooStorage, FooV1, FooV2, IFoo};
+    use crate::{FooLogic, FooStorage, FooV1, FooV2, FooV3, IFoo};
 
     const CALLER: Address = address!("0x1111111111111111111111111111111111111111");
 
@@ -116,6 +116,35 @@ mod tests {
 
         assert!(!output.is_revert());
         assert_eq!(IFoo::greetCall::abi_decode_returns(&output.bytes).unwrap(), "Hello, base!");
+    }
+
+    #[test]
+    fn greet_greeting_changes_in_v3() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        let output = dispatch(&mut storage, &calldata, &FooV3);
+
+        assert!(!output.is_revert());
+        assert_eq!(
+            IFoo::greetCall::abi_decode_returns(&output.bytes).unwrap(),
+            "Hey base, welcome to Base!"
+        );
+    }
+
+    #[test]
+    fn hello_world_is_unchanged_from_v2_in_v3() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata = IFoo::helloWorldCall {}.abi_encode();
+
+        let v2 = dispatch(&mut storage, &calldata, &FooV2);
+        let v3 = dispatch(&mut storage, &calldata, &FooV3);
+
+        assert_eq!(
+            IFoo::helloWorldCall::abi_decode_returns(&v2.bytes).unwrap(),
+            IFoo::helloWorldCall::abi_decode_returns(&v3.bytes).unwrap(),
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/foo/logic/mod.rs
+++ b/crates/common/precompiles/src/foo/logic/mod.rs
@@ -19,6 +19,9 @@ pub use v1::FooV1;
 mod v2;
 pub use v2::FooV2;
 
+mod v3;
+pub use v3::FooV3;
+
 /// Append-only business-logic interface shared by every `foo` version.
 ///
 /// `Sync` is required so a `&'static dyn FooLogic` can be captured by the

--- a/crates/common/precompiles/src/foo/logic/v3.rs
+++ b/crates/common/precompiles/src/foo/logic/v3.rs
@@ -1,0 +1,34 @@
+//! Version 3 of the `foo` precompile logic, staged for the next hardfork.
+
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+
+use alloy_primitives::Address;
+use base_precompile_storage::Result;
+
+use crate::{FooLogic, FooStorage};
+
+/// Third `foo` implementation.
+///
+/// A self-contained copy: `hello_world` is unchanged since V2, so its value is
+/// copied here verbatim rather than delegated to a predecessor; `greet`
+/// changes, so it is rewritten. V1 and V2 stay frozen.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV3;
+
+impl FooLogic for FooV3 {
+    fn hello_world(&self) -> String {
+        // Unchanged since V2: the literal is copied forward (copy-fork), so V2
+        // stays frozen and V3 has no runtime dependency on it.
+        "Hello, World! Welcome to Base.".to_string()
+    }
+
+    fn greet(&self, storage: &mut FooStorage<'_>, caller: Address, name: String) -> Result<String> {
+        // Goal 1: changed behavior. V2 returned "Hello, {name}!".
+        let greeting = format!("Hey {name}, welcome to Base!");
+        storage.record_greeting(caller, &greeting)?;
+        Ok(greeting)
+    }
+}

--- a/crates/common/precompiles/src/foo/mod.rs
+++ b/crates/common/precompiles/src/foo/mod.rs
@@ -27,7 +27,7 @@ mod versions;
 pub use versions::FooVersions;
 
 mod logic;
-pub use logic::{FooLogic, FooV1, FooV2};
+pub use logic::{FooLogic, FooV1, FooV2, FooV3};
 
 mod dispatch;
 

--- a/crates/common/precompiles/src/foo/versions.rs
+++ b/crates/common/precompiles/src/foo/versions.rs
@@ -6,7 +6,7 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{FooLogic, FooV1, FooV2};
+use crate::{FooLogic, FooV1, FooV2, FooV3};
 
 /// Resolver that selects the `foo` implementation active at a given hardfork.
 ///
@@ -21,7 +21,13 @@ impl FooVersions {
     /// Returns the implementation active at `upgrade`, or `None` before the
     /// introduction fork (Beryl), where `foo` is not installed at all.
     pub fn resolve(upgrade: BaseUpgrade) -> Option<&'static dyn FooLogic> {
-        if upgrade >= BaseUpgrade::Cobalt {
+        // V3 is staged behind the permanently-off `Zombie` gate: wired up and
+        // testable, but never selected on a live chain until this branch is
+        // repointed to a real, scheduled fork. This is the intended way to land
+        // a new version ahead of its activation without disturbing V1/V2.
+        if upgrade >= BaseUpgrade::Zombie {
+            Some(&FooV3)
+        } else if upgrade >= BaseUpgrade::Cobalt {
             Some(&FooV2)
         } else if upgrade >= BaseUpgrade::Beryl {
             Some(&FooV1)
@@ -52,6 +58,16 @@ mod tests {
     fn resolves_v2_from_cobalt() {
         assert_eq!(
             FooVersions::resolve(BaseUpgrade::Cobalt).unwrap().hello_world(),
+            "Hello, World! Welcome to Base."
+        );
+    }
+
+    #[test]
+    fn resolves_v3_at_zombie_gate() {
+        // V3 keeps V2's `hello_world`; the `greet` change is covered in the
+        // dispatch tests (a resolved `&dyn FooLogic` has no comparable identity).
+        assert_eq!(
+            FooVersions::resolve(BaseUpgrade::Zombie).unwrap().hello_world(),
             "Hello, World! Welcome to Base."
         );
     }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -85,4 +85,4 @@ mod nonce;
 pub use nonce::{INonceManager, NonceManager, NonceManagerStorage};
 
 mod foo;
-pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooVersions, IFoo};
+pub use foo::{Foo, FooLogic, FooStorage, FooV1, FooV2, FooV3, FooVersions, IFoo};


### PR DESCRIPTION
type=routine
risk=low
impact=sev5

## Summary

Stacked on #3941. Copy-fork counterpart to #3939, in the minimal-abstraction style: adds a **new self-contained version** with no `previous` link, no `FooVersion` enum, and no per-version dispatch match.

## The entire diff to add a version

- **`logic/v3.rs`** (new) — `FooV3` (plain unit struct implementing `FooLogic`).
- **`versions.rs`** — **one `resolve()` branch** (`if upgrade >= Zombie { Some(&FooV3) }`) plus the import. That's the whole routing change.
- **`logic/mod.rs` / `foo/mod.rs` / `lib.rs`** — re-exports.

**`logic/v1.rs` and `logic/v2.rs` have zero changes** — activated versions stay frozen.

Because the enum and `logic()` gate were removed in #3941, adding a version here does **not** touch a version enum, a `logic()` static table, or any per-method match. Contrast #3939 (composition), where the equivalent change also adds an enum variant and a `logic()` arm.

## Copy-fork vs composition (#3939)

- `hello_world` is unchanged since V2. Composition delegates (`self.previous.hello_world()`); here V3 **copies the literal**, so it has no runtime dependency on V2.
- Goal 1 (change existing logic): `greet` returns `"Hey <name>, welcome to Base!"` — same in both.

## Activation

V3 is staged behind the permanently-off **`Zombie`** gate: testable (`resolve(Zombie)` returns V3's impl), never selected on a live chain until repointed to a real fork.

## Test plan

- \`cargo test -p base-common-precompiles foo\` — 12 passed
- \`cargo clippy -p base-common-precompiles --all-targets\` — clean