### PR TITLE
fix(trie): initialize proofs from storage-v2 trie tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,6 +4774,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-common",
+ "reth-trie-db",
  "rocksdb",
  "secp256k1 0.30.0",
  "serde",

--- a/crates/execution/cli/src/commands/base_proofs/init.rs
+++ b/crates/execution/cli/src/commands/base_proofs/init.rs
@@ -6,7 +6,7 @@ use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
     BaseProofsInitialStateStore, BaseProofsStorage, BaseProofsStore, InitializationJob,
-    MdbxProofsStorage, RocksdbProofsStorage,
+    MdbxProofsStorage, RethTrieStorageLayout, RocksdbProofsStorage,
 };
 use base_node_core::args::{ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs};
 use clap::Parser;
@@ -14,7 +14,7 @@ use reth_chainspec::ChainInfo;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory};
+use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory, StorageSettingsCache};
 use tracing::info;
 
 /// Initializes the proofs storage with the current state of the chain.
@@ -97,7 +97,7 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
     ) -> eyre::Result<()>
     where
         S: BaseProofsInitialStateStore + BaseProofsStore + 'static,
-        F: BlockNumReader + DatabaseProviderFactory,
+        F: BlockNumReader + DatabaseProviderFactory + StorageSettingsCache,
     {
         // Check if already initialized
         if let Some((block_number, block_hash)) = storage.get_earliest_block_number()? {
@@ -122,11 +122,16 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
 
         // Run the backfill job
         {
+            let trie_layout = if provider_factory.cached_storage_settings().is_v2() {
+                RethTrieStorageLayout::Packed
+            } else {
+                RethTrieStorageLayout::Legacy
+            };
             let db_provider =
                 provider_factory.database_provider_ro()?.disable_long_read_transaction_safety();
             let db_tx = db_provider.into_tx();
 
-            InitializationJob::new(storage, db_tx).run(best_number, best_hash)?;
+            InitializationJob::new(storage, db_tx, trie_layout).run(best_number, best_hash)?;
         }
 
         info!(

--- a/crates/execution/trie/Cargo.toml
+++ b/crates/execution/trie/Cargo.toml
@@ -23,6 +23,7 @@ reth-codecs.workspace = true
 reth-revm = { workspace = true, features = ["witness"] }
 reth-trie = { workspace = true, features = ["serde"] }
 reth-trie-common = { workspace = true, features = ["serde"] }
+reth-trie-db.workspace = true
 
 # workaround: reth-trie/serde-bincode-compat activates serde-bincode-compat on
 # reth-ethereum-primitives (a transitive dep) without also activating its serde feature,

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -1,7 +1,7 @@
 //! Initialization job for proofs storage. Handles storing the existing state into the proofs
 //! storage.
 
-use std::{collections::HashMap, time::Instant};
+use std::{collections::HashMap, marker::PhantomData, time::Instant};
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, U256};
@@ -15,6 +15,9 @@ use reth_db::{
 use reth_primitives_traits::{Account, StorageEntry};
 use reth_trie_common::{
     BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
+};
+use reth_trie_db::{
+    LegacyKeyAdapter, PackedKeyAdapter, StorageTrieEntryLike, TrieKeyAdapter, TrieTableAdapter,
 };
 use tracing::{debug, info};
 
@@ -30,11 +33,21 @@ const INITIALIZE_STORAGE_THRESHOLD: usize = 100000;
 /// Threshold for logging progress during initialization
 const INITIALIZE_LOG_THRESHOLD: usize = 100000;
 
+/// Controls which physical reth trie-table encoding initialization reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RethTrieStorageLayout {
+    /// Storage-v2 packed trie keys.
+    Packed,
+    /// Storage-v1 legacy trie keys.
+    Legacy,
+}
+
 /// Initialization job for external storage.
 #[derive(Debug, Constructor)]
 pub struct InitializationJob<Tx: DbTx, S: BaseProofsStore + Send> {
     storage: S,
     tx: Tx,
+    trie_layout: RethTrieStorageLayout,
 }
 
 /// Macro to generate simple cursor iterators for tables
@@ -94,13 +107,73 @@ macro_rules! define_dup_cursor_iter {
 // Generate iterators for all 4 table types
 define_simple_cursor_iter!(HashedAccountsInit, tables::HashedAccounts, B256, Account);
 define_dup_cursor_iter!(HashedStoragesInit, tables::HashedStorages, B256, StorageEntry);
-define_simple_cursor_iter!(
-    AccountsTrieInit,
-    tables::AccountsTrie,
-    StoredNibbles,
-    BranchNodeCompact
-);
-define_dup_cursor_iter!(StoragesTrieInit, tables::StoragesTrie, B256, StorageTrieEntry);
+
+/// Converts physical account-trie keys from either storage layout to canonical nibbles.
+struct AccountsTrieInit<C, A>(C, PhantomData<A>);
+
+impl<C, A> AccountsTrieInit<C, A> {
+    const fn new(cursor: C) -> Self {
+        Self(cursor, PhantomData)
+    }
+}
+
+impl<C, A> Iterator for AccountsTrieInit<C, A>
+where
+    A: TrieTableAdapter,
+    C: DbCursorRO<A::AccountTrieTable>,
+{
+    type Item = Result<(StoredNibbles, BranchNodeCompact), DatabaseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().transpose().map(|entry| {
+            entry.map(|(path, branch)| (StoredNibbles(A::account_key_to_nibbles(&path)), branch))
+        })
+    }
+}
+
+/// Converts physical storage-trie values from either storage layout to canonical nibbles.
+struct StoragesTrieInit<C, A>(C, PhantomData<A>);
+
+impl<C, A> StoragesTrieInit<C, A> {
+    const fn new(cursor: C) -> Self {
+        Self(cursor, PhantomData)
+    }
+}
+
+impl<C, A> Iterator for StoragesTrieInit<C, A>
+where
+    A: TrieTableAdapter,
+    C: DbDupCursorRO<A::StorageTrieTable> + DbCursorRO<A::StorageTrieTable>,
+{
+    type Item = Result<(B256, StorageTrieEntry), DatabaseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(entry) = self.0.next_dup().transpose() {
+            return Some(entry.map(decode_storage_trie_entry::<A>));
+        }
+
+        let next_key = match self.0.next_no_dup() {
+            Ok(Some((next_key, _))) => next_key,
+            Ok(None) => return None,
+            Err(err) => return Some(Err(err)),
+        };
+
+        self.0.seek(next_key).transpose().map(|entry| entry.map(decode_storage_trie_entry::<A>))
+    }
+}
+
+fn decode_storage_trie_entry<A: TrieKeyAdapter>(
+    (hashed_address, entry): (B256, A::StorageValue),
+) -> (B256, StorageTrieEntry) {
+    let (path, branch) = entry.into_parts();
+    (
+        hashed_address,
+        StorageTrieEntry {
+            nibbles: StoredNibblesSubKey(A::subkey_to_nibbles(&path)),
+            node: branch,
+        },
+    )
+}
 
 /// Trait to estimate the progress of a initialization job based on the key.
 trait CompletionEstimatable {
@@ -269,16 +342,31 @@ impl<Tx: DbTx + Sync, S: BaseProofsStore + BaseProofsInitialStateStore + Send>
         &self,
         start_key: Option<StoredNibbles>,
     ) -> Result<(), BaseProofsStorageError> {
-        let mut start_cursor = self.tx.cursor_read::<tables::AccountsTrie>()?;
+        if matches!(self.trie_layout, RethTrieStorageLayout::Packed) {
+            self.initialize_accounts_trie_with_adapter::<PackedKeyAdapter>(start_key)
+        } else {
+            self.initialize_accounts_trie_with_adapter::<LegacyKeyAdapter>(start_key)
+        }
+    }
+
+    fn initialize_accounts_trie_with_adapter<A>(
+        &self,
+        start_key: Option<StoredNibbles>,
+    ) -> Result<(), BaseProofsStorageError>
+    where
+        A: TrieTableAdapter,
+    {
+        let mut start_cursor = self.tx.cursor_read::<A::AccountTrieTable>()?;
 
         if let Some(latest_key) = start_key {
+            let latest_path = latest_key.0;
             start_cursor
-                .seek(latest_key.clone())?
-                .filter(|(k, _)| *k == latest_key)
+                .seek(A::AccountKey::from(latest_path.clone()))?
+                .filter(|(key, _)| A::account_key_to_nibbles(key) == latest_path)
                 .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
 
-        let source = AccountsTrieInit::new(start_cursor);
+        let source = AccountsTrieInit::<_, A>::new(start_cursor);
         self.initialize(
             "accounts trie",
             source,
@@ -294,19 +382,34 @@ impl<Tx: DbTx + Sync, S: BaseProofsStore + BaseProofsInitialStateStore + Send>
         &self,
         start_key: Option<StorageTrieKey>,
     ) -> Result<(), BaseProofsStorageError> {
-        let mut start_cursor = self.tx.cursor_dup_read::<tables::StoragesTrie>()?;
+        if matches!(self.trie_layout, RethTrieStorageLayout::Packed) {
+            self.initialize_storages_trie_with_adapter::<PackedKeyAdapter>(start_key)
+        } else {
+            self.initialize_storages_trie_with_adapter::<LegacyKeyAdapter>(start_key)
+        }
+    }
+
+    fn initialize_storages_trie_with_adapter<A>(
+        &self,
+        start_key: Option<StorageTrieKey>,
+    ) -> Result<(), BaseProofsStorageError>
+    where
+        A: TrieTableAdapter,
+    {
+        let mut start_cursor = self.tx.cursor_dup_read::<A::StorageTrieTable>()?;
 
         if let Some(latest_key) = start_key {
+            let latest_path = latest_key.path.0;
             start_cursor
                 .seek_by_key_subkey(
                     latest_key.hashed_address,
-                    StoredNibblesSubKey::from(latest_key.path.0),
+                    A::StorageSubKey::from(latest_path.clone()),
                 )?
-                .filter(|v| v.nibbles.0 == latest_key.path.0)
+                .filter(|value| A::subkey_to_nibbles(value.nibbles()) == latest_path)
                 .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
 
-        let source = StoragesTrieInit::new(start_cursor);
+        let source = StoragesTrieInit::<_, A>::new(start_cursor);
         self.initialize(
             "storage trie",
             source,
@@ -415,7 +518,7 @@ impl<C> InitTable for HashedStoragesInit<C> {
     }
 }
 
-impl<C> InitTable for AccountsTrieInit<C> {
+impl<C, A> InitTable for AccountsTrieInit<C, A> {
     type Key = StoredNibbles;
     type Value = BranchNodeCompact;
 
@@ -432,7 +535,7 @@ impl<C> InitTable for AccountsTrieInit<C> {
     }
 }
 
-impl<C> InitTable for StoragesTrieInit<C> {
+impl<C, A> InitTable for StoragesTrieInit<C, A> {
     type Key = B256;
     type Value = StorageTrieEntry;
 
@@ -466,13 +569,18 @@ mod tests {
 
                 use alloy_primitives::{Address, U256, keccak256};
                 use reth_db::{
-                    Database, cursor::DbCursorRW, test_utils::create_test_rw_db,
+                    Database,
+                    cursor::DbCursorRW,
+                    table::{Decode, Encode},
+                    test_utils::create_test_rw_db,
                     transaction::DbTxMut,
                 };
                 use reth_primitives_traits::Account;
                 use reth_trie::{
-                    BranchNodeCompact, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
-                    TrieMask, hashed_cursor::HashedCursor, trie_cursor::TrieCursor,
+                    BranchNodeCompact, PackedStorageTrieEntry, PackedStoredNibbles,
+                    PackedStoredNibblesSubKey, StorageTrieEntry, StoredNibbles,
+                    StoredNibblesSubKey, TrieMask, hashed_cursor::HashedCursor,
+                    trie_cursor::TrieCursor,
                 };
                 use tempfile::TempDir;
 
@@ -537,7 +645,11 @@ mod tests {
 
                     // Run initialization
                     let tx = db.tx().unwrap();
-                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let job = InitializationJob::new(
+                        Arc::clone(&storage),
+                        tx,
+                        RethTrieStorageLayout::Legacy,
+                    );
                     job.initialize_hashed_accounts(None).unwrap();
 
                     // Verify data was stored (will be in sorted order)
@@ -597,7 +709,11 @@ mod tests {
 
                     // Run initialization
                     let tx = db.tx().unwrap();
-                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let job = InitializationJob::new(
+                        Arc::clone(&storage),
+                        tx,
+                        RethTrieStorageLayout::Legacy,
+                    );
                     job.initialize_hashed_storages(None).unwrap();
 
                     // Verify data was stored for addr1
@@ -645,7 +761,11 @@ mod tests {
 
                     // Run initialization
                     let tx = db.tx().unwrap();
-                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let job = InitializationJob::new(
+                        Arc::clone(&storage),
+                        tx,
+                        RethTrieStorageLayout::Legacy,
+                    );
                     job.initialize_accounts_trie(None).unwrap();
 
                     // Verify data was stored
@@ -710,7 +830,11 @@ mod tests {
 
                     // Run initialization
                     let tx = db.tx().unwrap();
-                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let job = InitializationJob::new(
+                        Arc::clone(&storage),
+                        tx,
+                        RethTrieStorageLayout::Legacy,
+                    );
                     job.initialize_storages_trie(None).unwrap();
 
                     // Verify data was stored for addr1
@@ -795,7 +919,11 @@ mod tests {
 
                     // Run full initialization
                     let tx = db.tx().unwrap();
-                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let job = InitializationJob::new(
+                        Arc::clone(&storage),
+                        tx,
+                        RethTrieStorageLayout::Legacy,
+                    );
                     let best_number = 100;
                     let best_hash = B256::repeat_byte(0x42);
 
@@ -826,6 +954,87 @@ mod tests {
                 }
 
                 #[test]
+                fn test_full_initialize_run_storage_v2_twice() {
+                    let db = create_test_rw_db();
+                    let dir = TempDir::new().unwrap();
+                    let storage = Arc::new($storage::new(dir.path()).expect("env"));
+                    let address = keccak256(Address::repeat_byte(0x01));
+                    let paths = vec![
+                        Nibbles::from_nibbles_unchecked(vec![0x00, 0x02]),
+                        Nibbles::from_nibbles_unchecked(vec![0x01, 0x02]),
+                    ];
+                    let packed_paths =
+                        paths.iter().cloned().map(PackedStoredNibbles::from).collect::<Vec<_>>();
+
+                    // A legacy `StoredNibbles` decoder discards the high nibble of each packed
+                    // byte, so these distinct packed keys are decoded as the same legacy path.
+                    assert_ne!(packed_paths[0].clone().encode(), packed_paths[1].clone().encode());
+                    assert_eq!(
+                        StoredNibbles::decode(&packed_paths[0].clone().encode()).unwrap(),
+                        StoredNibbles::decode(&packed_paths[1].clone().encode()).unwrap()
+                    );
+
+                    {
+                        let tx = db.tx_mut().unwrap();
+                        let mut accounts = tx.cursor_write::<tables::PackedAccountsTrie>().unwrap();
+                        accounts
+                            .append(packed_paths[0].clone(), &create_test_branch_node())
+                            .unwrap();
+                        accounts
+                            .append(packed_paths[1].clone(), &create_test_branch_node())
+                            .unwrap();
+                        drop(accounts);
+
+                        let mut storages =
+                            tx.cursor_dup_write::<tables::PackedStoragesTrie>().unwrap();
+                        for path in &paths {
+                            storages
+                                .upsert(
+                                    address,
+                                    &PackedStorageTrieEntry {
+                                        nibbles: PackedStoredNibblesSubKey::from(path.clone()),
+                                        node: create_test_branch_node(),
+                                    },
+                                )
+                                .unwrap();
+                        }
+                        drop(storages);
+                        tx.commit().unwrap();
+                    }
+
+                    let best_number = 100;
+                    let best_hash = B256::repeat_byte(0x42);
+                    for _ in 0..2 {
+                        let tx = db.tx().unwrap();
+                        InitializationJob::new(
+                            Arc::clone(&storage),
+                            tx,
+                            RethTrieStorageLayout::Packed,
+                        )
+                        .run(best_number, best_hash)
+                        .unwrap();
+                    }
+
+                    let mut accounts = storage.account_trie_cursor(best_number).unwrap();
+                    let mut stored_account_paths = Vec::new();
+                    while let Some((path, _)) = accounts.next().unwrap() {
+                        stored_account_paths.push(path);
+                    }
+                    assert_eq!(stored_account_paths, paths);
+
+                    let mut storages = storage.storage_trie_cursor(address, best_number).unwrap();
+                    let mut stored_storage_paths = Vec::new();
+                    while let Some((path, _)) = storages.next().unwrap() {
+                        stored_storage_paths.push(path);
+                    }
+                    assert_eq!(stored_storage_paths, paths);
+                    assert_eq!(
+                        storage.get_earliest_block_number().unwrap(),
+                        Some((best_number, best_hash))
+                    );
+                }
+
+                #[test]
                 fn test_initialize_run_skips_if_already_done() {
                     let db = create_test_rw_db();
                     let dir = TempDir::new().unwrap();
@@ -838,7 +1047,11 @@ mod tests {
                     storage.commit_initial_state().expect("commit anchor");
 
                     let tx = db.tx().unwrap();
-                    let job = InitializationJob::new(Arc::clone(&storage), tx);
+                    let job = InitializationJob::new(
+                        Arc::clone(&storage),
+                        tx,
+                        RethTrieStorageLayout::Legacy,
+                    );
 
                     // Run initialization - should skip
                     job.run(100, B256::repeat_byte(0x42)).unwrap();
@@ -890,7 +1103,11 @@ mod tests {
                     // Initialization #1
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_hashed_accounts(None).unwrap();
                     }
 
@@ -922,7 +1139,11 @@ mod tests {
                     // Initialization #2 (restart)
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_hashed_accounts(Some(k2)).unwrap();
                     }
 
@@ -985,7 +1206,11 @@ mod tests {
                     // Initialization #1
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_hashed_storages(None).unwrap();
                     }
 
@@ -1009,7 +1234,11 @@ mod tests {
                     // Initialization #2
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_hashed_storages(Some(HashedStorageKey::new(a2, s21)))
                             .unwrap();
                     }
@@ -1073,7 +1302,11 @@ mod tests {
                     // Initialization #1
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_accounts_trie(None).unwrap();
                     }
 
@@ -1094,7 +1327,11 @@ mod tests {
                     // Initialization #2
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_accounts_trie(Some(p2.clone())).unwrap();
                     }
 
@@ -1159,7 +1396,11 @@ mod tests {
                     // Initialization #1
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_storages_trie(None).unwrap();
                     }
 
@@ -1190,7 +1431,11 @@ mod tests {
                     // Initialization #2
                     {
                         let tx = db.tx().unwrap();
-                        let job = InitializationJob::new(Arc::clone(&store), tx);
+                        let job = InitializationJob::new(
+                            Arc::clone(&store),
+                            tx,
+                            RethTrieStorageLayout::Legacy,
+                        );
                         job.initialize_storages_trie(Some(StorageTrieKey::new(
                             a2,
                             StoredNibbles::from(n2.0),

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -361,7 +361,7 @@ impl<Tx: DbTx + Sync, S: BaseProofsStore + BaseProofsInitialStateStore + Send>
         if let Some(latest_key) = start_key {
             let latest_path = latest_key.0;
             start_cursor
-                .seek(A::AccountKey::from(latest_path.clone()))?
+                .seek(A::AccountKey::from(latest_path))?
                 .filter(|(key, _)| A::account_key_to_nibbles(key) == latest_path)
                 .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
@@ -401,10 +401,7 @@ impl<Tx: DbTx + Sync, S: BaseProofsStore + BaseProofsInitialStateStore + Send>
         if let Some(latest_key) = start_key {
             let latest_path = latest_key.path.0;
             start_cursor
-                .seek_by_key_subkey(
-                    latest_key.hashed_address,
-                    A::StorageSubKey::from(latest_path.clone()),
-                )?
+                .seek_by_key_subkey(latest_key.hashed_address, A::StorageSubKey::from(latest_path))?
                 .filter(|value| A::subkey_to_nibbles(value.nibbles()) == latest_path)
                 .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -18,7 +18,7 @@ pub use api::{
 };
 
 pub mod initialize;
-pub use initialize::InitializationJob;
+pub use initialize::{InitializationJob, RethTrieStorageLayout};
 
 pub mod in_memory;
 pub use in_memory::{

--- a/crates/execution/trie/tests/live.rs
+++ b/crates/execution/trie/tests/live.rs
@@ -6,8 +6,8 @@ use alloy_consensus::{BlockHeader, Header, SignableTransaction, TxEip2930, const
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use base_execution_trie::{
-    BaseProofsStorage, BaseProofsStorageError, RocksdbProofsStorage, initialize::InitializationJob,
-    live::LiveTrieCollector,
+    BaseProofsStorage, BaseProofsStorageError, RethTrieStorageLayout, RocksdbProofsStorage,
+    initialize::InitializationJob, live::LiveTrieCollector,
 };
 use derive_more::Constructor;
 use reth_chainspec::{ChainSpec, ChainSpecBuilder, EthereumHardfork, MAINNET, MIN_TRANSACTION_GAS};
@@ -20,7 +20,7 @@ use reth_node_api::{NodePrimitives, NodeTypesWithDB};
 use reth_primitives_traits::{Block as _, RecoveredBlock, crypto::secp256k1::sign_message};
 use reth_provider::{
     BlockWriter as _, ExecutionOutcome, HashedPostStateProvider, LatestStateProviderRef,
-    ProviderFactory, StateRootProvider,
+    ProviderFactory, StateRootProvider, StorageSettingsCache,
     providers::{BlockchainProvider, ProviderNodeTypes},
     test_utils::create_test_provider_factory_with_chain_spec,
 };
@@ -250,9 +250,14 @@ where
     }
 
     {
+        let trie_layout = if provider_factory.cached_storage_settings().is_v2() {
+            RethTrieStorageLayout::Packed
+        } else {
+            RethTrieStorageLayout::Legacy
+        };
         let provider = provider_factory.db_ref();
         let tx = provider.tx()?;
-        let initialization_job = InitializationJob::new(storage.clone(), tx);
+        let initialization_job = InitializationJob::new(storage.clone(), tx, trie_layout);
         initialization_job.run(last_block_number, last_block_hash)?;
     }
 


### PR DESCRIPTION
## Summary
- Select the packed or legacy trie table adapter from the execution database storage settings during proofs initialization.
- Normalize physical trie keys to canonical nibbles before persisting proof history.
- Add MDBX, RocksDB, and live collector coverage for storage-v2 bootstrap and idempotency.

## Test plan
- [x] `cargo test -p base-execution-trie --lib initialize::tests -- --nocapture`
- [x] `cargo test -p base-execution-trie --test live -- --nocapture`
- [x] `cargo check -p base-execution-cli`
- [x] `cargo test -p base-execution-cli --lib -- --nocapture`
- [x] `cargo fmt -p base-execution-trie -- --check`
- [x] `cargo fmt -p base-execution-cli -- --check`

type=routine
risk=low
impact=sev5