### PR TITLE
feat(precompiles): add foo versioned reference precompile (self-contained versions)

### DIFF
--- a/crates/common/precompiles/src/foo/abi.rs
+++ b/crates/common/precompiles/src/foo/abi.rs
@@ -1,0 +1,34 @@
+//! ABI definitions for the `foo` reference precompile.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// `foo` reference precompile ABI.
+    ///
+    /// The interface is append-only across versions: methods and errors are
+    /// added, never removed or repurposed, so historical calldata keeps
+    /// decoding the same way.
+    interface IFoo {
+        /// Precompile cannot be executed via delegatecall or callcode.
+        error DelegateCallNotAllowed();
+
+        /// The called method is not supported by the version active at this block.
+        ///
+        /// Returned for methods that had not yet been introduced at the target
+        /// hardfork, preserving their original pre-activation revert behavior.
+        error UnsupportedBeforeActivation();
+
+        /// Emitted when `greet` records a greeting for `caller`.
+        event Greeted(address indexed caller, string greeting);
+
+        /// Returns a fixed greeting. The value is version-specific and frozen
+        /// once its version is activated.
+        function helloWorld() external view returns (string);
+
+        /// Records and returns a personalized greeting for the caller.
+        ///
+        /// Introduced in a later version; reverts with
+        /// `UnsupportedBeforeActivation` before its activation fork.
+        function greet(string name) external returns (string);
+    }
+}

--- a/crates/common/precompiles/src/foo/dispatch.rs
+++ b/crates/common/precompiles/src/foo/dispatch.rs
@@ -1,0 +1,106 @@
+//! Shared precompile entry for the `foo` reference precompile.
+//!
+//! This is the *only* shared execution glue: it charges the flat calldata cost
+//! and hands off to the active version's own [`FooVersion::call`]. Selector
+//! decoding and routing live inside each version (see [`crate::logic`]), so a
+//! version fully owns "which selectors exist and what they do".
+
+use base_precompile_storage::{IntoPrecompileResult, StorageCtx};
+use revm::precompile::PrecompileResult;
+
+use crate::{FooStorage, FooVersion};
+
+/// Per-word calldata gas charge (`G_SHA3WORD`), matching other Base precompiles.
+const CALLDATA_WORD_GAS: u64 = 6;
+
+impl FooStorage<'_> {
+    /// Charges calldata gas, then dispatches to the `version` active for this
+    /// block. The version decodes and routes the call itself.
+    pub fn dispatch(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        version: &'static dyn FooVersion,
+    ) -> PrecompileResult {
+        let calldata_cost =
+            (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS);
+        if let Err(error) = ctx.deduct_gas(calldata_cost) {
+            return error.into_precompile_result(ctx.gas_used(), ctx.state_gas_used());
+        }
+        version.call(self, ctx, calldata).into_precompile_result(
+            ctx.gas_used(),
+            ctx.state_gas_used(),
+            0,
+            |output| output,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use alloy_sol_types::SolCall;
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+
+    use crate::{FooStorage, FooV1, FooV2, FooVersion, IFoo};
+
+    const CALLER: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn dispatch(
+        storage: &mut HashMapStorageProvider,
+        calldata: &[u8],
+        version: &'static dyn FooVersion,
+    ) -> revm::precompile::PrecompileOutput {
+        StorageCtx::enter(storage, |ctx| FooStorage::new(ctx).dispatch(ctx, calldata, version))
+            .expect("dispatch should not fail fatally")
+    }
+
+    #[test]
+    fn hello_world_differs_across_versions() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let calldata = IFoo::helloWorldCall {}.abi_encode();
+
+        let v1 = dispatch(&mut storage, &calldata, &FooV1);
+        assert!(!v1.is_revert());
+        assert_eq!(IFoo::helloWorldCall::abi_decode_returns(&v1.bytes).unwrap(), "Hello, World!");
+
+        let v2 = dispatch(&mut storage, &calldata, &FooV2);
+        assert!(!v2.is_revert());
+        assert_eq!(
+            IFoo::helloWorldCall::abi_decode_returns(&v2.bytes).unwrap(),
+            "Hello, World! Welcome to Base."
+        );
+    }
+
+    #[test]
+    fn greet_is_unsupported_before_v2() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        // V1's routing has no `greet` arm; it falls through to unsupported.
+        let output = dispatch(&mut storage, &calldata, &FooV1);
+
+        assert!(output.is_revert(), "greet must revert before its activation version");
+    }
+
+    #[test]
+    fn greet_returns_personalized_greeting_from_v2() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(CALLER);
+        let calldata = IFoo::greetCall { name: "base".into() }.abi_encode();
+
+        let output = dispatch(&mut storage, &calldata, &FooV2);
+
+        assert!(!output.is_revert());
+        assert_eq!(IFoo::greetCall::abi_decode_returns(&output.bytes).unwrap(), "Hello, base!");
+    }
+
+    #[test]
+    fn dispatch_reverts_on_unknown_selector() {
+        let mut storage = HashMapStorageProvider::new(1);
+        let output = dispatch(&mut storage, &[0xde, 0xad, 0xbe, 0xef], &FooV2);
+
+        assert!(output.is_revert());
+    }
+}

--- a/crates/common/precompiles/src/foo/logic/mod.rs
+++ b/crates/common/precompiles/src/foo/logic/mod.rs
@@ -1,0 +1,12 @@
+//! Self-contained per-version implementations of the `foo` precompile.
+//!
+//! Unlike a shared per-method logic trait, each version here implements the
+//! whole [`FooVersion::call`](crate::FooVersion) seam itself: it decodes and
+//! routes its own selectors and holds its own logic. Storage layout and the ABI
+//! stay shared (they are cross-version invariants); routing and behavior do not.
+
+mod v1;
+pub use v1::FooV1;
+
+mod v2;
+pub use v2::FooV2;

--- a/crates/common/precompiles/src/foo/logic/v1.rs
+++ b/crates/common/precompiles/src/foo/logic/v1.rs
@@ -1,0 +1,40 @@
+//! Version 1 of the `foo` precompile, activated at Beryl.
+//!
+//! Self-contained: V1 owns its own routing and logic. Selectors it does not
+//! implement (e.g. `greet`, added in V2) fall through to the unsupported
+//! revert, so V1 needs no edits when later versions add methods — it stays
+//! frozen.
+
+use alloc::string::ToString;
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
+
+use crate::{
+    FooStorage, FooVersion,
+    IFoo::{self, IFooCalls as C},
+    macros::decode_precompile_call,
+};
+
+/// First `foo` implementation. Frozen as of its activation at Beryl.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV1;
+
+impl FooVersion for FooV1 {
+    fn call(
+        &self,
+        _storage: &mut FooStorage<'_>,
+        _ctx: StorageCtx<'_>,
+        calldata: &[u8],
+    ) -> Result<Bytes> {
+        match decode_precompile_call!(calldata, IFoo::IFooCalls) {
+            C::helloWorld(_) => {
+                Ok(IFoo::helloWorldCall::abi_encode_returns(&"Hello, World!".to_string()).into())
+            }
+            // Any other (valid) selector had not been introduced at V1; reverting
+            // as unsupported preserves the original pre-activation behavior.
+            _ => Err(BasePrecompileError::revert(IFoo::UnsupportedBeforeActivation {})),
+        }
+    }
+}

--- a/crates/common/precompiles/src/foo/logic/v2.rs
+++ b/crates/common/precompiles/src/foo/logic/v2.rs
@@ -1,0 +1,46 @@
+//! Version 2 of the `foo` precompile, activated at Cobalt.
+//!
+//! Self-contained copy of V1's shape with the changed/added behavior written
+//! out in full: `helloWorld` returns a new string and `greet` is now routed and
+//! implemented. V1 is untouched and stays frozen.
+
+use alloc::{format, string::ToString};
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
+use base_precompile_storage::{Result, StorageCtx};
+
+use crate::{
+    FooStorage, FooVersion,
+    IFoo::{self, IFooCalls as C},
+    macros::decode_precompile_call,
+};
+
+/// Second `foo` implementation, activated at Cobalt.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooV2;
+
+impl FooVersion for FooV2 {
+    fn call(
+        &self,
+        storage: &mut FooStorage<'_>,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+    ) -> Result<Bytes> {
+        match decode_precompile_call!(calldata, IFoo::IFooCalls) {
+            C::helloWorld(_) => {
+                // Goal 1: changed behavior. V1 returned "Hello, World!".
+                Ok(IFoo::helloWorldCall::abi_encode_returns(
+                    &"Hello, World! Welcome to Base.".to_string(),
+                )
+                .into())
+            }
+            C::greet(call) => {
+                // Goal 3: new method, routed and implemented from Cobalt onward.
+                let greeting = format!("Hello, {}!", call.name);
+                storage.record_greeting(ctx.caller(), &greeting)?;
+                Ok(IFoo::greetCall::abi_encode_returns(&greeting).into())
+            }
+        }
+    }
+}

--- a/crates/common/precompiles/src/foo/mod.rs
+++ b/crates/common/precompiles/src/foo/mod.rs
@@ -1,0 +1,31 @@
+//! Reference precompile demonstrating hardfork-versioned execution logic.
+//!
+//! Pragmatic-split variant of the versioning design: the **ABI and storage are
+//! shared** because they are cross-version invariants (a selector must always
+//! decode the same way; every version reads/writes the same state slots), while
+//! each **version is self-contained** and owns its own selector routing and
+//! business logic behind the single [`FooVersion`] seam.
+//!
+//! - [`abi`](self) — shared, append-only external interface [`IFoo`].
+//! - [`storage`](self) — shared, append-only state [`FooStorage`].
+//! - [`versions`](self) — the [`FooVersion`] seam and the [`FooVersions`] resolver.
+//! - [`logic`](self) — self-contained per-version implementations.
+//! - [`dispatch`](self) — shared entry: charges calldata gas and hands off.
+//! - [`precompile`](self) — the installable entry point [`Foo`].
+
+mod abi;
+pub use abi::IFoo;
+
+mod storage;
+pub use storage::FooStorage;
+
+mod versions;
+pub use versions::{FooVersion, FooVersions};
+
+mod logic;
+pub use logic::{FooV1, FooV2};
+
+mod dispatch;
+
+mod precompile;
+pub use precompile::Foo;

--- a/crates/common/precompiles/src/foo/precompile.rs
+++ b/crates/common/precompiles/src/foo/precompile.rs
@@ -1,0 +1,60 @@
+//! Precompile entry point for the `foo` reference precompile.
+
+use alloy_evm::precompiles::PrecompilesMap;
+use base_common_genesis::BaseUpgrade;
+use base_precompile_macros::precompile;
+
+use crate::{FooStorage, FooVersion, FooVersions};
+
+/// Entry point for the `foo` reference precompile.
+///
+/// The `#[precompile]` macro generates `precompile(version)`, which threads the
+/// active implementation (`&dyn FooVersion`) into [`FooStorage::dispatch`].
+/// Fork→version selection is owned by [`FooVersions`]; the version does its own
+/// decoding and routing. All version logic therefore stays inside the `foo`
+/// module.
+#[precompile(args(version: &'static dyn FooVersion))]
+#[derive(Debug, Clone, Copy)]
+pub struct Foo;
+
+impl Foo {
+    /// Installs `foo` for `upgrade`, resolving the active version via
+    /// [`FooVersions`]. A no-op before the introduction fork (Beryl), where the
+    /// precompile does not exist.
+    pub fn install(precompiles: &mut PrecompilesMap, upgrade: BaseUpgrade) {
+        let Some(version) = FooVersions::resolve(upgrade) else {
+            return;
+        };
+        precompiles.extend_precompiles(core::iter::once((
+            FooStorage::ADDRESS,
+            Self::precompile(version),
+        )));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::precompiles::PrecompilesMap;
+    use base_common_genesis::BaseUpgrade;
+    use revm::precompile::Precompiles;
+
+    use crate::{Foo, FooStorage};
+
+    #[test]
+    fn install_registers_precompile_from_beryl() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+
+        Foo::install(&mut precompiles, BaseUpgrade::Beryl);
+
+        assert!(precompiles.get(&FooStorage::ADDRESS).is_some());
+    }
+
+    #[test]
+    fn install_is_noop_before_beryl() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+
+        Foo::install(&mut precompiles, BaseUpgrade::Azul);
+
+        assert!(precompiles.get(&FooStorage::ADDRESS).is_none());
+    }
+}

--- a/crates/common/precompiles/src/foo/storage.rs
+++ b/crates/common/precompiles/src/foo/storage.rs
@@ -1,0 +1,45 @@
+//! Storage layout for the `foo` reference precompile.
+
+use alloy_primitives::{Address, address};
+use base_precompile_macros::contract;
+use base_precompile_storage::{Handler, Mapping, Result};
+
+use crate::IFoo;
+
+/// Persistent state for the `foo` precompile.
+///
+/// State evolves append-only across versions (execution-consensus Goal 2): new
+/// fields may be added, but existing fields keep their slot and meaning so
+/// historical replay reads the same values.
+#[contract(addr = Self::ADDRESS)]
+#[namespace("base.foo")]
+pub struct FooStorage {
+    /// Number of times each caller has invoked `greet`.
+    pub greet_count: Mapping<Address, u64>,
+}
+
+impl FooStorage<'_> {
+    /// `foo` reference precompile address.
+    pub const ADDRESS: Address = address!("f00f000000000000000000000000000000000000");
+
+    /// Records a `greet` invocation: bumps the caller's counter and emits
+    /// [`IFoo::Greeted`].
+    ///
+    /// This is the shared storage primitive reused by every version that
+    /// supports `greet`; the version-specific behavior (the greeting text, and
+    /// whether `greet` exists at all) lives in [`crate::logic`].
+    pub fn record_greeting(&mut self, caller: Address, greeting: &str) -> Result<()> {
+        // The counter bump and its Greeted event must commit together; guard
+        // them with a checkpoint so a failure after the write reverts the
+        // advanced counter rather than leaving it advanced without a log.
+        let checkpoint = self.storage.checkpoint();
+
+        self.__initialize()?;
+        let count = self.greet_count.at(&caller).read()?;
+        self.greet_count.at_mut(&caller).write(count.saturating_add(1))?;
+        self.emit_event(IFoo::Greeted { caller, greeting: greeting.into() })?;
+
+        checkpoint.commit();
+        Ok(())
+    }
+}

--- a/crates/common/precompiles/src/foo/versions.rs
+++ b/crates/common/precompiles/src/foo/versions.rs
@@ -1,0 +1,73 @@
+//! Version seam and resolver for the `foo` precompile.
+//!
+//! [`FooVersion`] is the entire shared interface between the precompile entry
+//! and a version: a single `call` that takes calldata and returns encoded
+//! output. Each version decodes and routes internally, so versions are
+//! self-contained — the shared surface is one method plus [`FooVersions::resolve`].
+
+use alloy_primitives::Bytes;
+use base_common_genesis::BaseUpgrade;
+use base_precompile_storage::{Result, StorageCtx};
+
+use crate::{FooStorage, FooV1, FooV2};
+
+/// The single seam every `foo` version implements.
+///
+/// `Sync` is required so a `&'static dyn FooVersion` can be captured by the
+/// (thread-safe) precompile closure; the zero-sized version types satisfy it
+/// trivially.
+pub trait FooVersion: Sync {
+    /// Decodes `calldata`, routes it to this version's logic, and returns the
+    /// ABI-encoded output. Selectors this version does not implement revert
+    /// with [`IFoo::UnsupportedBeforeActivation`](crate::IFoo::UnsupportedBeforeActivation).
+    fn call(
+        &self,
+        storage: &mut FooStorage<'_>,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+    ) -> Result<Bytes>;
+}
+
+/// Resolver that selects the `foo` version active at a given hardfork.
+///
+/// Centralizing fork routing here keeps hardfork logic auditable and off the
+/// execution path: the version is resolved once at install time. The versions
+/// are zero-sized, so the returned reference is a pointer hand-back.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FooVersions;
+
+impl FooVersions {
+    /// Returns the version active at `upgrade`, or `None` before the
+    /// introduction fork (Beryl), where `foo` is not installed at all.
+    pub fn resolve(upgrade: BaseUpgrade) -> Option<&'static dyn FooVersion> {
+        if upgrade >= BaseUpgrade::Cobalt {
+            Some(&FooV2)
+        } else if upgrade >= BaseUpgrade::Beryl {
+            Some(&FooV1)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::BaseUpgrade;
+
+    use crate::FooVersions;
+
+    #[test]
+    fn resolves_none_before_beryl() {
+        assert!(FooVersions::resolve(BaseUpgrade::Azul).is_none());
+    }
+
+    #[test]
+    fn resolves_some_from_beryl() {
+        assert!(FooVersions::resolve(BaseUpgrade::Beryl).is_some());
+    }
+
+    #[test]
+    fn resolves_some_from_cobalt() {
+        assert!(FooVersions::resolve(BaseUpgrade::Cobalt).is_some());
+    }
+}

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -83,3 +83,6 @@ pub use tx_context::{ITransactionContext, TxContext, TxContextStorage};
 
 mod nonce;
 pub use nonce::{INonceManager, NonceManager, NonceManagerStorage};
+
+mod foo;
+pub use foo::{Foo, FooStorage, FooV1, FooV2, FooVersion, FooVersions, IFoo};

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -15,7 +15,7 @@ use revm::{
 
 use crate::{
     ActivationAdminConfig, ActivationRegistry, B20Factory, BasePrecompileSpec, BerylLookup,
-    NonceManager, NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver,
+    Foo, NonceManager, NoopPrecompileCallObserver, PolicyRegistryPrecompile, PrecompileCallObserver,
     TxContext, bls12_381, bn254_pair,
 };
 
@@ -220,6 +220,9 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             TxContext::install(&mut precompiles);
             NonceManager::install(&mut precompiles);
         }
+        // The `foo` reference precompile self-gates by fork: `Foo::install`
+        // resolves the active version and binds its implementation.
+        Foo::install(&mut precompiles, self.spec.upgrade());
         precompiles
     }
 }


### PR DESCRIPTION
type=routine
risk=low
impact=sev5

## Summary

A third structural option for the execution-consensus versioning design, alongside composition (#3933) and minimal copy (#3941). This is the **pragmatic split** for a B20-scale precompile: keep the genuine cross-version invariants **shared**, make each version **self-contained** for the parts that legitimately vary.

`foo` stands in for a B20-scale token precompile; the structure is the point.

## The split

- **Shared** (cross-version invariants — copying these is a hazard):
  - `abi.rs` — the append-only `IFoo` interface. A selector must always decode the same way across versions.
  - `storage.rs` — `FooStorage`. Every version reads/writes the **same** state slots; the layout cannot actually be made per-version (state is shared on-chain), so one definition is the safety mechanism.
  - `dispatch.rs` — a tiny shared entry that charges calldata gas and hands off. No selector routing.
- **Self-contained per version** (what actually varies):
  - Each version implements the whole `FooVersion::call(storage, ctx, calldata)` seam — it **decodes and routes its own selectors** and holds its own logic (`logic/v1.rs`, `logic/v2.rs`).

The entire shared interface between the entry and a version is one method:

```rust
pub trait FooVersion: Sync {
    fn call(&self, storage: &mut FooStorage<'_>, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<Bytes>;
}

pub fn resolve(upgrade: BaseUpgrade) -> Option<&'static dyn FooVersion> {
    if upgrade >= Cobalt { Some(&FooV2) } else if upgrade >= Beryl { Some(&FooV1) } else { None }
}
```

## How this differs from #3941 (minimal copy)

- No shared `FooLogic` per-method trait and no shared selector-routing. A version owns its selector table: V1 routes `helloWorld` and lets everything else fall through to `UnsupportedBeforeActivation`; V2 routes both.
- "Which selectors exist and what they do" is fully readable in one file per version.

## Honest tradeoffs

- **Win:** each version is a self-contained routing+logic unit; changing existing logic or adding a new version touches nothing shared. Storage/ABI invariants stay single-source.
- **Cost:** per-version selector routing is duplicated (each version re-runs `decode_precompile_call!`). And because the repo forbids `#[allow(unreachable_patterns)]`, a version that handles every current selector (V2) uses an exhaustive match with no catch-all — so adding a *brand-new selector* to the ABI later is compiler-enforced to touch each existing version (add an `unsupported` arm). That is a deliberate safety prompt, but it is not "zero edits to frozen files" for the new-selector case. Changing logic / adding versions remains edit-free on frozen code.
- Same foot-gun as every option: a version that omits an introduced selector reverts unsupported — covered by per-version golden tests.

## Test plan

- \`cargo test -p base-common-precompiles foo\` — 9 passed
- \`cargo clippy -p base-common-precompiles --all-targets\` — clean