### PR TITLE
fix(docker): decouple ingress bake targets from DEVNET_TARGETS

### DIFF
--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -26,8 +26,8 @@ variable "DEVNET_TARGETS" {
   default = ["base", "batcher", "prover-service", "zk-host"]
 }
 
-variable "INGRESS_EXTRA_TARGETS" {
-  default = ["ingress-rpc", "audit-archiver"]
+variable "INGRESS_TARGETS" {
+  default = ["base", "batcher", "ingress-rpc", "audit-archiver"]
 }
 
 group "default" {
@@ -58,7 +58,7 @@ group "devnet" {
 }
 
 group "ingress" {
-  targets = concat(DEVNET_TARGETS, INGRESS_EXTRA_TARGETS)
+  targets = INGRESS_TARGETS
 }
 
 target "_rust-service-common" {


### PR DESCRIPTION
## Summary
- Restore a dedicated `INGRESS_TARGETS` list for `just ingress` image builds.
- Avoid building `prover-service`/`zk-host` as a side effect of concatenating with `DEVNET_TARGETS`.

Follow-up to #3633 review feedback.

## Test plan
- [x] `docker buildx bake -f etc/docker/docker-bake.hcl --print ingress` shows only `base`, `batcher`, `ingress-rpc`, `audit-archiver`

type=routine
risk=low
impact=sev5