### PR TITLE
fix(snapshotter): restart consensus container after snapshot

### DIFF
--- a/crates/infra/snapshotter/README.md
+++ b/crates/infra/snapshotter/README.md
@@ -6,12 +6,12 @@ Sidecar for generating and uploading reth node snapshots to S3-compatible storag
 
 Runs alongside a Base execution layer node (base-node-reth) and orchestrates periodic snapshot
 creation. `Snapshotter` coordinates the full lifecycle: verifying the EL is at chain tip (its
-latest block is within a configurable freshness window, default 10s), stopping the EL container
-via the Docker socket, generating a snapshot manifest and chunk archives using reth's
+latest block is within a configurable freshness window, default 10s), stopping the CL and EL
+containers via the Docker socket, generating a snapshot manifest and chunk archives using reth's
 `SnapshotManifestCommand`, uploading all artifacts to an S3-compatible store (e.g. Cloudflare R2),
-then restarting the EL.
+then restarting the EL followed by the CL so it reconnects to the EL.
 
-If the EL is not at tip when a run begins, the snapshot is skipped and the container is left
+If the EL is not at tip when a run begins, the snapshot is skipped and both containers are left
 running untouched.
 
 The Docker socket (`/var/run/docker.sock`) is volume-mounted into the sidecar container, giving

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -29,6 +29,10 @@ pub struct SnapshotterConfig {
     #[arg(long)]
     pub container_name: String,
 
+    /// Docker container name of the consensus layer node to stop/start.
+    #[arg(long)]
+    pub consensus_container_name: String,
+
     /// HTTP JSON-RPC URL of the execution layer node.
     ///
     /// Used to verify the EL is at tip (latest block is recent) before pausing
@@ -41,7 +45,7 @@ pub struct SnapshotterConfig {
     ///
     /// If the latest block's timestamp is older than this many seconds relative
     /// to the current wall-clock time, the snapshot run is skipped and the EL
-    /// container is left untouched.
+    /// and CL containers are left untouched.
     #[arg(long, env = "SNAPSHOTTER_TIP_THRESHOLD_SECS", default_value_t = DEFAULT_TIP_THRESHOLD_SECS)]
     pub tip_threshold_secs: u64,
 

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -17,10 +17,11 @@ use crate::{
     upload::SnapshotUploader,
 };
 
-/// Orchestrates the full snapshot flow: stop EL → generate → upload → restart EL.
+/// Orchestrates the full snapshot flow: stop CL and EL → generate → upload → restart EL and CL.
 ///
-/// The EL container is always restarted, even if snapshot generation or upload
-/// fails. This prevents leaving the node in a stopped state on errors.
+/// Both containers are always restarted, even if snapshot generation or upload
+/// fails. This prevents leaving the node in a stopped state on errors and ensures
+/// the CL reconnects to the EL after the snapshot.
 pub struct Snapshotter<C: ContainerManager, T: TipChecker> {
     container_manager: C,
     tip_checker: T,
@@ -49,12 +50,12 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
     /// Executes the full snapshot lifecycle.
     ///
     /// 0. Verifies the EL is at chain tip; skips the run if it is not
-    /// 1. Stops the EL container
-    /// 2. Verifies the container is stopped
+    /// 1. Stops the CL and EL containers
+    /// 2. Verifies both containers are stopped
     /// 3. Generates snapshot archives
     /// 4. Uploads to S3/R2
     /// 5. Clears reth's persisted peer list (best effort)
-    /// 6. Restarts the EL container (always, even on failure)
+    /// 6. Restarts the EL and then the CL (always, even on failure)
     ///
     /// When `upload_existing_run_timestamp` is set, the snapshotter skips the
     /// container lifecycle entirely and uploads the existing `run-<timestamp>`
@@ -80,16 +81,21 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         if !at_tip {
             warn!(
                 threshold_secs = self.config.tip_threshold_secs,
-                "EL is not at tip; skipping snapshot run and leaving container running"
+                "EL is not at tip; skipping snapshot run and leaving containers running"
             );
             return Ok(());
         }
 
-        let stop_result = self.container_manager.stop(&self.config.container_name).await;
-
-        let result = match stop_result {
-            Ok(()) => self.generate_and_upload().await,
-            Err(e) => Err(e).context("failed to stop EL container"),
+        // Stop the dependent CL first, then the EL. Restarting in the reverse
+        // order below ensures the EL is available when the CL reconnects.
+        let cl_stop_result =
+            self.container_manager.stop(&self.config.consensus_container_name).await;
+        let result = match cl_stop_result {
+            Ok(()) => match self.container_manager.stop(&self.config.container_name).await {
+                Ok(()) => self.generate_and_upload().await,
+                Err(e) => Err(e).context("failed to stop EL container"),
+            },
+            Err(e) => Err(e).context("failed to stop CL container"),
         };
 
         // Clear reth's persisted peer list before the EL restarts so the node
@@ -98,9 +104,9 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         // never aborts the run or blocks the restart.
         self.clear_known_peers();
 
-        let restart_result = self.container_manager.start(&self.config.container_name).await;
+        let el_restart_result = self.container_manager.start(&self.config.container_name).await;
 
-        if let Err(ref restart_err) = restart_result {
+        if let Err(ref restart_err) = el_restart_result {
             error!(
                 error = %restart_err,
                 container = %self.config.container_name,
@@ -108,23 +114,43 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             );
         }
 
+        let cl_restart_result =
+            self.container_manager.start(&self.config.consensus_container_name).await;
+
+        if let Err(ref restart_err) = cl_restart_result {
+            error!(
+                error = %restart_err,
+                container = %self.config.consensus_container_name,
+                "CRITICAL: failed to restart CL container after snapshot"
+            );
+        }
+
+        let restart_result = match (el_restart_result, cl_restart_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(el_err), Ok(())) => Err(el_err).context("failed to restart EL container"),
+            (Ok(()), Err(cl_err)) => Err(cl_err).context("failed to restart CL container"),
+            (Err(el_err), Err(cl_err)) => {
+                bail!("failed to restart EL container ({el_err}) and CL container ({cl_err})")
+            }
+        };
+
         match (result, restart_result) {
             (Ok(()), Ok(())) => {
                 info!("snapshot lifecycle complete");
                 Ok(())
             }
             (Err(snapshot_err), Ok(())) => {
-                Err(snapshot_err).context("snapshot failed but EL container was restarted")
+                Err(snapshot_err).context("snapshot failed but EL and CL containers were restarted")
             }
             (Ok(()), Err(restart_err)) => {
                 bail!(
-                    "snapshot succeeded but EL container restart failed: {restart_err}. \
+                    "snapshot succeeded but container restart failed: {restart_err}. \
                      MANUAL INTERVENTION REQUIRED."
                 )
             }
             (Err(snapshot_err), Err(restart_err)) => {
                 bail!(
-                    "snapshot failed ({snapshot_err}) AND EL container restart failed \
+                    "snapshot failed ({snapshot_err}) AND container restart failed \
                      ({restart_err}). MANUAL INTERVENTION REQUIRED."
                 )
             }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -4,7 +4,10 @@ use std::{
     collections::{BTreeMap, HashMap},
     num::NonZeroUsize,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use anyhow::Result;
@@ -31,6 +34,8 @@ struct MockContainerManager {
     running: AtomicBool,
     stop_called: AtomicBool,
     start_called: AtomicBool,
+    stopped_containers: Mutex<Vec<String>>,
+    started_containers: Mutex<Vec<String>>,
 }
 
 impl MockContainerManager {
@@ -39,6 +44,8 @@ impl MockContainerManager {
             running: AtomicBool::new(true),
             stop_called: AtomicBool::new(false),
             start_called: AtomicBool::new(false),
+            stopped_containers: Mutex::new(Vec::new()),
+            started_containers: Mutex::new(Vec::new()),
         }
     }
 
@@ -49,19 +56,43 @@ impl MockContainerManager {
     fn was_started(&self) -> bool {
         self.start_called.load(Ordering::Relaxed)
     }
+
+    fn stopped_container(&self, container_name: &str) -> bool {
+        self.stopped_containers
+            .lock()
+            .expect("lock should not be poisoned")
+            .iter()
+            .any(|name| name == container_name)
+    }
+
+    fn started_container(&self, container_name: &str) -> bool {
+        self.started_containers
+            .lock()
+            .expect("lock should not be poisoned")
+            .iter()
+            .any(|name| name == container_name)
+    }
 }
 
 #[async_trait]
 impl ContainerManager for MockContainerManager {
-    async fn stop(&self, _container_name: &str) -> Result<()> {
+    async fn stop(&self, container_name: &str) -> Result<()> {
         self.running.store(false, Ordering::Relaxed);
         self.stop_called.store(true, Ordering::Relaxed);
+        self.stopped_containers
+            .lock()
+            .expect("lock should not be poisoned")
+            .push(container_name.to_string());
         Ok(())
     }
 
-    async fn start(&self, _container_name: &str) -> Result<()> {
+    async fn start(&self, container_name: &str) -> Result<()> {
         self.running.store(true, Ordering::Relaxed);
         self.start_called.store(true, Ordering::Relaxed);
+        self.started_containers
+            .lock()
+            .expect("lock should not be poisoned")
+            .push(container_name.to_string());
         Ok(())
     }
 
@@ -93,6 +124,7 @@ impl TipChecker for MockTipChecker {
 fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig {
     base_snapshotter::SnapshotterConfig {
         container_name: "fake-el".to_string(),
+        consensus_container_name: "fake-cl".to_string(),
         el_rpc_url: "http://127.0.0.1:8545".parse().expect("valid test URL"),
         tip_threshold_secs: base_snapshotter::DEFAULT_TIP_THRESHOLD_SECS,
         source_datadir: tmp.join("nonexistent-datadir"),
@@ -848,12 +880,16 @@ async fn orchestrator_always_restarts_on_failure() -> Result<()> {
     assert!(result.is_err(), "should fail because source_datadir doesn't exist");
     assert!(manager.was_stopped(), "container should have been stopped");
     assert!(manager.was_started(), "container should always be restarted even on failure");
+    assert!(manager.stopped_container("fake-el"), "EL container should have been stopped");
+    assert!(manager.stopped_container("fake-cl"), "CL container should have been stopped");
+    assert!(manager.started_container("fake-el"), "EL container should have been restarted");
+    assert!(manager.started_container("fake-cl"), "CL container should have been restarted");
 
     Ok(())
 }
 
-/// When the EL is not at tip, the run must be skipped entirely: the container is
-/// neither stopped nor started, and `run` returns `Ok`.
+/// When the EL is not at tip, the run must be skipped entirely: neither container
+/// is stopped or started, and `run` returns `Ok`.
 #[tokio::test]
 #[serial]
 async fn orchestrator_skips_when_not_at_tip() -> Result<()> {
@@ -948,6 +984,10 @@ async fn orchestrator_proceeds_when_at_tip() -> Result<()> {
     assert!(result.is_err(), "should fail downstream because source_datadir doesn't exist");
     assert!(manager.was_stopped(), "container should have been stopped when EL is at tip");
     assert!(manager.was_started(), "container should always be restarted");
+    assert!(manager.stopped_container("fake-el"), "EL container should have been stopped");
+    assert!(manager.stopped_container("fake-cl"), "CL container should have been stopped");
+    assert!(manager.started_container("fake-el"), "EL container should have been restarted");
+    assert!(manager.started_container("fake-cl"), "CL container should have been restarted");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a consensus container name to snapshotter configuration
- stop the CL before the EL during snapshot creation
- restart the EL before the CL so the CL reconnects cleanly
- attempt both restarts even when snapshotting or one restart fails