### PR TITLE
ci: add code coverage (cargo-llvm-cov + Codecov, report-only)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,8 +11,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,120 @@
+name: Coverage
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit + Integration Coverage
+    runs-on:
+      group: BasePerfRunnerGroup
+    timeout-minutes: 60
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          components: llvm-tools-preview
+          tools: cargo-nextest,cargo-llvm-cov
+          rust-cache-shared-key: "stable"
+      - name: Collect unit coverage
+        run: just cov::unit
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/unit.lcov
+          flags: unit
+          fail_ci_if_error: false
+          disable_search: true
+
+  action:
+    name: Action Test Coverage
+    runs-on:
+      group: BasePerfRunnerGroup
+    timeout-minutes: 60
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          components: llvm-tools-preview
+          tools: cargo-nextest,cargo-llvm-cov
+          rust-cache-shared-key: "stable"
+      - name: Collect action-test coverage
+        run: just cov::action
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/action.lcov
+          flags: action
+          fail_ci_if_error: false
+          disable_search: true
+
+  system:
+    name: System Test Coverage
+    runs-on:
+      group: BasePerfRunnerGroup
+    timeout-minutes: 90
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          sp1: "true"
+          components: llvm-tools-preview
+          tools: cargo-nextest,cargo-llvm-cov
+          rust-cache-shared-key: "stable"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - name: Pull system-test images
+        run: just devnet pull-images
+      - name: Collect system-test coverage
+        run: just cov::system
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/system.lcov
+          flags: system
+          fail_ci_if_error: false
+          disable_search: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,13 +36,14 @@ jobs:
           free-disk: "true"
           native-deps: "true"
           foundry: "true"
+          sp1: "true"
           components: llvm-tools-preview
           tools: cargo-nextest,cargo-llvm-cov
           rust-cache-shared-key: "stable"
       - name: Collect unit coverage
         run: just cov::unit
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/coverage/unit.lcov
@@ -74,7 +75,7 @@ jobs:
       - name: Collect action-test coverage
         run: just cov::action
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/coverage/action.lcov
@@ -111,7 +112,7 @@ jobs:
       - name: Collect system-test coverage
         run: just cov::system
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/coverage/system.lcov

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,8 @@ mod build 'etc/just/build.just'
 mod succinct 'etc/just/succinct.just'
 # Prover-service JSON-RPC request helpers
 mod zk-prover 'etc/just/zk-prover.just'
+# Code coverage collection via cargo-llvm-cov
+mod cov 'etc/just/coverage.just'
 
 alias t := test
 alias f := fix

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,59 @@
+# Codecov configuration.
+#
+# Coverage is informational only: no status check ever fails a PR. Reports are
+# uploaded from the coverage workflow (.github/workflows/coverage.yml) under
+# three flags matching the `just cov` tiers.
+
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...90"
+  status:
+    project:
+      default:
+        informational: true
+        target: auto
+    patch:
+      default:
+        informational: true
+        target: auto
+
+github_checks:
+  annotations: false
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        informational: true
+      - type: patch
+        informational: true
+  individual_flags:
+    - name: unit
+      paths:
+        - "crates/"
+    - name: action
+      paths:
+        - "actions/"
+        - "crates/"
+    - name: system
+      paths:
+        - "etc/systems/"
+        - "crates/"
+
+ignore:
+  - "**/tests/**"
+  - "**/benches/**"
+  - "**/build.rs"
+  - "**/*.md"
+  - "etc/docker/**"
+  - "etc/scripts/**"

--- a/etc/just/coverage.just
+++ b/etc/just/coverage.just
@@ -1,0 +1,61 @@
+# Code coverage collection via cargo-llvm-cov.
+#
+# Coverage is gathered on the host for three test tiers, each emitting its own
+# lcov file so they can be uploaded to Codecov under distinct flags:
+#   - unit:   workspace unit + integration tests (excludes system tests)
+#   - action: the base-action-harness action tests
+#   - system: the Docker-backed system tests (base-system-tests)
+#
+# The L2 `base` node runs in-process inside the system-test binary (see
+# etc/systems/src/l2/stack.rs), so host-side instrumentation captures node
+# coverage directly. Only third-party L1 containers (reth/lighthouse) run in
+# Docker, and those are not instrumented.
+
+set working-directory := '../..'
+
+# Show coverage commands
+default:
+    @just --justfile {{ source_file() }} --list --list-prefix '  cov::'
+
+# Installs cargo-llvm-cov if not present
+[private]
+_install-llvm-cov:
+    @command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install cargo-llvm-cov --locked
+
+# Installs cargo-nextest if not present
+[private]
+_install-nextest:
+    @command -v cargo-nextest >/dev/null 2>&1 || cargo install cargo-nextest --locked
+
+# Builds the test contracts required by the test suites
+[private]
+_build-contracts:
+    cd crates/utilities/test-utils/contracts && forge soldeer install && forge build
+
+# Removes previously collected coverage artifacts
+clean:
+    cargo llvm-cov clean --workspace
+    rm -rf target/coverage
+
+# Collects coverage for workspace unit + integration tests (excludes system tests)
+unit *args: _install-llvm-cov _install-nextest _build-contracts
+    mkdir -p target/coverage
+    cargo llvm-cov nextest --workspace --all-features --exclude base-system-tests --lcov --output-path target/coverage/unit.lcov {{ args }}
+
+# Collects coverage for the action-test harness (base-action-harness)
+action *args: _install-llvm-cov _install-nextest _build-contracts
+    mkdir -p target/coverage
+    cargo llvm-cov nextest -p base-action-harness --lcov --output-path target/coverage/action.lcov {{ args }}
+
+# Collects coverage for the Docker-backed system tests (needs `just devnet pull-images`)
+system *args: _install-llvm-cov _install-nextest _build-contracts
+    mkdir -p target/coverage
+    cargo llvm-cov nextest -p base-system-tests --lcov --output-path target/coverage/system.lcov {{ args }}
+
+# Collects coverage for all three tiers
+all: unit action system
+
+# Generates a local HTML report for the workspace (excludes system tests)
+html: _install-llvm-cov _install-nextest _build-contracts
+    cargo llvm-cov nextest --workspace --all-features --exclude base-system-tests --html
+    @echo "Open target/llvm-cov/html/index.html"

--- a/etc/just/coverage.just
+++ b/etc/just/coverage.just
@@ -40,22 +40,22 @@ clean:
 # Collects coverage for workspace unit + integration tests (excludes system tests)
 unit *args: _install-llvm-cov _install-nextest _build-contracts
     mkdir -p target/coverage
-    cargo llvm-cov nextest --workspace --all-features --exclude base-system-tests --lcov --output-path target/coverage/unit.lcov {{ args }}
+    cargo llvm-cov nextest --locked --workspace --all-features --exclude base-system-tests --lcov --output-path target/coverage/unit.lcov {{ args }}
 
 # Collects coverage for the action-test harness (base-action-harness)
 action *args: _install-llvm-cov _install-nextest _build-contracts
     mkdir -p target/coverage
-    cargo llvm-cov nextest -p base-action-harness --lcov --output-path target/coverage/action.lcov {{ args }}
+    cargo llvm-cov nextest --locked -p base-action-harness --lcov --output-path target/coverage/action.lcov {{ args }}
 
 # Collects coverage for the Docker-backed system tests (needs `just devnet pull-images`)
 system *args: _install-llvm-cov _install-nextest _build-contracts
     mkdir -p target/coverage
-    cargo llvm-cov nextest -p base-system-tests --lcov --output-path target/coverage/system.lcov {{ args }}
+    cargo llvm-cov nextest --locked -p base-system-tests --lcov --output-path target/coverage/system.lcov {{ args }}
 
 # Collects coverage for all three tiers
 all: unit action system
 
 # Generates a local HTML report for the workspace (excludes system tests)
 html: _install-llvm-cov _install-nextest _build-contracts
-    cargo llvm-cov nextest --workspace --all-features --exclude base-system-tests --html
+    cargo llvm-cov nextest --locked --workspace --all-features --exclude base-system-tests --html
     @echo "Open target/llvm-cov/html/index.html"


### PR DESCRIPTION
## What

Adds host-side code-coverage collection via `cargo-llvm-cov`, uploaded to
Codecov as **report-only** (informational; never fails a PR).

Coverage is split into three tiers, each producing its own lcov file and a
distinct Codecov flag:

| Flag | Recipe | Scope |
|------|--------|-------|
| `unit` | `just cov::unit` | workspace unit + integration tests (excludes system tests) |
| `action` | `just cov::action` | `base-action-harness` action tests |
| `system` | `just cov::system` | `base-system-tests` Docker-backed system tests |

## Why host-side (and not an instrumented container)?

The L2 `base` node runs **in-process** inside the `base-system-tests` binary
(`etc/systems/src/l2/stack.rs`): `InProcessBuilder`, `InProcessConsensus`,
`InProcessBatcher`, `InProcessClient`, `InProcessFollowConsensus`. The only
Docker containers system tests launch are third-party L1 nodes (reth,
lighthouse), the shell-based `system-test-setup:local`, and `op-deployer` —
none of which contain our code.

Therefore a custom instrumented `base:local` image would capture nothing of
ours. Running `cargo llvm-cov nextest -p base-system-tests` on the host
instruments and captures the in-process node directly. No Dockerfile/bake
changes or profraw-from-container extraction are needed.

## Files

- `etc/just/coverage.just` — `cov::{unit,action,system,all,html,clean}` recipes.
- `Justfile` — registers `mod cov`.
- `codecov.yml` — report-only config (project + patch `informational: true`),
  per-flag path mapping, standard ignores.
- `.github/workflows/coverage.yml` — three jobs (unit/action/system) on
  `BasePerfRunnerGroup`, upload to Codecov with `fail_ci_if_error: false`.

## Requirements / follow-ups

- **`CODECOV_TOKEN`** repo secret must be added for uploads to succeed.
- `codecov/codecov-action@v5` is not yet SHA-pinned; reviewers should pin it to
  a commit SHA per the repo's action-pinning convention before merge.

Draft: opening for review of the approach and the report-only stance.
